### PR TITLE
Fix Windows adapter task startup

### DIFF
--- a/scripts/install-client.ps1
+++ b/scripts/install-client.ps1
@@ -261,7 +261,8 @@ if (Test-Path -LiteralPath $configFile) {
 & $mailbox '--state-dir' $MailboxStateDir 'group' 'create' '--group' $AttachedGroup
 if ($LASTEXITCODE -ne 0) {
     $groups = Invoke-Program -Program $mailbox -Arguments @('--state-dir', $MailboxStateDir, 'group', 'list', '--json') -Description 'attachment group lookup' | ConvertFrom-Json
-    if ($groups -notcontains $AttachedGroup) { Stop-Install 'could not create the local Punaro attachment group' }
+    $groupAddresses = @($groups | ForEach-Object { $_.address })
+    if ($groupAddresses -notcontains $AttachedGroup) { Stop-Install 'could not create the local Punaro attachment group' }
 }
 
 if (-not [string]::IsNullOrWhiteSpace($AttachmentRole)) {
@@ -274,7 +275,7 @@ try {
     $windowsPowerShell = if (-not [string]::IsNullOrWhiteSpace($powerShellCommand.Path)) { $powerShellCommand.Path } else { $powerShellCommand.Source }
     if ([string]::IsNullOrWhiteSpace($windowsPowerShell)) { Stop-Install 'Windows PowerShell is required to register the adapter task' }
 } catch { Stop-Install 'Windows PowerShell is required to register the adapter task' }
-$action = New-ScheduledTaskAction -Execute $windowsPowerShell -Argument ('-NoProfile -NonInteractive -File "{0}"' -f $runner)
+$action = New-ScheduledTaskAction -Execute $windowsPowerShell -Argument ('-NoProfile -NonInteractive -ExecutionPolicy Bypass -File "{0}"' -f $runner)
 $trigger = New-ScheduledTaskTrigger -AtLogOn -User $user
 $principal = New-ScheduledTaskPrincipal -UserId $user -LogonType Interactive -RunLevel Limited
 $settings = New-ScheduledTaskSettingsSet -AllowStartIfOnBatteries -DontStopIfGoingOnBatteries -ExecutionTimeLimit ([TimeSpan]::Zero)

--- a/scripts/test-install-client-windows.ps1
+++ b/scripts/test-install-client-windows.ps1
@@ -17,7 +17,7 @@ foreach ($path in $paths) {
 }
 
 $installer = [System.IO.File]::ReadAllText((Join-Path $repoDir 'scripts\install-client.ps1'))
-foreach ($expected in @('LogonType Interactive', 'ExecutionTimeLimit ([TimeSpan]::Zero)', 'SetAccessRuleProtection($true, $false)', 'PUNARO_ATTACHMENT_HOST_DPAPI_FILE', 'punaro-dpapi.exe', 'agent-mailbox', 'AgentGuidanceDir')) {
+foreach ($expected in @('LogonType Interactive', 'ExecutionTimeLimit ([TimeSpan]::Zero)', 'SetAccessRuleProtection($true, $false)', '-ExecutionPolicy Bypass', 'ForEach-Object { $_.address }', 'PUNARO_ATTACHMENT_HOST_DPAPI_FILE', 'punaro-dpapi.exe', 'agent-mailbox', 'AgentGuidanceDir')) {
     if (-not $installer.Contains($expected)) { throw "Windows installer is missing required behavior: $expected" }
 }
 $allScripts = ($paths | ForEach-Object { [System.IO.File]::ReadAllText($_) }) -join "`n"
@@ -38,6 +38,7 @@ try {
 
     $global:punaroRegisteredTask = $null
     $global:punaroRegisteredSettings = $null
+    $global:punaroRegisteredAction = $null
     function New-ScheduledTaskAction { param([string]$Execute, [string]$Argument) return [pscustomobject]@{ Execute = $Execute; Argument = $Argument } }
     function New-ScheduledTaskTrigger { param([switch]$AtLogOn, [string]$User) return [pscustomobject]@{ User = $User } }
     function New-ScheduledTaskPrincipal { param([string]$UserId, [string]$LogonType, [string]$RunLevel) return [pscustomobject]@{ UserId = $UserId } }
@@ -46,6 +47,7 @@ try {
         param([string]$TaskName, $Action, $Trigger, $Principal, $Settings, [string]$Description, [switch]$Force)
         $global:punaroRegisteredTask = $TaskName
         $global:punaroRegisteredSettings = $Settings
+        $global:punaroRegisteredAction = $Action
         return [pscustomobject]@{}
     }
 
@@ -57,6 +59,22 @@ try {
     }
     if ($global:punaroRegisteredTask -ne 'Punaro Adapter') { throw 'Windows client installer did not register the expected per-user task' }
     if ($global:punaroRegisteredSettings.ExecutionTimeLimit -ne [TimeSpan]::Zero) { throw 'Windows client adapter task must have no execution time limit' }
+    if (-not ([string]$global:punaroRegisteredAction.Argument -match '(^|\s)-ExecutionPolicy\s+Bypass(\s|$)')) { throw 'Windows client adapter task must use only process-scoped ExecutionPolicy Bypass' }
+    $existingGroupMailbox = @'
+@echo off
+echo %* | findstr /C:"group create" >nul
+if not errorlevel 1 (
+  echo group already exists 1>&2
+  exit /b 1
+)
+echo %* | findstr /C:"group list --json" >nul
+if not errorlevel 1 (
+  echo [{"group_id":"grp_test","address":"group/punaro-attached","created_at":"2026-01-01T00:00:00Z"}]
+  exit /b 0
+)
+exit /b 0
+'@
+    [System.IO.File]::WriteAllText($mailbox, $existingGroupMailbox, [System.Text.Encoding]::ASCII)
     & (Join-Path $repoDir 'scripts\install-client.ps1') -RelayUrl 'https://relay.example.test' -MachineId 'windows-test' -AgentMailboxBin $mailbox -AgentGuidanceDir $project
     if ($LASTEXITCODE -ne 0) { throw 'Windows client installer was not idempotent' }
 } finally {


### PR DESCRIPTION
## Summary

- start the Windows adapter scheduled task with process-scoped PowerShell policy bypass, preserving a restrictive machine policy
- recognize `agent-mailbox group list --json` records by their `address`, so a rerun accepts an already-bound attachment group
- cover both installer invariants in the Windows PowerShell regression test

## Root cause

The scheduled task omitted the policy override required to run its checked-in runner under a Restricted execution policy. Separately, the installer compared a JSON object to the group-address string rather than comparing the object’s address field.

## Validation

- Windows PowerShell installer regression test on Mattone (including the Go/MSYS2 toolchain)
- `make test`
- `make test-race`
- `make lint`
- `make security`
- `make release-gates`
- live Mattone Cloudflare Access health preflight (200), with credentials never printed
