### PR TITLE
M-5: add operator bootstrap and device ingress

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -603,6 +603,8 @@ here is limited to strict, bounded enrollment redemption and a
 bearer-authenticated session check. PostgreSQL remains dark for mail and
 project identity APIs. A non-loopback device listener cannot be combined with
 legacy relay, directory, permit, or attachment routes; those remain loopback-only.
+Health and readiness use a distinct concrete loopback-only listener and are
+never mounted on the device/legacy listener.
 
 ## Required adversarial acceptance tests
 

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -548,9 +548,10 @@ prints the exact `trusted-agent` grant expansion before issuing a short-lived,
 single-use enrollment. Redemption is bound to an opaque client value; the dark
 store generates a fresh 256-bit secret
 internally, stores only its indexed SHA-256 digest, and composes the device
-principal, credential, grants, audit, and change sequence atomically. No public
-bootstrap, issuance, redemption, or device-auth route is mounted in this slice;
-ingress arrives with the later operator/ingress milestone. Credential caches
+principal, credential, grants, audit, and change sequence atomically. At the
+M-3 boundary no public bootstrap, issuance, redemption, or device-auth route was
+mounted; M-5 adds only bounded redemption and device session authentication
+behind its explicit ingress transport policy. Credential caches
 and long-lived sessions revalidate within two seconds. The existing Ed25519
 relay remains active while its intended machines are durably inventoried as
 pending, migrated, or retired; the global legacy gate cannot close while any
@@ -578,6 +579,29 @@ Application-role mutation privileges are column-exact, and readiness verifies
 the new catalog objects, indexes, constraints, and grants. These primitives
 remain internal: no public identity or merge route is mounted, PostgreSQL mail
 authority remains dark, and SQLite routing is unchanged.
+
+The fifth foundation slice adds the host-local `punaro` operator wrapper and
+the first device-credential ingress. `init` validates private data and backup
+directories, distinct owner/application DSN files, and a digest-pinned release
+image. Canonical-path checks keep both credentials and operator state outside
+the daemon-writable data tree, including across symlinked ancestors. It durably
+stages a private daemon environment and immutable-image-only Compose file,
+creates the first owner, then publishes one `installation.json` marker by
+rename. An uncertain owner outcome is recoverable with `punaro init --resume`;
+the staging directory is synchronized before the database mutation. `up`
+starts only an already-compatible owned database, refuses pristine/reset,
+upgrade-required, newer, dirty, and incompatible states before service start,
+waits boundedly for readiness, then runs doctor. Initial pristine migration is
+part of `init`; raw daemon and Compose startup remain non-migrating.
+
+Internet and existing-proxy profiles require a canonical HTTPS public URL and
+a loopback origin. Trusted-LAN plaintext is an explicit exception requiring a
+concrete private or link-local bind, a containing private/link-local CIDR, and
+an observed peer in that CIDR. Wildcard/public binds and peers fail closed;
+forwarded headers never establish TLS or source trust. The public surface added
+here is limited to strict, bounded enrollment redemption and a
+bearer-authenticated session check. PostgreSQL remains dark for mail and
+project identity APIs.
 
 ## Required adversarial acceptance tests
 

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -601,7 +601,8 @@ an observed peer in that CIDR. Wildcard/public binds and peers fail closed;
 forwarded headers never establish TLS or source trust. The public surface added
 here is limited to strict, bounded enrollment redemption and a
 bearer-authenticated session check. PostgreSQL remains dark for mail and
-project identity APIs.
+project identity APIs. A non-loopback device listener cannot be combined with
+legacy relay, directory, permit, or attachment routes; those remain loopback-only.
 
 ## Required adversarial acceptance tests
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,5 +23,5 @@ COPY --from=build /out/punaro-directory /usr/local/bin/punaro-directory
 COPY --from=build /out/punaro-telegram /usr/local/bin/punaro-telegram
 COPY --from=build /out/punaro-attachment /usr/local/bin/punaro-attachment
 USER nonroot:nonroot
-EXPOSE 8080
+EXPOSE 8080 8081
 ENTRYPOINT ["/usr/local/bin/punarod"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,8 @@ COPY go.mod go.sum ./
 RUN go mod download
 COPY cmd ./cmd
 COPY internal ./internal
-RUN CGO_ENABLED=0 go build -trimpath -ldflags='-s -w' -o /out/punarod ./cmd/punarod \
+RUN CGO_ENABLED=0 go build -trimpath -ldflags='-s -w' -o /out/punaro ./cmd/punaro \
+ && CGO_ENABLED=0 go build -trimpath -ldflags='-s -w' -o /out/punarod ./cmd/punarod \
  && CGO_ENABLED=0 go build -trimpath -ldflags='-s -w' -o /out/punaro-migrate ./cmd/punaro-migrate \
  && CGO_ENABLED=0 go build -trimpath -ldflags='-s -w' -o /out/punaro-admin ./cmd/punaro-admin \
  && CGO_ENABLED=0 go build -trimpath -ldflags='-s -w' -o /out/punaro-adapter ./cmd/punaro-adapter \
@@ -13,6 +14,7 @@ RUN CGO_ENABLED=0 go build -trimpath -ldflags='-s -w' -o /out/punarod ./cmd/puna
  && CGO_ENABLED=0 go build -trimpath -ldflags='-s -w' -o /out/punaro-attachment ./cmd/punaro-attachment
 
 FROM gcr.io/distroless/static-debian12:nonroot@sha256:b7bb25d9f7c31d2bdd1982feb4dafcaf137703c7075dbe2febb41c24212b946f
+COPY --from=build /out/punaro /usr/local/bin/punaro
 COPY --from=build /out/punarod /usr/local/bin/punarod
 COPY --from=build /out/punaro-migrate /usr/local/bin/punaro-migrate
 COPY --from=build /out/punaro-admin /usr/local/bin/punaro-admin

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,10 @@
-.PHONY: test test-race test-postgres vet staticcheck golangci windows-build vuln gosec secrets lint security ci fmt dockerfile-lint workflow-lint deployment-lint release-gates fuzz
+.PHONY: test test-race test-postgres vet staticcheck golangci windows-build vuln gosec secrets lint security ci fmt dockerfile-lint workflow-lint deployment-lint release-gates fuzz operator-binary
+
+PUNARO_OPERATOR_OUTPUT ?= ./bin/punaro
+
+operator-binary:
+	mkdir -p "$$(dirname "$(PUNARO_OPERATOR_OUTPUT)")"
+	go build -trimpath -o "$(PUNARO_OPERATOR_OUTPUT)" ./cmd/punaro
 
 test:
 	go test -covermode=atomic ./...

--- a/README.md
+++ b/README.md
@@ -49,6 +49,14 @@ Read the [accepted platform and Big Brain plan](docs/big-brain-plan.md),
 
 Requires Go 1.26 or later.
 
+Build the host-side operator wrapper explicitly; it must run on the non-root
+Unix host where Docker Compose is available:
+
+```sh
+make operator-binary
+./bin/punaro
+```
+
 ```sh
 cp .env.example .env
 go run ./cmd/punarod --env-file .env
@@ -88,12 +96,17 @@ precedence over dotenv values.
 
 | Variable | Default | Description |
 | --- | --- | --- |
-| `PUNARO_LISTEN_ADDR` | `127.0.0.1:8080` | Loopback-only HTTP listener address. |
+| `PUNARO_LISTEN_ADDR` | `127.0.0.1:8080` | Concrete HTTP listener. It remains loopback-only unless validated device ingress explicitly selects trusted-LAN mode. |
 | `PUNARO_DATA_DIR` | `./data` | Relay SQLite state location when `PUNARO_RELAY_ENABLED=true`. |
 | `PUNARO_LOG_LEVEL` | `info` | Validated reserved setting; current standard logging does not filter by it. |
 | `PUNARO_ENV_FILE` | unset | Optional dotenv file when no CLI flag is used. |
 | `PUNARO_POSTGRES_ENABLED` | `false` | Opts into the dark PostgreSQL platform substrate. It does not select PostgreSQL as the relay store. Ordinary startup only checks compatibility and never migrates. |
 | `PUNARO_POSTGRES_DSN_FILE` | unset | Required with PostgreSQL enabled: absolute path to a private application-role DSN file. The application role has no DDL authority. |
+| `PUNARO_DEVICE_AUTH_ENABLED` | `false` | Mounts bounded enrollment redemption and device-session authentication; requires PostgreSQL and a complete ingress policy. |
+| `PUNARO_INGRESS_MODE` | unset | Required with device auth: `lan`, `proxy`, or `internet`. Proxy and Internet origins bind loopback and require `PUNARO_PUBLIC_URL=https://...`. |
+| `PUNARO_PUBLIC_URL` | unset | Canonical HTTPS public URL for proxy/Internet mode. It does not make forwarded headers trustworthy. |
+| `PUNARO_TRUSTED_LAN_CIDR` | unset | Private/link-local CIDR containing the concrete LAN bind. Valid only in LAN mode. |
+| `PUNARO_TRUSTED_LAN_HTTP` | `false` | Explicit plaintext credential exception for observed peers inside the validated trusted LAN. Public peers never qualify. |
 | `PUNARO_RELAY_ENABLED` | `false` | Enables the loopback text relay; requires public machine enrollment records. |
 | `PUNARO_RELAY_MACHINES_JSON` | unset | Explicit public-key machine enrollment records. `endpoint_prefixes` claims disjoint machine namespaces; `endpoints` can grant a named exact endpoint without creating a prefix. An issuer-capable machine additionally has canonical raw-base64url `attachment_device_id` (16 bytes), bound to exactly one directory device. |
 | `PUNARO_DIRECTORY_ENABLED` | `false` | Serves a current complete signed directory snapshot to authenticated enrolled machines; requires the relay. |

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ make operator-binary
 ```sh
 cp .env.example .env
 go run ./cmd/punarod --env-file .env
-curl http://127.0.0.1:8080/healthz
+curl http://127.0.0.1:8081/healthz
 ```
 
 The development container is a hardened build/run baseline:
@@ -97,6 +97,7 @@ precedence over dotenv values.
 | Variable | Default | Description |
 | --- | --- | --- |
 | `PUNARO_LISTEN_ADDR` | `127.0.0.1:8080` | Concrete HTTP listener. It remains loopback-only unless validated device ingress explicitly selects trusted-LAN mode. |
+| `PUNARO_HEALTH_LISTEN_ADDR` | `127.0.0.1:8081` | Distinct concrete loopback-only listener for `/healthz` and `/readyz`; health routes are never mounted on the device/legacy listener. |
 | `PUNARO_DATA_DIR` | `./data` | Relay SQLite state location when `PUNARO_RELAY_ENABLED=true`. |
 | `PUNARO_LOG_LEVEL` | `info` | Validated reserved setting; current standard logging does not filter by it. |
 | `PUNARO_ENV_FILE` | unset | Optional dotenv file when no CLI flag is used. |

--- a/cmd/punaro/main.go
+++ b/cmd/punaro/main.go
@@ -160,6 +160,7 @@ func runInit(args []string, stdout, stderr io.Writer) int {
 	publicURL := flags.String("public-url", "", "canonical HTTPS public URL")
 	trustedLAN := flags.String("trusted-lan-cidr", "", "private or link-local trusted LAN")
 	allowLANHTTP := flags.Bool("allow-lan-http", false, "explicitly allow plaintext credentials from the trusted LAN")
+	healthListen := flags.String("health-listen-addr", "127.0.0.1:8081", "distinct loopback-only health listener")
 	resume := flags.Bool("resume", false, "resume a durably staged initialization")
 	if flags.Parse(args) != nil || flags.NArg() != 0 || *directory == "" {
 		return 2
@@ -192,7 +193,7 @@ func runInit(args []string, stdout, stderr io.Writer) int {
 		}
 		return createOwner(ctx, ownerFile, name)
 	}
-	installation, err := operator.Init(context.Background(), operator.InitOptions{Directory: *directory, DataDir: *dataDir, BackupDir: *backupDir, Image: *image, OwnerDSNFile: *ownerDSN, AppDSNFile: *appDSN, OwnerName: *ownerName, Ingress: ingress.Policy{Mode: ingress.Mode(*mode), ListenAddr: *listen, PublicURL: *publicURL, TrustedLAN: *trustedLAN, AllowPlaintext: *allowLANHTTP}}, bootstrap)
+	installation, err := operator.Init(context.Background(), operator.InitOptions{Directory: *directory, DataDir: *dataDir, BackupDir: *backupDir, Image: *image, OwnerDSNFile: *ownerDSN, AppDSNFile: *appDSN, OwnerName: *ownerName, Ingress: ingress.Policy{Mode: ingress.Mode(*mode), ListenAddr: *listen, PublicURL: *publicURL, TrustedLAN: *trustedLAN, AllowPlaintext: *allowLANHTTP}, HealthListenAddr: *healthListen}, bootstrap)
 	if err != nil {
 		_, _ = fmt.Fprintf(stderr, "punaro init failed: %v\n", err)
 		return 1

--- a/cmd/punaro/main.go
+++ b/cmd/punaro/main.go
@@ -110,7 +110,11 @@ var (
 		return admin.CreateEnrollment(ctx, installation.OwnerPrincipalID, request, previewHash)
 	}
 	startServices = func(ctx context.Context, installation operator.Installation) error {
-		command := exec.CommandContext(ctx, "docker", "compose", "--env-file", operator.EnvFile(installation.Directory), "-f", operator.OverrideFile(installation.Directory), "up", "-d") // #nosec G204 -- fixed executable and generated private file arguments.
+		arguments, err := composeUpArgs(installation)
+		if err != nil {
+			return err
+		}
+		command := exec.CommandContext(ctx, "docker", arguments...) // #nosec G204 -- fixed executable and generated private file arguments.
 		command.Dir = installation.Directory
 		output, err := command.CombinedOutput()
 		if err != nil {
@@ -120,6 +124,14 @@ var (
 	}
 	probe = probeHTTP
 )
+
+func composeUpArgs(installation operator.Installation) ([]string, error) {
+	projectName, err := operator.ComposeProjectName(installation)
+	if err != nil {
+		return nil, err
+	}
+	return []string{"compose", "--project-name", projectName, "--env-file", operator.EnvFile(installation.Directory), "-f", operator.OverrideFile(installation.Directory), "up", "-d"}, nil
+}
 
 func main() { os.Exit(run(os.Args[1:], os.Stdout, os.Stderr)) }
 

--- a/cmd/punaro/main.go
+++ b/cmd/punaro/main.go
@@ -100,6 +100,14 @@ var (
 		}
 		return owner, err
 	}
+	issueEnrollment = func(ctx context.Context, installation operator.Installation, request punaropostgres.EnrollmentRequest, previewHash string) (punaropostgres.PendingEnrollment, error) {
+		admin, err := punaropostgres.OpenAdministration(ctx, punaropostgres.Config{DSNFile: installation.OwnerDSNFile})
+		if err != nil {
+			return punaropostgres.PendingEnrollment{}, err
+		}
+		defer func() { _ = admin.Close() }()
+		return admin.CreateEnrollment(ctx, installation.OwnerPrincipalID, request, previewHash)
+	}
 	startServices = func(ctx context.Context, installation operator.Installation) error {
 		command := exec.CommandContext(ctx, "docker", "compose", "--env-file", operator.EnvFile(installation.Directory), "-f", operator.OverrideFile(installation.Directory), "up", "-d") // #nosec G204 -- fixed executable and generated private file arguments.
 		command.Dir = installation.Directory
@@ -357,16 +365,23 @@ func runClientAdd(args []string, stdout, stderr io.Writer) int {
 		return 1
 	}
 	preview := map[string]any{"template": "trusted-agent", "preview_hash": previewHash, "grants": grants}
-	if code := writeJSON(stdout, stderr, preview); code != 0 {
-		return code
-	}
 	if !*confirmed {
+		if code := writeJSON(stdout, stderr, preview); code != 0 {
+			return code
+		}
 		_, _ = fmt.Fprintln(stderr, "grant preview printed; rerun with --yes and --confirm-preview-hash to create the enrollment")
 		return 3
 	}
 	if *confirmedHash == "" || *confirmedHash != previewHash {
+		if code := writeJSON(stdout, stderr, preview); code != 0 {
+			return code
+		}
 		_, _ = fmt.Fprintln(stderr, "client enrollment refused: confirmed preview hash does not match the exact grants above")
 		return 3
+	}
+	if failures := operator.CheckPaths(installation); len(failures) != 0 {
+		_, _ = fmt.Fprintln(stderr, "client enrollment refused: installation safety checks failed; run punaro doctor")
+		return 1
 	}
 	state, err := inspectSchema(context.Background(), installation.AppDSNFile)
 	if err != nil || state.Classification != punaropostgres.Compatible {
@@ -377,13 +392,12 @@ func runClientAdd(args []string, stdout, stderr io.Writer) int {
 		_, _ = fmt.Fprintln(stderr, "client enrollment refused: database roles do not target the same installation")
 		return 1
 	}
-	admin, err := punaropostgres.OpenAdministration(context.Background(), punaropostgres.Config{DSNFile: installation.OwnerDSNFile})
-	if err != nil {
-		_, _ = fmt.Fprintln(stderr, "client enrollment failed: host-local administration is unavailable")
+	owner, err := inspectOwner(context.Background(), installation.AppDSNFile)
+	if err != nil || owner.ID != installation.OwnerPrincipalID {
+		_, _ = fmt.Fprintln(stderr, "client enrollment refused: database owner does not match the installation configuration")
 		return 1
 	}
-	defer func() { _ = admin.Close() }()
-	pending, err := admin.CreateEnrollment(context.Background(), installation.OwnerPrincipalID, punaropostgres.EnrollmentRequest{ClientBinding: uuid.NewString(), Label: *name, ProjectIDs: projects, AllProjects: *allProjects, TTL: *ttl, CredentialTTL: *credentialTTL}, previewHash)
+	pending, err := issueEnrollment(context.Background(), installation, punaropostgres.EnrollmentRequest{ClientBinding: uuid.NewString(), Label: *name, ProjectIDs: projects, AllProjects: *allProjects, TTL: *ttl, CredentialTTL: *credentialTTL}, previewHash)
 	if err != nil {
 		_, _ = fmt.Fprintln(stderr, "client enrollment failed")
 		return 1

--- a/cmd/punaro/main.go
+++ b/cmd/punaro/main.go
@@ -241,8 +241,8 @@ func runUp(args []string, stdout, stderr io.Writer) int {
 	}
 	switch operator.DecideUp(state) {
 	case operator.StartCompatible:
-	case operator.RefuseAndUpdate:
-		_, _ = fmt.Fprintln(stderr, "punaro up refused: existing schema requires migration; run punaro update")
+	case operator.RefuseUpgradeRequired:
+		_, _ = fmt.Fprintln(stderr, "punaro up refused: existing schema requires migration, but this staged release has no in-place updater; continue the previous compatible release")
 		return 1
 	default:
 		_, _ = fmt.Fprintf(stderr, "punaro up refused: schema is %s; follow the documented recovery procedure\n", state.Classification)

--- a/cmd/punaro/main.go
+++ b/cmd/punaro/main.go
@@ -1,0 +1,439 @@
+// punaro is the supported host-local operator wrapper.
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/rock3r/punaro/internal/ingress"
+	"github.com/rock3r/punaro/internal/operator"
+	punaropostgres "github.com/rock3r/punaro/internal/postgres"
+)
+
+var (
+	inspectSchema = func(ctx context.Context, dsnFile string) (punaropostgres.SchemaState, error) {
+		database, err := punaropostgres.OpenApplication(ctx, punaropostgres.Config{DSNFile: dsnFile})
+		if err != nil {
+			return punaropostgres.SchemaState{}, err
+		}
+		defer func() { _ = database.Close() }()
+		return database.SchemaState(ctx)
+	}
+	inspectOwner = func(ctx context.Context, dsnFile string) (punaropostgres.Principal, error) {
+		database, err := punaropostgres.OpenApplication(ctx, punaropostgres.Config{DSNFile: dsnFile})
+		if err != nil {
+			return punaropostgres.Principal{}, err
+		}
+		defer func() { _ = database.Close() }()
+		return database.InstallationOwner(ctx)
+	}
+	migrateSchema = func(ctx context.Context, dsnFile string) (punaropostgres.SchemaState, error) {
+		return punaropostgres.Migrate(ctx, punaropostgres.Config{DSNFile: dsnFile})
+	}
+	createOwner = func(ctx context.Context, dsnFile, name string) (punaropostgres.Principal, error) {
+		admin, err := punaropostgres.OpenAdministration(ctx, punaropostgres.Config{DSNFile: dsnFile})
+		if err != nil {
+			return punaropostgres.Principal{}, err
+		}
+		defer func() { _ = admin.Close() }()
+		return admin.BootstrapOwner(ctx, name)
+	}
+	verifyInstallationPair = func(ctx context.Context, appDSNFile, ownerDSNFile string) error {
+		app, err := punaropostgres.OpenApplication(ctx, punaropostgres.Config{DSNFile: appDSNFile})
+		if err != nil {
+			return err
+		}
+		defer func() { _ = app.Close() }()
+		admin, err := punaropostgres.OpenAdministration(ctx, punaropostgres.Config{DSNFile: ownerDSNFile})
+		if err != nil {
+			return err
+		}
+		defer func() { _ = admin.Close() }()
+		appState, err := app.InstallationState(ctx)
+		if err != nil {
+			return err
+		}
+		ownerState, err := admin.InstallationState(ctx)
+		if err != nil {
+			return err
+		}
+		if appState.InstallationID != ownerState.InstallationID || appState.TimelineID != ownerState.TimelineID {
+			return errors.New("application and owner DSNs target different installations")
+		}
+		return nil
+	}
+	recoverInstallationOwner = func(ctx context.Context, installation operator.Installation) (punaropostgres.Principal, error) {
+		state, err := inspectSchema(ctx, installation.AppDSNFile)
+		if err != nil {
+			return punaropostgres.Principal{}, err
+		}
+		if state.Classification == punaropostgres.Pristine {
+			if _, err = migrateSchema(ctx, installation.OwnerDSNFile); err == nil {
+				state, err = inspectSchema(ctx, installation.AppDSNFile)
+			}
+		}
+		if err != nil || state.Classification != punaropostgres.Compatible {
+			return punaropostgres.Principal{}, errors.New("database schema is not compatible")
+		}
+		if err := verifyInstallationPair(ctx, installation.AppDSNFile, installation.OwnerDSNFile); err != nil {
+			return punaropostgres.Principal{}, err
+		}
+		admin, err := punaropostgres.OpenAdministration(ctx, punaropostgres.Config{DSNFile: installation.OwnerDSNFile})
+		if err != nil {
+			return punaropostgres.Principal{}, err
+		}
+		defer func() { _ = admin.Close() }()
+		owner, err := admin.InstallationOwner(ctx)
+		if errors.Is(err, punaropostgres.ErrNotFound) {
+			return admin.BootstrapOwner(ctx, installation.OwnerName)
+		}
+		return owner, err
+	}
+	startServices = func(ctx context.Context, installation operator.Installation) error {
+		command := exec.CommandContext(ctx, "docker", "compose", "--env-file", operator.EnvFile(installation.Directory), "-f", operator.OverrideFile(installation.Directory), "up", "-d") // #nosec G204 -- fixed executable and generated private file arguments.
+		command.Dir = installation.Directory
+		output, err := command.CombinedOutput()
+		if err != nil {
+			return fmt.Errorf("service start failed: %s", boundedText(output))
+		}
+		return nil
+	}
+	probe = probeHTTP
+)
+
+func main() { os.Exit(run(os.Args[1:], os.Stdout, os.Stderr)) }
+
+func run(args []string, stdout, stderr io.Writer) int {
+	if len(args) == 0 {
+		_, _ = fmt.Fprintln(stderr, "usage: punaro init|up|status|doctor|client")
+		return 2
+	}
+	switch args[0] {
+	case "init":
+		return runInit(args[1:], stdout, stderr)
+	case "up":
+		return runUp(args[1:], stdout, stderr)
+	case "status":
+		return runStatus(args[1:], stdout, stderr, false)
+	case "doctor":
+		return runStatus(args[1:], stdout, stderr, true)
+	case "client":
+		if len(args) > 1 && args[1] == "add" {
+			return runClientAdd(args[2:], stdout, stderr)
+		}
+	}
+	_, _ = fmt.Fprintln(stderr, "unsupported operator command")
+	return 2
+}
+
+func runInit(args []string, stdout, stderr io.Writer) int {
+	flags := flag.NewFlagSet("init", flag.ContinueOnError)
+	flags.SetOutput(stderr)
+	directory := flags.String("directory", "", "new absolute installation directory")
+	dataDir := flags.String("data-dir", "", "existing private data directory")
+	backupDir := flags.String("backup-dir", "", "existing private backup directory")
+	image := flags.String("image", "", "release image reference pinned by sha256 digest")
+	ownerDSN := flags.String("owner-dsn-file", "", "protected schema-owner DSN file")
+	appDSN := flags.String("app-dsn-file", "", "protected application DSN file")
+	ownerName := flags.String("owner-name", "", "first operator display name")
+	mode := flags.String("mode", "", "lan, proxy, or internet")
+	listen := flags.String("listen-addr", "127.0.0.1:8080", "concrete listen IP and port")
+	publicURL := flags.String("public-url", "", "canonical HTTPS public URL")
+	trustedLAN := flags.String("trusted-lan-cidr", "", "private or link-local trusted LAN")
+	allowLANHTTP := flags.Bool("allow-lan-http", false, "explicitly allow plaintext credentials from the trusted LAN")
+	resume := flags.Bool("resume", false, "resume a durably staged initialization")
+	if flags.Parse(args) != nil || flags.NArg() != 0 || *directory == "" {
+		return 2
+	}
+	if *resume {
+		installation, err := operator.Resume(context.Background(), *directory, recoverInstallationOwner)
+		if err != nil {
+			_, _ = fmt.Fprintf(stderr, "punaro init recovery failed: %v\n", err)
+			return 1
+		}
+		return writeJSON(stdout, stderr, map[string]any{"status": "initialized", "owner_principal_id": installation.OwnerPrincipalID, "directory": *directory})
+	}
+	if *dataDir == "" || *backupDir == "" || *image == "" || *ownerDSN == "" || *appDSN == "" || *ownerName == "" || *mode == "" {
+		return 2
+	}
+	bootstrap := func(ctx context.Context, ownerFile, name string) (punaropostgres.Principal, error) {
+		state, err := inspectSchema(ctx, *appDSN)
+		if err != nil || state.Classification != punaropostgres.Pristine {
+			return punaropostgres.Principal{}, operator.ErrBootstrapNotAttempted
+		}
+		if _, err = migrateSchema(ctx, ownerFile); err != nil {
+			return punaropostgres.Principal{}, err
+		}
+		state, err = inspectSchema(ctx, *appDSN)
+		if err != nil || state.Classification != punaropostgres.Compatible {
+			return punaropostgres.Principal{}, errors.New("database schema is not compatible")
+		}
+		if err := verifyInstallationPair(ctx, *appDSN, ownerFile); err != nil {
+			return punaropostgres.Principal{}, err
+		}
+		return createOwner(ctx, ownerFile, name)
+	}
+	installation, err := operator.Init(context.Background(), operator.InitOptions{Directory: *directory, DataDir: *dataDir, BackupDir: *backupDir, Image: *image, OwnerDSNFile: *ownerDSN, AppDSNFile: *appDSN, OwnerName: *ownerName, Ingress: ingress.Policy{Mode: ingress.Mode(*mode), ListenAddr: *listen, PublicURL: *publicURL, TrustedLAN: *trustedLAN, AllowPlaintext: *allowLANHTTP}}, bootstrap)
+	if err != nil {
+		_, _ = fmt.Fprintf(stderr, "punaro init failed: %v\n", err)
+		return 1
+	}
+	if installation.Ingress.Mode == ingress.LAN {
+		_, _ = fmt.Fprintln(stderr, "WARNING: trusted-LAN HTTP sends enrollment and device credentials without TLS; use only on the validated private/link-local network")
+	}
+	return writeJSON(stdout, stderr, map[string]any{"status": "initialized", "owner_principal_id": installation.OwnerPrincipalID, "directory": *directory})
+}
+
+func runUp(args []string, stdout, stderr io.Writer) int {
+	directory, ok := parseDirectory("up", args, stderr)
+	if !ok {
+		return 2
+	}
+	installation, err := operator.Load(directory)
+	if err != nil {
+		_, _ = fmt.Fprintf(stderr, "punaro up refused: %v\n", err)
+		return 1
+	}
+	if failures := operator.CheckPaths(installation); len(failures) != 0 {
+		_, _ = fmt.Fprintf(stderr, "punaro up refused: %s; run punaro doctor\n", strings.Join(failures, ", "))
+		return 1
+	}
+	state, err := inspectSchema(context.Background(), installation.AppDSNFile)
+	if err != nil {
+		_, _ = fmt.Fprintln(stderr, "punaro up refused: database schema state is unavailable")
+		return 1
+	}
+	switch operator.DecideUp(state) {
+	case operator.StartCompatible:
+	case operator.RefuseAndUpdate:
+		_, _ = fmt.Fprintln(stderr, "punaro up refused: existing schema requires migration; run punaro update")
+		return 1
+	default:
+		_, _ = fmt.Fprintf(stderr, "punaro up refused: schema is %s; follow the documented recovery procedure\n", state.Classification)
+		return 1
+	}
+	if err := verifyInstallationPair(context.Background(), installation.AppDSNFile, installation.OwnerDSNFile); err != nil {
+		_, _ = fmt.Fprintln(stderr, "punaro up refused: database roles do not target the same installation; follow recovery")
+		return 1
+	}
+	owner, err := inspectOwner(context.Background(), installation.AppDSNFile)
+	if err != nil || owner.ID != installation.OwnerPrincipalID {
+		_, _ = fmt.Fprintln(stderr, "punaro up refused: database owner does not match the installation configuration; follow recovery")
+		return 1
+	}
+	if err := startServices(context.Background(), installation); err != nil {
+		_, _ = fmt.Fprintln(stderr, "punaro up failed: services could not be started")
+		return 1
+	}
+	readyURL := strings.TrimRight(installation.HealthURL, "/") + "/readyz"
+	deadline := time.Now().Add(30 * time.Second)
+	for {
+		if err := probe(context.Background(), readyURL); err == nil {
+			break
+		}
+		if time.Now().After(deadline) {
+			_, _ = fmt.Fprintln(stderr, "punaro up failed: readiness deadline exceeded; run punaro doctor")
+			return 1
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+	result := diagnose(context.Background(), installation)
+	if !result.Healthy {
+		_ = writeJSON(stdout, stderr, result)
+		return 1
+	}
+	return writeJSON(stdout, stderr, result)
+}
+
+type statusResult struct {
+	Healthy      bool                          `json:"healthy"`
+	Reachable    bool                          `json:"reachable"`
+	Ready        bool                          `json:"ready"`
+	Schema       punaropostgres.Classification `json:"schema"`
+	Core         []string                      `json:"core_capabilities"`
+	Optional     []string                      `json:"optional_capabilities"`
+	FailedChecks []string                      `json:"failed_checks,omitempty"`
+}
+
+func runStatus(args []string, stdout, stderr io.Writer, doctor bool) int {
+	name := "status"
+	if doctor {
+		name = "doctor"
+	}
+	directory, ok := parseDirectory(name, args, stderr)
+	if !ok {
+		return 2
+	}
+	installation, err := operator.Load(directory)
+	if err != nil {
+		_, _ = fmt.Fprintf(stderr, "punaro %s failed: %v\n", name, err)
+		return 1
+	}
+	result := diagnose(context.Background(), installation)
+	if code := writeJSON(stdout, stderr, result); code != 0 {
+		return code
+	}
+	if doctor && !result.Healthy {
+		return 1
+	}
+	return 0
+}
+
+func diagnose(ctx context.Context, installation operator.Installation) statusResult {
+	result := statusResult{Core: []string{"postgresql", "device-enrollment", "device-authentication"}, Optional: []string{}}
+	result.FailedChecks = append(result.FailedChecks, operator.CheckPaths(installation)...)
+	state, err := inspectSchema(ctx, installation.AppDSNFile)
+	if err != nil {
+		result.FailedChecks = append(result.FailedChecks, "database unavailable")
+	} else {
+		result.Schema = state.Classification
+		if state.Classification != punaropostgres.Compatible {
+			result.FailedChecks = append(result.FailedChecks, "schema not compatible")
+		} else if err := verifyInstallationPair(ctx, installation.AppDSNFile, installation.OwnerDSNFile); err != nil {
+			result.FailedChecks = append(result.FailedChecks, "database roles target different installations")
+		}
+	}
+	owner, ownerErr := inspectOwner(ctx, installation.AppDSNFile)
+	if ownerErr != nil || owner.ID != installation.OwnerPrincipalID {
+		result.FailedChecks = append(result.FailedChecks, "database owner does not match installation configuration")
+	}
+	base := strings.TrimRight(installation.HealthURL, "/")
+	if err := probe(ctx, base+"/healthz"); err == nil {
+		result.Reachable = true
+	} else {
+		result.FailedChecks = append(result.FailedChecks, "daemon unreachable")
+	}
+	if err := probe(ctx, base+"/readyz"); err == nil {
+		result.Ready = true
+	} else {
+		result.FailedChecks = append(result.FailedChecks, "daemon not ready")
+	}
+	result.Healthy = len(result.FailedChecks) == 0
+	return result
+}
+
+type stringList []string
+
+func (s *stringList) String() string { return fmt.Sprint([]string(*s)) }
+func (s *stringList) Set(value string) error {
+	*s = append(*s, value)
+	return nil
+}
+
+func runClientAdd(args []string, stdout, stderr io.Writer) int {
+	flags := flag.NewFlagSet("client add", flag.ContinueOnError)
+	flags.SetOutput(stderr)
+	directory := flags.String("directory", "", "absolute installation directory")
+	name := flags.String("name", "", "client display name")
+	allProjects := flags.Bool("all-projects", false, "grant current and future project access")
+	confirmed := flags.Bool("yes", false, "confirm the exact printed grants")
+	confirmedHash := flags.String("confirm-preview-hash", "", "exact preview hash printed by the prior preview-only run")
+	ttl := flags.Duration("ttl", 10*time.Minute, "single-use code lifetime")
+	credentialTTL := flags.Duration("credential-ttl", 0, "optional credential lifetime")
+	var projects stringList
+	flags.Var(&projects, "project", "selected opaque project UUID (repeatable)")
+	if flags.Parse(args) != nil || flags.NArg() != 0 || *directory == "" || *name == "" {
+		return 2
+	}
+	installation, err := operator.Load(*directory)
+	if err != nil {
+		_, _ = fmt.Fprintln(stderr, "client enrollment refused: installation configuration is unavailable")
+		return 1
+	}
+	grants, previewHash, err := punaropostgres.PreviewTrustedAgentEnrollment(projects, *allProjects)
+	if err != nil {
+		_, _ = fmt.Fprintln(stderr, "client enrollment refused: grants are invalid")
+		return 1
+	}
+	preview := map[string]any{"template": "trusted-agent", "preview_hash": previewHash, "grants": grants}
+	if code := writeJSON(stdout, stderr, preview); code != 0 {
+		return code
+	}
+	if !*confirmed {
+		_, _ = fmt.Fprintln(stderr, "grant preview printed; rerun with --yes and --confirm-preview-hash to create the enrollment")
+		return 3
+	}
+	if *confirmedHash == "" || *confirmedHash != previewHash {
+		_, _ = fmt.Fprintln(stderr, "client enrollment refused: confirmed preview hash does not match the exact grants above")
+		return 3
+	}
+	state, err := inspectSchema(context.Background(), installation.AppDSNFile)
+	if err != nil || state.Classification != punaropostgres.Compatible {
+		_, _ = fmt.Fprintln(stderr, "client enrollment refused: database schema is not compatible")
+		return 1
+	}
+	if err := verifyInstallationPair(context.Background(), installation.AppDSNFile, installation.OwnerDSNFile); err != nil {
+		_, _ = fmt.Fprintln(stderr, "client enrollment refused: database roles do not target the same installation")
+		return 1
+	}
+	admin, err := punaropostgres.OpenAdministration(context.Background(), punaropostgres.Config{DSNFile: installation.OwnerDSNFile})
+	if err != nil {
+		_, _ = fmt.Fprintln(stderr, "client enrollment failed: host-local administration is unavailable")
+		return 1
+	}
+	defer func() { _ = admin.Close() }()
+	pending, err := admin.CreateEnrollment(context.Background(), installation.OwnerPrincipalID, punaropostgres.EnrollmentRequest{ClientBinding: uuid.NewString(), Label: *name, ProjectIDs: projects, AllProjects: *allProjects, TTL: *ttl, CredentialTTL: *credentialTTL}, previewHash)
+	if err != nil {
+		_, _ = fmt.Fprintln(stderr, "client enrollment failed")
+		return 1
+	}
+	return writeJSON(stdout, stderr, pending)
+}
+
+func parseDirectory(name string, args []string, stderr io.Writer) (string, bool) {
+	flags := flag.NewFlagSet(name, flag.ContinueOnError)
+	flags.SetOutput(stderr)
+	directory := flags.String("directory", "", "absolute installation directory")
+	if flags.Parse(args) != nil || flags.NArg() != 0 || *directory == "" || !filepath.IsAbs(*directory) {
+		return "", false
+	}
+	return *directory, true
+}
+
+func probeHTTP(ctx context.Context, rawURL string) error {
+	requestCtx, cancel := context.WithTimeout(ctx, 3*time.Second)
+	defer cancel()
+	request, err := http.NewRequestWithContext(requestCtx, http.MethodGet, rawURL, nil)
+	if err != nil {
+		return err
+	}
+	client := &http.Client{Timeout: 3 * time.Second, CheckRedirect: func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse }}
+	response, err := client.Do(request)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = response.Body.Close() }()
+	_, _ = io.Copy(io.Discard, io.LimitReader(response.Body, 4096))
+	if response.StatusCode != http.StatusOK {
+		return errors.New("health check failed")
+	}
+	return nil
+}
+
+func boundedText(body []byte) string {
+	if len(body) > 512 {
+		body = body[:512]
+	}
+	return strings.TrimSpace(string(body))
+}
+
+func writeJSON(stdout, stderr io.Writer, value any) int {
+	encoder := json.NewEncoder(stdout)
+	encoder.SetIndent("", "  ")
+	if err := encoder.Encode(value); err != nil {
+		_, _ = fmt.Fprintln(stderr, "operator output failed")
+		return 1
+	}
+	return 0
+}

--- a/cmd/punaro/main.go
+++ b/cmd/punaro/main.go
@@ -38,8 +38,8 @@ var (
 		defer func() { _ = database.Close() }()
 		return database.InstallationOwner(ctx)
 	}
-	migrateSchema = func(ctx context.Context, dsnFile string) (punaropostgres.SchemaState, error) {
-		return punaropostgres.Migrate(ctx, punaropostgres.Config{DSNFile: dsnFile})
+	migratePristinePair = func(ctx context.Context, appDSNFile, ownerDSNFile string) (punaropostgres.SchemaState, error) {
+		return punaropostgres.MigratePristinePair(ctx, punaropostgres.Config{DSNFile: appDSNFile}, punaropostgres.Config{DSNFile: ownerDSNFile})
 	}
 	createOwner = func(ctx context.Context, dsnFile, name string) (punaropostgres.Principal, error) {
 		admin, err := punaropostgres.OpenAdministration(ctx, punaropostgres.Config{DSNFile: dsnFile})
@@ -79,7 +79,8 @@ var (
 			return punaropostgres.Principal{}, err
 		}
 		if state.Classification == punaropostgres.Pristine {
-			if _, err = migrateSchema(ctx, installation.OwnerDSNFile); err == nil {
+			_, err = migratePristinePair(ctx, installation.AppDSNFile, installation.OwnerDSNFile)
+			if err == nil {
 				state, err = inspectSchema(ctx, installation.AppDSNFile)
 			}
 		}
@@ -181,7 +182,10 @@ func runInit(args []string, stdout, stderr io.Writer) int {
 		if err != nil || state.Classification != punaropostgres.Pristine {
 			return punaropostgres.Principal{}, operator.ErrBootstrapNotAttempted
 		}
-		if _, err = migrateSchema(ctx, ownerFile); err != nil {
+		if _, err = migratePristinePair(ctx, *appDSN, ownerFile); err != nil {
+			if errors.Is(err, punaropostgres.ErrMigrationNotAttempted) {
+				return punaropostgres.Principal{}, operator.ErrBootstrapNotAttempted
+			}
 			return punaropostgres.Principal{}, err
 		}
 		state, err = inspectSchema(ctx, *appDSN)

--- a/cmd/punaro/main.go
+++ b/cmd/punaro/main.go
@@ -110,12 +110,10 @@ var (
 		return admin.CreateEnrollment(ctx, installation.OwnerPrincipalID, request, previewHash)
 	}
 	startServices = func(ctx context.Context, installation operator.Installation) error {
-		arguments, err := composeUpArgs(installation)
+		command, err := composeUpCommand(ctx, installation)
 		if err != nil {
 			return err
 		}
-		command := exec.CommandContext(ctx, "docker", arguments...) // #nosec G204 -- fixed executable and generated private file arguments.
-		command.Dir = installation.Directory
 		output, err := command.CombinedOutput()
 		if err != nil {
 			return fmt.Errorf("service start failed: %s", boundedText(output))
@@ -125,12 +123,36 @@ var (
 	probe = probeHTTP
 )
 
+func composeUpCommand(ctx context.Context, installation operator.Installation) (*exec.Cmd, error) {
+	arguments, err := composeUpArgs(installation)
+	if err != nil {
+		return nil, err
+	}
+	command := exec.CommandContext(ctx, "docker", arguments...) // #nosec G204 -- fixed executable and generated private file arguments.
+	command.Dir = installation.Directory
+	command.Env = composeEnvironment(os.Environ(), installation.Directory)
+	return command, nil
+}
+
 func composeUpArgs(installation operator.Installation) ([]string, error) {
 	projectName, err := operator.ComposeProjectName(installation)
 	if err != nil {
 		return nil, err
 	}
 	return []string{"compose", "--project-name", projectName, "--env-file", operator.EnvFile(installation.Directory), "-f", operator.OverrideFile(installation.Directory), "up", "-d"}, nil
+}
+
+func composeEnvironment(environment []string, directory string) []string {
+	sanitized := make([]string, 0, len(environment)+1)
+	for _, entry := range environment {
+		name, _, found := strings.Cut(entry, "=")
+		canonicalName := strings.ToUpper(name)
+		if !found || canonicalName == "PWD" || strings.HasPrefix(canonicalName, "PUNARO_") || strings.HasPrefix(canonicalName, "COMPOSE_") {
+			continue
+		}
+		sanitized = append(sanitized, entry)
+	}
+	return append(sanitized, "PWD="+directory)
 }
 
 func main() { os.Exit(run(os.Args[1:], os.Stdout, os.Stderr)) }

--- a/cmd/punaro/main_test.go
+++ b/cmd/punaro/main_test.go
@@ -64,6 +64,23 @@ func preserveDependencies(t *testing.T) {
 	}
 }
 
+func TestComposeUpArgsUseInstallationSpecificProjectName(t *testing.T) {
+	first := operator.Installation{Directory: filepath.Join(string(filepath.Separator), "srv", "a", "punaro"), OwnerPrincipalID: "11111111-1111-4111-8111-111111111111"}
+	second := operator.Installation{Directory: filepath.Join(string(filepath.Separator), "srv", "b", "punaro"), OwnerPrincipalID: "22222222-2222-4222-8222-222222222222"}
+	firstArgs, firstErr := composeUpArgs(first)
+	secondArgs, secondErr := composeUpArgs(second)
+	firstProject, _ := operator.ComposeProjectName(first)
+	if firstErr != nil || secondErr != nil || len(firstArgs) < 3 || firstArgs[1] != "--project-name" || firstArgs[2] != firstProject {
+		t.Fatalf("first args=%v", firstArgs)
+	}
+	if firstArgs[2] == secondArgs[2] {
+		t.Fatalf("same-basename installations share project name: %q", firstArgs[2])
+	}
+	if _, err := composeUpArgs(operator.Installation{OwnerPrincipalID: "invalid"}); err == nil {
+		t.Fatal("invalid owner identity reached Docker arguments")
+	}
+}
+
 func TestUpRefusesExistingUpgradeBeforeMigrationOrStart(t *testing.T) {
 	preserveDependencies(t)
 	directory := testInstallation(t)

--- a/cmd/punaro/main_test.go
+++ b/cmd/punaro/main_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -43,12 +44,12 @@ func testInstallation(t *testing.T) string {
 
 func preserveDependencies(t *testing.T) {
 	t.Helper()
-	originalInspect, originalOwner, originalMigrate := inspectSchema, inspectOwner, migrateSchema
+	originalInspect, originalOwner, originalMigrate := inspectSchema, inspectOwner, migratePristinePair
 	originalCreate, originalRecover := createOwner, recoverInstallationOwner
 	originalVerify := verifyInstallationPair
 	originalStart, originalProbe, originalIssue := startServices, probe, issueEnrollment
 	t.Cleanup(func() {
-		inspectSchema, inspectOwner, migrateSchema = originalInspect, originalOwner, originalMigrate
+		inspectSchema, inspectOwner, migratePristinePair = originalInspect, originalOwner, originalMigrate
 		createOwner, recoverInstallationOwner = originalCreate, originalRecover
 		verifyInstallationPair = originalVerify
 		startServices, probe = originalStart, originalProbe
@@ -58,6 +59,9 @@ func preserveDependencies(t *testing.T) {
 		return punaropostgres.Principal{ID: "11111111-1111-4111-8111-111111111111", DisplayName: "owner"}, nil
 	}
 	verifyInstallationPair = func(context.Context, string, string) error { return nil }
+	migratePristinePair = func(context.Context, string, string) (punaropostgres.SchemaState, error) {
+		return punaropostgres.SchemaState{Classification: punaropostgres.Compatible, Version: 4}, nil
+	}
 }
 
 func TestUpRefusesExistingUpgradeBeforeMigrationOrStart(t *testing.T) {
@@ -67,7 +71,7 @@ func TestUpRefusesExistingUpgradeBeforeMigrationOrStart(t *testing.T) {
 	inspectSchema = func(context.Context, string) (punaropostgres.SchemaState, error) {
 		return punaropostgres.SchemaState{Classification: punaropostgres.UpgradeRequired, Version: 3}, nil
 	}
-	migrateSchema = func(context.Context, string) (punaropostgres.SchemaState, error) {
+	migratePristinePair = func(context.Context, string, string) (punaropostgres.SchemaState, error) {
 		migrated = true
 		return punaropostgres.SchemaState{}, nil
 	}
@@ -101,7 +105,7 @@ func TestUpRefusesResetPristineDatabase(t *testing.T) {
 	inspectSchema = func(context.Context, string) (punaropostgres.SchemaState, error) {
 		return punaropostgres.SchemaState{Classification: punaropostgres.Pristine}, nil
 	}
-	migrateSchema = func(context.Context, string) (punaropostgres.SchemaState, error) {
+	migratePristinePair = func(context.Context, string, string) (punaropostgres.SchemaState, error) {
 		migrateCalls++
 		return punaropostgres.SchemaState{Classification: punaropostgres.Compatible, Version: 4}, nil
 	}
@@ -196,7 +200,7 @@ func TestInitMigratesPristineBeforeCreatingOwner(t *testing.T) {
 		}
 		return punaropostgres.SchemaState{Classification: punaropostgres.Compatible, Version: 4}, nil
 	}
-	migrateSchema = func(context.Context, string) (punaropostgres.SchemaState, error) {
+	migratePristinePair = func(context.Context, string, string) (punaropostgres.SchemaState, error) {
 		sequence = append(sequence, "migrate")
 		return punaropostgres.SchemaState{Classification: punaropostgres.Compatible, Version: 4}, nil
 	}
@@ -208,6 +212,35 @@ func TestInitMigratesPristineBeforeCreatingOwner(t *testing.T) {
 	var stdout, stderr bytes.Buffer
 	if code := run(args, &stdout, &stderr); code != 0 || strings.Join(sequence, ",") != "inspect,migrate,inspect,owner" {
 		t.Fatalf("code=%d sequence=%v stdout=%q stderr=%q", code, sequence, stdout.String(), stderr.String())
+	}
+}
+
+func TestInitProvesPristineDSNPairBeforeMigration(t *testing.T) {
+	preserveDependencies(t)
+	root := t.TempDir()
+	for _, name := range []string{"data", "backup"} {
+		if err := os.Mkdir(filepath.Join(root, name), 0o700); err != nil {
+			t.Fatal(err)
+		}
+	}
+	for _, name := range []string{"owner.dsn", "app.dsn"} {
+		if err := os.WriteFile(filepath.Join(root, name), []byte("postgres://invalid\n"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	inspectSchema = func(context.Context, string) (punaropostgres.SchemaState, error) {
+		return punaropostgres.SchemaState{Classification: punaropostgres.Pristine}, nil
+	}
+	migratePristinePair = func(context.Context, string, string) (punaropostgres.SchemaState, error) {
+		return punaropostgres.SchemaState{}, fmt.Errorf("%w: different pristine databases", punaropostgres.ErrMigrationNotAttempted)
+	}
+	args := []string{"init", "--directory", filepath.Join(root, "install"), "--data-dir", filepath.Join(root, "data"), "--backup-dir", filepath.Join(root, "backup"), "--image", cliTestImage, "--owner-dsn-file", filepath.Join(root, "owner.dsn"), "--app-dsn-file", filepath.Join(root, "app.dsn"), "--owner-name", "operator", "--mode", "internet", "--public-url", "https://punaro.example"}
+	var stdout, stderr bytes.Buffer
+	if code := run(args, &stdout, &stderr); code != 1 || !strings.Contains(stderr.String(), "requires a pristine") {
+		t.Fatalf("code=%d stdout=%q stderr=%q", code, stdout.String(), stderr.String())
+	}
+	if _, err := os.Stat(filepath.Join(root, "install")); !os.IsNotExist(err) {
+		t.Fatalf("pre-migration refusal left a resumable stage: %v", err)
 	}
 }
 

--- a/cmd/punaro/main_test.go
+++ b/cmd/punaro/main_test.go
@@ -95,7 +95,7 @@ func TestUpRefusesExistingUpgradeBeforeMigrationOrStart(t *testing.T) {
 	startServices = func(context.Context, operator.Installation) error { started = true; return nil }
 	verifyInstallationPair = func(context.Context, string, string) error { pairChecked = true; return errors.New("must not run") }
 	var stdout, stderr bytes.Buffer
-	if code := run([]string{"up", "--directory", directory}, &stdout, &stderr); code != 1 || migrated || started || pairChecked || !strings.Contains(stderr.String(), "punaro update") {
+	if code := run([]string{"up", "--directory", directory}, &stdout, &stderr); code != 1 || migrated || started || pairChecked || !strings.Contains(stderr.String(), "no in-place updater") || !strings.Contains(stderr.String(), "previous compatible release") || strings.Contains(stderr.String(), "punaro update") {
 		t.Fatalf("code=%d migrated=%t started=%t pairChecked=%t stdout=%q stderr=%q", code, migrated, started, pairChecked, stdout.String(), stderr.String())
 	}
 }

--- a/cmd/punaro/main_test.go
+++ b/cmd/punaro/main_test.go
@@ -1,0 +1,333 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/rock3r/punaro/internal/ingress"
+	"github.com/rock3r/punaro/internal/operator"
+	punaropostgres "github.com/rock3r/punaro/internal/postgres"
+)
+
+const cliTestImage = "registry.example/punaro@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+
+func testInstallation(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	for _, name := range []string{"data", "backup"} {
+		if err := os.Mkdir(filepath.Join(root, name), 0o700); err != nil {
+			t.Fatal(err)
+		}
+	}
+	for _, name := range []string{"owner.dsn", "app.dsn"} {
+		if err := os.WriteFile(filepath.Join(root, name), []byte("postgres://invalid\n"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	directory := filepath.Join(root, "installation")
+	_, err := operator.Init(context.Background(), operator.InitOptions{Directory: directory, DataDir: filepath.Join(root, "data"), BackupDir: filepath.Join(root, "backup"), Image: cliTestImage, OwnerDSNFile: filepath.Join(root, "owner.dsn"), AppDSNFile: filepath.Join(root, "app.dsn"), OwnerName: "owner", Ingress: ingress.Policy{Mode: ingress.Internet, ListenAddr: "127.0.0.1:8080", PublicURL: "https://punaro.example"}}, func(context.Context, string, string) (punaropostgres.Principal, error) {
+		return punaropostgres.Principal{ID: "11111111-1111-4111-8111-111111111111"}, nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return directory
+}
+
+func preserveDependencies(t *testing.T) {
+	t.Helper()
+	originalInspect, originalOwner, originalMigrate := inspectSchema, inspectOwner, migrateSchema
+	originalCreate, originalRecover := createOwner, recoverInstallationOwner
+	originalVerify := verifyInstallationPair
+	originalStart, originalProbe := startServices, probe
+	t.Cleanup(func() {
+		inspectSchema, inspectOwner, migrateSchema = originalInspect, originalOwner, originalMigrate
+		createOwner, recoverInstallationOwner = originalCreate, originalRecover
+		verifyInstallationPair = originalVerify
+		startServices, probe = originalStart, originalProbe
+	})
+	inspectOwner = func(context.Context, string) (punaropostgres.Principal, error) {
+		return punaropostgres.Principal{ID: "11111111-1111-4111-8111-111111111111", DisplayName: "owner"}, nil
+	}
+	verifyInstallationPair = func(context.Context, string, string) error { return nil }
+}
+
+func TestUpRefusesExistingUpgradeBeforeMigrationOrStart(t *testing.T) {
+	preserveDependencies(t)
+	directory := testInstallation(t)
+	migrated, started, pairChecked := false, false, false
+	inspectSchema = func(context.Context, string) (punaropostgres.SchemaState, error) {
+		return punaropostgres.SchemaState{Classification: punaropostgres.UpgradeRequired, Version: 3}, nil
+	}
+	migrateSchema = func(context.Context, string) (punaropostgres.SchemaState, error) {
+		migrated = true
+		return punaropostgres.SchemaState{}, nil
+	}
+	startServices = func(context.Context, operator.Installation) error { started = true; return nil }
+	verifyInstallationPair = func(context.Context, string, string) error { pairChecked = true; return errors.New("must not run") }
+	var stdout, stderr bytes.Buffer
+	if code := run([]string{"up", "--directory", directory}, &stdout, &stderr); code != 1 || migrated || started || pairChecked || !strings.Contains(stderr.String(), "punaro update") {
+		t.Fatalf("code=%d migrated=%t started=%t pairChecked=%t stdout=%q stderr=%q", code, migrated, started, pairChecked, stdout.String(), stderr.String())
+	}
+}
+
+func TestDoctorClassifiesOldSchemaBeforeRolePair(t *testing.T) {
+	preserveDependencies(t)
+	directory := testInstallation(t)
+	inspectSchema = func(context.Context, string) (punaropostgres.SchemaState, error) {
+		return punaropostgres.SchemaState{Classification: punaropostgres.UpgradeRequired, Version: 3}, nil
+	}
+	pairChecked := false
+	verifyInstallationPair = func(context.Context, string, string) error { pairChecked = true; return errors.New("must not run") }
+	probe = func(context.Context, string) error { return nil }
+	var stdout, stderr bytes.Buffer
+	if code := run([]string{"doctor", "--directory", directory}, &stdout, &stderr); code != 1 || pairChecked || !strings.Contains(stdout.String(), "schema not compatible") || strings.Contains(stdout.String(), "database roles target different") {
+		t.Fatalf("code=%d pairChecked=%t stdout=%q stderr=%q", code, pairChecked, stdout.String(), stderr.String())
+	}
+}
+
+func TestUpRefusesResetPristineDatabase(t *testing.T) {
+	preserveDependencies(t)
+	directory := testInstallation(t)
+	migrateCalls, startCalls, probeCalls := 0, 0, 0
+	inspectSchema = func(context.Context, string) (punaropostgres.SchemaState, error) {
+		return punaropostgres.SchemaState{Classification: punaropostgres.Pristine}, nil
+	}
+	migrateSchema = func(context.Context, string) (punaropostgres.SchemaState, error) {
+		migrateCalls++
+		return punaropostgres.SchemaState{Classification: punaropostgres.Compatible, Version: 4}, nil
+	}
+	startServices = func(context.Context, operator.Installation) error { startCalls++; return nil }
+	probe = func(context.Context, string) error { probeCalls++; return nil }
+	var stdout, stderr bytes.Buffer
+	if code := run([]string{"up", "--directory", directory}, &stdout, &stderr); code != 1 {
+		t.Fatalf("code=%d stdout=%q stderr=%q", code, stdout.String(), stderr.String())
+	}
+	if migrateCalls != 0 || startCalls != 0 || probeCalls != 0 || !strings.Contains(stderr.String(), "schema is pristine") {
+		t.Fatalf("migrate=%d start=%d probe=%d stderr=%q", migrateCalls, startCalls, probeCalls, stderr.String())
+	}
+}
+
+func TestUpStartsCompatibleThenDoctors(t *testing.T) {
+	preserveDependencies(t)
+	directory := testInstallation(t)
+	inspectCalls, startCalls, probeCalls := 0, 0, 0
+	inspectSchema = func(context.Context, string) (punaropostgres.SchemaState, error) {
+		inspectCalls++
+		return punaropostgres.SchemaState{Classification: punaropostgres.Compatible, Version: 4}, nil
+	}
+	startServices = func(context.Context, operator.Installation) error { startCalls++; return nil }
+	probe = func(context.Context, string) error { probeCalls++; return nil }
+	var stdout, stderr bytes.Buffer
+	if code := run([]string{"up", "--directory", directory}, &stdout, &stderr); code != 0 {
+		t.Fatalf("code=%d stdout=%q stderr=%q", code, stdout.String(), stderr.String())
+	}
+	if startCalls != 1 || inspectCalls != 2 || probeCalls != 3 {
+		t.Fatalf("inspect=%d start=%d probe=%d", inspectCalls, startCalls, probeCalls)
+	}
+}
+
+func TestUpRefusesMismatchedInstallationPairBeforeStart(t *testing.T) {
+	preserveDependencies(t)
+	directory := testInstallation(t)
+	inspectSchema = func(context.Context, string) (punaropostgres.SchemaState, error) {
+		return punaropostgres.SchemaState{Classification: punaropostgres.Compatible, Version: 4}, nil
+	}
+	verifyInstallationPair = func(context.Context, string, string) error {
+		return errors.New("different installation")
+	}
+	started := false
+	startServices = func(context.Context, operator.Installation) error { started = true; return nil }
+	var stdout, stderr bytes.Buffer
+	if code := run([]string{"up", "--directory", directory}, &stdout, &stderr); code != 1 || started || !strings.Contains(stderr.String(), "database roles") {
+		t.Fatalf("code=%d started=%t stdout=%q stderr=%q", code, started, stdout.String(), stderr.String())
+	}
+}
+
+func TestDoctorFailsForConfigurationDriftAndRoleMismatch(t *testing.T) {
+	preserveDependencies(t)
+	directory := testInstallation(t)
+	installation, err := operator.Load(directory)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Remove(installation.BackupDir); err != nil {
+		t.Fatal(err)
+	}
+	inspectSchema = func(context.Context, string) (punaropostgres.SchemaState, error) {
+		return punaropostgres.SchemaState{Classification: punaropostgres.Compatible, Version: 4}, nil
+	}
+	verifyInstallationPair = func(context.Context, string, string) error {
+		return errors.New("different installation")
+	}
+	probe = func(context.Context, string) error { return nil }
+	var stdout, stderr bytes.Buffer
+	if code := run([]string{"doctor", "--directory", directory}, &stdout, &stderr); code != 1 || !strings.Contains(stdout.String(), `"healthy": false`) || !strings.Contains(stdout.String(), "database roles target different installations") || !strings.Contains(stdout.String(), "backup directory") {
+		t.Fatalf("code=%d stdout=%q stderr=%q", code, stdout.String(), stderr.String())
+	}
+}
+
+func TestInitMigratesPristineBeforeCreatingOwner(t *testing.T) {
+	preserveDependencies(t)
+	root := t.TempDir()
+	for _, name := range []string{"data", "backup"} {
+		if err := os.Mkdir(filepath.Join(root, name), 0o700); err != nil {
+			t.Fatal(err)
+		}
+	}
+	for _, name := range []string{"owner.dsn", "app.dsn"} {
+		if err := os.WriteFile(filepath.Join(root, name), []byte("postgres://invalid\n"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	sequence := []string{}
+	inspectSchema = func(context.Context, string) (punaropostgres.SchemaState, error) {
+		sequence = append(sequence, "inspect")
+		if len(sequence) == 1 {
+			return punaropostgres.SchemaState{Classification: punaropostgres.Pristine}, nil
+		}
+		return punaropostgres.SchemaState{Classification: punaropostgres.Compatible, Version: 4}, nil
+	}
+	migrateSchema = func(context.Context, string) (punaropostgres.SchemaState, error) {
+		sequence = append(sequence, "migrate")
+		return punaropostgres.SchemaState{Classification: punaropostgres.Compatible, Version: 4}, nil
+	}
+	createOwner = func(context.Context, string, string) (punaropostgres.Principal, error) {
+		sequence = append(sequence, "owner")
+		return punaropostgres.Principal{ID: "11111111-1111-4111-8111-111111111111"}, nil
+	}
+	args := []string{"init", "--directory", filepath.Join(root, "install"), "--data-dir", filepath.Join(root, "data"), "--backup-dir", filepath.Join(root, "backup"), "--image", cliTestImage, "--owner-dsn-file", filepath.Join(root, "owner.dsn"), "--app-dsn-file", filepath.Join(root, "app.dsn"), "--owner-name", "operator", "--mode", "internet", "--public-url", "https://punaro.example"}
+	var stdout, stderr bytes.Buffer
+	if code := run(args, &stdout, &stderr); code != 0 || strings.Join(sequence, ",") != "inspect,migrate,inspect,owner" {
+		t.Fatalf("code=%d sequence=%v stdout=%q stderr=%q", code, sequence, stdout.String(), stderr.String())
+	}
+}
+
+func TestInitRefusesAlreadyCompatibleDatabase(t *testing.T) {
+	preserveDependencies(t)
+	root := t.TempDir()
+	for _, name := range []string{"data", "backup"} {
+		if err := os.Mkdir(filepath.Join(root, name), 0o700); err != nil {
+			t.Fatal(err)
+		}
+	}
+	for _, name := range []string{"owner.dsn", "app.dsn"} {
+		if err := os.WriteFile(filepath.Join(root, name), []byte("postgres://invalid\n"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	inspectSchema = func(context.Context, string) (punaropostgres.SchemaState, error) {
+		return punaropostgres.SchemaState{Classification: punaropostgres.Compatible, Version: 4}, nil
+	}
+	created := false
+	createOwner = func(context.Context, string, string) (punaropostgres.Principal, error) {
+		created = true
+		return punaropostgres.Principal{}, nil
+	}
+	args := []string{"init", "--directory", filepath.Join(root, "install"), "--data-dir", filepath.Join(root, "data"), "--backup-dir", filepath.Join(root, "backup"), "--image", cliTestImage, "--owner-dsn-file", filepath.Join(root, "owner.dsn"), "--app-dsn-file", filepath.Join(root, "app.dsn"), "--owner-name", "operator", "--mode", "internet", "--public-url", "https://punaro.example"}
+	var stdout, stderr bytes.Buffer
+	if code := run(args, &stdout, &stderr); code != 1 || created || !strings.Contains(stderr.String(), "requires a pristine") {
+		t.Fatalf("code=%d created=%t stdout=%q stderr=%q", code, created, stdout.String(), stderr.String())
+	}
+	if _, err := os.Stat(filepath.Join(root, "install")); !os.IsNotExist(err) {
+		t.Fatalf("refused fresh init left a resumable stage: %v", err)
+	}
+}
+
+func TestUpRefusesCompatibleDatabaseWithDifferentOwner(t *testing.T) {
+	preserveDependencies(t)
+	directory := testInstallation(t)
+	inspectSchema = func(context.Context, string) (punaropostgres.SchemaState, error) {
+		return punaropostgres.SchemaState{Classification: punaropostgres.Compatible, Version: 4}, nil
+	}
+	inspectOwner = func(context.Context, string) (punaropostgres.Principal, error) {
+		return punaropostgres.Principal{ID: "22222222-2222-4222-8222-222222222222"}, nil
+	}
+	started := false
+	startServices = func(context.Context, operator.Installation) error { started = true; return nil }
+	var stdout, stderr bytes.Buffer
+	if code := run([]string{"up", "--directory", directory}, &stdout, &stderr); code != 1 || started || !strings.Contains(stderr.String(), "owner does not match") {
+		t.Fatalf("code=%d started=%t stdout=%q stderr=%q", code, started, stdout.String(), stderr.String())
+	}
+}
+
+func TestInitResumeRecoversUncertainOwnerOutcome(t *testing.T) {
+	preserveDependencies(t)
+	root := t.TempDir()
+	for _, name := range []string{"data", "backup"} {
+		if err := os.Mkdir(filepath.Join(root, name), 0o700); err != nil {
+			t.Fatal(err)
+		}
+	}
+	for _, name := range []string{"owner.dsn", "app.dsn"} {
+		if err := os.WriteFile(filepath.Join(root, name), []byte("postgres://invalid\n"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	inspectCalls := 0
+	inspectSchema = func(context.Context, string) (punaropostgres.SchemaState, error) {
+		inspectCalls++
+		if inspectCalls == 1 {
+			return punaropostgres.SchemaState{Classification: punaropostgres.Pristine}, nil
+		}
+		return punaropostgres.SchemaState{Classification: punaropostgres.Compatible, Version: 4}, nil
+	}
+	createOwner = func(context.Context, string, string) (punaropostgres.Principal, error) {
+		return punaropostgres.Principal{}, context.DeadlineExceeded
+	}
+	directory := filepath.Join(root, "install")
+	args := []string{"init", "--directory", directory, "--data-dir", filepath.Join(root, "data"), "--backup-dir", filepath.Join(root, "backup"), "--image", cliTestImage, "--owner-dsn-file", filepath.Join(root, "owner.dsn"), "--app-dsn-file", filepath.Join(root, "app.dsn"), "--owner-name", "operator", "--mode", "internet", "--public-url", "https://punaro.example"}
+	var stdout, stderr bytes.Buffer
+	if code := run(args, &stdout, &stderr); code != 1 || !strings.Contains(stderr.String(), "--resume") {
+		t.Fatalf("code=%d stdout=%q stderr=%q", code, stdout.String(), stderr.String())
+	}
+	recoverInstallationOwner = func(_ context.Context, installation operator.Installation) (punaropostgres.Principal, error) {
+		return punaropostgres.Principal{ID: "11111111-1111-4111-8111-111111111111", DisplayName: installation.OwnerName}, nil
+	}
+	stdout.Reset()
+	stderr.Reset()
+	if code := run([]string{"init", "--resume", "--directory", directory}, &stdout, &stderr); code != 0 {
+		t.Fatalf("resume code=%d stdout=%q stderr=%q", code, stdout.String(), stderr.String())
+	}
+}
+
+func TestClientAddPrintsPreviewWithoutDatabaseMutation(t *testing.T) {
+	directory := testInstallation(t)
+	var stdout, stderr bytes.Buffer
+	if code := run([]string{"client", "add", "--directory", directory, "--name", "laptop", "--all-projects"}, &stdout, &stderr); code != 3 || !strings.Contains(stdout.String(), "trusted-agent") || !strings.Contains(stderr.String(), "rerun with --yes") {
+		t.Fatalf("code=%d stdout=%q stderr=%q", code, stdout.String(), stderr.String())
+	}
+}
+
+func TestClientAddRefusesYesWithoutPriorExactPreviewHash(t *testing.T) {
+	directory := testInstallation(t)
+	var stdout, stderr bytes.Buffer
+	if code := run([]string{"client", "add", "--directory", directory, "--name", "laptop", "--all-projects", "--yes", "--confirm-preview-hash", "stale"}, &stdout, &stderr); code != 3 || !strings.Contains(stderr.String(), "does not match") {
+		t.Fatalf("code=%d stdout=%q stderr=%q", code, stdout.String(), stderr.String())
+	}
+}
+
+func TestClientAddRefusesMutationWhenDatabaseRolesDiffer(t *testing.T) {
+	preserveDependencies(t)
+	directory := testInstallation(t)
+	verifyInstallationPair = func(context.Context, string, string) error {
+		return errors.New("different installation")
+	}
+	inspectSchema = func(context.Context, string) (punaropostgres.SchemaState, error) {
+		return punaropostgres.SchemaState{Classification: punaropostgres.Compatible, Version: 4}, nil
+	}
+	var stdout, stderr bytes.Buffer
+	_, previewHash, err := punaropostgres.PreviewTrustedAgentEnrollment(nil, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	args := []string{"client", "add", "--directory", directory, "--name", "laptop", "--all-projects", "--yes", "--confirm-preview-hash", previewHash}
+	if code := run(args, &stdout, &stderr); code != 1 || !strings.Contains(stderr.String(), "database roles") {
+		t.Fatalf("code=%d stdout=%q stderr=%q", code, stdout.String(), stderr.String())
+	}
+}

--- a/cmd/punaro/main_test.go
+++ b/cmd/punaro/main_test.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 
@@ -78,6 +79,70 @@ func TestComposeUpArgsUseInstallationSpecificProjectName(t *testing.T) {
 	}
 	if _, err := composeUpArgs(operator.Installation{OwnerPrincipalID: "invalid"}); err == nil {
 		t.Fatal("invalid owner identity reached Docker arguments")
+	}
+}
+
+func TestComposeEnvironmentMakesGeneratedInputsAuthoritative(t *testing.T) {
+	directory := filepath.Join(string(filepath.Separator), "srv", "punaro")
+	got := composeEnvironment([]string{
+		"PATH=/usr/bin:/bin",
+		"HOME=/home/operator",
+		"DOCKER_HOST=unix:///run/user/1000/docker.sock",
+		"DOCKER_CONTEXT=desktop-linux",
+		"DOCKER_CONFIG=/home/operator/.docker",
+		"HTTPS_PROXY=http://proxy.example",
+		"PWD=/stale",
+		"pwd=/also-stale",
+		"PUNARO_IMAGE=attacker.example/punaro:latest",
+		"PuNaRo_Listen_Addr=attacker",
+		"PUNARO_POSTGRES_DSN_FILE=/attacker.dsn",
+		"PUNARO_FUTURE=attacker",
+		"COMPOSE_FILE=/attacker.yaml",
+		"compose_path_separator=attacker",
+		"COMPOSE_PROJECT_NAME=attacker",
+		"COMPOSE_ENV_FILES=/attacker.env",
+		"COMPOSE_PROFILES=attacker",
+		"XPUNARO_IMAGE=unrelated",
+		"XCOMPOSE_FILE=unrelated",
+	}, directory)
+	want := []string{
+		"PATH=/usr/bin:/bin",
+		"HOME=/home/operator",
+		"DOCKER_HOST=unix:///run/user/1000/docker.sock",
+		"DOCKER_CONTEXT=desktop-linux",
+		"DOCKER_CONFIG=/home/operator/.docker",
+		"HTTPS_PROXY=http://proxy.example",
+		"XPUNARO_IMAGE=unrelated",
+		"XCOMPOSE_FILE=unrelated",
+		"PWD=" + directory,
+	}
+	if !slices.Equal(got, want) {
+		t.Fatalf("environment=%v want=%v", got, want)
+	}
+}
+
+func TestComposeUpCommandWiresSanitizedEnvironmentAndDirectory(t *testing.T) {
+	t.Setenv("PUNARO_IMAGE", "attacker.example/punaro:latest")
+	t.Setenv("COMPOSE_FILE", "/attacker.yaml")
+	installation := operator.Installation{
+		Directory:        filepath.Join(string(filepath.Separator), "srv", "punaro"),
+		OwnerPrincipalID: "11111111-1111-4111-8111-111111111111",
+	}
+	command, err := composeUpCommand(context.Background(), installation)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if command.Dir != installation.Directory {
+		t.Fatalf("command directory=%q", command.Dir)
+	}
+	for _, entry := range command.Env {
+		name, _, _ := strings.Cut(entry, "=")
+		if strings.HasPrefix(name, "PUNARO_") || strings.HasPrefix(name, "COMPOSE_") {
+			t.Fatalf("unsafe inherited variable %q", name)
+		}
+	}
+	if !slices.Contains(command.Env, "PWD="+installation.Directory) {
+		t.Fatalf("command environment lacks trusted PWD: %v", command.Env)
 	}
 }
 

--- a/cmd/punaro/main_test.go
+++ b/cmd/punaro/main_test.go
@@ -3,7 +3,9 @@ package main
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -44,12 +46,13 @@ func preserveDependencies(t *testing.T) {
 	originalInspect, originalOwner, originalMigrate := inspectSchema, inspectOwner, migrateSchema
 	originalCreate, originalRecover := createOwner, recoverInstallationOwner
 	originalVerify := verifyInstallationPair
-	originalStart, originalProbe := startServices, probe
+	originalStart, originalProbe, originalIssue := startServices, probe, issueEnrollment
 	t.Cleanup(func() {
 		inspectSchema, inspectOwner, migrateSchema = originalInspect, originalOwner, originalMigrate
 		createOwner, recoverInstallationOwner = originalCreate, originalRecover
 		verifyInstallationPair = originalVerify
 		startServices, probe = originalStart, originalProbe
+		issueEnrollment = originalIssue
 	})
 	inspectOwner = func(context.Context, string) (punaropostgres.Principal, error) {
 		return punaropostgres.Principal{ID: "11111111-1111-4111-8111-111111111111", DisplayName: "owner"}, nil
@@ -329,5 +332,80 @@ func TestClientAddRefusesMutationWhenDatabaseRolesDiffer(t *testing.T) {
 	args := []string{"client", "add", "--directory", directory, "--name", "laptop", "--all-projects", "--yes", "--confirm-preview-hash", previewHash}
 	if code := run(args, &stdout, &stderr); code != 1 || !strings.Contains(stderr.String(), "database roles") {
 		t.Fatalf("code=%d stdout=%q stderr=%q", code, stdout.String(), stderr.String())
+	}
+}
+
+func TestClientAddRevalidatesPathsAndOwnerBeforeMutation(t *testing.T) {
+	tests := []struct {
+		name   string
+		mutate func(*testing.T, string)
+	}{
+		{name: "path drift", mutate: func(t *testing.T, directory string) {
+			installation, err := operator.Load(directory)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := os.Remove(installation.BackupDir); err != nil {
+				t.Fatal(err)
+			}
+		}},
+		{name: "owner mismatch", mutate: func(_ *testing.T, _ string) {
+			inspectOwner = func(context.Context, string) (punaropostgres.Principal, error) {
+				return punaropostgres.Principal{ID: "22222222-2222-4222-8222-222222222222"}, nil
+			}
+		}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			preserveDependencies(t)
+			directory := testInstallation(t)
+			inspectSchema = func(context.Context, string) (punaropostgres.SchemaState, error) {
+				return punaropostgres.SchemaState{Classification: punaropostgres.Compatible, Version: 4}, nil
+			}
+			test.mutate(t, directory)
+			issued := false
+			issueEnrollment = func(context.Context, operator.Installation, punaropostgres.EnrollmentRequest, string) (punaropostgres.PendingEnrollment, error) {
+				issued = true
+				return punaropostgres.PendingEnrollment{}, nil
+			}
+			_, previewHash, err := punaropostgres.PreviewTrustedAgentEnrollment(nil, true)
+			if err != nil {
+				t.Fatal(err)
+			}
+			var stdout, stderr bytes.Buffer
+			args := []string{"client", "add", "--directory", directory, "--name", "laptop", "--all-projects", "--yes", "--confirm-preview-hash", previewHash}
+			if code := run(args, &stdout, &stderr); code != 1 || issued {
+				t.Fatalf("code=%d issued=%t stdout=%q stderr=%q", code, issued, stdout.String(), stderr.String())
+			}
+		})
+	}
+}
+
+func TestConfirmedClientAddEmitsOnlyEnrollmentJSON(t *testing.T) {
+	preserveDependencies(t)
+	directory := testInstallation(t)
+	inspectSchema = func(context.Context, string) (punaropostgres.SchemaState, error) {
+		return punaropostgres.SchemaState{Classification: punaropostgres.Compatible, Version: 4}, nil
+	}
+	issueEnrollment = func(_ context.Context, _ operator.Installation, request punaropostgres.EnrollmentRequest, previewHash string) (punaropostgres.PendingEnrollment, error) {
+		return punaropostgres.PendingEnrollment{ID: "22222222-2222-4222-8222-222222222222", ClientBinding: request.ClientBinding, Code: "one-time-code", PreviewHash: previewHash}, nil
+	}
+	_, previewHash, err := punaropostgres.PreviewTrustedAgentEnrollment(nil, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var stdout, stderr bytes.Buffer
+	args := []string{"client", "add", "--directory", directory, "--name", "laptop", "--all-projects", "--yes", "--confirm-preview-hash", previewHash}
+	if code := run(args, &stdout, &stderr); code != 0 {
+		t.Fatalf("code=%d stdout=%q stderr=%q", code, stdout.String(), stderr.String())
+	}
+	decoder := json.NewDecoder(&stdout)
+	var pending punaropostgres.PendingEnrollment
+	if err := decoder.Decode(&pending); err != nil || pending.Code != "one-time-code" {
+		t.Fatalf("pending=%#v err=%v", pending, err)
+	}
+	var extra any
+	if err := decoder.Decode(&extra); !errors.Is(err, io.EOF) {
+		t.Fatalf("confirmed add emitted multiple JSON documents: extra=%#v err=%v", extra, err)
 	}
 }

--- a/cmd/punarod/main.go
+++ b/cmd/punarod/main.go
@@ -22,6 +22,8 @@ import (
 	attachmentv2 "github.com/rock3r/punaro/internal/attachment/v2"
 	attachmentv3 "github.com/rock3r/punaro/internal/attachment/v3"
 	"github.com/rock3r/punaro/internal/config"
+	"github.com/rock3r/punaro/internal/devicehttp"
+	"github.com/rock3r/punaro/internal/ingress"
 	punaropostgres "github.com/rock3r/punaro/internal/postgres"
 	"github.com/rock3r/punaro/internal/relay"
 )
@@ -34,6 +36,11 @@ const (
 type platformDatabase interface {
 	Ready(context.Context) error
 	Close() error
+}
+
+type deviceDatabase interface {
+	RedeemEnrollment(context.Context, punaropostgres.RedeemEnrollment) (punaropostgres.DeviceCredential, error)
+	AuthenticateDevice(context.Context, string) (punaropostgres.AuthenticatedDevice, error)
 }
 
 var openPlatformDatabase = func(ctx context.Context, cfg punaropostgres.Config) (platformDatabase, error) {
@@ -128,6 +135,21 @@ func run(args []string, stderr io.Writer) int {
 		}
 		_, _ = w.Write([]byte(`{"status":"ready"}\n`))
 	})
+	if cfg.DeviceAuthEnabled {
+		database, ok := platformDB.(deviceDatabase)
+		if !ok {
+			_, _ = fmt.Fprintln(stderr, "punarod device ingress error: PostgreSQL device store is unavailable")
+			return 2
+		}
+		policy := &ingress.Policy{Mode: ingress.Mode(cfg.IngressMode), ListenAddr: cfg.ListenAddr, PublicURL: cfg.PublicURL, TrustedLAN: cfg.TrustedLANCIDR, AllowPlaintext: cfg.TrustedLANHTTP}
+		if err := policy.Validate(); err != nil {
+			_, _ = fmt.Fprintln(stderr, "punarod device ingress error: invalid transport policy")
+			return 2
+		}
+		deviceHandler := devicehttp.New(database, policy)
+		mux.Handle("/v1/enrollments/redeem", deviceHandler)
+		mux.Handle("/v1/device/session", deviceHandler)
+	}
 	if relayHandler != nil {
 		mux.Handle("/v1/", relayHandler)
 	}

--- a/cmd/punarod/main.go
+++ b/cmd/punarod/main.go
@@ -218,16 +218,31 @@ func configuredServer(address string, handler http.Handler) *http.Server {
 	return &http.Server{Addr: address, Handler: handler, ReadHeaderTimeout: 5 * time.Second, ReadTimeout: 15 * time.Second, WriteTimeout: 15 * time.Second, IdleTimeout: 60 * time.Second, MaxHeaderBytes: 16 << 10}
 }
 
-func shutdownHTTPServers(ctx context.Context, servers ...*http.Server) error {
-	var failures []error
+type httpShutdowner interface {
+	Shutdown(context.Context) error
+}
+
+func shutdownHTTPServers(ctx context.Context, servers ...httpShutdowner) error {
+	failures := make(chan error, len(servers))
+	var wait sync.WaitGroup
 	for _, server := range servers {
 		if server != nil {
-			if err := server.Shutdown(ctx); err != nil {
-				failures = append(failures, err)
-			}
+			wait.Add(1)
+			go func() {
+				defer wait.Done()
+				if err := server.Shutdown(ctx); err != nil {
+					failures <- err
+				}
+			}()
 		}
 	}
-	return errors.Join(failures...)
+	wait.Wait()
+	close(failures)
+	var joined []error
+	for err := range failures {
+		joined = append(joined, err)
+	}
+	return errors.Join(joined...)
 }
 
 type permitRouteAuthorizer struct{ authenticator *relay.Authenticator }

--- a/cmd/punarod/main.go
+++ b/cmd/punarod/main.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"net"
 	"net/http"
 	"os"
 	"os/signal"
@@ -46,6 +47,8 @@ type deviceDatabase interface {
 var openPlatformDatabase = func(ctx context.Context, cfg punaropostgres.Config) (platformDatabase, error) {
 	return punaropostgres.OpenApplication(ctx, cfg)
 }
+
+var listenTCP = net.Listen
 
 func main() {
 	os.Exit(run(os.Args[1:], os.Stderr))
@@ -126,15 +129,16 @@ func run(args []string, stderr io.Writer) int {
 		defer closeV3()
 	}
 	logger := log.New(os.Stderr, "punarod ", log.LstdFlags|log.LUTC)
-	mux := http.NewServeMux()
-	mux.HandleFunc("GET /healthz", func(w http.ResponseWriter, _ *http.Request) { _, _ = w.Write([]byte(`{"status":"ok"}\n`)) })
-	mux.HandleFunc("GET /readyz", func(w http.ResponseWriter, _ *http.Request) {
+	healthMux := http.NewServeMux()
+	healthMux.HandleFunc("GET /healthz", func(w http.ResponseWriter, _ *http.Request) { _, _ = w.Write([]byte(`{"status":"ok"}\n`)) })
+	healthMux.HandleFunc("GET /readyz", func(w http.ResponseWriter, _ *http.Request) {
 		if postgresReadiness() != nil || accessReadiness() != nil || (permitReadiness != nil && permitReadiness() != nil) || (v3Readiness != nil && v3Readiness() != nil) {
 			http.Error(w, `{"status":"not_ready"}`, http.StatusServiceUnavailable)
 			return
 		}
 		_, _ = w.Write([]byte(`{"status":"ready"}\n`))
 	})
+	mux := http.NewServeMux()
 	if cfg.DeviceAuthEnabled {
 		database, ok := platformDB.(deviceDatabase)
 		if !ok {
@@ -165,29 +169,65 @@ func run(args []string, stderr io.Writer) int {
 	if v3AttachmentHandler != nil {
 		mux.Handle("/v3/attachments/", v3AttachmentHandler)
 	}
-	server := &http.Server{Addr: cfg.ListenAddr, Handler: securityHeaders(mux), ReadHeaderTimeout: 5 * time.Second, ReadTimeout: 15 * time.Second, WriteTimeout: 15 * time.Second, IdleTimeout: 60 * time.Second, MaxHeaderBytes: 16 << 10}
-	serverErrors := make(chan error, 1)
-	go func() { serverErrors <- server.ListenAndServe() }()
+	server := configuredServer(cfg.ListenAddr, securityHeaders(mux))
+	healthServer := configuredServer(cfg.HealthListenAddr, securityHeaders(healthMux))
+	publicListener, err := listenTCP("tcp", cfg.ListenAddr)
+	if err != nil {
+		logger.Printf("public listener bind failed error=%v", err)
+		return 1
+	}
+	healthListener, err := listenTCP("tcp", cfg.HealthListenAddr)
+	if err != nil {
+		_ = publicListener.Close()
+		logger.Printf("health listener bind failed error=%v", err)
+		return 1
+	}
+	type serverResult struct {
+		name string
+		err  error
+	}
+	serverErrors := make(chan serverResult, 2)
+	go func() { serverErrors <- serverResult{name: "public", err: server.Serve(publicListener)} }()
+	go func() { serverErrors <- serverResult{name: "health", err: healthServer.Serve(healthListener)} }()
 	signals := make(chan os.Signal, 1)
 	signal.Notify(signals, syscall.SIGINT, syscall.SIGTERM)
 	defer signal.Stop(signals)
-	logger.Printf("listening address=%s data_dir=%s log_level=%s", cfg.ListenAddr, cfg.DataDir, cfg.LogLevel)
+	logger.Printf("listening address=%s health_address=%s data_dir=%s log_level=%s", cfg.ListenAddr, cfg.HealthListenAddr, cfg.DataDir, cfg.LogLevel)
 	select {
-	case err := <-serverErrors:
-		if err != nil && !errors.Is(err, http.ErrServerClosed) {
-			logger.Printf("server stopped error=%v", err)
+	case result := <-serverErrors:
+		shutdown, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		_ = shutdownHTTPServers(shutdown, server, healthServer)
+		if result.err != nil && !errors.Is(result.err, http.ErrServerClosed) {
+			logger.Printf("%s server stopped error=%v", result.name, result.err)
 			return 1
 		}
 		return 0
 	case <-signals:
 		shutdown, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 		defer cancel()
-		if err := server.Shutdown(shutdown); err != nil {
+		if err := shutdownHTTPServers(shutdown, server, healthServer); err != nil {
 			logger.Printf("graceful shutdown failed error=%v", err)
 			return 1
 		}
 		return 0
 	}
+}
+
+func configuredServer(address string, handler http.Handler) *http.Server {
+	return &http.Server{Addr: address, Handler: handler, ReadHeaderTimeout: 5 * time.Second, ReadTimeout: 15 * time.Second, WriteTimeout: 15 * time.Second, IdleTimeout: 60 * time.Second, MaxHeaderBytes: 16 << 10}
+}
+
+func shutdownHTTPServers(ctx context.Context, servers ...*http.Server) error {
+	var failures []error
+	for _, server := range servers {
+		if server != nil {
+			if err := server.Shutdown(ctx); err != nil {
+				failures = append(failures, err)
+			}
+		}
+	}
+	return errors.Join(failures...)
 }
 
 type permitRouteAuthorizer struct{ authenticator *relay.Authenticator }

--- a/cmd/punarod/main_test.go
+++ b/cmd/punarod/main_test.go
@@ -7,6 +7,7 @@ import (
 	"net"
 	"strings"
 	"testing"
+	"time"
 
 	punaropostgres "github.com/rock3r/punaro/internal/postgres"
 )
@@ -103,3 +104,42 @@ type testAddr string
 
 func (testAddr) Network() string  { return "tcp" }
 func (a testAddr) String() string { return string(a) }
+
+func TestShutdownHTTPServersStartsAllDrainsConcurrently(t *testing.T) {
+	started := make(chan struct{}, 2)
+	release := make(chan struct{})
+	servers := []httpShutdowner{
+		blockingShutdowner{started: started, release: release},
+		blockingShutdowner{started: started, release: release},
+	}
+	result := make(chan error, 1)
+	ctx, cancel := context.WithTimeout(t.Context(), time.Second)
+	defer cancel()
+	go func() { result <- shutdownHTTPServers(ctx, servers...) }()
+	for range 2 {
+		select {
+		case <-started:
+		case <-ctx.Done():
+			t.Fatal("both server drains did not start under the shared deadline")
+		}
+	}
+	close(release)
+	if err := <-result; err != nil {
+		t.Fatal(err)
+	}
+}
+
+type blockingShutdowner struct {
+	started chan<- struct{}
+	release <-chan struct{}
+}
+
+func (s blockingShutdowner) Shutdown(ctx context.Context) error {
+	s.started <- struct{}{}
+	select {
+	case <-s.release:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}

--- a/cmd/punarod/main_test.go
+++ b/cmd/punarod/main_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"net"
 	"strings"
 	"testing"
 
@@ -58,3 +59,47 @@ func TestRunRejectsIncompatiblePostgresWithoutStartingServer(t *testing.T) {
 		t.Fatalf("ready=%t closed=%t stderr=%q", database.readyCalled, database.closed, stderr.String())
 	}
 }
+
+func TestRunDoesNotServePublicSocketWhenHealthBindFails(t *testing.T) {
+	originalListen := listenTCP
+	t.Cleanup(func() { listenTCP = originalListen })
+	tracked := &trackingListener{}
+	calls := 0
+	listenTCP = func(string, string) (net.Listener, error) {
+		calls++
+		if calls == 1 {
+			return tracked, nil
+		}
+		return nil, errors.New("health address occupied")
+	}
+	t.Setenv("PUNARO_LISTEN_ADDR", "127.0.0.1:18080")
+	t.Setenv("PUNARO_HEALTH_LISTEN_ADDR", "127.0.0.1:18081")
+	var stderr bytes.Buffer
+	if code := run(nil, &stderr); code != 1 {
+		t.Fatalf("code=%d stderr=%q", code, stderr.String())
+	}
+	if tracked.acceptCalled {
+		t.Fatal("public server began accepting before the health bind succeeded")
+	}
+	if !tracked.closed {
+		t.Fatal("public listener remained open after the health bind failed")
+	}
+}
+
+type trackingListener struct {
+	acceptCalled bool
+	closed       bool
+}
+
+func (l *trackingListener) Accept() (net.Conn, error) {
+	l.acceptCalled = true
+	return nil, errors.New("unexpected Accept call")
+}
+
+func (l *trackingListener) Close() error { l.closed = true; return nil }
+func (*trackingListener) Addr() net.Addr { return testAddr("127.0.0.1:18080") }
+
+type testAddr string
+
+func (testAddr) Network() string  { return "tcp" }
+func (a testAddr) String() string { return string(a) }

--- a/deploy/postgres-test-init.sql
+++ b/deploy/postgres-test-init.sql
@@ -2,3 +2,7 @@
 -- private, ephemeral Compose network and MUST NOT be copied to deployments.
 CREATE ROLE punaro_app LOGIN NOSUPERUSER NOCREATEDB NOCREATEROLE NOINHERIT;
 GRANT CONNECT ON DATABASE punaro TO punaro_app;
+CREATE DATABASE punaro_other OWNER punaro_owner;
+GRANT CONNECT ON DATABASE punaro_other TO punaro_app;
+CREATE DATABASE punaro_pair OWNER punaro_owner;
+GRANT CONNECT ON DATABASE punaro_pair TO punaro_app;

--- a/docker-compose.postgres-test.yml
+++ b/docker-compose.postgres-test.yml
@@ -26,6 +26,9 @@ services:
     environment:
       PUNARO_TEST_POSTGRES_OWNER_DSN: postgres://punaro_owner@postgres:5432/punaro?sslmode=disable
       PUNARO_TEST_POSTGRES_APP_DSN: postgres://punaro_app@postgres:5432/punaro?sslmode=disable
+      PUNARO_TEST_POSTGRES_OTHER_OWNER_DSN: postgres://punaro_owner@postgres:5432/punaro_other?sslmode=disable
+      PUNARO_TEST_POSTGRES_PAIR_OWNER_DSN: postgres://punaro_owner@postgres:5432/punaro_pair?sslmode=disable
+      PUNARO_TEST_POSTGRES_PAIR_APP_DSN: postgres://punaro_app@postgres:5432/punaro_pair?sslmode=disable
     depends_on:
       postgres:
         condition: service_healthy

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -57,7 +57,7 @@ for the tunnel service and maintenance checks.
 Verify the finished server:
 
 ```sh
-curl --fail http://127.0.0.1:8080/readyz
+curl --fail http://127.0.0.1:8081/readyz
 systemctl status punarod.service punaro-jwks-refresh.timer
 ```
 

--- a/docs/operator-guide.md
+++ b/docs/operator-guide.md
@@ -553,6 +553,11 @@ punaro init ... --mode lan --listen-addr 192.168.50.4:8080 \
   --trusted-lan-cidr 192.168.50.0/24 --allow-lan-http
 ```
 
+A non-loopback trusted-LAN listener is valid only for the two bounded device
+routes added by M-5. Configuration fails closed if legacy relay, directory,
+permit, or attachment routes are enabled on that process. Those surfaces stay
+loopback-only until their separately reviewed public runtime milestone.
+
 Fresh initialization requires the application-role view to be pristine,
 migrates through the owner role, then reopens both roles and proves their
 installation and timeline IDs match before creating the owner. It publishes

--- a/docs/operator-guide.md
+++ b/docs/operator-guide.md
@@ -529,7 +529,9 @@ with `make operator-binary`; do not run it inside the daemon container. Supply
 only the reviewed release image by immutable registry digest. Run init as the
 non-root Unix account that owns the private paths; root is rejected and the
 same numeric identity runs the container. Data and backup must resolve to
-non-overlapping locations. Neither DSN nor the installation directory may
+non-overlapping locations. Supply every path in its already-clean absolute
+form: `.`/`..` components, duplicate separators, and trailing separators are
+rejected. Neither DSN nor the installation directory may
 resolve beneath the daemon-writable data directory, including through a
 symlinked ancestor. Each private directory and DSN file must be owned by that
 account. Every path ancestor must be owned by root or that account and may not
@@ -589,7 +591,10 @@ has no build context and accepts only the pinned image. The wrapper supplies a
 stable Compose project name from the verified owner UUID, so equal installation
 directory basenames cannot share containers. It starts only a compatible schema;
 a pristine database after initialization is treated as data loss, an old schema
-directs the operator to `punaro update`, and dirty/newer/incompatible state
+refuses startup and directs the operator to keep running the previous compatible
+release. This staged M-5 wrapper deliberately has no in-place update command;
+the separately reviewed M-7 durable update milestone adds that transaction after
+consistent backup/restore exists. Dirty/newer/incompatible state
 requires recovery. It waits up to 30 seconds for readiness and then runs the
 same checks as doctor. Raw `docker compose up` and `punarod` never migrate.
 

--- a/docs/operator-guide.md
+++ b/docs/operator-guide.md
@@ -423,7 +423,7 @@ create or repair schema objects. A pristine, dirty, upgrade-required, newer, or
 incompatible schema makes startup fail with a content-free classification. Do
 not grant DDL to `punaro_app` to bypass that refusal.
 
-M-1 through M-3 expose the schema-owner action directly for controlled development and
+M-1 through M-5 expose the schema-owner action directly for controlled development and
 integration use:
 
 ```sh
@@ -457,8 +457,8 @@ update procedure. The digest-pinned `make test-postgres` stack is ephemeral
 test infrastructure, publishes no database port, and deletes its volume on
 exit.
 
-The current binary requires schema version 3. Versions 1 and 2 are reported as
-`upgrade_required`; damaged older objects remain `incompatible`. Migration 3 is
+The current binary requires schema version 4. Versions 1 through 3 are reported
+as `upgrade_required`; damaged older objects remain `incompatible`. Migration 3 is
 additive and creates the host-local ownership, pending enrollment, device
 credential, cache/session generation, and Ed25519 migration-inventory records.
 There is still no relay cutover, backup, or production update wrapper. Do not
@@ -488,10 +488,10 @@ punaro-admin client add -owner-dsn-file /absolute/private/owner.dsn \
   -project PROJECT_UUID
 ```
 
-The confirmed run returns one enrollment ID and code. M-3 deliberately mounts
-no public bootstrap, issuance, redemption, or device-auth route; the bounded
-store redemption primitive is staged and tested for the later ingress
-milestone. It binds the code to the opaque client value, generates the 256-bit
+The confirmed run returns one enrollment ID and code. M-5 mounts bounded
+redemption and device-session authentication under the transport policy below;
+ownership and issuance remain host-local. Redemption binds the code to the
+opaque client value, generates the 256-bit
 credential secret by domain-separated derivation from the internally generated
 256-bit code, and stores only an indexed SHA-256 digest. An exact retry with the
 same code, client binding, and idempotency UUID returns the same result without
@@ -513,6 +513,94 @@ and other processes/sessions force reauthentication within the documented
 two-second bound. Existing Ed25519 relay authentication remains active in this
 slice; its PostgreSQL inventory and disable gate stage the later explicit
 cutover and do not silently change current SQLite routing.
+
+Migration 4 adds project identities, aliases, generation-bound merge previews,
+and bounded reconciliation records. M-5 adds no schema migration and does not
+rewrite or remove any M-1 through M-4 record during rollback.
+
+### Operator wrapper and device ingress
+
+`punaro init` is the supported first-install path for the staged PostgreSQL
+platform. Create separate private data and backup directories and separate
+`0600` DSN files for `punaro_owner` and `punaro_app`. Build the host wrapper
+with `make operator-binary`; do not run it inside the daemon container. Supply
+only the reviewed release image by immutable registry digest. Run init as the
+non-root Unix account that owns the private paths; root is rejected and the
+same numeric identity runs the container. Data and backup must resolve to
+non-overlapping locations. Neither DSN nor the installation directory may
+resolve beneath the daemon-writable data directory, including through a
+symlinked ancestor:
+
+```sh
+punaro init \
+  --directory /absolute/private/punaro-installation \
+  --data-dir /absolute/private/punaro-data \
+  --backup-dir /absolute/private/punaro-backups \
+  --image registry.example/punaro@sha256:REVIEWED_DIGEST \
+  --owner-dsn-file /absolute/private/owner.dsn \
+  --app-dsn-file /absolute/private/app.dsn \
+  --owner-name "local owner" \
+  --mode internet \
+  --public-url https://punaro.example
+```
+
+Proxy mode has the same HTTPS and loopback-origin requirements. Trusted-LAN
+plaintext is deliberately noisy and must name both a concrete private or
+link-local bind and the containing CIDR:
+
+```sh
+punaro init ... --mode lan --listen-addr 192.168.50.4:8080 \
+  --trusted-lan-cidr 192.168.50.0/24 --allow-lan-http
+```
+
+Fresh initialization requires the application-role view to be pristine,
+migrates through the owner role, then reopens both roles and proves their
+installation and timeline IDs match before creating the owner. It publishes
+the generated configuration last. If the process reports
+an uncertain owner outcome or publication failure, preserve the staging
+directory and run only:
+
+```sh
+punaro init --resume --directory /absolute/private/punaro-installation
+```
+
+Resume verifies the staged files and exact owner label, adopts the singleton
+owner if it committed, or finishes bootstrap if it did not. Do not delete the
+staging directory or run a second bootstrap elsewhere while recovering.
+
+`punaro up --directory ...` rechecks the generated Compose file, protected
+paths, exact singleton-owner identity, and schema before invoking Compose. Status
+and doctor enforce the same owner binding. The generated file
+has no build context and accepts only the pinned image. It starts only a compatible schema;
+a pristine database after initialization is treated as data loss, an old schema
+directs the operator to `punaro update`, and dirty/newer/incompatible state
+requires recovery. It waits up to 30 seconds for readiness and then runs the
+same checks as doctor. Raw `docker compose up` and `punarod` never migrate.
+
+Use `punaro status --directory ...` for a non-mutating report and `punaro doctor
+--directory ...` for a failing health gate. Reports contain only capability and
+content-free path/schema/health states. The generated M-5 server Compose file
+still uses an externally provisioned PostgreSQL service; the bundled production
+PostgreSQL/profile shape arrives in M-23.
+
+Create a client in two exact steps. The first prints the effective grants and
+preview hash without touching the database. The confirmed invocation must
+repeat the same grant flags and bind the prior hash:
+
+```sh
+punaro client add --directory /absolute/private/punaro-installation \
+  --name laptop --project PROJECT_UUID
+punaro client add --directory /absolute/private/punaro-installation \
+  --name laptop --project PROJECT_UUID --yes \
+  --confirm-preview-hash HASH_FROM_THE_PRIOR_OUTPUT
+```
+
+The second response contains the generated client binding, enrollment ID, and
+single-use code. Send the exact four-field JSON object to
+`POST /v1/enrollments/redeem`; retain the returned bearer credential only in
+protected client storage. `GET /v1/device/session` is the bounded authentication
+check. Forwarded headers never qualify a direct request for TLS or trusted-LAN
+admission.
 
 ## Operations and incident response
 

--- a/docs/operator-guide.md
+++ b/docs/operator-guide.md
@@ -17,13 +17,15 @@ Use Go for the current local smoke test:
 
 ```sh
 go run ./cmd/punarod
-curl --fail http://127.0.0.1:8080/healthz
+curl --fail http://127.0.0.1:8081/healthz
 ```
 
-The listener is deliberately restricted to a **literal** loopback IP.
+The legacy/application listener is deliberately restricted to a **literal**
+loopback IP unless the isolated M-5 device policy is enabled.
 `PUNARO_LISTEN_ADDR` must use `127.0.0.1:8080` or `[::1]:8080`; hostnames such
 as `localhost` are rejected until the daemon can verify their resolved address.
-A non-loopback address is a configuration error, even for health checks.
+Health and readiness use the distinct loopback-only
+`PUNARO_HEALTH_LISTEN_ADDR` (`127.0.0.1:8081` by default).
 
 Set `PUNARO_RELAY_ENABLED=true` plus a public
 `PUNARO_RELAY_MACHINES_JSON` enrollment set to enable the alpha relay; see the
@@ -556,7 +558,10 @@ punaro init ... --mode lan --listen-addr 192.168.50.4:8080 \
 A non-loopback trusted-LAN listener is valid only for the two bounded device
 routes added by M-5. Configuration fails closed if legacy relay, directory,
 permit, or attachment routes are enabled on that process. Those surfaces stay
-loopback-only until their separately reviewed public runtime milestone.
+loopback-only until their separately reviewed public runtime milestone. Health
+and readiness are mounted on the separate `127.0.0.1:8081` listener by default;
+override it only with `--health-listen-addr` naming another distinct concrete
+loopback address.
 
 Fresh initialization requires the application-role view to be pristine,
 migrates through the owner role, then reopens both roles and proves their
@@ -574,7 +579,8 @@ owner if it committed, or finishes bootstrap if it did not. Do not delete the
 staging directory or run a second bootstrap elsewhere while recovering.
 
 `punaro up --directory ...` rechecks the generated Compose file, protected
-paths, exact singleton-owner identity, and schema before invoking Compose. Status
+paths (including private installation-directory permissions), exact
+singleton-owner identity, and schema before invoking Compose. Status
 and doctor enforce the same owner binding. The generated file
 has no build context and accepts only the pinned image. It starts only a compatible schema;
 a pristine database after initialization is treated as data loss, an old schema

--- a/docs/operator-guide.md
+++ b/docs/operator-guide.md
@@ -589,7 +589,13 @@ singleton-owner identity, and schema before invoking Compose. Status
 and doctor enforce the same owner binding. The generated file
 has no build context and accepts only the pinned image. The wrapper supplies a
 stable Compose project name from the verified owner UUID, so equal installation
-directory basenames cannot share containers. It starts only a compatible schema;
+directory basenames cannot share containers. It also removes inherited
+`PUNARO_*` and `COMPOSE_*` variables from the Compose subprocess, making the
+validated generated environment authoritative while retaining Docker connection
+settings. The operator-controlled Docker executable, CLI plugins, configuration,
+and selected daemon/context remain trusted dependencies; use a local daemon for
+this host-local wrapper because bind-path validation does not extend to a remote
+Docker host. It starts only a compatible schema;
 a pristine database after initialization is treated as data loss, an old schema
 refuses startup and directs the operator to keep running the previous compatible
 release. This staged M-5 wrapper deliberately has no in-place update command;

--- a/docs/operator-guide.md
+++ b/docs/operator-guide.md
@@ -531,7 +531,10 @@ non-root Unix account that owns the private paths; root is rejected and the
 same numeric identity runs the container. Data and backup must resolve to
 non-overlapping locations. Neither DSN nor the installation directory may
 resolve beneath the daemon-writable data directory, including through a
-symlinked ancestor:
+symlinked ancestor. Each private directory and DSN file must be owned by that
+account. Every path ancestor must be owned by root or that account and may not
+be group/world writable unless sticky; only root-owned system symlinks with a
+separately trusted resolved chain are accepted:
 
 ```sh
 punaro init \
@@ -579,10 +582,12 @@ owner if it committed, or finishes bootstrap if it did not. Do not delete the
 staging directory or run a second bootstrap elsewhere while recovering.
 
 `punaro up --directory ...` rechecks the generated Compose file, protected
-paths (including private installation-directory permissions), exact
+paths (including ownership and ancestor permissions), exact
 singleton-owner identity, and schema before invoking Compose. Status
 and doctor enforce the same owner binding. The generated file
-has no build context and accepts only the pinned image. It starts only a compatible schema;
+has no build context and accepts only the pinned image. The wrapper supplies a
+stable Compose project name from the verified owner UUID, so equal installation
+directory basenames cannot share containers. It starts only a compatible schema;
 a pristine database after initialization is treated as data loss, an old schema
 directs the operator to `punaro update`, and dirty/newer/incompatible state
 requires recovery. It waits up to 30 seconds for readiness and then runs the

--- a/docs/platform-contracts.md
+++ b/docs/platform-contracts.md
@@ -37,9 +37,11 @@ optional worker load. PostgreSQL and blob services are private and never
 host-published by the reference deployment.
 
 Ordinary `punarod` startup and raw `docker compose up` never apply migrations.
-The supported `punaro up` wrapper may initialize a pristine schema or start an
-already compatible one. Every required upgrade migration goes through the
-operator update transaction with its declared backup and rollback boundary.
+The supported wrapper initializes a pristine schema only inside the durable
+`punaro init` ownership transaction. After publication, `punaro up` starts only
+an already-compatible schema; pristine state is a reset/data-loss fence. Every
+required upgrade migration goes through the operator update transaction with
+its declared backup and rollback boundary.
 
 ## Narrow store interfaces
 
@@ -128,6 +130,15 @@ can consume only the fixed redemption columns, insert a credential with its
 server-constrained defaults, and coalesce `last_used_at`; it cannot rotate or
 revoke credentials. Host-local administration uses a direct `punaro_owner`
 connection and is not exposed as an HTTP route.
+
+M-5 mounts only `POST /v1/enrollments/redeem` and authenticated
+`GET /v1/device/session`. Redemption requires exact `application/json`, a
+bounded object with four unique string fields, and the store's exact enrollment
+binding. Device bearer failures are uniform and content-free. A fixed
+concurrency ceiling and per-operation database deadline bound public work.
+Both routes admit credentials only over TLS, same-host loopback, or the
+explicitly configured trusted-LAN HTTP exception. `X-Forwarded-For` and
+`X-Forwarded-Proto` are never transport evidence.
 
 The `trusted-agent` template contains installation `project.create`; selected
 or explicit dynamic-all project discover/read/write and attach-unclaimed;

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -133,8 +133,10 @@ func Load(explicitEnvFile string) (Config, error) {
 	}
 	listenAddr := value("PUNARO_LISTEN_ADDR", "127.0.0.1:8080")
 	// The legacy relay origin stays loopback-only. A non-loopback listener is
-	// admitted only by the complete device-ingress policy validated below.
-	if !deviceAuthEnabled && !isLoopbackListener(listenAddr) {
+	// admitted only when the complete device-ingress policy is validated below
+	// and no legacy route can share that listener.
+	legacyRoutesEnabled := relayEnabled || directoryEnabled || permitIssuanceEnabled || attachmentsEnabled || attachmentV3Enabled
+	if !isLoopbackListener(listenAddr) && (!deviceAuthEnabled || legacyRoutesEnabled) {
 		return Config{}, fmt.Errorf("PUNARO_LISTEN_ADDR must be a loopback address until the authenticated public runtime is released")
 	}
 	if deviceAuthEnabled {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -11,6 +11,8 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+
+	"github.com/rock3r/punaro/internal/ingress"
 )
 
 // Config is the explicit environment-derived daemon configuration.
@@ -44,6 +46,11 @@ type Config struct {
 	AccessJWKSFile              string
 	PostgresEnabled             bool
 	PostgresDSNFile             string
+	DeviceAuthEnabled           bool
+	IngressMode                 string
+	PublicURL                   string
+	TrustedLANCIDR              string
+	TrustedLANHTTP              bool
 }
 
 // Load reads configuration and optionally loads an explicitly named dotenv file.
@@ -113,12 +120,33 @@ func Load(explicitEnvFile string) (Config, error) {
 		return Config{}, fmt.Errorf("parse PUNARO_POSTGRES_ENABLED: %w", err)
 	}
 	postgresDSNFile := value("PUNARO_POSTGRES_DSN_FILE", "")
+	deviceAuthEnabled, err := strconv.ParseBool(value("PUNARO_DEVICE_AUTH_ENABLED", "false"))
+	if err != nil {
+		return Config{}, fmt.Errorf("parse PUNARO_DEVICE_AUTH_ENABLED: %w", err)
+	}
+	ingressMode := value("PUNARO_INGRESS_MODE", "")
+	publicURL := value("PUNARO_PUBLIC_URL", "")
+	trustedLANCIDR := value("PUNARO_TRUSTED_LAN_CIDR", "")
+	trustedLANHTTP, err := strconv.ParseBool(value("PUNARO_TRUSTED_LAN_HTTP", "false"))
+	if err != nil {
+		return Config{}, fmt.Errorf("parse PUNARO_TRUSTED_LAN_HTTP: %w", err)
+	}
 	listenAddr := value("PUNARO_LISTEN_ADDR", "127.0.0.1:8080")
-	// The relay origin stays loopback-only even when Cloudflare Access protects
-	// the public hostname. This prevents an operator from accidentally creating
-	// a direct-origin path that could bypass the Access and tunnel boundary.
-	if !isLoopbackListener(listenAddr) {
+	// The legacy relay origin stays loopback-only. A non-loopback listener is
+	// admitted only by the complete device-ingress policy validated below.
+	if !deviceAuthEnabled && !isLoopbackListener(listenAddr) {
 		return Config{}, fmt.Errorf("PUNARO_LISTEN_ADDR must be a loopback address until the authenticated public runtime is released")
+	}
+	if deviceAuthEnabled {
+		if !postgresEnabled {
+			return Config{}, fmt.Errorf("device authentication requires PUNARO_POSTGRES_ENABLED")
+		}
+		policy := ingress.Policy{Mode: ingress.Mode(ingressMode), ListenAddr: listenAddr, PublicURL: publicURL, TrustedLAN: trustedLANCIDR, AllowPlaintext: trustedLANHTTP}
+		if err := policy.Validate(); err != nil {
+			return Config{}, fmt.Errorf("device ingress policy: %w", err)
+		}
+	} else if ingressMode != "" || publicURL != "" || trustedLANCIDR != "" || trustedLANHTTP {
+		return Config{}, fmt.Errorf("ingress policy requires PUNARO_DEVICE_AUTH_ENABLED")
 	}
 	if attachmentsEnabled && (deviceKeys == "" || membership == "") {
 		return Config{}, fmt.Errorf("attachments require PUNARO_ATTACHMENT_DEVICE_KEYS_JSON and PUNARO_ATTACHMENT_MEMBERSHIP_JSON")
@@ -208,7 +236,7 @@ func Load(explicitEnvFile string) (Config, error) {
 	if !postgresEnabled && postgresDSNFile != "" {
 		return Config{}, fmt.Errorf("PUNARO_POSTGRES_DSN_FILE requires PUNARO_POSTGRES_ENABLED")
 	}
-	return Config{ListenAddr: listenAddr, DataDir: dataDir, LogLevel: level, AttachmentsEnabled: attachmentsEnabled, AttachmentDeviceKeysJSON: deviceKeys, AttachmentMembershipJSON: membership, AttachmentV3Enabled: attachmentV3Enabled, AttachmentV3SourceStoreFile: attachmentV3SourceStoreFile, DirectoryEnabled: directoryEnabled, DirectorySnapshotFile: directorySnapshotFile, PermitIssuanceEnabled: permitIssuanceEnabled, DirectoryAudience: audience, DirectoryRootKeyID: rootKeyID, DirectoryRootPublicKey: rootPublicKey, PermitIssuerKeyID: issuerKeyID, PermitIssuerPrivateKeyFile: permitIssuerPrivateKeyFile, PermitMaxLifetimeSeconds: maxLifetime, PermitMaxBytes: maxBytes, PermitMaxChunks: maxChunks, PermitMaxOperations: maxOperations, PermitMaxActive: maxActive, RelayEnabled: relayEnabled, RelayMachinesJSON: relayMachines, AccessIssuer: accessIssuer, AccessAudience: accessAudience, AccessJWKSURL: accessJWKSURL, AccessJWKSFile: accessJWKSFile, PostgresEnabled: postgresEnabled, PostgresDSNFile: postgresDSNFile}, nil
+	return Config{ListenAddr: listenAddr, DataDir: dataDir, LogLevel: level, AttachmentsEnabled: attachmentsEnabled, AttachmentDeviceKeysJSON: deviceKeys, AttachmentMembershipJSON: membership, AttachmentV3Enabled: attachmentV3Enabled, AttachmentV3SourceStoreFile: attachmentV3SourceStoreFile, DirectoryEnabled: directoryEnabled, DirectorySnapshotFile: directorySnapshotFile, PermitIssuanceEnabled: permitIssuanceEnabled, DirectoryAudience: audience, DirectoryRootKeyID: rootKeyID, DirectoryRootPublicKey: rootPublicKey, PermitIssuerKeyID: issuerKeyID, PermitIssuerPrivateKeyFile: permitIssuerPrivateKeyFile, PermitMaxLifetimeSeconds: maxLifetime, PermitMaxBytes: maxBytes, PermitMaxChunks: maxChunks, PermitMaxOperations: maxOperations, PermitMaxActive: maxActive, RelayEnabled: relayEnabled, RelayMachinesJSON: relayMachines, AccessIssuer: accessIssuer, AccessAudience: accessAudience, AccessJWKSURL: accessJWKSURL, AccessJWKSFile: accessJWKSFile, PostgresEnabled: postgresEnabled, PostgresDSNFile: postgresDSNFile, DeviceAuthEnabled: deviceAuthEnabled, IngressMode: ingressMode, PublicURL: publicURL, TrustedLANCIDR: trustedLANCIDR, TrustedLANHTTP: trustedLANHTTP}, nil
 }
 
 func decodeFixedBase64URL(name, value string, size int) ([32]byte, error) {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -6,11 +6,12 @@ import (
 	"crypto/ed25519"
 	"encoding/base64"
 	"fmt"
-	"net"
 	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
+
+	"github.com/rock3r/punaro/internal/listener"
 
 	"github.com/rock3r/punaro/internal/ingress"
 )
@@ -134,14 +135,14 @@ func Load(explicitEnvFile string) (Config, error) {
 	}
 	listenAddr := value("PUNARO_LISTEN_ADDR", "127.0.0.1:8080")
 	healthListenAddr := value("PUNARO_HEALTH_LISTEN_ADDR", "127.0.0.1:8081")
-	if !isLoopbackListener(healthListenAddr) || sameListener(listenAddr, healthListenAddr) {
+	if !listener.IsLoopback(healthListenAddr) || listener.Same(listenAddr, healthListenAddr) {
 		return Config{}, fmt.Errorf("PUNARO_HEALTH_LISTEN_ADDR must be a distinct concrete loopback address")
 	}
 	// The legacy relay origin stays loopback-only. A non-loopback listener is
 	// admitted only when the complete device-ingress policy is validated below
 	// and no legacy route can share that listener.
 	legacyRoutesEnabled := relayEnabled || directoryEnabled || permitIssuanceEnabled || attachmentsEnabled || attachmentV3Enabled
-	if !isLoopbackListener(listenAddr) && (!deviceAuthEnabled || legacyRoutesEnabled) {
+	if !listener.IsLoopback(listenAddr) && (!deviceAuthEnabled || legacyRoutesEnabled) {
 		return Config{}, fmt.Errorf("PUNARO_LISTEN_ADDR must be a loopback address until the authenticated public runtime is released")
 	}
 	if deviceAuthEnabled {
@@ -265,30 +266,6 @@ func parsePositiveUint64(name, value string, maximum uint64) (uint64, error) {
 		return 0, fmt.Errorf("%s must be an integer from 1 to %d", name, maximum)
 	}
 	return parsed, nil
-}
-
-func isLoopbackListener(address string) bool {
-	ip, _, ok := listenerEndpoint(address)
-	return ok && ip.IsLoopback()
-}
-
-func sameListener(first, second string) bool {
-	firstIP, firstPort, firstOK := listenerEndpoint(first)
-	secondIP, secondPort, secondOK := listenerEndpoint(second)
-	return firstOK && secondOK && firstIP.Equal(secondIP) && firstPort == secondPort
-}
-
-func listenerEndpoint(address string) (net.IP, uint16, bool) {
-	host, portText, err := net.SplitHostPort(address)
-	if err != nil {
-		return nil, 0, false
-	}
-	ip := net.ParseIP(host)
-	port, err := strconv.ParseUint(portText, 10, 16)
-	if ip == nil || err != nil || port == 0 || portText != strconv.FormatUint(port, 10) {
-		return nil, 0, false
-	}
-	return ip, uint16(port), true
 }
 
 func value(name, fallback string) string {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -18,6 +18,7 @@ import (
 // Config is the explicit environment-derived daemon configuration.
 type Config struct {
 	ListenAddr                  string
+	HealthListenAddr            string
 	DataDir                     string
 	LogLevel                    string
 	AttachmentsEnabled          bool
@@ -132,6 +133,10 @@ func Load(explicitEnvFile string) (Config, error) {
 		return Config{}, fmt.Errorf("parse PUNARO_TRUSTED_LAN_HTTP: %w", err)
 	}
 	listenAddr := value("PUNARO_LISTEN_ADDR", "127.0.0.1:8080")
+	healthListenAddr := value("PUNARO_HEALTH_LISTEN_ADDR", "127.0.0.1:8081")
+	if !isLoopbackListener(healthListenAddr) || sameListener(listenAddr, healthListenAddr) {
+		return Config{}, fmt.Errorf("PUNARO_HEALTH_LISTEN_ADDR must be a distinct concrete loopback address")
+	}
 	// The legacy relay origin stays loopback-only. A non-loopback listener is
 	// admitted only when the complete device-ingress policy is validated below
 	// and no legacy route can share that listener.
@@ -238,7 +243,7 @@ func Load(explicitEnvFile string) (Config, error) {
 	if !postgresEnabled && postgresDSNFile != "" {
 		return Config{}, fmt.Errorf("PUNARO_POSTGRES_DSN_FILE requires PUNARO_POSTGRES_ENABLED")
 	}
-	return Config{ListenAddr: listenAddr, DataDir: dataDir, LogLevel: level, AttachmentsEnabled: attachmentsEnabled, AttachmentDeviceKeysJSON: deviceKeys, AttachmentMembershipJSON: membership, AttachmentV3Enabled: attachmentV3Enabled, AttachmentV3SourceStoreFile: attachmentV3SourceStoreFile, DirectoryEnabled: directoryEnabled, DirectorySnapshotFile: directorySnapshotFile, PermitIssuanceEnabled: permitIssuanceEnabled, DirectoryAudience: audience, DirectoryRootKeyID: rootKeyID, DirectoryRootPublicKey: rootPublicKey, PermitIssuerKeyID: issuerKeyID, PermitIssuerPrivateKeyFile: permitIssuerPrivateKeyFile, PermitMaxLifetimeSeconds: maxLifetime, PermitMaxBytes: maxBytes, PermitMaxChunks: maxChunks, PermitMaxOperations: maxOperations, PermitMaxActive: maxActive, RelayEnabled: relayEnabled, RelayMachinesJSON: relayMachines, AccessIssuer: accessIssuer, AccessAudience: accessAudience, AccessJWKSURL: accessJWKSURL, AccessJWKSFile: accessJWKSFile, PostgresEnabled: postgresEnabled, PostgresDSNFile: postgresDSNFile, DeviceAuthEnabled: deviceAuthEnabled, IngressMode: ingressMode, PublicURL: publicURL, TrustedLANCIDR: trustedLANCIDR, TrustedLANHTTP: trustedLANHTTP}, nil
+	return Config{ListenAddr: listenAddr, HealthListenAddr: healthListenAddr, DataDir: dataDir, LogLevel: level, AttachmentsEnabled: attachmentsEnabled, AttachmentDeviceKeysJSON: deviceKeys, AttachmentMembershipJSON: membership, AttachmentV3Enabled: attachmentV3Enabled, AttachmentV3SourceStoreFile: attachmentV3SourceStoreFile, DirectoryEnabled: directoryEnabled, DirectorySnapshotFile: directorySnapshotFile, PermitIssuanceEnabled: permitIssuanceEnabled, DirectoryAudience: audience, DirectoryRootKeyID: rootKeyID, DirectoryRootPublicKey: rootPublicKey, PermitIssuerKeyID: issuerKeyID, PermitIssuerPrivateKeyFile: permitIssuerPrivateKeyFile, PermitMaxLifetimeSeconds: maxLifetime, PermitMaxBytes: maxBytes, PermitMaxChunks: maxChunks, PermitMaxOperations: maxOperations, PermitMaxActive: maxActive, RelayEnabled: relayEnabled, RelayMachinesJSON: relayMachines, AccessIssuer: accessIssuer, AccessAudience: accessAudience, AccessJWKSURL: accessJWKSURL, AccessJWKSFile: accessJWKSFile, PostgresEnabled: postgresEnabled, PostgresDSNFile: postgresDSNFile, DeviceAuthEnabled: deviceAuthEnabled, IngressMode: ingressMode, PublicURL: publicURL, TrustedLANCIDR: trustedLANCIDR, TrustedLANHTTP: trustedLANHTTP}, nil
 }
 
 func decodeFixedBase64URL(name, value string, size int) ([32]byte, error) {
@@ -263,12 +268,27 @@ func parsePositiveUint64(name, value string, maximum uint64) (uint64, error) {
 }
 
 func isLoopbackListener(address string) bool {
-	host, _, err := net.SplitHostPort(address)
+	ip, _, ok := listenerEndpoint(address)
+	return ok && ip.IsLoopback()
+}
+
+func sameListener(first, second string) bool {
+	firstIP, firstPort, firstOK := listenerEndpoint(first)
+	secondIP, secondPort, secondOK := listenerEndpoint(second)
+	return firstOK && secondOK && firstIP.Equal(secondIP) && firstPort == secondPort
+}
+
+func listenerEndpoint(address string) (net.IP, uint16, bool) {
+	host, portText, err := net.SplitHostPort(address)
 	if err != nil {
-		return false
+		return nil, 0, false
 	}
 	ip := net.ParseIP(host)
-	return ip != nil && ip.IsLoopback()
+	port, err := strconv.ParseUint(portText, 10, 16)
+	if ip == nil || err != nil || port == 0 || portText != strconv.FormatUint(port, 10) {
+		return nil, 0, false
+	}
+	return ip, uint16(port), true
 }
 
 func value(name, fallback string) string {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -84,6 +84,42 @@ func TestLoadRejectsNonLoopbackListenerWhilePublicRuntimeIsUnavailable(t *testin
 	}
 }
 
+func TestLoadAcceptsOnlyValidatedDeviceIngressProfiles(t *testing.T) {
+	t.Setenv("PUNARO_POSTGRES_ENABLED", "true")
+	t.Setenv("PUNARO_POSTGRES_DSN_FILE", "/run/secrets/punaro-app-dsn")
+	t.Setenv("PUNARO_DEVICE_AUTH_ENABLED", "true")
+	t.Setenv("PUNARO_INGRESS_MODE", "internet")
+	t.Setenv("PUNARO_PUBLIC_URL", "https://punaro.example")
+	cfg, err := Load("")
+	if err != nil || !cfg.DeviceAuthEnabled || cfg.IngressMode != "internet" {
+		t.Fatalf("config=%#v err=%v", cfg, err)
+	}
+
+	t.Setenv("PUNARO_INGRESS_MODE", "lan")
+	t.Setenv("PUNARO_PUBLIC_URL", "")
+	t.Setenv("PUNARO_LISTEN_ADDR", "192.168.50.4:8080")
+	t.Setenv("PUNARO_TRUSTED_LAN_CIDR", "192.168.50.0/24")
+	t.Setenv("PUNARO_TRUSTED_LAN_HTTP", "true")
+	cfg, err = Load("")
+	if err != nil || cfg.IngressMode != "lan" || !cfg.TrustedLANHTTP {
+		t.Fatalf("LAN config=%#v err=%v", cfg, err)
+	}
+
+	t.Setenv("PUNARO_LISTEN_ADDR", "0.0.0.0:8080")
+	if _, err := Load(""); err == nil {
+		t.Fatal("device ingress accepted a wildcard LAN bind")
+	}
+}
+
+func TestLoadRejectsDeviceIngressWithoutPostgres(t *testing.T) {
+	t.Setenv("PUNARO_DEVICE_AUTH_ENABLED", "true")
+	t.Setenv("PUNARO_INGRESS_MODE", "internet")
+	t.Setenv("PUNARO_PUBLIC_URL", "https://punaro.example")
+	if _, err := Load(""); err == nil {
+		t.Fatal("device ingress accepted no PostgreSQL application store")
+	}
+}
+
 func TestLoadRejectsLocalhostNameUntilResolvedBindingIsImplemented(t *testing.T) {
 	t.Setenv("PUNARO_LISTEN_ADDR", "localhost:8080")
 	if _, err := Load(""); err == nil {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -111,6 +111,32 @@ func TestLoadAcceptsOnlyValidatedDeviceIngressProfiles(t *testing.T) {
 	}
 }
 
+func TestLoadRequiresDistinctLoopbackHealthListener(t *testing.T) {
+	cfg, err := Load("")
+	if err != nil || cfg.HealthListenAddr != "127.0.0.1:8081" {
+		t.Fatalf("config=%#v err=%v", cfg, err)
+	}
+	t.Setenv("PUNARO_HEALTH_LISTEN_ADDR", "192.168.50.4:8081")
+	if _, err := Load(""); err == nil {
+		t.Fatal("health listener accepted a non-loopback address")
+	}
+	t.Setenv("PUNARO_HEALTH_LISTEN_ADDR", "127.0.0.1:8080")
+	if _, err := Load(""); err == nil {
+		t.Fatal("health listener accepted the public listener address")
+	}
+	for _, address := range []string{"127.0.0.1:0", "127.0.0.1:", "127.0.0.1:http", "127.0.0.1:65536"} {
+		t.Setenv("PUNARO_HEALTH_LISTEN_ADDR", address)
+		if _, err := Load(""); err == nil {
+			t.Fatalf("health listener accepted invalid port in %q", address)
+		}
+	}
+	t.Setenv("PUNARO_LISTEN_ADDR", "127.0.0.1:8081")
+	t.Setenv("PUNARO_HEALTH_LISTEN_ADDR", "127.0.0.1:08081")
+	if _, err := Load(""); err == nil {
+		t.Fatal("health listener accepted a zero-padded alias of the public listener")
+	}
+}
+
 func TestLoadRejectsLegacyRoutesOnNonLoopbackDeviceIngress(t *testing.T) {
 	t.Setenv("PUNARO_POSTGRES_ENABLED", "true")
 	t.Setenv("PUNARO_POSTGRES_DSN_FILE", "/run/secrets/punaro-app-dsn")

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -111,6 +111,21 @@ func TestLoadAcceptsOnlyValidatedDeviceIngressProfiles(t *testing.T) {
 	}
 }
 
+func TestLoadRejectsLegacyRoutesOnNonLoopbackDeviceIngress(t *testing.T) {
+	t.Setenv("PUNARO_POSTGRES_ENABLED", "true")
+	t.Setenv("PUNARO_POSTGRES_DSN_FILE", "/run/secrets/punaro-app-dsn")
+	t.Setenv("PUNARO_DEVICE_AUTH_ENABLED", "true")
+	t.Setenv("PUNARO_INGRESS_MODE", "lan")
+	t.Setenv("PUNARO_LISTEN_ADDR", "192.168.50.4:8080")
+	t.Setenv("PUNARO_TRUSTED_LAN_CIDR", "192.168.50.0/24")
+	t.Setenv("PUNARO_TRUSTED_LAN_HTTP", "true")
+	t.Setenv("PUNARO_RELAY_ENABLED", "true")
+	t.Setenv("PUNARO_RELAY_MACHINES_JSON", `[{"id":"machine-a","public_key":"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA","endpoint_prefixes":["agent/a/"]}]`)
+	if _, err := Load(""); err == nil {
+		t.Fatal("non-loopback device ingress exposed legacy relay routes")
+	}
+}
+
 func TestLoadRejectsDeviceIngressWithoutPostgres(t *testing.T) {
 	t.Setenv("PUNARO_DEVICE_AUTH_ENABLED", "true")
 	t.Setenv("PUNARO_INGRESS_MODE", "internet")

--- a/internal/devicehttp/handler.go
+++ b/internal/devicehttp/handler.go
@@ -1,0 +1,207 @@
+// Package devicehttp exposes the bounded network edge for device enrollment
+// and bearer authentication. Host-local administration is deliberately absent.
+package devicehttp
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"mime"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/rock3r/punaro/internal/ingress"
+	punaropostgres "github.com/rock3r/punaro/internal/postgres"
+)
+
+const maxRequestBytes = 4096
+
+const (
+	maxConcurrentRequests = 32
+	storeOperationTimeout = 5 * time.Second
+)
+
+type store interface {
+	RedeemEnrollment(context.Context, punaropostgres.RedeemEnrollment) (punaropostgres.DeviceCredential, error)
+	AuthenticateDevice(context.Context, string) (punaropostgres.AuthenticatedDevice, error)
+}
+
+type handler struct {
+	store   store
+	policy  *ingress.Policy
+	mux     *http.ServeMux
+	slots   chan struct{}
+	timeout time.Duration
+}
+
+// New builds the only device credential ingress routes.
+func New(database store, policy *ingress.Policy) http.Handler {
+	return newHandler(database, policy, maxConcurrentRequests, storeOperationTimeout)
+}
+
+func newHandler(database store, policy *ingress.Policy, concurrency int, timeout time.Duration) http.Handler {
+	if concurrency < 1 {
+		concurrency = 1
+	}
+	h := &handler{store: database, policy: policy, mux: http.NewServeMux(), slots: make(chan struct{}, concurrency), timeout: timeout}
+	h.mux.HandleFunc("POST /v1/enrollments/redeem", h.redeem)
+	h.mux.Handle("GET /v1/device/session", h.authenticate(http.HandlerFunc(h.session)))
+	return h
+}
+
+func (h *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if h.store == nil || h.policy == nil || !h.policy.AllowsCredential(r) {
+		writeError(w, http.StatusForbidden, "credential transport is forbidden")
+		return
+	}
+	select {
+	case h.slots <- struct{}{}:
+		defer func() { <-h.slots }()
+	default:
+		w.Header().Set("Retry-After", "1")
+		writeError(w, http.StatusTooManyRequests, "credential ingress is busy")
+		return
+	}
+	h.mux.ServeHTTP(w, r)
+}
+
+func (h *handler) redeem(w http.ResponseWriter, r *http.Request) {
+	if len(r.Header.Values("Content-Type")) != 1 {
+		writeError(w, http.StatusUnsupportedMediaType, "application/json is required")
+		return
+	}
+	mediaType, params, err := mime.ParseMediaType(r.Header.Get("Content-Type"))
+	if err != nil || mediaType != "application/json" || len(params) != 0 {
+		writeError(w, http.StatusUnsupportedMediaType, "application/json is required")
+		return
+	}
+	if r.ContentLength > maxRequestBytes {
+		writeError(w, http.StatusRequestEntityTooLarge, "request is too large")
+		return
+	}
+	body, err := io.ReadAll(io.LimitReader(r.Body, maxRequestBytes+1))
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "request is malformed")
+		return
+	}
+	if len(body) > maxRequestBytes {
+		writeError(w, http.StatusRequestEntityTooLarge, "request is too large")
+		return
+	}
+	redeem, err := decodeRedeem(body)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "request is malformed")
+		return
+	}
+	operationCtx, cancel := context.WithTimeout(r.Context(), h.timeout)
+	defer cancel()
+	credential, err := h.store.RedeemEnrollment(operationCtx, redeem)
+	if err != nil {
+		if errors.Is(err, punaropostgres.ErrInvalidEnrollment) {
+			unauthenticated(w)
+			return
+		}
+		writeError(w, http.StatusServiceUnavailable, "enrollment service is unavailable")
+		return
+	}
+	w.Header().Set("Cache-Control", "no-store")
+	writeJSON(w, http.StatusCreated, credential)
+}
+
+func decodeRedeem(body []byte) (punaropostgres.RedeemEnrollment, error) {
+	decoder := json.NewDecoder(strings.NewReader(string(body)))
+	start, err := decoder.Token()
+	if err != nil || start != json.Delim('{') {
+		return punaropostgres.RedeemEnrollment{}, errors.New("not an object")
+	}
+	values := make(map[string]string, 4)
+	for decoder.More() {
+		token, err := decoder.Token()
+		name, ok := token.(string)
+		if err != nil || !ok {
+			return punaropostgres.RedeemEnrollment{}, errors.New("invalid field")
+		}
+		if _, duplicate := values[name]; duplicate {
+			return punaropostgres.RedeemEnrollment{}, errors.New("duplicate field")
+		}
+		switch name {
+		case "enrollment_id", "client_binding", "code", "idempotency_key":
+		default:
+			return punaropostgres.RedeemEnrollment{}, errors.New("unknown field")
+		}
+		var value string
+		if err := decoder.Decode(&value); err != nil || value == "" {
+			return punaropostgres.RedeemEnrollment{}, errors.New("invalid value")
+		}
+		values[name] = value
+	}
+	end, err := decoder.Token()
+	if err != nil || end != json.Delim('}') || len(values) != 4 {
+		return punaropostgres.RedeemEnrollment{}, errors.New("incomplete object")
+	}
+	if _, err := decoder.Token(); !errors.Is(err, io.EOF) {
+		return punaropostgres.RedeemEnrollment{}, errors.New("trailing input")
+	}
+	return punaropostgres.RedeemEnrollment{EnrollmentID: values["enrollment_id"], ClientBinding: values["client_binding"], Code: values["code"], IdempotencyKey: values["idempotency_key"]}, nil
+}
+
+type authenticatedKey struct{}
+
+// AuthenticatedDevice returns the independently authenticated device identity.
+func AuthenticatedDevice(ctx context.Context) (punaropostgres.AuthenticatedDevice, bool) {
+	device, ok := ctx.Value(authenticatedKey{}).(punaropostgres.AuthenticatedDevice)
+	return device, ok
+}
+
+func (h *handler) authenticate(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if len(r.Header.Values("Authorization")) != 1 {
+			unauthenticated(w)
+			return
+		}
+		authorization := r.Header.Get("Authorization")
+		if !strings.HasPrefix(authorization, "Bearer ") {
+			unauthenticated(w)
+			return
+		}
+		credential := strings.TrimPrefix(authorization, "Bearer ")
+		if credential == "" || strings.ContainsAny(credential, " \t\r\n") {
+			unauthenticated(w)
+			return
+		}
+		operationCtx, cancel := context.WithTimeout(r.Context(), h.timeout)
+		defer cancel()
+		device, err := h.store.AuthenticateDevice(operationCtx, credential)
+		if err != nil {
+			unauthenticated(w)
+			return
+		}
+		next.ServeHTTP(w, r.WithContext(context.WithValue(r.Context(), authenticatedKey{}, device)))
+	})
+}
+
+func (h *handler) session(w http.ResponseWriter, r *http.Request) {
+	if _, ok := AuthenticatedDevice(r.Context()); !ok {
+		unauthenticated(w)
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]string{"status": "authenticated"})
+}
+
+func unauthenticated(w http.ResponseWriter) {
+	w.Header().Set("WWW-Authenticate", "Bearer")
+	writeError(w, http.StatusUnauthorized, "unauthenticated")
+}
+
+func writeError(w http.ResponseWriter, status int, message string) {
+	writeJSON(w, status, map[string]string{"error": message})
+}
+
+func writeJSON(w http.ResponseWriter, status int, value any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Cache-Control", "no-store")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(value)
+}

--- a/internal/devicehttp/handler_test.go
+++ b/internal/devicehttp/handler_test.go
@@ -15,9 +15,10 @@ import (
 )
 
 type fakeStore struct {
-	redeem punaropostgres.RedeemEnrollment
-	auth   punaropostgres.AuthenticatedDevice
-	err    error
+	redeem     punaropostgres.RedeemEnrollment
+	credential punaropostgres.DeviceCredential
+	auth       punaropostgres.AuthenticatedDevice
+	err        error
 }
 
 type blockingStore struct{ started chan struct{} }
@@ -38,6 +39,9 @@ func (f *fakeStore) RedeemEnrollment(_ context.Context, redeem punaropostgres.Re
 	f.redeem = redeem
 	if f.err != nil {
 		return punaropostgres.DeviceCredential{}, f.err
+	}
+	if f.credential.Encoded != "" {
+		return f.credential, nil
 	}
 	return punaropostgres.DeviceCredential{Encoded: "punaro_device_credential"}, nil
 }
@@ -67,8 +71,18 @@ func TestRedeemEnrollmentUsesStrictBoundedRequest(t *testing.T) {
 	req.RemoteAddr = "192.168.1.20:1234"
 	response := httptest.NewRecorder()
 	handler.ServeHTTP(response, req)
-	if response.Code != http.StatusCreated || store.redeem.EnrollmentID == "" || !strings.Contains(response.Body.String(), "credential") {
+	if response.Code != http.StatusCreated || store.redeem.EnrollmentID == "" || !strings.Contains(response.Body.String(), "credential") || strings.Contains(response.Body.String(), "expires_at") || strings.Contains(response.Body.String(), "0001-01-01") {
 		t.Fatalf("status=%d body=%q redeem=%#v", response.Code, response.Body.String(), store.redeem)
+	}
+	expiresAt := time.Date(2030, time.January, 2, 3, 4, 5, 0, time.UTC)
+	store.credential = punaropostgres.DeviceCredential{Encoded: "expiring_credential", ExpiresAt: expiresAt}
+	expiring := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/v1/enrollments/redeem", strings.NewReader(body))
+	expiring.Header.Set("Content-Type", "application/json")
+	expiring.RemoteAddr = "192.168.1.20:1234"
+	expiringResponse := httptest.NewRecorder()
+	handler.ServeHTTP(expiringResponse, expiring)
+	if expiringResponse.Code != http.StatusCreated || !strings.Contains(expiringResponse.Body.String(), `"expires_at":"2030-01-02T03:04:05Z"`) {
+		t.Fatalf("expiring status=%d body=%q", expiringResponse.Code, expiringResponse.Body.String())
 	}
 
 	badBodies := []struct {

--- a/internal/devicehttp/handler_test.go
+++ b/internal/devicehttp/handler_test.go
@@ -1,0 +1,171 @@
+package devicehttp
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/rock3r/punaro/internal/ingress"
+	punaropostgres "github.com/rock3r/punaro/internal/postgres"
+)
+
+type fakeStore struct {
+	redeem punaropostgres.RedeemEnrollment
+	auth   punaropostgres.AuthenticatedDevice
+	err    error
+}
+
+type blockingStore struct{ started chan struct{} }
+
+func (b *blockingStore) RedeemEnrollment(ctx context.Context, _ punaropostgres.RedeemEnrollment) (punaropostgres.DeviceCredential, error) {
+	close(b.started)
+	<-ctx.Done()
+	return punaropostgres.DeviceCredential{}, ctx.Err()
+}
+
+func (b *blockingStore) AuthenticateDevice(ctx context.Context, _ string) (punaropostgres.AuthenticatedDevice, error) {
+	close(b.started)
+	<-ctx.Done()
+	return punaropostgres.AuthenticatedDevice{}, ctx.Err()
+}
+
+func (f *fakeStore) RedeemEnrollment(_ context.Context, redeem punaropostgres.RedeemEnrollment) (punaropostgres.DeviceCredential, error) {
+	f.redeem = redeem
+	if f.err != nil {
+		return punaropostgres.DeviceCredential{}, f.err
+	}
+	return punaropostgres.DeviceCredential{Encoded: "punaro_device_credential"}, nil
+}
+
+func (f *fakeStore) AuthenticateDevice(_ context.Context, _ string) (punaropostgres.AuthenticatedDevice, error) {
+	if f.err != nil {
+		return punaropostgres.AuthenticatedDevice{}, f.err
+	}
+	return f.auth, nil
+}
+
+func testPolicy(t *testing.T) *ingress.Policy {
+	t.Helper()
+	p := &ingress.Policy{Mode: ingress.LAN, ListenAddr: "192.168.1.4:8080", TrustedLAN: "192.168.1.0/24", AllowPlaintext: true}
+	if err := p.Validate(); err != nil {
+		t.Fatal(err)
+	}
+	return p
+}
+
+func TestRedeemEnrollmentUsesStrictBoundedRequest(t *testing.T) {
+	store := &fakeStore{}
+	handler := New(store, testPolicy(t))
+	body := `{"enrollment_id":"11111111-1111-4111-8111-111111111111","client_binding":"22222222-2222-4222-8222-222222222222","code":"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA","idempotency_key":"33333333-3333-4333-8333-333333333333"}`
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/v1/enrollments/redeem", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.RemoteAddr = "192.168.1.20:1234"
+	response := httptest.NewRecorder()
+	handler.ServeHTTP(response, req)
+	if response.Code != http.StatusCreated || store.redeem.EnrollmentID == "" || !strings.Contains(response.Body.String(), "credential") {
+		t.Fatalf("status=%d body=%q redeem=%#v", response.Code, response.Body.String(), store.redeem)
+	}
+
+	badBodies := []struct {
+		name string
+		body string
+	}{
+		{name: "duplicate", body: `{"enrollment_id":"11111111-1111-4111-8111-111111111111","enrollment_id":"11111111-1111-4111-8111-111111111111","client_binding":"22222222-2222-4222-8222-222222222222","code":"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA","idempotency_key":"33333333-3333-4333-8333-333333333333"}`},
+		{name: "unknown", body: `{"enrollment_id":"11111111-1111-4111-8111-111111111111","client_binding":"22222222-2222-4222-8222-222222222222","code":"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA","idempotency_key":"33333333-3333-4333-8333-333333333333","extra":true}`},
+		{name: "trailing", body: body + `{}`},
+	}
+	for _, test := range badBodies {
+		t.Run(test.name, func(t *testing.T) {
+			r := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/v1/enrollments/redeem", strings.NewReader(test.body))
+			r.Header.Set("Content-Type", "application/json")
+			r.RemoteAddr = "192.168.1.20:1234"
+			w := httptest.NewRecorder()
+			handler.ServeHTTP(w, r)
+			if w.Code != http.StatusBadRequest {
+				t.Fatalf("status=%d body=%q", w.Code, w.Body.String())
+			}
+		})
+	}
+
+	large := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/v1/enrollments/redeem", bytes.NewReader(make([]byte, maxRequestBytes+1)))
+	large.Header.Set("Content-Type", "application/json")
+	large.RemoteAddr = "192.168.1.20:1234"
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, large)
+	if w.Code != http.StatusRequestEntityTooLarge {
+		t.Fatalf("oversize status=%d", w.Code)
+	}
+}
+
+func TestCredentialRoutesEnforceTransportAndUniformAuthentication(t *testing.T) {
+	store := &fakeStore{auth: punaropostgres.AuthenticatedDevice{PrincipalID: "11111111-1111-4111-8111-111111111111", LookupID: "22222222-2222-4222-8222-222222222222", Generation: 2}}
+	handler := New(store, testPolicy(t))
+
+	request := func(remote, authorization string) *httptest.ResponseRecorder {
+		r := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/v1/device/session", nil)
+		r.RemoteAddr = remote
+		r.Header.Set("Authorization", authorization)
+		w := httptest.NewRecorder()
+		handler.ServeHTTP(w, r)
+		return w
+	}
+	if got := request("192.168.1.20:1234", "Bearer opaque"); got.Code != http.StatusOK {
+		t.Fatalf("trusted status=%d body=%q", got.Code, got.Body.String())
+	}
+	if got := request("203.0.113.20:1234", "Bearer opaque"); got.Code != http.StatusForbidden {
+		t.Fatalf("public plaintext status=%d", got.Code)
+	}
+	for _, authorization := range []string{"", "Basic opaque", "Bearer ", "Bearer one two"} {
+		if got := request("192.168.1.20:1234", authorization); got.Code != http.StatusUnauthorized || !strings.Contains(got.Body.String(), "unauthenticated") {
+			t.Fatalf("authorization=%q status=%d body=%q", authorization, got.Code, got.Body.String())
+		}
+	}
+	store.err = errors.New("database detail that must not escape")
+	if got := request("192.168.1.20:1234", "Bearer opaque"); got.Code != http.StatusUnauthorized || strings.Contains(got.Body.String(), "database") {
+		t.Fatalf("store failure status=%d body=%q", got.Code, got.Body.String())
+	}
+	duplicate := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/v1/device/session", nil)
+	duplicate.RemoteAddr = "192.168.1.20:1234"
+	duplicate.Header["Authorization"] = []string{"Bearer opaque", "Bearer second"}
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, duplicate)
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("duplicate Authorization status=%d", w.Code)
+	}
+}
+
+func TestCredentialIngressBoundsBlockedStoreWork(t *testing.T) {
+	store := &blockingStore{started: make(chan struct{})}
+	handler := newHandler(store, testPolicy(t), 1, 25*time.Millisecond)
+	request := func() *http.Request {
+		r := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/v1/device/session", nil)
+		r.RemoteAddr = "192.168.1.20:1234"
+		r.Header.Set("Authorization", "Bearer opaque")
+		return r
+	}
+	first := httptest.NewRecorder()
+	done := make(chan struct{})
+	go func() {
+		handler.ServeHTTP(first, request())
+		close(done)
+	}()
+	<-store.started
+	second := httptest.NewRecorder()
+	handler.ServeHTTP(second, request())
+	if second.Code != http.StatusTooManyRequests || second.Header().Get("Retry-After") == "" {
+		t.Fatalf("overflow status=%d headers=%v", second.Code, second.Header())
+	}
+	select {
+	case <-done:
+		if first.Code != http.StatusUnauthorized {
+			t.Fatalf("timed-out auth status=%d body=%q", first.Code, first.Body.String())
+		}
+	case <-time.After(time.Second):
+		t.Fatal("blocked store request outlived its operation deadline")
+	}
+}

--- a/internal/ingress/policy.go
+++ b/internal/ingress/policy.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"strconv"
 	"strings"
 )
 
@@ -36,9 +37,13 @@ type Policy struct {
 
 // Validate rejects ambiguous, wildcard, and publicly routable boundaries.
 func (p *Policy) Validate() error {
-	host, _, err := net.SplitHostPort(p.ListenAddr)
+	host, portText, err := net.SplitHostPort(p.ListenAddr)
 	if err != nil {
 		return errors.New("ingress listen address must be a concrete IP and port")
+	}
+	port, err := strconv.ParseUint(portText, 10, 16)
+	if err != nil || port == 0 || portText != strconv.FormatUint(port, 10) {
+		return errors.New("ingress listen address must use a canonical nonzero numeric port")
 	}
 	bind := parseIP(host)
 	if bind == nil || bind.IsUnspecified() || bind.IsMulticast() {

--- a/internal/ingress/policy.go
+++ b/internal/ingress/policy.go
@@ -1,0 +1,149 @@
+// Package ingress validates the transport boundary for device credentials.
+package ingress
+
+import (
+	"errors"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+// Mode is one explicit operator-selected ingress profile.
+type Mode string
+
+const (
+	// LAN permits an explicit private or link-local plaintext exception.
+	LAN Mode = "lan"
+	// Proxy requires a loopback listener behind a canonical HTTPS origin.
+	Proxy Mode = "proxy"
+	// Internet requires a loopback listener behind a canonical HTTPS origin.
+	Internet Mode = "internet"
+)
+
+// Policy is the complete transport policy needed before credentials can be
+// accepted. Forwarded headers are intentionally absent: a direct request
+// cannot assert its own transport or source boundary.
+type Policy struct {
+	Mode           Mode
+	ListenAddr     string
+	PublicURL      string
+	TrustedLAN     string
+	AllowPlaintext bool
+
+	trustedNetwork *net.IPNet
+}
+
+// Validate rejects ambiguous, wildcard, and publicly routable boundaries.
+func (p *Policy) Validate() error {
+	host, _, err := net.SplitHostPort(p.ListenAddr)
+	if err != nil {
+		return errors.New("ingress listen address must be a concrete IP and port")
+	}
+	bind := parseIP(host)
+	if bind == nil || bind.IsUnspecified() || bind.IsMulticast() {
+		return errors.New("ingress listen address must be a concrete IP and port")
+	}
+	switch p.Mode {
+	case Internet, Proxy:
+		if !bind.IsLoopback() {
+			return errors.New("proxy and Internet origins must bind to loopback")
+		}
+		if err := validateHTTPSURL(p.PublicURL); err != nil {
+			return err
+		}
+		if p.TrustedLAN != "" || p.AllowPlaintext {
+			return errors.New("trusted-LAN plaintext is valid only in LAN mode")
+		}
+	case LAN:
+		if !p.AllowPlaintext {
+			return errors.New("LAN plaintext must be explicitly enabled")
+		}
+		if !privateOrLinkLocal(bind) {
+			return errors.New("LAN bind must be private or link-local")
+		}
+		_, network, err := net.ParseCIDR(p.TrustedLAN)
+		if err != nil || !privateNetwork(network) || !network.Contains(bind) {
+			return errors.New("trusted LAN must be a private or link-local network containing the bind")
+		}
+		if p.PublicURL != "" {
+			return errors.New("LAN mode does not accept a public URL")
+		}
+		p.trustedNetwork = network
+	default:
+		return errors.New("ingress mode must be lan, proxy, or internet")
+	}
+	return nil
+}
+
+// AllowsCredential admits TLS, same-host plaintext, or the exact explicit
+// trusted-LAN exception. X-Forwarded-* is never consulted.
+func (p *Policy) AllowsCredential(r *http.Request) bool {
+	if r == nil {
+		return false
+	}
+	if r.TLS != nil {
+		return true
+	}
+	host, _, err := net.SplitHostPort(r.RemoteAddr)
+	if err != nil {
+		return false
+	}
+	peer := parseIP(strings.Trim(host, "[]"))
+	if peer == nil {
+		return false
+	}
+	if peer.IsLoopback() {
+		return true
+	}
+	if p.Mode != LAN || !p.AllowPlaintext || !privateOrLinkLocal(peer) {
+		return false
+	}
+	if p.trustedNetwork == nil {
+		if err := p.Validate(); err != nil {
+			return false
+		}
+	}
+	return p.trustedNetwork.Contains(peer)
+}
+
+func validateHTTPSURL(raw string) error {
+	u, err := url.Parse(raw)
+	if err != nil || u.Scheme != "https" || u.Host == "" || u.User != nil || u.RawQuery != "" || u.Fragment != "" || (u.Path != "" && u.Path != "/") {
+		return errors.New("proxy and Internet modes require a canonical HTTPS public URL")
+	}
+	if net.ParseIP(u.Hostname()) != nil && (net.ParseIP(u.Hostname()).IsLoopback() || net.ParseIP(u.Hostname()).IsUnspecified()) {
+		return errors.New("public URL must not name a loopback or wildcard address")
+	}
+	return nil
+}
+
+func privateOrLinkLocal(ip net.IP) bool {
+	return ip.IsPrivate() || ip.IsLinkLocalUnicast()
+}
+
+func parseIP(host string) net.IP {
+	if zone := strings.LastIndexByte(host, '%'); zone >= 0 {
+		host = host[:zone]
+	}
+	return net.ParseIP(host)
+}
+
+func privateNetwork(network *net.IPNet) bool {
+	if network == nil {
+		return false
+	}
+	ones, bits := network.Mask.Size()
+	if ones < 0 {
+		return false
+	}
+	allowed := []string{"10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16", "169.254.0.0/16", "fc00::/7", "fe80::/10"}
+	for _, raw := range allowed {
+		_, parent, _ := net.ParseCIDR(raw)
+		parentOnes, parentBits := parent.Mask.Size()
+		if bits == parentBits && ones >= parentOnes && parent.Contains(network.IP) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/ingress/policy.go
+++ b/internal/ingress/policy.go
@@ -6,8 +6,9 @@ import (
 	"net"
 	"net/http"
 	"net/url"
-	"strconv"
 	"strings"
+
+	"github.com/rock3r/punaro/internal/listener"
 )
 
 // Mode is one explicit operator-selected ingress profile.
@@ -37,18 +38,11 @@ type Policy struct {
 
 // Validate rejects ambiguous, wildcard, and publicly routable boundaries.
 func (p *Policy) Validate() error {
-	host, portText, err := net.SplitHostPort(p.ListenAddr)
-	if err != nil {
+	endpoint, err := listener.Parse(p.ListenAddr)
+	if err != nil || endpoint.Address.IsUnspecified() || endpoint.Address.IsMulticast() {
 		return errors.New("ingress listen address must be a concrete IP and port")
 	}
-	port, err := strconv.ParseUint(portText, 10, 16)
-	if err != nil || port == 0 || portText != strconv.FormatUint(port, 10) {
-		return errors.New("ingress listen address must use a canonical nonzero numeric port")
-	}
-	bind := parseIP(host)
-	if bind == nil || bind.IsUnspecified() || bind.IsMulticast() {
-		return errors.New("ingress listen address must be a concrete IP and port")
-	}
+	bind := net.IP(endpoint.Address.AsSlice())
 	switch p.Mode {
 	case Internet, Proxy:
 		if !bind.IsLoopback() {

--- a/internal/ingress/policy_test.go
+++ b/internal/ingress/policy_test.go
@@ -18,6 +18,10 @@ func TestPolicyValidationFailsClosed(t *testing.T) {
 		{name: "lan public bind", policy: Policy{Mode: LAN, ListenAddr: "8.8.8.8:8080", TrustedLAN: "8.8.8.0/24", AllowPlaintext: true}},
 		{name: "lan public network", policy: Policy{Mode: LAN, ListenAddr: "192.168.1.4:8080", TrustedLAN: "8.8.8.0/24", AllowPlaintext: true}},
 		{name: "lan plaintext not explicit", policy: Policy{Mode: LAN, ListenAddr: "192.168.1.4:8080", TrustedLAN: "192.168.1.0/24"}},
+		{name: "zero port", policy: Policy{Mode: Internet, ListenAddr: "127.0.0.1:0", PublicURL: "https://punaro.example"}},
+		{name: "service port", policy: Policy{Mode: Internet, ListenAddr: "127.0.0.1:http", PublicURL: "https://punaro.example"}},
+		{name: "out of range port", policy: Policy{Mode: Internet, ListenAddr: "127.0.0.1:65536", PublicURL: "https://punaro.example"}},
+		{name: "noncanonical port", policy: Policy{Mode: Internet, ListenAddr: "127.0.0.1:08080", PublicURL: "https://punaro.example"}},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {

--- a/internal/ingress/policy_test.go
+++ b/internal/ingress/policy_test.go
@@ -1,0 +1,85 @@
+package ingress
+
+import (
+	"crypto/tls"
+	"net/http"
+	"testing"
+)
+
+func TestPolicyValidationFailsClosed(t *testing.T) {
+	tests := []struct {
+		name   string
+		policy Policy
+	}{
+		{name: "internet needs https", policy: Policy{Mode: Internet, ListenAddr: "127.0.0.1:8080", PublicURL: "http://punaro.example"}},
+		{name: "internet origin cannot be public", policy: Policy{Mode: Internet, ListenAddr: "203.0.113.4:8080", PublicURL: "https://punaro.example"}},
+		{name: "proxy needs https", policy: Policy{Mode: Proxy, ListenAddr: "127.0.0.1:8080", PublicURL: ""}},
+		{name: "lan wildcard", policy: Policy{Mode: LAN, ListenAddr: "0.0.0.0:8080", TrustedLAN: "192.168.1.0/24", AllowPlaintext: true}},
+		{name: "lan public bind", policy: Policy{Mode: LAN, ListenAddr: "8.8.8.8:8080", TrustedLAN: "8.8.8.0/24", AllowPlaintext: true}},
+		{name: "lan public network", policy: Policy{Mode: LAN, ListenAddr: "192.168.1.4:8080", TrustedLAN: "8.8.8.0/24", AllowPlaintext: true}},
+		{name: "lan plaintext not explicit", policy: Policy{Mode: LAN, ListenAddr: "192.168.1.4:8080", TrustedLAN: "192.168.1.0/24"}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if err := test.policy.Validate(); err == nil {
+				t.Fatal("unsafe ingress policy was accepted")
+			}
+		})
+	}
+}
+
+func TestCredentialTransportAdmission(t *testing.T) {
+	lan := Policy{Mode: LAN, ListenAddr: "192.168.1.4:8080", TrustedLAN: "192.168.1.0/24", AllowPlaintext: true}
+	if err := lan.Validate(); err != nil {
+		t.Fatal(err)
+	}
+	request := func(remote string, secure bool) *http.Request {
+		r, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "http://punaro.invalid/v1/device/session", nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		r.RemoteAddr = remote
+		if secure {
+			r.TLS = &tls.ConnectionState{}
+		}
+		return r
+	}
+	if !lan.AllowsCredential(request("192.168.1.20:41234", false)) {
+		t.Fatal("explicit trusted-LAN peer was rejected")
+	}
+	spoofed := request("203.0.113.20:41234", false)
+	spoofed.Header.Set("X-Forwarded-For", "192.168.1.20")
+	spoofed.Header.Set("X-Forwarded-Proto", "https")
+	if lan.AllowsCredential(spoofed) {
+		t.Fatal("forwarded headers bypassed direct-origin transport policy")
+	}
+	if !lan.AllowsCredential(request("203.0.113.20:41234", true)) {
+		t.Fatal("TLS peer was rejected")
+	}
+
+	internet := Policy{Mode: Internet, ListenAddr: "127.0.0.1:8080", PublicURL: "https://punaro.example"}
+	if err := internet.Validate(); err != nil {
+		t.Fatal(err)
+	}
+	if internet.AllowsCredential(request("203.0.113.20:41234", false)) {
+		t.Fatal("internet profile accepted plaintext credential transport")
+	}
+	if !internet.AllowsCredential(request("127.0.0.1:41234", false)) {
+		t.Fatal("same-host credential transport was rejected")
+	}
+}
+
+func TestLinkLocalIPv6ZoneIsValidatedWithoutTrustingItAsAnAddress(t *testing.T) {
+	policy := Policy{Mode: LAN, ListenAddr: "[fe80::1234%en0]:8080", TrustedLAN: "fe80::/64", AllowPlaintext: true}
+	if err := policy.Validate(); err != nil {
+		t.Fatal(err)
+	}
+	r, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "http://punaro.invalid", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	r.RemoteAddr = "[fe80::20%en0]:41234"
+	if !policy.AllowsCredential(r) {
+		t.Fatal("validated link-local IPv6 peer was rejected")
+	}
+}

--- a/internal/listener/address.go
+++ b/internal/listener/address.go
@@ -1,0 +1,45 @@
+// Package listener provides one canonical parser for configured TCP listeners.
+package listener
+
+import (
+	"errors"
+	"net"
+	"net/netip"
+	"strconv"
+)
+
+// Endpoint is one validated, comparable configured listener.
+type Endpoint struct {
+	Address netip.Addr
+	Port    uint16
+}
+
+// Parse accepts only a concrete IP and a canonical decimal port in 1..65535.
+func Parse(address string) (Endpoint, error) {
+	host, portText, err := net.SplitHostPort(address)
+	if err != nil {
+		return Endpoint{}, errors.New("listener must be a concrete IP and port")
+	}
+	ip, ipErr := netip.ParseAddr(host)
+	port, err := strconv.ParseUint(portText, 10, 16)
+	if ipErr != nil || err != nil || port == 0 || portText != strconv.FormatUint(port, 10) {
+		return Endpoint{}, errors.New("listener must use a concrete IP and canonical nonzero numeric port")
+	}
+	if ip.Is6() && ip.IsLinkLocalUnicast() != (ip.Zone() != "") {
+		return Endpoint{}, errors.New("listener must use a concrete IP and canonical nonzero numeric port")
+	}
+	return Endpoint{Address: ip.Unmap(), Port: uint16(port)}, nil
+}
+
+// IsLoopback reports whether address is a valid canonical loopback listener.
+func IsLoopback(address string) bool {
+	endpoint, err := Parse(address)
+	return err == nil && endpoint.Address.IsLoopback()
+}
+
+// Same reports whether two valid canonical listeners identify the same IP/port.
+func Same(first, second string) bool {
+	firstEndpoint, firstErr := Parse(first)
+	secondEndpoint, secondErr := Parse(second)
+	return firstErr == nil && secondErr == nil && firstEndpoint == secondEndpoint
+}

--- a/internal/listener/address_test.go
+++ b/internal/listener/address_test.go
@@ -1,0 +1,23 @@
+package listener
+
+import "testing"
+
+func TestCanonicalListenerParsingAndEquality(t *testing.T) {
+	for _, address := range []string{"127.0.0.1:0", "127.0.0.1:http", "127.0.0.1:65536", "127.0.0.1:08080", ":8080", "[fe80::1%]:8080", "[fe80::1]:8080", "[127.0.0.1%en0]:8080", "[::ffff:127.0.0.1%en0]:8080", "[::1%lo0]:8080", "[2001:db8::1%en0]:8080"} {
+		if _, err := Parse(address); err == nil {
+			t.Errorf("Parse(%q) accepted an ambiguous listener", address)
+		}
+	}
+	if _, err := Parse("[fe80::1%en0]:8080"); err != nil {
+		t.Fatalf("valid scoped IPv6 listener was rejected: %v", err)
+	}
+	if !IsLoopback("127.0.0.1:8080") || !IsLoopback("[::1]:8080") {
+		t.Fatal("canonical loopback listener was rejected")
+	}
+	if !Same("127.0.0.1:8080", "127.0.0.1:8080") || Same("127.0.0.1:8080", "127.0.0.1:8081") {
+		t.Fatal("listener equality is incorrect")
+	}
+	if Same("[fe80::1%en0]:8080", "[fe80::1%en1]:8080") {
+		t.Fatal("listener equality discarded the IPv6 scope zone")
+	}
+}

--- a/internal/operator/identity_unix.go
+++ b/internal/operator/identity_unix.go
@@ -1,0 +1,16 @@
+//go:build !windows
+
+package operator
+
+import (
+	"errors"
+	"os"
+	"strconv"
+)
+
+func runtimeIdentity() (string, string, error) {
+	if os.Getuid() == 0 || os.Getgid() == 0 {
+		return "", "", errors.New("server operator initialization must run as a non-root user")
+	}
+	return strconv.Itoa(os.Getuid()), strconv.Itoa(os.Getgid()), nil
+}

--- a/internal/operator/identity_windows.go
+++ b/internal/operator/identity_windows.go
@@ -1,0 +1,9 @@
+//go:build windows
+
+package operator
+
+import "errors"
+
+func runtimeIdentity() (string, string, error) {
+	return "", "", errors.New("the server operator wrapper requires a Unix host")
+}

--- a/internal/operator/installation.go
+++ b/internal/operator/installation.go
@@ -1,0 +1,571 @@
+// Package operator implements host-local Punaro installation workflows.
+package operator
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/url"
+	"os"
+	"path/filepath"
+	"regexp"
+	"runtime"
+	"strconv"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/rock3r/punaro/internal/ingress"
+	punaropostgres "github.com/rock3r/punaro/internal/postgres"
+)
+
+const (
+	configName   = "installation.json"
+	pendingName  = ".installation.pending.json"
+	envName      = "punarod.env"
+	overrideName = "compose.operator.yaml"
+)
+
+// EnvFile returns the generated daemon dotenv path for one installation.
+func EnvFile(directory string) string { return filepath.Join(directory, envName) }
+
+// OverrideFile returns the generated immutable-image Compose file.
+func OverrideFile(directory string) string { return filepath.Join(directory, overrideName) }
+
+// Installation is the content-free operator configuration. DSN values remain
+// in separately protected files and are never copied here.
+type Installation struct {
+	Version          int            `json:"version"`
+	Directory        string         `json:"-"`
+	DataDir          string         `json:"data_dir"`
+	BackupDir        string         `json:"backup_dir"`
+	Image            string         `json:"image"`
+	OwnerDSNFile     string         `json:"owner_dsn_file"`
+	AppDSNFile       string         `json:"app_dsn_file"`
+	OwnerPrincipalID string         `json:"owner_principal_id"`
+	OwnerName        string         `json:"owner_name"`
+	RuntimeUID       string         `json:"runtime_uid"`
+	RuntimeGID       string         `json:"runtime_gid"`
+	Ingress          ingress.Policy `json:"ingress"`
+	HealthURL        string         `json:"health_url"`
+}
+
+// InitOptions is the complete explicit input to a first installation.
+type InitOptions struct {
+	Directory    string
+	DataDir      string
+	BackupDir    string
+	Image        string
+	OwnerDSNFile string
+	AppDSNFile   string
+	OwnerName    string
+	Ingress      ingress.Policy
+}
+
+// BootstrapOwner is the only database mutation performed by Init.
+type BootstrapOwner func(context.Context, string, string) (punaropostgres.Principal, error)
+
+// RecoverOwner resolves or creates the exact owner during a resumed init.
+type RecoverOwner func(context.Context, Installation) (punaropostgres.Principal, error)
+
+// ErrBootstrapNotAttempted tells Init that validation refused before any
+// database mutation, so its private stage may be removed safely.
+var ErrBootstrapNotAttempted = errors.New("owner bootstrap was not attempted")
+
+// Init reserves a new installation directory, prepares every generated file,
+// bootstraps ownership, and publishes installation.json as the final marker.
+func Init(ctx context.Context, options InitOptions, bootstrap BootstrapOwner) (Installation, error) {
+	installation, err := validateInit(options)
+	if err != nil {
+		return Installation{}, err
+	}
+	if bootstrap == nil {
+		return Installation{}, errors.New("owner bootstrap is unavailable")
+	}
+	if err := os.Mkdir(options.Directory, 0o700); err != nil {
+		return Installation{}, errors.New("installation directory must be new")
+	}
+	preserveStage := false
+	defer func() {
+		if !preserveStage {
+			_ = os.Remove(filepath.Join(options.Directory, pendingName))
+			_ = os.Remove(filepath.Join(options.Directory, envName))
+			_ = os.Remove(filepath.Join(options.Directory, overrideName))
+			_ = os.Remove(options.Directory)
+		}
+	}()
+	if err := writeExclusiveJSON(filepath.Join(options.Directory, pendingName), installation); err != nil {
+		return Installation{}, errors.New("generated configuration could not be staged")
+	}
+	if err := writeExclusive(filepath.Join(options.Directory, envName), []byte(daemonEnv(installation))); err != nil {
+		return Installation{}, errors.New("generated daemon environment could not be staged")
+	}
+	if err := writeExclusive(filepath.Join(options.Directory, overrideName), []byte(composeOverride())); err != nil {
+		return Installation{}, errors.New("generated Compose override could not be staged")
+	}
+	if err := syncDirectory(options.Directory); err != nil || syncDirectory(filepath.Dir(options.Directory)) != nil {
+		return Installation{}, errors.New("generated configuration staging could not be made durable")
+	}
+	preserveStage = true
+	owner, err := bootstrap(ctx, options.OwnerDSNFile, options.OwnerName)
+	if err != nil {
+		if errors.Is(err, ErrBootstrapNotAttempted) {
+			preserveStage = false
+			return Installation{}, errors.New("fresh initialization requires a pristine database")
+		}
+		return Installation{}, errors.New("first operator outcome is uncertain; rerun punaro init --resume for this directory")
+	}
+	if uuid.Validate(owner.ID) != nil {
+		return Installation{}, errors.New("first operator was created; rerun punaro init --resume for this directory")
+	}
+	installation.OwnerPrincipalID = owner.ID
+	finalPending := filepath.Join(options.Directory, ".installation.final.json")
+	if err := writeExclusiveJSON(finalPending, installation); err != nil {
+		return Installation{}, errors.New("first operator was created; rerun punaro init --resume for this directory")
+	}
+	if err := os.Rename(finalPending, filepath.Join(options.Directory, configName)); err != nil {
+		return Installation{}, errors.New("first operator was created; rerun punaro init --resume for this directory")
+	}
+	if err := syncDirectory(options.Directory); err != nil {
+		return Installation{}, errors.New("configuration was published but durability verification failed")
+	}
+	_ = os.Remove(filepath.Join(options.Directory, pendingName))
+	if err := syncDirectory(options.Directory); err != nil {
+		return Installation{}, errors.New("configuration was published but staging cleanup durability failed")
+	}
+	return installation, nil
+}
+
+// Resume completes an initialization whose durable staging directory survived
+// an uncertain database outcome or post-bootstrap publication failure.
+func Resume(ctx context.Context, directory string, recoverOwner RecoverOwner) (Installation, error) {
+	if recoverOwner == nil || !filepath.IsAbs(directory) {
+		return Installation{}, errors.New("initialization recovery input is invalid")
+	}
+	if installation, err := Load(directory); err == nil {
+		_ = os.Remove(filepath.Join(directory, pendingName))
+		_ = os.Remove(filepath.Join(directory, ".installation.final.json"))
+		if err := syncDirectory(directory); err != nil {
+			return Installation{}, errors.New("published initialization staging cleanup failed")
+		}
+		return installation, nil
+	}
+	if err := requirePrivateDirectory(directory); err != nil {
+		return Installation{}, errors.New("initialization staging directory is unavailable or unsafe")
+	}
+	pendingPath := filepath.Join(directory, pendingName)
+	installation, err := readInstallation(pendingPath)
+	if err != nil || installation.Version != 1 || installation.OwnerPrincipalID != "" || !numericIdentity(installation.RuntimeUID) || !numericIdentity(installation.RuntimeGID) {
+		return Installation{}, errors.New("initialization staging configuration is corrupt")
+	}
+	installation.Directory = directory
+	if _, err := validateStatic(InitOptions{Directory: directory, DataDir: installation.DataDir, BackupDir: installation.BackupDir, Image: installation.Image, OwnerDSNFile: installation.OwnerDSNFile, AppDSNFile: installation.AppDSNFile, OwnerName: installation.OwnerName, Ingress: installation.Ingress}); err != nil {
+		return Installation{}, errors.New("initialization staging configuration is invalid")
+	}
+	if failures := CheckPaths(installation); len(failures) != 0 {
+		return Installation{}, fmt.Errorf("initialization recovery refused: %s", strings.Join(failures, ", "))
+	}
+	owner, err := recoverOwner(ctx, installation)
+	if err != nil || uuid.Validate(owner.ID) != nil || owner.DisplayName != installation.OwnerName {
+		return Installation{}, errors.New("installation owner could not be recovered safely")
+	}
+	installation.OwnerPrincipalID = owner.ID
+	finalPending := filepath.Join(directory, ".installation.final.json")
+	if err := os.Remove(finalPending); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return Installation{}, errors.New("initialization publication staging could not be reset")
+	}
+	if err := writeExclusiveJSON(finalPending, installation); err != nil || os.Rename(finalPending, filepath.Join(directory, configName)) != nil {
+		return Installation{}, errors.New("installation owner was recovered; rerun punaro init --resume")
+	}
+	if err := syncDirectory(directory); err != nil {
+		return Installation{}, errors.New("configuration was published but durability verification failed")
+	}
+	_ = os.Remove(pendingPath)
+	if err := syncDirectory(directory); err != nil {
+		return Installation{}, errors.New("configuration was published but staging cleanup durability failed")
+	}
+	return installation, nil
+}
+
+func validateInit(options InitOptions) (Installation, error) {
+	installation, err := validateStatic(options)
+	if err != nil {
+		return Installation{}, err
+	}
+	if err := requirePrivateDirectory(options.DataDir); err != nil {
+		return Installation{}, fmt.Errorf("data directory: %w", err)
+	}
+	if err := requirePrivateDirectory(options.BackupDir); err != nil {
+		return Installation{}, fmt.Errorf("backup directory: %w", err)
+	}
+	dataInfo, dataErr := os.Stat(options.DataDir)
+	backupInfo, backupErr := os.Stat(options.BackupDir)
+	overlaps, overlapErr := canonicalDirectoriesOverlap(options.DataDir, options.BackupDir)
+	if dataErr != nil || backupErr != nil || overlapErr != nil || os.SameFile(dataInfo, backupInfo) || overlaps {
+		return Installation{}, errors.New("data and backup directories must be separate non-overlapping locations")
+	}
+	if _, err := punaropostgres.ReadDSNFile(options.OwnerDSNFile); err != nil {
+		return Installation{}, fmt.Errorf("owner DSN file: %w", err)
+	}
+	if _, err := punaropostgres.ReadDSNFile(options.AppDSNFile); err != nil {
+		return Installation{}, fmt.Errorf("application DSN file: %w", err)
+	}
+	daemonOverlap, daemonOverlapErr := daemonWritableOverlap(options.DataDir, options.Directory, options.OwnerDSNFile, options.AppDSNFile, false)
+	if daemonOverlapErr != nil || daemonOverlap {
+		return Installation{}, errors.New("daemon-writable data directory must not contain database credentials or operator state")
+	}
+	ownerInfo, ownerErr := os.Stat(options.OwnerDSNFile)
+	appInfo, appErr := os.Stat(options.AppDSNFile)
+	if ownerErr != nil || appErr != nil || os.SameFile(ownerInfo, appInfo) {
+		return Installation{}, errors.New("owner and application DSN files must be distinct")
+	}
+	uid, gid, err := runtimeIdentity()
+	if err != nil {
+		return Installation{}, err
+	}
+	installation.RuntimeUID = uid
+	installation.RuntimeGID = gid
+	return installation, nil
+}
+
+func validateStatic(options InitOptions) (Installation, error) {
+	for _, path := range []string{options.Directory, options.DataDir, options.BackupDir, options.OwnerDSNFile, options.AppDSNFile} {
+		if !filepath.IsAbs(path) || !safeEnvPath(path) {
+			return Installation{}, errors.New("installation paths must be absolute and single-line")
+		}
+	}
+	if filepath.Clean(options.DataDir) == filepath.Clean(options.BackupDir) || strings.TrimSpace(options.OwnerName) == "" || strings.ContainsAny(options.OwnerName, "\r\n") {
+		return Installation{}, errors.New("data, backup, and owner inputs are invalid")
+	}
+	if !validImageDigest(options.Image) {
+		return Installation{}, errors.New("image must be an explicit repository reference pinned by sha256 digest")
+	}
+	for _, value := range []string{options.Ingress.ListenAddr, options.Ingress.PublicURL, options.Ingress.TrustedLAN} {
+		if strings.ContainsAny(value, " \t\r\n#$'\"\\") {
+			return Installation{}, errors.New("ingress values contain characters unsafe for generated configuration")
+		}
+	}
+	policy := options.Ingress
+	if err := policy.Validate(); err != nil {
+		return Installation{}, err
+	}
+	return Installation{Version: 1, Directory: options.Directory, DataDir: options.DataDir, BackupDir: options.BackupDir, Image: options.Image, OwnerDSNFile: options.OwnerDSNFile, AppDSNFile: options.AppDSNFile, OwnerName: options.OwnerName, Ingress: policy, HealthURL: localURL(policy.ListenAddr)}, nil
+}
+
+// Load reads only a completely published installation marker.
+func Load(directory string) (Installation, error) {
+	if !filepath.IsAbs(directory) {
+		return Installation{}, errors.New("installation directory must be absolute")
+	}
+	info, err := os.Lstat(directory)
+	if err != nil || !info.IsDir() || info.Mode()&os.ModeSymlink != 0 {
+		return Installation{}, errors.New("installation directory is unavailable")
+	}
+	path := filepath.Join(directory, configName)
+	if err := requireProtectedFile(path, 64<<10); err != nil {
+		return Installation{}, errors.New("published installation configuration is unavailable or unsafe")
+	}
+	installation, err := readInstallation(path)
+	if err != nil {
+		return Installation{}, errors.New("published installation configuration is corrupt")
+	}
+	if installation.Version != 1 || uuid.Validate(installation.OwnerPrincipalID) != nil || !numericIdentity(installation.RuntimeUID) || !numericIdentity(installation.RuntimeGID) {
+		return Installation{}, errors.New("published installation configuration is corrupt")
+	}
+	if _, err := validateStatic(InitOptions{Directory: directory, DataDir: installation.DataDir, BackupDir: installation.BackupDir, Image: installation.Image, OwnerDSNFile: installation.OwnerDSNFile, AppDSNFile: installation.AppDSNFile, OwnerName: installation.OwnerName, Ingress: installation.Ingress}); err != nil {
+		return Installation{}, errors.New("published installation configuration is invalid")
+	}
+	if installation.HealthURL != localURL(installation.Ingress.ListenAddr) {
+		return Installation{}, errors.New("published installation health URL is invalid")
+	}
+	installation.Directory = directory
+	return installation, nil
+}
+
+func readInstallation(path string) (Installation, error) {
+	if err := requireProtectedFile(path, 64<<10); err != nil {
+		return Installation{}, err
+	}
+	file, err := os.Open(path) // #nosec G304 -- fixed file below an explicit private installation directory.
+	if err != nil {
+		return Installation{}, err
+	}
+	defer func() { _ = file.Close() }()
+	decoder := json.NewDecoder(io.LimitReader(file, 64<<10))
+	decoder.DisallowUnknownFields()
+	var installation Installation
+	if err := decoder.Decode(&installation); err != nil {
+		return Installation{}, err
+	}
+	if err := ensureJSONEOF(decoder); err != nil {
+		return Installation{}, err
+	}
+	return installation, nil
+}
+
+func ensureJSONEOF(decoder *json.Decoder) error {
+	var extra any
+	if err := decoder.Decode(&extra); !errors.Is(err, io.EOF) {
+		return errors.New("trailing JSON")
+	}
+	return nil
+}
+
+func writeExclusiveJSON(path string, value any) error {
+	body, err := json.MarshalIndent(value, "", "  ")
+	if err != nil {
+		return err
+	}
+	body = append(body, '\n')
+	return writeExclusive(path, body)
+}
+
+func writeExclusive(path string, body []byte) error {
+	file, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600) // #nosec G304 -- validated installation-local output.
+	if err != nil {
+		return err
+	}
+	if _, err := file.Write(body); err != nil {
+		_ = file.Close()
+		return err
+	}
+	if err := file.Sync(); err != nil {
+		_ = file.Close()
+		return err
+	}
+	return file.Close()
+}
+
+func requirePrivateDirectory(path string) error {
+	info, err := os.Lstat(path)
+	if err != nil || !info.IsDir() || info.Mode()&os.ModeSymlink != 0 || (runtime.GOOS != "windows" && info.Mode().Perm()&0o077 != 0) {
+		return errors.New("must be an existing non-symlink directory inaccessible to group and other")
+	}
+	return nil
+}
+
+func requireProtectedFile(path string, maximum int64) error {
+	info, err := os.Lstat(path)
+	if err != nil || !info.Mode().IsRegular() || info.Size() > maximum || (runtime.GOOS != "windows" && info.Mode().Perm()&0o077 != 0) {
+		return errors.New("must be a regular file inaccessible to group and other")
+	}
+	return nil
+}
+
+// CheckPaths returns actionable, content-free failures for installation paths.
+func CheckPaths(installation Installation) []string {
+	var failures []string
+	if err := requirePrivateDirectory(installation.DataDir); err != nil {
+		failures = append(failures, "data directory unavailable or unsafe")
+	}
+	if err := requirePrivateDirectory(installation.BackupDir); err != nil {
+		failures = append(failures, "backup directory unavailable or unsafe")
+	}
+	if overlaps, err := canonicalDirectoriesOverlap(installation.DataDir, installation.BackupDir); err == nil && overlaps {
+		failures = append(failures, "data and backup directories overlap")
+	}
+	if _, err := punaropostgres.ReadDSNFile(installation.OwnerDSNFile); err != nil {
+		failures = append(failures, "owner DSN file unavailable or unsafe")
+	}
+	if _, err := punaropostgres.ReadDSNFile(installation.AppDSNFile); err != nil {
+		failures = append(failures, "application DSN file unavailable or unsafe")
+	}
+	if overlaps, err := daemonWritableOverlap(installation.DataDir, installation.Directory, installation.OwnerDSNFile, installation.AppDSNFile, true); err == nil && overlaps {
+		failures = append(failures, "daemon-writable data directory overlaps database credentials or operator state")
+	}
+	envPath := EnvFile(installation.Directory)
+	if err := requireProtectedFile(envPath, 64<<10); err != nil {
+		failures = append(failures, "generated daemon environment unavailable or unsafe")
+	} else {
+		// #nosec G304 -- fixed generated file below the explicit validated installation directory.
+		body, err := os.ReadFile(envPath)
+		if err != nil || string(body) != daemonEnv(installation) {
+			failures = append(failures, "generated daemon environment does not match installation configuration")
+		}
+	}
+	overridePath := OverrideFile(installation.Directory)
+	if err := requireProtectedFile(overridePath, 64<<10); err != nil {
+		failures = append(failures, "generated Compose override unavailable or unsafe")
+	} else {
+		// #nosec G304 -- fixed generated file below the explicit validated installation directory.
+		body, err := os.ReadFile(overridePath)
+		if err != nil || string(body) != composeOverride() {
+			failures = append(failures, "generated Compose override does not match installation configuration")
+		}
+	}
+	return failures
+}
+
+func syncDirectory(path string) error {
+	directory, err := os.Open(path) // #nosec G304 -- explicit validated installation directory.
+	if err != nil {
+		return err
+	}
+	defer func() { _ = directory.Close() }()
+	return directory.Sync()
+}
+
+func localURL(listenAddr string) string {
+	return (&url.URL{Scheme: "http", Host: listenAddr}).String()
+}
+
+func daemonEnv(installation Installation) string {
+	return strings.Join([]string{
+		"PUNARO_IMAGE=" + installation.Image,
+		"PUNARO_HOST_DATA_DIR=" + installation.DataDir,
+		"PUNARO_DATA_DIR=/var/lib/punaro",
+		"PUNARO_LISTEN_ADDR=" + installation.Ingress.ListenAddr,
+		"PUNARO_POSTGRES_ENABLED=true",
+		"PUNARO_POSTGRES_DSN_FILE=" + installation.AppDSNFile,
+		"PUNARO_DEVICE_AUTH_ENABLED=true",
+		"PUNARO_INGRESS_MODE=" + string(installation.Ingress.Mode),
+		"PUNARO_PUBLIC_URL=" + installation.Ingress.PublicURL,
+		"PUNARO_TRUSTED_LAN_CIDR=" + installation.Ingress.TrustedLAN,
+		fmt.Sprintf("PUNARO_TRUSTED_LAN_HTTP=%t", installation.Ingress.AllowPlaintext),
+		"PUNARO_RUNTIME_UID=" + installation.RuntimeUID,
+		"PUNARO_RUNTIME_GID=" + installation.RuntimeGID,
+	}, "\n") + "\n"
+}
+
+func composeOverride() string {
+	return `services:
+  punarod:
+    image: ${PUNARO_IMAGE:?required}
+    init: true
+    network_mode: host
+    user: ${PUNARO_RUNTIME_UID:?required}:${PUNARO_RUNTIME_GID:?required}
+    read_only: true
+    cap_drop:
+      - ALL
+    security_opt:
+      - no-new-privileges:true
+    tmpfs:
+      - /tmp:mode=1777,noexec,nosuid,nodev
+    restart: unless-stopped
+    environment:
+      PUNARO_DATA_DIR: /var/lib/punaro
+      PUNARO_LISTEN_ADDR: ${PUNARO_LISTEN_ADDR:?required}
+      PUNARO_POSTGRES_ENABLED: ${PUNARO_POSTGRES_ENABLED:?required}
+      PUNARO_POSTGRES_DSN_FILE: ${PUNARO_POSTGRES_DSN_FILE:?required}
+      PUNARO_DEVICE_AUTH_ENABLED: ${PUNARO_DEVICE_AUTH_ENABLED:?required}
+      PUNARO_INGRESS_MODE: ${PUNARO_INGRESS_MODE:?required}
+      PUNARO_PUBLIC_URL: ${PUNARO_PUBLIC_URL:-}
+      PUNARO_TRUSTED_LAN_CIDR: ${PUNARO_TRUSTED_LAN_CIDR:-}
+      PUNARO_TRUSTED_LAN_HTTP: ${PUNARO_TRUSTED_LAN_HTTP:?required}
+    volumes:
+      - type: bind
+        source: ${PUNARO_HOST_DATA_DIR:?required}
+        target: /var/lib/punaro
+      - type: bind
+        source: ${PUNARO_POSTGRES_DSN_FILE:?required}
+        target: ${PUNARO_POSTGRES_DSN_FILE:?required}
+        read_only: true
+`
+}
+
+func numericIdentity(value string) bool {
+	parsed, err := strconv.ParseUint(value, 10, 32)
+	return err == nil && parsed > 0 && strconv.FormatUint(parsed, 10) == value
+}
+
+func safeEnvPath(value string) bool {
+	if value == "" {
+		return false
+	}
+	for _, char := range value {
+		if (char >= 'a' && char <= 'z') || (char >= 'A' && char <= 'Z') || (char >= '0' && char <= '9') || strings.ContainsRune("/._-+@", char) {
+			continue
+		}
+		return false
+	}
+	return true
+}
+
+func nestedPath(parent, child string) bool {
+	relative, err := filepath.Rel(filepath.Clean(parent), filepath.Clean(child))
+	return err == nil && relative != "." && relative != ".." && !strings.HasPrefix(relative, ".."+string(filepath.Separator))
+}
+
+func canonicalDirectoriesOverlap(first, second string) (bool, error) {
+	canonicalFirst, err := filepath.EvalSymlinks(first)
+	if err != nil {
+		return false, err
+	}
+	canonicalSecond, err := filepath.EvalSymlinks(second)
+	if err != nil {
+		return false, err
+	}
+	return filepath.Clean(canonicalFirst) == filepath.Clean(canonicalSecond) || nestedPath(canonicalFirst, canonicalSecond) || nestedPath(canonicalSecond, canonicalFirst), nil
+}
+
+func daemonWritableOverlap(dataDir, directory, ownerDSNFile, appDSNFile string, directoryExists bool) (bool, error) {
+	canonicalData, err := filepath.EvalSymlinks(dataDir)
+	if err != nil {
+		return false, err
+	}
+	canonicalDirectory := ""
+	if directoryExists {
+		canonicalDirectory, err = filepath.EvalSymlinks(directory)
+	} else {
+		var canonicalParent string
+		canonicalParent, err = filepath.EvalSymlinks(filepath.Dir(filepath.Clean(directory)))
+		canonicalDirectory = filepath.Join(canonicalParent, filepath.Base(filepath.Clean(directory)))
+	}
+	if err != nil {
+		return false, err
+	}
+	canonicalOwner, err := filepath.EvalSymlinks(ownerDSNFile)
+	if err != nil {
+		return false, err
+	}
+	canonicalApp, err := filepath.EvalSymlinks(appDSNFile)
+	if err != nil {
+		return false, err
+	}
+	for _, protectedPath := range []string{canonicalDirectory, canonicalOwner, canonicalApp} {
+		if filepath.Clean(canonicalData) == filepath.Clean(protectedPath) || nestedPath(canonicalData, protectedPath) {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func validImageDigest(value string) bool {
+	repository, digest, found := strings.Cut(value, "@sha256:")
+	if !found || !imageRepositoryPattern.MatchString(repository) || len(digest) != 64 {
+		return false
+	}
+	for _, char := range digest {
+		if (char < '0' || char > '9') && (char < 'a' || char > 'f') {
+			return false
+		}
+	}
+	return true
+}
+
+var imageRepositoryPattern = regexp.MustCompile(`^(?:(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?)(?:\.(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?))*(?::[0-9]+)?/)?[a-z0-9]+(?:(?:[._]|__|-+)[a-z0-9]+)*(?:/[a-z0-9]+(?:(?:[._]|__|-+)[a-z0-9]+)*)*$`)
+
+// UpAction is the only allowed pre-start transition for one schema state.
+type UpAction string
+
+const (
+	// StartCompatible permits startup without changing the schema.
+	StartCompatible UpAction = "start_compatible"
+	// RefuseAndUpdate directs the operator to the explicit update workflow.
+	RefuseAndUpdate UpAction = "refuse_and_update"
+	// RefuseAndRecover directs the operator to documented recovery.
+	RefuseAndRecover UpAction = "refuse_and_recover"
+)
+
+// DecideUp ensures ordinary startup never upgrades an existing schema.
+func DecideUp(state punaropostgres.SchemaState) UpAction {
+	switch state.Classification {
+	case punaropostgres.Compatible:
+		return StartCompatible
+	case punaropostgres.UpgradeRequired:
+		return RefuseAndUpdate
+	default:
+		return RefuseAndRecover
+	}
+}

--- a/internal/operator/installation.go
+++ b/internal/operator/installation.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -21,10 +22,11 @@ import (
 )
 
 const (
-	configName   = "installation.json"
-	pendingName  = ".installation.pending.json"
-	envName      = "punarod.env"
-	overrideName = "compose.operator.yaml"
+	configName              = "installation.json"
+	pendingName             = ".installation.pending.json"
+	envName                 = "punarod.env"
+	overrideName            = "compose.operator.yaml"
+	defaultHealthListenAddr = "127.0.0.1:8081"
 )
 
 // EnvFile returns the generated daemon dotenv path for one installation.
@@ -48,19 +50,21 @@ type Installation struct {
 	RuntimeUID       string         `json:"runtime_uid"`
 	RuntimeGID       string         `json:"runtime_gid"`
 	Ingress          ingress.Policy `json:"ingress"`
+	HealthListenAddr string         `json:"health_listen_addr"`
 	HealthURL        string         `json:"health_url"`
 }
 
 // InitOptions is the complete explicit input to a first installation.
 type InitOptions struct {
-	Directory    string
-	DataDir      string
-	BackupDir    string
-	Image        string
-	OwnerDSNFile string
-	AppDSNFile   string
-	OwnerName    string
-	Ingress      ingress.Policy
+	Directory        string
+	DataDir          string
+	BackupDir        string
+	Image            string
+	OwnerDSNFile     string
+	AppDSNFile       string
+	OwnerName        string
+	Ingress          ingress.Policy
+	HealthListenAddr string
 }
 
 // BootstrapOwner is the only database mutation performed by Init.
@@ -160,7 +164,7 @@ func Resume(ctx context.Context, directory string, recoverOwner RecoverOwner) (I
 		return Installation{}, errors.New("initialization staging configuration is corrupt")
 	}
 	installation.Directory = directory
-	if _, err := validateStatic(InitOptions{Directory: directory, DataDir: installation.DataDir, BackupDir: installation.BackupDir, Image: installation.Image, OwnerDSNFile: installation.OwnerDSNFile, AppDSNFile: installation.AppDSNFile, OwnerName: installation.OwnerName, Ingress: installation.Ingress}); err != nil {
+	if _, err := validateStatic(InitOptions{Directory: directory, DataDir: installation.DataDir, BackupDir: installation.BackupDir, Image: installation.Image, OwnerDSNFile: installation.OwnerDSNFile, AppDSNFile: installation.AppDSNFile, OwnerName: installation.OwnerName, Ingress: installation.Ingress, HealthListenAddr: installation.HealthListenAddr}); err != nil {
 		return Installation{}, errors.New("initialization staging configuration is invalid")
 	}
 	if failures := CheckPaths(installation); len(failures) != 0 {
@@ -250,7 +254,14 @@ func validateStatic(options InitOptions) (Installation, error) {
 	if err := policy.Validate(); err != nil {
 		return Installation{}, err
 	}
-	return Installation{Version: 1, Directory: options.Directory, DataDir: options.DataDir, BackupDir: options.BackupDir, Image: options.Image, OwnerDSNFile: options.OwnerDSNFile, AppDSNFile: options.AppDSNFile, OwnerName: options.OwnerName, Ingress: policy, HealthURL: localURL(policy.ListenAddr)}, nil
+	healthListenAddr := options.HealthListenAddr
+	if healthListenAddr == "" {
+		healthListenAddr = defaultHealthListenAddr
+	}
+	if !loopbackListener(healthListenAddr) || sameListener(policy.ListenAddr, healthListenAddr) {
+		return Installation{}, errors.New("health listener must be a distinct concrete loopback address")
+	}
+	return Installation{Version: 1, Directory: options.Directory, DataDir: options.DataDir, BackupDir: options.BackupDir, Image: options.Image, OwnerDSNFile: options.OwnerDSNFile, AppDSNFile: options.AppDSNFile, OwnerName: options.OwnerName, Ingress: policy, HealthListenAddr: healthListenAddr, HealthURL: localURL(healthListenAddr)}, nil
 }
 
 // Load reads only a completely published installation marker.
@@ -258,8 +269,7 @@ func Load(directory string) (Installation, error) {
 	if !filepath.IsAbs(directory) {
 		return Installation{}, errors.New("installation directory must be absolute")
 	}
-	info, err := os.Lstat(directory)
-	if err != nil || !info.IsDir() || info.Mode()&os.ModeSymlink != 0 {
+	if err := requirePrivateDirectory(directory); err != nil {
 		return Installation{}, errors.New("installation directory is unavailable")
 	}
 	path := filepath.Join(directory, configName)
@@ -273,10 +283,11 @@ func Load(directory string) (Installation, error) {
 	if installation.Version != 1 || uuid.Validate(installation.OwnerPrincipalID) != nil || !numericIdentity(installation.RuntimeUID) || !numericIdentity(installation.RuntimeGID) {
 		return Installation{}, errors.New("published installation configuration is corrupt")
 	}
-	if _, err := validateStatic(InitOptions{Directory: directory, DataDir: installation.DataDir, BackupDir: installation.BackupDir, Image: installation.Image, OwnerDSNFile: installation.OwnerDSNFile, AppDSNFile: installation.AppDSNFile, OwnerName: installation.OwnerName, Ingress: installation.Ingress}); err != nil {
+	validated, err := validateStatic(InitOptions{Directory: directory, DataDir: installation.DataDir, BackupDir: installation.BackupDir, Image: installation.Image, OwnerDSNFile: installation.OwnerDSNFile, AppDSNFile: installation.AppDSNFile, OwnerName: installation.OwnerName, Ingress: installation.Ingress, HealthListenAddr: installation.HealthListenAddr})
+	if err != nil {
 		return Installation{}, errors.New("published installation configuration is invalid")
 	}
-	if installation.HealthURL != localURL(installation.Ingress.ListenAddr) {
+	if installation.HealthListenAddr != validated.HealthListenAddr || installation.HealthURL != validated.HealthURL {
 		return Installation{}, errors.New("published installation health URL is invalid")
 	}
 	installation.Directory = directory
@@ -356,6 +367,9 @@ func requireProtectedFile(path string, maximum int64) error {
 // CheckPaths returns actionable, content-free failures for installation paths.
 func CheckPaths(installation Installation) []string {
 	var failures []string
+	if err := requirePrivateDirectory(installation.Directory); err != nil {
+		failures = append(failures, "installation directory unavailable or unsafe")
+	}
 	if err := requirePrivateDirectory(installation.DataDir); err != nil {
 		failures = append(failures, "data directory unavailable or unsafe")
 	}
@@ -410,12 +424,37 @@ func localURL(listenAddr string) string {
 	return (&url.URL{Scheme: "http", Host: listenAddr}).String()
 }
 
+func loopbackListener(address string) bool {
+	ip, _, ok := listenerEndpoint(address)
+	return ok && ip.IsLoopback()
+}
+
+func sameListener(first, second string) bool {
+	firstIP, firstPort, firstOK := listenerEndpoint(first)
+	secondIP, secondPort, secondOK := listenerEndpoint(second)
+	return firstOK && secondOK && firstIP.Equal(secondIP) && firstPort == secondPort
+}
+
+func listenerEndpoint(address string) (net.IP, uint16, bool) {
+	host, portText, err := net.SplitHostPort(address)
+	if err != nil {
+		return nil, 0, false
+	}
+	ip := net.ParseIP(host)
+	port, err := strconv.ParseUint(portText, 10, 16)
+	if ip == nil || err != nil || port == 0 || portText != strconv.FormatUint(port, 10) {
+		return nil, 0, false
+	}
+	return ip, uint16(port), true
+}
+
 func daemonEnv(installation Installation) string {
 	return strings.Join([]string{
 		"PUNARO_IMAGE=" + installation.Image,
 		"PUNARO_HOST_DATA_DIR=" + installation.DataDir,
 		"PUNARO_DATA_DIR=/var/lib/punaro",
 		"PUNARO_LISTEN_ADDR=" + installation.Ingress.ListenAddr,
+		"PUNARO_HEALTH_LISTEN_ADDR=" + installation.HealthListenAddr,
 		"PUNARO_POSTGRES_ENABLED=true",
 		"PUNARO_POSTGRES_DSN_FILE=" + installation.AppDSNFile,
 		"PUNARO_DEVICE_AUTH_ENABLED=true",
@@ -446,6 +485,7 @@ func composeOverride() string {
     environment:
       PUNARO_DATA_DIR: /var/lib/punaro
       PUNARO_LISTEN_ADDR: ${PUNARO_LISTEN_ADDR:?required}
+      PUNARO_HEALTH_LISTEN_ADDR: ${PUNARO_HEALTH_LISTEN_ADDR:?required}
       PUNARO_POSTGRES_ENABLED: ${PUNARO_POSTGRES_ENABLED:?required}
       PUNARO_POSTGRES_DSN_FILE: ${PUNARO_POSTGRES_DSN_FILE:?required}
       PUNARO_DEVICE_AUTH_ENABLED: ${PUNARO_DEVICE_AUTH_ENABLED:?required}

--- a/internal/operator/installation.go
+++ b/internal/operator/installation.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"net"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -18,6 +17,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/rock3r/punaro/internal/ingress"
+	"github.com/rock3r/punaro/internal/listener"
 	punaropostgres "github.com/rock3r/punaro/internal/postgres"
 )
 
@@ -258,7 +258,7 @@ func validateStatic(options InitOptions) (Installation, error) {
 	if healthListenAddr == "" {
 		healthListenAddr = defaultHealthListenAddr
 	}
-	if !loopbackListener(healthListenAddr) || sameListener(policy.ListenAddr, healthListenAddr) {
+	if !listener.IsLoopback(healthListenAddr) || listener.Same(policy.ListenAddr, healthListenAddr) {
 		return Installation{}, errors.New("health listener must be a distinct concrete loopback address")
 	}
 	return Installation{Version: 1, Directory: options.Directory, DataDir: options.DataDir, BackupDir: options.BackupDir, Image: options.Image, OwnerDSNFile: options.OwnerDSNFile, AppDSNFile: options.AppDSNFile, OwnerName: options.OwnerName, Ingress: policy, HealthListenAddr: healthListenAddr, HealthURL: localURL(healthListenAddr)}, nil
@@ -422,30 +422,6 @@ func syncDirectory(path string) error {
 
 func localURL(listenAddr string) string {
 	return (&url.URL{Scheme: "http", Host: listenAddr}).String()
-}
-
-func loopbackListener(address string) bool {
-	ip, _, ok := listenerEndpoint(address)
-	return ok && ip.IsLoopback()
-}
-
-func sameListener(first, second string) bool {
-	firstIP, firstPort, firstOK := listenerEndpoint(first)
-	secondIP, secondPort, secondOK := listenerEndpoint(second)
-	return firstOK && secondOK && firstIP.Equal(secondIP) && firstPort == secondPort
-}
-
-func listenerEndpoint(address string) (net.IP, uint16, bool) {
-	host, portText, err := net.SplitHostPort(address)
-	if err != nil {
-		return nil, 0, false
-	}
-	ip := net.ParseIP(host)
-	port, err := strconv.ParseUint(portText, 10, 16)
-	if ip == nil || err != nil || port == 0 || portText != strconv.FormatUint(port, 10) {
-		return nil, 0, false
-	}
-	return ip, uint16(port), true
 }
 
 func daemonEnv(installation Installation) string {

--- a/internal/operator/installation.go
+++ b/internal/operator/installation.go
@@ -258,8 +258,8 @@ func validateInit(options InitOptions) (Installation, error) {
 
 func validateStatic(options InitOptions) (Installation, error) {
 	for _, path := range []string{options.Directory, options.DataDir, options.BackupDir, options.OwnerDSNFile, options.AppDSNFile} {
-		if !filepath.IsAbs(path) || !safeEnvPath(path) {
-			return Installation{}, errors.New("installation paths must be absolute and single-line")
+		if !filepath.IsAbs(path) || filepath.Clean(path) != path || !safeEnvPath(path) {
+			return Installation{}, errors.New("installation paths must be absolute, canonical, and single-line")
 		}
 	}
 	if filepath.Clean(options.DataDir) == filepath.Clean(options.BackupDir) || strings.TrimSpace(options.OwnerName) == "" || strings.ContainsAny(options.OwnerName, "\r\n") {
@@ -595,8 +595,8 @@ type UpAction string
 const (
 	// StartCompatible permits startup without changing the schema.
 	StartCompatible UpAction = "start_compatible"
-	// RefuseAndUpdate directs the operator to the explicit update workflow.
-	RefuseAndUpdate UpAction = "refuse_and_update"
+	// RefuseUpgradeRequired keeps this staged release from migrating in place.
+	RefuseUpgradeRequired UpAction = "refuse_upgrade_required"
 	// RefuseAndRecover directs the operator to documented recovery.
 	RefuseAndRecover UpAction = "refuse_and_recover"
 )
@@ -607,7 +607,7 @@ func DecideUp(state punaropostgres.SchemaState) UpAction {
 	case punaropostgres.Compatible:
 		return StartCompatible
 	case punaropostgres.UpgradeRequired:
-		return RefuseAndUpdate
+		return RefuseUpgradeRequired
 	default:
 		return RefuseAndRecover
 	}

--- a/internal/operator/installation.go
+++ b/internal/operator/installation.go
@@ -35,6 +35,16 @@ func EnvFile(directory string) string { return filepath.Join(directory, envName)
 // OverrideFile returns the generated immutable-image Compose file.
 func OverrideFile(directory string) string { return filepath.Join(directory, overrideName) }
 
+// ComposeProjectName returns the stable, installation-specific Docker Compose
+// project name derived from the persisted and database-verified owner identity.
+func ComposeProjectName(installation Installation) (string, error) {
+	ownerID, err := uuid.Parse(installation.OwnerPrincipalID)
+	if err != nil {
+		return "", errors.New("installation owner identity is invalid")
+	}
+	return "punaro-" + strings.ReplaceAll(ownerID.String(), "-", ""), nil
+}
+
 // Installation is the content-free operator configuration. DSN values remain
 // in separately protected files and are never copied here.
 type Installation struct {
@@ -89,6 +99,10 @@ func Init(ctx context.Context, options InitOptions, bootstrap BootstrapOwner) (I
 	}
 	if err := os.Mkdir(options.Directory, 0o700); err != nil {
 		return Installation{}, errors.New("installation directory must be new")
+	}
+	if err := requireTrustedPrivateDirectory(options.Directory); err != nil {
+		_ = os.Remove(options.Directory)
+		return Installation{}, errors.New("installation directory must have trusted ancestors")
 	}
 	preserveStage := false
 	defer func() {
@@ -155,12 +169,12 @@ func Resume(ctx context.Context, directory string, recoverOwner RecoverOwner) (I
 		}
 		return installation, nil
 	}
-	if err := requirePrivateDirectory(directory); err != nil {
+	if err := requireTrustedPrivateDirectory(directory); err != nil {
 		return Installation{}, errors.New("initialization staging directory is unavailable or unsafe")
 	}
 	pendingPath := filepath.Join(directory, pendingName)
 	installation, err := readInstallation(pendingPath)
-	if err != nil || installation.Version != 1 || installation.OwnerPrincipalID != "" || !numericIdentity(installation.RuntimeUID) || !numericIdentity(installation.RuntimeGID) {
+	if err != nil || installation.Version != 1 || installation.OwnerPrincipalID != "" || !numericIdentity(installation.RuntimeUID) || !numericIdentity(installation.RuntimeGID) || !runtimeIdentityMatches(installation) {
 		return Installation{}, errors.New("initialization staging configuration is corrupt")
 	}
 	installation.Directory = directory
@@ -197,10 +211,13 @@ func validateInit(options InitOptions) (Installation, error) {
 	if err != nil {
 		return Installation{}, err
 	}
-	if err := requirePrivateDirectory(options.DataDir); err != nil {
+	if err := requireTrustedDirectoryAncestors(filepath.Dir(options.Directory)); err != nil {
+		return Installation{}, errors.New("installation parent path is unavailable or unsafe")
+	}
+	if err := requireTrustedPrivateDirectory(options.DataDir); err != nil {
 		return Installation{}, fmt.Errorf("data directory: %w", err)
 	}
-	if err := requirePrivateDirectory(options.BackupDir); err != nil {
+	if err := requireTrustedPrivateDirectory(options.BackupDir); err != nil {
 		return Installation{}, fmt.Errorf("backup directory: %w", err)
 	}
 	dataInfo, dataErr := os.Stat(options.DataDir)
@@ -209,8 +226,14 @@ func validateInit(options InitOptions) (Installation, error) {
 	if dataErr != nil || backupErr != nil || overlapErr != nil || os.SameFile(dataInfo, backupInfo) || overlaps {
 		return Installation{}, errors.New("data and backup directories must be separate non-overlapping locations")
 	}
+	if err := requireTrustedProtectedFile(options.OwnerDSNFile, 64<<10); err != nil {
+		return Installation{}, fmt.Errorf("owner DSN file: %w", err)
+	}
 	if _, err := punaropostgres.ReadDSNFile(options.OwnerDSNFile); err != nil {
 		return Installation{}, fmt.Errorf("owner DSN file: %w", err)
+	}
+	if err := requireTrustedProtectedFile(options.AppDSNFile, 64<<10); err != nil {
+		return Installation{}, fmt.Errorf("application DSN file: %w", err)
 	}
 	if _, err := punaropostgres.ReadDSNFile(options.AppDSNFile); err != nil {
 		return Installation{}, fmt.Errorf("application DSN file: %w", err)
@@ -269,18 +292,18 @@ func Load(directory string) (Installation, error) {
 	if !filepath.IsAbs(directory) {
 		return Installation{}, errors.New("installation directory must be absolute")
 	}
-	if err := requirePrivateDirectory(directory); err != nil {
+	if err := requireTrustedPrivateDirectory(directory); err != nil {
 		return Installation{}, errors.New("installation directory is unavailable")
 	}
 	path := filepath.Join(directory, configName)
-	if err := requireProtectedFile(path, 64<<10); err != nil {
+	if err := requireTrustedProtectedFile(path, 64<<10); err != nil {
 		return Installation{}, errors.New("published installation configuration is unavailable or unsafe")
 	}
 	installation, err := readInstallation(path)
 	if err != nil {
 		return Installation{}, errors.New("published installation configuration is corrupt")
 	}
-	if installation.Version != 1 || uuid.Validate(installation.OwnerPrincipalID) != nil || !numericIdentity(installation.RuntimeUID) || !numericIdentity(installation.RuntimeGID) {
+	if installation.Version != 1 || uuid.Validate(installation.OwnerPrincipalID) != nil || !numericIdentity(installation.RuntimeUID) || !numericIdentity(installation.RuntimeGID) || !runtimeIdentityMatches(installation) {
 		return Installation{}, errors.New("published installation configuration is corrupt")
 	}
 	validated, err := validateStatic(InitOptions{Directory: directory, DataDir: installation.DataDir, BackupDir: installation.BackupDir, Image: installation.Image, OwnerDSNFile: installation.OwnerDSNFile, AppDSNFile: installation.AppDSNFile, OwnerName: installation.OwnerName, Ingress: installation.Ingress, HealthListenAddr: installation.HealthListenAddr})
@@ -295,7 +318,7 @@ func Load(directory string) (Installation, error) {
 }
 
 func readInstallation(path string) (Installation, error) {
-	if err := requireProtectedFile(path, 64<<10); err != nil {
+	if err := requireTrustedProtectedFile(path, 64<<10); err != nil {
 		return Installation{}, err
 	}
 	file, err := os.Open(path) // #nosec G304 -- fixed file below an explicit private installation directory.
@@ -367,29 +390,33 @@ func requireProtectedFile(path string, maximum int64) error {
 // CheckPaths returns actionable, content-free failures for installation paths.
 func CheckPaths(installation Installation) []string {
 	var failures []string
-	if err := requirePrivateDirectory(installation.Directory); err != nil {
+	if err := requireTrustedPrivateDirectory(installation.Directory); err != nil {
 		failures = append(failures, "installation directory unavailable or unsafe")
 	}
-	if err := requirePrivateDirectory(installation.DataDir); err != nil {
+	if err := requireTrustedPrivateDirectory(installation.DataDir); err != nil {
 		failures = append(failures, "data directory unavailable or unsafe")
 	}
-	if err := requirePrivateDirectory(installation.BackupDir); err != nil {
+	if err := requireTrustedPrivateDirectory(installation.BackupDir); err != nil {
 		failures = append(failures, "backup directory unavailable or unsafe")
 	}
 	if overlaps, err := canonicalDirectoriesOverlap(installation.DataDir, installation.BackupDir); err == nil && overlaps {
 		failures = append(failures, "data and backup directories overlap")
 	}
-	if _, err := punaropostgres.ReadDSNFile(installation.OwnerDSNFile); err != nil {
+	if err := requireTrustedProtectedFile(installation.OwnerDSNFile, 64<<10); err != nil {
+		failures = append(failures, "owner DSN file unavailable or unsafe")
+	} else if _, err := punaropostgres.ReadDSNFile(installation.OwnerDSNFile); err != nil {
 		failures = append(failures, "owner DSN file unavailable or unsafe")
 	}
-	if _, err := punaropostgres.ReadDSNFile(installation.AppDSNFile); err != nil {
+	if err := requireTrustedProtectedFile(installation.AppDSNFile, 64<<10); err != nil {
+		failures = append(failures, "application DSN file unavailable or unsafe")
+	} else if _, err := punaropostgres.ReadDSNFile(installation.AppDSNFile); err != nil {
 		failures = append(failures, "application DSN file unavailable or unsafe")
 	}
 	if overlaps, err := daemonWritableOverlap(installation.DataDir, installation.Directory, installation.OwnerDSNFile, installation.AppDSNFile, true); err == nil && overlaps {
 		failures = append(failures, "daemon-writable data directory overlaps database credentials or operator state")
 	}
 	envPath := EnvFile(installation.Directory)
-	if err := requireProtectedFile(envPath, 64<<10); err != nil {
+	if err := requireTrustedProtectedFile(envPath, 64<<10); err != nil {
 		failures = append(failures, "generated daemon environment unavailable or unsafe")
 	} else {
 		// #nosec G304 -- fixed generated file below the explicit validated installation directory.
@@ -399,7 +426,7 @@ func CheckPaths(installation Installation) []string {
 		}
 	}
 	overridePath := OverrideFile(installation.Directory)
-	if err := requireProtectedFile(overridePath, 64<<10); err != nil {
+	if err := requireTrustedProtectedFile(overridePath, 64<<10); err != nil {
 		failures = append(failures, "generated Compose override unavailable or unsafe")
 	} else {
 		// #nosec G304 -- fixed generated file below the explicit validated installation directory.

--- a/internal/operator/installation_test.go
+++ b/internal/operator/installation_test.go
@@ -1,0 +1,305 @@
+package operator
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/rock3r/punaro/internal/ingress"
+	punaropostgres "github.com/rock3r/punaro/internal/postgres"
+)
+
+const testImage = "registry.example/punaro@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+
+func protectedFile(t *testing.T, path string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte("postgres://example.invalid/punaro\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func validInitOptions(t *testing.T) InitOptions {
+	t.Helper()
+	root := t.TempDir()
+	data := filepath.Join(root, "data")
+	backup := filepath.Join(root, "backup")
+	if err := os.Mkdir(data, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(backup, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	ownerDSN := filepath.Join(root, "owner.dsn")
+	appDSN := filepath.Join(root, "app.dsn")
+	protectedFile(t, ownerDSN)
+	protectedFile(t, appDSN)
+	return InitOptions{
+		Directory:    filepath.Join(root, "installation"),
+		DataDir:      data,
+		BackupDir:    backup,
+		Image:        testImage,
+		OwnerDSNFile: ownerDSN,
+		AppDSNFile:   appDSN,
+		OwnerName:    "Primary operator",
+		Ingress:      ingress.Policy{Mode: ingress.Internet, ListenAddr: "127.0.0.1:8080", PublicURL: "https://punaro.example"},
+	}
+}
+
+func TestInitPublishesConfigurationOnlyAfterOwnerBootstrap(t *testing.T) {
+	options := validInitOptions(t)
+	called := false
+	installation, err := Init(context.Background(), options, func(_ context.Context, dsnFile, name string) (punaropostgres.Principal, error) {
+		called = true
+		if dsnFile != options.OwnerDSNFile || name != options.OwnerName {
+			t.Fatalf("dsn=%q name=%q", dsnFile, name)
+		}
+		if _, err := os.Stat(filepath.Join(options.Directory, configName)); !errors.Is(err, os.ErrNotExist) {
+			t.Fatalf("configuration was visible before bootstrap: %v", err)
+		}
+		return punaropostgres.Principal{ID: "11111111-1111-4111-8111-111111111111", DisplayName: name}, nil
+	})
+	if err != nil || !called {
+		t.Fatalf("installation=%#v called=%t err=%v", installation, called, err)
+	}
+	loaded, err := Load(options.Directory)
+	if err != nil || loaded.OwnerPrincipalID != "11111111-1111-4111-8111-111111111111" {
+		t.Fatalf("loaded=%#v err=%v", loaded, err)
+	}
+	info, err := os.Stat(filepath.Join(options.Directory, configName))
+	if err != nil || info.Mode().Perm() != 0o600 {
+		t.Fatalf("config mode=%v err=%v", info.Mode(), err)
+	}
+}
+
+func TestInitFailureAndExistingDestinationAreFailClosed(t *testing.T) {
+	options := validInitOptions(t)
+	if _, err := Init(context.Background(), options, func(context.Context, string, string) (punaropostgres.Principal, error) {
+		return punaropostgres.Principal{}, errors.New("bootstrap failed")
+	}); err == nil {
+		t.Fatal("bootstrap failure was accepted")
+	}
+	if _, err := os.Stat(filepath.Join(options.Directory, configName)); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("uncertain initialization published state: %v", err)
+	}
+	if _, err := Resume(context.Background(), options.Directory, func(_ context.Context, installation Installation) (punaropostgres.Principal, error) {
+		return punaropostgres.Principal{ID: "11111111-1111-4111-8111-111111111111", DisplayName: installation.OwnerName}, nil
+	}); err != nil {
+		t.Fatalf("staged initialization did not recover: %v", err)
+	}
+	called := false
+	if _, err := Init(context.Background(), options, func(context.Context, string, string) (punaropostgres.Principal, error) {
+		called = true
+		return punaropostgres.Principal{}, nil
+	}); err == nil || called {
+		t.Fatalf("existing destination err=%v bootstrapCalled=%t", err, called)
+	}
+}
+
+func TestUpActionNeverMigratesExistingSchema(t *testing.T) {
+	tests := []struct {
+		state punaropostgres.Classification
+		want  UpAction
+	}{
+		{state: punaropostgres.Pristine, want: RefuseAndRecover},
+		{state: punaropostgres.Compatible, want: StartCompatible},
+		{state: punaropostgres.UpgradeRequired, want: RefuseAndUpdate},
+		{state: punaropostgres.Newer, want: RefuseAndRecover},
+		{state: punaropostgres.Dirty, want: RefuseAndRecover},
+		{state: punaropostgres.Incompatible, want: RefuseAndRecover},
+	}
+	for _, test := range tests {
+		if got := DecideUp(punaropostgres.SchemaState{Classification: test.state}); got != test.want {
+			t.Errorf("state=%s action=%s want=%s", test.state, got, test.want)
+		}
+	}
+}
+
+func TestLoadPreservesMissingPathDiagnosticsForDoctor(t *testing.T) {
+	options := validInitOptions(t)
+	if _, err := Init(context.Background(), options, func(context.Context, string, string) (punaropostgres.Principal, error) {
+		return punaropostgres.Principal{ID: "11111111-1111-4111-8111-111111111111"}, nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Remove(options.BackupDir); err != nil {
+		t.Fatal(err)
+	}
+	installation, err := Load(options.Directory)
+	if err != nil {
+		t.Fatalf("missing runtime path hid the published configuration: %v", err)
+	}
+	failures := CheckPaths(installation)
+	if len(failures) != 1 || failures[0] != "backup directory unavailable or unsafe" {
+		t.Fatalf("failures=%v", failures)
+	}
+}
+
+func TestInitRequiresDistinctRoleSecretFiles(t *testing.T) {
+	options := validInitOptions(t)
+	options.AppDSNFile = options.OwnerDSNFile
+	called := false
+	if _, err := Init(context.Background(), options, func(context.Context, string, string) (punaropostgres.Principal, error) {
+		called = true
+		return punaropostgres.Principal{}, nil
+	}); err == nil || called {
+		t.Fatalf("same role file err=%v bootstrapCalled=%t", err, called)
+	}
+}
+
+func TestInitRejectsOverlappingPathsAndUnpinnedImages(t *testing.T) {
+	options := validInitOptions(t)
+	options.BackupDir = filepath.Join(options.DataDir, ".")
+	if _, err := Init(context.Background(), options, func(context.Context, string, string) (punaropostgres.Principal, error) {
+		return punaropostgres.Principal{}, nil
+	}); err == nil {
+		t.Fatal("aliased data and backup directories were accepted")
+	}
+	options = validInitOptions(t)
+	options.Image = "registry.example/punaro:latest"
+	if _, err := Init(context.Background(), options, func(context.Context, string, string) (punaropostgres.Principal, error) {
+		return punaropostgres.Principal{}, nil
+	}); err == nil {
+		t.Fatal("unpinned image was accepted")
+	}
+}
+
+func TestInitRejectsOverlapThroughSymlinkedAncestor(t *testing.T) {
+	options := validInitOptions(t)
+	alias := filepath.Join(filepath.Dir(options.DataDir), "data-alias")
+	if err := os.Symlink(options.DataDir, alias); err != nil {
+		t.Fatal(err)
+	}
+	backup := filepath.Join(alias, "backup")
+	if err := os.Mkdir(backup, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	options.BackupDir = backup
+	called := false
+	if _, err := Init(context.Background(), options, func(context.Context, string, string) (punaropostgres.Principal, error) {
+		called = true
+		return punaropostgres.Principal{}, nil
+	}); err == nil || called {
+		t.Fatalf("symlinked overlap err=%v bootstrapCalled=%t", err, called)
+	}
+}
+
+func TestInitRejectsMalformedPinnedImageReference(t *testing.T) {
+	options := validInitOptions(t)
+	options.Image = "::::@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	called := false
+	if _, err := Init(context.Background(), options, func(context.Context, string, string) (punaropostgres.Principal, error) {
+		called = true
+		return punaropostgres.Principal{}, nil
+	}); err == nil || called {
+		t.Fatalf("malformed image err=%v bootstrapCalled=%t", err, called)
+	}
+}
+
+func TestInitRejectsCredentialsAndOperatorStateBelowData(t *testing.T) {
+	tests := []struct {
+		name   string
+		mutate func(*testing.T, *InitOptions)
+	}{
+		{name: "owner DSN direct", mutate: func(t *testing.T, options *InitOptions) {
+			options.OwnerDSNFile = filepath.Join(options.DataDir, "owner.dsn")
+			protectedFile(t, options.OwnerDSNFile)
+		}},
+		{name: "application DSN through symlinked ancestor", mutate: func(t *testing.T, options *InitOptions) {
+			alias := filepath.Join(filepath.Dir(options.DataDir), "data-alias")
+			if err := os.Symlink(options.DataDir, alias); err != nil {
+				t.Fatal(err)
+			}
+			options.AppDSNFile = filepath.Join(alias, "app.dsn")
+			protectedFile(t, options.AppDSNFile)
+		}},
+		{name: "operator state direct", mutate: func(_ *testing.T, options *InitOptions) {
+			options.Directory = filepath.Join(options.DataDir, "operator")
+		}},
+		{name: "operator state through symlinked ancestor", mutate: func(t *testing.T, options *InitOptions) {
+			alias := filepath.Join(filepath.Dir(options.DataDir), "data-alias")
+			if err := os.Symlink(options.DataDir, alias); err != nil {
+				t.Fatal(err)
+			}
+			options.Directory = filepath.Join(alias, "operator")
+		}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			options := validInitOptions(t)
+			test.mutate(t, &options)
+			called := false
+			if _, err := Init(context.Background(), options, func(context.Context, string, string) (punaropostgres.Principal, error) {
+				called = true
+				return punaropostgres.Principal{}, nil
+			}); err == nil || called {
+				t.Fatalf("unsafe daemon overlap err=%v bootstrapCalled=%t", err, called)
+			}
+		})
+	}
+}
+
+func TestCheckPathsDetectsBackupAncestorRetargetedBelowData(t *testing.T) {
+	options := validInitOptions(t)
+	root := filepath.Dir(options.DataDir)
+	realBackupParent := filepath.Join(root, "real-backup-parent")
+	if err := os.Mkdir(realBackupParent, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	realBackup := filepath.Join(realBackupParent, "backup")
+	if err := os.Mkdir(realBackup, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	alias := filepath.Join(root, "backup-alias")
+	if err := os.Symlink(realBackupParent, alias); err != nil {
+		t.Fatal(err)
+	}
+	options.BackupDir = filepath.Join(alias, "backup")
+	installation, err := Init(context.Background(), options, func(context.Context, string, string) (punaropostgres.Principal, error) {
+		return punaropostgres.Principal{ID: "11111111-1111-4111-8111-111111111111"}, nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(filepath.Join(options.DataDir, "backup"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Remove(alias); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(options.DataDir, alias); err != nil {
+		t.Fatal(err)
+	}
+	failures := CheckPaths(installation)
+	if !containsFailure(failures, "data and backup directories overlap") {
+		t.Fatalf("failures=%v", failures)
+	}
+}
+
+func containsFailure(failures []string, want string) bool {
+	for _, failure := range failures {
+		if failure == want {
+			return true
+		}
+	}
+	return false
+}
+
+func TestGeneratedComposeUsesOnlyPinnedImage(t *testing.T) {
+	options := validInitOptions(t)
+	installation, err := Init(context.Background(), options, func(context.Context, string, string) (punaropostgres.Principal, error) {
+		return punaropostgres.Principal{ID: "11111111-1111-4111-8111-111111111111"}, nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	body, err := os.ReadFile(OverrideFile(installation.Directory))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(body), "image: ${PUNARO_IMAGE:?required}") || strings.Contains(string(body), "build:") {
+		t.Fatalf("generated Compose is not immutable-image-only:\n%s", body)
+	}
+}

--- a/internal/operator/installation_test.go
+++ b/internal/operator/installation_test.go
@@ -107,7 +107,7 @@ func TestUpActionNeverMigratesExistingSchema(t *testing.T) {
 	}{
 		{state: punaropostgres.Pristine, want: RefuseAndRecover},
 		{state: punaropostgres.Compatible, want: StartCompatible},
-		{state: punaropostgres.UpgradeRequired, want: RefuseAndUpdate},
+		{state: punaropostgres.UpgradeRequired, want: RefuseUpgradeRequired},
 		{state: punaropostgres.Newer, want: RefuseAndRecover},
 		{state: punaropostgres.Dirty, want: RefuseAndRecover},
 		{state: punaropostgres.Incompatible, want: RefuseAndRecover},
@@ -310,6 +310,29 @@ func TestInitRejectsUnsafeSensitivePathAncestorsBeforeBootstrap(t *testing.T) {
 	}
 }
 
+func TestLoadAndResumeRejectExistingNonCanonicalInstallationPath(t *testing.T) {
+	options := validInitOptions(t)
+	if _, err := Init(context.Background(), options, func(context.Context, string, string) (punaropostgres.Principal, error) {
+		return punaropostgres.Principal{ID: "11111111-1111-4111-8111-111111111111"}, nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	rawDirectory := options.Directory + string(filepath.Separator) + ".." + string(filepath.Separator) + filepath.Base(options.Directory)
+	if _, err := os.Stat(rawDirectory); err != nil {
+		t.Fatalf("non-canonical path does not resolve to the installation: %v", err)
+	}
+	if _, err := Load(rawDirectory); err == nil {
+		t.Fatal("Load accepted an existing non-canonical installation path")
+	}
+	recovered := false
+	if _, err := Resume(context.Background(), rawDirectory, func(context.Context, Installation) (punaropostgres.Principal, error) {
+		recovered = true
+		return punaropostgres.Principal{}, nil
+	}); err == nil || recovered {
+		t.Fatalf("Resume err=%v recoveryCalled=%t", err, recovered)
+	}
+}
+
 func TestCheckPathsRejectsSensitivePathAncestorPermissionDrift(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("Unix directory trust semantics")
@@ -456,6 +479,38 @@ func TestInitRequiresDistinctRoleSecretFiles(t *testing.T) {
 		return punaropostgres.Principal{}, nil
 	}); err == nil || called {
 		t.Fatalf("same role file err=%v bootstrapCalled=%t", err, called)
+	}
+}
+
+func TestInitRejectsNonCanonicalSensitivePathsBeforeBootstrap(t *testing.T) {
+	for _, kind := range []string{"installation", "data", "backup", "owner DSN", "application DSN"} {
+		t.Run(kind, func(t *testing.T) {
+			options := validInitOptions(t)
+			root := filepath.Dir(options.Directory)
+			nonCanonical := root + string(filepath.Separator) + "alias" + string(filepath.Separator) + ".." + string(filepath.Separator) + "target"
+			switch kind {
+			case "installation":
+				options.Directory = nonCanonical
+			case "data":
+				options.DataDir = nonCanonical
+			case "backup":
+				options.BackupDir = nonCanonical
+			case "owner DSN":
+				options.OwnerDSNFile = nonCanonical
+			case "application DSN":
+				options.AppDSNFile = nonCanonical
+			}
+			if _, err := validateStatic(options); err == nil {
+				t.Fatalf("validateStatic accepted non-canonical %s path", kind)
+			}
+			called := false
+			if _, err := Init(context.Background(), options, func(context.Context, string, string) (punaropostgres.Principal, error) {
+				called = true
+				return punaropostgres.Principal{}, nil
+			}); err == nil || called {
+				t.Fatalf("non-canonical %s path err=%v bootstrapCalled=%t", kind, err, called)
+			}
+		})
 	}
 }
 

--- a/internal/operator/installation_test.go
+++ b/internal/operator/installation_test.go
@@ -137,6 +137,57 @@ func TestLoadPreservesMissingPathDiagnosticsForDoctor(t *testing.T) {
 	}
 }
 
+func TestLoadAndCheckPathsRejectInstallationDirectoryPermissionDrift(t *testing.T) {
+	options := validInitOptions(t)
+	installation, err := Init(context.Background(), options, func(context.Context, string, string) (punaropostgres.Principal, error) {
+		return punaropostgres.Principal{ID: "11111111-1111-4111-8111-111111111111"}, nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// #nosec G302 -- the regression deliberately creates unsafe permission drift.
+	if err := os.Chmod(options.Directory, 0o770); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Load(options.Directory); err == nil {
+		t.Fatal("Load accepted a group-writable installation directory")
+	}
+	if !containsFailure(CheckPaths(installation), "installation directory unavailable or unsafe") {
+		t.Fatalf("failures=%v", CheckPaths(installation))
+	}
+}
+
+func TestGeneratedConfigurationUsesDedicatedLoopbackHealthListener(t *testing.T) {
+	options := validInitOptions(t)
+	installation, err := Init(context.Background(), options, func(context.Context, string, string) (punaropostgres.Principal, error) {
+		return punaropostgres.Principal{ID: "11111111-1111-4111-8111-111111111111"}, nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if installation.HealthListenAddr != "127.0.0.1:8081" || installation.HealthURL != "http://127.0.0.1:8081" {
+		t.Fatalf("health listener=%q URL=%q", installation.HealthListenAddr, installation.HealthURL)
+	}
+	body, err := os.ReadFile(EnvFile(installation.Directory))
+	if err != nil || !strings.Contains(string(body), "PUNARO_HEALTH_LISTEN_ADDR=127.0.0.1:8081\n") {
+		t.Fatalf("env=%q err=%v", body, err)
+	}
+}
+
+func TestInitRejectsInvalidOrAliasingHealthListener(t *testing.T) {
+	for _, address := range []string{"127.0.0.1:0", "127.0.0.1:", "127.0.0.1:http", "127.0.0.1:65536", "127.0.0.1:08080"} {
+		t.Run(address, func(t *testing.T) {
+			options := validInitOptions(t)
+			options.HealthListenAddr = address
+			if _, err := Init(context.Background(), options, func(context.Context, string, string) (punaropostgres.Principal, error) {
+				return punaropostgres.Principal{}, nil
+			}); err == nil {
+				t.Fatalf("health listener accepted %q", address)
+			}
+		})
+	}
+}
+
 func TestInitRequiresDistinctRoleSecretFiles(t *testing.T) {
 	options := validInitOptions(t)
 	options.AppDSNFile = options.OwnerDSNFile

--- a/internal/operator/installation_test.go
+++ b/internal/operator/installation_test.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"regexp"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -157,6 +159,263 @@ func TestLoadAndCheckPathsRejectInstallationDirectoryPermissionDrift(t *testing.
 	}
 }
 
+func TestLoadAndCheckPathsRejectWritableInstallationAncestor(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix directory trust semantics")
+	}
+	options := validInitOptions(t)
+	installation, err := Init(context.Background(), options, func(context.Context, string, string) (punaropostgres.Principal, error) {
+		return punaropostgres.Principal{ID: "11111111-1111-4111-8111-111111111111"}, nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	ancestor := filepath.Dir(options.Directory)
+	// #nosec G302 -- the regression deliberately creates an unsafe ancestor.
+	if err := os.Chmod(ancestor, 0o777); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		// #nosec G302 -- restore the required private directory mode.
+		_ = os.Chmod(ancestor, 0o700)
+	})
+	if _, err := Load(options.Directory); err == nil {
+		t.Fatal("Load accepted an installation below a writable non-sticky ancestor")
+	}
+	if !containsFailure(CheckPaths(installation), "installation directory unavailable or unsafe") {
+		t.Fatalf("failures=%v", CheckPaths(installation))
+	}
+}
+
+func TestInitRejectsWritableInstallationAncestorBeforeBootstrap(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix directory trust semantics")
+	}
+	options := validInitOptions(t)
+	ancestor := filepath.Dir(options.Directory)
+	// #nosec G302 -- the regression deliberately creates an unsafe ancestor.
+	if err := os.Chmod(ancestor, 0o777); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		// #nosec G302 -- restore the required private directory mode.
+		_ = os.Chmod(ancestor, 0o700)
+	})
+	called := false
+	if _, err := Init(context.Background(), options, func(context.Context, string, string) (punaropostgres.Principal, error) {
+		called = true
+		return punaropostgres.Principal{}, nil
+	}); err == nil || called {
+		t.Fatalf("unsafe ancestor err=%v bootstrapCalled=%t", err, called)
+	}
+}
+
+func TestLoadAcceptsStickyWritableInstallationAncestor(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix directory trust semantics")
+	}
+	options := validInitOptions(t)
+	installation, err := Init(context.Background(), options, func(context.Context, string, string) (punaropostgres.Principal, error) {
+		return punaropostgres.Principal{ID: "11111111-1111-4111-8111-111111111111"}, nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	ancestor := filepath.Dir(options.Directory)
+	if err := os.Chmod(ancestor, os.ModeSticky|0o777); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		// #nosec G302 -- restore the required private directory mode.
+		_ = os.Chmod(ancestor, 0o700)
+	})
+	if _, err := Load(options.Directory); err != nil {
+		t.Fatalf("Load rejected sticky writable ancestor: %v", err)
+	}
+	if failures := CheckPaths(installation); len(failures) != 0 {
+		t.Fatalf("failures=%v", failures)
+	}
+}
+
+func TestInitRejectsSymlinkedInstallationAncestor(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix directory trust semantics")
+	}
+	options := validInitOptions(t)
+	target := filepath.Join(filepath.Dir(options.Directory), "trusted-parent")
+	if err := os.Mkdir(target, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(filepath.Dir(options.Directory), "parent-link")
+	if err := os.Symlink(target, link); err != nil {
+		t.Fatal(err)
+	}
+	options.Directory = filepath.Join(link, "installation")
+	called := false
+	if _, err := Init(context.Background(), options, func(context.Context, string, string) (punaropostgres.Principal, error) {
+		called = true
+		return punaropostgres.Principal{}, nil
+	}); err == nil || called {
+		t.Fatalf("symlinked ancestor err=%v bootstrapCalled=%t", err, called)
+	}
+}
+
+func TestInitRejectsUnsafeSensitivePathAncestorsBeforeBootstrap(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix directory trust semantics")
+	}
+	for _, kind := range []string{"data", "backup", "owner DSN", "application DSN"} {
+		t.Run(kind, func(t *testing.T) {
+			options := validInitOptions(t)
+			parent := filepath.Join(filepath.Dir(options.Directory), strings.ReplaceAll(kind, " ", "-")+"-parent")
+			if err := os.Mkdir(parent, 0o700); err != nil {
+				t.Fatal(err)
+			}
+			switch kind {
+			case "data", "backup":
+				leaf := filepath.Join(parent, "private")
+				if err := os.Mkdir(leaf, 0o700); err != nil {
+					t.Fatal(err)
+				}
+				if kind == "data" {
+					options.DataDir = leaf
+				} else {
+					options.BackupDir = leaf
+				}
+			case "owner DSN", "application DSN":
+				leaf := filepath.Join(parent, "database.dsn")
+				protectedFile(t, leaf)
+				if kind == "owner DSN" {
+					options.OwnerDSNFile = leaf
+				} else {
+					options.AppDSNFile = leaf
+				}
+			}
+			// #nosec G302 -- the regression deliberately creates an unsafe ancestor.
+			if err := os.Chmod(parent, 0o777); err != nil {
+				t.Fatal(err)
+			}
+			t.Cleanup(func() {
+				// #nosec G302 -- restore the required private directory mode.
+				_ = os.Chmod(parent, 0o700)
+			})
+			called := false
+			if _, err := Init(context.Background(), options, func(context.Context, string, string) (punaropostgres.Principal, error) {
+				called = true
+				return punaropostgres.Principal{}, nil
+			}); err == nil || called {
+				t.Fatalf("unsafe %s ancestor err=%v bootstrapCalled=%t", kind, err, called)
+			}
+		})
+	}
+}
+
+func TestCheckPathsRejectsSensitivePathAncestorPermissionDrift(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix directory trust semantics")
+	}
+	for _, test := range []struct {
+		kind    string
+		failure string
+	}{
+		{kind: "data", failure: "data directory unavailable or unsafe"},
+		{kind: "backup", failure: "backup directory unavailable or unsafe"},
+		{kind: "owner DSN", failure: "owner DSN file unavailable or unsafe"},
+		{kind: "application DSN", failure: "application DSN file unavailable or unsafe"},
+	} {
+		t.Run(test.kind, func(t *testing.T) {
+			options := validInitOptions(t)
+			parent := filepath.Join(filepath.Dir(options.Directory), strings.ReplaceAll(test.kind, " ", "-")+"-parent")
+			if err := os.Mkdir(parent, 0o700); err != nil {
+				t.Fatal(err)
+			}
+			switch test.kind {
+			case "data", "backup":
+				leaf := filepath.Join(parent, "private")
+				if err := os.Mkdir(leaf, 0o700); err != nil {
+					t.Fatal(err)
+				}
+				if test.kind == "data" {
+					options.DataDir = leaf
+				} else {
+					options.BackupDir = leaf
+				}
+			case "owner DSN", "application DSN":
+				leaf := filepath.Join(parent, "database.dsn")
+				protectedFile(t, leaf)
+				if test.kind == "owner DSN" {
+					options.OwnerDSNFile = leaf
+				} else {
+					options.AppDSNFile = leaf
+				}
+			}
+			installation, err := Init(context.Background(), options, func(context.Context, string, string) (punaropostgres.Principal, error) {
+				return punaropostgres.Principal{ID: "11111111-1111-4111-8111-111111111111"}, nil
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			// #nosec G302 -- the regression deliberately creates unsafe permission drift.
+			if err := os.Chmod(parent, 0o777); err != nil {
+				t.Fatal(err)
+			}
+			t.Cleanup(func() {
+				// #nosec G302 -- restore the required private directory mode.
+				_ = os.Chmod(parent, 0o700)
+			})
+			if _, err := Load(options.Directory); err != nil {
+				t.Fatalf("unrelated published installation became unreadable: %v", err)
+			}
+			if failures := CheckPaths(installation); !containsFailure(failures, test.failure) {
+				t.Fatalf("failures=%v", failures)
+			}
+		})
+	}
+}
+
+func TestLoadRejectsPersistedRuntimeIdentityMismatch(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix runtime identity semantics")
+	}
+	options := validInitOptions(t)
+	installation, err := Init(context.Background(), options, func(context.Context, string, string) (punaropostgres.Principal, error) {
+		return punaropostgres.Principal{ID: "11111111-1111-4111-8111-111111111111"}, nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(options.Directory, configName)
+	body, err := os.ReadFile(path) // #nosec G304 -- fixed generated marker in the test installation.
+	if err != nil {
+		t.Fatal(err)
+	}
+	body = []byte(strings.Replace(string(body), `"runtime_uid": "`+installation.RuntimeUID+`"`, `"runtime_uid": "4294967294"`, 1))
+	if err := os.WriteFile(path, body, 0o600); err != nil { // #nosec G703 -- fixed generated marker in the test installation.
+		t.Fatal(err)
+	}
+	if _, err := Load(options.Directory); err == nil {
+		t.Fatal("Load accepted a persisted runtime identity mismatch")
+	}
+}
+
+func TestComposeProjectNameUsesStableOwnerIdentity(t *testing.T) {
+	first := Installation{Directory: "/srv/a/punaro", OwnerPrincipalID: "11111111-1111-4111-8111-111111111111"}
+	moved := Installation{Directory: "/srv/b/punaro", OwnerPrincipalID: first.OwnerPrincipalID}
+	second := Installation{Directory: "/srv/c/punaro", OwnerPrincipalID: "22222222-2222-4222-8222-222222222222"}
+	firstName, firstErr := ComposeProjectName(first)
+	movedName, movedErr := ComposeProjectName(moved)
+	secondName, secondErr := ComposeProjectName(second)
+	if firstErr != nil || movedErr != nil || secondErr != nil || firstName != movedName || firstName == secondName {
+		t.Fatalf("first=%q/%v moved=%q/%v second=%q/%v", firstName, firstErr, movedName, movedErr, secondName, secondErr)
+	}
+	if !regexp.MustCompile(`^punaro-[0-9a-f]{32}$`).MatchString(firstName) {
+		t.Fatalf("invalid Compose project name %q", firstName)
+	}
+	if _, err := ComposeProjectName(Installation{OwnerPrincipalID: "invalid"}); err == nil {
+		t.Fatal("invalid owner identity produced a Compose project name")
+	}
+}
+
 func TestGeneratedConfigurationUsesDedicatedLoopbackHealthListener(t *testing.T) {
 	options := validInitOptions(t)
 	installation, err := Init(context.Background(), options, func(context.Context, string, string) (punaropostgres.Principal, error) {
@@ -295,19 +554,15 @@ func TestInitRejectsCredentialsAndOperatorStateBelowData(t *testing.T) {
 func TestCheckPathsDetectsBackupAncestorRetargetedBelowData(t *testing.T) {
 	options := validInitOptions(t)
 	root := filepath.Dir(options.DataDir)
-	realBackupParent := filepath.Join(root, "real-backup-parent")
-	if err := os.Mkdir(realBackupParent, 0o700); err != nil {
+	backupParent := filepath.Join(root, "backup-parent")
+	if err := os.Mkdir(backupParent, 0o700); err != nil {
 		t.Fatal(err)
 	}
-	realBackup := filepath.Join(realBackupParent, "backup")
+	realBackup := filepath.Join(backupParent, "backup")
 	if err := os.Mkdir(realBackup, 0o700); err != nil {
 		t.Fatal(err)
 	}
-	alias := filepath.Join(root, "backup-alias")
-	if err := os.Symlink(realBackupParent, alias); err != nil {
-		t.Fatal(err)
-	}
-	options.BackupDir = filepath.Join(alias, "backup")
+	options.BackupDir = realBackup
 	installation, err := Init(context.Background(), options, func(context.Context, string, string) (punaropostgres.Principal, error) {
 		return punaropostgres.Principal{ID: "11111111-1111-4111-8111-111111111111"}, nil
 	})
@@ -317,10 +572,10 @@ func TestCheckPathsDetectsBackupAncestorRetargetedBelowData(t *testing.T) {
 	if err := os.Mkdir(filepath.Join(options.DataDir, "backup"), 0o700); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.Remove(alias); err != nil {
+	if err := os.Rename(backupParent, backupParent+".original"); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.Symlink(options.DataDir, alias); err != nil {
+	if err := os.Symlink(options.DataDir, backupParent); err != nil {
 		t.Fatal(err)
 	}
 	failures := CheckPaths(installation)

--- a/internal/operator/path_security_unix.go
+++ b/internal/operator/path_security_unix.go
@@ -1,0 +1,116 @@
+//go:build !windows
+
+package operator
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strconv"
+	"syscall"
+)
+
+func requireTrustedPrivateDirectory(path string) error {
+	if err := requirePrivateDirectory(path); err != nil {
+		return err
+	}
+	if !ownedByCurrentUser(path) {
+		return errors.New("private directory must be owned by the current user")
+	}
+	return requireTrustedDirectoryAncestors(filepath.Dir(filepath.Clean(path)))
+}
+
+func requireTrustedProtectedFile(path string, maximum int64) error {
+	if err := requireProtectedFile(path, maximum); err != nil {
+		return err
+	}
+	if !ownedByCurrentUser(path) {
+		return errors.New("protected file must be owned by the current user")
+	}
+	return requireTrustedDirectoryAncestors(filepath.Dir(filepath.Clean(path)))
+}
+
+func ownedByCurrentUser(path string) bool {
+	info, err := os.Lstat(path)
+	if err != nil {
+		return false
+	}
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	return ok && int(stat.Uid) == os.Getuid()
+}
+
+func runtimeIdentityMatches(installation Installation) bool {
+	return installation.RuntimeUID == strconv.Itoa(os.Getuid()) && installation.RuntimeGID == strconv.Itoa(os.Getgid())
+}
+
+func requireTrustedDirectoryAncestors(path string) error {
+	current := filepath.Clean(path)
+	for {
+		info, err := os.Lstat(current)
+		if err != nil {
+			return errors.New("installation path ancestors must exist")
+		}
+		if info.Mode()&os.ModeSymlink != 0 {
+			stat, ok := info.Sys().(*syscall.Stat_t)
+			if !ok || stat.Uid != 0 {
+				return errors.New("installation path may only traverse root-owned system symlinks")
+			}
+			if err := requireTrustedDirectoryAncestors(filepath.Dir(current)); err != nil {
+				return err
+			}
+			resolved, err := filepath.EvalSymlinks(path)
+			if err != nil {
+				return errors.New("installation path ancestors could not be resolved")
+			}
+			return requireResolvedDirectoryAncestors(resolved)
+		}
+		if !info.IsDir() {
+			return errors.New("installation path ancestors must be directories")
+		}
+		if !trustedAncestor(info) {
+			return errors.New("installation path ancestors must be owned by root or the current user")
+		}
+		if writableWithoutSticky(info) {
+			return errors.New("installation path ancestors must not be group or world writable unless sticky")
+		}
+		parent := filepath.Dir(current)
+		if parent == current {
+			return nil
+		}
+		current = parent
+	}
+}
+
+func requireResolvedDirectoryAncestors(path string) error {
+	current := filepath.Clean(path)
+	for {
+		info, err := os.Lstat(current)
+		if err != nil || !info.IsDir() || info.Mode()&os.ModeSymlink != 0 {
+			return errors.New("resolved installation path ancestors must be existing directories")
+		}
+		if !trustedAncestor(info) {
+			return errors.New("resolved installation path ancestors must be owned by root or the current user")
+		}
+		if writableWithoutSticky(info) {
+			return errors.New("resolved installation path ancestors must not be group or world writable unless sticky")
+		}
+		parent := filepath.Dir(current)
+		if parent == current {
+			return nil
+		}
+		current = parent
+	}
+}
+
+func trustedAncestor(info os.FileInfo) bool {
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	return ok && trustedAncestorUID(int(stat.Uid))
+}
+
+func trustedAncestorUID(uid int) bool {
+	return uid == 0 || uid == os.Getuid()
+}
+
+func writableWithoutSticky(info os.FileInfo) bool {
+	return info.Mode().Perm()&0o022 != 0 && info.Mode()&os.ModeSticky == 0
+}

--- a/internal/operator/path_security_unix_test.go
+++ b/internal/operator/path_security_unix_test.go
@@ -1,0 +1,21 @@
+//go:build !windows
+
+package operator
+
+import (
+	"os"
+	"testing"
+)
+
+func TestTrustedAncestorOwnershipPolicy(t *testing.T) {
+	if !trustedAncestorUID(0) || !trustedAncestorUID(os.Getuid()) {
+		t.Fatal("root or current user was rejected")
+	}
+	foreign := os.Getuid() + 1
+	if foreign == 0 {
+		foreign++
+	}
+	if trustedAncestorUID(foreign) {
+		t.Fatal("foreign-owned ancestor was accepted")
+	}
+}

--- a/internal/operator/path_security_windows.go
+++ b/internal/operator/path_security_windows.go
@@ -1,0 +1,15 @@
+//go:build windows
+
+package operator
+
+func requireTrustedPrivateDirectory(path string) error {
+	return requirePrivateDirectory(path)
+}
+
+func requireTrustedDirectoryAncestors(string) error { return nil }
+
+func requireTrustedProtectedFile(path string, maximum int64) error {
+	return requireProtectedFile(path, maximum)
+}
+
+func runtimeIdentityMatches(Installation) bool { return true }

--- a/internal/postgres/db.go
+++ b/internal/postgres/db.go
@@ -111,6 +111,23 @@ func (d *Database) InstallationState(ctx context.Context) (InstallationState, er
 	return state, nil
 }
 
+// InstallationOwner returns the singleton owner identity visible to the
+// application role so runtime configuration can be bound to one installation.
+func (d *Database) InstallationOwner(ctx context.Context) (Principal, error) {
+	var owner Principal
+	err := d.db.QueryRowContext(ctx, `SELECT principal.id::text, principal.kind, principal.display_name
+FROM auth.installation_owner AS installation
+JOIN auth.principals AS principal ON principal.id = installation.principal_id
+WHERE installation.singleton`).Scan(&owner.ID, &owner.Kind, &owner.DisplayName)
+	if errors.Is(err, sql.ErrNoRows) {
+		return Principal{}, ErrNotFound
+	}
+	if err != nil {
+		return Principal{}, errors.New("installation owner is unavailable")
+	}
+	return owner, nil
+}
+
 // AdvanceChange atomically increments and returns the global change sequence.
 func (d *Database) AdvanceChange(ctx context.Context) (InstallationState, error) {
 	var state InstallationState

--- a/internal/postgres/device_auth_integration_test.go
+++ b/internal/postgres/device_auth_integration_test.go
@@ -53,6 +53,18 @@ func testDeviceAuthIntegration(ctx context.Context, t *testing.T, app *Database,
 	if _, err := admin.BootstrapOwner(ctx, "second owner"); !errors.Is(err, ErrAlreadyInitialized) {
 		t.Fatalf("second bootstrap error=%v", err)
 	}
+	recoveredOwner, err := admin.InstallationOwner(ctx)
+	if err != nil || recoveredOwner.ID != owner.ID || recoveredOwner.DisplayName != owner.DisplayName {
+		t.Fatalf("recovered owner=%#v err=%v", recoveredOwner, err)
+	}
+	appInstallation, err := app.InstallationState(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	adminInstallation, err := admin.InstallationState(ctx)
+	if err != nil || appInstallation.InstallationID != adminInstallation.InstallationID || appInstallation.TimelineID != adminInstallation.TimelineID {
+		t.Fatalf("app installation=%#v admin installation=%#v err=%v", appInstallation, adminInstallation, err)
+	}
 
 	project, err := app.CreateProject(ctx, ProjectCreate{PrincipalID: owner.ID, IdempotencyKey: uuid.NewString(), DisplayName: "enrollment project"})
 	if err != nil {

--- a/internal/postgres/device_auth_json_test.go
+++ b/internal/postgres/device_auth_json_test.go
@@ -1,0 +1,47 @@
+package postgres
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestDeviceCredentialJSONRepresentsOptionalExpiry(t *testing.T) {
+	credential := DeviceCredential{PrincipalID: "principal", LookupID: "lookup", Encoded: "secret", Generation: 1}
+	body, err := json.Marshal(credential)
+	if err != nil || strings.Contains(string(body), "expires_at") || strings.Contains(string(body), "0001-01-01") {
+		t.Fatalf("non-expiring JSON=%q err=%v", body, err)
+	}
+	credential.ExpiresAt = time.Date(2030, time.January, 2, 3, 4, 5, 0, time.UTC)
+	body, err = json.Marshal(credential)
+	if err != nil || !strings.Contains(string(body), `"expires_at":"2030-01-02T03:04:05Z"`) {
+		t.Fatalf("expiring JSON=%q err=%v", body, err)
+	}
+}
+
+func TestDeviceCredentialMetadataJSONOmitsAbsentLifecycleTimes(t *testing.T) {
+	metadata := DeviceCredentialMetadata{PrincipalID: "principal", LookupID: "lookup", Label: "laptop", Generation: 1, CreatedAt: time.Date(2029, time.January, 1, 0, 0, 0, 0, time.UTC)}
+	body, err := json.Marshal(metadata)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, field := range []string{"last_used_at", "expires_at", "rotated_at", "revoked_at", "0001-01-01"} {
+		if strings.Contains(string(body), field) {
+			t.Fatalf("metadata JSON=%q contains absent value %q", body, field)
+		}
+	}
+	metadata.LastUsedAt = time.Date(2030, time.January, 2, 3, 4, 5, 0, time.UTC)
+	metadata.ExpiresAt = metadata.LastUsedAt.Add(time.Hour)
+	metadata.RotatedAt = metadata.LastUsedAt.Add(2 * time.Hour)
+	metadata.RevokedAt = metadata.LastUsedAt.Add(3 * time.Hour)
+	body, err = json.Marshal(metadata)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, field := range []string{"last_used_at", "expires_at", "rotated_at", "revoked_at"} {
+		if !strings.Contains(string(body), field) {
+			t.Fatalf("metadata JSON=%q omits present value %q", body, field)
+		}
+	}
+}

--- a/internal/postgres/device_auth_store.go
+++ b/internal/postgres/device_auth_store.go
@@ -126,7 +126,7 @@ type DeviceCredential struct {
 	LookupID    string    `json:"lookup_id"`
 	Encoded     string    `json:"credential"`
 	Generation  int64     `json:"generation"`
-	ExpiresAt   time.Time `json:"expires_at,omitempty"`
+	ExpiresAt   time.Time `json:"expires_at,omitzero"`
 }
 
 // AuthenticatedDevice is the generation fence carried by caches and sessions.
@@ -143,10 +143,10 @@ type DeviceCredentialMetadata struct {
 	Label       string    `json:"label"`
 	Generation  int64     `json:"generation"`
 	CreatedAt   time.Time `json:"created_at"`
-	LastUsedAt  time.Time `json:"last_used_at,omitempty"`
-	ExpiresAt   time.Time `json:"expires_at,omitempty"`
-	RotatedAt   time.Time `json:"rotated_at,omitempty"`
-	RevokedAt   time.Time `json:"revoked_at,omitempty"`
+	LastUsedAt  time.Time `json:"last_used_at,omitzero"`
+	ExpiresAt   time.Time `json:"expires_at,omitzero"`
+	RotatedAt   time.Time `json:"rotated_at,omitzero"`
+	RevokedAt   time.Time `json:"revoked_at,omitzero"`
 }
 
 // RedeemEnrollment binds a one-time code to the exact approved client.

--- a/internal/postgres/device_auth_store.go
+++ b/internal/postgres/device_auth_store.go
@@ -80,6 +80,34 @@ func OpenAdministration(ctx context.Context, cfg Config) (*Administration, error
 // Close releases the host-local owner connection pool.
 func (a *Administration) Close() error { return a.db.Close() }
 
+// InstallationOwner returns the existing singleton owner for host-local
+// initialization recovery. It exposes no network route and no secret material.
+func (a *Administration) InstallationOwner(ctx context.Context) (Principal, error) {
+	var owner Principal
+	err := a.db.QueryRowContext(ctx, `SELECT principal.id::text, principal.kind, principal.display_name
+FROM auth.installation_owner AS installation
+JOIN auth.principals AS principal ON principal.id = installation.principal_id
+WHERE installation.singleton`).Scan(&owner.ID, &owner.Kind, &owner.DisplayName)
+	if errors.Is(err, sql.ErrNoRows) {
+		return Principal{}, ErrNotFound
+	}
+	if err != nil {
+		return Principal{}, errors.New("installation owner is unavailable")
+	}
+	return owner, nil
+}
+
+// InstallationState returns the owner-role view used to prove that host-local
+// administration and the public application role target the same installation.
+func (a *Administration) InstallationState(ctx context.Context) (InstallationState, error) {
+	var state InstallationState
+	err := a.db.QueryRowContext(ctx, `SELECT installation_id::text, timeline_id::text, change_sequence FROM jobs.server_state WHERE singleton`).Scan(&state.InstallationID, &state.TimelineID, &state.ChangeSequence)
+	if err != nil {
+		return InstallationState{}, errors.New("PostgreSQL installation metadata is unavailable")
+	}
+	return state, nil
+}
+
 // PendingEnrollment contains the one-time secret and exact confirmed grants.
 // Callers must display/store Code once and must never log this value.
 type PendingEnrollment struct {

--- a/internal/postgres/migrate.go
+++ b/internal/postgres/migrate.go
@@ -75,14 +75,18 @@ func Migrate(ctx context.Context, cfg Config) (SchemaState, error) {
 }
 
 func migrate(ctx context.Context, db *sql.DB, manifest Manifest) (SchemaState, error) {
-	if err := manifest.Validate(); err != nil {
-		return SchemaState{}, err
-	}
 	conn, err := db.Conn(ctx)
 	if err != nil {
 		return SchemaState{}, errors.New("PostgreSQL migration connection is unavailable")
 	}
 	defer func() { _ = conn.Close() }()
+	return migrateConn(ctx, conn, manifest)
+}
+
+func migrateConn(ctx context.Context, conn *sql.Conn, manifest Manifest) (SchemaState, error) {
+	if err := manifest.Validate(); err != nil {
+		return SchemaState{}, err
+	}
 	if _, err := conn.ExecContext(ctx, `SELECT pg_advisory_lock($1)`, advisoryLockKey); err != nil {
 		return SchemaState{}, errors.New("PostgreSQL migration lock is unavailable")
 	}

--- a/internal/postgres/pair.go
+++ b/internal/postgres/pair.go
@@ -1,0 +1,115 @@
+package postgres
+
+import (
+	"context"
+	"crypto/rand"
+	"database/sql"
+	"encoding/binary"
+	"errors"
+	"fmt"
+)
+
+// ErrMigrationNotAttempted marks failures that occurred before any schema
+// mutation, allowing first-install staging to be rolled back safely.
+var ErrMigrationNotAttempted = errors.New("PostgreSQL migration was not attempted")
+
+// MigratePristinePair proves that the application and schema-owner DSNs reach
+// the same pristine database, then migrates through the already-verified owner
+// pool while the proof remains held. The random advisory-lock probe is scoped
+// by PostgreSQL to one database, so a second session can observe it only when
+// both connections share that target.
+func MigratePristinePair(ctx context.Context, appConfig, ownerConfig Config) (SchemaState, error) {
+	return withPristinePair(ctx, appConfig, ownerConfig, func(ownerConn *sql.Conn) (SchemaState, error) {
+		return migrateConn(ctx, ownerConn, CurrentManifest())
+	})
+}
+
+func withPristinePair(ctx context.Context, appConfig, ownerConfig Config, action func(*sql.Conn) (SchemaState, error)) (SchemaState, error) {
+	appDSN, err := ReadDSNFile(appConfig.DSNFile)
+	if err != nil {
+		return SchemaState{}, preMigrationError(err)
+	}
+	ownerDSN, err := ReadDSNFile(ownerConfig.DSNFile)
+	if err != nil {
+		return SchemaState{}, preMigrationError(err)
+	}
+	appDB, err := open(ctx, appDSN)
+	if err != nil {
+		return SchemaState{}, preMigrationError(err)
+	}
+	defer func() { _ = appDB.Close() }()
+	ownerDB, err := open(ctx, ownerDSN)
+	if err != nil {
+		return SchemaState{}, preMigrationError(err)
+	}
+	defer func() { _ = ownerDB.Close() }()
+	appConn, err := appDB.Conn(ctx)
+	if err != nil {
+		return SchemaState{}, preMigrationError(errors.New("PostgreSQL application target cannot be verified"))
+	}
+	defer func() { _ = appConn.Close() }()
+	ownerConn, err := ownerDB.Conn(ctx)
+	if err != nil {
+		return SchemaState{}, preMigrationError(errors.New("PostgreSQL owner target cannot be verified"))
+	}
+	defer func() { _ = ownerConn.Close() }()
+	if err := verifyApplicationRole(ctx, appConn); err != nil {
+		return SchemaState{}, preMigrationError(err)
+	}
+	if err := verifyMigrationRoles(ctx, ownerConn); err != nil {
+		return SchemaState{}, preMigrationError(err)
+	}
+	if err := requirePristine(ctx, appConn); err != nil {
+		return SchemaState{}, preMigrationError(err)
+	}
+	if err := requirePristine(ctx, ownerConn); err != nil {
+		return SchemaState{}, preMigrationError(err)
+	}
+	key, err := randomAdvisoryKey()
+	if err != nil {
+		return SchemaState{}, preMigrationError(errors.New("PostgreSQL target proof cannot be created"))
+	}
+	var ownerLocked bool
+	if err := ownerConn.QueryRowContext(ctx, `SELECT pg_try_advisory_lock($1)`, key).Scan(&ownerLocked); err != nil || !ownerLocked {
+		return SchemaState{}, preMigrationError(errors.New("PostgreSQL owner target cannot be locked for verification"))
+	}
+	defer unlockAdvisory(ownerConn, key)
+	var appLocked bool
+	if err := appConn.QueryRowContext(ctx, `SELECT pg_try_advisory_lock($1)`, key).Scan(&appLocked); err != nil {
+		return SchemaState{}, preMigrationError(errors.New("PostgreSQL application target cannot be probed"))
+	}
+	if appLocked {
+		unlockAdvisory(appConn, key)
+		return SchemaState{}, preMigrationError(errors.New("application and owner DSNs target different pristine databases"))
+	}
+	return action(ownerConn)
+}
+
+func preMigrationError(err error) error {
+	return fmt.Errorf("%w: %w", ErrMigrationNotAttempted, err)
+}
+
+func requirePristine(ctx context.Context, conn *sql.Conn) error {
+	snapshot, err := inspect(ctx, conn)
+	if err != nil {
+		return err
+	}
+	if Classify(snapshot, CurrentManifest()).Classification != Pristine {
+		return errors.New("PostgreSQL initialization requires a pristine database")
+	}
+	return nil
+}
+
+func randomAdvisoryKey() (int64, error) {
+	var key int64
+	if err := binary.Read(rand.Reader, binary.BigEndian, &key); err != nil {
+		return 0, err
+	}
+	return key, nil
+}
+
+func unlockAdvisory(conn *sql.Conn, key int64) {
+	unlockCtx, cancel := context.WithTimeout(context.Background(), operationTimeout)
+	defer cancel()
+	_, _ = conn.ExecContext(unlockCtx, `SELECT pg_advisory_unlock($1)`, key)
+}

--- a/internal/postgres/postgres_integration_test.go
+++ b/internal/postgres/postgres_integration_test.go
@@ -19,9 +19,32 @@ func TestPostgresPlatformSubstrateIntegration(t *testing.T) {
 	if ownerDSN == "" || appDSN == "" {
 		t.Skip("set PUNARO_TEST_POSTGRES_OWNER_DSN and PUNARO_TEST_POSTGRES_APP_DSN to run PostgreSQL integration tests")
 	}
+	otherOwnerDSN := os.Getenv("PUNARO_TEST_POSTGRES_OTHER_OWNER_DSN")
+	pairOwnerDSN := os.Getenv("PUNARO_TEST_POSTGRES_PAIR_OWNER_DSN")
+	pairAppDSN := os.Getenv("PUNARO_TEST_POSTGRES_PAIR_APP_DSN")
+	if otherOwnerDSN == "" || pairOwnerDSN == "" || pairAppDSN == "" {
+		t.Fatal("PostgreSQL integration requires the distinct-target and pair-migration DSNs")
+	}
 	ctx := context.Background()
 	ownerFile := writeTestDSN(t, "owner.dsn", ownerDSN)
 	appFile := writeTestDSN(t, "app.dsn", appDSN)
+	otherOwnerFile := writeTestDSN(t, "other-owner.dsn", otherOwnerDSN)
+	pairOwnerFile := writeTestDSN(t, "pair-owner.dsn", pairOwnerDSN)
+	pairAppFile := writeTestDSN(t, "pair-app.dsn", pairAppDSN)
+	if _, err := withPristinePair(ctx, Config{DSNFile: appFile}, Config{DSNFile: otherOwnerFile}, func(*sql.Conn) (SchemaState, error) {
+		t.Fatal("distinct database pair reached the migration action")
+		return SchemaState{}, nil
+	}); !errors.Is(err, ErrMigrationNotAttempted) {
+		t.Fatalf("distinct database pair error=%v, want pre-migration refusal", err)
+	}
+	if _, err := withPristinePair(ctx, Config{DSNFile: appFile}, Config{DSNFile: ownerFile}, func(*sql.Conn) (SchemaState, error) {
+		return SchemaState{Classification: Pristine}, nil
+	}); err != nil {
+		t.Fatalf("pristine DSN pair proof failed: %v", err)
+	}
+	if state, err := MigratePristinePair(ctx, Config{DSNFile: pairAppFile}, Config{DSNFile: pairOwnerFile}); err != nil || state.Classification != Compatible {
+		t.Fatalf("connection-bound pair migration state=%#v err=%v", state, err)
+	}
 
 	app, err := OpenApplication(ctx, Config{DSNFile: appFile})
 	if err != nil {

--- a/internal/postgres/postgres_integration_test.go
+++ b/internal/postgres/postgres_integration_test.go
@@ -45,6 +45,17 @@ func TestPostgresPlatformSubstrateIntegration(t *testing.T) {
 	if state, err := MigratePristinePair(ctx, Config{DSNFile: pairAppFile}, Config{DSNFile: pairOwnerFile}); err != nil || state.Classification != Compatible {
 		t.Fatalf("connection-bound pair migration state=%#v err=%v", state, err)
 	}
+	pairDB, err := open(ctx, pairOwnerDSN)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := pairDB.ExecContext(ctx, `DROP SCHEMA auth, relay, attachment, brain, jobs, audit CASCADE; REVOKE CONNECT ON DATABASE punaro_pair FROM punaro_app; REVOKE CONNECT ON DATABASE punaro_other FROM punaro_app`); err != nil {
+		_ = pairDB.Close()
+		t.Fatalf("auxiliary pair cleanup failed: %v", err)
+	}
+	if err := pairDB.Close(); err != nil {
+		t.Fatal(err)
+	}
 
 	app, err := OpenApplication(ctx, Config{DSNFile: appFile})
 	if err != nil {

--- a/scripts/install-server.sh
+++ b/scripts/install-server.sh
@@ -285,4 +285,4 @@ fi
 printf '%s\n' 'Punaro relay files installed.' \
 	"Configuration: $config_file" \
 	'Use --machines-file /approved/public-machines.json --enable on a fresh host to configure and start in one command.' \
-	'Verify: curl --fail http://127.0.0.1:8080/readyz'
+	'Verify: curl --fail http://127.0.0.1:8081/readyz'

--- a/scripts/verify-container-binaries.sh
+++ b/scripts/verify-container-binaries.sh
@@ -3,7 +3,7 @@ set -eu
 
 dockerfile=${1:-Dockerfile}
 
-for binary in punarod punaro-migrate punaro-admin punaro-adapter punaro-directory punaro-telegram punaro-attachment; do
+for binary in punaro punarod punaro-migrate punaro-admin punaro-adapter punaro-directory punaro-telegram punaro-attachment; do
 	if ! grep -Fq -- "-o /out/$binary ./cmd/$binary" "$dockerfile"; then
 		echo "container build does not produce $binary" >&2
 		exit 1

--- a/scripts/verify-postgres-compose.sh
+++ b/scripts/verify-postgres-compose.sh
@@ -12,3 +12,6 @@ fi
 grep -Eq 'condition:[[:space:]]*service_healthy' "$compose_file"
 grep -Eq 'PUNARO_TEST_POSTGRES_OWNER_DSN:' "$compose_file"
 grep -Eq 'PUNARO_TEST_POSTGRES_APP_DSN:' "$compose_file"
+grep -Eq 'PUNARO_TEST_POSTGRES_OTHER_OWNER_DSN:' "$compose_file"
+grep -Eq 'PUNARO_TEST_POSTGRES_PAIR_OWNER_DSN:' "$compose_file"
+grep -Eq 'PUNARO_TEST_POSTGRES_PAIR_APP_DSN:' "$compose_file"


### PR DESCRIPTION
## What changed

- add the host-local `punaro` wrapper with recoverable `init`, compatible-only `up`, `status`, failing `doctor`, and two-step confirmed `client add`
- generate a private, atomic, digest-pinned, non-root Compose installation with strict canonical path isolation
- add LAN, proxy, and Internet ingress policies plus bounded enrollment redemption and device-session authentication
- revalidate schema, installation/timeline identity, singleton owner identity, generated files, and path boundaries before operational mutation/start
- package the host wrapper and update operator, design, and platform documentation

## Why

This is Big Brain milestone M-5: it makes the M-1 through M-4 PostgreSQL ownership and device-credential substrate safely operable without enabling later relay, backup/update, production-profile, or Compose Pi scope.

## Impact

Operators get an explicit first-install and health workflow with fail-closed recovery and ingress behavior. Existing SQLite routing and all M-1 through M-4 records remain unchanged and dark.

## Validation

- `GOCACHE=/tmp/punaro-go-cache make ci`
- independent alignment, adversarial, and auth/identity reviews: PASS, no P0-P2 findings
- focused red-first regressions for bootstrap recovery, schema ordering, identity pairing, path/symlink isolation, immutable image generation, ingress admission, strict HTTP parsing, deadlines, and concurrency
- local Docker/PostgreSQL integration unavailable; hosted PostgreSQL integration remains required before merge
