### PR TITLE
Add attachment v3 provisioning installers

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -262,7 +262,10 @@ is present. It will remain fail-closed until all gates in the
 CBOR record core: verified signed manifests, manifest commitments,
 recipient-bound HPKE envelopes, a fresh root-signed device/membership snapshot
 resolver with a durable anti-rollback checkpoint, and a source-artifact helper
-that reserves file-key/content-salt/nonce uniqueness before encryption. It has
+that reserves file-key/content-salt/nonce uniqueness before encryption. The
+published directory snapshot is group-readable by the relay but lives below a
+root-owned configuration hierarchy; privileged installers and publishers never
+create, repair, or write snapshot paths below service-owned state. It has
 canonical permits whose issuer, sender/recipient membership, device
 generations, directory head, epoch, and expiry are all checked against the
 same fresh directory snapshot, plus a private SQLite serial and

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -16,10 +16,11 @@ current `punarod` binary provides a loopback-only alpha text relay: explicit
 machine enrollment, signed requests, durable append/lease/ack, attached-endpoint
 advertising, and payload-free WebSocket wake hints. A local adapter bridges
 this to `agent-mailbox`. The separately deployable `punaro-telegram` bridge
-adds explicit Telegram topic routing and a restricted Bot API client. The full
-attachment data plane remains a testable foundation and enablement fails closed
-before listening. A separately opt-in permit issuer exists only for
-directory/authorization drills; it does not mount a transfer route. The
+adds explicit Telegram topic routing and a restricted Bot API client. V3
+attachments are a separately provisioned, controlled runtime: the offline
+root key, relay issuer key, and per-client device keys are distinct, and the
+relay starts v3 only with a current signed directory plus explicit
+machine-to-device bindings. Legacy v2 switches still fail closed. The
 authoritative release conditions are in
 [`docs/security-release-gates.md`](docs/security-release-gates.md).
 

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ precedence over dotenv values.
 | `PUNARO_RELAY_ENABLED` | `false` | Enables the loopback text relay; requires public machine enrollment records. |
 | `PUNARO_RELAY_MACHINES_JSON` | unset | Explicit public-key machine enrollment records. `endpoint_prefixes` claims disjoint machine namespaces; `endpoints` can grant a named exact endpoint without creating a prefix. An issuer-capable machine additionally has canonical raw-base64url `attachment_device_id` (16 bytes), bound to exactly one directory device. |
 | `PUNARO_DIRECTORY_ENABLED` | `false` | Serves a current complete signed directory snapshot to authenticated enrolled machines; requires the relay. |
-| `PUNARO_DIRECTORY_SNAPSHOT_FILE` | unset | Absolute, service-private (`0700` parent, `0600` regular non-symlink) canonical directory snapshot publication file. |
+| `PUNARO_DIRECTORY_SNAPSHOT_FILE` | unset | Absolute, root-owned and service-group-readable (`2750` parent, `0640` regular non-symlink) canonical directory snapshot publication file. |
 | `PUNARO_PERMIT_ISSUANCE_ENABLED` | `false` | Enables only authenticated attachment-permit issuance; it requires directory service, pinned trust, an issuer key file, explicit limits, and at least one machine/device binding. It does not enable file transfer. |
 | `PUNARO_DIRECTORY_AUDIENCE`, `PUNARO_DIRECTORY_ROOT_KEY_ID`, `PUNARO_DIRECTORY_ROOT_PUBLIC_KEY` | unset | Canonical raw-base64url 32-byte pinned directory trust material for permit issuance. |
 | `PUNARO_PERMIT_ISSUER_KEY_ID` | unset | Canonical raw-base64url 32-byte active issuer key ID. |

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -203,11 +203,14 @@ controlled deployment rather than an unattended file-sharing feature.
    tokens, or host-specific values. For image/package checks, use `--root
    /absolute/staging-root` without `--enable`.
 
-5. Before mapping, approving, sending, or receiving an offer on every client,
+5. Before mapping, approving, or receiving an offer, receiver-capable clients
    run `punaro-attachment check` with the two owner-only environment files
-   loaded. A stale, missing, rolled-back, or mismatched signed directory fails
-   closed. Continue publishing a fresh snapshot (at most five minutes old;
-   the supplied publisher uses two minutes) for the lifetime of the service.
+   loaded. Sender-only clients instead use their first `punaro-attachment
+   map-sender` operation as the preflight; it fresh-verifies the same signed
+   directory while also requiring that the source device match the local sender
+   identity. A stale, missing, rolled-back, or mismatched directory fails
+   closed. Continue publishing a fresh snapshot (at most five minutes old; the
+   supplied publisher uses two minutes) for the lifetime of the service.
 
 ## Agent mailbox behavior
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -106,6 +106,106 @@ and local paths. It refuses to overwrite an existing key, enrollment record,
 configuration file, or project skill that does not match. To revoke a client,
 follow the [alpha onboarding revocation procedure](alpha-text-relay.md#onboard-and-revoke-a-machine): remove attached aliases, remove the relay enrollment, revoke the machine's Access token, stop the service, and securely erase its key.
 
+## 4. Provision and enable controlled attachment v3
+
+Attachment v3 has an explicit, multi-role setup. Do not enable it by setting
+environment variables by hand: the provisioning helpers create private key
+files with owner-only permissions, keep raw key values out of command output,
+and make the public approval artifacts separate from secrets. It remains a
+controlled deployment rather than an unattended file-sharing feature.
+
+1. On a trusted, offline authority machine, create the directory authority:
+
+   ```sh
+   ./scripts/provision-attachment-v3.sh authority \
+     --directory "$HOME/.config/punaro/attachment-authority"
+   ```
+
+   Keep `root.private` in that directory offline. It signs the short-lived
+   directory snapshot and must never be copied to the relay, a client, a
+   message, or a repository. The relay receives the separate `issuer.private`
+   only through an approved private transfer or secret-management mechanism.
+
+2. On each client, create one directory device and its local controller
+   configuration. The client key material stays on that client:
+
+   ```sh
+   ./scripts/provision-attachment-v3.sh client \
+     --directory "$HOME/.config/punaro/attachment-v3" \
+     --authority-public "$HOME/.config/punaro/attachment-authority/public.json" \
+     --machine-id laptop-review --role receiver
+   ```
+
+   A sender-capable client additionally requires an existing host-bound
+   wrapping-key reference. On macOS this names a Keychain generic-password
+   item; on Linux it must be a systemd `LoadCredential` reference. The secret
+   value is never accepted by Punaro's scripts, `.env` files, or command-line
+   arguments:
+
+   ```sh
+   ./scripts/provision-attachment-v3.sh client \
+     --directory "$HOME/.config/punaro/attachment-v3-sender" \
+     --authority-public "$HOME/.config/punaro/attachment-authority/public.json" \
+     --machine-id laptop-review --role both \
+     --host-key-service punaro.attachment-v3 \
+     --host-key-account laptop-review
+   ```
+
+   On Linux, replace the last two flags with the private systemd credential
+   reference:
+
+   ```sh
+   --host-credential-directory /run/credentials/punaro-attachment \
+   --host-credential-name sender-key
+   ```
+
+   Source the ordinary `adapter.env` followed by this new owner-only
+   `attachment-v3.env` only in the local controller process. Do not add either
+   to the adapter service or an agent prompt. The service token remains in the
+   existing owner-only `adapter.env` and is distinct per machine.
+
+3. On the authority machine, inspect the public device record and add it to
+   the directory manifest. This advances the manifest sequence but does not
+   sign or publish it yet:
+
+   ```sh
+   ./scripts/provision-attachment-v3.sh authority-add-device \
+     --directory "$HOME/.config/punaro/attachment-authority" \
+     --device-enrollment /approved/path/device-enrollment.json
+   ```
+
+   Add the device ID from that same public record to the corresponding public
+   machine enrollment as `attachment_device_id`; one transport machine maps to
+   exactly one directory device. Then use
+   `scripts/publish-directory-snapshot.sh` with the authority's root key to
+   publish a fresh snapshot. It deliberately sends only the signed snapshot to
+   the relay.
+
+4. On the Linux relay, after `install-server.sh` and after reviewing the
+   public machine enrollment JSON, activate the v3 runtime:
+
+   ```sh
+   ./scripts/configure-attachment-v3-relay.sh \
+     --authority-public /secure/authority/public.json \
+     --issuer-private-key /secure/relay-input/issuer.private \
+     --directory-snapshot /secure/relay-input/current.snapshot \
+     --relay-machines-file /secure/relay-input/machines.json \
+     --enable
+   ```
+
+   The helper copies the issuer key and snapshot into service-private paths,
+   writes v3-only limits and directory trust, disables v2 switches, and starts
+   `punarod` only when the enrollment contains at least one explicit device
+   binding. It does not use 1Password references, Cloudflare account details,
+   tokens, or host-specific values. For image/package checks, use `--root
+   /absolute/staging-root` without `--enable`.
+
+5. Before mapping, approving, sending, or receiving an offer on every client,
+   run `punaro-attachment check` with the two owner-only environment files
+   loaded. A stale, missing, rolled-back, or mismatched signed directory fails
+   closed. Continue publishing a fresh snapshot (at most five minutes old;
+   the supplied publisher uses two minutes) for the lifetime of the service.
+
 ## Agent mailbox behavior
 
 Agents use the local `agent-mailbox` MCP, not a remote Punaro MCP. Call

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -133,7 +133,8 @@ controlled deployment rather than an unattended file-sharing feature.
    ./scripts/provision-attachment-v3.sh client \
      --directory "$HOME/.config/punaro/attachment-v3" \
      --authority-public "$HOME/.config/punaro/attachment-authority/public.json" \
-     --machine-id laptop-review --role receiver
+     --machine-id laptop-review --relay-url https://relay.example.invalid \
+     --role receiver
    ```
 
    A sender-capable client additionally requires an existing host-bound
@@ -146,7 +147,8 @@ controlled deployment rather than an unattended file-sharing feature.
    ./scripts/provision-attachment-v3.sh client \
      --directory "$HOME/.config/punaro/attachment-v3-sender" \
      --authority-public "$HOME/.config/punaro/attachment-authority/public.json" \
-     --machine-id laptop-review --role both \
+     --machine-id laptop-review --relay-url https://relay.example.invalid \
+     --role both \
      --host-key-service punaro.attachment-v3 \
      --host-key-account laptop-review
    ```
@@ -160,9 +162,10 @@ controlled deployment rather than an unattended file-sharing feature.
    ```
 
    Source the ordinary `adapter.env` followed by this new owner-only
-   `attachment-v3.env` only in the local controller process. Do not add either
-   to the adapter service or an agent prompt. The service token remains in the
-   existing owner-only `adapter.env` and is distinct per machine.
+   `attachment-v3.env` only in the local controller process. The latter carries
+   the attachment relay URL; the former carries the distinct machine identity
+   and any Access service token. Do not add either to the adapter service or an
+   agent prompt.
 
 3. On the authority machine, inspect the public device record and add it to
    the directory manifest. This advances the manifest sequence but does not

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -196,7 +196,9 @@ controlled deployment rather than an unattended file-sharing feature.
      --enable
    ```
 
-   The helper copies the issuer key and snapshot into service-private paths,
+   The helper copies the issuer key into an owner-controlled credential path
+   and the snapshot into root-owned, service-group-readable
+   `/etc/punaro/directory`,
    writes v3-only limits and directory trust, disables v2 switches, and starts
    `punarod` only when the enrollment contains at least one explicit device
    binding. It does not use 1Password references, Cloudflare account details,

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -207,12 +207,12 @@ controlled deployment rather than an unattended file-sharing feature.
 
 5. Before mapping, approving, or receiving an offer, receiver-capable clients
    run `punaro-attachment check` with the two owner-only environment files
-   loaded. Sender-only clients instead use their first `punaro-attachment
-   map-sender` operation as the preflight; it fresh-verifies the same signed
-   directory while also requiring that the source device match the local sender
-   identity. A stale, missing, rolled-back, or mismatched directory fails
-   closed. Continue publishing a fresh snapshot (at most five minutes old; the
-   supplied publisher uses two minutes) for the lifetime of the service.
+   loaded. Sender-only clients use `punaro-attachment map-sender` only to pin
+   the local relationship; their first `punaro-attachment send` fresh-verifies
+   the signed directory before it accepts a source. A stale, missing,
+   rolled-back, or mismatched directory fails closed. Continue publishing a
+   fresh snapshot (at most five minutes old; the supplied publisher uses two
+   minutes) for the lifetime of the service.
 
 ## Agent mailbox behavior
 

--- a/docs/operator-guide.md
+++ b/docs/operator-guide.md
@@ -146,6 +146,14 @@ leave both `PUNARO_ATTACHMENTS_ENABLED` and
 directory, root trust, issuer key, permit limits, and enrolled
 `attachment_device_id` records listed above, provide:
 
+Use the reviewed provisioning helpers in
+[the installation guide](installation.md#4-provision-and-enable-controlled-attachment-v3)
+to create these files and enable the relay. They intentionally separate the
+offline root authority, relay issuer, and per-client device keys; they never
+copy a root key to the relay or accept a wrapping key/token as a command-line
+value. Manual configuration must preserve the same separation and private file
+permissions.
+
 - `PUNARO_ATTACHMENT_V3_SOURCE_STORE_FILE`: an absolute path beneath an
   existing private, non-symlinked `0700` directory. The daemon creates a
   `0600` SQLite file there; do not put it on NFS, a shared filesystem, or a

--- a/scripts/configure-attachment-v3-relay.sh
+++ b/scripts/configure-attachment-v3-relay.sh
@@ -26,7 +26,10 @@ EOF
 fail() { printf '%s\n' "$1" >&2; exit 2; }
 
 file_mode() {
-	if stat -f %Lp "$1" >/dev/null 2>&1; then stat -f %Lp "$1"; else stat -c %a "$1"; fi
+	case "$(uname -s)" in
+		Darwin) stat -f %Lp "$1" ;;
+		*) stat -c %a "$1" ;;
+	esac
 }
 
 require_absolute_regular_file() {

--- a/scripts/configure-attachment-v3-relay.sh
+++ b/scripts/configure-attachment-v3-relay.sh
@@ -1,0 +1,241 @@
+#!/bin/sh
+# Configure a previously installed Punaro relay for the separately versioned
+# attachment-v3 runtime. All inputs are local files: private material is never
+# accepted through command-line values or printed by this script.
+set -eu
+
+umask 077
+
+usage() {
+	cat <<'EOF'
+Usage: scripts/configure-attachment-v3-relay.sh \
+  --authority-public ABSOLUTE_PUBLIC_JSON \
+  --issuer-private-key ABSOLUTE_PRIVATE_KEY \
+  --directory-snapshot ABSOLUTE_SIGNED_SNAPSHOT \
+  --relay-machines-file ABSOLUTE_PUBLIC_JSON \
+  [--root ABSOLUTE_STAGING_ROOT] [--enable]
+
+Run after install-server.sh. It installs a private issuer credential and the
+current root-signed directory snapshot, writes the v3-only relay settings, and
+requires each configured transport machine to be explicitly bound to an
+attachment device. --enable starts the systemd service only on a live Linux
+relay; it is unavailable with --root.
+EOF
+}
+
+fail() { printf '%s\n' "$1" >&2; exit 2; }
+
+file_mode() {
+	if stat -f %Lp "$1" >/dev/null 2>&1; then stat -f %Lp "$1"; else stat -c %a "$1"; fi
+}
+
+require_absolute_regular_file() {
+	case "$1" in /*) ;; *) fail "$2 must be an absolute path" ;; esac
+	[ -f "$1" ] && [ ! -L "$1" ] || fail "$2 must be a non-symlink regular file"
+}
+
+root_dir=/
+authority_public=
+issuer_private_key=
+directory_snapshot=
+relay_machines_file=
+enable=0
+while [ "$#" -gt 0 ]; do
+	case "$1" in
+		--root) [ "$#" -ge 2 ] || fail '--root requires a value'; root_dir=$2; shift 2 ;;
+		--authority-public) [ "$#" -ge 2 ] || fail '--authority-public requires a value'; authority_public=$2; shift 2 ;;
+		--issuer-private-key) [ "$#" -ge 2 ] || fail '--issuer-private-key requires a value'; issuer_private_key=$2; shift 2 ;;
+		--directory-snapshot) [ "$#" -ge 2 ] || fail '--directory-snapshot requires a value'; directory_snapshot=$2; shift 2 ;;
+		--relay-machines-file) [ "$#" -ge 2 ] || fail '--relay-machines-file requires a value'; relay_machines_file=$2; shift 2 ;;
+		--enable) enable=1; shift ;;
+		--help) usage; exit 0 ;;
+		*) fail "unknown option: $1" ;;
+	esac
+done
+
+case "$root_dir" in /*) ;; *) fail 'root directory must be an absolute path' ;; esac
+[ -n "$authority_public" ] || fail '--authority-public is required'
+[ -n "$issuer_private_key" ] || fail '--issuer-private-key is required'
+[ -n "$directory_snapshot" ] || fail '--directory-snapshot is required'
+[ -n "$relay_machines_file" ] || fail '--relay-machines-file is required'
+require_absolute_regular_file "$authority_public" 'authority public record'
+require_absolute_regular_file "$issuer_private_key" 'issuer private key'
+require_absolute_regular_file "$directory_snapshot" 'directory snapshot'
+require_absolute_regular_file "$relay_machines_file" 'relay machines file'
+[ "$(file_mode "$issuer_private_key")" = 600 ] || fail 'issuer private key must have mode 0600'
+command -v python3 >/dev/null 2>&1 || fail 'python3 is required to validate and render relay configuration'
+
+if [ "$root_dir" = / ]; then
+	[ "$(uname -s)" = Linux ] || fail 'live v3 relay configuration supports Linux systemd hosts only'
+	[ "$(id -u)" -eq 0 ] || fail 'run live v3 relay configuration as root'
+else
+	[ "$enable" -eq 0 ] || fail '--enable is unavailable with a staging root'
+fi
+
+path_in_root() {
+	if [ "$root_dir" = / ]; then printf '/%s\n' "$1"; else printf '%s/%s\n' "${root_dir%/}" "$1"; fi
+}
+
+config_file=$(path_in_root etc/punaro/punaro.env)
+credentials_dir=$(path_in_root etc/punaro/credentials)
+issuer_destination="$credentials_dir/v3-issuer.private"
+private_dir=$(path_in_root var/lib/punaro/private)
+snapshot_destination="$private_dir/v3-directory.snapshot"
+v3_state_dir=$(path_in_root var/lib/punaro/attachment-v3)
+[ -f "$config_file" ] && [ ! -L "$config_file" ] || fail 'install-server must create a regular relay configuration before v3 configuration'
+issuer_stage="$issuer_destination.v3-next"
+snapshot_stage="$snapshot_destination.v3-next"
+config_stage="$config_file.v3-next"
+[ ! -e "$issuer_stage" ] && [ ! -L "$issuer_stage" ] || fail 'staged issuer file already exists; inspect it before retrying'
+[ ! -e "$snapshot_stage" ] && [ ! -L "$snapshot_stage" ] || fail 'staged snapshot file already exists; inspect it before retrying'
+[ ! -e "$config_stage" ] && [ ! -L "$config_stage" ] || fail 'staged relay configuration already exists; inspect it before retrying'
+cleanup_staged() {
+	rm -f -- "$issuer_stage" "$snapshot_stage" "$config_stage"
+}
+trap cleanup_staged EXIT HUP INT TERM
+
+render_error=$(mktemp "${TMPDIR:-/tmp}/punaro-attachment-relay-render.XXXXXXXX")
+if ! python3 - "$config_file" "$authority_public" "$relay_machines_file" \
+	'/etc/punaro/credentials/v3-issuer.private' '/var/lib/punaro/private/v3-directory.snapshot' \
+	'/var/lib/punaro/attachment-v3/source.db' <<'PY' 2>"$render_error"
+import base64
+import json
+import os
+import sys
+
+config_path, authority_path, machines_path, issuer_path, snapshot_path, source_store_path = sys.argv[1:]
+
+def read_json(path):
+    with open(path, encoding="utf-8") as handle:
+        return json.load(handle)
+
+def valid(value, size):
+    if not isinstance(value, str) or "=" in value:
+        raise ValueError("invalid public value")
+    if len(base64.urlsafe_b64decode(value + "=" * (-len(value) % 4))) != size:
+        raise ValueError("unexpected public value length")
+    return value
+
+authority = read_json(authority_path)
+if authority.get("version") != 3:
+    raise ValueError("authority public record must be version 3")
+audience = valid(authority.get("audience"), 32)
+root_key_id = valid(authority.get("root_key_id"), 32)
+root_public_key = valid(authority.get("root_public_key"), 32)
+issuer_key_id = valid(authority.get("issuer_key_id"), 32)
+valid(authority.get("issuer_public_key"), 32)
+
+machines = read_json(machines_path)
+if not isinstance(machines, list) or not machines:
+    raise ValueError("relay machine enrollment must be a non-empty JSON array")
+bound = 0
+seen_ids = set()
+seen_devices = set()
+for machine in machines:
+    if not isinstance(machine, dict) or not isinstance(machine.get("id"), str) or machine["id"] in seen_ids:
+        raise ValueError("relay machine enrollment contains invalid or duplicate machine IDs")
+    seen_ids.add(machine["id"])
+    device = machine.get("attachment_device_id")
+    if device is not None:
+        valid(device, 16)
+        if device in seen_devices:
+            raise ValueError("relay machine enrollment reuses an attachment_device_id")
+        seen_devices.add(device)
+        bound += 1
+if bound == 0:
+    raise ValueError("relay machine enrollment must contain an attachment_device_id binding")
+machines_json = json.dumps(machines, sort_keys=True, separators=(",", ":"))
+
+managed = {
+    "PUNARO_DIRECTORY_ENABLED",
+    "PUNARO_DIRECTORY_SNAPSHOT_FILE",
+    "PUNARO_DIRECTORY_AUDIENCE",
+    "PUNARO_DIRECTORY_ROOT_KEY_ID",
+    "PUNARO_DIRECTORY_ROOT_PUBLIC_KEY",
+    "PUNARO_PERMIT_ISSUANCE_ENABLED",
+    "PUNARO_PERMIT_ISSUER_KEY_ID",
+    "PUNARO_PERMIT_ISSUER_PRIVATE_KEY_FILE",
+    "PUNARO_PERMIT_MAX_LIFETIME_SECONDS",
+    "PUNARO_PERMIT_MAX_BYTES",
+    "PUNARO_PERMIT_MAX_CHUNKS",
+    "PUNARO_PERMIT_MAX_OPERATIONS",
+    "PUNARO_PERMIT_MAX_ACTIVE",
+    "PUNARO_ATTACHMENT_V3_ENABLED",
+    "PUNARO_ATTACHMENT_V3_SOURCE_STORE_FILE",
+    "PUNARO_ATTACHMENTS_ENABLED",
+    "PUNARO_ATTACHMENT_RELAY_ENABLED",
+    "PUNARO_RELAY_MACHINES_JSON",
+}
+with open(config_path, encoding="utf-8") as handle:
+    retained = [line.rstrip("\n") for line in handle if line.split("=", 1)[0].strip() not in managed]
+settings = {
+    "PUNARO_RELAY_MACHINES_JSON": machines_json,
+    "PUNARO_DIRECTORY_ENABLED": "true",
+    "PUNARO_DIRECTORY_SNAPSHOT_FILE": snapshot_path,
+    "PUNARO_DIRECTORY_AUDIENCE": audience,
+    "PUNARO_DIRECTORY_ROOT_KEY_ID": root_key_id,
+    "PUNARO_DIRECTORY_ROOT_PUBLIC_KEY": root_public_key,
+    "PUNARO_PERMIT_ISSUANCE_ENABLED": "false",
+    "PUNARO_PERMIT_ISSUER_KEY_ID": issuer_key_id,
+    "PUNARO_PERMIT_ISSUER_PRIVATE_KEY_FILE": issuer_path,
+    "PUNARO_PERMIT_MAX_LIFETIME_SECONDS": "30",
+    "PUNARO_PERMIT_MAX_BYTES": str(64 << 20),
+    "PUNARO_PERMIT_MAX_CHUNKS": "4096",
+    "PUNARO_PERMIT_MAX_OPERATIONS": "4096",
+    "PUNARO_PERMIT_MAX_ACTIVE": "4096",
+    "PUNARO_ATTACHMENT_V3_ENABLED": "true",
+    "PUNARO_ATTACHMENT_V3_SOURCE_STORE_FILE": source_store_path,
+    "PUNARO_ATTACHMENTS_ENABLED": "false",
+    "PUNARO_ATTACHMENT_RELAY_ENABLED": "false",
+}
+temporary = config_path + ".v3-next"
+fd = os.open(temporary, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o640)
+with os.fdopen(fd, "w", encoding="utf-8") as handle:
+    for line in retained:
+        handle.write(line + "\n")
+    handle.write("\n# Attachment v3: generated from explicit local public records and private files.\n")
+    for key in sorted(settings):
+        handle.write(f"{key}={settings[key]}\n")
+os.chmod(temporary, 0o640)
+PY
+then
+	message=$(sed -n '$s/^ValueError: //p' "$render_error")
+	rm -f -- "$render_error"
+	[ -n "$message" ] || message='could not validate or render attachment v3 relay configuration'
+	fail "$message"
+fi
+rm -f -- "$render_error"
+
+[ -f "$config_stage" ] && [ ! -L "$config_stage" ] || fail 'could not safely render staged relay configuration'
+
+if [ "$root_dir" = / ]; then
+	install -d -o root -g punaro -m 0750 "$credentials_dir"
+	install -d -o root -g punaro -m 2750 "$private_dir"
+	install -d -o punaro -g punaro -m 0700 "$v3_state_dir"
+	install -m 0600 -o punaro -g punaro "$issuer_private_key" "$issuer_stage"
+	install -m 0640 -o root -g punaro "$directory_snapshot" "$snapshot_stage"
+else
+	install -d -m 0700 "$credentials_dir" "$private_dir" "$v3_state_dir"
+	install -m 0600 "$issuer_private_key" "$issuer_stage"
+	install -m 0600 "$directory_snapshot" "$snapshot_stage"
+fi
+mv -f -- "$issuer_stage" "$issuer_destination"
+mv -f -- "$snapshot_stage" "$snapshot_destination"
+mv -f -- "$config_stage" "$config_file"
+
+if [ "$root_dir" = / ]; then
+	chown root:punaro "$config_file"
+	chmod 0640 "$config_file"
+fi
+
+if [ "$enable" -eq 1 ]; then
+	systemctl daemon-reload
+	systemctl enable --now punarod.service
+	systemctl is-active --quiet punarod.service
+fi
+
+printf '%s\n' 'attachment_v3_relay_configured'
+printf '%s\n' 'V3 remains fail-closed until the signed directory is current and each machine-to-device binding matches a directory device.'
+if [ "$enable" -eq 0 ]; then
+	printf '%s\n' 'After reviewing the relay machine bindings, rerun with --enable on the Linux relay host.'
+fi

--- a/scripts/configure-attachment-v3-relay.sh
+++ b/scripts/configure-attachment-v3-relay.sh
@@ -82,37 +82,28 @@ path_in_root() {
 config_file=$(path_in_root etc/punaro/punaro.env)
 credentials_dir=$(path_in_root etc/punaro/credentials)
 issuer_destination="$credentials_dir/v3-issuer.private"
-private_dir=$(path_in_root var/lib/punaro/private)
-snapshot_destination="$private_dir/v3-directory.snapshot"
-v3_state_dir=$(path_in_root var/lib/punaro/attachment-v3)
-relay_state_dir=$(path_in_root var/lib/punaro)
+directory_dir=$(path_in_root etc/punaro/directory)
+snapshot_destination="$directory_dir/v3-directory.snapshot"
 [ -f "$config_file" ] && [ ! -L "$config_file" ] || fail 'install-server must create a regular relay configuration before v3 configuration'
-[ -d "$relay_state_dir" ] && [ ! -L "$relay_state_dir" ] || fail 'relay state directory must be a non-symlink directory'
-if [ -e "$private_dir" ] || [ -L "$private_dir" ]; then
-	[ -d "$private_dir" ] && [ ! -L "$private_dir" ] || fail 'existing directory snapshot parent must be a non-symlink directory'
-fi
-if [ -e "$v3_state_dir" ] || [ -L "$v3_state_dir" ]; then
-	[ -d "$v3_state_dir" ] && [ ! -L "$v3_state_dir" ] || fail 'existing v3 state directory must be a non-symlink directory'
+if [ -e "$directory_dir" ] || [ -L "$directory_dir" ]; then
+	[ -d "$directory_dir" ] && [ ! -L "$directory_dir" ] || fail 'directory snapshot parent must be a non-symlink directory'
 fi
 
 verify_live_v3_paths() {
-	[ -d "$relay_state_dir" ] && [ ! -L "$relay_state_dir" ] || fail 'relay state directory must be a non-symlink directory'
-	[ "$(stat -c %U "$relay_state_dir")" = punaro ] && [ "$(stat -c %a "$relay_state_dir")" = 700 ] || fail 'relay state directory has unexpected ownership or mode'
-	[ -d "$private_dir" ] && [ ! -L "$private_dir" ] || fail 'directory snapshot parent must be a non-symlink directory'
-	[ "$(stat -c %U "$private_dir")" = root ] && [ "$(stat -c %G "$private_dir")" = punaro ] && [ "$(stat -c %a "$private_dir")" = 2750 ] || fail 'directory snapshot parent has unexpected ownership or mode'
-	[ -d "$v3_state_dir" ] && [ ! -L "$v3_state_dir" ] || fail 'v3 state directory must be a non-symlink directory'
-	[ "$(stat -c %U "$v3_state_dir")" = punaro ] && [ "$(stat -c %G "$v3_state_dir")" = punaro ] && [ "$(stat -c %a "$v3_state_dir")" = 700 ] || fail 'v3 state directory has unexpected ownership or mode'
+	[ -d "$directory_dir" ] && [ ! -L "$directory_dir" ] || fail 'directory snapshot parent must be a non-symlink directory'
+	[ "$(stat -c %U "$directory_dir")" = root ] && [ "$(stat -c %G "$directory_dir")" = punaro ] && [ "$(stat -c %a "$directory_dir")" = 2750 ] || fail 'directory snapshot parent has unexpected ownership or mode'
 }
 
 if [ "$root_dir" = / ]; then
 	install -d -o root -g punaro -m 0750 "$credentials_dir"
-	install -d -o root -g punaro -m 2750 "$private_dir"
-	install -d -o punaro -g punaro -m 0700 "$v3_state_dir"
+	# This directory is below the root-owned configuration hierarchy, never the
+	# service-owned state directory. Root therefore never repairs or writes
+	# through a path that the relay account can replace with a symlink.
+	install -d -o root -g punaro -m 2750 "$directory_dir"
 	verify_live_v3_paths
 else
 	install -d -m 0700 "$credentials_dir"
-	[ -d "$private_dir" ] || install -d -m 0700 "$private_dir"
-	[ -d "$v3_state_dir" ] || install -d -m 0700 "$v3_state_dir"
+	install -d -m 0700 "$directory_dir"
 fi
 issuer_stage="$issuer_destination.v3-next"
 snapshot_stage="$snapshot_destination.v3-next"
@@ -127,7 +118,7 @@ trap cleanup_staged EXIT HUP INT TERM
 
 render_error=$(mktemp "${TMPDIR:-/tmp}/punaro-attachment-relay-render.XXXXXXXX")
 if ! python3 - "$config_file" "$authority_public" "$relay_machines_file" \
-	'/etc/punaro/credentials/v3-issuer.private' '/var/lib/punaro/private/v3-directory.snapshot' \
+	'/etc/punaro/credentials/v3-issuer.private' '/etc/punaro/directory/v3-directory.snapshot' \
 	'/var/lib/punaro/attachment-v3/source.db' <<'PY' 2>"$render_error"
 import base64
 import json
@@ -143,7 +134,11 @@ def read_json(path):
 def valid(value, size):
     if not isinstance(value, str) or "=" in value:
         raise ValueError("invalid public value")
-    if len(base64.urlsafe_b64decode(value + "=" * (-len(value) % 4))) != size:
+    try:
+        decoded = base64.urlsafe_b64decode(value + "=" * (-len(value) % 4))
+    except Exception as error:
+        raise ValueError("invalid public value") from error
+    if len(decoded) != size or base64.urlsafe_b64encode(decoded).rstrip(b"=").decode() != value:
         raise ValueError("unexpected public value length")
     return value
 
@@ -162,20 +157,38 @@ if not isinstance(machines, list) or not machines:
 bound = 0
 seen_ids = set()
 seen_devices = set()
+allowed_machine_fields = {"id", "public_key", "endpoint_prefixes", "endpoints", "attachment_device_id"}
+normalized_machines = []
 for machine in machines:
-    if not isinstance(machine, dict) or not isinstance(machine.get("id"), str) or machine["id"] in seen_ids:
+    if not isinstance(machine, dict) or set(machine) - allowed_machine_fields:
+        raise ValueError("relay machine enrollment contains unsupported or secret fields")
+    if not isinstance(machine.get("id"), str) or machine["id"] in seen_ids:
         raise ValueError("relay machine enrollment contains invalid or duplicate machine IDs")
+    if not isinstance(machine.get("public_key"), str):
+        raise ValueError("relay machine enrollment contains an invalid public_key")
+    public_key = valid(machine["public_key"], 32)
+    for field in ("endpoint_prefixes", "endpoints"):
+        if field in machine and machine[field] is not None and (not isinstance(machine[field], list) or not all(isinstance(value, str) for value in machine[field])):
+            raise ValueError("relay machine enrollment contains invalid endpoints")
     seen_ids.add(machine["id"])
     device = machine.get("attachment_device_id")
-    if device is not None:
+    normalized = {"id": machine["id"], "public_key": public_key}
+    for field in ("endpoint_prefixes", "endpoints"):
+        if field in machine and machine[field] is not None:
+            normalized[field] = machine[field]
+    if device not in (None, ""):
         valid(device, 16)
         if device in seen_devices:
             raise ValueError("relay machine enrollment reuses an attachment_device_id")
         seen_devices.add(device)
+        normalized["attachment_device_id"] = device
         bound += 1
+    elif device == "":
+        normalized["attachment_device_id"] = ""
+    normalized_machines.append(normalized)
 if bound == 0:
     raise ValueError("relay machine enrollment must contain an attachment_device_id binding")
-machines_json = json.dumps(machines, sort_keys=True, separators=(",", ":"))
+machines_json = json.dumps(normalized_machines, sort_keys=True, separators=(",", ":"))
 
 managed = {
     "PUNARO_DIRECTORY_ENABLED",
@@ -240,8 +253,8 @@ rm -f -- "$render_error"
 [ -f "$config_stage" ] && [ ! -L "$config_stage" ] || fail 'could not safely render staged relay configuration'
 
 if [ "$root_dir" = / ]; then
-	# The service account owns its state parent. Recheck immediately before
-	# privileged writes so a renamed directory or planted symlink fails closed.
+	# The directory is root-owned; recheck immediately before privileged writes
+	# so any unexpected local tampering fails closed.
 	verify_live_v3_paths
 	install -m 0600 -o punaro -g punaro "$issuer_private_key" "$issuer_stage"
 	install -m 0640 -o root -g punaro "$directory_snapshot" "$snapshot_stage"

--- a/scripts/configure-attachment-v3-relay.sh
+++ b/scripts/configure-attachment-v3-relay.sh
@@ -95,10 +95,20 @@ if [ -e "$v3_state_dir" ] || [ -L "$v3_state_dir" ]; then
 	[ -d "$v3_state_dir" ] && [ ! -L "$v3_state_dir" ] || fail 'existing v3 state directory must be a non-symlink directory'
 fi
 
+verify_live_v3_paths() {
+	[ -d "$relay_state_dir" ] && [ ! -L "$relay_state_dir" ] || fail 'relay state directory must be a non-symlink directory'
+	[ "$(stat -c %U "$relay_state_dir")" = punaro ] && [ "$(stat -c %a "$relay_state_dir")" = 700 ] || fail 'relay state directory has unexpected ownership or mode'
+	[ -d "$private_dir" ] && [ ! -L "$private_dir" ] || fail 'directory snapshot parent must be a non-symlink directory'
+	[ "$(stat -c %U "$private_dir")" = root ] && [ "$(stat -c %G "$private_dir")" = punaro ] && [ "$(stat -c %a "$private_dir")" = 2750 ] || fail 'directory snapshot parent has unexpected ownership or mode'
+	[ -d "$v3_state_dir" ] && [ ! -L "$v3_state_dir" ] || fail 'v3 state directory must be a non-symlink directory'
+	[ "$(stat -c %U "$v3_state_dir")" = punaro ] && [ "$(stat -c %G "$v3_state_dir")" = punaro ] && [ "$(stat -c %a "$v3_state_dir")" = 700 ] || fail 'v3 state directory has unexpected ownership or mode'
+}
+
 if [ "$root_dir" = / ]; then
 	install -d -o root -g punaro -m 0750 "$credentials_dir"
-	[ -d "$private_dir" ] || install -d -o root -g punaro -m 2750 "$private_dir"
-	[ -d "$v3_state_dir" ] || install -d -o punaro -g punaro -m 0700 "$v3_state_dir"
+	install -d -o root -g punaro -m 2750 "$private_dir"
+	install -d -o punaro -g punaro -m 0700 "$v3_state_dir"
+	verify_live_v3_paths
 else
 	install -d -m 0700 "$credentials_dir"
 	[ -d "$private_dir" ] || install -d -m 0700 "$private_dir"
@@ -230,6 +240,9 @@ rm -f -- "$render_error"
 [ -f "$config_stage" ] && [ ! -L "$config_stage" ] || fail 'could not safely render staged relay configuration'
 
 if [ "$root_dir" = / ]; then
+	# The service account owns its state parent. Recheck immediately before
+	# privileged writes so a renamed directory or planted symlink fails closed.
+	verify_live_v3_paths
 	install -m 0600 -o punaro -g punaro "$issuer_private_key" "$issuer_stage"
 	install -m 0640 -o root -g punaro "$directory_snapshot" "$snapshot_stage"
 else

--- a/scripts/configure-attachment-v3-relay.sh
+++ b/scripts/configure-attachment-v3-relay.sh
@@ -85,7 +85,25 @@ issuer_destination="$credentials_dir/v3-issuer.private"
 private_dir=$(path_in_root var/lib/punaro/private)
 snapshot_destination="$private_dir/v3-directory.snapshot"
 v3_state_dir=$(path_in_root var/lib/punaro/attachment-v3)
+relay_state_dir=$(path_in_root var/lib/punaro)
 [ -f "$config_file" ] && [ ! -L "$config_file" ] || fail 'install-server must create a regular relay configuration before v3 configuration'
+[ -d "$relay_state_dir" ] && [ ! -L "$relay_state_dir" ] || fail 'relay state directory must be a non-symlink directory'
+if [ -e "$private_dir" ] || [ -L "$private_dir" ]; then
+	[ -d "$private_dir" ] && [ ! -L "$private_dir" ] || fail 'existing directory snapshot parent must be a non-symlink directory'
+fi
+if [ -e "$v3_state_dir" ] || [ -L "$v3_state_dir" ]; then
+	[ -d "$v3_state_dir" ] && [ ! -L "$v3_state_dir" ] || fail 'existing v3 state directory must be a non-symlink directory'
+fi
+
+if [ "$root_dir" = / ]; then
+	install -d -o root -g punaro -m 0750 "$credentials_dir"
+	[ -d "$private_dir" ] || install -d -o root -g punaro -m 2750 "$private_dir"
+	[ -d "$v3_state_dir" ] || install -d -o punaro -g punaro -m 0700 "$v3_state_dir"
+else
+	install -d -m 0700 "$credentials_dir"
+	[ -d "$private_dir" ] || install -d -m 0700 "$private_dir"
+	[ -d "$v3_state_dir" ] || install -d -m 0700 "$v3_state_dir"
+fi
 issuer_stage="$issuer_destination.v3-next"
 snapshot_stage="$snapshot_destination.v3-next"
 config_stage="$config_file.v3-next"
@@ -212,13 +230,9 @@ rm -f -- "$render_error"
 [ -f "$config_stage" ] && [ ! -L "$config_stage" ] || fail 'could not safely render staged relay configuration'
 
 if [ "$root_dir" = / ]; then
-	install -d -o root -g punaro -m 0750 "$credentials_dir"
-	install -d -o root -g punaro -m 2750 "$private_dir"
-	install -d -o punaro -g punaro -m 0700 "$v3_state_dir"
 	install -m 0600 -o punaro -g punaro "$issuer_private_key" "$issuer_stage"
 	install -m 0640 -o root -g punaro "$directory_snapshot" "$snapshot_stage"
 else
-	install -d -m 0700 "$credentials_dir" "$private_dir" "$v3_state_dir"
 	install -m 0600 "$issuer_private_key" "$issuer_stage"
 	install -m 0600 "$directory_snapshot" "$snapshot_stage"
 fi
@@ -233,7 +247,8 @@ fi
 
 if [ "$enable" -eq 1 ]; then
 	systemctl daemon-reload
-	systemctl enable --now punarod.service
+	systemctl enable punarod.service
+	systemctl restart punarod.service
 	systemctl is-active --quiet punarod.service
 fi
 

--- a/scripts/install-adapter.sh
+++ b/scripts/install-adapter.sh
@@ -231,6 +231,7 @@ printf '%s\n' 'Punaro adapter installed. The service is not useful until this pu
 cat "$enrollment_file"
 printf '%s\n' '' \
 	'Next: approve that record on the relay; create a distinct Cloudflare Access service token for this machine; add it to the owner-only adapter.env; bind and attach the desired agent aliases; then rerun this command with --enable.' \
+	'Optional controlled attachments: use scripts/provision-attachment-v3.sh after the machine enrollment is approved; it creates separate local device material and never modifies this adapter configuration.' \
 	"Verify with: $service_hint"
 if [ -z "$agent_guidance_dir" ]; then
 	printf '%s\n' "Optional agent guidance: $repo_dir/scripts/install-agent-guidance.sh --directory /path/to/project"

--- a/scripts/provision-attachment-v3.sh
+++ b/scripts/provision-attachment-v3.sh
@@ -1,0 +1,417 @@
+#!/bin/sh
+# Provision the local key material and public records required by Punaro
+# attachment v3. This does not enable transfer: relay activation and explicit
+# device/membership approval remain separate, fail-closed operator actions.
+set -eu
+
+umask 077
+
+usage() {
+	cat <<'EOF'
+Usage:
+  scripts/provision-attachment-v3.sh authority --directory ABSOLUTE_PRIVATE_DIRECTORY
+  scripts/provision-attachment-v3.sh client --directory ABSOLUTE_PRIVATE_DIRECTORY \
+    --authority-public ABSOLUTE_PUBLIC_JSON --machine-id ID \
+    --role receiver|sender|both \
+    [--host-key-service SERVICE --host-key-account ACCOUNT] \
+    [--host-credential-directory DIRECTORY --host-credential-name NAME] \
+    [--adapter-data-dir ABSOLUTE_DIRECTORY]
+
+authority creates an offline root key, an issuer key, and public directory
+records. Keep its directory off the relay and out of backups shared with
+clients. client creates one device's signing and HPKE key material locally and
+prints only a public enrollment record. Sender-capable devices require a
+host-bound wrapping-key reference: Keychain service/account on macOS, or a
+systemd credential directory/name on Linux. Provide the key itself through the
+platform credential store, never through this command or an environment file.
+EOF
+}
+
+fail() {
+	printf '%s\n' "$1" >&2
+	exit 2
+}
+
+require_absolute_new_directory() {
+	case "$1" in
+		/*) ;;
+		*) fail "$2 must be an absolute path" ;;
+	esac
+	[ ! -e "$1" ] && [ ! -L "$1" ] || fail "$2 must not already exist"
+}
+
+require_absolute_regular_file() {
+	case "$1" in
+		/*) ;;
+		*) fail "$2 must be an absolute path" ;;
+	esac
+	[ -f "$1" ] && [ ! -L "$1" ] || fail "$2 must be a non-symlink regular file"
+}
+
+require_absolute_private_directory() {
+	case "$1" in
+		/*) ;;
+		*) fail "$2 must be an absolute path" ;;
+	esac
+	[ -d "$1" ] && [ ! -L "$1" ] || fail "$2 must be a non-symlink directory"
+	if stat -f %Lp "$1" >/dev/null 2>&1; then mode=$(stat -f %Lp "$1"); else mode=$(stat -c %a "$1"); fi
+	[ "$mode" = 700 ] || fail "$2 must have mode 0700"
+}
+
+require_safe_dotenv_value() {
+	case "$1" in
+		''|*[!A-Za-z0-9_./:@%+=,-]*) fail "$2 contains unsupported characters" ;;
+	esac
+}
+
+require_machine_id() {
+	case "$1" in
+		''|*[!A-Za-z0-9._-]*|.*|-*) fail 'machine ID must start with a letter or digit and contain only letters, digits, dot, underscore, or hyphen' ;;
+	esac
+}
+
+script_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+repo_dir=$(CDPATH= cd -- "$script_dir/.." && pwd)
+[ -f "$repo_dir/go.mod" ] && [ -d "$repo_dir/cmd/punaro-directory" ] || fail 'run this provisioner from a complete Punaro source checkout'
+command -v go >/dev/null 2>&1 || fail 'Go is required to provision attachment v3 material from this checkout'
+command -v python3 >/dev/null 2>&1 || fail 'python3 is required to render public provisioning records'
+
+build_dir=$(mktemp -d "${TMPDIR:-/tmp}/punaro-attachment-provision.XXXXXXXX")
+cleanup() { rm -rf -- "$build_dir"; }
+trap cleanup EXIT HUP INT TERM
+(
+	cd "$repo_dir"
+	go build -trimpath -buildvcs=true -o "$build_dir/punaro-directory" ./cmd/punaro-directory
+)
+directory_bin="$build_dir/punaro-directory"
+
+new_id() {
+	"$directory_bin" id --bytes "$1" >"$2"
+}
+
+authority() {
+	directory=
+	while [ "$#" -gt 0 ]; do
+		case "$1" in
+			--directory) [ "$#" -ge 2 ] || fail '--directory requires a value'; directory=$2; shift 2 ;;
+			--help) usage; exit 0 ;;
+			*) fail "unknown authority option: $1" ;;
+		esac
+	done
+	[ -n "$directory" ] || fail 'authority requires --directory'
+	require_absolute_new_directory "$directory" 'authority directory'
+	require_safe_dotenv_value "$directory" 'authority directory'
+	mkdir -m 700 "$directory"
+
+	"$directory_bin" keygen --algorithm ed25519 --private-key-file "$directory/root.private" >"$build_dir/root.public.json"
+	"$directory_bin" keygen --algorithm ed25519 --private-key-file "$directory/issuer.private" >"$build_dir/issuer.public.json"
+	new_id 32 "$build_dir/audience.json"
+	new_id 32 "$build_dir/root-key-id.json"
+	new_id 32 "$build_dir/issuer-key-id.json"
+	chmod 600 "$directory/root.private" "$directory/issuer.private"
+
+	python3 - "$directory" "$build_dir/audience.json" "$build_dir/root-key-id.json" "$build_dir/root.public.json" "$build_dir/issuer-key-id.json" "$build_dir/issuer.public.json" <<'PY'
+import base64
+import json
+import os
+import sys
+
+directory, audience_path, root_id_path, root_path, issuer_id_path, issuer_path = sys.argv[1:]
+
+def read_json(path):
+    with open(path, encoding="utf-8") as handle:
+        return json.load(handle)
+
+def valid(value, size):
+    if not isinstance(value, str) or "=" in value:
+        raise ValueError("invalid public value")
+    if base64.urlsafe_b64decode(value + "=" * (-len(value) % 4)).__len__() != size:
+        raise ValueError("unexpected public value length")
+    return value
+
+audience = valid(read_json(audience_path)["id"], 32)
+root_key_id = valid(read_json(root_id_path)["id"], 32)
+root_public_key = valid(read_json(root_path)["public_key"], 32)
+issuer_key_id = valid(read_json(issuer_id_path)["id"], 32)
+issuer_public_key = valid(read_json(issuer_path)["public_key"], 32)
+
+public = {
+    "version": 3,
+    "audience": audience,
+    "root_key_id": root_key_id,
+    "root_public_key": root_public_key,
+    "issuer_key_id": issuer_key_id,
+    "issuer_public_key": issuer_public_key,
+}
+manifest = {
+    "audience": audience,
+    "root_key_id": root_key_id,
+    "sequence": 1,
+    "revocation_epoch": 1,
+    "entries": [{"issuer": {"key_id": issuer_key_id, "public_key": issuer_public_key, "revoked": False}}],
+}
+
+for name, value, mode in (("public.json", public, 0o600), ("directory-manifest.json", manifest, 0o600)):
+    path = os.path.join(directory, name)
+    fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, mode)
+    with os.fdopen(fd, "w", encoding="utf-8") as handle:
+        json.dump(value, handle, sort_keys=True, separators=(",", ":"))
+        handle.write("\n")
+    os.chmod(path, mode)
+PY
+	printf '%s\n' 'attachment_v3_authority_provisioned'
+	printf '%s\n' "Public authority record: $directory/public.json"
+	printf '%s\n' "Directory manifest seed: $directory/directory-manifest.json"
+	printf '%s\n' 'Keep root.private offline. Copy only public.json and approved public device entries between roles.'
+}
+
+client() {
+	directory=
+	authority_public=
+	machine_id=
+	role=
+	host_key_service=
+	host_key_account=
+	host_credential_directory=
+	host_credential_name=
+	adapter_data_dir="$HOME/.local/state/punaro-adapter"
+	while [ "$#" -gt 0 ]; do
+		case "$1" in
+			--directory) [ "$#" -ge 2 ] || fail '--directory requires a value'; directory=$2; shift 2 ;;
+			--authority-public) [ "$#" -ge 2 ] || fail '--authority-public requires a value'; authority_public=$2; shift 2 ;;
+			--machine-id) [ "$#" -ge 2 ] || fail '--machine-id requires a value'; machine_id=$2; shift 2 ;;
+			--role) [ "$#" -ge 2 ] || fail '--role requires a value'; role=$2; shift 2 ;;
+			--host-key-service) [ "$#" -ge 2 ] || fail '--host-key-service requires a value'; host_key_service=$2; shift 2 ;;
+			--host-key-account) [ "$#" -ge 2 ] || fail '--host-key-account requires a value'; host_key_account=$2; shift 2 ;;
+			--host-credential-directory) [ "$#" -ge 2 ] || fail '--host-credential-directory requires a value'; host_credential_directory=$2; shift 2 ;;
+			--host-credential-name) [ "$#" -ge 2 ] || fail '--host-credential-name requires a value'; host_credential_name=$2; shift 2 ;;
+			--adapter-data-dir) [ "$#" -ge 2 ] || fail '--adapter-data-dir requires a value'; adapter_data_dir=$2; shift 2 ;;
+			--help) usage; exit 0 ;;
+			*) fail "unknown client option: $1" ;;
+		esac
+	done
+	[ -n "$directory" ] || fail 'client requires --directory'
+	[ -n "$authority_public" ] || fail 'client requires --authority-public'
+	[ -n "$machine_id" ] || fail 'client requires --machine-id'
+	case "$role" in receiver|sender|both) ;; *) fail '--role must be receiver, sender, or both' ;; esac
+	require_absolute_new_directory "$directory" 'client directory'
+	require_absolute_regular_file "$authority_public" 'authority public record'
+	require_safe_dotenv_value "$directory" 'client directory'
+	require_safe_dotenv_value "$adapter_data_dir" 'adapter data directory'
+	require_machine_id "$machine_id"
+	host_platform=$(uname -s)
+	if [ "$role" = sender ] || [ "$role" = both ]; then
+		case "$host_platform" in
+			Darwin)
+				[ -n "$host_key_service" ] && [ -n "$host_key_account" ] || fail 'sender provisioning requires --host-key-service and --host-key-account'
+				[ -z "$host_credential_directory$host_credential_name" ] || fail 'macOS sender provisioning does not accept systemd credential references'
+				require_safe_dotenv_value "$host_key_service" 'host key service'
+				require_safe_dotenv_value "$host_key_account" 'host key account'
+				;;
+			*)
+				[ -n "$host_credential_directory" ] && [ -n "$host_credential_name" ] || fail 'sender provisioning requires --host-credential-directory and --host-credential-name'
+				[ -z "$host_key_service$host_key_account" ] || fail 'Linux sender provisioning does not accept macOS keychain references'
+				require_safe_dotenv_value "$host_credential_directory" 'host credential directory'
+				require_safe_dotenv_value "$host_credential_name" 'host credential name'
+				;;
+		esac
+	elif [ -n "$host_key_service$host_key_account$host_credential_directory$host_credential_name" ]; then
+		fail 'host key references are only valid for sender-capable provisioning'
+	fi
+	mkdir -m 700 "$directory"
+
+	"$directory_bin" keygen --algorithm ed25519 --private-key-file "$directory/device-signing.private" >"$build_dir/device-signing.public.json"
+	"$directory_bin" keygen --algorithm x25519 --private-key-file "$directory/device-hpke.private" >"$build_dir/device-hpke.public.json"
+	new_id 16 "$build_dir/device-id.json"
+	new_id 32 "$build_dir/signing-key-id.json"
+	new_id 32 "$build_dir/hpke-key-id.json"
+	chmod 600 "$directory/device-signing.private" "$directory/device-hpke.private"
+
+	python3 - "$directory" "$authority_public" "$machine_id" "$role" "$host_platform" "$adapter_data_dir" "$host_key_service" "$host_key_account" "$host_credential_directory" "$host_credential_name" "$build_dir/device-id.json" "$build_dir/signing-key-id.json" "$build_dir/device-signing.public.json" "$build_dir/hpke-key-id.json" "$build_dir/device-hpke.public.json" <<'PY'
+import base64
+import json
+import os
+import sys
+
+(directory, authority_path, machine_id, role, host_platform, adapter_data_dir, host_service,
+ host_account, host_credential_directory, host_credential_name, device_id_path,
+ signing_id_path, signing_path, hpke_id_path, hpke_path) = sys.argv[1:]
+
+def read_json(path):
+    with open(path, encoding="utf-8") as handle:
+        return json.load(handle)
+
+def valid(value, size):
+    if not isinstance(value, str) or "=" in value:
+        raise ValueError("invalid public value")
+    if len(base64.urlsafe_b64decode(value + "=" * (-len(value) % 4))) != size:
+        raise ValueError("unexpected public value length")
+    return value
+
+authority = read_json(authority_path)
+if authority.get("version") != 3:
+    raise ValueError("authority public record must be version 3")
+audience = valid(authority["audience"], 32)
+root_key_id = valid(authority["root_key_id"], 32)
+root_public_key = valid(authority["root_public_key"], 32)
+device_id = valid(read_json(device_id_path)["id"], 16)
+signing_key_id = valid(read_json(signing_id_path)["id"], 32)
+signing_public_key = valid(read_json(signing_path)["public_key"], 32)
+hpke_key_id = valid(read_json(hpke_id_path)["id"], 32)
+hpke_public_key = valid(read_json(hpke_path)["public_key"], 32)
+
+device = {
+    "device_id": device_id,
+    "generation": 1,
+    "signing_key_id": signing_key_id,
+    "signing_public_key": signing_public_key,
+    "hpke_key_id": hpke_key_id,
+    "hpke_public_key": hpke_public_key,
+    "revoked": False,
+}
+enrollment = {
+    "version": 3,
+    "machine_id": machine_id,
+    "role": role,
+    "attachment_device_id": device_id,
+    "directory_entry": {"device": device},
+}
+public_path = os.path.join(directory, "device-enrollment.json")
+fd = os.open(public_path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+with os.fdopen(fd, "w", encoding="utf-8") as handle:
+    json.dump(enrollment, handle, sort_keys=True, separators=(",", ":"))
+    handle.write("\n")
+os.chmod(public_path, 0o600)
+
+env = [
+    "# Created by Punaro attachment-v3 provisioning. This owner-only file contains paths, not credentials.",
+    "# Source adapter.env first; it supplies relay URL, machine key, and any Cloudflare Access service token.",
+    f"PUNARO_ATTACHMENT_DIRECTORY_CHECKPOINT_FILE={directory}/directory-checkpoints.db",
+    f"PUNARO_DIRECTORY_AUDIENCE={audience}",
+    f"PUNARO_DIRECTORY_ROOT_KEY_ID={root_key_id}",
+    f"PUNARO_DIRECTORY_ROOT_PUBLIC_KEY={root_public_key}",
+]
+if role in ("receiver", "both"):
+    env += [
+        f"PUNARO_ATTACHMENT_RECIPIENT_SIGNING_PRIVATE_KEY_FILE={directory}/device-signing.private",
+        f"PUNARO_ATTACHMENT_RECIPIENT_HPKE_PRIVATE_KEY_FILE={directory}/device-hpke.private",
+        f"PUNARO_ATTACHMENT_RECIPIENT_ID={device_id}",
+        "PUNARO_ATTACHMENT_RECIPIENT_GENERATION=1",
+        f"PUNARO_ATTACHMENT_CONTROLLER_JOURNAL={directory}/controller.db",
+    ]
+if role in ("sender", "both"):
+    env += [
+        f"PUNARO_ATTACHMENT_SENDER_SIGNING_PRIVATE_KEY_FILE={directory}/device-signing.private",
+        f"PUNARO_ATTACHMENT_SENDER_ID={device_id}",
+        "PUNARO_ATTACHMENT_SENDER_GENERATION=1",
+        f"PUNARO_ATTACHMENT_SENDER_JOURNAL={directory}/sender.db",
+        f"PUNARO_ATTACHMENT_ARTIFACT_STORE={directory}/artifacts.db",
+        f"PUNARO_ATTACHMENT_OFFER_OUTBOX={adapter_data_dir}/attachment-offers.db",
+    ]
+    if host_platform == "Darwin":
+        env += [
+            f"PUNARO_ATTACHMENT_HOST_KEY_SERVICE={host_service}",
+            f"PUNARO_ATTACHMENT_HOST_KEY_ACCOUNT={host_account}",
+        ]
+    else:
+        env += [
+            f"PUNARO_ATTACHMENT_HOST_CREDENTIAL_DIRECTORY={host_credential_directory}",
+            f"PUNARO_ATTACHMENT_HOST_CREDENTIAL_NAME={host_credential_name}",
+        ]
+env_path = os.path.join(directory, "attachment-v3.env")
+fd = os.open(env_path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+with os.fdopen(fd, "w", encoding="utf-8") as handle:
+    handle.write("\n".join(env) + "\n")
+os.chmod(env_path, 0o600)
+PY
+	printf '%s\n' 'attachment_v3_client_provisioned'
+	printf '%s\n' "Public device enrollment: $directory/device-enrollment.json"
+	printf '%s\n' 'Next: have the offline authority add that public device entry to the directory manifest, publish a fresh signed snapshot, configure the relay, then run punaro-attachment check before mapping or approving an offer.'
+}
+
+authority_add_device() {
+	directory=
+	device_enrollment=
+	while [ "$#" -gt 0 ]; do
+		case "$1" in
+			--directory) [ "$#" -ge 2 ] || fail '--directory requires a value'; directory=$2; shift 2 ;;
+			--device-enrollment) [ "$#" -ge 2 ] || fail '--device-enrollment requires a value'; device_enrollment=$2; shift 2 ;;
+			--help) usage; exit 0 ;;
+			*) fail "unknown authority-add-device option: $1" ;;
+		esac
+	done
+	[ -n "$directory" ] || fail 'authority-add-device requires --directory'
+	[ -n "$device_enrollment" ] || fail 'authority-add-device requires --device-enrollment'
+	require_absolute_private_directory "$directory" 'authority directory'
+	require_absolute_regular_file "$directory/public.json" 'authority public record'
+	require_absolute_regular_file "$directory/directory-manifest.json" 'directory manifest'
+	require_absolute_regular_file "$device_enrollment" 'device enrollment'
+
+	python3 - "$directory" "$device_enrollment" <<'PY'
+import base64
+import json
+import os
+import sys
+
+directory, enrollment_path = sys.argv[1:]
+
+def read_json(path):
+    with open(path, encoding="utf-8") as handle:
+        return json.load(handle)
+
+def valid(value, size):
+    if not isinstance(value, str) or "=" in value:
+        raise ValueError("invalid public value")
+    if len(base64.urlsafe_b64decode(value + "=" * (-len(value) % 4))) != size:
+        raise ValueError("unexpected public value length")
+    return value
+
+authority = read_json(os.path.join(directory, "public.json"))
+manifest_path = os.path.join(directory, "directory-manifest.json")
+manifest = read_json(manifest_path)
+enrollment = read_json(enrollment_path)
+if authority.get("version") != 3 or enrollment.get("version") != 3:
+    raise ValueError("authority and device enrollment records must be version 3")
+if manifest.get("audience") != authority.get("audience") or manifest.get("root_key_id") != authority.get("root_key_id"):
+    raise ValueError("directory manifest does not match authority public record")
+device = enrollment.get("directory_entry", {}).get("device")
+if not isinstance(device, dict) or enrollment.get("attachment_device_id") != device.get("device_id"):
+    raise ValueError("device enrollment has no matching directory device entry")
+valid(device.get("device_id"), 16)
+valid(device.get("signing_key_id"), 32)
+valid(device.get("signing_public_key"), 32)
+valid(device.get("hpke_key_id"), 32)
+valid(device.get("hpke_public_key"), 32)
+if device.get("generation") != 1 or device.get("revoked") is not False:
+    raise ValueError("device enrollment must be an active generation-one device")
+entries = manifest.get("entries")
+if not isinstance(entries, list) or not isinstance(manifest.get("sequence"), int) or manifest["sequence"] < 1:
+    raise ValueError("invalid directory manifest")
+for entry in entries:
+    prior = entry.get("device") if isinstance(entry, dict) else None
+    if isinstance(prior, dict) and prior.get("device_id") == device["device_id"]:
+        raise ValueError("directory already contains this attachment device")
+entries.append({"device": device})
+manifest["sequence"] += 1
+temp_path = manifest_path + ".next"
+fd = os.open(temp_path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+with os.fdopen(fd, "w", encoding="utf-8") as handle:
+    json.dump(manifest, handle, sort_keys=True, separators=(",", ":"))
+    handle.write("\n")
+os.chmod(temp_path, 0o600)
+os.replace(temp_path, manifest_path)
+PY
+	printf '%s\n' 'attachment_v3_directory_device_added'
+	printf '%s\n' 'Publish a new signed snapshot before enabling or using attachment v3.'
+}
+
+[ "$#" -gt 0 ] || { usage >&2; exit 2; }
+command=$1
+shift
+case "$command" in
+	authority) authority "$@" ;;
+	client) client "$@" ;;
+	authority-add-device) authority_add_device "$@" ;;
+	--help|-h) usage ;;
+	*) fail "unknown command: $command" ;;
+esac

--- a/scripts/provision-attachment-v3.sh
+++ b/scripts/provision-attachment-v3.sh
@@ -54,7 +54,10 @@ require_absolute_private_directory() {
 		*) fail "$2 must be an absolute path" ;;
 	esac
 	[ -d "$1" ] && [ ! -L "$1" ] || fail "$2 must be a non-symlink directory"
-	if stat -f %Lp "$1" >/dev/null 2>&1; then mode=$(stat -f %Lp "$1"); else mode=$(stat -c %a "$1"); fi
+	case "$(uname -s)" in
+		Darwin) mode=$(stat -f %Lp "$1") ;;
+		*) mode=$(stat -c %a "$1") ;;
+	esac
 	[ "$mode" = 700 ] || fail "$2 must have mode 0700"
 }
 

--- a/scripts/provision-attachment-v3.sh
+++ b/scripts/provision-attachment-v3.sh
@@ -11,7 +11,7 @@ usage() {
 Usage:
   scripts/provision-attachment-v3.sh authority --directory ABSOLUTE_PRIVATE_DIRECTORY
   scripts/provision-attachment-v3.sh client --directory ABSOLUTE_PRIVATE_DIRECTORY \
-    --authority-public ABSOLUTE_PUBLIC_JSON --machine-id ID \
+    --authority-public ABSOLUTE_PUBLIC_JSON --machine-id ID --relay-url HTTPS_URL \
     --role receiver|sender|both \
     [--host-key-service SERVICE --host-key-account ACCOUNT] \
     [--host-credential-directory DIRECTORY --host-credential-name NAME] \
@@ -172,6 +172,7 @@ client() {
 	directory=
 	authority_public=
 	machine_id=
+	relay_url=
 	role=
 	host_key_service=
 	host_key_account=
@@ -183,6 +184,7 @@ client() {
 			--directory) [ "$#" -ge 2 ] || fail '--directory requires a value'; directory=$2; shift 2 ;;
 			--authority-public) [ "$#" -ge 2 ] || fail '--authority-public requires a value'; authority_public=$2; shift 2 ;;
 			--machine-id) [ "$#" -ge 2 ] || fail '--machine-id requires a value'; machine_id=$2; shift 2 ;;
+			--relay-url) [ "$#" -ge 2 ] || fail '--relay-url requires a value'; relay_url=$2; shift 2 ;;
 			--role) [ "$#" -ge 2 ] || fail '--role requires a value'; role=$2; shift 2 ;;
 			--host-key-service) [ "$#" -ge 2 ] || fail '--host-key-service requires a value'; host_key_service=$2; shift 2 ;;
 			--host-key-account) [ "$#" -ge 2 ] || fail '--host-key-account requires a value'; host_key_account=$2; shift 2 ;;
@@ -196,11 +198,14 @@ client() {
 	[ -n "$directory" ] || fail 'client requires --directory'
 	[ -n "$authority_public" ] || fail 'client requires --authority-public'
 	[ -n "$machine_id" ] || fail 'client requires --machine-id'
+	[ -n "$relay_url" ] || fail 'client requires --relay-url'
 	case "$role" in receiver|sender|both) ;; *) fail '--role must be receiver, sender, or both' ;; esac
+	case "$relay_url" in https://*) ;; *) fail 'relay URL must use https://' ;; esac
 	require_absolute_new_directory "$directory" 'client directory'
 	require_absolute_regular_file "$authority_public" 'authority public record'
 	require_safe_dotenv_value "$directory" 'client directory'
 	require_safe_dotenv_value "$adapter_data_dir" 'adapter data directory'
+	require_safe_dotenv_value "$relay_url" 'relay URL'
 	require_machine_id "$machine_id"
 	host_platform=$(uname -s)
 	if [ "$role" = sender ] || [ "$role" = both ]; then
@@ -230,13 +235,13 @@ client() {
 	new_id 32 "$build_dir/hpke-key-id.json"
 	chmod 600 "$directory/device-signing.private" "$directory/device-hpke.private"
 
-	python3 - "$directory" "$authority_public" "$machine_id" "$role" "$host_platform" "$adapter_data_dir" "$host_key_service" "$host_key_account" "$host_credential_directory" "$host_credential_name" "$build_dir/device-id.json" "$build_dir/signing-key-id.json" "$build_dir/device-signing.public.json" "$build_dir/hpke-key-id.json" "$build_dir/device-hpke.public.json" <<'PY'
+	python3 - "$directory" "$authority_public" "$machine_id" "$relay_url" "$role" "$host_platform" "$adapter_data_dir" "$host_key_service" "$host_key_account" "$host_credential_directory" "$host_credential_name" "$build_dir/device-id.json" "$build_dir/signing-key-id.json" "$build_dir/device-signing.public.json" "$build_dir/hpke-key-id.json" "$build_dir/device-hpke.public.json" <<'PY'
 import base64
 import json
 import os
 import sys
 
-(directory, authority_path, machine_id, role, host_platform, adapter_data_dir, host_service,
+(directory, authority_path, machine_id, relay_url, role, host_platform, adapter_data_dir, host_service,
  host_account, host_credential_directory, host_credential_name, device_id_path,
  signing_id_path, signing_path, hpke_id_path, hpke_path) = sys.argv[1:]
 
@@ -288,7 +293,8 @@ os.chmod(public_path, 0o600)
 
 env = [
     "# Created by Punaro attachment-v3 provisioning. This owner-only file contains paths, not credentials.",
-    "# Source adapter.env first; it supplies relay URL, machine key, and any Cloudflare Access service token.",
+    "# Source adapter.env first; it supplies the machine key and any Cloudflare Access service token.",
+    f"PUNARO_ATTACHMENT_RELAY_URL={relay_url}",
     f"PUNARO_ATTACHMENT_DIRECTORY_CHECKPOINT_FILE={directory}/directory-checkpoints.db",
     f"PUNARO_DIRECTORY_AUDIENCE={audience}",
     f"PUNARO_DIRECTORY_ROOT_KEY_ID={root_key_id}",

--- a/scripts/publish-directory-snapshot.sh
+++ b/scripts/publish-directory-snapshot.sh
@@ -26,13 +26,13 @@ else
 	scp_pve() { scp -q -o BatchMode=yes -o ConnectTimeout=10 "$@"; }
 fi
 
-container_snapshot_file=${PUNARO_CONTAINER_SNAPSHOT_FILE:-/var/lib/punaro/private/v3-directory.snapshot}
-case "$container_snapshot_file" in /var/lib/punaro/private/*) ;; *) printf '%s\n' 'PUNARO_CONTAINER_SNAPSHOT_FILE must be below /var/lib/punaro/private' >&2; exit 2;; esac
+container_snapshot_file=${PUNARO_CONTAINER_SNAPSHOT_FILE:-/etc/punaro/directory/v3-directory.snapshot}
+case "$container_snapshot_file" in /etc/punaro/directory/*) ;; *) printf '%s\n' 'PUNARO_CONTAINER_SNAPSHOT_FILE must be below /etc/punaro/directory' >&2; exit 2;; esac
 case "$container_snapshot_file" in *[!A-Za-z0-9_./-]*) printf '%s\n' 'PUNARO_CONTAINER_SNAPSHOT_FILE contains unsafe characters' >&2; exit 2;; esac
 case "$container_snapshot_file/" in *'//'*) printf '%s\n' 'PUNARO_CONTAINER_SNAPSHOT_FILE must be canonical' >&2; exit 2;; esac
 case "$container_snapshot_file/" in *'/../'*) printf '%s\n' 'PUNARO_CONTAINER_SNAPSHOT_FILE must not contain parent traversal' >&2; exit 2;; esac
 container_snapshot_parent=$(dirname "$container_snapshot_file")
-[ "$container_snapshot_parent" = /var/lib/punaro/private ] || { printf '%s\n' 'PUNARO_CONTAINER_SNAPSHOT_FILE must be directly below /var/lib/punaro/private' >&2; exit 2; }
+[ "$container_snapshot_parent" = /etc/punaro/directory ] || { printf '%s\n' 'PUNARO_CONTAINER_SNAPSHOT_FILE must be directly below /etc/punaro/directory' >&2; exit 2; }
 
 # Keep an advisory lock across exec, so the kernel releases it after a crash,
 # kill -9, or reboot. The file itself may persist safely; only its live lock
@@ -78,14 +78,15 @@ case "$remote_stage" in /tmp/punaro-directory.*) ;; *) printf '%s\n' 'Proxmox re
 case "$remote_stage" in *[!A-Za-z0-9_./-]*) printf '%s\n' 'Proxmox returned an unsafe staging path' >&2; exit 1;; esac
 scp_pve "$snapshot" "$PUNARO_PVE_SSH_TARGET:$remote_stage"
 # The relay account cannot write either this staging directory or the final
-# snapshot parent.  `pct push` therefore cannot be redirected through a
-# service-created symlink, and the final same-filesystem rename is atomic.
-ssh_pve "$PUNARO_PVE_SSH_TARGET" "pct exec $PUNARO_PVE_CONTAINER_ID -- /bin/sh -ceu 'install -d -o root -g root -m 700 /root/.punaro-directory-stage; install -d -o root -g punaro -m 2750 /var/lib/punaro/private'"
-container_stage=$(ssh_pve "$PUNARO_PVE_SSH_TARGET" "pct exec $PUNARO_PVE_CONTAINER_ID -- /bin/sh -ceu 'stage=\$(mktemp /root/.punaro-directory-stage/snapshot.XXXXXXXX); chmod 600 \"\$stage\"; printf %s \"\$stage\"'")
-case "$container_stage" in /root/.punaro-directory-stage/snapshot.*) ;; *) printf '%s\n' 'container returned an unsafe staging path' >&2; exit 1;; esac
+# snapshot parent.  Both are under the root-owned /etc/punaro hierarchy, so
+# root never publishes through service-owned paths. The final same-filesystem
+# rename is atomic.
+ssh_pve "$PUNARO_PVE_SSH_TARGET" "pct exec $PUNARO_PVE_CONTAINER_ID -- /bin/sh -ceu 'install -d -o root -g root -m 700 /etc/punaro/.punaro-directory-stage; install -d -o root -g punaro -m 2750 /etc/punaro/directory'"
+container_stage=$(ssh_pve "$PUNARO_PVE_SSH_TARGET" "pct exec $PUNARO_PVE_CONTAINER_ID -- /bin/sh -ceu 'stage=\$(mktemp /etc/punaro/.punaro-directory-stage/snapshot.XXXXXXXX); chmod 600 \"\$stage\"; printf %s \"\$stage\"'")
+case "$container_stage" in /etc/punaro/.punaro-directory-stage/snapshot.*) ;; *) printf '%s\n' 'container returned an unsafe staging path' >&2; exit 1;; esac
 case "$container_stage" in *[!A-Za-z0-9_./-]*) printf '%s\n' 'container returned an unsafe staging path' >&2; exit 1;; esac
 ssh_pve "$PUNARO_PVE_SSH_TARGET" pct push "$PUNARO_PVE_CONTAINER_ID" "$remote_stage" "$container_stage"
-ssh_pve "$PUNARO_PVE_SSH_TARGET" "pct exec $PUNARO_PVE_CONTAINER_ID -- /bin/sh -ceu 'stage=\$1; target=\$2; parent=\$(dirname \"\$target\"); [ \"\$parent\" = /var/lib/punaro/private ]; [ ! -L \"\$parent\" ]; [ -f \"\$stage\" ]; [ ! -L \"\$stage\" ]; [ \"\$(stat -c %U \"\$parent\")\" = root ]; [ \"\$(stat -c %G \"\$parent\")\" = punaro ]; [ \"\$(stat -c %a \"\$parent\")\" = 2750 ]; [ \"\$(stat -c %d /root/.punaro-directory-stage)\" = \"\$(stat -c %d \"\$parent\")\" ]; chown root:punaro \"\$stage\"; chmod 640 \"\$stage\"; mv -f -- \"\$stage\" \"\$target\"' sh '$container_stage' '$container_snapshot_file'"
+ssh_pve "$PUNARO_PVE_SSH_TARGET" "pct exec $PUNARO_PVE_CONTAINER_ID -- /bin/sh -ceu 'stage=\$1; target=\$2; parent=\$(dirname \"\$target\"); [ \"\$parent\" = /etc/punaro/directory ]; [ ! -L \"\$parent\" ]; [ -f \"\$stage\" ]; [ ! -L \"\$stage\" ]; [ \"\$(stat -c %U \"\$parent\")\" = root ]; [ \"\$(stat -c %G \"\$parent\")\" = punaro ]; [ \"\$(stat -c %a \"\$parent\")\" = 2750 ]; [ \"\$(stat -c %d /etc/punaro/.punaro-directory-stage)\" = \"\$(stat -c %d \"\$parent\")\" ]; chown root:punaro \"\$stage\"; chmod 640 \"\$stage\"; mv -f -- \"\$stage\" \"\$target\"' sh '$container_stage' '$container_snapshot_file'"
 container_stage=
 ssh_pve "$PUNARO_PVE_SSH_TARGET" rm -f -- "$remote_stage"
 remote_stage=

--- a/scripts/test-configure-attachment-v3-relay.sh
+++ b/scripts/test-configure-attachment-v3-relay.sh
@@ -46,7 +46,7 @@ sh "$repo_dir/scripts/configure-attachment-v3-relay.sh" --root "$stage" \
 
 config="$stage/etc/punaro/punaro.env"
 issuer="$stage/etc/punaro/credentials/v3-issuer.private"
-published_snapshot="$stage/var/lib/punaro/private/v3-directory.snapshot"
+published_snapshot="$stage/etc/punaro/directory/v3-directory.snapshot"
 [ -f "$issuer" ] || { printf '%s\n' 'relay issuer key was not installed' >&2; exit 1; }
 [ -f "$published_snapshot" ] || { printf '%s\n' 'relay directory snapshot was not installed' >&2; exit 1; }
 [ "$(file_mode "$issuer")" = 600 ] || { printf '%s\n' 'relay issuer key is not private' >&2; exit 1; }
@@ -55,6 +55,7 @@ grep -Fqx 'PUNARO_PERMIT_ISSUANCE_ENABLED=false' "$config"
 grep -Fqx 'PUNARO_ATTACHMENTS_ENABLED=false' "$config"
 grep -Fqx 'PUNARO_ATTACHMENT_RELAY_ENABLED=false' "$config"
 grep -Fqx 'PUNARO_DIRECTORY_ENABLED=true' "$config"
+grep -Fqx 'PUNARO_DIRECTORY_SNAPSHOT_FILE=/etc/punaro/directory/v3-directory.snapshot' "$config"
 grep -Fq "PUNARO_RELAY_MACHINES_JSON=[{\"attachment_device_id\":\"$device_id\"" "$config"
 if grep -Fq -- "$(cat "$authority/issuer.private")" "$config" "$fixture_dir/out"; then
 	printf '%s\n' 'relay configuration leaked the issuer private key' >&2; exit 1
@@ -64,15 +65,15 @@ grep -Fq 'systemctl restart punarod.service' "$repo_dir/scripts/configure-attach
 symlink_stage="$fixture_dir/symlink-stage"
 sh "$repo_dir/scripts/install-server.sh" --root "$symlink_stage" >/dev/null
 mkdir "$fixture_dir/redirected-state"
-ln -s "$fixture_dir/redirected-state" "$symlink_stage/var/lib/punaro/attachment-v3"
+ln -s "$fixture_dir/redirected-state" "$symlink_stage/etc/punaro/directory"
 set +e
 sh "$repo_dir/scripts/configure-attachment-v3-relay.sh" --root "$symlink_stage" \
 	--authority-public "$authority/public.json" --issuer-private-key "$authority/issuer.private" \
 	--directory-snapshot "$snapshot" --relay-machines-file "$machines" >"$fixture_dir/symlink-state.out" 2>&1
 status=$?
 set -e
-[ "$status" -eq 2 ] || { printf '%s\n' 'relay configuration followed a service-owned state symlink' >&2; exit 1; }
-grep -Fqx 'existing v3 state directory must be a non-symlink directory' "$fixture_dir/symlink-state.out"
+[ "$status" -eq 2 ] || { printf '%s\n' 'relay configuration followed a directory snapshot symlink' >&2; exit 1; }
+grep -Fqx 'directory snapshot parent must be a non-symlink directory' "$fixture_dir/symlink-state.out"
 
 printf '%s\n' '[{"id":"macbook","public_key":"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA","endpoint_prefixes":["agent/macbook/"]}]' >"$fixture_dir/no-device-binding.json"
 set +e
@@ -83,5 +84,15 @@ status=$?
 set -e
 [ "$status" -eq 2 ] || { printf '%s\n' 'relay configuration accepted unbound machines' >&2; exit 1; }
 grep -Fqx 'relay machine enrollment must contain an attachment_device_id binding' "$fixture_dir/no-binding.out"
+
+printf '%s\n' "[{\"id\":\"macbook\",\"public_key\":\"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\",\"endpoint_prefixes\":[\"agent/macbook/\"],\"attachment_device_id\":\"$device_id\",\"private_key\":\"forbidden\"}]" >"$fixture_dir/private-machine-field.json"
+set +e
+sh "$repo_dir/scripts/configure-attachment-v3-relay.sh" --root "$stage" \
+	--authority-public "$authority/public.json" --issuer-private-key "$authority/issuer.private" \
+	--directory-snapshot "$snapshot" --relay-machines-file "$fixture_dir/private-machine-field.json" >"$fixture_dir/private-machine-field.out" 2>&1
+status=$?
+set -e
+[ "$status" -eq 2 ] || { printf '%s\n' 'relay configuration accepted a private machine field' >&2; exit 1; }
+grep -Fqx 'relay machine enrollment contains unsupported or secret fields' "$fixture_dir/private-machine-field.out"
 
 printf '%s\n' attachment_v3_relay_configuration_tests_passed

--- a/scripts/test-configure-attachment-v3-relay.sh
+++ b/scripts/test-configure-attachment-v3-relay.sh
@@ -7,6 +7,13 @@ fixture_dir=$(mktemp -d "${TMPDIR:-/tmp}/punaro-attachment-relay-test.XXXXXXXX")
 cleanup() { chmod -R u+w -- "$fixture_dir" 2>/dev/null || true; rm -rf -- "$fixture_dir"; }
 trap cleanup EXIT HUP INT TERM
 
+file_mode() {
+	case "$(uname -s)" in
+		Darwin) stat -f %Lp "$1" ;;
+		*) stat -c %a "$1" ;;
+	esac
+}
+
 stage="$fixture_dir/stage"
 authority="$fixture_dir/authority"
 client="$fixture_dir/client"
@@ -42,7 +49,7 @@ issuer="$stage/etc/punaro/credentials/v3-issuer.private"
 published_snapshot="$stage/var/lib/punaro/private/v3-directory.snapshot"
 [ -f "$issuer" ] || { printf '%s\n' 'relay issuer key was not installed' >&2; exit 1; }
 [ -f "$published_snapshot" ] || { printf '%s\n' 'relay directory snapshot was not installed' >&2; exit 1; }
-[ "$(stat -f %Lp "$issuer" 2>/dev/null || stat -c %a "$issuer")" = 600 ] || { printf '%s\n' 'relay issuer key is not private' >&2; exit 1; }
+[ "$(file_mode "$issuer")" = 600 ] || { printf '%s\n' 'relay issuer key is not private' >&2; exit 1; }
 grep -Fqx 'PUNARO_ATTACHMENT_V3_ENABLED=true' "$config"
 grep -Fqx 'PUNARO_PERMIT_ISSUANCE_ENABLED=false' "$config"
 grep -Fqx 'PUNARO_ATTACHMENTS_ENABLED=false' "$config"

--- a/scripts/test-configure-attachment-v3-relay.sh
+++ b/scripts/test-configure-attachment-v3-relay.sh
@@ -24,7 +24,7 @@ sh "$repo_dir/scripts/install-server.sh" --root "$stage" >/dev/null
 sh "$repo_dir/scripts/provision-attachment-v3.sh" authority --directory "$authority" >/dev/null
 sh "$repo_dir/scripts/provision-attachment-v3.sh" client \
 	--directory "$client" --authority-public "$authority/public.json" --machine-id macbook \
-	--role receiver >/dev/null
+	--relay-url https://relay.example.invalid --role receiver >/dev/null
 sh "$repo_dir/scripts/provision-attachment-v3.sh" authority-add-device \
 	--directory "$authority" --device-enrollment "$client/device-enrollment.json" >/dev/null
 
@@ -59,6 +59,20 @@ grep -Fq "PUNARO_RELAY_MACHINES_JSON=[{\"attachment_device_id\":\"$device_id\"" 
 if grep -Fq -- "$(cat "$authority/issuer.private")" "$config" "$fixture_dir/out"; then
 	printf '%s\n' 'relay configuration leaked the issuer private key' >&2; exit 1
 fi
+grep -Fq 'systemctl restart punarod.service' "$repo_dir/scripts/configure-attachment-v3-relay.sh"
+
+symlink_stage="$fixture_dir/symlink-stage"
+sh "$repo_dir/scripts/install-server.sh" --root "$symlink_stage" >/dev/null
+mkdir "$fixture_dir/redirected-state"
+ln -s "$fixture_dir/redirected-state" "$symlink_stage/var/lib/punaro/attachment-v3"
+set +e
+sh "$repo_dir/scripts/configure-attachment-v3-relay.sh" --root "$symlink_stage" \
+	--authority-public "$authority/public.json" --issuer-private-key "$authority/issuer.private" \
+	--directory-snapshot "$snapshot" --relay-machines-file "$machines" >"$fixture_dir/symlink-state.out" 2>&1
+status=$?
+set -e
+[ "$status" -eq 2 ] || { printf '%s\n' 'relay configuration followed a service-owned state symlink' >&2; exit 1; }
+grep -Fqx 'existing v3 state directory must be a non-symlink directory' "$fixture_dir/symlink-state.out"
 
 printf '%s\n' '[{"id":"macbook","public_key":"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA","endpoint_prefixes":["agent/macbook/"]}]' >"$fixture_dir/no-device-binding.json"
 set +e

--- a/scripts/test-configure-attachment-v3-relay.sh
+++ b/scripts/test-configure-attachment-v3-relay.sh
@@ -1,0 +1,66 @@
+#!/bin/sh
+# Exercise v3 relay configuration in a staging root. No service is enabled.
+set -eu
+
+repo_dir=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+fixture_dir=$(mktemp -d "${TMPDIR:-/tmp}/punaro-attachment-relay-test.XXXXXXXX")
+cleanup() { chmod -R u+w -- "$fixture_dir" 2>/dev/null || true; rm -rf -- "$fixture_dir"; }
+trap cleanup EXIT HUP INT TERM
+
+stage="$fixture_dir/stage"
+authority="$fixture_dir/authority"
+client="$fixture_dir/client"
+snapshot="$fixture_dir/directory.snapshot"
+machines="$fixture_dir/machines.json"
+
+sh "$repo_dir/scripts/install-server.sh" --root "$stage" >/dev/null
+sh "$repo_dir/scripts/provision-attachment-v3.sh" authority --directory "$authority" >/dev/null
+sh "$repo_dir/scripts/provision-attachment-v3.sh" client \
+	--directory "$client" --authority-public "$authority/public.json" --machine-id macbook \
+	--role receiver >/dev/null
+sh "$repo_dir/scripts/provision-attachment-v3.sh" authority-add-device \
+	--directory "$authority" --device-enrollment "$client/device-enrollment.json" >/dev/null
+
+build_dir=$(mktemp -d "${TMPDIR:-/tmp}/punaro-attachment-relay-build.XXXXXXXX")
+trap 'rm -rf -- "$build_dir"; cleanup' EXIT HUP INT TERM
+(
+	cd "$repo_dir"
+	go build -trimpath -buildvcs=true -o "$build_dir/punaro-directory" ./cmd/punaro-directory
+)
+"$build_dir/punaro-directory" build --config "$authority/directory-manifest.json" \
+	--root-private-key-file "$authority/root.private" --output "$snapshot" --ttl 2m
+
+device_id=$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["attachment_device_id"])' "$client/device-enrollment.json")
+printf '%s\n' "[{\"id\":\"macbook\",\"public_key\":\"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\",\"endpoint_prefixes\":[\"agent/macbook/\"],\"attachment_device_id\":\"$device_id\"}]" >"$machines"
+
+sh "$repo_dir/scripts/configure-attachment-v3-relay.sh" --root "$stage" \
+	--authority-public "$authority/public.json" --issuer-private-key "$authority/issuer.private" \
+	--directory-snapshot "$snapshot" --relay-machines-file "$machines" >"$fixture_dir/out"
+
+config="$stage/etc/punaro/punaro.env"
+issuer="$stage/etc/punaro/credentials/v3-issuer.private"
+published_snapshot="$stage/var/lib/punaro/private/v3-directory.snapshot"
+[ -f "$issuer" ] || { printf '%s\n' 'relay issuer key was not installed' >&2; exit 1; }
+[ -f "$published_snapshot" ] || { printf '%s\n' 'relay directory snapshot was not installed' >&2; exit 1; }
+[ "$(stat -f %Lp "$issuer" 2>/dev/null || stat -c %a "$issuer")" = 600 ] || { printf '%s\n' 'relay issuer key is not private' >&2; exit 1; }
+grep -Fqx 'PUNARO_ATTACHMENT_V3_ENABLED=true' "$config"
+grep -Fqx 'PUNARO_PERMIT_ISSUANCE_ENABLED=false' "$config"
+grep -Fqx 'PUNARO_ATTACHMENTS_ENABLED=false' "$config"
+grep -Fqx 'PUNARO_ATTACHMENT_RELAY_ENABLED=false' "$config"
+grep -Fqx 'PUNARO_DIRECTORY_ENABLED=true' "$config"
+grep -Fq "PUNARO_RELAY_MACHINES_JSON=[{\"attachment_device_id\":\"$device_id\"" "$config"
+if grep -Fq -- "$(cat "$authority/issuer.private")" "$config" "$fixture_dir/out"; then
+	printf '%s\n' 'relay configuration leaked the issuer private key' >&2; exit 1
+fi
+
+printf '%s\n' '[{"id":"macbook","public_key":"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA","endpoint_prefixes":["agent/macbook/"]}]' >"$fixture_dir/no-device-binding.json"
+set +e
+sh "$repo_dir/scripts/configure-attachment-v3-relay.sh" --root "$stage" \
+	--authority-public "$authority/public.json" --issuer-private-key "$authority/issuer.private" \
+	--directory-snapshot "$snapshot" --relay-machines-file "$fixture_dir/no-device-binding.json" >"$fixture_dir/no-binding.out" 2>&1
+status=$?
+set -e
+[ "$status" -eq 2 ] || { printf '%s\n' 'relay configuration accepted unbound machines' >&2; exit 1; }
+grep -Fqx 'relay machine enrollment must contain an attachment_device_id binding' "$fixture_dir/no-binding.out"
+
+printf '%s\n' attachment_v3_relay_configuration_tests_passed

--- a/scripts/test-provision-attachment-v3.sh
+++ b/scripts/test-provision-attachment-v3.sh
@@ -35,14 +35,14 @@ case "$(uname -s)" in
 	Darwin)
 		sh "$repo_dir/scripts/provision-attachment-v3.sh" client \
 			--directory "$client" --authority-public "$authority/public.json" --machine-id macbook \
-			--role both --host-key-service punaro.test --host-key-account macbook >"$fixture_dir/client.out"
+			--relay-url https://relay.example.invalid --role both --host-key-service punaro.test --host-key-account macbook >"$fixture_dir/client.out"
 		grep -Fqx 'PUNARO_ATTACHMENT_HOST_KEY_SERVICE=punaro.test' "$client/attachment-v3.env"
 		grep -Fqx 'PUNARO_ATTACHMENT_HOST_KEY_ACCOUNT=macbook' "$client/attachment-v3.env"
 		;;
 	*)
 		sh "$repo_dir/scripts/provision-attachment-v3.sh" client \
 			--directory "$client" --authority-public "$authority/public.json" --machine-id macbook \
-			--role both --host-credential-directory /run/credentials/punaro --host-credential-name sender-key >"$fixture_dir/client.out"
+			--relay-url https://relay.example.invalid --role both --host-credential-directory /run/credentials/punaro --host-credential-name sender-key >"$fixture_dir/client.out"
 		grep -Fqx 'PUNARO_ATTACHMENT_HOST_CREDENTIAL_DIRECTORY=/run/credentials/punaro' "$client/attachment-v3.env"
 		grep -Fqx 'PUNARO_ATTACHMENT_HOST_CREDENTIAL_NAME=sender-key' "$client/attachment-v3.env"
 		;;
@@ -54,6 +54,7 @@ done
 [ -f "$client/attachment-v3.env" ] || { printf '%s\n' 'missing attachment environment' >&2; exit 1; }
 [ -f "$client/device-enrollment.json" ] || { printf '%s\n' 'missing public device enrollment' >&2; exit 1; }
 [ "$(file_mode "$client/attachment-v3.env")" = 600 ] || { printf '%s\n' 'attachment environment is not private' >&2; exit 1; }
+grep -Fqx 'PUNARO_ATTACHMENT_RELAY_URL=https://relay.example.invalid' "$client/attachment-v3.env"
 grep -Fq '"attachment_device_id"' "$client/device-enrollment.json"
 if grep -Fq -- "$(cat "$client/device-signing.private")" "$client/device-enrollment.json"; then
 	printf '%s\n' 'client enrollment leaked the signing private key' >&2; exit 1
@@ -71,13 +72,13 @@ chmod 700 "$fake_bin/uname"
 linux_client="$fixture_dir/linux-client"
 PATH="$fake_bin:$PATH" sh "$repo_dir/scripts/provision-attachment-v3.sh" client \
 	--directory "$linux_client" --authority-public "$authority/public.json" --machine-id linuxbox \
-	--role sender --host-credential-directory /run/credentials/punaro --host-credential-name sender-key >"$fixture_dir/linux-client.out"
+	--relay-url https://relay.example.invalid --role sender --host-credential-directory /run/credentials/punaro --host-credential-name sender-key >"$fixture_dir/linux-client.out"
 grep -Fqx 'PUNARO_ATTACHMENT_HOST_CREDENTIAL_DIRECTORY=/run/credentials/punaro' "$linux_client/attachment-v3.env"
 grep -Fqx 'PUNARO_ATTACHMENT_HOST_CREDENTIAL_NAME=sender-key' "$linux_client/attachment-v3.env"
 
 set +e
 sh "$repo_dir/scripts/provision-attachment-v3.sh" client --directory "$fixture_dir/insecure" \
-	--authority-public "$authority/public.json" --machine-id macbook --role sender >"$fixture_dir/sender-without-host-key.out" 2>&1
+	--authority-public "$authority/public.json" --machine-id macbook --relay-url https://relay.example.invalid --role sender >"$fixture_dir/sender-without-host-key.out" 2>&1
 status=$?
 set -e
 [ "$status" -eq 2 ] || { printf '%s\n' 'sender provisioning accepted a missing host key reference' >&2; exit 1; }

--- a/scripts/test-provision-attachment-v3.sh
+++ b/scripts/test-provision-attachment-v3.sh
@@ -12,7 +12,10 @@ authority="$fixture_dir/authority"
 client="$fixture_dir/client"
 
 file_mode() {
-	if stat -f %Lp "$1" >/dev/null 2>&1; then stat -f %Lp "$1"; else stat -c %a "$1"; fi
+	case "$(uname -s)" in
+		Darwin) stat -f %Lp "$1" ;;
+		*) stat -c %a "$1" ;;
+	esac
 }
 
 sh "$repo_dir/scripts/provision-attachment-v3.sh" authority --directory "$authority" >"$fixture_dir/authority.out"

--- a/scripts/test-provision-attachment-v3.sh
+++ b/scripts/test-provision-attachment-v3.sh
@@ -28,9 +28,22 @@ if grep -Fq -- "$(cat "$authority/root.private")" "$authority/public.json" "$aut
 fi
 grep -Fq '"issuer"' "$authority/directory-manifest.json"
 
-sh "$repo_dir/scripts/provision-attachment-v3.sh" client \
-	--directory "$client" --authority-public "$authority/public.json" --machine-id macbook \
-	--role both --host-key-service punaro.test --host-key-account macbook >"$fixture_dir/client.out"
+case "$(uname -s)" in
+	Darwin)
+		sh "$repo_dir/scripts/provision-attachment-v3.sh" client \
+			--directory "$client" --authority-public "$authority/public.json" --machine-id macbook \
+			--role both --host-key-service punaro.test --host-key-account macbook >"$fixture_dir/client.out"
+		grep -Fqx 'PUNARO_ATTACHMENT_HOST_KEY_SERVICE=punaro.test' "$client/attachment-v3.env"
+		grep -Fqx 'PUNARO_ATTACHMENT_HOST_KEY_ACCOUNT=macbook' "$client/attachment-v3.env"
+		;;
+	*)
+		sh "$repo_dir/scripts/provision-attachment-v3.sh" client \
+			--directory "$client" --authority-public "$authority/public.json" --machine-id macbook \
+			--role both --host-credential-directory /run/credentials/punaro --host-credential-name sender-key >"$fixture_dir/client.out"
+		grep -Fqx 'PUNARO_ATTACHMENT_HOST_CREDENTIAL_DIRECTORY=/run/credentials/punaro' "$client/attachment-v3.env"
+		grep -Fqx 'PUNARO_ATTACHMENT_HOST_CREDENTIAL_NAME=sender-key' "$client/attachment-v3.env"
+		;;
+esac
 for key in device-signing.private device-hpke.private; do
 	[ -f "$client/$key" ] || { printf '%s\n' "missing client key: $key" >&2; exit 1; }
 	[ "$(file_mode "$client/$key")" = 600 ] || { printf '%s\n' "client key is not private: $key" >&2; exit 1; }
@@ -38,8 +51,6 @@ done
 [ -f "$client/attachment-v3.env" ] || { printf '%s\n' 'missing attachment environment' >&2; exit 1; }
 [ -f "$client/device-enrollment.json" ] || { printf '%s\n' 'missing public device enrollment' >&2; exit 1; }
 [ "$(file_mode "$client/attachment-v3.env")" = 600 ] || { printf '%s\n' 'attachment environment is not private' >&2; exit 1; }
-grep -Fqx 'PUNARO_ATTACHMENT_HOST_KEY_SERVICE=punaro.test' "$client/attachment-v3.env"
-grep -Fqx 'PUNARO_ATTACHMENT_HOST_KEY_ACCOUNT=macbook' "$client/attachment-v3.env"
 grep -Fq '"attachment_device_id"' "$client/device-enrollment.json"
 if grep -Fq -- "$(cat "$client/device-signing.private")" "$client/device-enrollment.json"; then
 	printf '%s\n' 'client enrollment leaked the signing private key' >&2; exit 1
@@ -67,6 +78,9 @@ sh "$repo_dir/scripts/provision-attachment-v3.sh" client --directory "$fixture_d
 status=$?
 set -e
 [ "$status" -eq 2 ] || { printf '%s\n' 'sender provisioning accepted a missing host key reference' >&2; exit 1; }
-grep -Fqx 'sender provisioning requires --host-key-service and --host-key-account' "$fixture_dir/sender-without-host-key.out"
+case "$(uname -s)" in
+	Darwin) grep -Fqx 'sender provisioning requires --host-key-service and --host-key-account' "$fixture_dir/sender-without-host-key.out" ;;
+	*) grep -Fqx 'sender provisioning requires --host-credential-directory and --host-credential-name' "$fixture_dir/sender-without-host-key.out" ;;
+esac
 
 printf '%s\n' attachment_v3_provisioning_tests_passed

--- a/scripts/test-provision-attachment-v3.sh
+++ b/scripts/test-provision-attachment-v3.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Exercise v3 authority/client provisioning without enabling a relay or
+# exposing private material.
+set -eu
+
+repo_dir=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+fixture_dir=$(mktemp -d "${TMPDIR:-/tmp}/punaro-attachment-provision-test.XXXXXXXX")
+cleanup() { chmod -R u+w -- "$fixture_dir" 2>/dev/null || true; rm -rf -- "$fixture_dir"; }
+trap cleanup EXIT HUP INT TERM
+
+authority="$fixture_dir/authority"
+client="$fixture_dir/client"
+
+file_mode() {
+	if stat -f %Lp "$1" >/dev/null 2>&1; then stat -f %Lp "$1"; else stat -c %a "$1"; fi
+}
+
+sh "$repo_dir/scripts/provision-attachment-v3.sh" authority --directory "$authority" >"$fixture_dir/authority.out"
+[ "$(file_mode "$authority")" = 700 ] || { printf '%s\n' 'authority directory is not private' >&2; exit 1; }
+for key in root.private issuer.private; do
+	[ -f "$authority/$key" ] || { printf '%s\n' "missing authority key: $key" >&2; exit 1; }
+	[ "$(file_mode "$authority/$key")" = 600 ] || { printf '%s\n' "authority key is not private: $key" >&2; exit 1; }
+done
+[ -f "$authority/public.json" ] || { printf '%s\n' 'missing public authority record' >&2; exit 1; }
+[ -f "$authority/directory-manifest.json" ] || { printf '%s\n' 'missing initial directory manifest' >&2; exit 1; }
+if grep -Fq -- "$(cat "$authority/root.private")" "$authority/public.json" "$authority/directory-manifest.json"; then
+	printf '%s\n' 'authority output leaked the root private key' >&2; exit 1
+fi
+grep -Fq '"issuer"' "$authority/directory-manifest.json"
+
+sh "$repo_dir/scripts/provision-attachment-v3.sh" client \
+	--directory "$client" --authority-public "$authority/public.json" --machine-id macbook \
+	--role both --host-key-service punaro.test --host-key-account macbook >"$fixture_dir/client.out"
+for key in device-signing.private device-hpke.private; do
+	[ -f "$client/$key" ] || { printf '%s\n' "missing client key: $key" >&2; exit 1; }
+	[ "$(file_mode "$client/$key")" = 600 ] || { printf '%s\n' "client key is not private: $key" >&2; exit 1; }
+done
+[ -f "$client/attachment-v3.env" ] || { printf '%s\n' 'missing attachment environment' >&2; exit 1; }
+[ -f "$client/device-enrollment.json" ] || { printf '%s\n' 'missing public device enrollment' >&2; exit 1; }
+[ "$(file_mode "$client/attachment-v3.env")" = 600 ] || { printf '%s\n' 'attachment environment is not private' >&2; exit 1; }
+grep -Fqx 'PUNARO_ATTACHMENT_HOST_KEY_SERVICE=punaro.test' "$client/attachment-v3.env"
+grep -Fqx 'PUNARO_ATTACHMENT_HOST_KEY_ACCOUNT=macbook' "$client/attachment-v3.env"
+grep -Fq '"attachment_device_id"' "$client/device-enrollment.json"
+if grep -Fq -- "$(cat "$client/device-signing.private")" "$client/device-enrollment.json"; then
+	printf '%s\n' 'client enrollment leaked the signing private key' >&2; exit 1
+fi
+
+sh "$repo_dir/scripts/provision-attachment-v3.sh" authority-add-device \
+	--directory "$authority" --device-enrollment "$client/device-enrollment.json" >"$fixture_dir/add-device.out"
+grep -Fq '"device"' "$authority/directory-manifest.json"
+grep -Fq '"sequence":2' "$authority/directory-manifest.json"
+
+fake_bin="$fixture_dir/fake-bin"
+mkdir "$fake_bin"
+printf '%s\n' '#!/bin/sh' 'printf "%s\\n" Linux' >"$fake_bin/uname"
+chmod 700 "$fake_bin/uname"
+linux_client="$fixture_dir/linux-client"
+PATH="$fake_bin:$PATH" sh "$repo_dir/scripts/provision-attachment-v3.sh" client \
+	--directory "$linux_client" --authority-public "$authority/public.json" --machine-id linuxbox \
+	--role sender --host-credential-directory /run/credentials/punaro --host-credential-name sender-key >"$fixture_dir/linux-client.out"
+grep -Fqx 'PUNARO_ATTACHMENT_HOST_CREDENTIAL_DIRECTORY=/run/credentials/punaro' "$linux_client/attachment-v3.env"
+grep -Fqx 'PUNARO_ATTACHMENT_HOST_CREDENTIAL_NAME=sender-key' "$linux_client/attachment-v3.env"
+
+set +e
+sh "$repo_dir/scripts/provision-attachment-v3.sh" client --directory "$fixture_dir/insecure" \
+	--authority-public "$authority/public.json" --machine-id macbook --role sender >"$fixture_dir/sender-without-host-key.out" 2>&1
+status=$?
+set -e
+[ "$status" -eq 2 ] || { printf '%s\n' 'sender provisioning accepted a missing host key reference' >&2; exit 1; }
+grep -Fqx 'sender provisioning requires --host-key-service and --host-key-account' "$fixture_dir/sender-without-host-key.out"
+
+printf '%s\n' attachment_v3_provisioning_tests_passed

--- a/scripts/test-publish-directory-snapshot.sh
+++ b/scripts/test-publish-directory-snapshot.sh
@@ -29,9 +29,9 @@ assert_rejected() {
 	[ "$output" = "$expected" ] || { printf '%s\n' "unexpected validation result for $path: $output" >&2; exit 1; }
 }
 
-assert_rejected /var/lib/punaro/private/../../etc/passwd 'PUNARO_CONTAINER_SNAPSHOT_FILE must not contain parent traversal'
-assert_rejected /var/lib/punaro/private//snapshot 'PUNARO_CONTAINER_SNAPSHOT_FILE must be canonical'
-assert_rejected /var/lib/punaro/private/nested/snapshot 'PUNARO_CONTAINER_SNAPSHOT_FILE must be directly below /var/lib/punaro/private'
+assert_rejected /etc/punaro/directory/../../etc/passwd 'PUNARO_CONTAINER_SNAPSHOT_FILE must not contain parent traversal'
+assert_rejected /etc/punaro/directory//snapshot 'PUNARO_CONTAINER_SNAPSHOT_FILE must be canonical'
+assert_rejected /etc/punaro/directory/nested/snapshot 'PUNARO_CONTAINER_SNAPSHOT_FILE must be directly below /etc/punaro/directory'
 
 publisher_env() {
 	env \

--- a/scripts/verify-deployment-files.sh
+++ b/scripts/verify-deployment-files.sh
@@ -11,17 +11,21 @@ client_installer=scripts/install-client.sh
 adapter_installer_test=scripts/test-install-adapter.sh
 server_installer=scripts/install-server.sh
 server_installer_test=scripts/test-install-server.sh
+attachment_provisioner=scripts/provision-attachment-v3.sh
+attachment_provisioner_test=scripts/test-provision-attachment-v3.sh
+attachment_relay_configurer=scripts/configure-attachment-v3-relay.sh
+attachment_relay_configurer_test=scripts/test-configure-attachment-v3-relay.sh
 agent_guidance_installer=scripts/install-agent-guidance.sh
 agent_guidance_installer_test=scripts/test-install-agent-guidance.sh
 
-for path in "$unit" "$example" "$launch_agent" "$snapshot_publisher" "$snapshot_publisher_test" "$adapter_installer" "$client_installer" "$adapter_installer_test" "$server_installer" "$server_installer_test" "$agent_guidance_installer" "$agent_guidance_installer_test"; do
+for path in "$unit" "$example" "$launch_agent" "$snapshot_publisher" "$snapshot_publisher_test" "$adapter_installer" "$client_installer" "$adapter_installer_test" "$server_installer" "$server_installer_test" "$attachment_provisioner" "$attachment_provisioner_test" "$attachment_relay_configurer" "$attachment_relay_configurer_test" "$agent_guidance_installer" "$agent_guidance_installer_test"; do
 	if [ ! -f "$path" ]; then
 		printf '%s\n' "missing adapter deployment artifact: $path" >&2
 		exit 1
 	fi
 done
 
-for executable in "$adapter_installer" "$client_installer" "$adapter_installer_test" "$server_installer" "$server_installer_test" "$agent_guidance_installer" "$agent_guidance_installer_test"; do
+for executable in "$adapter_installer" "$client_installer" "$adapter_installer_test" "$server_installer" "$server_installer_test" "$attachment_provisioner" "$attachment_provisioner_test" "$attachment_relay_configurer" "$attachment_relay_configurer_test" "$agent_guidance_installer" "$agent_guidance_installer_test"; do
 	if [ ! -x "$executable" ]; then
 		printf '%s\n' "deployment helper is not executable: $executable" >&2
 		exit 1
@@ -48,6 +52,8 @@ fi
 "$snapshot_publisher_test"
 "$adapter_installer_test"
 "$server_installer_test"
+"$attachment_provisioner_test"
+"$attachment_relay_configurer_test"
 "$agent_guidance_installer_test"
 
 for expected in \

--- a/scripts/verify-deployment-files.sh
+++ b/scripts/verify-deployment-files.sh
@@ -70,15 +70,15 @@ for expected in \
 	'close_fds=True' \
 	'PUNARO_CONTAINER_SNAPSHOT_FILE must be canonical' \
 	'PUNARO_CONTAINER_SNAPSHOT_FILE must not contain parent traversal' \
-	'PUNARO_CONTAINER_SNAPSHOT_FILE must be directly below /var/lib/punaro/private' \
-	'/root/.punaro-directory-stage' \
-	'install -d -o root -g punaro -m 2750 /var/lib/punaro/private' \
+	'PUNARO_CONTAINER_SNAPSHOT_FILE must be directly below /etc/punaro/directory' \
+	'/etc/punaro/.punaro-directory-stage' \
+	'install -d -o root -g punaro -m 2750 /etc/punaro/directory' \
 	'chown root:punaro' \
 	'[ ! -L' \
 	'[ ! -L \"\$parent\" ]' \
 	'stat -c %d' \
 	'--ttl 2m' \
-	'PUNARO_CONTAINER_SNAPSHOT_FILE must be below /var/lib/punaro/private' \
+	'PUNARO_CONTAINER_SNAPSHOT_FILE must be below /etc/punaro/directory' \
 	'PUNARO_CONTAINER_SNAPSHOT_FILE contains unsafe characters' \
 	'directory_snapshot_published'; do
 	if ! grep -Fq -- "$expected" "$snapshot_publisher"; then


### PR DESCRIPTION
## What changed

- Adds explicit offline-authority, per-client device, and relay-v3 provisioning helpers.
- Keeps root keys offline; copies only the relay issuer key and signed snapshot to private service paths.
- Enforces explicit machine-to-directory-device binding and disables legacy v2 switches during v3 activation.
- Adds staged fixture tests, deployment-lint integration, and installation/operator documentation for macOS Keychain and Linux systemd credential references.

## Why

The text relay installer did not provide a safe, repeatable way to provision or turn on controlled attachment v3.

## Validation

- make test
- make test-race
- make staticcheck
- make security
- make lint
- make deployment-lint
- Secret/deployment-detail scan: no real credentials, 1Password references, hostnames, account IDs, or tokens added.