### PR TITLE
Tolerate practical attachment clock skew

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -451,7 +451,10 @@ lists what is not yet a supported production operation.
   mailbox boundary.
 - Use SQLite-aware online backups or checkpoint/quiesce before snapshots; do
   not assume a live Proxmox snapshot is a consistent database backup. Monitor
-  NTP/clock skew because leases and credentials are time-bound.
+  NTP/clock skew because leases and credentials are time-bound. Attachment
+  directory heads permit at most 60 seconds of future skew and remain valid
+  for at most five minutes; permits and operation records remain bounded to
+  30 seconds and never receive an expiry extension for skew.
 
 ## Implementation plan
 

--- a/cmd/punaro-directory/main.go
+++ b/cmd/punaro-directory/main.go
@@ -97,15 +97,15 @@ func runBuild(args []string) error {
 	configPath := fs.String("config", "", "non-secret directory JSON manifest")
 	rootPath := fs.String("root-private-key-file", "", "absolute private Ed25519 root key file")
 	output := fs.String("output", "", "absolute snapshot output file")
-	ttl := fs.Duration("ttl", 30*time.Second, "snapshot lifetime (1s-30s)")
+	ttl := fs.Duration("ttl", 2*time.Minute, "snapshot lifetime (1s-5m)")
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
 	if *configPath == "" || *rootPath == "" || *output == "" || !filepath.IsAbs(*configPath) || !filepath.IsAbs(*rootPath) || !filepath.IsAbs(*output) {
 		return errors.New("--config, --root-private-key-file, and --output must be absolute paths")
 	}
-	if *ttl < time.Second || *ttl > 30*time.Second {
-		return errors.New("--ttl must be between 1s and 30s")
+	if *ttl < time.Second || *ttl > 5*time.Minute {
+		return errors.New("--ttl must be between 1s and 5m")
 	}
 	raw, err := os.ReadFile(*configPath)
 	if err != nil {

--- a/cmd/punaro-directory/main_test.go
+++ b/cmd/punaro-directory/main_test.go
@@ -67,6 +67,19 @@ func TestBuildSnapshotRejectsInvalidPublicManifest(t *testing.T) {
 	}
 }
 
+func TestRunBuildRejectsDirectoryTTLAbovePracticalLimit(t *testing.T) {
+	root := t.TempDir()
+	err := runBuild([]string{
+		"--config", filepath.Join(root, "config.json"),
+		"--root-private-key-file", filepath.Join(root, "root.key"),
+		"--output", filepath.Join(root, "snapshot.cbor"),
+		"--ttl", "5m1s",
+	})
+	if err == nil || err.Error() != "--ttl must be between 1s and 5m" {
+		t.Fatalf("err=%v, want practical TTL range rejection", err)
+	}
+}
+
 func TestPrivateOutputsRequirePrivateParentAndNeverOverwrite(t *testing.T) {
 	unsafe := filepath.Join(t.TempDir(), "unsafe")
 	if err := os.Mkdir(unsafe, 0o700); err != nil {

--- a/docs/alpha-text-relay.md
+++ b/docs/alpha-text-relay.md
@@ -212,8 +212,9 @@ advance its revocation state and publish the signed snapshot, then remove its
 relay enrollment and revoke its Access token as in the preceding section. The
 next permit or attachment operation refreshes the directory and fails closed;
 the daemon's bounded reaper releases expired state after the ten-minute
-manifest lifetime; each directory head and permit remains valid for at most
-30 seconds. This cannot recall ciphertext already delivered to a recipient.
+manifest lifetime; each directory head remains valid for at most five minutes
+and each permit for at most 30 seconds. This cannot recall ciphertext already
+delivered to a recipient.
 
 Create a new explicit conversation from an attached creator endpoint with one
 or more declared members:

--- a/docs/attachments-v2-rfc.md
+++ b/docs/attachments-v2-rfc.md
@@ -36,12 +36,12 @@ procedure that requires explicit operator approval.
 
 A directory head is a canonical signed record containing version, audience,
 root key ID, tree size, tree root, sequence, issued time, expiry, and revocation
-epoch.  Its maximum validity is 30 seconds.  Each adapter persists its last
+epoch.  Its maximum validity is five minutes.  Each adapter persists its last
 accepted `(sequence, tree root, revocation epoch)` in anti-rollback storage;
 every newer head needs a consistency proof from that checkpoint.  The adapter
-rejects a head that is expired, has `expires_at > issued_at + 30 seconds`, is
-issued more than 120 seconds from trusted local time, is not yet effective
-(`issued_at > local_time`), decreases sequence or epoch, lacks a valid
+rejects a head that is expired, has `expires_at > issued_at + 5 minutes`, is
+issued more than 60 seconds from trusted local time, decreases sequence or
+epoch, lacks a valid
 consistency/inclusion proof, or has the wrong audience.  A missing fresh head is a hard failure, not an
 offline grace period.  Two valid heads for the same audience and sequence with
 different roots are equivocation: freeze that audience, retain the evidence,
@@ -165,9 +165,8 @@ The manifest's maximum encoded size is 4 KiB and an envelope's is 16 KiB.
 `manifest_commitment` is BLAKE3-256 over the complete canonical signed Manifest
 encoding, including field `99`; a Manifest is not eligible for commitment until
 its signature has been verified against the fresh directory key-ID binding.
-Manifests have a maximum 30-second lifetime, may not be issued more than 120
-seconds in the future, are not accepted before `issued_at <= local_time`, and
-are accepted only when a fresh directory head proves
+Manifests have a maximum 30-second lifetime, may not be issued more than 60
+seconds in the future, and are accepted only when a fresh directory head proves
 the sender/recipient inclusions, the exact membership commitment, and the exact
 revocation epoch recorded by the Manifest.  A newer head or epoch, a changed
 membership commitment, an expired Manifest, or an unprovable historic head is
@@ -470,11 +469,11 @@ recipient-signed `offered -> accepted` transition. A retry returns the original
 redemption result; a distinct operation cannot consume the nonce again.
 
 Revocation stops new offers, acceptances, uploads, downloads, permits, and
-signaling immediately after a fresh directory view.  Direct transport closes
-on revocation notification or permit expiry.  Because a permit cannot outlive
-its 30-second directory head, the documented residual exposure is at most 30
-seconds after publication of a correctly authenticated revoking head for bytes
-already in flight; delivered plaintext is never recalled.
+signaling after the participant has fetched the fresh directory view. Direct
+transport closes on revocation notification or permit expiry. A cached signed
+directory head can remain usable for up to five minutes, so this is the maximum
+revocation-propagation exposure for bytes already in flight; delivered
+plaintext is never recalled.
 
 ## Transport and resource safety
 

--- a/docs/attachments-v3-rfc.md
+++ b/docs/attachments-v3-rfc.md
@@ -82,10 +82,13 @@ body must bind the identical audience, transfer/conversation IDs,
 sender/recipient generations, manifest commitment, directory-head commitment,
 membership commitment, revocation epoch, and expiry.
 
-An immutable v3 Manifest may live for at most ten minutes. Directory heads and
-permits remain independently short-lived (at most 30 seconds). After strict
-source-init, each operation obtains a new permit from a fresh current directory
-view. That permit remains exactly bound to the Manifest commitment, transfer
+An immutable v3 Manifest may live for at most ten minutes. Directory heads may
+live for at most five minutes; permits remain independently short-lived (at
+most 30 seconds). Verifiers tolerate up to 60 seconds of future clock skew for
+signed attachment records, including the root-signed directory head, but never
+extend any record's expiry. After strict source-init, each operation obtains a
+new permit from a fresh current directory view. That permit remains exactly
+bound to the Manifest commitment, transfer
 identities, and membership commitment, but its directory head and revocation
 epoch are the current values and may therefore differ from the Manifest's
 admission provenance. Every operation rejects a current missing/revoked

--- a/docs/operator-guide.md
+++ b/docs/operator-guide.md
@@ -62,11 +62,12 @@ health probe, does not prove that a newly started attachment receiver can
 complete its own TLS handshake and signed `GET /v2/directory` request.
 
 Every directory publisher, relay, sender, and receiver also needs working NTP
-time synchronization. Directory snapshots and permits are deliberately
-short-lived and reject future-dated, expired, or otherwise invalid time
-windows. Do not compensate for clock drift by lengthening validity windows or
-disabling freshness checks: repair the host's normal time synchronization,
-then run the receiver preflight again.
+time synchronization. A directory head may be valid for up to five minutes
+and accepts at most 60 seconds of future clock skew; per-operation permits
+remain valid for at most 30 seconds. This margin handles normal scheduling and
+NTP convergence, but never extends expiry or replaces NTP. Do not disable
+freshness checks: repair a materially drifting host, then run the receiver
+preflight again.
 
 Before enabling controlled attachment delivery on each machine, and after an
 Access, firewall, certificate, network, or directory-publisher change, run
@@ -297,7 +298,7 @@ The manifest has only `audience`, `root_key_id`, `sequence`,
 of `device`, `membership`, or `issuer`. Unknown or
 duplicate fields are rejected. Build a short-lived snapshot from that
 non-secret JSON manifest using `build --config ... --root-private-key-file ...
---output ... --ttl 30s`, then atomically publish that new file at
+--output ... --ttl 2m`, then atomically publish that new file at
 `PUNARO_DIRECTORY_SNAPSHOT_FILE`. Keep the root and issuer private keys
 separate from the relay runtime; only the issuer key belongs in the relay's
 private credential directory. Never place device private keys, root keys, or
@@ -305,12 +306,12 @@ issuer keys in the manifest, an environment file, or source control.
 
 For a Proxmox-contained relay, use
 [`scripts/publish-directory-snapshot.sh`](../scripts/publish-directory-snapshot.sh)
-from the separate root-key host. It builds one fresh 30-second snapshot and
+from the separate root-key host. It builds one fresh two-minute snapshot and
 copies only that signed snapshot through the Proxmox host, then changes mode
 and atomically renames it inside the target container. Put its environment in
 an owner-only service configuration and schedule the next publication only
-after the prior 30-second snapshot and every permit it could have issued have
-expired (for example, a 31-second interval). Do not rotate a still-valid head:
+after the prior two-minute snapshot and every permit it could have issued have
+expired (for example, a 121-second interval). Do not rotate a still-valid head:
 permits bind to that exact signed head. Do not run it on the relay or copy the
 root key into the container. This deliberately creates a brief unready
 rollover boundary; callers must retry a fresh operation after it. If a publish

--- a/internal/attachment/v2/directory.go
+++ b/internal/attachment/v2/directory.go
@@ -15,6 +15,11 @@ const (
 	directoryNodeDomain = "punaro/attachment/directory-node/v2\x00"
 	maxDirectoryLeaves  = 4096
 	maxDirectoryHead    = 4 << 10
+	// Directory snapshots are refreshed frequently, but they must survive
+	// ordinary scheduling, transport, and NTP convergence delays. Permits stay
+	// much shorter-lived and are independently bound to a fresh directory view.
+	maxDirectoryHeadLifetimeSeconds = 5 * 60
+	maxDirectoryFutureSkewSeconds   = 60
 )
 
 // DirectoryHead is the root-signed, canonical, short-lived authority snapshot
@@ -90,7 +95,7 @@ func (h DirectoryHead) wire() directoryHeadWire {
 }
 
 func validateDirectoryHead(h DirectoryHead) error {
-	if isZero32(h.Audience) || isZero32(h.RootKeyID) || isZero32(h.TreeRoot) || h.TreeSize == 0 || h.TreeSize > maxDirectoryLeaves || h.Sequence == 0 || h.ExpiresAt <= h.IssuedAt || h.ExpiresAt-h.IssuedAt > 30 {
+	if isZero32(h.Audience) || isZero32(h.RootKeyID) || isZero32(h.TreeRoot) || h.TreeSize == 0 || h.TreeSize > maxDirectoryLeaves || h.Sequence == 0 || h.ExpiresAt <= h.IssuedAt || h.ExpiresAt-h.IssuedAt > maxDirectoryHeadLifetimeSeconds {
 		return errors.New("invalid directory head")
 	}
 	return nil
@@ -167,7 +172,7 @@ func verifyDirectoryHead(raw []byte, trust DirectoryTrust, now time.Time) (Direc
 		return DirectoryHead{}, errors.New("invalid directory signature")
 	}
 	nowUnix := now.UTC().Unix()
-	if nowUnix < 0 || head.IssuedAt > uint64(nowUnix) || head.IssuedAt > uint64(nowUnix)+120 || head.ExpiresAt <= uint64(nowUnix) {
+	if nowUnix < 0 || head.IssuedAt > uint64(nowUnix)+maxDirectoryFutureSkewSeconds || head.ExpiresAt <= uint64(nowUnix) {
 		return DirectoryHead{}, errors.New("stale directory head")
 	}
 	return head, nil

--- a/internal/attachment/v2/directory_snapshot.go
+++ b/internal/attachment/v2/directory_snapshot.go
@@ -470,7 +470,7 @@ func (r *DirectorySnapshotResolver) ValidateManifestAuthority(manifest Manifest,
 // ValidateV3ManifestAdmissionAuthority is the v3-only source-init authority
 // check. It retains v2's exact current head, epoch, device, key, and
 // membership requirements, but allows v3's separately bounded immutable
-// Manifest to outlive the 30-second directory head. v2 callers must continue
+// Manifest to outlive the five-minute directory head. v2 callers must continue
 // using ValidateManifestAuthority.
 func (r *DirectorySnapshotResolver) ValidateV3ManifestAdmissionAuthority(manifest Manifest, now time.Time) (ed25519.PublicKey, error) {
 	return r.validateManifestAuthority(manifest, now, false)
@@ -485,7 +485,7 @@ func (r *DirectorySnapshotResolver) validateManifestAuthority(manifest Manifest,
 		return nil, errors.New("invalid manifest directory authority")
 	}
 	headCommitment, err := directoryHeadCommitment(r.head)
-	if err != nil || manifest.Audience != r.head.Audience || manifest.RevocationEpoch != r.head.RevocationEpoch || manifest.DirectoryHead != headCommitment || manifest.IssuedAt > uint64(nowUnix) || manifest.ExpiresAt <= uint64(nowUnix) || (requireManifestWithinHead && manifest.ExpiresAt > r.head.ExpiresAt) {
+	if err != nil || manifest.Audience != r.head.Audience || manifest.RevocationEpoch != r.head.RevocationEpoch || manifest.DirectoryHead != headCommitment || manifest.IssuedAt > uint64(nowUnix)+maxDirectoryFutureSkewSeconds || manifest.ExpiresAt <= uint64(nowUnix) || (requireManifestWithinHead && manifest.ExpiresAt > r.head.ExpiresAt) {
 		return nil, errors.New("invalid manifest directory authority")
 	}
 	sender, found := r.device(manifest.SenderDeviceID, manifest.SenderGeneration)
@@ -506,7 +506,7 @@ func (r *DirectorySnapshotResolver) ValidateRetainedManifestAuthority(manifest M
 		return nil, errors.New("invalid retained manifest directory authority")
 	}
 	nowUnix := now.UTC().Unix()
-	if nowUnix < 0 || manifest.Audience != r.head.Audience || manifest.IssuedAt > uint64(nowUnix) || manifest.ExpiresAt <= uint64(nowUnix) {
+	if nowUnix < 0 || manifest.Audience != r.head.Audience || manifest.IssuedAt > uint64(nowUnix)+maxDirectoryFutureSkewSeconds || manifest.ExpiresAt <= uint64(nowUnix) {
 		return nil, errors.New("invalid retained manifest directory authority")
 	}
 	sender, found := r.device(manifest.SenderDeviceID, manifest.SenderGeneration)
@@ -549,7 +549,7 @@ func (r *DirectorySnapshotResolver) fresh(now time.Time) bool {
 		return false
 	}
 	nowUnix := uint64(unix)
-	return r.head.IssuedAt <= nowUnix && r.head.ExpiresAt > nowUnix
+	return r.head.IssuedAt <= nowUnix+maxDirectoryFutureSkewSeconds && r.head.ExpiresAt > nowUnix
 }
 
 func (r *DirectorySnapshotResolver) current() bool {

--- a/internal/attachment/v2/directory_snapshot_test.go
+++ b/internal/attachment/v2/directory_snapshot_test.go
@@ -72,6 +72,15 @@ func TestDirectorySnapshotResolverBindsManifestAndRecipientKeysToFreshMembership
 	if _, err := resolver.ValidateV3ManifestAdmissionAuthority(manifest, clock); err != nil {
 		t.Fatalf("v3 strict admission rejected exact ten-minute manifest: %v", err)
 	}
+	manifest.IssuedAt = testUnix(t, clock.Add(60*time.Second))
+	if _, err := resolver.ValidateV3ManifestAdmissionAuthority(manifest, clock); err != nil {
+		t.Fatalf("v3 admission rejected bounded future clock skew: %v", err)
+	}
+	manifest.IssuedAt = testUnix(t, clock.Add(61*time.Second))
+	if _, err := resolver.ValidateV3ManifestAdmissionAuthority(manifest, clock); err == nil {
+		t.Fatal("v3 admission accepted excessive future clock skew")
+	}
+	manifest.IssuedAt = testUnix(t, clock.Add(-time.Second))
 	admissionHead := manifest.DirectoryHead
 	manifest.DirectoryHead = directoryBytes32(99)
 	if _, err := resolver.ValidateV3ManifestAdmissionAuthority(manifest, clock); err == nil {
@@ -80,6 +89,22 @@ func TestDirectorySnapshotResolverBindsManifestAndRecipientKeysToFreshMembership
 	manifest.DirectoryHead, manifest.RevocationEpoch = admissionHead, 2
 	if _, err := resolver.ValidateV3ManifestAdmissionAuthority(manifest, clock); err == nil {
 		t.Fatal("v3 strict admission accepted a different revocation epoch")
+	}
+
+	futureHead := head
+	futureHead.IssuedAt = testUnix(t, clock.Add(60*time.Second))
+	futureHead.ExpiresAt = testUnix(t, clock.Add(5*time.Minute))
+	futureHead = signedDirectoryHead(t, rootPrivate, futureHead)
+	futureRaw, err := EncodeDirectoryHead(futureHead)
+	if err != nil {
+		t.Fatal(err)
+	}
+	futureResolver, err := NewDirectorySnapshotResolver(futureRaw, DirectoryTrust{Audience: audience, RootKeyID: rootID, RootPublicKey: rootPublic, Checkpoints: &memoryCheckpointStore{checkpoints: make(map[[32]byte]DirectoryCheckpoint)}}, clock, nil, entries)
+	if err != nil {
+		t.Fatalf("future-skew directory resolver: %v", err)
+	}
+	if _, _, err := futureResolver.CurrentRecipientHPKEKey(bytes16(5), 2); err != nil {
+		t.Fatalf("bounded future-skew directory head was not usable: %v", err)
 	}
 }
 

--- a/internal/attachment/v2/directory_test.go
+++ b/internal/attachment/v2/directory_test.go
@@ -196,6 +196,41 @@ func TestVerifyAndAdvanceDirectoryHeadRejectsEquivocationAndMissingProof(t *test
 	}
 }
 
+func TestVerifyDirectoryHeadAllowsBoundedClockSkewAndPracticalLifetime(t *testing.T) {
+	rootPublic, rootPrivate, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	now := time.Date(2026, time.July, 17, 12, 0, 0, 0, time.UTC)
+	trust := DirectoryTrust{Audience: directoryBytes32(1), RootKeyID: directoryBytes32(2), RootPublicKey: rootPublic, Checkpoints: &memoryCheckpointStore{checkpoints: make(map[[32]byte]DirectoryCheckpoint)}}
+
+	accepted := signedDirectoryHead(t, rootPrivate, DirectoryHead{
+		Audience: trust.Audience, RootKeyID: trust.RootKeyID, TreeSize: 1, TreeRoot: directoryBytes32(3), Sequence: 1,
+		IssuedAt: testUnix(t, now.Add(60*time.Second)), ExpiresAt: testUnix(t, now.Add(5*time.Minute)),
+	})
+	raw, err := EncodeDirectoryHead(accepted)
+	if err != nil {
+		t.Fatalf("encode bounded-skew head: %v", err)
+	}
+	if _, err := verifyDirectoryHead(raw, trust, now); err != nil {
+		t.Fatalf("bounded future clock skew rejected: %v", err)
+	}
+
+	rejected := accepted
+	rejected.IssuedAt = testUnix(t, now.Add(61*time.Second))
+	rejected.ExpiresAt = testUnix(t, now.Add(5*time.Minute+time.Second))
+	if err := SignDirectoryHead(&rejected, rootPrivate); err != nil {
+		t.Fatal(err)
+	}
+	raw, err = EncodeDirectoryHead(rejected)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := verifyDirectoryHead(raw, trust, now); err == nil {
+		t.Fatal("directory head beyond bounded future clock skew accepted")
+	}
+}
+
 func TestSQLiteCheckpointStoreConcurrentAdvancesCannotDowngradeCheckpoint(t *testing.T) {
 	t.Parallel()
 	parent := filepath.Join(t.TempDir(), "private")

--- a/internal/attachment/v3/manifest.go
+++ b/internal/attachment/v3/manifest.go
@@ -19,6 +19,10 @@ const (
 	// MaxManifestLifetime bounds immutable v3 transfer state. Directory heads
 	// and operation permits remain independently short-lived (at most 30s).
 	MaxManifestLifetime = 10 * time.Minute
+	// MaxFutureClockSkew tolerates ordinary NTP convergence and scheduling
+	// differences between enrolled machines. It never extends an expiry and is
+	// not a substitute for normal time synchronization.
+	MaxFutureClockSkew = time.Minute
 )
 
 var (
@@ -258,11 +262,15 @@ func (v VerifiedSource) PlaintextSize() uint64 { return v.manifest.PlaintextSize
 
 func validateManifestTime(m Manifest, now time.Time) error {
 	seconds := now.UTC().Unix()
-	if seconds < 0 || m.ExpiresAt > math.MaxInt64 || m.IssuedAt > uint64(seconds) {
+	if seconds < 0 || !issuedWithinClockSkew(m.IssuedAt, seconds) || m.ExpiresAt > math.MaxInt64 {
 		return errors.New("invalid manifest time")
 	}
 	if uint64(seconds) >= m.ExpiresAt {
 		return errors.New("expired manifest")
 	}
 	return nil
+}
+
+func issuedWithinClockSkew(issued uint64, nowUnix int64) bool {
+	return nowUnix >= 0 && issued <= uint64(nowUnix)+uint64(MaxFutureClockSkew/time.Second)
 }

--- a/internal/attachment/v3/manifest_test.go
+++ b/internal/attachment/v3/manifest_test.go
@@ -37,13 +37,13 @@ func TestDecodeAndVerifySourceInitDerivesImmutableSource(t *testing.T) {
 	}
 }
 
-func TestDecodeAndVerifySourceInitRejectsFutureOrUnrepresentableTime(t *testing.T) {
+func TestDecodeAndVerifySourceInitAllowsBoundedFutureClockSkew(t *testing.T) {
 	public, private, err := ed25519.GenerateKey(rand.Reader)
 	if err != nil {
 		t.Fatal(err)
 	}
 	now := time.Date(2026, time.July, 15, 0, 0, 0, 0, time.UTC)
-	manifest := testManifest(now.Add(time.Second))
+	manifest := testManifest(now.Add(60 * time.Second))
 	if err := SignManifest(&manifest, private); err != nil {
 		t.Fatal(err)
 	}
@@ -51,8 +51,19 @@ func TestDecodeAndVerifySourceInitRejectsFutureOrUnrepresentableTime(t *testing.
 	if err != nil {
 		t.Fatal(err)
 	}
+	if _, err := DecodeAndVerifySourceInit(raw, manifestAuthorityStub{public: public}, now); err != nil {
+		t.Fatalf("bounded future-issued manifest rejected: %v", err)
+	}
+	manifest = testManifest(now.Add(61 * time.Second))
+	if err := SignManifest(&manifest, private); err != nil {
+		t.Fatal(err)
+	}
+	raw, err = EncodeManifest(manifest)
+	if err != nil {
+		t.Fatal(err)
+	}
 	if _, err := DecodeAndVerifySourceInit(raw, manifestAuthorityStub{public: public}, now); err == nil {
-		t.Fatal("future-issued manifest accepted")
+		t.Fatal("manifest beyond bounded future clock skew accepted")
 	}
 	manifest.IssuedAt = ^uint64(0) - 20
 	manifest.ExpiresAt = ^uint64(0) - 10

--- a/internal/attachment/v3/operation.go
+++ b/internal/attachment/v3/operation.go
@@ -183,7 +183,7 @@ func VerifyOperation(r OperationRecord, permit Permit, holders OperationHolderRe
 		return errors.New("invalid v3 operation permit binding")
 	}
 	seconds := now.UTC().Unix()
-	if seconds < 0 || r.IssuedAt > uint64(seconds) || r.ExpiresAt <= uint64(seconds) {
+	if seconds < 0 || !issuedWithinClockSkew(r.IssuedAt, seconds) || r.ExpiresAt <= uint64(seconds) {
 		return errors.New("expired v3 operation record")
 	}
 	holder, err := holders.CurrentDeviceSigningKey(permit.HolderDeviceID, permit.HolderGeneration)

--- a/internal/attachment/v3/operation_test.go
+++ b/internal/attachment/v3/operation_test.go
@@ -44,6 +44,35 @@ func TestOperationRecordBindsV3RequestPermitAndStagedSource(t *testing.T) {
 	}
 }
 
+func TestOperationAllowsBoundedFutureClockSkew(t *testing.T) {
+	public, private, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	now := time.Date(2026, time.July, 15, 0, 0, 0, 0, time.UTC)
+	permit := testPermit(now.Add(60 * time.Second))
+	permit.Operation = permitOperationSourceUpload
+	_, request, err := NewAttachmentOperationRequest("PUT", "/v3/attachments/05000000000000000000000000000000/source/chunks/0", []byte("ciphertext"), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	record := testOperation(permit, request, now.Add(60*time.Second))
+	if err := SignOperation(&record, private); err != nil {
+		t.Fatal(err)
+	}
+	holders := operationHolderStub{device: permit.HolderDeviceID, generation: permit.HolderGeneration, key: public}
+	if err := VerifyOperation(record, permit, holders, now); err != nil {
+		t.Fatalf("bounded future-issued operation rejected: %v", err)
+	}
+	record = testOperation(permit, request, now.Add(61*time.Second))
+	if err := SignOperation(&record, private); err != nil {
+		t.Fatal(err)
+	}
+	if err := VerifyOperation(record, permit, holders, now); err == nil {
+		t.Fatal("operation beyond bounded future clock skew accepted")
+	}
+}
+
 func TestDownloadOperationAdmissionDoesNotTakeCiphertextFromCaller(t *testing.T) {
 	public, private, err := ed25519.GenerateKey(rand.Reader)
 	if err != nil {

--- a/internal/attachment/v3/permit.go
+++ b/internal/attachment/v3/permit.go
@@ -167,7 +167,7 @@ func VerifyPermit(p Permit, authority PermitAuthorityResolver, now time.Time) er
 		return errors.New("invalid permit")
 	}
 	seconds := now.UTC().Unix()
-	if seconds < 0 || p.IssuedAt > uint64(seconds) || p.ExpiresAt <= uint64(seconds) {
+	if seconds < 0 || !issuedWithinClockSkew(p.IssuedAt, seconds) || p.ExpiresAt <= uint64(seconds) {
 		return errors.New("expired permit")
 	}
 	key, err := authority.ValidatePermitAuthority(p, now)

--- a/internal/attachment/v3/permit_issuer.go
+++ b/internal/attachment/v3/permit_issuer.go
@@ -179,9 +179,13 @@ func (i *PermitIssuer) Issue(ctx context.Context, request PermitRequest, authori
 	}
 	now := i.now().UTC()
 	nowUnix := now.Unix()
-	if nowUnix < 0 || request.IssuedAt > uint64(nowUnix) {
+	if nowUnix < 0 {
 		return Permit{}, false, errors.New("invalid v3 permit request time")
 	}
+	if !issuedWithinClockSkew(request.IssuedAt, nowUnix) {
+		return Permit{}, false, errors.New("invalid v3 permit request time")
+	}
+	nowSeconds := uint64(nowUnix)
 	holder, err := authority.CurrentDeviceSigningKey(request.HolderDeviceID, request.HolderGeneration)
 	if err != nil || len(holder) != ed25519.PublicKeySize {
 		return Permit{}, false, errors.New("unknown v3 permit request holder")
@@ -199,7 +203,7 @@ func (i *PermitIssuer) Issue(ctx context.Context, request PermitRequest, authori
 	// expired) permit gives the controller the precise serial needed for an
 	// outcome query. Replacing it with a fresh serial would strand a committed
 	// source-init behind an unrecoverable ambiguity.
-	if request.ExpiresAt <= uint64(nowUnix) {
+	if request.ExpiresAt <= nowSeconds {
 		stored, found, err := i.existingRequest(ctx, request.RequestID, rawRequest)
 		if err != nil {
 			return Permit{}, false, err
@@ -222,7 +226,7 @@ func (i *PermitIssuer) Issue(ctx context.Context, request PermitRequest, authori
 		return Permit{}, false, errors.New("invalid v3 issuer clock")
 	}
 	expiresAt := minPermitExpiry(request.ExpiresAt, binding.ExpiresAt, uint64(issuerExpiry))
-	if expiresAt <= uint64(nowUnix) || request.MaxBytes > i.maxBytes || request.MaxChunks > i.maxChunks || request.MaxOperations > i.maxOperations {
+	if expiresAt <= nowSeconds || request.MaxBytes > i.maxBytes || request.MaxChunks > i.maxChunks || request.MaxOperations > i.maxOperations {
 		return Permit{}, false, errors.New("v3 permit request exceeds issuer policy")
 	}
 	for attempt := 0; attempt < 8; attempt++ {
@@ -230,7 +234,7 @@ func (i *PermitIssuer) Issue(ctx context.Context, request PermitRequest, authori
 		if _, err := io.ReadFull(i.random, serial[:]); err != nil || serial == [16]byte{} {
 			return Permit{}, false, errors.New("generate v3 permit serial")
 		}
-		permit := Permit{Audience: binding.Audience, Serial: serial, IssuerKeyID: i.issuerKeyID, HolderDeviceID: request.HolderDeviceID, HolderGeneration: request.HolderGeneration, HolderRole: request.HolderRole, TransferID: request.TransferID, ConversationID: request.ConversationID, SenderDeviceID: request.SenderDeviceID, SenderGeneration: request.SenderGeneration, RecipientDeviceID: request.RecipientDeviceID, RecipientGeneration: request.RecipientGeneration, AttemptGeneration: request.AttemptGeneration, Operation: request.Operation, DirectoryHead: binding.DirectoryHead, MembershipCommitment: request.MembershipCommitment, RevocationEpoch: binding.RevocationEpoch, IssuedAt: uint64(nowUnix), ExpiresAt: expiresAt, MaxBytes: request.MaxBytes, MaxChunks: request.MaxChunks, MaxOperations: request.MaxOperations, StagedManifestCommitment: request.StagedManifestCommitment, OutcomeOfSerial: request.OutcomeOfSerial}
+		permit := Permit{Audience: binding.Audience, Serial: serial, IssuerKeyID: i.issuerKeyID, HolderDeviceID: request.HolderDeviceID, HolderGeneration: request.HolderGeneration, HolderRole: request.HolderRole, TransferID: request.TransferID, ConversationID: request.ConversationID, SenderDeviceID: request.SenderDeviceID, SenderGeneration: request.SenderGeneration, RecipientDeviceID: request.RecipientDeviceID, RecipientGeneration: request.RecipientGeneration, AttemptGeneration: request.AttemptGeneration, Operation: request.Operation, DirectoryHead: binding.DirectoryHead, MembershipCommitment: request.MembershipCommitment, RevocationEpoch: binding.RevocationEpoch, IssuedAt: nowSeconds, ExpiresAt: expiresAt, MaxBytes: request.MaxBytes, MaxChunks: request.MaxChunks, MaxOperations: request.MaxOperations, StagedManifestCommitment: request.StagedManifestCommitment, OutcomeOfSerial: request.OutcomeOfSerial}
 		if err := SignPermit(&permit, i.privateKey); err != nil || VerifyPermit(permit, authority, now) != nil {
 			return Permit{}, false, errors.New("issuer generated an invalid v3 permit")
 		}

--- a/internal/attachment/v3/permit_issuer_test.go
+++ b/internal/attachment/v3/permit_issuer_test.go
@@ -18,6 +18,15 @@ type permitIssuanceAuthorityStub struct {
 	binding   DirectoryPermitBinding
 }
 
+func testUnix(t *testing.T, value time.Time) uint64 {
+	t.Helper()
+	seconds := value.Unix()
+	if seconds < 0 {
+		t.Fatal("test time precedes Unix epoch")
+	}
+	return uint64(seconds) // #nosec G115 -- the negative Unix-time case returns above.
+}
+
 func (s permitIssuanceAuthorityStub) CurrentPermitIssuerKey(keyID [32]byte) (ed25519.PublicKey, error) {
 	if keyID != s.issuerID {
 		return nil, errors.New("unknown issuer")
@@ -93,6 +102,43 @@ func TestPermitIssuerMintsV3PermitAndReturnsExactRetry(t *testing.T) {
 	}
 	if _, _, err := issuer.Issue(context.Background(), request, authority); err == nil {
 		t.Fatal("changed request reused v3 issuance ID")
+	}
+}
+
+func TestPermitIssuerAllowsBoundedFutureRequestClockSkew(t *testing.T) {
+	issuerPublic, issuerPrivate, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	holderPublic, holderPrivate, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	clock := time.Date(2026, time.July, 15, 1, 0, 0, 0, time.UTC)
+	store, err := openSourceStore(privateDatabase(t), defaultSourceLimits())
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = store.close() })
+	authority := permitIssuanceAuthorityStub{issuerID: requestIssuerID(), issuer: issuerPublic, holderID: testID(4), holderGen: 1, holder: holderPublic, binding: DirectoryPermitBinding{Audience: testHash(1), DirectoryHead: testHash(8), RevocationEpoch: 4, ExpiresAt: testUnix(t, clock.Add(2*time.Minute))}}
+	issuer, err := NewPermitIssuer(PermitIssuerOptions{Store: store, IssuerKeyID: requestIssuerID(), PrivateKey: issuerPrivate, MaxLifetime: 30 * time.Second, MaxBytes: 1 << 20, MaxChunks: 4, MaxOperations: 2, MaxActive: 4, Now: func() time.Time { return clock }})
+	if err != nil {
+		t.Fatal(err)
+	}
+	request := testPermitRequest(clock.Add(60 * time.Second))
+	if err := SignPermitRequest(&request, holderPrivate); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := issuer.Issue(context.Background(), request, authority); err != nil {
+		t.Fatalf("bounded future-issued request rejected: %v", err)
+	}
+	request = testPermitRequest(clock.Add(61 * time.Second))
+	request.RequestID = testID(111)
+	if err := SignPermitRequest(&request, holderPrivate); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := issuer.Issue(context.Background(), request, authority); err == nil {
+		t.Fatal("request beyond bounded future clock skew accepted")
 	}
 }
 

--- a/internal/attachment/v3/permit_test.go
+++ b/internal/attachment/v3/permit_test.go
@@ -36,6 +36,28 @@ func TestPermitUsesV3DomainAndBindsStagedManifest(t *testing.T) {
 	}
 }
 
+func TestPermitAllowsBoundedFutureClockSkew(t *testing.T) {
+	public, private, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	now := time.Date(2026, time.July, 15, 0, 0, 0, 0, time.UTC)
+	permit := testPermit(now.Add(60 * time.Second))
+	if err := SignPermit(&permit, private); err != nil {
+		t.Fatal(err)
+	}
+	if err := VerifyPermit(permit, permitAuthorityStub{key: public}, now); err != nil {
+		t.Fatalf("bounded future-issued permit rejected: %v", err)
+	}
+	permit = testPermit(now.Add(61 * time.Second))
+	if err := SignPermit(&permit, private); err != nil {
+		t.Fatal(err)
+	}
+	if err := VerifyPermit(permit, permitAuthorityStub{key: public}, now); err == nil {
+		t.Fatal("permit beyond bounded future clock skew accepted")
+	}
+}
+
 func TestPermitRejectsInvalidHolderOperationAndAttempt(t *testing.T) {
 	now := time.Date(2026, time.July, 15, 0, 0, 0, 0, time.UTC)
 	for _, operation := range []uint64{permitOperationSourceInit, permitOperationSourceUpload, permitOperationOffer, permitOperationCancel} {

--- a/scripts/publish-directory-snapshot.sh
+++ b/scripts/publish-directory-snapshot.sh
@@ -70,7 +70,7 @@ cleanup() {
 trap cleanup EXIT HUP INT TERM
 
 snapshot="$work_dir/snapshot"
-"$PUNARO_DIRECTORY_BINARY" build --config "$PUNARO_DIRECTORY_MANIFEST" --root-private-key-file "$PUNARO_DIRECTORY_ROOT_PRIVATE_KEY" --output "$snapshot" --ttl 30s >/dev/null
+"$PUNARO_DIRECTORY_BINARY" build --config "$PUNARO_DIRECTORY_MANIFEST" --root-private-key-file "$PUNARO_DIRECTORY_ROOT_PRIVATE_KEY" --output "$snapshot" --ttl 2m >/dev/null
 
 # The root key never leaves this host. Only its signed snapshot crosses this hop.
 remote_stage=$(ssh_pve "$PUNARO_PVE_SSH_TARGET" mktemp /tmp/punaro-directory.XXXXXXXX)

--- a/scripts/verify-deployment-files.sh
+++ b/scripts/verify-deployment-files.sh
@@ -54,7 +54,7 @@ for expected in \
 	'[ ! -L' \
 	'[ ! -L \"\$parent\" ]' \
 	'stat -c %d' \
-	'--ttl 30s' \
+	'--ttl 2m' \
 	'PUNARO_CONTAINER_SNAPSHOT_FILE must be below /var/lib/punaro/private' \
 	'PUNARO_CONTAINER_SNAPSHOT_FILE contains unsafe characters' \
 	'directory_snapshot_published'; do


### PR DESCRIPTION
## Summary

- Make signed directory heads practical: a two-minute publisher default, with a five-minute protocol maximum.
- Tolerate up to 60 seconds of ordinary future clock skew across directory, manifest, permit, operation, and permit-request verification.
- Keep expiry strict and per-operation permits bounded to 30 seconds.
- Update the publisher script and operator/protocol documentation with the resulting revocation-propagation trade-off.

## Root cause

The protocol nominally mentioned clock skew, but its verification paths rejected every future timestamp. A bounded head accepted during decode could also be rejected immediately by a second resolver freshness check.

## Validation

- `make test`
- `make test-race`
- `make staticcheck`
- `make security`
- `make lint`
