### PR TITLE
Apply clock skew allowance in attachment controllers

### DIFF
--- a/docs/attachments-v3-rfc.md
+++ b/docs/attachments-v3-rfc.md
@@ -84,9 +84,10 @@ membership commitment, revocation epoch, and expiry.
 
 An immutable v3 Manifest may live for at most ten minutes. Directory heads may
 live for at most five minutes; permits remain independently short-lived (at
-most 30 seconds). Verifiers tolerate up to 60 seconds of future clock skew for
-signed attachment records, including the root-signed directory head, but never
-extend any record's expiry. After strict source-init, each operation obtains a
+most 30 seconds). Verifiers, including durable sender and recipient
+controllers, tolerate up to 60 seconds of future clock skew for signed
+attachment records, including the root-signed directory head, but never extend
+any record's expiry. After strict source-init, each operation obtains a
 new permit from a fresh current directory view. That permit remains exactly
 bound to the Manifest commitment, transfer
 identities, and membership commitment, but its directory head and revocation

--- a/internal/attachment/v3/controller/receipt_download_worker.go
+++ b/internal/attachment/v3/controller/receipt_download_worker.go
@@ -424,7 +424,7 @@ func (w *RecipientDownloadWorker) receiptDownloadOutcomeCredentials(ctx context.
 func exactReceiptDownloadOutcomePermit(permit attachmentv3.Permit, request attachmentv3.PermitRequest, record receiptDownloadRecord, original receiptDownloadOperation, now time.Time) bool {
 	origin, err := attachmentv3.DecodePermit(original.permit)
 	// #nosec G115 -- the surrounding v3 validation bounds this conversion and fails closed.
-	if err != nil || request.OutcomeOfSerial != origin.Serial || request.RequestID == [16]byte{} || request.Operation != attachmentv3.PermitOperationOutcome || request.AttemptGeneration != 0 || request.TransferID != record.transferID || request.StagedManifestCommitment != record.manifestCommitment || request.HolderRole != attachmentv3.PermitHolderRecipient || request.IssuedAt > uint64(now.Unix()) || request.ExpiresAt <= uint64(now.Unix()) {
+	if err != nil || request.OutcomeOfSerial != origin.Serial || request.RequestID == [16]byte{} || request.Operation != attachmentv3.PermitOperationOutcome || request.AttemptGeneration != 0 || request.TransferID != record.transferID || request.StagedManifestCommitment != record.manifestCommitment || request.HolderRole != attachmentv3.PermitHolderRecipient || !attachmentv3.IssuedWithinClockSkew(request.IssuedAt, now) || request.ExpiresAt <= uint64(now.Unix()) {
 		return false
 	}
 	// #nosec G115 -- the surrounding v3 validation bounds this conversion and fails closed.

--- a/internal/attachment/v3/controller/sender.go
+++ b/internal/attachment/v3/controller/sender.go
@@ -152,7 +152,7 @@ func (s *SenderStager) Stage(ctx context.Context, stageID [16]byte, relayConvers
 
 func exactStagedManifest(manifest attachmentv3.Manifest, mapping Mapping, binding attachmentv2.DirectoryTransferBinding, now time.Time) bool {
 	// #nosec G115 -- the surrounding v3 validation bounds this conversion and fails closed.
-	return now.Unix() >= 0 && manifest.IssuedAt <= uint64(now.Unix()) && manifest.Audience == binding.Permit.Audience && manifest.ConversationID == mapping.ConversationID && manifest.SenderDeviceID == mapping.SenderDeviceID && manifest.SenderGeneration == mapping.SenderGeneration && manifest.RecipientDeviceID == mapping.RecipientDeviceID && manifest.RecipientGeneration == mapping.RecipientGeneration && manifest.MembershipCommitment == mapping.MembershipCommitment && manifest.SignerKeyID == binding.Sender.SigningKeyID && manifest.ExpiresAt > uint64(now.Unix()) && manifest.ExpiresAt <= manifest.IssuedAt+uint64(attachmentv3.MaxManifestLifetime/time.Second)
+	return now.Unix() >= 0 && attachmentv3.IssuedWithinClockSkew(manifest.IssuedAt, now) && manifest.Audience == binding.Permit.Audience && manifest.ConversationID == mapping.ConversationID && manifest.SenderDeviceID == mapping.SenderDeviceID && manifest.SenderGeneration == mapping.SenderGeneration && manifest.RecipientDeviceID == mapping.RecipientDeviceID && manifest.RecipientGeneration == mapping.RecipientGeneration && manifest.MembershipCommitment == mapping.MembershipCommitment && manifest.SignerKeyID == binding.Sender.SigningKeyID && manifest.ExpiresAt > uint64(now.Unix()) && manifest.ExpiresAt <= manifest.IssuedAt+uint64(attachmentv3.MaxManifestLifetime/time.Second)
 }
 
 func newSourceArtifactMaterial() (attachmentv3.SourceArtifactMaterial, error) {

--- a/internal/attachment/v3/controller/sender_worker.go
+++ b/internal/attachment/v3/controller/sender_worker.go
@@ -1172,7 +1172,7 @@ func exactSenderPermit(permit attachmentv3.Permit, request attachmentv3.PermitRe
 		return false
 	}
 	// #nosec G115 -- the surrounding v3 validation bounds this conversion and fails closed.
-	return now.Unix() >= 0 && permit.IssuedAt >= request.IssuedAt && permit.ExpiresAt <= request.ExpiresAt && permit.IssuedAt <= uint64(now.Unix()) && permit.ExpiresAt > uint64(now.Unix())
+	return now.Unix() >= 0 && permit.IssuedAt >= request.IssuedAt && permit.ExpiresAt <= request.ExpiresAt && attachmentv3.IssuedWithinClockSkew(permit.IssuedAt, now) && permit.ExpiresAt > uint64(now.Unix())
 }
 
 func exactSenderPermitFields(permit attachmentv3.Permit, request attachmentv3.PermitRequest, transfer senderTransferRecord, operation uint64) bool {
@@ -1188,7 +1188,7 @@ func exactSenderOutcomeRequest(request attachmentv3.PermitRequest, original send
 		return false
 	}
 	// #nosec G115 -- the surrounding v3 validation bounds this conversion and fails closed.
-	return request.IssuedAt <= uint64(now.Unix()) && request.ExpiresAt > uint64(now.Unix())
+	return attachmentv3.IssuedWithinClockSkew(request.IssuedAt, now) && request.ExpiresAt > uint64(now.Unix())
 }
 
 func exactSenderOutcomePermit(permit attachmentv3.Permit, request attachmentv3.PermitRequest, original senderOperationRecord, transfer senderTransferRecord, now time.Time) bool {
@@ -1202,7 +1202,7 @@ func exactSenderOutcomePermit(permit attachmentv3.Permit, request attachmentv3.P
 		return false
 	}
 	// #nosec G115 -- the surrounding v3 validation bounds this conversion and fails closed.
-	return permit.IssuedAt >= request.IssuedAt && permit.ExpiresAt <= request.ExpiresAt && permit.IssuedAt <= uint64(now.Unix()) && permit.ExpiresAt > uint64(now.Unix())
+	return permit.IssuedAt >= request.IssuedAt && permit.ExpiresAt <= request.ExpiresAt && attachmentv3.IssuedWithinClockSkew(permit.IssuedAt, now) && permit.ExpiresAt > uint64(now.Unix())
 }
 
 func verifySenderOperation(operation attachmentv3.OperationRecord, permit attachmentv3.Permit, method, path string, body []byte, authority SenderDeliveryAuthority, now time.Time) error {

--- a/internal/attachment/v3/controller/sender_worker_test.go
+++ b/internal/attachment/v3/controller/sender_worker_test.go
@@ -68,6 +68,38 @@ func TestSenderSourceInitializerPersistsExactCredentialsBeforeSubmission(t *test
 	}
 }
 
+func TestSenderSourceInitializerAllowsBoundedFuturePermitIssue(t *testing.T) {
+	journal, err := OpenJournalForSender(filepath.Join(t.TempDir(), "private", "controller.db"), SenderIdentity{DeviceID: bytes16(2), Generation: 1})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = journal.Close() }()
+	mapping := Mapping{RelayConversationID: "relay-conversation", ConversationID: bytes16(1), SenderDeviceID: bytes16(2), SenderGeneration: 1, RecipientDeviceID: bytes16(3), RecipientGeneration: 1, MembershipCommitment: bytes32(4)}
+	if err := journal.AddMapping(mapping); err != nil {
+		t.Fatal(err)
+	}
+	_, senderPrivate, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	now := time.Unix(100, 0).UTC()
+	manifest, raw := stagedSenderManifest(t, mapping, senderPrivate, now)
+	if err := insertStagedSenderTransfer(journal, mapping, manifest, raw); err != nil {
+		t.Fatal(err)
+	}
+	transport := &senderTransportStub{result: sourceUploadingTransferResult(t, manifest.TransferID, attachmentCommitment(t, raw), int64(manifest.ExpiresAt)), permitIssueOffsetSeconds: 3} // #nosec G115 -- test fixture Manifest validation bounds expiry.
+	worker, err := NewSenderSourceInitializer(SenderSourceInitializerOptions{
+		Journal: journal, AuthorityProvider: senderAuthorityProviderStub{authority: testSenderAuthority(t, mapping, senderPrivate)}, Signer: NewLocalSenderOperationSigner(SenderIdentity{DeviceID: mapping.SenderDeviceID, Generation: mapping.SenderGeneration}, senderPrivate), Transport: transport,
+		Now: func() time.Time { return now }, NewID: sequenceID(bytes16(70), bytes16(71)), NewIdempotencyKey: sequenceKey(bytes32(72)),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := worker.Initialize(context.Background(), manifest.TransferID); err != nil {
+		t.Fatalf("bounded future-issued permit rejected: %v", err)
+	}
+}
+
 func TestSenderSourceInitializerUploadsDurableChunksBeforeReady(t *testing.T) {
 	journal, err := OpenJournalForSender(filepath.Join(t.TempDir(), "private", "controller.db"), SenderIdentity{DeviceID: bytes16(2), Generation: 1})
 	if err != nil {
@@ -353,12 +385,13 @@ type senderTransportStub struct {
 	body                       []byte
 	issueCalls, operationCalls int
 	operationErr               error
+	permitIssueOffsetSeconds   uint64
 }
 
 func (s *senderTransportStub) IssueV3Permit(_ context.Context, request attachmentv3.PermitRequest) (attachmentv3.Permit, error) {
 	s.issueCalls++
 	s.request = request
-	s.permit = attachmentv3.Permit{Audience: bytes32(31), Serial: bytes16(80), IssuerKeyID: bytes32(81), HolderDeviceID: request.HolderDeviceID, HolderGeneration: request.HolderGeneration, HolderRole: request.HolderRole, TransferID: request.TransferID, ConversationID: request.ConversationID, SenderDeviceID: request.SenderDeviceID, SenderGeneration: request.SenderGeneration, RecipientDeviceID: request.RecipientDeviceID, RecipientGeneration: request.RecipientGeneration, AttemptGeneration: request.AttemptGeneration, Operation: request.Operation, DirectoryHead: bytes32(32), MembershipCommitment: request.MembershipCommitment, RevocationEpoch: 1, IssuedAt: request.IssuedAt, ExpiresAt: request.ExpiresAt, MaxBytes: request.MaxBytes, MaxChunks: request.MaxChunks, MaxOperations: request.MaxOperations, StagedManifestCommitment: request.StagedManifestCommitment, OutcomeOfSerial: request.OutcomeOfSerial}
+	s.permit = attachmentv3.Permit{Audience: bytes32(31), Serial: bytes16(80), IssuerKeyID: bytes32(81), HolderDeviceID: request.HolderDeviceID, HolderGeneration: request.HolderGeneration, HolderRole: request.HolderRole, TransferID: request.TransferID, ConversationID: request.ConversationID, SenderDeviceID: request.SenderDeviceID, SenderGeneration: request.SenderGeneration, RecipientDeviceID: request.RecipientDeviceID, RecipientGeneration: request.RecipientGeneration, AttemptGeneration: request.AttemptGeneration, Operation: request.Operation, DirectoryHead: bytes32(32), MembershipCommitment: request.MembershipCommitment, RevocationEpoch: 1, IssuedAt: request.IssuedAt + s.permitIssueOffsetSeconds, ExpiresAt: request.ExpiresAt, MaxBytes: request.MaxBytes, MaxChunks: request.MaxChunks, MaxOperations: request.MaxOperations, StagedManifestCommitment: request.StagedManifestCommitment, OutcomeOfSerial: request.OutcomeOfSerial}
 	_, signer := testOfferSigner()
 	if err := attachmentv3.SignPermit(&s.permit, signer); err != nil {
 		return attachmentv3.Permit{}, err

--- a/internal/attachment/v3/controller/worker.go
+++ b/internal/attachment/v3/controller/worker.go
@@ -713,7 +713,7 @@ func exactAcceptancePermit(permit attachmentv3.Permit, request attachmentv3.Perm
 		return false
 	}
 	// #nosec G115 -- the initial nonnegative-time predicate makes this comparison fail closed.
-	return now.Unix() >= 0 && permit.IssuedAt <= uint64(now.Unix()) && permit.ExpiresAt > uint64(now.Unix())
+	return now.Unix() >= 0 && attachmentv3.IssuedWithinClockSkew(permit.IssuedAt, now) && permit.ExpiresAt > uint64(now.Unix())
 }
 
 // exactOutcomeRequest and exactOutcomePermit bind a reconciliation lookup to
@@ -727,7 +727,7 @@ func exactOutcomeRequest(request attachmentv3.PermitRequest, record receiptAccep
 		return false
 	}
 	// #nosec G115 -- the caller rejects pre-epoch time before this capability check.
-	return request.IssuedAt <= uint64(now.Unix()) && request.ExpiresAt > uint64(now.Unix())
+	return attachmentv3.IssuedWithinClockSkew(request.IssuedAt, now) && request.ExpiresAt > uint64(now.Unix())
 }
 
 func exactOutcomePermit(permit attachmentv3.Permit, request attachmentv3.PermitRequest, record receiptAcceptanceRecord, now time.Time) bool {
@@ -741,7 +741,7 @@ func exactOutcomePermit(permit attachmentv3.Permit, request attachmentv3.PermitR
 		return false
 	}
 	// #nosec G115 -- the caller rejects pre-epoch time before this capability check.
-	return permit.IssuedAt >= request.IssuedAt && permit.ExpiresAt <= request.ExpiresAt && permit.IssuedAt <= uint64(now.Unix()) && permit.ExpiresAt > uint64(now.Unix())
+	return permit.IssuedAt >= request.IssuedAt && permit.ExpiresAt <= request.ExpiresAt && attachmentv3.IssuedWithinClockSkew(permit.IssuedAt, now) && permit.ExpiresAt > uint64(now.Unix())
 }
 func mustEncodePermit(permit attachmentv3.Permit) []byte {
 	raw, err := attachmentv3.EncodePermit(permit)

--- a/internal/attachment/v3/manifest.go
+++ b/internal/attachment/v3/manifest.go
@@ -274,3 +274,10 @@ func validateManifestTime(m Manifest, now time.Time) error {
 func issuedWithinClockSkew(issued uint64, nowUnix int64) bool {
 	return nowUnix >= 0 && issued <= uint64(nowUnix)+uint64(MaxFutureClockSkew/time.Second)
 }
+
+// IssuedWithinClockSkew reports whether a signed record's issue time is within
+// the protocol's bounded future-clock-skew allowance. It never grants any
+// expiry grace; callers must check expiration independently.
+func IssuedWithinClockSkew(issued uint64, now time.Time) bool {
+	return issuedWithinClockSkew(issued, now.UTC().Unix())
+}


### PR DESCRIPTION
## Summary

- Apply the existing 60-second bounded clock-skew rule consistently in durable v3 sender and recipient controller predicates.
- Keep every expiry comparison strict and unchanged.
- Add an end-to-end controller regression where a relay permit is issued three seconds ahead of the sender’s local clock.

## Root cause

PR #8 updated record verification, but controller-side durable-record guards still rejected a permit whose `issued_at` was even slightly ahead of the local clock. This made a valid relay-issued permit unusable in practice.

## Validation

- `make test`
- `make test-race`
- `make lint`
- `make vuln`
- targeted `gosec` over `internal/attachment/v3` and its controller
- `make secrets`
