### PR TITLE
M-2: add PostgreSQL control-plane primitives

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -523,6 +523,16 @@ dirty, old, newer, or incompatible schemas without performing DDL. The normal
 application role is distinct from the schema owner. SQLite remains the active
 and default relay authority until the later fenced mail cutover.
 
+The second dark foundation slice adds opaque principals/projects, explicit
+selected-project and dynamic all-project capability grants, globally unique
+operation-bound idempotency keys, closed content-free audit events, and a
+capacity-bounded transactional work queue. Project creation proves that
+authorization, immutable retry outcome, ordinary creator grants, audit, queued
+work, and one change-sequence advance commit atomically. Worker publication is
+accepted only for the exact unexpired lease token and generation. None of these
+primitives is exposed through the alpha HTTP relay yet, and they do not change
+SQLite routing or establish a production authority barrier.
+
 ## Required adversarial acceptance tests
 
 The implementation is not internet-exposure-ready until these cases pass:

--- a/README.md
+++ b/README.md
@@ -72,8 +72,11 @@ make test-postgres
 ```
 
 That target starts a fresh private, digest-pinned pgvector service, runs the
-PostgreSQL substrate contract tests inside the isolated network, and removes
-the database volume afterward. It requires Docker Compose v2.
+PostgreSQL substrate and dark control-plane contract tests inside the isolated
+network, and removes the database volume afterward. The tests cover migration
+compatibility, explicit project scopes, operation-bound idempotency, closed
+audit records, queue ceilings, and fenced job leases. It requires Docker
+Compose v2 and does not switch the active SQLite relay.
 
 ## Configuration and secrets
 

--- a/docs/operator-guide.md
+++ b/docs/operator-guide.md
@@ -423,7 +423,7 @@ create or repair schema objects. A pristine, dirty, upgrade-required, newer, or
 incompatible schema makes startup fail with a content-free classification. Do
 not grant DDL to `punaro_app` to bypass that refusal.
 
-M-1 exposes the schema-owner action directly for controlled development and
+M-1/M-2 expose the schema-owner action directly for controlled development and
 integration use:
 
 ```sh
@@ -441,7 +441,7 @@ docker run --rm --entrypoint /usr/local/bin/punaro-migrate \
   PUNARO_IMAGE_BY_DIGEST -owner-dsn-file /run/secrets/owner.dsn
 ```
 
-The initial M-1 role contract uses the exact roles `punaro_owner` and
+The role contract uses the exact roles `punaro_owner` and
 `punaro_app`. Provision `punaro_app` first as a login with no superuser,
 database-create, role-create, public-schema-create, or `punaro_owner` membership;
 the migrator refuses to bootstrap otherwise. The owner DSN must authenticate
@@ -456,6 +456,15 @@ recovery arrive in later milestones, so this command is not yet a production
 update procedure. The digest-pinned `make test-postgres` stack is ephemeral
 test infrastructure, publishes no database port, and deletes its volume on
 exit.
+
+The current binary requires schema version 2. Version 1 is reported as
+`upgrade_required`; damaged version-1 objects remain `incompatible`. Migration
+2 is additive and creates only dark control-plane rows and bounded queue/audit
+primitives. There is still no supported public project/grant/job API, device
+enrollment, relay cutover, backup, or production update wrapper. Do not hand
+edit idempotency, capacity, lease, migration, or audit rows to bypass a failure.
+Before any later authority cutover, rollback remains disabling the PostgreSQL
+opt-in and retaining SQLite as the unchanged active relay.
 
 ## Operations and incident response
 

--- a/docs/platform-contracts.md
+++ b/docs/platform-contracts.md
@@ -90,14 +90,17 @@ delivery destination requires separate fan-out. Database constraints and a
 locked capacity counter bound payload size, depth, attempts, and state. Claims
 use `FOR UPDATE SKIP LOCKED`, database-time expiry, a fresh token, and an
 increasing generation. Completion or retry requires the exact unexpired fence;
-expired final attempts become terminal failures. Terminal and audit pruning is
-limited to bounded security-definer functions. Audit rows contain only closed
+the holder must also remain active and authorized for the job project. Expired
+final attempts become terminal failures independently of caller authorization,
+so dead rows cannot pin queue capacity. Terminal and audit pruning is limited
+to bounded security-definer functions. Audit rows contain only closed
 action/outcome/target classes, opaque IDs, sequence, and time—never arbitrary
 details.
 
 Queue scheduling is a bounded delay from PostgreSQL time, never an
 application-clock timestamp. Each claimable job kind maps to a server-selected
-capability; only an active principal holding that capability for the opaque job
+capability and target shape; enqueue rejects unknown kinds and missing required
+project IDs. Only an active principal holding that capability for the opaque job
 project can receive its payload and lease fence. Unknown kinds, disabled
 principals, and unauthorized holders receive no lease.
 

--- a/docs/platform-contracts.md
+++ b/docs/platform-contracts.md
@@ -79,6 +79,13 @@ dynamic-all scoped, while only `project.create` is currently installation
 scoped. A dynamic grant applies to current and future projects but still
 requires the queried opaque project to exist.
 
+Grant and revoke mutations carry an explicit acting principal and lock its
+active administration grant in the same transaction. Exact-project
+`project.administer` can mutate grants only for that project; dynamic
+all-project `project.administer` can mutate selected-project, installation, and
+all-project grants. `project.create`, subject identifiers, and requested scopes
+never authorize grant administration.
+
 Idempotency keys are globally unique UUIDs bound to principal, operation, and a
 SHA-256 request hash. Only the hash and a bounded immutable JSON outcome are
 stored; the request body is not. Exact concurrent and lost-response retries
@@ -103,6 +110,14 @@ capability and target shape; enqueue rejects unknown kinds and missing required
 project IDs. Only an active principal holding that capability for the opaque job
 project can receive its payload and lease fence. Unknown kinds, disabled
 principals, and unauthorized holders receive no lease.
+
+Enqueue, completion, retry/failure, and exhausted-lease terminalization append
+closed, content-free job audit events in the same transaction as the queue
+state change. Claim locks the exact active principal/grant evidence used to
+authorize the lease, so concurrent disablement or revocation cannot commit
+between authorization and lease publication. A bounded `SKIP LOCKED`
+pre-candidate batch first reserves disjoint job rows, then locks authorization
+evidence only for those projects instead of unrelated grants held by the worker.
 
 ## Server invariants
 

--- a/docs/platform-contracts.md
+++ b/docs/platform-contracts.md
@@ -95,6 +95,12 @@ limited to bounded security-definer functions. Audit rows contain only closed
 action/outcome/target classes, opaque IDs, sequence, and time—never arbitrary
 details.
 
+Queue scheduling is a bounded delay from PostgreSQL time, never an
+application-clock timestamp. Each claimable job kind maps to a server-selected
+capability; only an active principal holding that capability for the opaque job
+project can receive its payload and lease fence. Unknown kinds, disabled
+principals, and unauthorized holders receive no lease.
+
 ## Server invariants
 
 - At-least-once mail delivery, immutable message IDs, operation-bound

--- a/docs/platform-contracts.md
+++ b/docs/platform-contracts.md
@@ -68,6 +68,33 @@ implementation it replaces where parity is required. Transactions stay inside
 one store when possible; cross-domain atomic operations are explicit service
 methods whose interface documents the shared transaction boundary.
 
+### Implemented dark control-plane primitives
+
+Schema version 2 is the minimum for the current PostgreSQL opt-in. It adds
+opaque principals and projects, active capability grants with exactly one of
+installation, selected-project, or dynamic all-project scope, generic
+idempotency, closed audit events, and one transactional work/outbox table.
+`project.discover` is never installation-wide: it is selected-project or
+dynamic-all scoped, while only `project.create` is currently installation
+scoped. A dynamic grant applies to current and future projects but still
+requires the queried opaque project to exist.
+
+Idempotency keys are globally unique UUIDs bound to principal, operation, and a
+SHA-256 request hash. Only the hash and a bounded immutable JSON outcome are
+stored; the request body is not. Exact concurrent and lost-response retries
+return the first outcome. Reusing a key with another body, operation, or
+principal returns one content-free conflict.
+
+The work table is both transactional outbox and worker queue until a real
+delivery destination requires separate fan-out. Database constraints and a
+locked capacity counter bound payload size, depth, attempts, and state. Claims
+use `FOR UPDATE SKIP LOCKED`, database-time expiry, a fresh token, and an
+increasing generation. Completion or retry requires the exact unexpired fence;
+expired final attempts become terminal failures. Terminal and audit pruning is
+limited to bounded security-definer functions. Audit rows contain only closed
+action/outcome/target classes, opaque IDs, sequence, and time—never arbitrary
+details.
+
 ## Server invariants
 
 - At-least-once mail delivery, immutable message IDs, operation-bound

--- a/internal/postgres/control.go
+++ b/internal/postgres/control.go
@@ -248,12 +248,12 @@ type EnqueueJob struct {
 	ProjectID   string
 	Payload     json.RawMessage
 	MaxAttempts int
-	AvailableAt time.Time
+	Delay       time.Duration
 }
 
 // Validate enforces queue storage and retry ceilings before a transaction starts.
 func (j EnqueueJob) Validate() error {
-	if !boundedTokenPattern.MatchString(j.Kind) || (j.ProjectID != "" && !validOpaqueID(j.ProjectID)) || len(j.Payload) == 0 || len(j.Payload) > maxJobPayloadBytes || !json.Valid(j.Payload) || j.MaxAttempts < 1 || j.MaxAttempts > maxJobAttempts {
+	if !boundedTokenPattern.MatchString(j.Kind) || (j.ProjectID != "" && !validOpaqueID(j.ProjectID)) || len(j.Payload) == 0 || len(j.Payload) > maxJobPayloadBytes || !json.Valid(j.Payload) || j.MaxAttempts < 1 || j.MaxAttempts > maxJobAttempts || j.Delay < 0 || j.Delay > maxJobDelay {
 		return errors.New("invalid job")
 	}
 	return nil
@@ -277,5 +277,5 @@ func (c ClaimJobs) Validate() error {
 
 func validOpaqueID(value string) bool {
 	id, err := uuid.Parse(value)
-	return err == nil && id != uuid.Nil
+	return err == nil && id != uuid.Nil && id.String() == value
 }

--- a/internal/postgres/control.go
+++ b/internal/postgres/control.go
@@ -184,6 +184,7 @@ const (
 	AuditGrantDelete     AuditAction = "grant.delete"
 	AuditJobEnqueue      AuditAction = "job.enqueue"
 	AuditJobComplete     AuditAction = "job.complete"
+	AuditJobRetry        AuditAction = "job.retry"
 	AuditJobFail         AuditAction = "job.fail"
 )
 
@@ -208,7 +209,7 @@ const (
 )
 
 var validAuditActions = map[AuditAction]struct{}{
-	AuditPrincipalCreate: {}, AuditProjectCreate: {}, AuditGrantCreate: {}, AuditGrantDelete: {}, AuditJobEnqueue: {}, AuditJobComplete: {}, AuditJobFail: {},
+	AuditPrincipalCreate: {}, AuditProjectCreate: {}, AuditGrantCreate: {}, AuditGrantDelete: {}, AuditJobEnqueue: {}, AuditJobComplete: {}, AuditJobRetry: {}, AuditJobFail: {},
 }
 
 // AuditEvent contains identifiers and closed classification values only.
@@ -244,17 +245,18 @@ func (e AuditEvent) Validate() error {
 
 // EnqueueJob is one bounded transactional outbox entry.
 type EnqueueJob struct {
-	Kind        string
-	ProjectID   string
-	Payload     json.RawMessage
-	MaxAttempts int
-	Delay       time.Duration
+	ActorPrincipalID string
+	Kind             string
+	ProjectID        string
+	Payload          json.RawMessage
+	MaxAttempts      int
+	Delay            time.Duration
 }
 
 // Validate enforces queue storage and retry ceilings before a transaction starts.
 func (j EnqueueJob) Validate() error {
 	_, knownKind := jobClaimCapability(j.Kind)
-	if !knownKind || !validOpaqueID(j.ProjectID) || len(j.Payload) == 0 || len(j.Payload) > maxJobPayloadBytes || !json.Valid(j.Payload) || j.MaxAttempts < 1 || j.MaxAttempts > maxJobAttempts || j.Delay < 0 || j.Delay > maxJobDelay {
+	if !validOpaqueID(j.ActorPrincipalID) || !knownKind || !validOpaqueID(j.ProjectID) || len(j.Payload) == 0 || len(j.Payload) > maxJobPayloadBytes || !json.Valid(j.Payload) || j.MaxAttempts < 1 || j.MaxAttempts > maxJobAttempts || j.Delay < 0 || j.Delay > maxJobDelay {
 		return errors.New("invalid job")
 	}
 	return nil

--- a/internal/postgres/control.go
+++ b/internal/postgres/control.go
@@ -253,7 +253,8 @@ type EnqueueJob struct {
 
 // Validate enforces queue storage and retry ceilings before a transaction starts.
 func (j EnqueueJob) Validate() error {
-	if !boundedTokenPattern.MatchString(j.Kind) || (j.ProjectID != "" && !validOpaqueID(j.ProjectID)) || len(j.Payload) == 0 || len(j.Payload) > maxJobPayloadBytes || !json.Valid(j.Payload) || j.MaxAttempts < 1 || j.MaxAttempts > maxJobAttempts || j.Delay < 0 || j.Delay > maxJobDelay {
+	_, knownKind := jobClaimCapability(j.Kind)
+	if !knownKind || !validOpaqueID(j.ProjectID) || len(j.Payload) == 0 || len(j.Payload) > maxJobPayloadBytes || !json.Valid(j.Payload) || j.MaxAttempts < 1 || j.MaxAttempts > maxJobAttempts || j.Delay < 0 || j.Delay > maxJobDelay {
 		return errors.New("invalid job")
 	}
 	return nil

--- a/internal/postgres/control.go
+++ b/internal/postgres/control.go
@@ -1,0 +1,281 @@
+package postgres
+
+import (
+	"crypto/sha256"
+	"encoding/json"
+	"errors"
+	"regexp"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+const (
+	maxIdempotencyRequestBytes = 1 << 20
+	maxIdempotencyResultBytes  = 64 << 10
+	maxJobPayloadBytes         = 256 << 10
+	maxJobAttempts             = 25
+	maxJobClaimBatch           = 100
+	maxJobLeaseDuration        = 15 * time.Minute
+	minJobLeaseDuration        = time.Second
+)
+
+var boundedTokenPattern = regexp.MustCompile(`^[a-z][a-z0-9_.:-]{0,127}$`)
+
+// Capability is a bounded server-understood authority token.
+type Capability string
+
+// Capabilities are intentionally explicit and friendly values never imply one.
+const (
+	CapabilityProjectDiscover        Capability = "project.discover"
+	CapabilityProjectCreate          Capability = "project.create"
+	CapabilityProjectRead            Capability = "project.read"
+	CapabilityProjectWrite           Capability = "project.write"
+	CapabilityProjectAttachUnclaimed Capability = "project.identity.attach-unclaimed"
+	CapabilityProjectAdminister      Capability = "project.administer"
+	CapabilityConversationSend       Capability = "conversation.send"
+	CapabilityConversationReceive    Capability = "conversation.receive"
+	CapabilityConversationAdminister Capability = "conversation.administer"
+	CapabilityMemorySearch           Capability = "memory.search"
+	CapabilityMemoryRead             Capability = "memory.read"
+	CapabilityMemoryPropose          Capability = "memory.propose"
+	CapabilityMemoryWrite            Capability = "memory.write"
+	CapabilityMemoryAdminister       Capability = "memory.administer"
+	CapabilityMemoryPurge            Capability = "memory.purge"
+	CapabilityAttachmentUpload       Capability = "attachment.upload"
+	CapabilityAttachmentDownload     Capability = "attachment.download"
+	CapabilityAttachmentDelete       Capability = "attachment.delete"
+)
+
+type capabilityScope uint8
+
+const (
+	allowInstallation capabilityScope = 1 << iota
+	allowProject
+	allowAllProjects
+)
+
+var capabilityScopes = map[Capability]capabilityScope{
+	CapabilityProjectDiscover:        allowProject | allowAllProjects,
+	CapabilityProjectCreate:          allowInstallation,
+	CapabilityProjectRead:            allowProject | allowAllProjects,
+	CapabilityProjectWrite:           allowProject | allowAllProjects,
+	CapabilityProjectAttachUnclaimed: allowProject | allowAllProjects,
+	CapabilityProjectAdminister:      allowProject | allowAllProjects,
+	CapabilityConversationSend:       allowProject | allowAllProjects,
+	CapabilityConversationReceive:    allowProject | allowAllProjects,
+	CapabilityConversationAdminister: allowProject | allowAllProjects,
+	CapabilityMemorySearch:           allowProject | allowAllProjects,
+	CapabilityMemoryRead:             allowProject | allowAllProjects,
+	CapabilityMemoryPropose:          allowProject | allowAllProjects,
+	CapabilityMemoryWrite:            allowProject | allowAllProjects,
+	CapabilityMemoryAdminister:       allowProject | allowAllProjects,
+	CapabilityMemoryPurge:            allowProject | allowAllProjects,
+	CapabilityAttachmentUpload:       allowProject | allowAllProjects,
+	CapabilityAttachmentDownload:     allowProject | allowAllProjects,
+	CapabilityAttachmentDelete:       allowProject | allowAllProjects,
+}
+
+// GrantScope distinguishes installation authority, one opaque project, and a
+// dynamic grant over all current and future projects.
+type GrantScope string
+
+// Supported explicit grant scopes.
+const (
+	ScopeInstallation GrantScope = "installation"
+	ScopeProject      GrantScope = "project"
+	ScopeAllProjects  GrantScope = "all_projects"
+)
+
+// Grant binds one principal and capability to an explicit scope.
+type Grant struct {
+	PrincipalID string
+	Scope       GrantScope
+	ProjectID   string
+	Capability  Capability
+}
+
+// Validate fails closed on malformed identifiers, capabilities, or scope shape.
+func (g Grant) Validate() error {
+	if !validOpaqueID(g.PrincipalID) {
+		return errors.New("invalid grant principal")
+	}
+	allowed, ok := capabilityScopes[g.Capability]
+	if !ok {
+		return errors.New("invalid grant capability")
+	}
+	switch g.Scope {
+	case ScopeInstallation:
+		if g.ProjectID != "" || allowed&allowInstallation == 0 {
+			return errors.New("invalid installation grant")
+		}
+	case ScopeProject:
+		if !validOpaqueID(g.ProjectID) || allowed&allowProject == 0 {
+			return errors.New("invalid project grant")
+		}
+	case ScopeAllProjects:
+		if g.ProjectID != "" || allowed&allowAllProjects == 0 {
+			return errors.New("invalid all-projects grant")
+		}
+	default:
+		return errors.New("invalid grant scope")
+	}
+	return nil
+}
+
+// IdempotencyRequest identifies one globally unique mutation attempt. The body
+// is hashed but never persisted by the idempotency layer.
+type IdempotencyRequest struct {
+	PrincipalID string
+	Operation   string
+	Key         string
+	Body        []byte
+}
+
+// Validate enforces opaque UUID keys so a key cannot silently change principal
+// or operation without conflicting with the original record.
+func (r IdempotencyRequest) Validate() error {
+	if !validOpaqueID(r.PrincipalID) || !boundedTokenPattern.MatchString(r.Operation) || !validOpaqueID(r.Key) || len(r.Body) > maxIdempotencyRequestBytes {
+		return errors.New("invalid idempotency request")
+	}
+	return nil
+}
+
+func requestDigest(body []byte) [sha256.Size]byte { return sha256.Sum256(body) }
+
+// OutcomeStatus is a closed terminal mutation status.
+type OutcomeStatus string
+
+// Supported immutable idempotency outcome statuses.
+const (
+	OutcomeSucceeded OutcomeStatus = "succeeded"
+	OutcomeRejected  OutcomeStatus = "rejected"
+)
+
+// IdempotencyOutcome is the bounded immutable result returned to exact retries.
+type IdempotencyOutcome struct {
+	Status     OutcomeStatus
+	ResourceID string
+	Result     json.RawMessage
+}
+
+// Validate rejects free-form statuses, malformed IDs, and oversized/non-JSON results.
+func (o IdempotencyOutcome) Validate() error {
+	if o.Status != OutcomeSucceeded && o.Status != OutcomeRejected {
+		return errors.New("invalid idempotency outcome status")
+	}
+	if o.ResourceID != "" && !validOpaqueID(o.ResourceID) {
+		return errors.New("invalid idempotency outcome resource")
+	}
+	if len(o.Result) == 0 || len(o.Result) > maxIdempotencyResultBytes || !json.Valid(o.Result) {
+		return errors.New("invalid idempotency outcome result")
+	}
+	return nil
+}
+
+// AuditAction is a closed content-free security or administrative event class.
+type AuditAction string
+
+// Supported content-free audit actions.
+const (
+	AuditPrincipalCreate AuditAction = "principal.create"
+	AuditProjectCreate   AuditAction = "project.create"
+	AuditGrantCreate     AuditAction = "grant.create"
+	AuditGrantDelete     AuditAction = "grant.delete"
+	AuditJobEnqueue      AuditAction = "job.enqueue"
+	AuditJobComplete     AuditAction = "job.complete"
+	AuditJobFail         AuditAction = "job.fail"
+)
+
+// AuditOutcome is a closed content-free result class.
+type AuditOutcome string
+
+// Supported content-free audit outcomes.
+const (
+	AuditSucceeded AuditOutcome = "succeeded"
+	AuditRejected  AuditOutcome = "rejected"
+)
+
+// AuditTargetKind is a closed content-free target class.
+type AuditTargetKind string
+
+// Supported content-free audit target kinds.
+const (
+	AuditTargetPrincipal AuditTargetKind = "principal"
+	AuditTargetProject   AuditTargetKind = "project"
+	AuditTargetGrant     AuditTargetKind = "grant"
+	AuditTargetJob       AuditTargetKind = "job"
+)
+
+var validAuditActions = map[AuditAction]struct{}{
+	AuditPrincipalCreate: {}, AuditProjectCreate: {}, AuditGrantCreate: {}, AuditGrantDelete: {}, AuditJobEnqueue: {}, AuditJobComplete: {}, AuditJobFail: {},
+}
+
+// AuditEvent contains identifiers and closed classification values only.
+type AuditEvent struct {
+	PrincipalID string
+	ProjectID   string
+	Action      AuditAction
+	Outcome     AuditOutcome
+	TargetKind  AuditTargetKind
+	TargetID    string
+}
+
+// Validate prevents request bodies, labels, paths, or other free-form content
+// from entering the audit primitive.
+func (e AuditEvent) Validate() error {
+	if e.PrincipalID != "" && !validOpaqueID(e.PrincipalID) {
+		return errors.New("invalid audit principal")
+	}
+	if e.ProjectID != "" && !validOpaqueID(e.ProjectID) {
+		return errors.New("invalid audit project")
+	}
+	if e.TargetID != "" && !validOpaqueID(e.TargetID) {
+		return errors.New("invalid audit target")
+	}
+	if _, ok := validAuditActions[e.Action]; !ok {
+		return errors.New("invalid audit classification")
+	}
+	if (e.Outcome != AuditSucceeded && e.Outcome != AuditRejected) || (e.TargetKind != AuditTargetPrincipal && e.TargetKind != AuditTargetProject && e.TargetKind != AuditTargetGrant && e.TargetKind != AuditTargetJob) {
+		return errors.New("invalid audit classification")
+	}
+	return nil
+}
+
+// EnqueueJob is one bounded transactional outbox entry.
+type EnqueueJob struct {
+	Kind        string
+	ProjectID   string
+	Payload     json.RawMessage
+	MaxAttempts int
+	AvailableAt time.Time
+}
+
+// Validate enforces queue storage and retry ceilings before a transaction starts.
+func (j EnqueueJob) Validate() error {
+	if !boundedTokenPattern.MatchString(j.Kind) || (j.ProjectID != "" && !validOpaqueID(j.ProjectID)) || len(j.Payload) == 0 || len(j.Payload) > maxJobPayloadBytes || !json.Valid(j.Payload) || j.MaxAttempts < 1 || j.MaxAttempts > maxJobAttempts {
+		return errors.New("invalid job")
+	}
+	return nil
+}
+
+// ClaimJobs bounds one worker claim operation.
+type ClaimJobs struct {
+	Kind          string
+	Holder        string
+	Limit         int
+	LeaseDuration time.Duration
+}
+
+// Validate enforces bounded batches and leases.
+func (c ClaimJobs) Validate() error {
+	if !boundedTokenPattern.MatchString(c.Kind) || !validOpaqueID(c.Holder) || c.Limit < 1 || c.Limit > maxJobClaimBatch || c.LeaseDuration < minJobLeaseDuration || c.LeaseDuration > maxJobLeaseDuration {
+		return errors.New("invalid job claim")
+	}
+	return nil
+}
+
+func validOpaqueID(value string) bool {
+	id, err := uuid.Parse(value)
+	return err == nil && id != uuid.Nil
+}

--- a/internal/postgres/control_store.go
+++ b/internal/postgres/control_store.go
@@ -442,7 +442,7 @@ func (d *Database) ClaimJobs(ctx context.Context, claim ClaimJobs) ([]LeasedJob,
 	}
 	capability, knownKind := jobClaimCapability(claim.Kind)
 	if !knownKind {
-		return nil, errors.New("invalid job claim")
+		return []LeasedJob{}, nil
 	}
 	tx, err := d.db.BeginTx(ctx, nil)
 	if err != nil {
@@ -452,21 +452,13 @@ func (d *Database) ClaimJobs(ctx context.Context, claim ClaimJobs) ([]LeasedJob,
 	if _, err := tx.ExecContext(ctx, `WITH exhausted AS (
     SELECT job.id FROM jobs.outbox AS job
     WHERE job.kind = $1 AND job.state = 'running' AND job.lease_until <= statement_timestamp() AND job.attempts >= job.max_attempts
-      AND EXISTS (
-          SELECT 1 FROM auth.principals AS principal
-          JOIN auth.capability_grants AS capability_grant ON capability_grant.principal_id = principal.id
-          WHERE principal.id = $3 AND principal.disabled_at IS NULL AND capability_grant.revoked_at IS NULL
-            AND capability_grant.capability = $4 AND job.project_id IS NOT NULL
-            AND ((capability_grant.scope = 'project' AND capability_grant.project_id = job.project_id)
-                 OR (capability_grant.scope = 'all_projects' AND capability_grant.project_id IS NULL))
-      )
     ORDER BY job.lease_until, job.created_at, job.id
     FOR UPDATE SKIP LOCKED
     LIMIT $2
 )
 UPDATE jobs.outbox AS job
 SET state = 'failed', last_error_code = 'attempts_exhausted', lease_holder = NULL, lease_token = NULL, lease_until = NULL, completed_at = statement_timestamp()
-FROM exhausted WHERE job.id = exhausted.id`, claim.Kind, claim.Limit, claim.Holder, capability); err != nil {
+FROM exhausted WHERE job.id = exhausted.id`, claim.Kind, claim.Limit); err != nil {
 		return nil, errors.New("expired jobs could not be fenced")
 	}
 	rows, err := tx.QueryContext(ctx, `WITH candidates AS (
@@ -520,7 +512,12 @@ func (d *Database) CompleteJob(ctx context.Context, lease JobLease) error {
 	if !validJobLease(lease) {
 		return errors.New("invalid job lease")
 	}
-	result, err := d.db.ExecContext(ctx, `UPDATE jobs.outbox
+	tx, err := d.authorizedJobLeaseTx(ctx, lease)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = tx.Rollback() }()
+	result, err := tx.ExecContext(ctx, `UPDATE jobs.outbox
 SET state = 'succeeded', lease_holder = NULL, lease_token = NULL, lease_until = NULL, completed_at = statement_timestamp()
 WHERE id = $1 AND state = 'running' AND lease_token = $2 AND lease_generation = $3 AND lease_until > statement_timestamp()`, lease.ID, lease.Token, lease.Generation)
 	if err != nil {
@@ -528,6 +525,9 @@ WHERE id = $1 AND state = 'running' AND lease_token = $2 AND lease_generation = 
 	}
 	if count, err := result.RowsAffected(); err != nil || count != 1 {
 		return ErrStaleLease
+	}
+	if err := tx.Commit(); err != nil {
+		return errors.New("job completion could not commit")
 	}
 	return nil
 }
@@ -537,7 +537,12 @@ func (d *Database) RetryJob(ctx context.Context, retry JobRetry) error {
 	if !validJobLease(retry.Lease) || !boundedTokenPattern.MatchString(retry.ErrorCode) || retry.Delay < 0 || retry.Delay > maxJobDelay {
 		return errors.New("invalid job retry")
 	}
-	result, err := d.db.ExecContext(ctx, `UPDATE jobs.outbox
+	tx, err := d.authorizedJobLeaseTx(ctx, retry.Lease)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = tx.Rollback() }()
+	result, err := tx.ExecContext(ctx, `UPDATE jobs.outbox
 SET state = CASE WHEN attempts >= max_attempts THEN 'failed' ELSE 'queued' END,
     available_at = CASE WHEN attempts >= max_attempts THEN available_at ELSE statement_timestamp() + ($4 * interval '1 microsecond') END,
     last_error_code = $5, lease_holder = NULL, lease_token = NULL, lease_until = NULL,
@@ -549,7 +554,48 @@ WHERE id = $1 AND state = 'running' AND lease_token = $2 AND lease_generation = 
 	if count, err := result.RowsAffected(); err != nil || count != 1 {
 		return ErrStaleLease
 	}
+	if err := tx.Commit(); err != nil {
+		return errors.New("job retry could not commit")
+	}
 	return nil
+}
+
+// authorizedJobLeaseTx locks the lease, its active holder, and the exact grant
+// that authorizes the holder for the job project. Revocation or disablement
+// therefore fences already-issued leases before they can publish or requeue.
+func (d *Database) authorizedJobLeaseTx(ctx context.Context, lease JobLease) (*sql.Tx, error) {
+	tx, err := d.db.BeginTx(ctx, nil)
+	if err != nil {
+		return nil, errors.New("job lease transaction cannot start")
+	}
+	var kind, holder, projectID string
+	err = tx.QueryRowContext(ctx, `SELECT kind, lease_holder::text, COALESCE(project_id::text, '')
+FROM jobs.outbox
+WHERE id = $1 AND state = 'running' AND lease_token = $2 AND lease_generation = $3 AND lease_until > statement_timestamp()
+FOR UPDATE`, lease.ID, lease.Token, lease.Generation).Scan(&kind, &holder, &projectID)
+	if errors.Is(err, sql.ErrNoRows) {
+		_ = tx.Rollback()
+		return nil, ErrStaleLease
+	}
+	if err != nil {
+		_ = tx.Rollback()
+		return nil, errors.New("job lease could not be locked")
+	}
+	capability, knownKind := jobClaimCapability(kind)
+	if !knownKind || projectID == "" {
+		_ = tx.Rollback()
+		return nil, ErrStaleLease
+	}
+	allowed, err := lockCapability(ctx, tx, holder, projectID, capability)
+	if err != nil {
+		_ = tx.Rollback()
+		return nil, err
+	}
+	if !allowed {
+		_ = tx.Rollback()
+		return nil, ErrStaleLease
+	}
+	return tx, nil
 }
 
 // PruneTerminalJobs removes only a bounded batch of old terminal rows.

--- a/internal/postgres/control_store.go
+++ b/internal/postgres/control_store.go
@@ -212,15 +212,15 @@ func (d *Database) HasCapability(ctx context.Context, principalID, projectID str
 
 const capabilityMatchSQL = `
 FROM auth.principals AS principal
-JOIN auth.capability_grants AS grant ON grant.principal_id = principal.id
-WHERE principal.id = $1 AND principal.disabled_at IS NULL AND grant.revoked_at IS NULL
-  AND grant.capability = $3
+JOIN auth.capability_grants AS capability_grant ON capability_grant.principal_id = principal.id
+WHERE principal.id = $1 AND principal.disabled_at IS NULL AND capability_grant.revoked_at IS NULL
+  AND capability_grant.capability = $3
   AND (
-      ($2::uuid IS NULL AND grant.scope = 'installation' AND grant.project_id IS NULL)
+      ($2::uuid IS NULL AND capability_grant.scope = 'installation' AND capability_grant.project_id IS NULL)
       OR
       ($2::uuid IS NOT NULL
        AND EXISTS (SELECT 1 FROM relay.projects WHERE id = $2)
-       AND ((grant.scope = 'project' AND grant.project_id = $2) OR (grant.scope = 'all_projects' AND grant.project_id IS NULL)))
+       AND ((capability_grant.scope = 'project' AND capability_grant.project_id = $2) OR (capability_grant.scope = 'all_projects' AND capability_grant.project_id IS NULL)))
   )`
 
 func hasCapability(ctx context.Context, q queryer, principalID, projectID string, capability Capability) (bool, error) {
@@ -235,8 +235,8 @@ func hasCapability(ctx context.Context, q queryer, principalID, projectID string
 
 func lockCapability(ctx context.Context, tx *sql.Tx, principalID, projectID string, capability Capability) (bool, error) {
 	var grantID string
-	err := tx.QueryRowContext(ctx, `SELECT grant.id::text `+capabilityMatchSQL+`
-ORDER BY grant.id LIMIT 1 FOR SHARE OF principal, grant`, principalID, nullableID(projectID), capability).Scan(&grantID)
+	err := tx.QueryRowContext(ctx, `SELECT capability_grant.id::text `+capabilityMatchSQL+`
+ORDER BY capability_grant.id LIMIT 1 FOR SHARE OF principal, capability_grant`, principalID, nullableID(projectID), capability).Scan(&grantID)
 	if errors.Is(err, sql.ErrNoRows) {
 		return false, nil
 	}

--- a/internal/postgres/control_store.go
+++ b/internal/postgres/control_store.go
@@ -21,7 +21,14 @@ var (
 	ErrNotFound            = errors.New("control-plane record was not found")
 )
 
-const maxJobRetryDelay = 24 * time.Hour
+const maxJobDelay = 24 * time.Hour
+
+func jobClaimCapability(kind string) (Capability, bool) {
+	if kind == "project.created" {
+		return CapabilityProjectAdminister, true
+	}
+	return "", false
+}
 
 // PrincipalKind is a closed principal classification. M-3 adds enrollment behavior.
 type PrincipalKind string
@@ -403,13 +410,9 @@ func (t *ControlTx) EnqueueJob(ctx context.Context, job EnqueueJob) (string, err
 	if t == nil || t.tx == nil || job.Validate() != nil {
 		return "", errors.New("invalid job")
 	}
-	available := job.AvailableAt
-	if available.IsZero() {
-		available = time.Now().UTC()
-	}
 	var id string
 	err := t.tx.QueryRowContext(ctx, `INSERT INTO jobs.outbox (project_id, kind, payload, max_attempts, available_at)
-VALUES ($1, $2, $3, $4, $5) RETURNING id::text`, nullableID(job.ProjectID), job.Kind, []byte(job.Payload), job.MaxAttempts, available).Scan(&id)
+VALUES ($1, $2, $3, $4, statement_timestamp() + ($5 * interval '1 microsecond')) RETURNING id::text`, nullableID(job.ProjectID), job.Kind, []byte(job.Payload), job.MaxAttempts, job.Delay.Microseconds()).Scan(&id)
 	if isSQLState(err, "54000") {
 		return "", ErrQueueFull
 	}
@@ -437,39 +440,59 @@ func (d *Database) ClaimJobs(ctx context.Context, claim ClaimJobs) ([]LeasedJob,
 	if err := claim.Validate(); err != nil {
 		return nil, err
 	}
+	capability, knownKind := jobClaimCapability(claim.Kind)
+	if !knownKind {
+		return nil, errors.New("invalid job claim")
+	}
 	tx, err := d.db.BeginTx(ctx, nil)
 	if err != nil {
 		return nil, errors.New("job claim transaction cannot start")
 	}
 	defer func() { _ = tx.Rollback() }()
 	if _, err := tx.ExecContext(ctx, `WITH exhausted AS (
-    SELECT id FROM jobs.outbox
-    WHERE kind = $1 AND state = 'running' AND lease_until <= statement_timestamp() AND attempts >= max_attempts
-    ORDER BY lease_until, created_at, id
+    SELECT job.id FROM jobs.outbox AS job
+    WHERE job.kind = $1 AND job.state = 'running' AND job.lease_until <= statement_timestamp() AND job.attempts >= job.max_attempts
+      AND EXISTS (
+          SELECT 1 FROM auth.principals AS principal
+          JOIN auth.capability_grants AS capability_grant ON capability_grant.principal_id = principal.id
+          WHERE principal.id = $3 AND principal.disabled_at IS NULL AND capability_grant.revoked_at IS NULL
+            AND capability_grant.capability = $4 AND job.project_id IS NOT NULL
+            AND ((capability_grant.scope = 'project' AND capability_grant.project_id = job.project_id)
+                 OR (capability_grant.scope = 'all_projects' AND capability_grant.project_id IS NULL))
+      )
+    ORDER BY job.lease_until, job.created_at, job.id
     FOR UPDATE SKIP LOCKED
     LIMIT $2
 )
 UPDATE jobs.outbox AS job
 SET state = 'failed', last_error_code = 'attempts_exhausted', lease_holder = NULL, lease_token = NULL, lease_until = NULL, completed_at = statement_timestamp()
-FROM exhausted WHERE job.id = exhausted.id`, claim.Kind, claim.Limit); err != nil {
+FROM exhausted WHERE job.id = exhausted.id`, claim.Kind, claim.Limit, claim.Holder, capability); err != nil {
 		return nil, errors.New("expired jobs could not be fenced")
 	}
 	rows, err := tx.QueryContext(ctx, `WITH candidates AS (
-    SELECT id FROM jobs.outbox
-    WHERE kind = $1 AND attempts < max_attempts
-      AND ((state = 'queued' AND available_at <= statement_timestamp()) OR (state = 'running' AND lease_until <= statement_timestamp()))
-    ORDER BY COALESCE(lease_until, available_at), created_at, id
+    SELECT job.id FROM jobs.outbox AS job
+    WHERE job.kind = $1 AND job.attempts < job.max_attempts
+      AND ((job.state = 'queued' AND job.available_at <= statement_timestamp()) OR (job.state = 'running' AND job.lease_until <= statement_timestamp()))
+      AND EXISTS (
+          SELECT 1 FROM auth.principals AS principal
+          JOIN auth.capability_grants AS capability_grant ON capability_grant.principal_id = principal.id
+          WHERE principal.id = $3 AND principal.disabled_at IS NULL AND capability_grant.revoked_at IS NULL
+            AND capability_grant.capability = $4 AND job.project_id IS NOT NULL
+            AND ((capability_grant.scope = 'project' AND capability_grant.project_id = job.project_id)
+                 OR (capability_grant.scope = 'all_projects' AND capability_grant.project_id IS NULL))
+      )
+    ORDER BY COALESCE(job.lease_until, job.available_at), job.created_at, job.id
     FOR UPDATE SKIP LOCKED
     LIMIT $2
 )
 UPDATE jobs.outbox AS job
 SET state = 'running', attempts = job.attempts + 1, lease_holder = $3,
     lease_token = gen_random_uuid(), lease_generation = job.lease_generation + 1,
-    lease_until = statement_timestamp() + ($4 * interval '1 microsecond')
+    lease_until = statement_timestamp() + ($5 * interval '1 microsecond')
 FROM candidates WHERE job.id = candidates.id
 RETURNING job.id::text, COALESCE(job.project_id::text, ''), job.kind, job.payload,
           job.attempts, job.max_attempts, job.lease_holder::text, job.lease_token::text,
-          job.lease_generation, job.lease_until`, claim.Kind, claim.Limit, claim.Holder, claim.LeaseDuration.Microseconds())
+          job.lease_generation, job.lease_until`, claim.Kind, claim.Limit, claim.Holder, capability, claim.LeaseDuration.Microseconds())
 	if err != nil {
 		return nil, errors.New("jobs could not be claimed")
 	}
@@ -511,7 +534,7 @@ WHERE id = $1 AND state = 'running' AND lease_token = $2 AND lease_generation = 
 
 // RetryJob conditionally requeues or terminally fails one exact unexpired lease.
 func (d *Database) RetryJob(ctx context.Context, retry JobRetry) error {
-	if !validJobLease(retry.Lease) || !boundedTokenPattern.MatchString(retry.ErrorCode) || retry.Delay < 0 || retry.Delay > maxJobRetryDelay {
+	if !validJobLease(retry.Lease) || !boundedTokenPattern.MatchString(retry.ErrorCode) || retry.Delay < 0 || retry.Delay > maxJobDelay {
 		return errors.New("invalid job retry")
 	}
 	result, err := d.db.ExecContext(ctx, `UPDATE jobs.outbox

--- a/internal/postgres/control_store.go
+++ b/internal/postgres/control_store.go
@@ -1,0 +1,590 @@
+package postgres
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"strings"
+	"time"
+	"unicode"
+	"unicode/utf8"
+)
+
+// Content-free sentinel errors allow callers to branch without exposing stored data.
+var (
+	ErrForbidden           = errors.New("operation is not authorized")
+	ErrIdempotencyConflict = errors.New("idempotency key conflicts with an earlier operation")
+	ErrQueueFull           = errors.New("job queue is full")
+	ErrStaleLease          = errors.New("job lease is stale")
+	ErrNotFound            = errors.New("control-plane record was not found")
+)
+
+const maxJobRetryDelay = 24 * time.Hour
+
+// PrincipalKind is a closed principal classification. M-3 adds enrollment behavior.
+type PrincipalKind string
+
+// Supported principal kinds.
+const (
+	PrincipalKindOwner         PrincipalKind = "owner"
+	PrincipalKindDevice        PrincipalKind = "device"
+	PrincipalKindService       PrincipalKind = "service"
+	PrincipalKindLegacyMachine PrincipalKind = "legacy_machine"
+)
+
+// Principal is an opaque control-plane identity.
+type Principal struct {
+	ID          string
+	Kind        PrincipalKind
+	DisplayName string
+}
+
+// ProjectCreate is the one concrete M-2 mutation used to prove atomic composition.
+type ProjectCreate struct {
+	PrincipalID    string
+	IdempotencyKey string
+	DisplayName    string
+}
+
+// ProjectResult is the immutable result returned to exact retries.
+type ProjectResult struct {
+	ProjectID      string `json:"project_id"`
+	ChangeSequence int64  `json:"change_sequence"`
+}
+
+// ControlTx exposes only bounded cross-domain transaction primitives.
+type ControlTx struct{ tx *sql.Tx }
+
+// JobLease is the complete fencing authority required for publication.
+type JobLease struct {
+	ID         string
+	Token      string
+	Generation int64
+}
+
+// LeasedJob is one bounded claimed transactional outbox entry.
+type LeasedJob struct {
+	ID          string
+	ProjectID   string
+	Kind        string
+	Payload     json.RawMessage
+	Attempts    int
+	MaxAttempts int
+	Holder      string
+	Token       string
+	Generation  int64
+	LeaseUntil  time.Time
+}
+
+// Lease returns the exact opaque fence required to complete or retry this claim.
+func (j LeasedJob) Lease() JobLease {
+	return JobLease{ID: j.ID, Token: j.Token, Generation: j.Generation}
+}
+
+// JobRetry releases one valid lease for a bounded retry or terminal exhaustion.
+type JobRetry struct {
+	Lease     JobLease
+	ErrorCode string
+	Delay     time.Duration
+}
+
+// CreatePrincipal adds an opaque principal for later bootstrap/enrollment composition.
+func (d *Database) CreatePrincipal(ctx context.Context, kind PrincipalKind, displayName string) (Principal, error) {
+	if !validPrincipalKind(kind) || !validDisplayName(displayName) {
+		return Principal{}, errors.New("invalid principal")
+	}
+	tx, err := d.db.BeginTx(ctx, nil)
+	if err != nil {
+		return Principal{}, errors.New("principal transaction cannot start")
+	}
+	defer func() { _ = tx.Rollback() }()
+	var principal Principal
+	err = tx.QueryRowContext(ctx, `INSERT INTO auth.principals (kind, display_name) VALUES ($1, $2) RETURNING id::text, kind, display_name`, kind, displayName).Scan(&principal.ID, &principal.Kind, &principal.DisplayName)
+	if err != nil {
+		return Principal{}, errors.New("principal could not be created")
+	}
+	control := &ControlTx{tx: tx}
+	if err := control.AppendAudit(ctx, AuditEvent{Action: AuditPrincipalCreate, Outcome: AuditSucceeded, TargetKind: AuditTargetPrincipal, TargetID: principal.ID}); err != nil {
+		return Principal{}, err
+	}
+	if _, err := control.AdvanceChange(ctx); err != nil {
+		return Principal{}, err
+	}
+	if err := tx.Commit(); err != nil {
+		return Principal{}, errors.New("principal transaction could not commit")
+	}
+	return principal, nil
+}
+
+// GrantCapability adds or returns one active explicit capability grant.
+func (d *Database) GrantCapability(ctx context.Context, grant Grant) (string, error) {
+	if err := grant.Validate(); err != nil {
+		return "", err
+	}
+	tx, err := d.db.BeginTx(ctx, nil)
+	if err != nil {
+		return "", errors.New("grant transaction cannot start")
+	}
+	defer func() { _ = tx.Rollback() }()
+	project := nullableID(grant.ProjectID)
+	var grantID string
+	inserted := true
+	err = tx.QueryRowContext(ctx, `INSERT INTO auth.capability_grants (principal_id, scope, project_id, capability)
+VALUES ($1, $2, $3, $4)
+ON CONFLICT DO NOTHING
+RETURNING id::text`, grant.PrincipalID, grant.Scope, project, grant.Capability).Scan(&grantID)
+	if errors.Is(err, sql.ErrNoRows) {
+		inserted = false
+		err = tx.QueryRowContext(ctx, `SELECT id::text FROM auth.capability_grants
+WHERE principal_id = $1 AND scope = $2 AND project_id IS NOT DISTINCT FROM $3::uuid AND capability = $4 AND revoked_at IS NULL`, grant.PrincipalID, grant.Scope, project, grant.Capability).Scan(&grantID)
+	}
+	if err != nil {
+		return "", errors.New("capability grant could not be created")
+	}
+	if inserted {
+		control := &ControlTx{tx: tx}
+		if err := control.AppendAudit(ctx, AuditEvent{PrincipalID: grant.PrincipalID, ProjectID: grant.ProjectID, Action: AuditGrantCreate, Outcome: AuditSucceeded, TargetKind: AuditTargetGrant, TargetID: grantID}); err != nil {
+			return "", err
+		}
+		if _, err := control.AdvanceChange(ctx); err != nil {
+			return "", err
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		return "", errors.New("grant transaction could not commit")
+	}
+	return grantID, nil
+}
+
+// RevokeGrant revokes one active grant without deleting its audit-relevant identity.
+func (d *Database) RevokeGrant(ctx context.Context, grantID string) error {
+	if !validOpaqueID(grantID) {
+		return errors.New("invalid grant")
+	}
+	tx, err := d.db.BeginTx(ctx, nil)
+	if err != nil {
+		return errors.New("grant transaction cannot start")
+	}
+	defer func() { _ = tx.Rollback() }()
+	var principalID string
+	var projectID sql.NullString
+	err = tx.QueryRowContext(ctx, `UPDATE auth.capability_grants SET revoked_at = statement_timestamp()
+WHERE id = $1 AND revoked_at IS NULL RETURNING principal_id::text, project_id::text`, grantID).Scan(&principalID, &projectID)
+	if errors.Is(err, sql.ErrNoRows) {
+		return ErrNotFound
+	}
+	if err != nil {
+		return errors.New("capability grant could not be revoked")
+	}
+	control := &ControlTx{tx: tx}
+	if err := control.AppendAudit(ctx, AuditEvent{PrincipalID: principalID, ProjectID: projectID.String, Action: AuditGrantDelete, Outcome: AuditSucceeded, TargetKind: AuditTargetGrant, TargetID: grantID}); err != nil {
+		return err
+	}
+	if _, err := control.AdvanceChange(ctx); err != nil {
+		return err
+	}
+	if err := tx.Commit(); err != nil {
+		return errors.New("grant transaction could not commit")
+	}
+	return nil
+}
+
+// HasCapability checks one explicit installation/project/all-project grant.
+func (d *Database) HasCapability(ctx context.Context, principalID, projectID string, capability Capability) (bool, error) {
+	if !validOpaqueID(principalID) {
+		return false, errors.New("invalid authorization query")
+	}
+	allowedScopes, known := capabilityScopes[capability]
+	if !known {
+		return false, errors.New("invalid authorization query")
+	}
+	if projectID == "" {
+		if allowedScopes&allowInstallation == 0 {
+			return false, errors.New("invalid authorization query")
+		}
+	} else if !validOpaqueID(projectID) || allowedScopes&(allowProject|allowAllProjects) == 0 {
+		return false, errors.New("invalid authorization query")
+	}
+	return hasCapability(ctx, d.db, principalID, projectID, capability)
+}
+
+const capabilityMatchSQL = `
+FROM auth.principals AS principal
+JOIN auth.capability_grants AS grant ON grant.principal_id = principal.id
+WHERE principal.id = $1 AND principal.disabled_at IS NULL AND grant.revoked_at IS NULL
+  AND grant.capability = $3
+  AND (
+      ($2::uuid IS NULL AND grant.scope = 'installation' AND grant.project_id IS NULL)
+      OR
+      ($2::uuid IS NOT NULL
+       AND EXISTS (SELECT 1 FROM relay.projects WHERE id = $2)
+       AND ((grant.scope = 'project' AND grant.project_id = $2) OR (grant.scope = 'all_projects' AND grant.project_id IS NULL)))
+  )`
+
+func hasCapability(ctx context.Context, q queryer, principalID, projectID string, capability Capability) (bool, error) {
+	var allowed bool
+	project := nullableID(projectID)
+	err := q.QueryRowContext(ctx, `SELECT EXISTS (SELECT 1 `+capabilityMatchSQL+`)`, principalID, project, capability).Scan(&allowed)
+	if err != nil {
+		return false, errors.New("authorization could not be evaluated")
+	}
+	return allowed, nil
+}
+
+func lockCapability(ctx context.Context, tx *sql.Tx, principalID, projectID string, capability Capability) (bool, error) {
+	var grantID string
+	err := tx.QueryRowContext(ctx, `SELECT grant.id::text `+capabilityMatchSQL+`
+ORDER BY grant.id LIMIT 1 FOR SHARE OF principal, grant`, principalID, nullableID(projectID), capability).Scan(&grantID)
+	if errors.Is(err, sql.ErrNoRows) {
+		return false, nil
+	}
+	if err != nil {
+		return false, errors.New("authorization could not be locked")
+	}
+	return true, nil
+}
+
+// CreateProject atomically composes authorization, idempotency, grants, audit,
+// transactional work, and the global change sequence.
+func (d *Database) CreateProject(ctx context.Context, create ProjectCreate) (ProjectResult, error) {
+	if !validOpaqueID(create.PrincipalID) || !validOpaqueID(create.IdempotencyKey) || !validDisplayName(create.DisplayName) {
+		return ProjectResult{}, errors.New("invalid project create request")
+	}
+	body, err := json.Marshal(struct {
+		DisplayName string `json:"display_name"`
+	}{DisplayName: create.DisplayName})
+	if err != nil {
+		return ProjectResult{}, errors.New("project create request cannot be encoded")
+	}
+	tx, err := d.db.BeginTx(ctx, nil)
+	if err != nil {
+		return ProjectResult{}, errors.New("project transaction cannot start")
+	}
+	defer func() { _ = tx.Rollback() }()
+	outcome, err := executeIdempotentTx(ctx, tx, IdempotencyRequest{PrincipalID: create.PrincipalID, Operation: "project.create", Key: create.IdempotencyKey, Body: body}, func(control *ControlTx) (IdempotencyOutcome, error) {
+		allowed, err := lockCapability(ctx, tx, create.PrincipalID, "", CapabilityProjectCreate)
+		if err != nil {
+			return IdempotencyOutcome{}, err
+		}
+		if !allowed {
+			return IdempotencyOutcome{}, ErrForbidden
+		}
+		var projectID string
+		if err := tx.QueryRowContext(ctx, `INSERT INTO relay.projects (display_name, created_by) VALUES ($1, $2) RETURNING id::text`, create.DisplayName, create.PrincipalID).Scan(&projectID); err != nil {
+			return IdempotencyOutcome{}, errors.New("project could not be created")
+		}
+		for _, capability := range []Capability{CapabilityProjectDiscover, CapabilityProjectRead, CapabilityProjectWrite} {
+			if _, err := tx.ExecContext(ctx, `INSERT INTO auth.capability_grants (principal_id, scope, project_id, capability) VALUES ($1, 'project', $2, $3)`, create.PrincipalID, projectID, capability); err != nil {
+				return IdempotencyOutcome{}, errors.New("project membership could not be created")
+			}
+		}
+		if err := control.AppendAudit(ctx, AuditEvent{PrincipalID: create.PrincipalID, ProjectID: projectID, Action: AuditProjectCreate, Outcome: AuditSucceeded, TargetKind: AuditTargetProject, TargetID: projectID}); err != nil {
+			return IdempotencyOutcome{}, err
+		}
+		payload, _ := json.Marshal(struct {
+			ProjectID string `json:"project_id"`
+		}{ProjectID: projectID})
+		if _, err := control.EnqueueJob(ctx, EnqueueJob{Kind: "project.created", ProjectID: projectID, Payload: payload, MaxAttempts: 4}); err != nil {
+			return IdempotencyOutcome{}, err
+		}
+		state, err := control.AdvanceChange(ctx)
+		if err != nil {
+			return IdempotencyOutcome{}, err
+		}
+		result := ProjectResult{ProjectID: projectID, ChangeSequence: state.ChangeSequence}
+		encoded, err := json.Marshal(result)
+		if err != nil {
+			return IdempotencyOutcome{}, errors.New("project result cannot be encoded")
+		}
+		return IdempotencyOutcome{Status: OutcomeSucceeded, ResourceID: projectID, Result: encoded}, nil
+	})
+	if err != nil {
+		return ProjectResult{}, err
+	}
+	if err := tx.Commit(); err != nil {
+		return ProjectResult{}, errors.New("project transaction could not commit")
+	}
+	var result ProjectResult
+	if outcome.Status != OutcomeSucceeded || json.Unmarshal(outcome.Result, &result) != nil || !validOpaqueID(result.ProjectID) || result.ChangeSequence < 1 {
+		return ProjectResult{}, errors.New("project result is unavailable")
+	}
+	return result, nil
+}
+
+func (d *Database) executeIdempotent(ctx context.Context, request IdempotencyRequest, mutation func(*ControlTx) (IdempotencyOutcome, error)) (IdempotencyOutcome, error) {
+	if err := request.Validate(); err != nil {
+		return IdempotencyOutcome{}, err
+	}
+	tx, err := d.db.BeginTx(ctx, nil)
+	if err != nil {
+		return IdempotencyOutcome{}, errors.New("idempotency transaction cannot start")
+	}
+	defer func() { _ = tx.Rollback() }()
+	outcome, err := executeIdempotentTx(ctx, tx, request, mutation)
+	if err != nil {
+		return IdempotencyOutcome{}, err
+	}
+	if err := tx.Commit(); err != nil {
+		return IdempotencyOutcome{}, errors.New("idempotency transaction could not commit")
+	}
+	return outcome, nil
+}
+
+func executeIdempotentTx(ctx context.Context, tx *sql.Tx, request IdempotencyRequest, mutation func(*ControlTx) (IdempotencyOutcome, error)) (IdempotencyOutcome, error) {
+	if err := request.Validate(); err != nil || mutation == nil {
+		return IdempotencyOutcome{}, errors.New("invalid idempotency operation")
+	}
+	digest := requestDigest(request.Body)
+	result, err := tx.ExecContext(ctx, `INSERT INTO relay.idempotency_records (key, principal_id, operation, request_hash, status)
+VALUES ($1, $2, $3, $4, 'pending') ON CONFLICT DO NOTHING`, request.Key, request.PrincipalID, request.Operation, digest[:])
+	if err != nil {
+		return IdempotencyOutcome{}, errors.New("idempotency record could not be claimed")
+	}
+	inserted, err := result.RowsAffected()
+	if err != nil {
+		return IdempotencyOutcome{}, errors.New("idempotency record state is unavailable")
+	}
+	var storedPrincipal, storedOperation, storedStatus string
+	var storedHash []byte
+	var storedResource sql.NullString
+	var storedResult []byte
+	err = tx.QueryRowContext(ctx, `SELECT principal_id::text, operation, request_hash, status, resource_id::text, result
+FROM relay.idempotency_records WHERE key = $1 FOR UPDATE`, request.Key).Scan(&storedPrincipal, &storedOperation, &storedHash, &storedStatus, &storedResource, &storedResult)
+	if err != nil {
+		return IdempotencyOutcome{}, errors.New("idempotency record state is unavailable")
+	}
+	if storedPrincipal != request.PrincipalID || storedOperation != request.Operation || !bytes.Equal(storedHash, digest[:]) {
+		return IdempotencyOutcome{}, ErrIdempotencyConflict
+	}
+	if inserted == 0 {
+		outcome := IdempotencyOutcome{Status: OutcomeStatus(storedStatus), ResourceID: storedResource.String, Result: append(json.RawMessage(nil), storedResult...)}
+		if storedStatus == "pending" || outcome.Validate() != nil {
+			return IdempotencyOutcome{}, errors.New("idempotency record is incomplete")
+		}
+		return outcome, nil
+	}
+	outcome, err := mutation(&ControlTx{tx: tx})
+	if err != nil {
+		return IdempotencyOutcome{}, err
+	}
+	if err := outcome.Validate(); err != nil {
+		return IdempotencyOutcome{}, err
+	}
+	update, err := tx.ExecContext(ctx, `UPDATE relay.idempotency_records
+SET status = $2, resource_id = $3, result = $4, completed_at = statement_timestamp()
+WHERE key = $1 AND status = 'pending'`, request.Key, outcome.Status, nullableID(outcome.ResourceID), []byte(outcome.Result))
+	if err != nil {
+		return IdempotencyOutcome{}, errors.New("idempotency outcome could not be recorded")
+	}
+	if count, err := update.RowsAffected(); err != nil || count != 1 {
+		return IdempotencyOutcome{}, errors.New("idempotency record changed unexpectedly")
+	}
+	outcome.Result = append(json.RawMessage(nil), outcome.Result...)
+	return outcome, nil
+}
+
+// AppendAudit inserts one closed, content-free event in the surrounding transaction.
+func (t *ControlTx) AppendAudit(ctx context.Context, event AuditEvent) error {
+	if t == nil || t.tx == nil || event.Validate() != nil {
+		return errors.New("invalid audit event")
+	}
+	_, err := t.tx.ExecContext(ctx, `INSERT INTO audit.events (principal_id, project_id, action, outcome, target_kind, target_id)
+VALUES ($1, $2, $3, $4, $5, $6)`, nullableID(event.PrincipalID), nullableID(event.ProjectID), event.Action, event.Outcome, event.TargetKind, nullableID(event.TargetID))
+	if err != nil {
+		return errors.New("audit event could not be recorded")
+	}
+	return nil
+}
+
+// EnqueueJob adds one capacity-checked work item to the surrounding transaction.
+func (t *ControlTx) EnqueueJob(ctx context.Context, job EnqueueJob) (string, error) {
+	if t == nil || t.tx == nil || job.Validate() != nil {
+		return "", errors.New("invalid job")
+	}
+	available := job.AvailableAt
+	if available.IsZero() {
+		available = time.Now().UTC()
+	}
+	var id string
+	err := t.tx.QueryRowContext(ctx, `INSERT INTO jobs.outbox (project_id, kind, payload, max_attempts, available_at)
+VALUES ($1, $2, $3, $4, $5) RETURNING id::text`, nullableID(job.ProjectID), job.Kind, []byte(job.Payload), job.MaxAttempts, available).Scan(&id)
+	if isSQLState(err, "54000") {
+		return "", ErrQueueFull
+	}
+	if err != nil {
+		return "", errors.New("job could not be enqueued")
+	}
+	return id, nil
+}
+
+// AdvanceChange increments global change metadata in the surrounding transaction.
+func (t *ControlTx) AdvanceChange(ctx context.Context) (InstallationState, error) {
+	if t == nil || t.tx == nil {
+		return InstallationState{}, errors.New("invalid change transaction")
+	}
+	var state InstallationState
+	err := t.tx.QueryRowContext(ctx, `SELECT installation_id::text, timeline_id::text, change_sequence FROM jobs.advance_change_sequence()`).Scan(&state.InstallationID, &state.TimelineID, &state.ChangeSequence)
+	if err != nil {
+		return InstallationState{}, errors.New("PostgreSQL change sequence could not be advanced")
+	}
+	return state, nil
+}
+
+// ClaimJobs claims disjoint ready or expired jobs with database-time leases.
+func (d *Database) ClaimJobs(ctx context.Context, claim ClaimJobs) ([]LeasedJob, error) {
+	if err := claim.Validate(); err != nil {
+		return nil, err
+	}
+	tx, err := d.db.BeginTx(ctx, nil)
+	if err != nil {
+		return nil, errors.New("job claim transaction cannot start")
+	}
+	defer func() { _ = tx.Rollback() }()
+	if _, err := tx.ExecContext(ctx, `WITH exhausted AS (
+    SELECT id FROM jobs.outbox
+    WHERE kind = $1 AND state = 'running' AND lease_until <= statement_timestamp() AND attempts >= max_attempts
+    ORDER BY lease_until, created_at, id
+    FOR UPDATE SKIP LOCKED
+    LIMIT $2
+)
+UPDATE jobs.outbox AS job
+SET state = 'failed', last_error_code = 'attempts_exhausted', lease_holder = NULL, lease_token = NULL, lease_until = NULL, completed_at = statement_timestamp()
+FROM exhausted WHERE job.id = exhausted.id`, claim.Kind, claim.Limit); err != nil {
+		return nil, errors.New("expired jobs could not be fenced")
+	}
+	rows, err := tx.QueryContext(ctx, `WITH candidates AS (
+    SELECT id FROM jobs.outbox
+    WHERE kind = $1 AND attempts < max_attempts
+      AND ((state = 'queued' AND available_at <= statement_timestamp()) OR (state = 'running' AND lease_until <= statement_timestamp()))
+    ORDER BY COALESCE(lease_until, available_at), created_at, id
+    FOR UPDATE SKIP LOCKED
+    LIMIT $2
+)
+UPDATE jobs.outbox AS job
+SET state = 'running', attempts = job.attempts + 1, lease_holder = $3,
+    lease_token = gen_random_uuid(), lease_generation = job.lease_generation + 1,
+    lease_until = statement_timestamp() + ($4 * interval '1 microsecond')
+FROM candidates WHERE job.id = candidates.id
+RETURNING job.id::text, COALESCE(job.project_id::text, ''), job.kind, job.payload,
+          job.attempts, job.max_attempts, job.lease_holder::text, job.lease_token::text,
+          job.lease_generation, job.lease_until`, claim.Kind, claim.Limit, claim.Holder, claim.LeaseDuration.Microseconds())
+	if err != nil {
+		return nil, errors.New("jobs could not be claimed")
+	}
+	defer func() { _ = rows.Close() }()
+	claimed := make([]LeasedJob, 0, claim.Limit)
+	for rows.Next() {
+		var job LeasedJob
+		if err := rows.Scan(&job.ID, &job.ProjectID, &job.Kind, &job.Payload, &job.Attempts, &job.MaxAttempts, &job.Holder, &job.Token, &job.Generation, &job.LeaseUntil); err != nil {
+			return nil, errors.New("claimed job is malformed")
+		}
+		job.Payload = append(json.RawMessage(nil), job.Payload...)
+		claimed = append(claimed, job)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, errors.New("jobs could not be claimed")
+	}
+	if err := tx.Commit(); err != nil {
+		return nil, errors.New("job claim transaction could not commit")
+	}
+	return claimed, nil
+}
+
+// CompleteJob publishes success only for the exact unexpired lease fence.
+func (d *Database) CompleteJob(ctx context.Context, lease JobLease) error {
+	if !validJobLease(lease) {
+		return errors.New("invalid job lease")
+	}
+	result, err := d.db.ExecContext(ctx, `UPDATE jobs.outbox
+SET state = 'succeeded', lease_holder = NULL, lease_token = NULL, lease_until = NULL, completed_at = statement_timestamp()
+WHERE id = $1 AND state = 'running' AND lease_token = $2 AND lease_generation = $3 AND lease_until > statement_timestamp()`, lease.ID, lease.Token, lease.Generation)
+	if err != nil {
+		return errors.New("job could not be completed")
+	}
+	if count, err := result.RowsAffected(); err != nil || count != 1 {
+		return ErrStaleLease
+	}
+	return nil
+}
+
+// RetryJob conditionally requeues or terminally fails one exact unexpired lease.
+func (d *Database) RetryJob(ctx context.Context, retry JobRetry) error {
+	if !validJobLease(retry.Lease) || !boundedTokenPattern.MatchString(retry.ErrorCode) || retry.Delay < 0 || retry.Delay > maxJobRetryDelay {
+		return errors.New("invalid job retry")
+	}
+	result, err := d.db.ExecContext(ctx, `UPDATE jobs.outbox
+SET state = CASE WHEN attempts >= max_attempts THEN 'failed' ELSE 'queued' END,
+    available_at = CASE WHEN attempts >= max_attempts THEN available_at ELSE statement_timestamp() + ($4 * interval '1 microsecond') END,
+    last_error_code = $5, lease_holder = NULL, lease_token = NULL, lease_until = NULL,
+    completed_at = CASE WHEN attempts >= max_attempts THEN statement_timestamp() ELSE NULL END
+WHERE id = $1 AND state = 'running' AND lease_token = $2 AND lease_generation = $3 AND lease_until > statement_timestamp()`, retry.Lease.ID, retry.Lease.Token, retry.Lease.Generation, retry.Delay.Microseconds(), retry.ErrorCode)
+	if err != nil {
+		return errors.New("job could not be retried")
+	}
+	if count, err := result.RowsAffected(); err != nil || count != 1 {
+		return ErrStaleLease
+	}
+	return nil
+}
+
+// PruneTerminalJobs removes only a bounded batch of old terminal rows.
+func (d *Database) PruneTerminalJobs(ctx context.Context, before time.Time, limit int) (int64, error) {
+	if before.IsZero() || limit < 1 || limit > 1000 {
+		return 0, errors.New("invalid terminal prune request")
+	}
+	var count int64
+	if err := d.db.QueryRowContext(ctx, `SELECT jobs.prune_terminal($1, $2)`, before, limit).Scan(&count); err != nil {
+		return 0, errors.New("terminal jobs could not be pruned")
+	}
+	return count, nil
+}
+
+// PruneAuditEvents removes only a bounded batch older than the caller's retention cutoff.
+func (d *Database) PruneAuditEvents(ctx context.Context, before time.Time, limit int) (int64, error) {
+	if before.IsZero() || limit < 1 || limit > 1000 {
+		return 0, errors.New("invalid audit prune request")
+	}
+	var count int64
+	if err := d.db.QueryRowContext(ctx, `SELECT audit.prune_events($1, $2)`, before, limit).Scan(&count); err != nil {
+		return 0, errors.New("audit events could not be pruned")
+	}
+	return count, nil
+}
+
+func validPrincipalKind(kind PrincipalKind) bool {
+	return kind == PrincipalKindOwner || kind == PrincipalKindDevice || kind == PrincipalKindService || kind == PrincipalKindLegacyMachine
+}
+
+func validDisplayName(value string) bool {
+	if value == "" || value != strings.TrimSpace(value) || !utf8.ValidString(value) || len(value) > 512 {
+		return false
+	}
+	count := 0
+	for _, r := range value {
+		count++
+		if unicode.IsControl(r) || count > 128 {
+			return false
+		}
+	}
+	return true
+}
+
+func validJobLease(lease JobLease) bool {
+	return validOpaqueID(lease.ID) && validOpaqueID(lease.Token) && lease.Generation > 0
+}
+
+func nullableID(value string) any {
+	if value == "" {
+		return nil
+	}
+	return value
+}
+
+type sqlStateError interface{ SQLState() string }
+
+func isSQLState(err error, state string) bool {
+	var candidate sqlStateError
+	return errors.As(err, &candidate) && candidate.SQLState() == state
+}

--- a/internal/postgres/control_store.go
+++ b/internal/postgres/control_store.go
@@ -23,6 +23,11 @@ var (
 
 const maxJobDelay = 24 * time.Hour
 
+// Grant mutations are rare administrative operations. One transaction-scoped
+// lock gives every actor/target pair the same lock order and prevents reciprocal
+// revoke or delegate operations from deadlocking.
+const grantMutationLockKey int64 = 0x50756e61726f4752
+
 func jobClaimCapability(kind string) (Capability, bool) {
 	if kind == "project.created" {
 		return CapabilityProjectAdminister, true
@@ -125,16 +130,27 @@ func (d *Database) CreatePrincipal(ctx context.Context, kind PrincipalKind, disp
 	return principal, nil
 }
 
-// GrantCapability adds or returns one active explicit capability grant.
-func (d *Database) GrantCapability(ctx context.Context, grant Grant) (string, error) {
-	if err := grant.Validate(); err != nil {
-		return "", err
+// GrantCapability adds or returns one active explicit capability grant after
+// locking the actor's authority for the target scope.
+func (d *Database) GrantCapability(ctx context.Context, actorPrincipalID string, grant Grant) (string, error) {
+	if !validOpaqueID(actorPrincipalID) || grant.Validate() != nil {
+		return "", errors.New("invalid grant")
 	}
 	tx, err := d.db.BeginTx(ctx, nil)
 	if err != nil {
 		return "", errors.New("grant transaction cannot start")
 	}
 	defer func() { _ = tx.Rollback() }()
+	if err := lockGrantMutations(ctx, tx); err != nil {
+		return "", err
+	}
+	allowed, err := lockGrantAdministration(ctx, tx, actorPrincipalID, grant.Scope, grant.ProjectID)
+	if err != nil {
+		return "", err
+	}
+	if !allowed {
+		return "", ErrForbidden
+	}
 	project := nullableID(grant.ProjectID)
 	var grantID string
 	inserted := true
@@ -152,7 +168,7 @@ WHERE principal_id = $1 AND scope = $2 AND project_id IS NOT DISTINCT FROM $3::u
 	}
 	if inserted {
 		control := &ControlTx{tx: tx}
-		if err := control.AppendAudit(ctx, AuditEvent{PrincipalID: grant.PrincipalID, ProjectID: grant.ProjectID, Action: AuditGrantCreate, Outcome: AuditSucceeded, TargetKind: AuditTargetGrant, TargetID: grantID}); err != nil {
+		if err := control.AppendAudit(ctx, AuditEvent{PrincipalID: actorPrincipalID, ProjectID: grant.ProjectID, Action: AuditGrantCreate, Outcome: AuditSucceeded, TargetKind: AuditTargetGrant, TargetID: grantID}); err != nil {
 			return "", err
 		}
 		if _, err := control.AdvanceChange(ctx); err != nil {
@@ -165,9 +181,9 @@ WHERE principal_id = $1 AND scope = $2 AND project_id IS NOT DISTINCT FROM $3::u
 	return grantID, nil
 }
 
-// RevokeGrant revokes one active grant without deleting its audit-relevant identity.
-func (d *Database) RevokeGrant(ctx context.Context, grantID string) error {
-	if !validOpaqueID(grantID) {
+// RevokeGrant revokes one active grant after locking the actor's authority.
+func (d *Database) RevokeGrant(ctx context.Context, actorPrincipalID, grantID string) error {
+	if !validOpaqueID(actorPrincipalID) || !validOpaqueID(grantID) {
 		return errors.New("invalid grant")
 	}
 	tx, err := d.db.BeginTx(ctx, nil)
@@ -175,18 +191,35 @@ func (d *Database) RevokeGrant(ctx context.Context, grantID string) error {
 		return errors.New("grant transaction cannot start")
 	}
 	defer func() { _ = tx.Rollback() }()
-	var principalID string
+	if err := lockGrantMutations(ctx, tx); err != nil {
+		return err
+	}
 	var projectID sql.NullString
-	err = tx.QueryRowContext(ctx, `UPDATE auth.capability_grants SET revoked_at = statement_timestamp()
-WHERE id = $1 AND revoked_at IS NULL RETURNING principal_id::text, project_id::text`, grantID).Scan(&principalID, &projectID)
+	var scope GrantScope
+	err = tx.QueryRowContext(ctx, `SELECT scope, project_id::text
+FROM auth.capability_grants WHERE id = $1 AND revoked_at IS NULL`, grantID).Scan(&scope, &projectID)
 	if errors.Is(err, sql.ErrNoRows) {
 		return ErrNotFound
 	}
 	if err != nil {
+		return errors.New("capability grant could not be locked")
+	}
+	allowed, err := lockGrantAdministration(ctx, tx, actorPrincipalID, scope, projectID.String)
+	if err != nil {
+		return err
+	}
+	if !allowed {
+		return ErrForbidden
+	}
+	result, err := tx.ExecContext(ctx, `UPDATE auth.capability_grants SET revoked_at = statement_timestamp() WHERE id = $1 AND revoked_at IS NULL`, grantID)
+	if err != nil {
 		return errors.New("capability grant could not be revoked")
 	}
+	if count, err := result.RowsAffected(); err != nil || count != 1 {
+		return ErrNotFound
+	}
 	control := &ControlTx{tx: tx}
-	if err := control.AppendAudit(ctx, AuditEvent{PrincipalID: principalID, ProjectID: projectID.String, Action: AuditGrantDelete, Outcome: AuditSucceeded, TargetKind: AuditTargetGrant, TargetID: grantID}); err != nil {
+	if err := control.AppendAudit(ctx, AuditEvent{PrincipalID: actorPrincipalID, ProjectID: projectID.String, Action: AuditGrantDelete, Outcome: AuditSucceeded, TargetKind: AuditTargetGrant, TargetID: grantID}); err != nil {
 		return err
 	}
 	if _, err := control.AdvanceChange(ctx); err != nil {
@@ -196,6 +229,44 @@ WHERE id = $1 AND revoked_at IS NULL RETURNING principal_id::text, project_id::t
 		return errors.New("grant transaction could not commit")
 	}
 	return nil
+}
+
+func lockGrantAdministration(ctx context.Context, tx *sql.Tx, actorPrincipalID string, scope GrantScope, projectID string) (bool, error) {
+	switch scope {
+	case ScopeInstallation:
+		return lockAllProjectsAdministration(ctx, tx, actorPrincipalID)
+	case ScopeProject:
+		return lockCapability(ctx, tx, actorPrincipalID, projectID, CapabilityProjectAdminister)
+	case ScopeAllProjects:
+		return lockAllProjectsAdministration(ctx, tx, actorPrincipalID)
+	default:
+		return false, errors.New("invalid grant administration scope")
+	}
+}
+
+func lockGrantMutations(ctx context.Context, tx *sql.Tx) error {
+	if _, err := tx.ExecContext(ctx, `SELECT pg_advisory_xact_lock($1)`, grantMutationLockKey); err != nil {
+		return errors.New("grant mutation could not be serialized")
+	}
+	return nil
+}
+
+func lockAllProjectsAdministration(ctx context.Context, tx *sql.Tx, actorPrincipalID string) (bool, error) {
+	var grantID string
+	err := tx.QueryRowContext(ctx, `SELECT capability_grant.id::text
+FROM auth.principals AS principal
+JOIN auth.capability_grants AS capability_grant ON capability_grant.principal_id = principal.id
+WHERE principal.id = $1 AND principal.disabled_at IS NULL AND capability_grant.revoked_at IS NULL
+  AND capability_grant.scope = 'all_projects' AND capability_grant.project_id IS NULL
+  AND capability_grant.capability = 'project.administer'
+ORDER BY capability_grant.id LIMIT 1 FOR SHARE OF principal, capability_grant`, actorPrincipalID).Scan(&grantID)
+	if errors.Is(err, sql.ErrNoRows) {
+		return false, nil
+	}
+	if err != nil {
+		return false, errors.New("grant administration could not be locked")
+	}
+	return true, nil
 }
 
 // HasCapability checks one explicit installation/project/all-project grant.
@@ -293,7 +364,7 @@ func (d *Database) CreateProject(ctx context.Context, create ProjectCreate) (Pro
 		payload, _ := json.Marshal(struct {
 			ProjectID string `json:"project_id"`
 		}{ProjectID: projectID})
-		if _, err := control.EnqueueJob(ctx, EnqueueJob{Kind: "project.created", ProjectID: projectID, Payload: payload, MaxAttempts: 4}); err != nil {
+		if _, err := control.EnqueueJob(ctx, EnqueueJob{ActorPrincipalID: create.PrincipalID, Kind: "project.created", ProjectID: projectID, Payload: payload, MaxAttempts: 4}); err != nil {
 			return IdempotencyOutcome{}, err
 		}
 		state, err := control.AdvanceChange(ctx)
@@ -419,6 +490,9 @@ VALUES ($1, $2, $3, $4, statement_timestamp() + ($5 * interval '1 microsecond'))
 	if err != nil {
 		return "", errors.New("job could not be enqueued")
 	}
+	if err := t.AppendAudit(ctx, AuditEvent{PrincipalID: job.ActorPrincipalID, ProjectID: job.ProjectID, Action: AuditJobEnqueue, Outcome: AuditSucceeded, TargetKind: AuditTargetJob, TargetID: id}); err != nil {
+		return "", err
+	}
 	return id, nil
 }
 
@@ -450,31 +524,59 @@ func (d *Database) ClaimJobs(ctx context.Context, claim ClaimJobs) ([]LeasedJob,
 	}
 	defer func() { _ = tx.Rollback() }()
 	if _, err := tx.ExecContext(ctx, `WITH exhausted AS (
-    SELECT job.id FROM jobs.outbox AS job
+	SELECT job.id, job.project_id, job.lease_holder FROM jobs.outbox AS job
     WHERE job.kind = $1 AND job.state = 'running' AND job.lease_until <= statement_timestamp() AND job.attempts >= job.max_attempts
     ORDER BY job.lease_until, job.created_at, job.id
     FOR UPDATE SKIP LOCKED
     LIMIT $2
+), failed AS (
+    UPDATE jobs.outbox AS job
+    SET state = 'failed', last_error_code = 'attempts_exhausted', lease_holder = NULL, lease_token = NULL, lease_until = NULL, completed_at = statement_timestamp()
+    FROM exhausted WHERE job.id = exhausted.id
+	RETURNING job.id, exhausted.project_id, exhausted.lease_holder
 )
-UPDATE jobs.outbox AS job
-SET state = 'failed', last_error_code = 'attempts_exhausted', lease_holder = NULL, lease_token = NULL, lease_until = NULL, completed_at = statement_timestamp()
-FROM exhausted WHERE job.id = exhausted.id`, claim.Kind, claim.Limit); err != nil {
+INSERT INTO audit.events (principal_id, project_id, action, outcome, target_kind, target_id)
+SELECT lease_holder, project_id, 'job.fail', 'succeeded', 'job', id FROM failed`, claim.Kind, claim.Limit); err != nil {
 		return nil, errors.New("expired jobs could not be fenced")
 	}
-	rows, err := tx.QueryContext(ctx, `WITH candidates AS (
-    SELECT job.id FROM jobs.outbox AS job
+	rows, err := tx.QueryContext(ctx, `WITH pre_candidates AS MATERIALIZED (
+	SELECT job.id, job.project_id, job.available_at, job.lease_until, job.created_at
+	FROM jobs.outbox AS job
+	WHERE job.kind = $1 AND job.attempts < job.max_attempts AND job.project_id IS NOT NULL
+	  AND ((job.state = 'queued' AND job.available_at <= statement_timestamp()) OR (job.state = 'running' AND job.lease_until <= statement_timestamp()))
+	  AND EXISTS (
+		  SELECT 1 FROM auth.principals AS principal
+		  JOIN auth.capability_grants AS capability_grant ON capability_grant.principal_id = principal.id
+		  WHERE principal.id = $3 AND principal.disabled_at IS NULL AND capability_grant.revoked_at IS NULL
+		    AND capability_grant.capability = $4
+		    AND ((capability_grant.scope = 'project' AND capability_grant.project_id = job.project_id)
+		         OR (capability_grant.scope = 'all_projects' AND capability_grant.project_id IS NULL))
+	  )
+	ORDER BY COALESCE(job.lease_until, job.available_at), job.created_at, job.id
+	FOR UPDATE OF job SKIP LOCKED
+	LIMIT $2
+), authorized_grants AS MATERIALIZED (
+    SELECT capability_grant.scope, capability_grant.project_id
+    FROM auth.principals AS principal
+    JOIN auth.capability_grants AS capability_grant ON capability_grant.principal_id = principal.id
+    WHERE principal.id = $3 AND principal.disabled_at IS NULL AND capability_grant.revoked_at IS NULL
+      AND capability_grant.capability = $4
+      AND capability_grant.scope IN ('project', 'all_projects')
+	  AND (capability_grant.scope = 'all_projects'
+	       OR capability_grant.project_id IN (SELECT project_id FROM pre_candidates))
+    FOR SHARE OF principal, capability_grant
+), candidates AS (
+	SELECT job.id FROM jobs.outbox AS job
+	JOIN pre_candidates AS candidate ON candidate.id = job.id
     WHERE job.kind = $1 AND job.attempts < job.max_attempts
       AND ((job.state = 'queued' AND job.available_at <= statement_timestamp()) OR (job.state = 'running' AND job.lease_until <= statement_timestamp()))
       AND EXISTS (
-          SELECT 1 FROM auth.principals AS principal
-          JOIN auth.capability_grants AS capability_grant ON capability_grant.principal_id = principal.id
-          WHERE principal.id = $3 AND principal.disabled_at IS NULL AND capability_grant.revoked_at IS NULL
-            AND capability_grant.capability = $4 AND job.project_id IS NOT NULL
+          SELECT 1 FROM authorized_grants AS capability_grant
+          WHERE job.project_id IS NOT NULL
             AND ((capability_grant.scope = 'project' AND capability_grant.project_id = job.project_id)
                  OR (capability_grant.scope = 'all_projects' AND capability_grant.project_id IS NULL))
       )
-    ORDER BY COALESCE(job.lease_until, job.available_at), job.created_at, job.id
-    FOR UPDATE SKIP LOCKED
+	ORDER BY COALESCE(candidate.lease_until, candidate.available_at), candidate.created_at, candidate.id
     LIMIT $2
 )
 UPDATE jobs.outbox AS job
@@ -512,10 +614,11 @@ func (d *Database) CompleteJob(ctx context.Context, lease JobLease) error {
 	if !validJobLease(lease) {
 		return errors.New("invalid job lease")
 	}
-	tx, err := d.authorizedJobLeaseTx(ctx, lease)
+	locked, err := d.authorizedJobLeaseTx(ctx, lease)
 	if err != nil {
 		return err
 	}
+	tx := locked.tx
 	defer func() { _ = tx.Rollback() }()
 	result, err := tx.ExecContext(ctx, `UPDATE jobs.outbox
 SET state = 'succeeded', lease_holder = NULL, lease_token = NULL, lease_until = NULL, completed_at = statement_timestamp()
@@ -525,6 +628,9 @@ WHERE id = $1 AND state = 'running' AND lease_token = $2 AND lease_generation = 
 	}
 	if count, err := result.RowsAffected(); err != nil || count != 1 {
 		return ErrStaleLease
+	}
+	if err := (&ControlTx{tx: tx}).AppendAudit(ctx, AuditEvent{PrincipalID: locked.Holder, ProjectID: locked.ProjectID, Action: AuditJobComplete, Outcome: AuditSucceeded, TargetKind: AuditTargetJob, TargetID: lease.ID}); err != nil {
+		return err
 	}
 	if err := tx.Commit(); err != nil {
 		return errors.New("job completion could not commit")
@@ -537,22 +643,32 @@ func (d *Database) RetryJob(ctx context.Context, retry JobRetry) error {
 	if !validJobLease(retry.Lease) || !boundedTokenPattern.MatchString(retry.ErrorCode) || retry.Delay < 0 || retry.Delay > maxJobDelay {
 		return errors.New("invalid job retry")
 	}
-	tx, err := d.authorizedJobLeaseTx(ctx, retry.Lease)
+	locked, err := d.authorizedJobLeaseTx(ctx, retry.Lease)
 	if err != nil {
 		return err
 	}
+	tx := locked.tx
 	defer func() { _ = tx.Rollback() }()
-	result, err := tx.ExecContext(ctx, `UPDATE jobs.outbox
+	var state string
+	err = tx.QueryRowContext(ctx, `UPDATE jobs.outbox
 SET state = CASE WHEN attempts >= max_attempts THEN 'failed' ELSE 'queued' END,
     available_at = CASE WHEN attempts >= max_attempts THEN available_at ELSE statement_timestamp() + ($4 * interval '1 microsecond') END,
     last_error_code = $5, lease_holder = NULL, lease_token = NULL, lease_until = NULL,
-    completed_at = CASE WHEN attempts >= max_attempts THEN statement_timestamp() ELSE NULL END
-WHERE id = $1 AND state = 'running' AND lease_token = $2 AND lease_generation = $3 AND lease_until > statement_timestamp()`, retry.Lease.ID, retry.Lease.Token, retry.Lease.Generation, retry.Delay.Microseconds(), retry.ErrorCode)
+	completed_at = CASE WHEN attempts >= max_attempts THEN statement_timestamp() ELSE NULL END
+WHERE id = $1 AND state = 'running' AND lease_token = $2 AND lease_generation = $3 AND lease_until > statement_timestamp()
+RETURNING state`, retry.Lease.ID, retry.Lease.Token, retry.Lease.Generation, retry.Delay.Microseconds(), retry.ErrorCode).Scan(&state)
+	if errors.Is(err, sql.ErrNoRows) {
+		return ErrStaleLease
+	}
 	if err != nil {
 		return errors.New("job could not be retried")
 	}
-	if count, err := result.RowsAffected(); err != nil || count != 1 {
-		return ErrStaleLease
+	action := AuditJobRetry
+	if state == "failed" {
+		action = AuditJobFail
+	}
+	if err := (&ControlTx{tx: tx}).AppendAudit(ctx, AuditEvent{PrincipalID: locked.Holder, ProjectID: locked.ProjectID, Action: action, Outcome: AuditSucceeded, TargetKind: AuditTargetJob, TargetID: retry.Lease.ID}); err != nil {
+		return err
 	}
 	if err := tx.Commit(); err != nil {
 		return errors.New("job retry could not commit")
@@ -560,13 +676,20 @@ WHERE id = $1 AND state = 'running' AND lease_token = $2 AND lease_generation = 
 	return nil
 }
 
-// authorizedJobLeaseTx locks the lease, its active holder, and the exact grant
-// that authorizes the holder for the job project. Revocation or disablement
-// therefore fences already-issued leases before they can publish or requeue.
-func (d *Database) authorizedJobLeaseTx(ctx context.Context, lease JobLease) (*sql.Tx, error) {
+// authorizedJobLeaseTx locks and revalidates the opaque lease, then locks its
+// active holder and exact grant. Claim, completion, and retry therefore use the
+// same job-before-authorization lock order, while revocation or disablement
+// fences already-issued leases before publication.
+type authorizedJobLease struct {
+	tx        *sql.Tx
+	Holder    string
+	ProjectID string
+}
+
+func (d *Database) authorizedJobLeaseTx(ctx context.Context, lease JobLease) (authorizedJobLease, error) {
 	tx, err := d.db.BeginTx(ctx, nil)
 	if err != nil {
-		return nil, errors.New("job lease transaction cannot start")
+		return authorizedJobLease{}, errors.New("job lease transaction cannot start")
 	}
 	var kind, holder, projectID string
 	err = tx.QueryRowContext(ctx, `SELECT kind, lease_holder::text, COALESCE(project_id::text, '')
@@ -575,27 +698,27 @@ WHERE id = $1 AND state = 'running' AND lease_token = $2 AND lease_generation = 
 FOR UPDATE`, lease.ID, lease.Token, lease.Generation).Scan(&kind, &holder, &projectID)
 	if errors.Is(err, sql.ErrNoRows) {
 		_ = tx.Rollback()
-		return nil, ErrStaleLease
+		return authorizedJobLease{}, ErrStaleLease
 	}
 	if err != nil {
 		_ = tx.Rollback()
-		return nil, errors.New("job lease could not be locked")
+		return authorizedJobLease{}, errors.New("job lease could not be locked")
 	}
 	capability, knownKind := jobClaimCapability(kind)
 	if !knownKind || projectID == "" {
 		_ = tx.Rollback()
-		return nil, ErrStaleLease
+		return authorizedJobLease{}, ErrStaleLease
 	}
 	allowed, err := lockCapability(ctx, tx, holder, projectID, capability)
 	if err != nil {
 		_ = tx.Rollback()
-		return nil, err
+		return authorizedJobLease{}, err
 	}
 	if !allowed {
 		_ = tx.Rollback()
-		return nil, ErrStaleLease
+		return authorizedJobLease{}, ErrStaleLease
 	}
-	return tx, nil
+	return authorizedJobLease{tx: tx, Holder: holder, ProjectID: projectID}, nil
 }
 
 // PruneTerminalJobs removes only a bounded batch of old terminal rows.

--- a/internal/postgres/control_test.go
+++ b/internal/postgres/control_test.go
@@ -2,6 +2,7 @@ package postgres
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"strings"
 	"testing"
@@ -94,9 +95,19 @@ func TestOutcomeAuditAndJobBounds(t *testing.T) {
 		t.Fatal("free-form audit content accepted")
 	}
 
-	job := EnqueueJob{Kind: "project.reconcile", ProjectID: testProjectA, Payload: json.RawMessage(`{"project_id":"aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"}`), MaxAttempts: 4, Delay: time.Minute}
+	job := EnqueueJob{Kind: "project.created", ProjectID: testProjectA, Payload: json.RawMessage(`{"project_id":"aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"}`), MaxAttempts: 4, Delay: time.Minute}
 	if err := job.Validate(); err != nil {
 		t.Fatal(err)
+	}
+	unknown := job
+	unknown.Kind = "project.reconcile"
+	if err := unknown.Validate(); err == nil {
+		t.Fatal("unknown job kind accepted for enqueue")
+	}
+	installationScoped := job
+	installationScoped.ProjectID = ""
+	if err := installationScoped.Validate(); err == nil {
+		t.Fatal("project job without a project accepted for enqueue")
 	}
 	job.Payload = bytes.Repeat([]byte("x"), maxJobPayloadBytes+1)
 	if err := job.Validate(); err == nil {
@@ -137,5 +148,13 @@ func TestClaimOptionsAreHardBounded(t *testing.T) {
 				t.Fatal("invalid claim accepted")
 			}
 		})
+	}
+}
+
+func TestUnknownJobKindReceivesNoLease(t *testing.T) {
+	// The store returns before touching the nil test database.
+	jobs, err := (&Database{}).ClaimJobs(context.Background(), ClaimJobs{Kind: "project.reconcile", Holder: testPrincipalB, Limit: 1, LeaseDuration: time.Minute})
+	if err != nil || len(jobs) != 0 {
+		t.Fatalf("unknown kind jobs=%#v err=%v", jobs, err)
 	}
 }

--- a/internal/postgres/control_test.go
+++ b/internal/postgres/control_test.go
@@ -3,6 +3,7 @@ package postgres
 import (
 	"bytes"
 	"encoding/json"
+	"strings"
 	"testing"
 	"time"
 )
@@ -93,7 +94,7 @@ func TestOutcomeAuditAndJobBounds(t *testing.T) {
 		t.Fatal("free-form audit content accepted")
 	}
 
-	job := EnqueueJob{Kind: "project.reconcile", ProjectID: testProjectA, Payload: json.RawMessage(`{"project_id":"aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"}`), MaxAttempts: 4, AvailableAt: time.Now().UTC()}
+	job := EnqueueJob{Kind: "project.reconcile", ProjectID: testProjectA, Payload: json.RawMessage(`{"project_id":"aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"}`), MaxAttempts: 4, Delay: time.Minute}
 	if err := job.Validate(); err != nil {
 		t.Fatal(err)
 	}
@@ -101,9 +102,26 @@ func TestOutcomeAuditAndJobBounds(t *testing.T) {
 	if err := job.Validate(); err == nil {
 		t.Fatal("oversized job payload accepted")
 	}
+	job.Payload = json.RawMessage(`{}`)
+	job.Delay = maxJobDelay + time.Second
+	if err := job.Validate(); err == nil {
+		t.Fatal("oversized job delay accepted")
+	}
+}
+
+func TestOpaqueIDsRequireCanonicalUUIDEncoding(t *testing.T) {
+	if validOpaqueID(strings.ToUpper(testProjectA)) {
+		t.Fatal("uppercase UUID accepted as an opaque identifier")
+	}
 }
 
 func TestClaimOptionsAreHardBounded(t *testing.T) {
+	if capability, ok := jobClaimCapability("project.created"); !ok || capability != CapabilityProjectAdminister {
+		t.Fatalf("project.created claim capability=%q known=%t", capability, ok)
+	}
+	if _, ok := jobClaimCapability("project.reconcile"); ok {
+		t.Fatal("unknown job kind received a claim capability")
+	}
 	valid := ClaimJobs{Kind: "project.reconcile", Holder: testPrincipalB, Limit: 10, LeaseDuration: time.Minute}
 	if err := valid.Validate(); err != nil {
 		t.Fatal(err)

--- a/internal/postgres/control_test.go
+++ b/internal/postgres/control_test.go
@@ -1,0 +1,123 @@
+package postgres
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+	"time"
+)
+
+const (
+	testPrincipalA = "11111111-1111-4111-8111-111111111111"
+	testPrincipalB = "22222222-2222-4222-8222-222222222222"
+	testProjectA   = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"
+	testRequestKey = "dddddddd-dddd-4ddd-8ddd-dddddddddddd"
+)
+
+func TestGrantValidationEncodesExplicitScope(t *testing.T) {
+	if CapabilityProjectAttachUnclaimed != "project.identity.attach-unclaimed" {
+		t.Fatalf("persisted attach-unclaimed token=%q", CapabilityProjectAttachUnclaimed)
+	}
+	tests := []struct {
+		name    string
+		grant   Grant
+		wantErr bool
+	}{
+		{name: "installation create", grant: Grant{PrincipalID: testPrincipalA, Scope: ScopeInstallation, Capability: CapabilityProjectCreate}},
+		{name: "selected discover", grant: Grant{PrincipalID: testPrincipalA, Scope: ScopeProject, ProjectID: testProjectA, Capability: CapabilityProjectDiscover}},
+		{name: "selected project", grant: Grant{PrincipalID: testPrincipalA, Scope: ScopeProject, ProjectID: testProjectA, Capability: CapabilityProjectWrite}},
+		{name: "dynamic all projects", grant: Grant{PrincipalID: testPrincipalA, Scope: ScopeAllProjects, Capability: CapabilityMemoryRead}},
+		{name: "friendly project is not authority", grant: Grant{PrincipalID: testPrincipalA, Scope: ScopeProject, ProjectID: "friendly-name", Capability: CapabilityProjectRead}, wantErr: true},
+		{name: "missing selected project", grant: Grant{PrincipalID: testPrincipalA, Scope: ScopeProject, Capability: CapabilityProjectRead}, wantErr: true},
+		{name: "project on all-projects grant", grant: Grant{PrincipalID: testPrincipalA, Scope: ScopeAllProjects, ProjectID: testProjectA, Capability: CapabilityProjectRead}, wantErr: true},
+		{name: "project capability at installation", grant: Grant{PrincipalID: testPrincipalA, Scope: ScopeInstallation, Capability: CapabilityProjectWrite}, wantErr: true},
+		{name: "catalog-wide discover", grant: Grant{PrincipalID: testPrincipalA, Scope: ScopeInstallation, Capability: CapabilityProjectDiscover}, wantErr: true},
+		{name: "installation capability at project", grant: Grant{PrincipalID: testPrincipalA, Scope: ScopeProject, ProjectID: testProjectA, Capability: CapabilityProjectCreate}, wantErr: true},
+		{name: "unknown capability", grant: Grant{PrincipalID: testPrincipalA, Scope: ScopeProject, ProjectID: testProjectA, Capability: Capability("project.superuser")}, wantErr: true},
+		{name: "invalid principal", grant: Grant{PrincipalID: "principal-a", Scope: ScopeInstallation, Capability: CapabilityProjectCreate}, wantErr: true},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := test.grant.Validate()
+			if (err != nil) != test.wantErr {
+				t.Fatalf("Validate() error=%v, wantErr=%t", err, test.wantErr)
+			}
+		})
+	}
+}
+
+func TestIdempotencyRequestValidationAndDigest(t *testing.T) {
+	request := IdempotencyRequest{PrincipalID: testPrincipalA, Operation: "project.create", Key: testRequestKey, Body: []byte(`{"name":"alpha"}`)}
+	if err := request.Validate(); err != nil {
+		t.Fatal(err)
+	}
+	first := requestDigest(request.Body)
+	second := requestDigest(append([]byte(nil), request.Body...))
+	changed := requestDigest([]byte(`{"name":"beta"}`))
+	if !bytes.Equal(first[:], second[:]) || bytes.Equal(first[:], changed[:]) {
+		t.Fatal("request digest is not stable and body-bound")
+	}
+	for name, invalid := range map[string]IdempotencyRequest{
+		"principal": {PrincipalID: "friendly", Operation: request.Operation, Key: request.Key, Body: request.Body},
+		"operation": {PrincipalID: request.PrincipalID, Operation: "Project Create", Key: request.Key, Body: request.Body},
+		"key":       {PrincipalID: request.PrincipalID, Operation: request.Operation, Key: "reused-human-key", Body: request.Body},
+		"body":      {PrincipalID: request.PrincipalID, Operation: request.Operation, Key: request.Key, Body: bytes.Repeat([]byte("x"), maxIdempotencyRequestBytes+1)},
+	} {
+		t.Run(name, func(t *testing.T) {
+			if err := invalid.Validate(); err == nil {
+				t.Fatal("invalid idempotency request accepted")
+			}
+		})
+	}
+}
+
+func TestOutcomeAuditAndJobBounds(t *testing.T) {
+	outcome := IdempotencyOutcome{Status: OutcomeSucceeded, ResourceID: testProjectA, Result: json.RawMessage(`{"project_id":"aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"}`)}
+	if err := outcome.Validate(); err != nil {
+		t.Fatal(err)
+	}
+	if err := (IdempotencyOutcome{Status: OutcomeStatus("success with details"), Result: json.RawMessage(`{}`)}).Validate(); err == nil {
+		t.Fatal("free-form outcome status accepted")
+	}
+	if err := (IdempotencyOutcome{Status: OutcomeSucceeded, Result: bytes.Repeat([]byte("x"), maxIdempotencyResultBytes+1)}).Validate(); err == nil {
+		t.Fatal("oversized idempotency result accepted")
+	}
+
+	event := AuditEvent{PrincipalID: testPrincipalA, ProjectID: testProjectA, Action: "project.create", Outcome: "succeeded", TargetKind: "project", TargetID: testProjectA}
+	if err := event.Validate(); err != nil {
+		t.Fatal(err)
+	}
+	badEvent := event
+	badEvent.Action = "created project containing a request body"
+	if err := badEvent.Validate(); err == nil {
+		t.Fatal("free-form audit content accepted")
+	}
+
+	job := EnqueueJob{Kind: "project.reconcile", ProjectID: testProjectA, Payload: json.RawMessage(`{"project_id":"aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"}`), MaxAttempts: 4, AvailableAt: time.Now().UTC()}
+	if err := job.Validate(); err != nil {
+		t.Fatal(err)
+	}
+	job.Payload = bytes.Repeat([]byte("x"), maxJobPayloadBytes+1)
+	if err := job.Validate(); err == nil {
+		t.Fatal("oversized job payload accepted")
+	}
+}
+
+func TestClaimOptionsAreHardBounded(t *testing.T) {
+	valid := ClaimJobs{Kind: "project.reconcile", Holder: testPrincipalB, Limit: 10, LeaseDuration: time.Minute}
+	if err := valid.Validate(); err != nil {
+		t.Fatal(err)
+	}
+	for name, invalid := range map[string]ClaimJobs{
+		"limit":    {Kind: valid.Kind, Holder: valid.Holder, Limit: maxJobClaimBatch + 1, LeaseDuration: valid.LeaseDuration},
+		"lease":    {Kind: valid.Kind, Holder: valid.Holder, Limit: valid.Limit, LeaseDuration: maxJobLeaseDuration + time.Second},
+		"holder":   {Kind: valid.Kind, Holder: "worker-1", Limit: valid.Limit, LeaseDuration: valid.LeaseDuration},
+		"job kind": {Kind: "project reconcile", Holder: valid.Holder, Limit: valid.Limit, LeaseDuration: valid.LeaseDuration},
+	} {
+		t.Run(name, func(t *testing.T) {
+			if err := invalid.Validate(); err == nil {
+				t.Fatal("invalid claim accepted")
+			}
+		})
+	}
+}

--- a/internal/postgres/control_test.go
+++ b/internal/postgres/control_test.go
@@ -95,7 +95,7 @@ func TestOutcomeAuditAndJobBounds(t *testing.T) {
 		t.Fatal("free-form audit content accepted")
 	}
 
-	job := EnqueueJob{Kind: "project.created", ProjectID: testProjectA, Payload: json.RawMessage(`{"project_id":"aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"}`), MaxAttempts: 4, Delay: time.Minute}
+	job := EnqueueJob{ActorPrincipalID: testPrincipalA, Kind: "project.created", ProjectID: testProjectA, Payload: json.RawMessage(`{"project_id":"aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"}`), MaxAttempts: 4, Delay: time.Minute}
 	if err := job.Validate(); err != nil {
 		t.Fatal(err)
 	}
@@ -108,6 +108,11 @@ func TestOutcomeAuditAndJobBounds(t *testing.T) {
 	installationScoped.ProjectID = ""
 	if err := installationScoped.Validate(); err == nil {
 		t.Fatal("project job without a project accepted for enqueue")
+	}
+	actorless := job
+	actorless.ActorPrincipalID = ""
+	if err := actorless.Validate(); err == nil {
+		t.Fatal("actorless job accepted for enqueue")
 	}
 	job.Payload = bytes.Repeat([]byte("x"), maxJobPayloadBytes+1)
 	if err := job.Validate(); err == nil {

--- a/internal/postgres/db.go
+++ b/internal/postgres/db.go
@@ -210,10 +210,12 @@ WITH objects AS (
        AND bool_and(pg_get_userbyid(proowner) = 'punaro_owner')
        AND bool_and(prosecdef)
        AND bool_and(proconfig = ARRAY['search_path=pg_catalog']::text[])
+       -- PostgreSQL prosrc retains the dollar-quoted boundary newlines; btrim
+       -- removes only ordinary spaces, so these are catalog-exact fingerprints.
        AND bool_and(
-           (oid = guard_oid AND md5(btrim(prosrc)) = '41e8a2a4da5bd7808324e6d578683255')
-           OR (oid = audit_prune_oid AND md5(btrim(prosrc)) = '3d2f09c73e6a7be1c16e7430482ed6ea')
-           OR (oid = jobs_prune_oid AND md5(btrim(prosrc)) = 'db608e8aa6217526decd4ff30635c134')
+		   (oid = guard_oid AND md5(btrim(prosrc)) = '56cb3ea6402ffbf41f360cf4c8ba392f')
+		   OR (oid = audit_prune_oid AND md5(btrim(prosrc)) = 'd477a1e8ffc27e7a7c652975bdd06057')
+		   OR (oid = jobs_prune_oid AND md5(btrim(prosrc)) = 'ea4a8de811f6f8f9d5804f30fcd03869')
        ) AS owned
     FROM pg_proc, objects
     WHERE oid = ANY(ARRAY[guard_oid, audit_prune_oid, jobs_prune_oid])

--- a/internal/postgres/db.go
+++ b/internal/postgres/db.go
@@ -209,7 +209,7 @@ WITH objects AS (
     SELECT count(*) = 3
        AND bool_and(pg_get_userbyid(proowner) = 'punaro_owner')
        AND bool_and(prosecdef)
-       AND bool_and(proconfig = ARRAY['search_path=pg_catalog']::text[])
+	   AND bool_and(COALESCE(proconfig = ARRAY['search_path=pg_catalog']::text[], false))
        -- PostgreSQL prosrc retains the dollar-quoted boundary newlines; btrim
        -- removes only ordinary spaces, so these are catalog-exact fingerprints.
        AND bool_and(

--- a/internal/postgres/db.go
+++ b/internal/postgres/db.go
@@ -162,11 +162,11 @@ SELECT state_oid IS NOT NULL
    AND NOT COALESCE(has_table_privilege('punaro_app', state_oid, 'INSERT,UPDATE,DELETE,TRUNCATE,REFERENCES,TRIGGER'), false)
    AND NOT COALESCE(has_any_column_privilege('punaro_app', state_oid, 'INSERT,UPDATE,REFERENCES'), false)
    AND COALESCE(has_function_privilege('punaro_app', advance_oid, 'EXECUTE'), false)
-FROM objects`, []string{"auth", "relay", "attachment", "brain", "jobs", "audit"}).Scan(&snapshot.RequiredObjectsPresent); err != nil {
+FROM objects`, []string{"auth", "relay", "attachment", "brain", "jobs", "audit"}).Scan(&snapshot.BaseObjectsPresent); err != nil {
 		return Snapshot{}, errors.New("PostgreSQL schema state cannot be inspected")
 	}
-	if snapshot.RequiredObjectsPresent {
-		if err := q.QueryRowContext(ctx, `SELECT COALESCE(count(*) = 1 AND bool_and(singleton AND installation_id <> '00000000-0000-0000-0000-000000000000'::uuid AND timeline_id <> '00000000-0000-0000-0000-000000000000'::uuid AND change_sequence >= 0), false) FROM jobs.server_state`).Scan(&snapshot.RequiredObjectsPresent); err != nil {
+	if snapshot.BaseObjectsPresent {
+		if err := q.QueryRowContext(ctx, `SELECT COALESCE(count(*) = 1 AND bool_and(singleton AND installation_id <> '00000000-0000-0000-0000-000000000000'::uuid AND timeline_id <> '00000000-0000-0000-0000-000000000000'::uuid AND change_sequence >= 0), false) FROM jobs.server_state`).Scan(&snapshot.BaseObjectsPresent); err != nil {
 			return Snapshot{}, errors.New("PostgreSQL installation metadata cannot be inspected")
 		}
 	}
@@ -184,6 +184,119 @@ FROM objects`, []string{"auth", "relay", "attachment", "brain", "jobs", "audit"}
 	}
 	if err := rows.Err(); err != nil {
 		return Snapshot{}, errors.New("PostgreSQL migration history cannot be inspected")
+	}
+	if len(snapshot.Records) > 0 && snapshot.Records[len(snapshot.Records)-1].Version >= 2 {
+		if err := q.QueryRowContext(ctx, `
+WITH objects AS (
+    SELECT
+        to_regclass('auth.principals') AS principals_oid,
+        to_regclass('auth.capability_grants') AS grants_oid,
+        to_regclass('relay.projects') AS projects_oid,
+        to_regclass('relay.idempotency_records') AS idempotency_oid,
+        to_regclass('audit.events') AS audit_oid,
+        to_regclass('audit.events_event_id_seq') AS audit_sequence_oid,
+        to_regclass('jobs.queue_capacity') AS capacity_oid,
+        to_regclass('jobs.outbox') AS outbox_oid,
+        to_regclass('auth.capability_grants_active_unique') AS grants_active_oid,
+        to_regprocedure('jobs.guard_outbox_capacity_and_state()') AS guard_oid,
+        to_regprocedure('audit.prune_events(timestamp with time zone,integer)') AS audit_prune_oid,
+        to_regprocedure('jobs.prune_terminal(timestamp with time zone,integer)') AS jobs_prune_oid
+), ownership AS (
+    SELECT count(*) = 9 AND bool_and(pg_get_userbyid(relowner) = 'punaro_owner') AS owned
+    FROM pg_class, objects
+    WHERE oid = ANY(ARRAY[principals_oid, grants_oid, projects_oid, idempotency_oid, audit_oid, audit_sequence_oid, capacity_oid, outbox_oid, grants_active_oid])
+), function_ownership AS (
+    SELECT count(*) = 3
+       AND bool_and(pg_get_userbyid(proowner) = 'punaro_owner')
+       AND bool_and(prosecdef)
+       AND bool_and(proconfig = ARRAY['search_path=pg_catalog']::text[])
+       AND bool_and(
+           (oid = guard_oid AND md5(btrim(prosrc)) = '41e8a2a4da5bd7808324e6d578683255')
+           OR (oid = audit_prune_oid AND md5(btrim(prosrc)) = '3d2f09c73e6a7be1c16e7430482ed6ea')
+           OR (oid = jobs_prune_oid AND md5(btrim(prosrc)) = 'db608e8aa6217526decd4ff30635c134')
+       ) AS owned
+    FROM pg_proc, objects
+    WHERE oid = ANY(ARRAY[guard_oid, audit_prune_oid, jobs_prune_oid])
+)
+SELECT
+    principals_oid IS NOT NULL AND grants_oid IS NOT NULL AND projects_oid IS NOT NULL
+    AND idempotency_oid IS NOT NULL AND audit_oid IS NOT NULL AND audit_sequence_oid IS NOT NULL
+    AND capacity_oid IS NOT NULL AND outbox_oid IS NOT NULL AND grants_active_oid IS NOT NULL
+    AND guard_oid IS NOT NULL AND audit_prune_oid IS NOT NULL AND jobs_prune_oid IS NOT NULL
+    AND ownership.owned AND function_ownership.owned
+    AND EXISTS (
+        SELECT 1 FROM pg_trigger
+        WHERE tgrelid = outbox_oid AND tgfoid = guard_oid AND tgname = 'outbox_capacity_and_state'
+          AND tgenabled = 'O' AND NOT tgisinternal AND tgtype = 23
+    )
+    AND EXISTS (
+        SELECT 1 FROM pg_index
+        WHERE indexrelid = grants_active_oid AND indrelid = grants_oid
+          AND indisunique AND indisvalid AND indisready AND indnkeyatts = 4
+          AND indkey = '2 3 0 5'::int2vector
+          AND pg_get_expr(indexprs, indrelid) = 'COALESCE(project_id, ''00000000-0000-0000-0000-000000000000''::uuid)'
+          AND pg_get_expr(indpred, indrelid) = '(revoked_at IS NULL)'
+    )
+    AND has_table_privilege('punaro_app', principals_oid, 'SELECT')
+    AND has_table_privilege('punaro_app', principals_oid, 'INSERT')
+    AND has_table_privilege('punaro_app', principals_oid, 'UPDATE')
+    AND NOT has_table_privilege('punaro_app', principals_oid, 'DELETE')
+    AND NOT has_table_privilege('punaro_app', principals_oid, 'TRUNCATE')
+    AND NOT has_table_privilege('punaro_app', principals_oid, 'REFERENCES')
+    AND NOT has_table_privilege('punaro_app', principals_oid, 'TRIGGER')
+    AND has_table_privilege('punaro_app', grants_oid, 'SELECT')
+    AND has_table_privilege('punaro_app', grants_oid, 'INSERT')
+    AND has_table_privilege('punaro_app', grants_oid, 'UPDATE')
+    AND NOT has_table_privilege('punaro_app', grants_oid, 'DELETE')
+    AND NOT has_table_privilege('punaro_app', grants_oid, 'TRUNCATE')
+    AND NOT has_table_privilege('punaro_app', grants_oid, 'REFERENCES')
+    AND NOT has_table_privilege('punaro_app', grants_oid, 'TRIGGER')
+    AND has_table_privilege('punaro_app', projects_oid, 'SELECT')
+    AND has_table_privilege('punaro_app', projects_oid, 'INSERT')
+    AND has_table_privilege('punaro_app', projects_oid, 'UPDATE')
+    AND NOT has_table_privilege('punaro_app', projects_oid, 'DELETE')
+    AND NOT has_table_privilege('punaro_app', projects_oid, 'TRUNCATE')
+    AND NOT has_table_privilege('punaro_app', projects_oid, 'REFERENCES')
+    AND NOT has_table_privilege('punaro_app', projects_oid, 'TRIGGER')
+    AND has_table_privilege('punaro_app', idempotency_oid, 'SELECT')
+    AND has_table_privilege('punaro_app', idempotency_oid, 'INSERT')
+    AND has_table_privilege('punaro_app', idempotency_oid, 'UPDATE')
+    AND NOT has_table_privilege('punaro_app', idempotency_oid, 'DELETE')
+    AND NOT has_table_privilege('punaro_app', idempotency_oid, 'TRUNCATE')
+    AND NOT has_table_privilege('punaro_app', idempotency_oid, 'REFERENCES')
+    AND NOT has_table_privilege('punaro_app', idempotency_oid, 'TRIGGER')
+    AND has_table_privilege('punaro_app', audit_oid, 'SELECT')
+    AND has_table_privilege('punaro_app', audit_oid, 'INSERT')
+    AND NOT has_table_privilege('punaro_app', audit_oid, 'UPDATE')
+    AND NOT has_table_privilege('punaro_app', audit_oid, 'DELETE')
+    AND NOT has_table_privilege('punaro_app', audit_oid, 'TRUNCATE')
+    AND NOT has_table_privilege('punaro_app', audit_oid, 'REFERENCES')
+    AND NOT has_table_privilege('punaro_app', audit_oid, 'TRIGGER')
+    AND NOT has_any_column_privilege('punaro_app', audit_oid, 'UPDATE,REFERENCES')
+    AND has_sequence_privilege('punaro_app', audit_sequence_oid, 'USAGE')
+    AND has_sequence_privilege('punaro_app', audit_sequence_oid, 'SELECT')
+    AND NOT has_sequence_privilege('punaro_app', audit_sequence_oid, 'UPDATE')
+    AND has_table_privilege('punaro_app', capacity_oid, 'SELECT')
+    AND NOT has_table_privilege('punaro_app', capacity_oid, 'INSERT')
+    AND NOT has_table_privilege('punaro_app', capacity_oid, 'UPDATE')
+    AND NOT has_table_privilege('punaro_app', capacity_oid, 'DELETE')
+    AND NOT has_table_privilege('punaro_app', capacity_oid, 'TRUNCATE')
+    AND NOT has_table_privilege('punaro_app', capacity_oid, 'REFERENCES')
+    AND NOT has_table_privilege('punaro_app', capacity_oid, 'TRIGGER')
+    AND NOT has_any_column_privilege('punaro_app', capacity_oid, 'INSERT,UPDATE,REFERENCES')
+    AND has_table_privilege('punaro_app', outbox_oid, 'SELECT')
+    AND has_table_privilege('punaro_app', outbox_oid, 'INSERT')
+    AND has_table_privilege('punaro_app', outbox_oid, 'UPDATE')
+    AND NOT has_table_privilege('punaro_app', outbox_oid, 'DELETE')
+    AND NOT has_table_privilege('punaro_app', outbox_oid, 'TRUNCATE')
+    AND NOT has_table_privilege('punaro_app', outbox_oid, 'REFERENCES')
+    AND NOT has_table_privilege('punaro_app', outbox_oid, 'TRIGGER')
+    AND NOT has_function_privilege('punaro_app', guard_oid, 'EXECUTE')
+    AND has_function_privilege('punaro_app', audit_prune_oid, 'EXECUTE')
+    AND has_function_privilege('punaro_app', jobs_prune_oid, 'EXECUTE')
+FROM objects, ownership, function_ownership`).Scan(&snapshot.CurrentObjectsPresent); err != nil {
+			return Snapshot{}, errors.New("PostgreSQL control-plane schema cannot be inspected")
+		}
 	}
 	return snapshot, nil
 }

--- a/internal/postgres/migrate.go
+++ b/internal/postgres/migrate.go
@@ -18,6 +18,11 @@ var migrationFiles embed.FS
 
 const advisoryLockKey int64 = 0x50554e41524f4d31 // "PUNAROM1"
 
+var migrationCompatibilityFloors = map[int64]int64{
+	1: 1,
+	2: 2,
+}
+
 // CurrentManifest returns the immutable migrations embedded in this binary.
 func CurrentManifest() Manifest {
 	entries, err := fs.Glob(migrationFiles, "migrations/*.sql")
@@ -40,9 +45,13 @@ func CurrentManifest() Manifest {
 		if err != nil || version != int64(i+1) {
 			panic("non-contiguous embedded PostgreSQL migrations")
 		}
-		migrations = append(migrations, Migration{Version: version, Name: name, Checksum: hex.EncodeToString(sum[:]), CompatibilityFloor: 1, SQL: string(body)})
+		floor, ok := migrationCompatibilityFloors[version]
+		if !ok {
+			panic("missing PostgreSQL migration compatibility floor")
+		}
+		migrations = append(migrations, Migration{Version: version, Name: name, Checksum: hex.EncodeToString(sum[:]), CompatibilityFloor: floor, SQL: string(body)})
 	}
-	manifest := Manifest{MinSupported: 1, MaxSupported: int64(len(migrations)), Migrations: migrations}
+	manifest := Manifest{MinSupported: migrations[len(migrations)-1].CompatibilityFloor, MaxSupported: int64(len(migrations)), Migrations: migrations}
 	if err := manifest.Validate(); err != nil {
 		panic(err)
 	}

--- a/internal/postgres/migrations/002_control_plane.sql
+++ b/internal/postgres/migrations/002_control_plane.sql
@@ -95,7 +95,7 @@ CREATE TABLE audit.events (
     project_id uuid,
     action text NOT NULL CHECK (action IN (
         'principal.create', 'project.create', 'grant.create', 'grant.delete',
-        'job.enqueue', 'job.complete', 'job.fail'
+		'job.enqueue', 'job.complete', 'job.retry', 'job.fail'
     )),
     outcome text NOT NULL CHECK (outcome IN ('succeeded', 'rejected')),
     target_kind text NOT NULL CHECK (target_kind IN ('principal', 'project', 'grant', 'job')),

--- a/internal/postgres/migrations/002_control_plane.sql
+++ b/internal/postgres/migrations/002_control_plane.sql
@@ -1,0 +1,265 @@
+CREATE TABLE auth.principals (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    kind text NOT NULL CHECK (kind IN ('owner', 'device', 'service', 'legacy_machine')),
+    display_name text NOT NULL CHECK (
+        char_length(display_name) BETWEEN 1 AND 128
+        AND octet_length(display_name) <= 512
+        AND display_name !~ '[[:cntrl:]]'
+    ),
+    created_at timestamptz NOT NULL DEFAULT statement_timestamp(),
+    disabled_at timestamptz
+);
+
+CREATE TABLE relay.projects (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    display_name text NOT NULL CHECK (
+        char_length(display_name) BETWEEN 1 AND 128
+        AND octet_length(display_name) <= 512
+        AND display_name !~ '[[:cntrl:]]'
+    ),
+    created_by uuid NOT NULL REFERENCES auth.principals(id),
+    created_at timestamptz NOT NULL DEFAULT statement_timestamp()
+);
+
+CREATE TABLE auth.capability_grants (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    principal_id uuid NOT NULL REFERENCES auth.principals(id),
+    scope text NOT NULL CHECK (scope IN ('installation', 'project', 'all_projects')),
+    project_id uuid REFERENCES relay.projects(id),
+    capability text NOT NULL CHECK (capability IN (
+        'project.discover',
+        'project.create',
+        'project.read',
+        'project.write',
+        'project.identity.attach-unclaimed',
+        'project.administer',
+        'conversation.send',
+        'conversation.receive',
+        'conversation.administer',
+        'memory.search',
+        'memory.read',
+        'memory.propose',
+        'memory.write',
+        'memory.administer',
+        'memory.purge',
+        'attachment.upload',
+        'attachment.download',
+        'attachment.delete'
+    )),
+    created_at timestamptz NOT NULL DEFAULT statement_timestamp(),
+    revoked_at timestamptz,
+    CHECK (
+        (scope = 'installation' AND project_id IS NULL AND capability = 'project.create')
+        OR
+        (scope IN ('project', 'all_projects')
+         AND ((scope = 'project' AND project_id IS NOT NULL) OR (scope = 'all_projects' AND project_id IS NULL))
+         AND capability <> 'project.create')
+    )
+);
+
+CREATE UNIQUE INDEX capability_grants_active_unique
+ON auth.capability_grants (
+    principal_id,
+    scope,
+    COALESCE(project_id, '00000000-0000-0000-0000-000000000000'::uuid),
+    capability
+)
+WHERE revoked_at IS NULL;
+
+CREATE INDEX capability_grants_authorization_lookup
+ON auth.capability_grants (principal_id, capability, project_id, scope)
+WHERE revoked_at IS NULL;
+
+CREATE TABLE relay.idempotency_records (
+    key uuid PRIMARY KEY,
+    principal_id uuid NOT NULL REFERENCES auth.principals(id),
+    operation text NOT NULL CHECK (operation ~ '^[a-z][a-z0-9_.:-]{0,127}$'),
+    request_hash bytea NOT NULL CHECK (octet_length(request_hash) = 32),
+    status text NOT NULL CHECK (status IN ('pending', 'succeeded', 'rejected')),
+    resource_id uuid,
+    result jsonb,
+    created_at timestamptz NOT NULL DEFAULT statement_timestamp(),
+    completed_at timestamptz,
+    CHECK (
+        (status = 'pending' AND result IS NULL AND resource_id IS NULL AND completed_at IS NULL)
+        OR
+        (status IN ('succeeded', 'rejected') AND result IS NOT NULL AND completed_at IS NOT NULL
+         AND octet_length(result::text) <= 65536)
+    )
+);
+
+CREATE TABLE audit.events (
+    event_id bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    occurred_at timestamptz NOT NULL DEFAULT statement_timestamp(),
+    principal_id uuid,
+    project_id uuid,
+    action text NOT NULL CHECK (action IN (
+        'principal.create', 'project.create', 'grant.create', 'grant.delete',
+        'job.enqueue', 'job.complete', 'job.fail'
+    )),
+    outcome text NOT NULL CHECK (outcome IN ('succeeded', 'rejected')),
+    target_kind text NOT NULL CHECK (target_kind IN ('principal', 'project', 'grant', 'job')),
+    target_id uuid
+);
+
+CREATE TABLE jobs.queue_capacity (
+    singleton boolean PRIMARY KEY DEFAULT true CHECK (singleton),
+    active_count integer NOT NULL DEFAULT 0 CHECK (active_count >= 0),
+    max_depth integer NOT NULL DEFAULT 10000 CHECK (max_depth BETWEEN 1 AND 100000)
+);
+
+INSERT INTO jobs.queue_capacity (singleton) VALUES (true);
+
+CREATE TABLE jobs.outbox (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    project_id uuid REFERENCES relay.projects(id),
+    kind text NOT NULL CHECK (kind ~ '^[a-z][a-z0-9_.:-]{0,127}$'),
+    payload jsonb NOT NULL CHECK (octet_length(payload::text) <= 262144),
+    state text NOT NULL DEFAULT 'queued' CHECK (state IN ('queued', 'running', 'succeeded', 'failed')),
+    attempts integer NOT NULL DEFAULT 0 CHECK (attempts >= 0),
+    max_attempts integer NOT NULL CHECK (max_attempts BETWEEN 1 AND 25 AND attempts <= max_attempts),
+    available_at timestamptz NOT NULL DEFAULT statement_timestamp(),
+    lease_holder uuid,
+    lease_token uuid,
+    lease_generation bigint NOT NULL DEFAULT 0 CHECK (lease_generation >= 0),
+    lease_until timestamptz,
+    last_error_code text CHECK (last_error_code IS NULL OR last_error_code ~ '^[a-z][a-z0-9_.:-]{0,127}$'),
+    created_at timestamptz NOT NULL DEFAULT statement_timestamp(),
+    updated_at timestamptz NOT NULL DEFAULT statement_timestamp(),
+    completed_at timestamptz,
+    CHECK (
+        (state = 'queued' AND lease_holder IS NULL AND lease_token IS NULL AND lease_until IS NULL AND completed_at IS NULL)
+        OR
+        (state = 'running' AND lease_holder IS NOT NULL AND lease_token IS NOT NULL AND lease_until IS NOT NULL AND completed_at IS NULL)
+        OR
+        (state IN ('succeeded', 'failed') AND lease_holder IS NULL AND lease_token IS NULL AND lease_until IS NULL AND completed_at IS NOT NULL)
+    )
+);
+
+CREATE INDEX outbox_claim_order
+ON jobs.outbox (kind, available_at, created_at, id)
+WHERE state = 'queued';
+
+CREATE INDEX outbox_expired_lease
+ON jobs.outbox (kind, lease_until, created_at, id)
+WHERE state = 'running';
+
+CREATE FUNCTION jobs.guard_outbox_capacity_and_state()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog
+AS $function$
+DECLARE
+    capacity_changed integer;
+BEGIN
+    IF TG_OP = 'INSERT' THEN
+        IF NEW.state <> 'queued' OR NEW.attempts <> 0 OR NEW.lease_generation <> 0 THEN
+            RAISE EXCEPTION USING ERRCODE = '23514', MESSAGE = 'invalid initial job state';
+        END IF;
+        UPDATE jobs.queue_capacity
+        SET active_count = active_count + 1
+        WHERE singleton AND active_count < max_depth;
+        GET DIAGNOSTICS capacity_changed = ROW_COUNT;
+        IF capacity_changed <> 1 THEN
+            RAISE EXCEPTION USING ERRCODE = '54000', MESSAGE = 'job queue capacity exceeded';
+        END IF;
+        RETURN NEW;
+    END IF;
+
+    IF OLD.state IN ('succeeded', 'failed') AND NEW IS DISTINCT FROM OLD THEN
+        RAISE EXCEPTION USING ERRCODE = '23514', MESSAGE = 'terminal job is immutable';
+    END IF;
+    IF (OLD.state = 'queued' AND NEW.state NOT IN ('queued', 'running', 'failed'))
+       OR (OLD.state = 'running' AND NEW.state NOT IN ('running', 'queued', 'succeeded', 'failed')) THEN
+        RAISE EXCEPTION USING ERRCODE = '23514', MESSAGE = 'invalid job state transition';
+    END IF;
+    IF OLD.state IN ('queued', 'running') AND NEW.state IN ('succeeded', 'failed') THEN
+        UPDATE jobs.queue_capacity
+        SET active_count = active_count - 1
+        WHERE singleton AND active_count > 0;
+        GET DIAGNOSTICS capacity_changed = ROW_COUNT;
+        IF capacity_changed <> 1 THEN
+            RAISE EXCEPTION USING ERRCODE = '23514', MESSAGE = 'invalid job queue capacity';
+        END IF;
+    END IF;
+    NEW.updated_at = statement_timestamp();
+    RETURN NEW;
+END
+$function$;
+
+CREATE TRIGGER outbox_capacity_and_state
+BEFORE INSERT OR UPDATE ON jobs.outbox
+FOR EACH ROW EXECUTE FUNCTION jobs.guard_outbox_capacity_and_state();
+
+CREATE FUNCTION audit.prune_events(p_before timestamptz, p_limit integer)
+RETURNS bigint
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog
+AS $function$
+DECLARE
+    deleted_count bigint;
+BEGIN
+    IF p_limit < 1 OR p_limit > 1000 THEN
+        RAISE EXCEPTION USING ERRCODE = '22023', MESSAGE = 'invalid audit prune limit';
+    END IF;
+    WITH candidates AS (
+        SELECT event_id FROM audit.events
+        WHERE occurred_at < p_before
+        ORDER BY event_id
+        LIMIT p_limit
+        FOR UPDATE SKIP LOCKED
+    )
+    DELETE FROM audit.events AS event
+    USING candidates
+    WHERE event.event_id = candidates.event_id;
+    GET DIAGNOSTICS deleted_count = ROW_COUNT;
+    RETURN deleted_count;
+END
+$function$;
+
+CREATE FUNCTION jobs.prune_terminal(p_before timestamptz, p_limit integer)
+RETURNS bigint
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog
+AS $function$
+DECLARE
+    deleted_count bigint;
+BEGIN
+    IF p_limit < 1 OR p_limit > 1000 THEN
+        RAISE EXCEPTION USING ERRCODE = '22023', MESSAGE = 'invalid terminal prune limit';
+    END IF;
+    WITH candidates AS (
+        SELECT id FROM jobs.outbox
+        WHERE state IN ('succeeded', 'failed') AND completed_at < p_before
+        ORDER BY completed_at, id
+        LIMIT p_limit
+        FOR UPDATE SKIP LOCKED
+    )
+    DELETE FROM jobs.outbox AS job
+    USING candidates
+    WHERE job.id = candidates.id;
+    GET DIAGNOSTICS deleted_count = ROW_COUNT;
+    RETURN deleted_count;
+END
+$function$;
+
+REVOKE ALL ON FUNCTION jobs.guard_outbox_capacity_and_state() FROM PUBLIC;
+REVOKE ALL ON FUNCTION audit.prune_events(timestamptz, integer) FROM PUBLIC;
+REVOKE ALL ON FUNCTION jobs.prune_terminal(timestamptz, integer) FROM PUBLIC;
+
+GRANT USAGE ON SCHEMA auth, relay, jobs, audit TO punaro_app;
+GRANT SELECT, INSERT, UPDATE ON auth.principals TO punaro_app;
+GRANT SELECT, INSERT, UPDATE ON relay.projects TO punaro_app;
+GRANT SELECT, INSERT, UPDATE ON auth.capability_grants TO punaro_app;
+GRANT SELECT, INSERT, UPDATE ON relay.idempotency_records TO punaro_app;
+GRANT SELECT, INSERT ON audit.events TO punaro_app;
+GRANT USAGE, SELECT ON SEQUENCE audit.events_event_id_seq TO punaro_app;
+GRANT SELECT ON jobs.queue_capacity TO punaro_app;
+GRANT SELECT, INSERT, UPDATE ON jobs.outbox TO punaro_app;
+GRANT EXECUTE ON FUNCTION audit.prune_events(timestamptz, integer) TO punaro_app;
+GRANT EXECUTE ON FUNCTION jobs.prune_terminal(timestamptz, integer) TO punaro_app;
+
+REVOKE CREATE ON SCHEMA auth, relay, jobs, audit FROM punaro_app;

--- a/internal/postgres/postgres_integration_test.go
+++ b/internal/postgres/postgres_integration_test.go
@@ -525,6 +525,23 @@ func testControlPlaneIntegration(ctx context.Context, t *testing.T, app *Databas
 	if allowed, err := app.HasCapability(ctx, principalB.ID, second.ProjectID, CapabilityMemoryRead); err != nil || allowed {
 		t.Fatalf("revoked dynamic grant remained effective: allowed=%t err=%v", allowed, err)
 	}
+	for _, principalID := range []string{principalA.ID, principalB.ID} {
+		if _, err := app.GrantCapability(ctx, Grant{PrincipalID: principalID, Scope: ScopeAllProjects, Capability: CapabilityProjectAdminister}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if unauthorizedJobs, err := app.ClaimJobs(ctx, ClaimJobs{Kind: "project.created", Holder: principalC.ID, Limit: 1, LeaseDuration: time.Minute}); err != nil || len(unauthorizedJobs) != 0 {
+		t.Fatalf("unauthorized worker received jobs=%#v err=%v", unauthorizedJobs, err)
+	}
+	if _, err := ownerDB.ExecContext(ctx, `UPDATE auth.principals SET disabled_at = statement_timestamp() WHERE id = $1`, principalA.ID); err != nil {
+		t.Fatal(err)
+	}
+	if disabledJobs, err := app.ClaimJobs(ctx, ClaimJobs{Kind: "project.created", Holder: principalA.ID, Limit: 1, LeaseDuration: time.Minute}); err != nil || len(disabledJobs) != 0 {
+		t.Fatalf("disabled worker received jobs=%#v err=%v", disabledJobs, err)
+	}
+	if _, err := ownerDB.ExecContext(ctx, `UPDATE auth.principals SET disabled_at = NULL WHERE id = $1`, principalA.ID); err != nil {
+		t.Fatal(err)
+	}
 
 	type claimResult struct {
 		jobs []LeasedJob

--- a/internal/postgres/postgres_integration_test.go
+++ b/internal/postgres/postgres_integration_test.go
@@ -2,11 +2,15 @@ package postgres
 
 import (
 	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
 	"sync"
 	"testing"
+	"time"
 )
 
 func TestPostgresPlatformSubstrateIntegration(t *testing.T) {
@@ -38,6 +42,37 @@ func TestPostgresPlatformSubstrateIntegration(t *testing.T) {
 		t.Fatalf("application migrator attempt mutated state=%#v err=%v", state, err)
 	}
 	_ = app.Close()
+	ownerDB, err := open(ctx, ownerDSN)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = ownerDB.Close() }()
+	current := CurrentManifest()
+	v1Manifest := Manifest{MinSupported: 1, MaxSupported: 1, Migrations: append([]Migration(nil), current.Migrations[:1]...)}
+	if state, err := migrate(ctx, ownerDB, v1Manifest); err != nil || state.Classification != Compatible || state.Version != 1 {
+		t.Fatalf("v1 bootstrap state=%#v err=%v", state, err)
+	}
+	app, err = OpenApplication(ctx, Config{DSNFile: appFile})
+	if err != nil {
+		t.Fatal(err)
+	}
+	state, err = app.SchemaState(ctx)
+	if err != nil || state.Classification != UpgradeRequired || state.Version != 1 {
+		t.Fatalf("intact v1 state=%#v err=%v, want upgrade_required", state, err)
+	}
+	if _, err := ownerDB.ExecContext(ctx, `ALTER TABLE jobs.server_state RENAME TO server_state_missing`); err != nil {
+		t.Fatal(err)
+	}
+	state, err = app.SchemaState(ctx)
+	if err != nil || state.Classification != Incompatible {
+		t.Fatalf("damaged v1 state=%#v err=%v, want incompatible", state, err)
+	}
+	if _, err := ownerDB.ExecContext(ctx, `ALTER TABLE jobs.server_state_missing RENAME TO server_state`); err != nil {
+		t.Fatal(err)
+	}
+	if err := app.Close(); err != nil {
+		t.Fatal(err)
+	}
 
 	var wg sync.WaitGroup
 	errorsSeen := make(chan error, 2)
@@ -93,11 +128,7 @@ func TestPostgresPlatformSubstrateIntegration(t *testing.T) {
 		t.Fatalf("metadata changed across application restart: after=%#v err=%v", afterRestart, err)
 	}
 
-	ownerDB, err := open(ctx, ownerDSN)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer func() { _ = ownerDB.Close() }()
+	testControlPlaneIntegration(ctx, t, app, ownerDB)
 	if err := app.Close(); err != nil {
 		t.Fatal(err)
 	}
@@ -115,13 +146,13 @@ func TestPostgresPlatformSubstrateIntegration(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer func() { _ = app.Close() }()
-	if _, err := ownerDB.ExecContext(ctx, `DROP SCHEMA audit`); err != nil {
+	if _, err := ownerDB.ExecContext(ctx, `ALTER SCHEMA audit RENAME TO audit_missing`); err != nil {
 		t.Fatal(err)
 	}
 	if err := app.Ready(ctx); err == nil || !strings.Contains(err.Error(), string(Incompatible)) {
 		t.Fatalf("readiness accepted missing required schema: %v", err)
 	}
-	if _, err := ownerDB.ExecContext(ctx, `CREATE SCHEMA audit`); err != nil {
+	if _, err := ownerDB.ExecContext(ctx, `ALTER SCHEMA audit_missing RENAME TO audit`); err != nil {
 		t.Fatal(err)
 	}
 	if _, err := ownerDB.ExecContext(ctx, `ALTER TABLE jobs.server_state RENAME TO server_state_missing`); err != nil {
@@ -135,6 +166,63 @@ func TestPostgresPlatformSubstrateIntegration(t *testing.T) {
 	}
 	if err := app.Ready(ctx); err != nil {
 		t.Fatalf("readiness did not recover after required objects were restored: %v", err)
+	}
+	if _, err := ownerDB.ExecContext(ctx, `ALTER TABLE auth.principals RENAME TO principals_missing`); err != nil {
+		t.Fatal(err)
+	}
+	if err := app.Ready(ctx); err == nil || !strings.Contains(err.Error(), string(Incompatible)) {
+		t.Fatalf("readiness accepted missing control-plane object: %v", err)
+	}
+	if _, err := ownerDB.ExecContext(ctx, `ALTER TABLE auth.principals_missing RENAME TO principals`); err != nil {
+		t.Fatal(err)
+	}
+	if err := app.Ready(ctx); err != nil {
+		t.Fatalf("readiness did not recover after control-plane object restoration: %v", err)
+	}
+	var guardDefinition string
+	if err := ownerDB.QueryRowContext(ctx, `SELECT pg_get_functiondef('jobs.guard_outbox_capacity_and_state()'::regprocedure)`).Scan(&guardDefinition); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ownerDB.ExecContext(ctx, `CREATE OR REPLACE FUNCTION jobs.guard_outbox_capacity_and_state()
+RETURNS trigger LANGUAGE plpgsql SECURITY DEFINER SET search_path = pg_catalog
+AS $function$ BEGIN RETURN NEW; END $function$`); err != nil {
+		t.Fatal(err)
+	}
+	if err := app.Ready(ctx); err == nil {
+		t.Fatal("readiness accepted replacement capacity-trigger function body")
+	}
+	if _, err := ownerDB.ExecContext(ctx, guardDefinition); err != nil {
+		t.Fatal(err)
+	}
+	if err := app.Ready(ctx); err != nil {
+		t.Fatalf("readiness did not recover after capacity-trigger function restoration: %v", err)
+	}
+	for _, drift := range []struct {
+		name    string
+		apply   string
+		restore string
+	}{
+		{name: "project truncate", apply: `GRANT TRUNCATE ON relay.projects TO punaro_app`, restore: `REVOKE TRUNCATE ON relay.projects FROM punaro_app`},
+		{name: "audit update column", apply: `GRANT UPDATE (outcome) ON audit.events TO punaro_app`, restore: `REVOKE UPDATE (outcome) ON audit.events FROM punaro_app`},
+		{name: "audit sequence update", apply: `GRANT UPDATE ON SEQUENCE audit.events_event_id_seq TO punaro_app`, restore: `REVOKE UPDATE ON SEQUENCE audit.events_event_id_seq FROM punaro_app`},
+		{name: "active grant index expression", apply: `DROP INDEX auth.capability_grants_active_unique; CREATE UNIQUE INDEX capability_grants_active_unique ON auth.capability_grants (principal_id, scope, COALESCE(id, '00000000-0000-0000-0000-000000000000'::uuid), capability) WHERE revoked_at IS NULL`, restore: `DROP INDEX auth.capability_grants_active_unique; CREATE UNIQUE INDEX capability_grants_active_unique ON auth.capability_grants (principal_id, scope, COALESCE(project_id, '00000000-0000-0000-0000-000000000000'::uuid), capability) WHERE revoked_at IS NULL`},
+		{name: "function search path", apply: `ALTER FUNCTION jobs.prune_terminal(timestamptz, integer) RESET ALL`, restore: `ALTER FUNCTION jobs.prune_terminal(timestamptz, integer) SET search_path = pg_catalog`},
+		{name: "trigger events", apply: `DROP TRIGGER outbox_capacity_and_state ON jobs.outbox; CREATE TRIGGER outbox_capacity_and_state BEFORE UPDATE ON jobs.outbox FOR EACH ROW EXECUTE FUNCTION jobs.guard_outbox_capacity_and_state()`, restore: `DROP TRIGGER outbox_capacity_and_state ON jobs.outbox; CREATE TRIGGER outbox_capacity_and_state BEFORE INSERT OR UPDATE ON jobs.outbox FOR EACH ROW EXECUTE FUNCTION jobs.guard_outbox_capacity_and_state()`},
+	} {
+		t.Run("readiness rejects "+drift.name, func(t *testing.T) {
+			if _, err := ownerDB.ExecContext(ctx, drift.apply); err != nil {
+				t.Fatal(err)
+			}
+			if err := app.Ready(ctx); err == nil {
+				t.Fatalf("readiness accepted %s drift", drift.name)
+			}
+			if _, err := ownerDB.ExecContext(ctx, drift.restore); err != nil {
+				t.Fatal(err)
+			}
+			if err := app.Ready(ctx); err != nil {
+				t.Fatalf("readiness did not recover after %s drift: %v", drift.name, err)
+			}
+		})
 	}
 	if _, err := ownerDB.ExecContext(ctx, `CREATE SCHEMA unsafe_extra; GRANT CREATE ON SCHEMA unsafe_extra TO punaro_app`); err != nil {
 		t.Fatal(err)
@@ -211,8 +299,8 @@ func TestPostgresPlatformSubstrateIntegration(t *testing.T) {
 		t.Fatalf("application did not recover after unsafe role membership was revoked: %v", err)
 	}
 	var count int
-	if err := ownerDB.QueryRowContext(ctx, `SELECT count(*) FROM jobs.schema_migrations`).Scan(&count); err != nil || count != 1 {
-		t.Fatalf("migration rows=%d err=%v, want exactly one", count, err)
+	if err := ownerDB.QueryRowContext(ctx, `SELECT count(*) FROM jobs.schema_migrations`).Scan(&count); err != nil || count != len(CurrentManifest().Migrations) {
+		t.Fatalf("migration rows=%d err=%v, want exactly %d", count, err, len(CurrentManifest().Migrations))
 	}
 	if _, err := ownerDB.ExecContext(ctx, `CREATE EXTENSION IF NOT EXISTS vector`); err != nil {
 		t.Fatalf("pinned pgvector image cannot create vector extension: %v", err)
@@ -269,6 +357,272 @@ func TestPostgresPlatformSubstrateIntegration(t *testing.T) {
 	var trackerExists bool
 	if err := ownerDB.QueryRowContext(ctx, `SELECT to_regclass('jobs.schema_migrations') IS NOT NULL`).Scan(&trackerExists); err != nil || trackerExists {
 		t.Fatalf("missing-role refusal mutated schema: tracker_exists=%t err=%v", trackerExists, err)
+	}
+}
+
+func testControlPlaneIntegration(ctx context.Context, t *testing.T, app *Database, ownerDB *sql.DB) {
+	t.Helper()
+	principalA, err := app.CreatePrincipal(ctx, PrincipalKindDevice, "device A")
+	if err != nil {
+		t.Fatal(err)
+	}
+	principalB, err := app.CreatePrincipal(ctx, PrincipalKindDevice, "device B")
+	if err != nil {
+		t.Fatal(err)
+	}
+	creatorGrantID, err := app.GrantCapability(ctx, Grant{PrincipalID: principalA.ID, Scope: ScopeInstallation, Capability: CapabilityProjectCreate})
+	if err != nil {
+		t.Fatal(err)
+	}
+	dynamicGrantID, err := app.GrantCapability(ctx, Grant{PrincipalID: principalB.ID, Scope: ScopeAllProjects, Capability: CapabilityMemoryRead})
+	if err != nil {
+		t.Fatal(err)
+	}
+	grantState, err := app.InstallationState(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var grantAuditBefore int
+	if err := ownerDB.QueryRowContext(ctx, `SELECT count(*) FROM audit.events WHERE target_id = $1 AND action = 'grant.create'`, dynamicGrantID).Scan(&grantAuditBefore); err != nil {
+		t.Fatal(err)
+	}
+	type grantResult struct {
+		id  string
+		err error
+	}
+	grantResults := make(chan grantResult, 2)
+	grantStart := make(chan struct{})
+	for range 2 {
+		go func() {
+			<-grantStart
+			id, grantErr := app.GrantCapability(ctx, Grant{PrincipalID: principalB.ID, Scope: ScopeAllProjects, Capability: CapabilityMemoryRead})
+			grantResults <- grantResult{id: id, err: grantErr}
+		}()
+	}
+	close(grantStart)
+	grantRetryA, grantRetryB := <-grantResults, <-grantResults
+	grantStateAfter, err := app.InstallationState(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var grantAuditAfter int
+	if err := ownerDB.QueryRowContext(ctx, `SELECT count(*) FROM audit.events WHERE target_id = $1 AND action = 'grant.create'`, dynamicGrantID).Scan(&grantAuditAfter); err != nil {
+		t.Fatal(err)
+	}
+	if grantRetryA.err != nil || grantRetryB.err != nil || grantRetryA.id != dynamicGrantID || grantRetryB.id != dynamicGrantID || grantStateAfter.ChangeSequence != grantState.ChangeSequence || grantAuditAfter != grantAuditBefore {
+		t.Fatalf("no-op grant retries changed state: a=%#v b=%#v sequence=%d/%d audit=%d/%d", grantRetryA, grantRetryB, grantState.ChangeSequence, grantStateAfter.ChangeSequence, grantAuditBefore, grantAuditAfter)
+	}
+
+	before, err := app.InstallationState(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	create := ProjectCreate{PrincipalID: principalA.ID, IdempotencyKey: "33333333-3333-4333-8333-333333333333", DisplayName: "friendly alpha"}
+	type createResult struct {
+		result ProjectResult
+		err    error
+	}
+	concurrent := make(chan createResult, 2)
+	start := make(chan struct{})
+	for range 2 {
+		go func() {
+			<-start
+			result, createErr := app.CreateProject(ctx, create)
+			concurrent <- createResult{result: result, err: createErr}
+		}()
+	}
+	close(start)
+	firstCall, secondCall := <-concurrent, <-concurrent
+	if firstCall.err != nil || secondCall.err != nil || firstCall.result != secondCall.result {
+		t.Fatalf("concurrent project results=%#v/%#v", firstCall, secondCall)
+	}
+	first := firstCall.result
+	retry, err := app.CreateProject(ctx, create)
+	if err != nil || retry != first {
+		t.Fatalf("exact project retry=%#v err=%v, want %#v", retry, err, first)
+	}
+	after, err := app.InstallationState(ctx)
+	if err != nil || after.ChangeSequence != before.ChangeSequence+1 || first.ChangeSequence != after.ChangeSequence {
+		t.Fatalf("project sequence before=%#v result=%#v after=%#v err=%v", before, first, after, err)
+	}
+	if err := app.RevokeGrant(ctx, creatorGrantID); err != nil {
+		t.Fatal(err)
+	}
+	retryAfterRevoke, err := app.CreateProject(ctx, create)
+	if err != nil || retryAfterRevoke != first {
+		t.Fatalf("exact project retry after authority revocation=%#v err=%v, want %#v", retryAfterRevoke, err, first)
+	}
+	if _, err := app.GrantCapability(ctx, Grant{PrincipalID: principalA.ID, Scope: ScopeInstallation, Capability: CapabilityProjectCreate}); err != nil {
+		t.Fatal(err)
+	}
+	for _, check := range []struct {
+		principal  string
+		project    string
+		capability Capability
+		want       bool
+	}{
+		{principalA.ID, first.ProjectID, CapabilityProjectRead, true},
+		{principalA.ID, first.ProjectID, CapabilityProjectWrite, true},
+		{principalB.ID, first.ProjectID, CapabilityMemoryRead, true},
+		{principalB.ID, first.ProjectID, CapabilityProjectWrite, false},
+	} {
+		got, checkErr := app.HasCapability(ctx, check.principal, check.project, check.capability)
+		if checkErr != nil || got != check.want {
+			t.Fatalf("HasCapability(%s)=%t err=%v, want %t", check.capability, got, checkErr, check.want)
+		}
+	}
+	if _, err := app.HasCapability(ctx, principalA.ID, "friendly alpha", CapabilityProjectRead); err == nil {
+		t.Fatal("friendly project label accepted as authority")
+	}
+
+	changed := create
+	changed.DisplayName = "changed body"
+	if _, err := app.CreateProject(ctx, changed); !errors.Is(err, ErrIdempotencyConflict) {
+		t.Fatalf("changed idempotent body error=%v", err)
+	}
+	if _, err := app.GrantCapability(ctx, Grant{PrincipalID: principalB.ID, Scope: ScopeInstallation, Capability: CapabilityProjectCreate}); err != nil {
+		t.Fatal(err)
+	}
+	changed = create
+	changed.PrincipalID = principalB.ID
+	if _, err := app.CreateProject(ctx, changed); !errors.Is(err, ErrIdempotencyConflict) {
+		t.Fatalf("changed idempotent principal error=%v", err)
+	}
+	if _, err := app.executeIdempotent(ctx, IdempotencyRequest{PrincipalID: principalA.ID, Operation: "project.rename", Key: create.IdempotencyKey, Body: []byte(`{}`)}, func(*ControlTx) (IdempotencyOutcome, error) {
+		return IdempotencyOutcome{Status: OutcomeSucceeded, Result: json.RawMessage(`{}`)}, nil
+	}); !errors.Is(err, ErrIdempotencyConflict) {
+		t.Fatalf("changed idempotent operation error=%v", err)
+	}
+
+	principalC, err := app.CreatePrincipal(ctx, PrincipalKindDevice, "device C")
+	if err != nil {
+		t.Fatal(err)
+	}
+	unauthorized := ProjectCreate{PrincipalID: principalC.ID, IdempotencyKey: "44444444-4444-4444-8444-444444444444", DisplayName: "forbidden"}
+	if _, err := app.CreateProject(ctx, unauthorized); !errors.Is(err, ErrForbidden) {
+		t.Fatalf("unauthorized project error=%v", err)
+	}
+	var unauthorizedRecords int
+	if err := ownerDB.QueryRowContext(ctx, `SELECT
+        (SELECT count(*) FROM relay.projects WHERE display_name = 'forbidden')
+      + (SELECT count(*) FROM relay.idempotency_records WHERE key = '44444444-4444-4444-8444-444444444444')
+      + (SELECT count(*) FROM audit.events WHERE principal_id = $1 AND action = 'project.create')`, principalC.ID).Scan(&unauthorizedRecords); err != nil || unauthorizedRecords != 0 {
+		t.Fatalf("unauthorized mutation left %d rows err=%v", unauthorizedRecords, err)
+	}
+
+	secondCreate := ProjectCreate{PrincipalID: principalA.ID, IdempotencyKey: "55555555-5555-4555-8555-555555555555", DisplayName: "future beta"}
+	second, err := app.CreateProject(ctx, secondCreate)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if allowed, err := app.HasCapability(ctx, principalB.ID, second.ProjectID, CapabilityMemoryRead); err != nil || !allowed {
+		t.Fatalf("dynamic all-projects grant did not cover future project: allowed=%t err=%v", allowed, err)
+	}
+	if err := app.RevokeGrant(ctx, dynamicGrantID); err != nil {
+		t.Fatal(err)
+	}
+	if allowed, err := app.HasCapability(ctx, principalB.ID, second.ProjectID, CapabilityMemoryRead); err != nil || allowed {
+		t.Fatalf("revoked dynamic grant remained effective: allowed=%t err=%v", allowed, err)
+	}
+
+	type claimResult struct {
+		jobs []LeasedJob
+		err  error
+	}
+	claimResults := make(chan claimResult, 2)
+	claimStart := make(chan struct{})
+	for _, holder := range []string{principalA.ID, principalB.ID} {
+		go func() {
+			<-claimStart
+			claimed, claimErr := app.ClaimJobs(ctx, ClaimJobs{Kind: "project.created", Holder: holder, Limit: 1, LeaseDuration: time.Minute})
+			claimResults <- claimResult{jobs: claimed, err: claimErr}
+		}()
+	}
+	close(claimStart)
+	firstClaim, secondClaim := <-claimResults, <-claimResults
+	if firstClaim.err != nil || secondClaim.err != nil || len(firstClaim.jobs) != 1 || len(secondClaim.jobs) != 1 || firstClaim.jobs[0].ID == secondClaim.jobs[0].ID {
+		t.Fatalf("concurrent disjoint claims=%#v/%#v", firstClaim, secondClaim)
+	}
+	jobs, otherJobs := firstClaim.jobs, secondClaim.jobs
+	if err := app.CompleteJob(ctx, jobs[0].Lease()); err != nil {
+		t.Fatal(err)
+	}
+	stale := otherJobs[0].Lease()
+	if _, err := ownerDB.ExecContext(ctx, `UPDATE jobs.outbox SET lease_until = statement_timestamp() - interval '1 second' WHERE id = $1`, otherJobs[0].ID); err != nil {
+		t.Fatal(err)
+	}
+	reclaimed, err := app.ClaimJobs(ctx, ClaimJobs{Kind: "project.created", Holder: principalA.ID, Limit: 1, LeaseDuration: time.Minute})
+	if err != nil || len(reclaimed) != 1 || reclaimed[0].ID != otherJobs[0].ID || reclaimed[0].Generation <= stale.Generation || reclaimed[0].Token == stale.Token {
+		t.Fatalf("reclaimed=%#v err=%v, stale=%#v", reclaimed, err, stale)
+	}
+	if err := app.CompleteJob(ctx, stale); !errors.Is(err, ErrStaleLease) {
+		t.Fatalf("stale completion error=%v", err)
+	}
+	if err := app.RetryJob(ctx, JobRetry{Lease: reclaimed[0].Lease(), ErrorCode: "transient", Delay: time.Minute}); err != nil {
+		t.Fatal(err)
+	}
+	if premature, err := app.ClaimJobs(ctx, ClaimJobs{Kind: "project.created", Holder: principalB.ID, Limit: 1, LeaseDuration: time.Minute}); err != nil || len(premature) != 0 {
+		t.Fatalf("backoff job claimed before availability: jobs=%#v err=%v", premature, err)
+	}
+	if _, err := ownerDB.ExecContext(ctx, `UPDATE jobs.outbox SET available_at = statement_timestamp() - interval '1 second' WHERE id = $1`, reclaimed[0].ID); err != nil {
+		t.Fatal(err)
+	}
+
+	var activeBefore, projectsBefore, auditBefore, idempotencyBefore int
+	if err := ownerDB.QueryRowContext(ctx, `SELECT active_count FROM jobs.queue_capacity WHERE singleton`).Scan(&activeBefore); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ownerDB.ExecContext(ctx, `UPDATE jobs.queue_capacity SET max_depth = active_count WHERE singleton`); err != nil {
+		t.Fatal(err)
+	}
+	if err := ownerDB.QueryRowContext(ctx, `SELECT
+        (SELECT count(*) FROM relay.projects),
+        (SELECT count(*) FROM audit.events),
+        (SELECT count(*) FROM relay.idempotency_records)`).Scan(&projectsBefore, &auditBefore, &idempotencyBefore); err != nil {
+		t.Fatal(err)
+	}
+	full := ProjectCreate{PrincipalID: principalA.ID, IdempotencyKey: "66666666-6666-4666-8666-666666666666", DisplayName: "queue full rollback"}
+	if _, err := app.CreateProject(ctx, full); !errors.Is(err, ErrQueueFull) {
+		t.Fatalf("queue-full project error=%v", err)
+	}
+	var projectsAfter, auditAfter, idempotencyAfter, activeAfter int
+	if err := ownerDB.QueryRowContext(ctx, `SELECT
+        (SELECT count(*) FROM relay.projects),
+        (SELECT count(*) FROM audit.events),
+        (SELECT count(*) FROM relay.idempotency_records),
+        (SELECT active_count FROM jobs.queue_capacity WHERE singleton)`).Scan(&projectsAfter, &auditAfter, &idempotencyAfter, &activeAfter); err != nil {
+		t.Fatal(err)
+	}
+	if projectsAfter != projectsBefore || auditAfter != auditBefore || idempotencyAfter != idempotencyBefore || activeAfter != activeBefore {
+		t.Fatalf("queue-full rollback changed projects %d/%d audit %d/%d idempotency %d/%d active %d/%d", projectsBefore, projectsAfter, auditBefore, auditAfter, idempotencyBefore, idempotencyAfter, activeBefore, activeAfter)
+	}
+	if _, err := ownerDB.ExecContext(ctx, `UPDATE jobs.queue_capacity SET max_depth = 10000 WHERE singleton`); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := app.CompleteJob(ctx, reclaimed[0].Lease()); !errors.Is(err, ErrStaleLease) {
+		t.Fatalf("retried lease remained publishable: %v", err)
+	}
+	claimedAgain, err := app.ClaimJobs(ctx, ClaimJobs{Kind: "project.created", Holder: principalB.ID, Limit: 1, LeaseDuration: time.Minute})
+	if err != nil || len(claimedAgain) != 1 {
+		t.Fatalf("retry claim=%#v err=%v", claimedAgain, err)
+	}
+	if _, err := ownerDB.ExecContext(ctx, `UPDATE jobs.outbox SET attempts = max_attempts, lease_until = statement_timestamp() - interval '1 second' WHERE id = $1`, claimedAgain[0].ID); err != nil {
+		t.Fatal(err)
+	}
+	if jobs, err := app.ClaimJobs(ctx, ClaimJobs{Kind: "project.created", Holder: principalA.ID, Limit: 1, LeaseDuration: time.Minute}); err != nil || len(jobs) != 0 {
+		t.Fatalf("exhausted job was reclaimed: jobs=%#v err=%v", jobs, err)
+	}
+	var terminalState string
+	if err := ownerDB.QueryRowContext(ctx, `SELECT state FROM jobs.outbox WHERE id = $1`, claimedAgain[0].ID).Scan(&terminalState); err != nil || terminalState != "failed" {
+		t.Fatalf("exhausted state=%q err=%v", terminalState, err)
+	}
+	if _, err := ownerDB.ExecContext(ctx, `UPDATE jobs.outbox SET completed_at = statement_timestamp() - interval '2 hours' WHERE id = $1`, claimedAgain[0].ID); err == nil {
+		t.Fatal("terminal job was mutable")
+	}
+	pruned, err := app.PruneTerminalJobs(ctx, time.Now().Add(time.Hour), 1)
+	if err != nil || pruned != 1 {
+		t.Fatalf("pruned=%d err=%v", pruned, err)
 	}
 }
 

--- a/internal/postgres/postgres_integration_test.go
+++ b/internal/postgres/postgres_integration_test.go
@@ -88,6 +88,7 @@ func TestPostgresPlatformSubstrateIntegration(t *testing.T) {
 	close(errorsSeen)
 	for migrateErr := range errorsSeen {
 		if migrateErr != nil {
+			logControlPlaneCatalog(ctx, t, ownerDB)
 			t.Fatalf("concurrent migration failed: %v", migrateErr)
 		}
 	}
@@ -623,6 +624,45 @@ func testControlPlaneIntegration(ctx context.Context, t *testing.T, app *Databas
 	pruned, err := app.PruneTerminalJobs(ctx, time.Now().Add(time.Hour), 1)
 	if err != nil || pruned != 1 {
 		t.Fatalf("pruned=%d err=%v", pruned, err)
+	}
+}
+
+func logControlPlaneCatalog(ctx context.Context, t *testing.T, db *sql.DB) {
+	t.Helper()
+	rows, err := db.QueryContext(ctx, `SELECT oid::regprocedure::text, pg_get_userbyid(proowner), prosecdef, proconfig::text, md5(btrim(prosrc))
+FROM pg_proc WHERE oid = ANY(ARRAY[
+    to_regprocedure('jobs.guard_outbox_capacity_and_state()'),
+    to_regprocedure('audit.prune_events(timestamp with time zone,integer)'),
+    to_regprocedure('jobs.prune_terminal(timestamp with time zone,integer)')
+]) ORDER BY oid::regprocedure::text`)
+	if err != nil {
+		t.Logf("control-plane function diagnostics unavailable: %v", err)
+	} else {
+		defer func() { _ = rows.Close() }()
+		for rows.Next() {
+			var name, owner, config, hash string
+			var securityDefiner bool
+			if err := rows.Scan(&name, &owner, &securityDefiner, &config, &hash); err != nil {
+				t.Logf("control-plane function diagnostic malformed: %v", err)
+				break
+			}
+			t.Logf("control-plane function name=%s owner=%s security_definer=%t config=%v body_md5=%s", name, owner, securityDefiner, config, hash)
+		}
+	}
+	var indexKeys, indexExpression, indexPredicate string
+	var indexUnique, indexValid, indexReady bool
+	if err := db.QueryRowContext(ctx, `SELECT indkey::text, pg_get_expr(indexprs, indrelid), pg_get_expr(indpred, indrelid), indisunique, indisvalid, indisready
+FROM pg_index WHERE indexrelid = to_regclass('auth.capability_grants_active_unique')`).Scan(&indexKeys, &indexExpression, &indexPredicate, &indexUnique, &indexValid, &indexReady); err != nil {
+		t.Logf("control-plane index diagnostics unavailable: %v", err)
+	} else {
+		t.Logf("control-plane index keys=%s expression=%q predicate=%q unique=%t valid=%t ready=%t", indexKeys, indexExpression, indexPredicate, indexUnique, indexValid, indexReady)
+	}
+	var triggerType int
+	var triggerEnabled string
+	if err := db.QueryRowContext(ctx, `SELECT tgtype, tgenabled::text FROM pg_trigger WHERE tgrelid = to_regclass('jobs.outbox') AND tgname = 'outbox_capacity_and_state'`).Scan(&triggerType, &triggerEnabled); err != nil {
+		t.Logf("control-plane trigger diagnostics unavailable: %v", err)
+	} else {
+		t.Logf("control-plane trigger type=%d enabled=%s", triggerType, triggerEnabled)
 	}
 }
 

--- a/internal/postgres/postgres_integration_test.go
+++ b/internal/postgres/postgres_integration_test.go
@@ -371,13 +371,40 @@ func testControlPlaneIntegration(ctx context.Context, t *testing.T, app *Databas
 	if err != nil {
 		t.Fatal(err)
 	}
-	creatorGrantID, err := app.GrantCapability(ctx, Grant{PrincipalID: principalA.ID, Scope: ScopeInstallation, Capability: CapabilityProjectCreate})
+	// M-3 replaces this fixture with the host-local first-owner bootstrap. M-2
+	// seeds the minimum root authority out of band so every public grant mutation
+	// can prove actor authorization without adding an unauthenticated back door.
+	var creatorGrantID, bootstrapAdminGrantID string
+	err = ownerDB.QueryRowContext(ctx, `INSERT INTO auth.capability_grants (principal_id, scope, capability)
+VALUES ($1, 'installation', 'project.create') RETURNING id::text`, principalA.ID).Scan(&creatorGrantID)
 	if err != nil {
 		t.Fatal(err)
 	}
-	dynamicGrantID, err := app.GrantCapability(ctx, Grant{PrincipalID: principalB.ID, Scope: ScopeAllProjects, Capability: CapabilityMemoryRead})
+	err = ownerDB.QueryRowContext(ctx, `INSERT INTO auth.capability_grants (principal_id, scope, capability)
+VALUES ($1, 'all_projects', 'project.administer') RETURNING id::text`, principalA.ID).Scan(&bootstrapAdminGrantID)
 	if err != nil {
 		t.Fatal(err)
+	}
+	if _, err := app.GrantCapability(ctx, principalB.ID, Grant{PrincipalID: principalB.ID, Scope: ScopeAllProjects, Capability: CapabilityMemoryRead}); !errors.Is(err, ErrForbidden) {
+		t.Fatalf("unauthorized self-grant error=%v", err)
+	}
+	var unauthorizedGrantRows int
+	if err := ownerDB.QueryRowContext(ctx, `SELECT count(*) FROM auth.capability_grants
+WHERE principal_id = $1 AND scope = 'all_projects' AND capability = 'memory.read'`, principalB.ID).Scan(&unauthorizedGrantRows); err != nil || unauthorizedGrantRows != 0 {
+		t.Fatalf("unauthorized grant left rows=%d err=%v", unauthorizedGrantRows, err)
+	}
+	if _, err := app.GrantCapability(ctx, principalA.ID, Grant{PrincipalID: principalB.ID, Scope: ScopeInstallation, Capability: CapabilityProjectCreate}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := app.GrantCapability(ctx, principalB.ID, Grant{PrincipalID: principalB.ID, Scope: ScopeAllProjects, Capability: CapabilityMemoryRead}); !errors.Is(err, ErrForbidden) {
+		t.Fatalf("ordinary project creator administered grants: %v", err)
+	}
+	dynamicGrantID, err := app.GrantCapability(ctx, principalA.ID, Grant{PrincipalID: principalB.ID, Scope: ScopeAllProjects, Capability: CapabilityMemoryRead})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := app.RevokeGrant(ctx, principalB.ID, dynamicGrantID); !errors.Is(err, ErrForbidden) {
+		t.Fatalf("ordinary project creator revoked grant: %v", err)
 	}
 	grantState, err := app.InstallationState(ctx)
 	if err != nil {
@@ -386,6 +413,10 @@ func testControlPlaneIntegration(ctx context.Context, t *testing.T, app *Databas
 	var grantAuditBefore int
 	if err := ownerDB.QueryRowContext(ctx, `SELECT count(*) FROM audit.events WHERE target_id = $1 AND action = 'grant.create'`, dynamicGrantID).Scan(&grantAuditBefore); err != nil {
 		t.Fatal(err)
+	}
+	var grantAuditActor string
+	if err := ownerDB.QueryRowContext(ctx, `SELECT principal_id::text FROM audit.events WHERE target_id = $1 AND action = 'grant.create'`, dynamicGrantID).Scan(&grantAuditActor); err != nil || grantAuditActor != principalA.ID {
+		t.Fatalf("grant audit actor=%q err=%v", grantAuditActor, err)
 	}
 	type grantResult struct {
 		id  string
@@ -396,7 +427,7 @@ func testControlPlaneIntegration(ctx context.Context, t *testing.T, app *Databas
 	for range 2 {
 		go func() {
 			<-grantStart
-			id, grantErr := app.GrantCapability(ctx, Grant{PrincipalID: principalB.ID, Scope: ScopeAllProjects, Capability: CapabilityMemoryRead})
+			id, grantErr := app.GrantCapability(ctx, principalA.ID, Grant{PrincipalID: principalB.ID, Scope: ScopeAllProjects, Capability: CapabilityMemoryRead})
 			grantResults <- grantResult{id: id, err: grantErr}
 		}()
 	}
@@ -446,14 +477,14 @@ func testControlPlaneIntegration(ctx context.Context, t *testing.T, app *Databas
 	if err != nil || after.ChangeSequence != before.ChangeSequence+1 || first.ChangeSequence != after.ChangeSequence {
 		t.Fatalf("project sequence before=%#v result=%#v after=%#v err=%v", before, first, after, err)
 	}
-	if err := app.RevokeGrant(ctx, creatorGrantID); err != nil {
+	if err := app.RevokeGrant(ctx, principalA.ID, creatorGrantID); err != nil {
 		t.Fatal(err)
 	}
 	retryAfterRevoke, err := app.CreateProject(ctx, create)
 	if err != nil || retryAfterRevoke != first {
 		t.Fatalf("exact project retry after authority revocation=%#v err=%v, want %#v", retryAfterRevoke, err, first)
 	}
-	if _, err := app.GrantCapability(ctx, Grant{PrincipalID: principalA.ID, Scope: ScopeInstallation, Capability: CapabilityProjectCreate}); err != nil {
+	if _, err := app.GrantCapability(ctx, principalA.ID, Grant{PrincipalID: principalA.ID, Scope: ScopeInstallation, Capability: CapabilityProjectCreate}); err != nil {
 		t.Fatal(err)
 	}
 	for _, check := range []struct {
@@ -480,8 +511,8 @@ func testControlPlaneIntegration(ctx context.Context, t *testing.T, app *Databas
 		t.Fatal(err)
 	}
 	for name, invalidJob := range map[string]EnqueueJob{
-		"unknown kind":    {Kind: "project.reconcile", ProjectID: first.ProjectID, Payload: json.RawMessage(`{}`), MaxAttempts: 1},
-		"missing project": {Kind: "project.created", Payload: json.RawMessage(`{}`), MaxAttempts: 1},
+		"unknown kind":    {ActorPrincipalID: principalA.ID, Kind: "project.reconcile", ProjectID: first.ProjectID, Payload: json.RawMessage(`{}`), MaxAttempts: 1},
+		"missing project": {ActorPrincipalID: principalA.ID, Kind: "project.created", Payload: json.RawMessage(`{}`), MaxAttempts: 1},
 	} {
 		t.Run("invalid enqueue "+name, func(t *testing.T) {
 			tx, txErr := app.db.BeginTx(ctx, nil)
@@ -509,7 +540,7 @@ func testControlPlaneIntegration(ctx context.Context, t *testing.T, app *Databas
 	if _, err := app.CreateProject(ctx, changed); !errors.Is(err, ErrIdempotencyConflict) {
 		t.Fatalf("changed idempotent body error=%v", err)
 	}
-	if _, err := app.GrantCapability(ctx, Grant{PrincipalID: principalB.ID, Scope: ScopeInstallation, Capability: CapabilityProjectCreate}); err != nil {
+	if _, err := app.GrantCapability(ctx, principalA.ID, Grant{PrincipalID: principalB.ID, Scope: ScopeInstallation, Capability: CapabilityProjectCreate}); err != nil {
 		t.Fatal(err)
 	}
 	changed = create
@@ -547,7 +578,26 @@ func testControlPlaneIntegration(ctx context.Context, t *testing.T, app *Databas
 	if allowed, err := app.HasCapability(ctx, principalB.ID, second.ProjectID, CapabilityMemoryRead); err != nil || !allowed {
 		t.Fatalf("dynamic all-projects grant did not cover future project: allowed=%t err=%v", allowed, err)
 	}
-	if err := app.RevokeGrant(ctx, dynamicGrantID); err != nil {
+	if _, err := app.GrantCapability(ctx, principalA.ID, Grant{PrincipalID: principalB.ID, Scope: ScopeProject, ProjectID: first.ProjectID, Capability: CapabilityProjectAdminister}); err != nil {
+		t.Fatal(err)
+	}
+	exactProjectGrantID, err := app.GrantCapability(ctx, principalB.ID, Grant{PrincipalID: principalB.ID, Scope: ScopeProject, ProjectID: first.ProjectID, Capability: CapabilityMemoryWrite})
+	if err != nil {
+		t.Fatalf("exact-project administrator could not grant in its project: %v", err)
+	}
+	for name, forbiddenGrant := range map[string]Grant{
+		"other project": {PrincipalID: principalB.ID, Scope: ScopeProject, ProjectID: second.ProjectID, Capability: CapabilityMemoryWrite},
+		"installation":  {PrincipalID: principalB.ID, Scope: ScopeInstallation, Capability: CapabilityProjectCreate},
+		"all projects":  {PrincipalID: principalB.ID, Scope: ScopeAllProjects, Capability: CapabilityMemoryWrite},
+	} {
+		if _, err := app.GrantCapability(ctx, principalB.ID, forbiddenGrant); !errors.Is(err, ErrForbidden) {
+			t.Fatalf("exact-project administrator mutated %s scope: %v", name, err)
+		}
+	}
+	if err := app.RevokeGrant(ctx, principalB.ID, exactProjectGrantID); err != nil {
+		t.Fatalf("exact-project administrator could not revoke in its project: %v", err)
+	}
+	if err := app.RevokeGrant(ctx, principalA.ID, dynamicGrantID); err != nil {
 		t.Fatal(err)
 	}
 	if allowed, err := app.HasCapability(ctx, principalB.ID, second.ProjectID, CapabilityMemoryRead); err != nil || allowed {
@@ -555,7 +605,7 @@ func testControlPlaneIntegration(ctx context.Context, t *testing.T, app *Databas
 	}
 	adminGrantIDs := make(map[string]string, 2)
 	for _, principalID := range []string{principalA.ID, principalB.ID} {
-		grantID, err := app.GrantCapability(ctx, Grant{PrincipalID: principalID, Scope: ScopeAllProjects, Capability: CapabilityProjectAdminister})
+		grantID, err := app.GrantCapability(ctx, principalA.ID, Grant{PrincipalID: principalID, Scope: ScopeAllProjects, Capability: CapabilityProjectAdminister})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -616,13 +666,17 @@ func testControlPlaneIntegration(ctx context.Context, t *testing.T, app *Databas
 	if err := app.CompleteJob(ctx, stale); !errors.Is(err, ErrStaleLease) {
 		t.Fatalf("stale completion error=%v", err)
 	}
-	if err := app.RevokeGrant(ctx, adminGrantIDs[reclaimed[0].Holder]); err != nil {
+	revocationActor := principalB.ID
+	if reclaimed[0].Holder == principalB.ID {
+		revocationActor = principalA.ID
+	}
+	if err := app.RevokeGrant(ctx, revocationActor, adminGrantIDs[reclaimed[0].Holder]); err != nil {
 		t.Fatal(err)
 	}
 	if err := app.RetryJob(ctx, JobRetry{Lease: reclaimed[0].Lease(), ErrorCode: "transient", Delay: time.Minute}); !errors.Is(err, ErrStaleLease) {
 		t.Fatalf("revoked holder retried leased job: %v", err)
 	}
-	replacementGrantID, err := app.GrantCapability(ctx, Grant{PrincipalID: reclaimed[0].Holder, Scope: ScopeAllProjects, Capability: CapabilityProjectAdminister})
+	replacementGrantID, err := app.GrantCapability(ctx, revocationActor, Grant{PrincipalID: reclaimed[0].Holder, Scope: ScopeAllProjects, Capability: CapabilityProjectAdminister})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -676,15 +730,49 @@ func testControlPlaneIntegration(ctx context.Context, t *testing.T, app *Databas
 	if err != nil || len(claimedAgain) != 1 {
 		t.Fatalf("retry claim=%#v err=%v", claimedAgain, err)
 	}
-	if _, err := ownerDB.ExecContext(ctx, `UPDATE jobs.outbox SET attempts = max_attempts, lease_until = statement_timestamp() - interval '1 second' WHERE id = $1`, claimedAgain[0].ID); err != nil {
+	if _, err := ownerDB.ExecContext(ctx, `UPDATE jobs.outbox SET attempts = max_attempts WHERE id = $1`, claimedAgain[0].ID); err != nil {
+		t.Fatal(err)
+	}
+	if err := app.RetryJob(ctx, JobRetry{Lease: claimedAgain[0].Lease(), ErrorCode: "terminal", Delay: 0}); err != nil {
+		t.Fatalf("terminal retry failed: %v", err)
+	}
+	var terminalState string
+	if err := ownerDB.QueryRowContext(ctx, `SELECT state FROM jobs.outbox WHERE id = $1`, claimedAgain[0].ID).Scan(&terminalState); err != nil || terminalState != "failed" {
+		t.Fatalf("terminal retry state=%q err=%v", terminalState, err)
+	}
+	exhaustionProject, err := app.CreateProject(ctx, ProjectCreate{PrincipalID: principalA.ID, IdempotencyKey: "77777777-7777-4777-8777-777777777777", DisplayName: "exhaustion audit"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	exhaustionJobs, err := app.ClaimJobs(ctx, ClaimJobs{Kind: "project.created", Holder: principalB.ID, Limit: 1, LeaseDuration: time.Minute})
+	if err != nil || len(exhaustionJobs) != 1 || exhaustionJobs[0].ProjectID != exhaustionProject.ProjectID {
+		t.Fatalf("exhaustion setup jobs=%#v err=%v", exhaustionJobs, err)
+	}
+	if _, err := ownerDB.ExecContext(ctx, `UPDATE jobs.outbox SET attempts = max_attempts, lease_until = statement_timestamp() - interval '1 second' WHERE id = $1`, exhaustionJobs[0].ID); err != nil {
 		t.Fatal(err)
 	}
 	if jobs, err := app.ClaimJobs(ctx, ClaimJobs{Kind: "project.created", Holder: principalC.ID, Limit: 1, LeaseDuration: time.Minute}); err != nil || len(jobs) != 0 {
 		t.Fatalf("exhausted job was reclaimed: jobs=%#v err=%v", jobs, err)
 	}
-	var terminalState string
-	if err := ownerDB.QueryRowContext(ctx, `SELECT state FROM jobs.outbox WHERE id = $1`, claimedAgain[0].ID).Scan(&terminalState); err != nil || terminalState != "failed" {
+	if err := ownerDB.QueryRowContext(ctx, `SELECT state FROM jobs.outbox WHERE id = $1`, exhaustionJobs[0].ID).Scan(&terminalState); err != nil || terminalState != "failed" {
 		t.Fatalf("exhausted state=%q err=%v", terminalState, err)
+	}
+	var enqueueAudits, completionAudits, retryAudits, failureAudits int
+	if err := ownerDB.QueryRowContext(ctx, `SELECT
+		count(*) FILTER (WHERE action = 'job.enqueue'),
+		count(*) FILTER (WHERE action = 'job.complete'),
+		count(*) FILTER (WHERE action = 'job.retry'),
+		count(*) FILTER (WHERE action = 'job.fail')
+		FROM audit.events WHERE target_kind = 'job'`).Scan(&enqueueAudits, &completionAudits, &retryAudits, &failureAudits); err != nil {
+		t.Fatal(err)
+	}
+	if enqueueAudits != 3 || completionAudits != 1 || retryAudits != 1 || failureAudits != 2 {
+		t.Fatalf("job audit counts enqueue=%d complete=%d retry=%d fail=%d", enqueueAudits, completionAudits, retryAudits, failureAudits)
+	}
+	var exhaustedAuditActor string
+	if err := ownerDB.QueryRowContext(ctx, `SELECT principal_id::text FROM audit.events
+		WHERE target_id = $1 AND action = 'job.fail'`, exhaustionJobs[0].ID).Scan(&exhaustedAuditActor); err != nil || exhaustedAuditActor != exhaustionJobs[0].Holder {
+		t.Fatalf("exhausted audit actor=%q err=%v", exhaustedAuditActor, err)
 	}
 	if _, err := ownerDB.ExecContext(ctx, `UPDATE jobs.outbox SET completed_at = statement_timestamp() - interval '2 hours' WHERE id = $1`, claimedAgain[0].ID); err == nil {
 		t.Fatal("terminal job was mutable")

--- a/internal/postgres/postgres_integration_test.go
+++ b/internal/postgres/postgres_integration_test.go
@@ -475,6 +475,34 @@ func testControlPlaneIntegration(ctx context.Context, t *testing.T, app *Databas
 	if _, err := app.HasCapability(ctx, principalA.ID, "friendly alpha", CapabilityProjectRead); err == nil {
 		t.Fatal("friendly project label accepted as authority")
 	}
+	var capacityBeforeInvalidJobs int
+	if err := ownerDB.QueryRowContext(ctx, `SELECT active_count FROM jobs.queue_capacity WHERE singleton`).Scan(&capacityBeforeInvalidJobs); err != nil {
+		t.Fatal(err)
+	}
+	for name, invalidJob := range map[string]EnqueueJob{
+		"unknown kind":    {Kind: "project.reconcile", ProjectID: first.ProjectID, Payload: json.RawMessage(`{}`), MaxAttempts: 1},
+		"missing project": {Kind: "project.created", Payload: json.RawMessage(`{}`), MaxAttempts: 1},
+	} {
+		t.Run("invalid enqueue "+name, func(t *testing.T) {
+			tx, txErr := app.db.BeginTx(ctx, nil)
+			if txErr != nil {
+				t.Fatal(txErr)
+			}
+			defer func() { _ = tx.Rollback() }()
+			if _, enqueueErr := (&ControlTx{tx: tx}).EnqueueJob(ctx, invalidJob); enqueueErr == nil {
+				t.Fatal("invalid job was enqueued")
+			}
+		})
+	}
+	var capacityAfterInvalidJobs, invalidJobRows int
+	if err := ownerDB.QueryRowContext(ctx, `SELECT
+		(SELECT active_count FROM jobs.queue_capacity WHERE singleton),
+		(SELECT count(*) FROM jobs.outbox WHERE kind = 'project.reconcile' OR project_id IS NULL)`).Scan(&capacityAfterInvalidJobs, &invalidJobRows); err != nil {
+		t.Fatal(err)
+	}
+	if capacityAfterInvalidJobs != capacityBeforeInvalidJobs || invalidJobRows != 0 {
+		t.Fatalf("invalid enqueue changed capacity %d/%d or left %d rows", capacityBeforeInvalidJobs, capacityAfterInvalidJobs, invalidJobRows)
+	}
 
 	changed := create
 	changed.DisplayName = "changed body"
@@ -525,10 +553,13 @@ func testControlPlaneIntegration(ctx context.Context, t *testing.T, app *Databas
 	if allowed, err := app.HasCapability(ctx, principalB.ID, second.ProjectID, CapabilityMemoryRead); err != nil || allowed {
 		t.Fatalf("revoked dynamic grant remained effective: allowed=%t err=%v", allowed, err)
 	}
+	adminGrantIDs := make(map[string]string, 2)
 	for _, principalID := range []string{principalA.ID, principalB.ID} {
-		if _, err := app.GrantCapability(ctx, Grant{PrincipalID: principalID, Scope: ScopeAllProjects, Capability: CapabilityProjectAdminister}); err != nil {
+		grantID, err := app.GrantCapability(ctx, Grant{PrincipalID: principalID, Scope: ScopeAllProjects, Capability: CapabilityProjectAdminister})
+		if err != nil {
 			t.Fatal(err)
 		}
+		adminGrantIDs[principalID] = grantID
 	}
 	if unauthorizedJobs, err := app.ClaimJobs(ctx, ClaimJobs{Kind: "project.created", Holder: principalC.ID, Limit: 1, LeaseDuration: time.Minute}); err != nil || len(unauthorizedJobs) != 0 {
 		t.Fatalf("unauthorized worker received jobs=%#v err=%v", unauthorizedJobs, err)
@@ -562,6 +593,15 @@ func testControlPlaneIntegration(ctx context.Context, t *testing.T, app *Databas
 		t.Fatalf("concurrent disjoint claims=%#v/%#v", firstClaim, secondClaim)
 	}
 	jobs, otherJobs := firstClaim.jobs, secondClaim.jobs
+	if _, err := ownerDB.ExecContext(ctx, `UPDATE auth.principals SET disabled_at = statement_timestamp() WHERE id = $1`, jobs[0].Holder); err != nil {
+		t.Fatal(err)
+	}
+	if err := app.CompleteJob(ctx, jobs[0].Lease()); !errors.Is(err, ErrStaleLease) {
+		t.Fatalf("disabled holder completed leased job: %v", err)
+	}
+	if _, err := ownerDB.ExecContext(ctx, `UPDATE auth.principals SET disabled_at = NULL WHERE id = $1`, jobs[0].Holder); err != nil {
+		t.Fatal(err)
+	}
 	if err := app.CompleteJob(ctx, jobs[0].Lease()); err != nil {
 		t.Fatal(err)
 	}
@@ -576,6 +616,17 @@ func testControlPlaneIntegration(ctx context.Context, t *testing.T, app *Databas
 	if err := app.CompleteJob(ctx, stale); !errors.Is(err, ErrStaleLease) {
 		t.Fatalf("stale completion error=%v", err)
 	}
+	if err := app.RevokeGrant(ctx, adminGrantIDs[reclaimed[0].Holder]); err != nil {
+		t.Fatal(err)
+	}
+	if err := app.RetryJob(ctx, JobRetry{Lease: reclaimed[0].Lease(), ErrorCode: "transient", Delay: time.Minute}); !errors.Is(err, ErrStaleLease) {
+		t.Fatalf("revoked holder retried leased job: %v", err)
+	}
+	replacementGrantID, err := app.GrantCapability(ctx, Grant{PrincipalID: reclaimed[0].Holder, Scope: ScopeAllProjects, Capability: CapabilityProjectAdminister})
+	if err != nil {
+		t.Fatal(err)
+	}
+	adminGrantIDs[reclaimed[0].Holder] = replacementGrantID
 	if err := app.RetryJob(ctx, JobRetry{Lease: reclaimed[0].Lease(), ErrorCode: "transient", Delay: time.Minute}); err != nil {
 		t.Fatal(err)
 	}
@@ -628,7 +679,7 @@ func testControlPlaneIntegration(ctx context.Context, t *testing.T, app *Databas
 	if _, err := ownerDB.ExecContext(ctx, `UPDATE jobs.outbox SET attempts = max_attempts, lease_until = statement_timestamp() - interval '1 second' WHERE id = $1`, claimedAgain[0].ID); err != nil {
 		t.Fatal(err)
 	}
-	if jobs, err := app.ClaimJobs(ctx, ClaimJobs{Kind: "project.created", Holder: principalA.ID, Limit: 1, LeaseDuration: time.Minute}); err != nil || len(jobs) != 0 {
+	if jobs, err := app.ClaimJobs(ctx, ClaimJobs{Kind: "project.created", Holder: principalC.ID, Limit: 1, LeaseDuration: time.Minute}); err != nil || len(jobs) != 0 {
 		t.Fatalf("exhausted job was reclaimed: jobs=%#v err=%v", jobs, err)
 	}
 	var terminalState string

--- a/internal/postgres/state.go
+++ b/internal/postgres/state.go
@@ -63,11 +63,14 @@ type AppliedMigration struct {
 
 // Snapshot is the read-only evidence used to classify a database schema.
 type Snapshot struct {
-	OwnedSchemaCount       int
-	TrackingExists         bool
-	RequiredObjectsPresent bool
-	Records                []AppliedMigration
+	OwnedSchemaCount      int
+	TrackingExists        bool
+	BaseObjectsPresent    bool
+	CurrentObjectsPresent bool
+	Records               []AppliedMigration
 }
+
+const controlPlaneSchemaVersion int64 = 2
 
 // SchemaState contains a content-free classification and highest version.
 type SchemaState struct {
@@ -117,7 +120,7 @@ func Classify(snapshot Snapshot, manifest Manifest) SchemaState {
 			}
 		}
 	}
-	if snapshot.OwnedSchemaCount != 6 || !snapshot.RequiredObjectsPresent {
+	if snapshot.OwnedSchemaCount != 6 || !snapshot.BaseObjectsPresent {
 		return SchemaState{Classification: Incompatible}
 	}
 	version := records[len(records)-1].Version
@@ -126,6 +129,8 @@ func Classify(snapshot Snapshot, manifest Manifest) SchemaState {
 		return SchemaState{Classification: Newer, Version: version}
 	case version < manifest.MinSupported:
 		return SchemaState{Classification: UpgradeRequired, Version: version}
+	case version >= controlPlaneSchemaVersion && !snapshot.CurrentObjectsPresent:
+		return SchemaState{Classification: Incompatible, Version: version}
 	default:
 		return SchemaState{Classification: Compatible, Version: version}
 	}

--- a/internal/postgres/state_test.go
+++ b/internal/postgres/state_test.go
@@ -16,7 +16,7 @@ func TestClassifySchemaState(t *testing.T) {
 		return AppliedMigration{Version: version, Name: name, Checksum: checksum, CompatibilityFloor: floor, Status: "applied"}
 	}
 	tracked := func(records ...AppliedMigration) Snapshot {
-		return Snapshot{OwnedSchemaCount: 6, TrackingExists: true, RequiredObjectsPresent: true, Records: records}
+		return Snapshot{OwnedSchemaCount: 6, TrackingExists: true, BaseObjectsPresent: true, CurrentObjectsPresent: true, Records: records}
 	}
 	tests := []struct {
 		name     string
@@ -25,11 +25,12 @@ func TestClassifySchemaState(t *testing.T) {
 	}{
 		{name: "pristine", snapshot: Snapshot{}, want: Pristine},
 		{name: "partial bootstrap", snapshot: Snapshot{OwnedSchemaCount: 1}, want: Incompatible},
-		{name: "empty tracker", snapshot: Snapshot{OwnedSchemaCount: 6, TrackingExists: true, RequiredObjectsPresent: true}, want: Incompatible},
-		{name: "missing required schema", snapshot: Snapshot{OwnedSchemaCount: 5, TrackingExists: true, RequiredObjectsPresent: true, Records: []AppliedMigration{applied(1, "bootstrap", "one", 1)}}, want: Incompatible},
+		{name: "empty tracker", snapshot: Snapshot{OwnedSchemaCount: 6, TrackingExists: true, BaseObjectsPresent: true, CurrentObjectsPresent: true}, want: Incompatible},
+		{name: "missing required schema", snapshot: Snapshot{OwnedSchemaCount: 5, TrackingExists: true, BaseObjectsPresent: true, CurrentObjectsPresent: true, Records: []AppliedMigration{applied(1, "bootstrap", "one", 1)}}, want: Incompatible},
 		{name: "missing required object", snapshot: Snapshot{OwnedSchemaCount: 6, TrackingExists: true, Records: []AppliedMigration{applied(1, "bootstrap", "one", 1)}}, want: Incompatible},
-		{name: "upgrade required", snapshot: tracked(applied(1, "bootstrap", "one", 1)), want: UpgradeRequired},
+		{name: "upgrade required without future objects", snapshot: Snapshot{OwnedSchemaCount: 6, TrackingExists: true, BaseObjectsPresent: true, Records: []AppliedMigration{applied(1, "bootstrap", "one", 1)}}, want: UpgradeRequired},
 		{name: "compatible", snapshot: tracked(applied(1, "bootstrap", "one", 1), applied(2, "second", "two", 2)), want: Compatible},
+		{name: "compatible history missing current object", snapshot: Snapshot{OwnedSchemaCount: 6, TrackingExists: true, BaseObjectsPresent: true, Records: []AppliedMigration{applied(1, "bootstrap", "one", 1), applied(2, "second", "two", 2)}}, want: Incompatible},
 		{name: "compatible latest", snapshot: tracked(applied(1, "bootstrap", "one", 1), applied(2, "second", "two", 2), applied(3, "third", "three", 2)), want: Compatible},
 		{name: "newer", snapshot: tracked(applied(1, "bootstrap", "one", 1), applied(2, "second", "two", 2), applied(3, "third", "three", 2), applied(4, "future", "unknown", 3)), want: Newer},
 		{name: "dirty", snapshot: tracked(AppliedMigration{Version: 1, Name: "bootstrap", Checksum: "one", CompatibilityFloor: 1, Status: "applying"}), want: Dirty},
@@ -60,5 +61,15 @@ func TestManifestValidationRejectsMutableOrNonContiguousHistory(t *testing.T) {
 		if err := manifest.Validate(); err == nil {
 			t.Errorf("case %d: Validate() succeeded, want error", i)
 		}
+	}
+}
+
+func TestCurrentManifestRequiresControlPlaneSchema(t *testing.T) {
+	manifest := CurrentManifest()
+	if manifest.MinSupported != 2 || manifest.MaxSupported != 2 || len(manifest.Migrations) != 2 {
+		t.Fatalf("manifest=%#v, want exact v2 compatibility window", manifest)
+	}
+	if manifest.Migrations[0].CompatibilityFloor != 1 || manifest.Migrations[1].CompatibilityFloor != 2 {
+		t.Fatalf("migration floors=%d,%d, want 1,2", manifest.Migrations[0].CompatibilityFloor, manifest.Migrations[1].CompatibilityFloor)
 	}
 }


### PR DESCRIPTION
## Summary

- add opaque PostgreSQL principals/projects and explicit installation, selected-project, and dynamic all-project capability grants
- add generic request-hash-bound idempotency, closed content-free audit events, and a capacity-bounded transactional outbox/job queue with database-time fenced leases
- add atomic authorized project creation that commits creator grants, audit, queued work, change sequence, and immutable idempotency outcome together
- advance the dark PostgreSQL substrate to schema v2 with fail-closed readiness checks for ownership, privileges, critical index/trigger definitions, and security-definer bodies
- keep SQLite active; no relay cutover, enrollment, identity merge, attachment/brain data, live infrastructure, or Compose Pi behavior

## Validation

- `make ci`
- independent plan-alignment review: PASS
- independent adversarial review: PASS
- independent simplification review: PASS
- real digest-pinned PostgreSQL integration: required in GitHub Actions (no local Docker/Podman/DSN)

## Migration / rollback

Migration 002 is additive and PostgreSQL remains opt-in/dark. Before any later relay cutover, rollback disables PostgreSQL and may discard this control-plane-only schema; there are no dual writes or user-data migrations in this slice.
