### PR TITLE
Harden Cloudflare Access session setup

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -131,6 +131,15 @@ Cloudflare; revoking the machine credential stops it at Punaro. Store both in
 the OS keychain or a root-readable service secret file, never in an agent
 prompt, repository, or mailbox body.
 
+Some Cloudflare Access deployments establish a service-token session through
+an initial redirect. Before a signed adapter operation, the client may perform
+a payload-free session preflight that carries only the two Access headers. It
+may follow at most one HTTPS hop to a `*.cloudflareaccess.com` host and then
+only back to the exact relay origin; it requires an origin-scoped
+`CF_Authorization` cookie before proceeding. Signed request bodies, machine
+signatures, nonces, and idempotency keys are never replayed through this flow.
+All signed relay operations still reject redirects.
+
 `punarod` validates Cloudflare Access JWTs itself (audience, issuer, expiry,
 not-before, and signature via cached JWKS) in addition to accepting traffic
 only through the tunnel. Both the issuer and JWKS endpoint must be

--- a/internal/adapter/client.go
+++ b/internal/adapter/client.go
@@ -276,6 +276,9 @@ func (c *HTTPRelayClient) IssuePermit(ctx context.Context, permitRequest attachm
 	if err != nil {
 		return attachmentv2.Permit{}, fmt.Errorf("encode permit request: %w", err)
 	}
+	if err := c.ensureAccessSession(ctx); err != nil {
+		return attachmentv2.Permit{}, err
+	}
 	nonce, err := randomNonce()
 	if err != nil {
 		return attachmentv2.Permit{}, err
@@ -358,6 +361,9 @@ func (c *HTTPRelayClient) DoV3Attachment(ctx context.Context, method, path strin
 	route, err := attachmentv3.ParseAttachmentRoute(method, path)
 	if err != nil || attachmentv3.VerifyAttachmentRoute(route, permit) != nil {
 		return nil, errors.New("invalid v3 attachment route")
+	}
+	if err := c.ensureAccessSession(ctx); err != nil {
+		return nil, err
 	}
 	nonce, err := randomNonce()
 	if err != nil {
@@ -534,6 +540,7 @@ func (c *HTTPRelayClient) ReadNotifications(ctx context.Context, receive func(re
 		headers.Set("CF-Access-Client-Id", c.accessToken.ClientID)
 		headers.Set("CF-Access-Client-Secret", c.accessToken.ClientSecret)
 	}
+	c.addAccessCookies(headers)
 	connection, response, err := websocket.Dial(ctx, target.String(), &websocket.DialOptions{HTTPHeader: headers, CompressionMode: websocket.CompressionDisabled})
 	if response != nil && response.Body != nil {
 		defer func() { _ = response.Body.Close() }()
@@ -555,6 +562,15 @@ func (c *HTTPRelayClient) ReadNotifications(ctx context.Context, receive func(re
 			return fmt.Errorf("invalid relay notification")
 		}
 		receive(event)
+	}
+}
+
+func (c *HTTPRelayClient) addAccessCookies(headers http.Header) {
+	if c == nil || c.httpClient == nil || c.httpClient.Jar == nil {
+		return
+	}
+	for _, cookie := range c.httpClient.Jar.Cookies(c.baseURL) {
+		headers.Add("Cookie", cookie.Name+"="+cookie.Value)
 	}
 }
 

--- a/internal/adapter/client.go
+++ b/internal/adapter/client.go
@@ -12,8 +12,10 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"net/http/cookiejar"
 	"net/url"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/coder/websocket"
@@ -36,6 +38,17 @@ type HTTPRelayClient struct {
 	privateKey  ed25519.PrivateKey
 	httpClient  *http.Client
 	accessToken AccessServiceToken
+	access      *accessSession
+}
+
+// accessSession establishes and retains Cloudflare Access' short-lived
+// authorization cookie without ever replaying a signed relay request through
+// an Access redirect. It is used only for public, HTTPS relay origins.
+type accessSession struct {
+	baseURL *url.URL
+	client  *http.Client
+	token   AccessServiceToken
+	mu      sync.Mutex
 }
 
 type relayHTTPStatusError struct {
@@ -70,7 +83,91 @@ func NewHTTPRelayClient(rawURL, machineID string, privateKey ed25519.PrivateKey,
 	if client == nil {
 		client = http.DefaultClient
 	}
-	return &HTTPRelayClient{baseURL: baseURL, machineID: machineID, privateKey: append(ed25519.PrivateKey(nil), privateKey...), httpClient: client, accessToken: accessToken}, nil
+	clientCopy := *client
+	result := &HTTPRelayClient{baseURL: baseURL, machineID: machineID, privateKey: append(ed25519.PrivateKey(nil), privateKey...), httpClient: &clientCopy, accessToken: accessToken}
+	if accessToken.ClientID != "" && !loopbackHost(baseURL.Hostname()) {
+		jar, err := cookiejar.New(nil)
+		if err != nil {
+			return nil, fmt.Errorf("create Cloudflare Access cookie jar: %w", err)
+		}
+		result.httpClient.Jar = jar
+		result.access = &accessSession{baseURL: baseURL, client: result.httpClient, token: accessToken}
+	}
+	return result, nil
+}
+
+func (c *HTTPRelayClient) ensureAccessSession(ctx context.Context) error {
+	if c.access == nil {
+		return nil
+	}
+	return c.access.ensure(ctx)
+}
+
+func (a *accessSession) ensure(ctx context.Context) error {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if hasAccessAuthorizationCookie(a.client.Jar, a.baseURL) {
+		return nil
+	}
+
+	target := a.baseURL.ResolveReference(&url.URL{Path: "/.well-known/punaro-access-session"})
+	for hop := 0; hop < 3; hop++ {
+		request, err := http.NewRequestWithContext(ctx, http.MethodGet, target.String(), nil)
+		if err != nil {
+			return fmt.Errorf("build Cloudflare Access session request: %w", err)
+		}
+		request.Header.Set("CF-Access-Client-Id", a.token.ClientID)
+		request.Header.Set("CF-Access-Client-Secret", a.token.ClientSecret)
+		client := *a.client
+		client.CheckRedirect = func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse }
+		response, err := client.Do(request)
+		if err != nil {
+			return fmt.Errorf("establish Cloudflare Access session: %w", err)
+		}
+		_, _ = io.Copy(io.Discard, io.LimitReader(response.Body, 64<<10))
+		_ = response.Body.Close()
+		if response.StatusCode < http.StatusMultipleChoices || response.StatusCode >= http.StatusBadRequest {
+			if hasAccessAuthorizationCookie(a.client.Jar, a.baseURL) {
+				return nil
+			}
+			return fmt.Errorf("cloudflare Access session response did not set an authorization cookie (HTTP %d)", response.StatusCode)
+		}
+		next, err := response.Location()
+		if err != nil {
+			return errors.New("cloudflare Access session redirect omitted a valid Location")
+		}
+		next = target.ResolveReference(next)
+		if next.Scheme != "https" || next.User != nil {
+			return errors.New("cloudflare Access session redirect is unsafe")
+		}
+		if hop == 0 {
+			if !cloudflareAccessHost(next.Hostname()) {
+				return errors.New("cloudflare Access session redirect leaves the trusted Access domain")
+			}
+		} else if !sameOrigin(next, a.baseURL) {
+			return errors.New("cloudflare Access session redirect does not return to the relay origin")
+		}
+		target = next
+	}
+	return errors.New("cloudflare Access session exceeded redirect limit")
+}
+
+func hasAccessAuthorizationCookie(jar http.CookieJar, relayURL *url.URL) bool {
+	for _, cookie := range jar.Cookies(relayURL) {
+		if strings.EqualFold(cookie.Name, "CF_Authorization") && cookie.Value != "" {
+			return true
+		}
+	}
+	return false
+}
+
+func cloudflareAccessHost(host string) bool {
+	host = strings.TrimSuffix(strings.ToLower(strings.TrimSpace(host)), ".")
+	return strings.HasSuffix(host, ".cloudflareaccess.com") && host != "cloudflareaccess.com"
+}
+
+func sameOrigin(left, right *url.URL) bool {
+	return left.Scheme == right.Scheme && strings.EqualFold(left.Host, right.Host)
 }
 
 // Advertise replaces the machine's current local endpoint attachment set.
@@ -315,6 +412,9 @@ func (c *HTTPRelayClient) doSignedCBOR(ctx context.Context, method, path string,
 	if c == nil || maximum <= 0 || len(body) == 0 || path == "" || contentType != "application/cbor" {
 		return nil, errors.New("invalid signed CBOR request")
 	}
+	if err := c.ensureAccessSession(ctx); err != nil {
+		return nil, err
+	}
 	nonce, err := randomNonce()
 	if err != nil {
 		return nil, err
@@ -359,6 +459,9 @@ func (c *HTTPRelayClient) doSignedCBOR(ctx context.Context, method, path string,
 // policy: directory membership and public-key metadata are not public relay
 // content. Callers must still root-verify the returned snapshot before use.
 func (c *HTTPRelayClient) FetchDirectorySnapshot(ctx context.Context) (attachmentv2.DirectorySnapshot, error) {
+	if err := c.ensureAccessSession(ctx); err != nil {
+		return attachmentv2.DirectorySnapshot{}, err
+	}
 	nonce, err := randomNonce()
 	if err != nil {
 		return attachmentv2.DirectorySnapshot{}, err
@@ -405,6 +508,9 @@ func (c *HTTPRelayClient) FetchDirectorySnapshot(ctx context.Context) (attachmen
 // the connection ends. Durable polling remains authoritative.
 func (c *HTTPRelayClient) ReadNotifications(ctx context.Context, receive func(relay.WakeEvent)) error {
 	path := "/v1/notifications"
+	if err := c.ensureAccessSession(ctx); err != nil {
+		return err
+	}
 	nonce, err := randomNonce()
 	if err != nil {
 		return err
@@ -457,6 +563,9 @@ func (c *HTTPRelayClient) doJSON(ctx context.Context, method, path string, reque
 }
 
 func (c *HTTPRelayClient) doJSONWithIdempotency(ctx context.Context, method, path string, requestValue any, idempotencyKey string, responseValue any) (int, error) {
+	if err := c.ensureAccessSession(ctx); err != nil {
+		return 0, err
+	}
 	body, err := json.Marshal(requestValue)
 	if err != nil {
 		return 0, fmt.Errorf("encode relay request: %w", err)

--- a/internal/adapter/client_test.go
+++ b/internal/adapter/client_test.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -285,7 +286,7 @@ func TestHTTPRelayClientDoesNotFollowRedirectForOfferNotice(t *testing.T) {
 		http.Redirect(w, r, target.URL, http.StatusTemporaryRedirect)
 	}))
 	defer relayServer.Close()
-	client, err := NewHTTPRelayClient(relayServer.URL, "machine-a", machinePrivate, relayServer.Client(), AccessServiceToken{ClientID: "access-id", ClientSecret: "access-secret"})
+	client, err := NewHTTPRelayClient(relayServer.URL, "machine-a", machinePrivate, relayServer.Client(), AccessServiceToken{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -295,6 +296,140 @@ func TestHTTPRelayClientDoesNotFollowRedirectForOfferNotice(t *testing.T) {
 	if redirectTargetHit {
 		t.Fatal("offer notice followed redirect")
 	}
+}
+
+func TestHTTPRelayClientEstablishesAccessSessionWithoutReplayingSignedRequest(t *testing.T) {
+	_, machinePrivate, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	step := 0
+	client, err := NewHTTPRelayClient("https://relay.example", "machine-a", machinePrivate, &http.Client{Transport: roundTripperFunc(func(request *http.Request) (*http.Response, error) {
+		step++
+		if request.Header.Get("CF-Access-Client-Id") != "access-id" || request.Header.Get("CF-Access-Client-Secret") != "access-secret" {
+			t.Fatalf("request %d omitted Access headers", step)
+		}
+		switch step {
+		case 1:
+			if request.URL.Host != "relay.example" || request.URL.Path != "/.well-known/punaro-access-session" || request.Header.Get("X-Punaro-Signature") != "" {
+				t.Fatalf("unsafe initial preflight: %s %s", request.URL, request.Header.Get("X-Punaro-Signature"))
+			}
+			return testHTTPResponse(request, http.StatusFound, http.Header{"Location": []string{"https://team.cloudflareaccess.com/session"}}), nil
+		case 2:
+			if request.URL.Host != "team.cloudflareaccess.com" || request.Header.Get("X-Punaro-Signature") != "" {
+				t.Fatalf("signed relay request reached Access: %s", request.URL)
+			}
+			return testHTTPResponse(request, http.StatusFound, http.Header{"Location": []string{"https://relay.example/.well-known/punaro-access-session"}}), nil
+		case 3:
+			if request.URL.Host != "relay.example" || request.Header.Get("X-Punaro-Signature") != "" {
+				t.Fatalf("unsafe returning preflight: %s", request.URL)
+			}
+			return testHTTPResponse(request, http.StatusNotFound, http.Header{"Set-Cookie": []string{"CF_Authorization=session; Path=/; Secure"}}), nil
+		case 4:
+			if request.URL.Host != "relay.example" || request.Method != http.MethodPut || request.URL.Path != "/v1/machines/me/endpoints" {
+				t.Fatalf("unexpected signed request: %s %s", request.Method, request.URL)
+			}
+			if request.Header.Get("X-Punaro-Signature") == "" || !strings.Contains(request.Header.Get("Cookie"), "CF_Authorization=session") {
+				t.Fatal("signed request did not carry the origin-scoped Access session")
+			}
+			return testHTTPResponse(request, http.StatusNoContent, nil), nil
+		default:
+			t.Fatalf("unexpected request %d: %s", step, request.URL)
+			return nil, nil
+		}
+	})}, AccessServiceToken{ClientID: "access-id", ClientSecret: "access-secret"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := client.Advertise(context.Background(), []string{"agent/a"}); err != nil {
+		t.Fatal(err)
+	}
+	if step != 4 {
+		t.Fatalf("request count=%d want 4", step)
+	}
+}
+
+func TestHTTPRelayClientAcceptsAccessCookieFromUnauthorizedPreflight(t *testing.T) {
+	_, machinePrivate, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	requests := 0
+	client, err := NewHTTPRelayClient("https://relay.example", "machine-a", machinePrivate, &http.Client{Transport: roundTripperFunc(func(request *http.Request) (*http.Response, error) {
+		requests++
+		switch requests {
+		case 1:
+			if request.URL.Path != "/.well-known/punaro-access-session" || request.Header.Get("X-Punaro-Signature") != "" {
+				t.Fatalf("unexpected preflight request: %s %s", request.URL, request.Header.Get("X-Punaro-Signature"))
+			}
+			return testHTTPResponse(request, http.StatusUnauthorized, http.Header{"Set-Cookie": []string{"CF_Authorization=session; Path=/; Secure"}}), nil
+		case 2:
+			if request.Header.Get("X-Punaro-Signature") == "" || !strings.Contains(request.Header.Get("Cookie"), "CF_Authorization=session") {
+				t.Fatal("signed request did not use the Access cookie returned with HTTP 401")
+			}
+			return testHTTPResponse(request, http.StatusNoContent, nil), nil
+		default:
+			t.Fatalf("unexpected request %d", requests)
+			return nil, nil
+		}
+	})}, AccessServiceToken{ClientID: "access-id", ClientSecret: "access-secret"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := client.Advertise(context.Background(), []string{"agent/a"}); err != nil {
+		t.Fatal(err)
+	}
+	if requests != 2 {
+		t.Fatalf("requests=%d want 2", requests)
+	}
+}
+
+func TestHTTPRelayClientRejectsUntrustedAccessSessionRedirect(t *testing.T) {
+	_, machinePrivate, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	requests := 0
+	client, err := NewHTTPRelayClient("https://relay.example", "machine-a", machinePrivate, &http.Client{Transport: roundTripperFunc(func(request *http.Request) (*http.Response, error) {
+		requests++
+		if request.Header.Get("X-Punaro-Signature") != "" {
+			t.Fatal("signed relay request was sent before a trusted Access session")
+		}
+		return testHTTPResponse(request, http.StatusFound, http.Header{"Location": []string{"https://attacker.example/session"}}), nil
+	})}, AccessServiceToken{ClientID: "access-id", ClientSecret: "access-secret"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := client.Advertise(context.Background(), []string{"agent/a"}); err == nil {
+		t.Fatal("untrusted Access redirect was accepted")
+	}
+	if requests != 1 {
+		t.Fatalf("requests=%d want 1", requests)
+	}
+}
+
+func TestCloudflareAccessHost(t *testing.T) {
+	for host, want := range map[string]bool{
+		"team.cloudflareaccess.com":             true,
+		"TEAM.CLOUDFLAREACCESS.COM.":            true,
+		"cloudflareaccess.com":                  false,
+		"cloudflareaccess.com.attacker.example": false,
+	} {
+		if got := cloudflareAccessHost(host); got != want {
+			t.Fatalf("cloudflareAccessHost(%q)=%t want %t", host, got, want)
+		}
+	}
+}
+
+type roundTripperFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripperFunc) RoundTrip(request *http.Request) (*http.Response, error) { return f(request) }
+
+func testHTTPResponse(request *http.Request, status int, header http.Header) *http.Response {
+	if header == nil {
+		header = make(http.Header)
+	}
+	return &http.Response{StatusCode: status, Header: header, Body: io.NopCloser(strings.NewReader("")), Request: request}
 }
 
 func mustDecodeSignature(t testing.TB, raw string) []byte {

--- a/internal/adapter/client_test.go
+++ b/internal/adapter/client_test.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"io"
 	"net/http"
+	"net/http/cookiejar"
 	"net/http/httptest"
 	"strings"
 	"testing"
@@ -48,8 +49,19 @@ func TestHTTPRelayClientIssuesHolderSignedPermitRequest(t *testing.T) {
 		t.Fatal(err)
 	}
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/.well-known/punaro-access-session" {
+			if r.Header.Get("X-Punaro-Signature") != "" {
+				t.Fatal("signed permit request was replayed during Access preflight")
+			}
+			http.SetCookie(w, &http.Cookie{Name: "CF_Authorization", Value: "permit-session", Path: "/"})
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
 		if r.Method != http.MethodPost || r.URL.Path != "/v2/permits" || r.URL.RawQuery != "" || r.Header.Get("Content-Type") != "application/cbor" {
 			t.Fatalf("unexpected request %s %s type=%q", r.Method, r.URL.String(), r.Header.Get("Content-Type"))
+		}
+		if !strings.Contains(r.Header.Get("Cookie"), "CF_Authorization=permit-session") {
+			t.Fatal("permit request omitted Access session cookie")
 		}
 		body, err := io.ReadAll(r.Body)
 		if err != nil {
@@ -75,6 +87,7 @@ func TestHTTPRelayClientIssuesHolderSignedPermitRequest(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	enableTestAccessSession(t, client)
 	permit, err := client.IssuePermit(context.Background(), permitRequest)
 	if err != nil || permit != expectedPermit {
 		t.Fatalf("permit=%+v err=%v", permit, err)
@@ -202,6 +215,14 @@ func TestHTTPRelayClientSendsBoundV3AttachmentOperation(t *testing.T) {
 		t.Fatal(err)
 	}
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/.well-known/punaro-access-session" {
+			if r.Header.Get("X-Punaro-Signature") != "" {
+				t.Fatal("signed v3 attachment request was replayed during Access preflight")
+			}
+			http.SetCookie(w, &http.Cookie{Name: "CF_Authorization", Value: "attachment-session", Path: "/"})
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
 		gotBody := mustReadAll(t, r)
 		if r.Method != http.MethodPut || r.URL.Path != path || string(gotBody) != string(body) {
 			t.Fatalf("request=%s %s body=%q", r.Method, r.URL.Path, gotBody)
@@ -218,6 +239,9 @@ func TestHTTPRelayClientSendsBoundV3AttachmentOperation(t *testing.T) {
 		if !ed25519.Verify(machinePublic, relay.CanonicalRequest(request), request.Signature) {
 			t.Fatal("attachment request did not have valid machine signature")
 		}
+		if !strings.Contains(r.Header.Get("Cookie"), "CF_Authorization=attachment-session") {
+			t.Fatal("v3 attachment request omitted Access session cookie")
+		}
 		w.Header().Set("Content-Type", "application/cbor")
 		_, _ = w.Write([]byte{0xa1})
 	}))
@@ -226,6 +250,7 @@ func TestHTTPRelayClientSendsBoundV3AttachmentOperation(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	enableTestAccessSession(t, client)
 	result, err := client.DoV3Attachment(context.Background(), http.MethodPut, path, body, permit, op)
 	if err != nil || string(result) != string([]byte{0xa1}) {
 		t.Fatalf("result=%x err=%v", result, err)
@@ -595,6 +620,9 @@ func TestHTTPRelayClientReadsPayloadFreeWake(t *testing.T) {
 		if !ed25519.Verify(public, relay.CanonicalRequest(request), request.Signature) {
 			t.Fatal("unsigned wake handshake")
 		}
+		if !strings.Contains(r.Header.Get("Cookie"), "CF_Authorization=wake-session") {
+			t.Fatal("wake handshake omitted Access session cookie")
+		}
 		connection, err := websocket.Accept(w, r, nil)
 		if err != nil {
 			t.Fatal(err)
@@ -609,6 +637,12 @@ func TestHTTPRelayClientReadsPayloadFreeWake(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	jar, err := cookiejar.New(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	client.httpClient.Jar = jar
+	jar.SetCookies(client.baseURL, []*http.Cookie{{Name: "CF_Authorization", Value: "wake-session", Path: "/"}})
 	events := make(chan relay.WakeEvent, 1)
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
@@ -623,6 +657,16 @@ func TestHTTPRelayClientReadsPayloadFreeWake(t *testing.T) {
 	default:
 		t.Fatal("wake was not delivered")
 	}
+}
+
+func enableTestAccessSession(t *testing.T, client *HTTPRelayClient) {
+	t.Helper()
+	jar, err := cookiejar.New(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	client.httpClient.Jar = jar
+	client.access = &accessSession{baseURL: client.baseURL, client: client.httpClient, token: AccessServiceToken{ClientID: "access-id", ClientSecret: "access-secret"}}
 }
 
 func TestHTTPRelayClientRejectsInsecureRemoteURLAndPartialAccessToken(t *testing.T) {


### PR DESCRIPTION
## What changed

- Establish a short-lived Cloudflare Access session with a payload-free preflight before signed adapter operations.
- Permit only the expected Access redirect chain: relay origin → `*.cloudflareaccess.com` → the exact relay origin.
- Require an origin-scoped `CF_Authorization` cookie before any signed request proceeds; signed requests themselves still never follow redirects.
- Document the invariant and cover the redirect, untrusted-host, and `401`-with-cookie paths.

## Why

Some Cloudflare Access service-token deployments issue a session cookie through a redirect or alongside an otherwise unauthorized preflight response. Sending an already-signed operation through that flow risks replaying its nonce, signature, body, or idempotency key.

## Validation

- `go test ./internal/adapter -run 'TestHTTPRelayClient(AcceptsAccessCookieFromUnauthorizedPreflight|EstablishesAccessSessionWithoutReplayingSignedRequest|RejectsUntrustedAccessSessionRedirect)' -count=1`
- `make test`
- `make test-race`
- `make staticcheck`
- `make security`
- `make lint`

All passed. No deployment details or credentials are included.