### PR TITLE
Fix canonical machine key generation

### DIFF
--- a/cmd/punaro-keygen/main.go
+++ b/cmd/punaro-keygen/main.go
@@ -138,6 +138,18 @@ func normalizeLegacyPrivateKey(path string) error {
 	if err := os.Rename(temporaryPath, path); err != nil {
 		return fmt.Errorf("replace legacy private key: %w", err)
 	}
+	// #nosec G304 -- parent was verified as the private, owned directory above.
+	directory, err := os.Open(parent)
+	if err != nil {
+		return fmt.Errorf("open private key parent after replacement: %w", err)
+	}
+	if err := directory.Sync(); err != nil {
+		_ = directory.Close()
+		return fmt.Errorf("sync private key parent after replacement: %w", err)
+	}
+	if err := directory.Close(); err != nil {
+		return fmt.Errorf("close private key parent after replacement: %w", err)
+	}
 	return nil
 }
 

--- a/cmd/punaro-keygen/main.go
+++ b/cmd/punaro-keygen/main.go
@@ -14,6 +14,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"syscall"
 
 	"github.com/rock3r/punaro/internal/relay"
 )
@@ -85,15 +86,15 @@ func normalizeLegacyPrivateKey(path string) error {
 	}
 	parent := filepath.Dir(path)
 	parentInfo, err := os.Lstat(parent)
-	if err != nil || !parentInfo.IsDir() || parentInfo.Mode()&os.ModeSymlink != 0 || parentInfo.Mode().Perm()&0o077 != 0 {
-		return errors.New("legacy private key parent must be private and non-symlinked")
+	if err != nil || !isPrivateOwnedDirectory(parentInfo) {
+		return errors.New("legacy private key parent must be private, owned, and non-symlinked")
 	}
 	info, err := os.Lstat(path)
-	if err != nil || !info.Mode().IsRegular() || info.Mode()&os.ModeSymlink != 0 || info.Mode().Perm()&0o077 != 0 {
-		return errors.New("legacy private key file must be private and non-symlinked")
+	if err != nil || !isPrivateOwnedRegularFile(info) {
+		return errors.New("legacy private key file must be private, owned, and non-symlinked")
 	}
 	// #nosec G304 -- path is an explicit migration target, constrained above to a
-	// private, absolute, non-symlinked regular file.
+	// private, owned, absolute, non-symlinked regular file.
 	file, err := os.Open(path)
 	if err != nil {
 		return errors.New("legacy private key is unavailable")
@@ -138,6 +139,16 @@ func normalizeLegacyPrivateKey(path string) error {
 		return fmt.Errorf("replace legacy private key: %w", err)
 	}
 	return nil
+}
+
+func isPrivateOwnedDirectory(info os.FileInfo) bool {
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	return ok && info.IsDir() && info.Mode()&os.ModeSymlink == 0 && info.Mode().Perm()&0o077 == 0 && int(stat.Uid) == os.Geteuid()
+}
+
+func isPrivateOwnedRegularFile(info os.FileInfo) bool {
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	return ok && info.Mode().IsRegular() && info.Mode()&os.ModeSymlink == 0 && info.Mode().Perm()&0o077 == 0 && int(stat.Uid) == os.Geteuid()
 }
 
 func newMachineKey(id, prefix string) (ed25519.PrivateKey, relay.Machine, error) {

--- a/cmd/punaro-keygen/main.go
+++ b/cmd/punaro-keygen/main.go
@@ -7,9 +7,12 @@ import (
 	"crypto/rand"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
+	"io"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/rock3r/punaro/internal/relay"
@@ -20,8 +23,18 @@ func main() {
 	id := flags.String("id", "", "machine ID")
 	prefix := flags.String("endpoint-prefix", "", "exclusive endpoint prefix")
 	privateFile := flags.String("private-key-file", "", "new private key file (must not exist)")
+	normalizeLegacyFile := flags.String("normalize-legacy-private-key-file", "", "atomically remove the legacy trailing newline from one private key file")
 	if err := flags.Parse(os.Args[1:]); err != nil {
 		fail(err)
+	}
+	if *normalizeLegacyFile != "" {
+		if *id != "" || *prefix != "" || *privateFile != "" || flags.NArg() != 0 {
+			fail(errors.New("--normalize-legacy-private-key-file cannot be combined with key-generation flags"))
+		}
+		if err := normalizeLegacyPrivateKey(*normalizeLegacyFile); err != nil {
+			fail(err)
+		}
+		return
 	}
 	private, enrollment, err := newMachineKey(*id, *prefix)
 	if err != nil {
@@ -30,16 +43,8 @@ func main() {
 	if strings.TrimSpace(*privateFile) == "" {
 		fail(fmt.Errorf("--private-key-file is required"))
 	}
-	file, err := os.OpenFile(*privateFile, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
-	if err != nil {
-		fail(fmt.Errorf("create private key file: %w", err))
-	}
-	if _, err := file.WriteString(base64.RawURLEncoding.EncodeToString(private) + "\n"); err != nil {
-		_ = file.Close()
-		fail(fmt.Errorf("write private key file: %w", err))
-	}
-	if err := file.Close(); err != nil {
-		fail(fmt.Errorf("close private key file: %w", err))
+	if err := writePrivateKey(*privateFile, private); err != nil {
+		fail(err)
 	}
 	output := struct {
 		ID               string   `json:"id"`
@@ -49,6 +54,90 @@ func main() {
 	if err := json.NewEncoder(os.Stdout).Encode(output); err != nil {
 		fail(err)
 	}
+}
+
+func encodePrivateKey(private ed25519.PrivateKey) []byte {
+	return []byte(base64.RawURLEncoding.EncodeToString(private))
+}
+
+func writePrivateKey(path string, private ed25519.PrivateKey) error {
+	// #nosec G304 -- path is an explicit CLI output selected by the local owner.
+	file, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
+	if err != nil {
+		return fmt.Errorf("create private key file: %w", err)
+	}
+	if _, err := file.Write(encodePrivateKey(private)); err != nil {
+		_ = file.Close()
+		return fmt.Errorf("write private key file: %w", err)
+	}
+	if err := file.Close(); err != nil {
+		return fmt.Errorf("close private key file: %w", err)
+	}
+	return nil
+}
+
+// normalizeLegacyPrivateKey performs the one supported migration from the
+// historical newline-terminated writer to the canonical raw-base64url format.
+// It validates the whole Ed25519 private key before atomically replacing it.
+func normalizeLegacyPrivateKey(path string) error {
+	if !filepath.IsAbs(path) {
+		return errors.New("legacy private key path must be absolute")
+	}
+	parent := filepath.Dir(path)
+	parentInfo, err := os.Lstat(parent)
+	if err != nil || !parentInfo.IsDir() || parentInfo.Mode()&os.ModeSymlink != 0 || parentInfo.Mode().Perm()&0o077 != 0 {
+		return errors.New("legacy private key parent must be private and non-symlinked")
+	}
+	info, err := os.Lstat(path)
+	if err != nil || !info.Mode().IsRegular() || info.Mode()&os.ModeSymlink != 0 || info.Mode().Perm()&0o077 != 0 {
+		return errors.New("legacy private key file must be private and non-symlinked")
+	}
+	// #nosec G304 -- path is an explicit migration target, constrained above to a
+	// private, absolute, non-symlinked regular file.
+	file, err := os.Open(path)
+	if err != nil {
+		return errors.New("legacy private key is unavailable")
+	}
+	raw, readErr := io.ReadAll(io.LimitReader(file, int64(base64.RawURLEncoding.EncodedLen(ed25519.PrivateKeySize)+2)))
+	opened, statErr := file.Stat()
+	closeErr := file.Close()
+	if readErr != nil || statErr != nil || closeErr != nil || !opened.Mode().IsRegular() || !os.SameFile(info, opened) {
+		return errors.New("legacy private key is unavailable")
+	}
+	encodedLength := base64.RawURLEncoding.EncodedLen(ed25519.PrivateKeySize)
+	if len(raw) != encodedLength+1 || raw[encodedLength] != '\n' {
+		return errors.New("legacy private key does not have exactly one trailing newline")
+	}
+	encoded := raw[:encodedLength]
+	private, err := base64.RawURLEncoding.DecodeString(string(encoded))
+	if err != nil || len(private) != ed25519.PrivateKeySize || string(encodePrivateKey(ed25519.PrivateKey(private))) != string(encoded) || !ed25519.PrivateKey(private).Equal(ed25519.NewKeyFromSeed(ed25519.PrivateKey(private).Seed())) {
+		return errors.New("legacy private key is not a canonical Ed25519 private key")
+	}
+	temporary, err := os.CreateTemp(parent, ".punaro-machine-key-*")
+	if err != nil {
+		return fmt.Errorf("create private key migration file: %w", err)
+	}
+	temporaryPath := temporary.Name()
+	defer func() { _ = os.Remove(temporaryPath) }()
+	if err := temporary.Chmod(0o600); err != nil {
+		_ = temporary.Close()
+		return fmt.Errorf("set private key migration mode: %w", err)
+	}
+	if _, err := temporary.Write(encoded); err != nil {
+		_ = temporary.Close()
+		return fmt.Errorf("write private key migration file: %w", err)
+	}
+	if err := temporary.Sync(); err != nil {
+		_ = temporary.Close()
+		return fmt.Errorf("sync private key migration file: %w", err)
+	}
+	if err := temporary.Close(); err != nil {
+		return fmt.Errorf("close private key migration file: %w", err)
+	}
+	if err := os.Rename(temporaryPath, path); err != nil {
+		return fmt.Errorf("replace legacy private key: %w", err)
+	}
+	return nil
 }
 
 func newMachineKey(id, prefix string) (ed25519.PrivateKey, relay.Machine, error) {

--- a/cmd/punaro-keygen/main_test.go
+++ b/cmd/punaro-keygen/main_test.go
@@ -4,10 +4,24 @@ import (
 	"crypto/ed25519"
 	"os"
 	"path/filepath"
+	"syscall"
 	"testing"
+	"time"
 
 	attachmentv2 "github.com/rock3r/punaro/internal/attachment/v2"
 )
+
+type testFileInfo struct {
+	mode os.FileMode
+	sys  any
+}
+
+func (info testFileInfo) Name() string       { return "fixture" }
+func (info testFileInfo) Size() int64        { return 0 }
+func (info testFileInfo) Mode() os.FileMode  { return info.mode }
+func (info testFileInfo) ModTime() time.Time { return time.Time{} }
+func (info testFileInfo) IsDir() bool        { return info.mode.IsDir() }
+func (info testFileInfo) Sys() any           { return info.sys }
 
 func privateTestDirectory(t *testing.T) string {
 	t.Helper()
@@ -27,6 +41,28 @@ func TestNewMachineKeyProducesEd25519KeypairAndPublicEnrollment(t *testing.T) {
 	}
 	if len(private) != ed25519.PrivateKeySize || enrollment.ID != "mac-review" || len(enrollment.PublicKey) != ed25519.PublicKeySize || len(enrollment.EndpointPrefixes) != 1 {
 		t.Fatal("invalid generated machine enrollment")
+	}
+}
+
+func TestPrivateOwnershipChecksRejectOtherUsers(t *testing.T) {
+	t.Parallel()
+	// #nosec G115 -- os.Geteuid is non-negative on the supported Unix targets.
+	owner := uint32(os.Geteuid())
+	notOwner := owner + 1
+	if notOwner == owner {
+		notOwner--
+	}
+	if !isPrivateOwnedDirectory(testFileInfo{mode: os.ModeDir | 0o700, sys: &syscall.Stat_t{Uid: owner}}) {
+		t.Fatal("current-user private directory was rejected")
+	}
+	if isPrivateOwnedDirectory(testFileInfo{mode: os.ModeDir | 0o700, sys: &syscall.Stat_t{Uid: notOwner}}) {
+		t.Fatal("other-user private directory was accepted")
+	}
+	if !isPrivateOwnedRegularFile(testFileInfo{mode: 0o600, sys: &syscall.Stat_t{Uid: owner}}) {
+		t.Fatal("current-user private file was rejected")
+	}
+	if isPrivateOwnedRegularFile(testFileInfo{mode: 0o600, sys: &syscall.Stat_t{Uid: notOwner}}) {
+		t.Fatal("other-user private file was accepted")
 	}
 }
 

--- a/cmd/punaro-keygen/main_test.go
+++ b/cmd/punaro-keygen/main_test.go
@@ -2,8 +2,22 @@ package main
 
 import (
 	"crypto/ed25519"
+	"os"
+	"path/filepath"
 	"testing"
+
+	attachmentv2 "github.com/rock3r/punaro/internal/attachment/v2"
 )
+
+func privateTestDirectory(t *testing.T) string {
+	t.Helper()
+	directory, err := os.MkdirTemp("", "punaro-keygen-test-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(directory) })
+	return directory
+}
 
 func TestNewMachineKeyProducesEd25519KeypairAndPublicEnrollment(t *testing.T) {
 	t.Parallel()
@@ -13,5 +27,56 @@ func TestNewMachineKeyProducesEd25519KeypairAndPublicEnrollment(t *testing.T) {
 	}
 	if len(private) != ed25519.PrivateKeySize || enrollment.ID != "mac-review" || len(enrollment.PublicKey) != ed25519.PublicKeySize || len(enrollment.EndpointPrefixes) != 1 {
 		t.Fatal("invalid generated machine enrollment")
+	}
+}
+
+func TestWritePrivateKeyUsesCanonicalRawBase64URL(t *testing.T) {
+	t.Parallel()
+	private, _, err := newMachineKey("mac-review", "agent/mac-review/")
+	if err != nil {
+		t.Fatal(err)
+	}
+	directory := privateTestDirectory(t)
+	path := filepath.Join(directory, "machine.key")
+	if err := writePrivateKey(path, private); err != nil {
+		t.Fatal(err)
+	}
+	// #nosec G304 -- test-owned path inside a private temporary directory.
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(raw) != 86 || raw[len(raw)-1] == '\n' {
+		t.Fatalf("machine key is not canonical raw base64url: %q", raw)
+	}
+	if _, err := attachmentv2.LoadPrivateEd25519KeyFile(path); err != nil {
+		t.Fatalf("canonical machine key is not accepted by v3: %v", err)
+	}
+}
+
+func TestNormalizeLegacyPrivateKeyRemovesOnlyTrailingNewline(t *testing.T) {
+	t.Parallel()
+	private, _, err := newMachineKey("mac-review", "agent/mac-review/")
+	if err != nil {
+		t.Fatal(err)
+	}
+	directory := privateTestDirectory(t)
+	path := filepath.Join(directory, "machine.key")
+	if err := os.WriteFile(path, append(encodePrivateKey(private), '\n'), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := normalizeLegacyPrivateKey(path); err != nil {
+		t.Fatal(err)
+	}
+	// #nosec G304 -- test-owned path inside a private temporary directory.
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(raw) != 86 || raw[len(raw)-1] == '\n' {
+		t.Fatalf("legacy key was not normalized: %q", raw)
+	}
+	if _, err := attachmentv2.LoadPrivateEd25519KeyFile(path); err != nil {
+		t.Fatalf("normalized machine key is not accepted by v3: %v", err)
 	}
 }

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -115,11 +115,12 @@ v3 preflight. This preserves the same public key and does **not** require a
 relay enrollment change:
 
 ```sh
-punaro-keygen --normalize-legacy-private-key-file \
+go run ./cmd/punaro-keygen --normalize-legacy-private-key-file \
   "$HOME/.config/punaro/machine.key"
 ```
 
-Use the actual absolute `PUNARO_MACHINE_PRIVATE_KEY_FILE` path from
+Run this from the same reviewed Punaro checkout used for client installation,
+and use the actual absolute `PUNARO_MACHINE_PRIVATE_KEY_FILE` path from
 `adapter.env`. The command accepts only a private, non-symlinked regular file
 with exactly one legacy trailing newline, validates the complete Ed25519 key,
 and atomically replaces it with the canonical form. It never prints key

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -106,6 +106,25 @@ and local paths. It refuses to overwrite an existing key, enrollment record,
 configuration file, or project skill that does not match. To revoke a client,
 follow the [alpha onboarding revocation procedure](alpha-text-relay.md#onboard-and-revoke-a-machine): remove attached aliases, remove the relay enrollment, revoke the machine's Access token, stop the service, and securely erase its key.
 
+### Migrate a pre-v3 client key
+
+Older client installers wrote a harmless trailing newline after the encoded
+machine private key. Attachment v3 correctly requires the canonical raw
+base64url form, so migrate an existing enrolled key in place before its first
+v3 preflight. This preserves the same public key and does **not** require a
+relay enrollment change:
+
+```sh
+punaro-keygen --normalize-legacy-private-key-file \
+  "$HOME/.config/punaro/machine.key"
+```
+
+Use the actual absolute `PUNARO_MACHINE_PRIVATE_KEY_FILE` path from
+`adapter.env`. The command accepts only a private, non-symlinked regular file
+with exactly one legacy trailing newline, validates the complete Ed25519 key,
+and atomically replaces it with the canonical form. It never prints key
+material. New client installations already use the canonical format.
+
 ## 4. Provision and enable controlled attachment v3
 
 Attachment v3 has an explicit, multi-role setup. Do not enable it by setting


### PR DESCRIPTION
## What changed

- Write new machine private-key files in the canonical raw-base64url form required by attachment v3.
- Add a narrowly constrained, atomic migration for older newline-terminated local machine keys.
- Document the in-place migration; it preserves the enrolled public key and does not change relay enrollment.

## Root cause

The historical key generator appended a newline, while the v3 private-key loader correctly accepts only canonical raw-base64url private keys.

## Validation

- `make test`
- `make test-race`
- `make staticcheck`
- `make security`
- `make lint`
