### PR TITLE
Add transactional update fence and recovery

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -620,6 +620,31 @@ phase, and publishes only new data/operator paths. Exact-command retries resume
 without repeating completed mutation. Abandoned-timeline and future cursors fail closed. This is
 not the later update fence and does not let ordinary startup migrate.
 
+The seventh foundation slice adds the single-node supported update transaction.
+Every PostgreSQL business mutation takes the shared side of one transactional
+maintenance gate; the owner-side update fence drains prior writers, rejects
+later writes before acknowledgement, and remains durable through crashes. The
+host wrapper verifies protected release metadata, the exact pulled image digest,
+the generated Compose artifact, PostgreSQL major, installation identity, disk
+capacity, and current health before fencing. It then stops the generated writer,
+creates an update-bound M-6 backup, and runs the exact target image as a hardened
+one-shot owner migrator. The target starts under the still-active fence and must
+pass readiness and a non-mutating doctor before marker-last configuration
+publication and database commit reopen writes.
+
+Update phases and the previous image lock are durable. Exact retries resume;
+pre-migration abort restarts and doctors the previous image before releasing the
+fence. After migration starts, an explicit compatible-image recovery is allowed
+only when the previous image actually starts and passes its recovery doctor against
+the migrated schema. Otherwise the exact bound backup plus its independently
+durable host receipt must be restored into a pristine stopped/new stack; restore rotates the timeline,
+reconstructs the same fenced update transaction, and requires the restored source
+image to pass readiness and doctor before recovery commits. Raw daemon/Compose
+startup and the ordinary migrator cannot cross an existing-schema migration.
+This generated-stack contract covers the single configured `punarod` writer and
+externally provisioned PostgreSQL; the production PostgreSQL/profile bundle is
+still M-23.
+
 ## Required adversarial acceptance tests
 
 The implementation is not internet-exposure-ready until these cases pass:

--- a/README.md
+++ b/README.md
@@ -58,8 +58,9 @@ make operator-binary
 ```
 
 The host wrapper also provides exported-snapshot `backup`, strict `backup
-verify`, and clean-stack `restore --into-new-stack`; see the operator guide for
-the private-path, PostgreSQL-role, external-dependency, and restore-drill rules.
+verify`, clean-stack `restore --into-new-stack`, and the durable backup-gated
+`update` path; see the operator guide for private-path, PostgreSQL-role,
+rollback, recovery, external-dependency, and restore-drill rules.
 
 ```sh
 cp .env.example .env

--- a/cmd/punaro-migrate/main.go
+++ b/cmd/punaro-migrate/main.go
@@ -13,27 +13,44 @@ import (
 	punaropostgres "github.com/rock3r/punaro/internal/postgres"
 )
 
-var migratePostgres = punaropostgres.Migrate
+var migratePostgresUpdate = punaropostgres.MigrateUpdate
 
 func main() { os.Exit(run(os.Args[1:], os.Stderr)) }
 
 func run(args []string, stderr io.Writer) int {
 	flags := flag.NewFlagSet("punaro-migrate", flag.ContinueOnError)
 	flags.SetOutput(stderr)
-	var ownerDSNFile string
+	var ownerDSNFile, updateID, backupID, targetRelease, targetImage, exportedSnapshotID, manifestSHA256 string
+	var targetSchema int64
 	flags.StringVar(&ownerDSNFile, "owner-dsn-file", "", "absolute path to the protected PostgreSQL schema-owner DSN file")
+	flags.StringVar(&updateID, "update-id", "", "exact update transaction ID")
+	flags.StringVar(&backupID, "backup-id", "", "exact verified pre-update backup ID")
+	flags.StringVar(&targetRelease, "target-release", "", "exact target release")
+	flags.StringVar(&targetImage, "target-image", "", "exact full digest-pinned target image")
+	flags.Int64Var(&targetSchema, "target-schema", 0, "exact target schema version")
+	flags.StringVar(&exportedSnapshotID, "exported-snapshot-id", "", "exact exported snapshot ID")
+	flags.StringVar(&manifestSHA256, "manifest-sha256", "", "exact verified backup manifest SHA-256")
 	if err := flags.Parse(args); err != nil {
 		return 2
 	}
-	if ownerDSNFile == "" {
-		_, _ = fmt.Fprintln(stderr, "punaro-migrate requires -owner-dsn-file")
+	if flags.NArg() != 0 || ownerDSNFile == "" || updateID == "" || backupID == "" || targetRelease == "" || targetImage == "" || targetSchema < 1 || exportedSnapshotID == "" || manifestSHA256 == "" {
+		_, _ = fmt.Fprintln(stderr, "punaro-migrate requires complete update authorization")
+		return 2
+	}
+	authorization := punaropostgres.UpdateMigrationAuthorization{
+		UpdateID: updateID, BackupID: backupID, TargetRelease: targetRelease,
+		TargetImage: targetImage, TargetSchema: targetSchema,
+		ExportedSnapshotID: exportedSnapshotID, ManifestSHA256: manifestSHA256,
+	}
+	if authorization.Validate() != nil {
+		_, _ = fmt.Fprintln(stderr, "punaro-migrate update authorization is invalid")
 		return 2
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
 	defer cancel()
-	state, err := migratePostgres(ctx, punaropostgres.Config{DSNFile: ownerDSNFile})
+	state, err := migratePostgresUpdate(ctx, punaropostgres.Config{DSNFile: ownerDSNFile}, authorization)
 	if err != nil {
-		_, _ = fmt.Fprintf(stderr, "punaro-migrate failed: %v\n", err)
+		_, _ = fmt.Fprintln(stderr, "punaro-migrate failed")
 		return 1
 	}
 	_, _ = fmt.Fprintf(stderr, "punaro-migrate completed schema=%s version=%d\n", state.Classification, state.Version)

--- a/cmd/punaro-migrate/main_test.go
+++ b/cmd/punaro-migrate/main_test.go
@@ -3,35 +3,132 @@ package main
 import (
 	"bytes"
 	"context"
+	"errors"
+	"reflect"
 	"strings"
 	"testing"
+	"time"
 
 	punaropostgres "github.com/rock3r/punaro/internal/postgres"
 )
 
-func TestRunRequiresExplicitOwnerDSNFile(t *testing.T) {
-	var stderr bytes.Buffer
-	if code := run(nil, &stderr); code != 2 {
-		t.Fatalf("run() = %d, want 2; stderr=%q", code, stderr.String())
+var validArguments = []string{
+	"-owner-dsn-file", "/run/secrets/punaro-owner-dsn",
+	"-update-id", "0190ea2e-8a2d-7d42-b320-8515f7604bc1",
+	"-backup-id", "0290ea2e-8a2d-7d42-b320-8515f7604bc1",
+	"-target-release", "v0.7.0",
+	"-target-image", "registry.example/punaro@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+	"-target-schema", "6",
+	"-exported-snapshot-id", "00000003-0000001B-1",
+	"-manifest-sha256", "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+}
+
+func TestRunRequiresCompleteUpdateAuthorization(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+	}{
+		{name: "empty", args: nil},
+		{name: "missing owner DSN", args: withoutFlag(validArguments, "-owner-dsn-file")},
+		{name: "missing update ID", args: withoutFlag(validArguments, "-update-id")},
+		{name: "missing backup ID", args: withoutFlag(validArguments, "-backup-id")},
+		{name: "missing target release", args: withoutFlag(validArguments, "-target-release")},
+		{name: "missing target image", args: withoutFlag(validArguments, "-target-image")},
+		{name: "missing target schema", args: withoutFlag(validArguments, "-target-schema")},
+		{name: "missing snapshot", args: withoutFlag(validArguments, "-exported-snapshot-id")},
+		{name: "missing manifest hash", args: withoutFlag(validArguments, "-manifest-sha256")},
+		{name: "unknown flag", args: append(append([]string{}, validArguments...), "-unexpected", "value")},
+		{name: "trailing argument", args: append(append([]string{}, validArguments...), "unexpected")},
 	}
-	if !strings.Contains(stderr.String(), "owner-dsn-file") {
-		t.Fatalf("stderr = %q, want required flag guidance", stderr.String())
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var stderr bytes.Buffer
+			if code := run(test.args, &stderr); code != 2 {
+				t.Fatalf("run() = %d, want 2; stderr=%q", code, stderr.String())
+			}
+		})
 	}
 }
 
-func TestRunInvokesExplicitMigrator(t *testing.T) {
-	original := migratePostgres
-	t.Cleanup(func() { migratePostgres = original })
-	var gotFile string
-	migratePostgres = func(_ context.Context, cfg punaropostgres.Config) (punaropostgres.SchemaState, error) {
-		gotFile = cfg.DSNFile
-		return punaropostgres.SchemaState{Classification: punaropostgres.Compatible, Version: 1}, nil
+func TestRunInvokesUpdateAuthorizedMigrator(t *testing.T) {
+	original := migratePostgresUpdate
+	t.Cleanup(func() { migratePostgresUpdate = original })
+	var gotConfig punaropostgres.Config
+	var gotAuthorization punaropostgres.UpdateMigrationAuthorization
+	var gotDeadline time.Time
+	migratePostgresUpdate = func(ctx context.Context, cfg punaropostgres.Config, authorization punaropostgres.UpdateMigrationAuthorization) (punaropostgres.SchemaState, error) {
+		gotConfig = cfg
+		gotAuthorization = authorization
+		gotDeadline, _ = ctx.Deadline()
+		return punaropostgres.SchemaState{Classification: punaropostgres.Compatible, Version: 6}, nil
 	}
+	started := time.Now()
 	var stderr bytes.Buffer
-	if code := run([]string{"-owner-dsn-file", "/run/secrets/punaro-owner-dsn"}, &stderr); code != 0 {
+	if code := run(validArguments, &stderr); code != 0 {
 		t.Fatalf("run()=%d stderr=%q", code, stderr.String())
 	}
-	if gotFile != "/run/secrets/punaro-owner-dsn" || !strings.Contains(stderr.String(), "version=1") {
-		t.Fatalf("file=%q stderr=%q", gotFile, stderr.String())
+	wantAuthorization := punaropostgres.UpdateMigrationAuthorization{
+		UpdateID: "0190ea2e-8a2d-7d42-b320-8515f7604bc1", BackupID: "0290ea2e-8a2d-7d42-b320-8515f7604bc1",
+		TargetRelease: "v0.7.0", TargetImage: "registry.example/punaro@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+		TargetSchema: 6, ExportedSnapshotID: "00000003-0000001B-1",
+		ManifestSHA256: "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
 	}
+	if gotConfig.DSNFile != "/run/secrets/punaro-owner-dsn" || !reflect.DeepEqual(gotAuthorization, wantAuthorization) {
+		t.Fatalf("config=%#v authorization=%#v", gotConfig, gotAuthorization)
+	}
+	if gotDeadline.Before(started.Add(119*time.Second)) || gotDeadline.After(started.Add(121*time.Second)) {
+		t.Fatalf("deadline=%v, want approximately two minutes", gotDeadline)
+	}
+	if !strings.Contains(stderr.String(), "version=6") {
+		t.Fatalf("stderr=%q, want completion summary", stderr.String())
+	}
+}
+
+func TestRunRejectsInvalidAuthorizationBeforeMigration(t *testing.T) {
+	original := migratePostgresUpdate
+	t.Cleanup(func() { migratePostgresUpdate = original })
+	called := false
+	migratePostgresUpdate = func(context.Context, punaropostgres.Config, punaropostgres.UpdateMigrationAuthorization) (punaropostgres.SchemaState, error) {
+		called = true
+		return punaropostgres.SchemaState{Classification: punaropostgres.Compatible, Version: 6}, nil
+	}
+	arguments := append([]string{}, validArguments...)
+	for index := range arguments {
+		if arguments[index] == "-update-id" {
+			arguments[index+1] = "not-an-update-id"
+		}
+	}
+	var stderr bytes.Buffer
+	if code := run(arguments, &stderr); code != 2 {
+		t.Fatalf("run()=%d, want 2; stderr=%q", code, stderr.String())
+	}
+	if called {
+		t.Fatal("invalid authorization reached the migrator")
+	}
+}
+
+func TestRunDoesNotPrintMigratorErrorDetails(t *testing.T) {
+	original := migratePostgresUpdate
+	t.Cleanup(func() { migratePostgresUpdate = original })
+	const secret = "postgres://owner:top-secret@example.invalid/punaro" // #nosec G101 -- deliberate leak-suppression fixture.
+	migratePostgresUpdate = func(context.Context, punaropostgres.Config, punaropostgres.UpdateMigrationAuthorization) (punaropostgres.SchemaState, error) {
+		return punaropostgres.SchemaState{}, errors.New(secret)
+	}
+	var stderr bytes.Buffer
+	if code := run(validArguments, &stderr); code != 1 {
+		t.Fatalf("run()=%d stderr=%q", code, stderr.String())
+	}
+	if strings.Contains(stderr.String(), secret) || !strings.Contains(stderr.String(), "failed") {
+		t.Fatalf("stderr leaked migrator details: %q", stderr.String())
+	}
+}
+
+func withoutFlag(arguments []string, flagName string) []string {
+	result := make([]string, 0, len(arguments)-2)
+	for index := 0; index < len(arguments); index += 2 {
+		if arguments[index] != flagName {
+			result = append(result, arguments[index], arguments[index+1])
+		}
+	}
+	return result
 }

--- a/cmd/punaro/main.go
+++ b/cmd/punaro/main.go
@@ -41,6 +41,14 @@ var (
 		defer func() { _ = database.Close() }()
 		return database.InstallationOwner(ctx)
 	}
+	maintenanceActive = func(ctx context.Context, dsnFile string) (bool, error) {
+		database, err := punaropostgres.OpenApplication(ctx, punaropostgres.Config{DSNFile: dsnFile})
+		if err != nil {
+			return false, err
+		}
+		defer func() { _ = database.Close() }()
+		return database.MaintenanceActive(ctx)
+	}
 	migratePristinePair = func(ctx context.Context, appDSNFile, ownerDSNFile string) (punaropostgres.SchemaState, error) {
 		return punaropostgres.MigratePristinePair(ctx, punaropostgres.Config{DSNFile: appDSNFile}, punaropostgres.Config{DSNFile: ownerDSNFile})
 	}
@@ -135,6 +143,7 @@ var (
 
 type restoreRequest struct {
 	BackupDirectory string
+	RecoveryReceipt string
 	Directory       string
 	DataDir         string
 	BackupDir       string
@@ -310,7 +319,7 @@ func main() { os.Exit(run(os.Args[1:], os.Stdout, os.Stderr)) }
 
 func run(args []string, stdout, stderr io.Writer) int {
 	if len(args) == 0 {
-		_, _ = fmt.Fprintln(stderr, "usage: punaro init|up|status|doctor|client|backup|restore")
+		_, _ = fmt.Fprintln(stderr, "usage: punaro init|up|status|doctor|client|backup|restore|update")
 		return 2
 	}
 	switch args[0] {
@@ -330,6 +339,8 @@ func run(args []string, stdout, stderr io.Writer) int {
 		return runBackup(args[1:], stdout, stderr)
 	case "restore":
 		return runRestore(args[1:], stdout, stderr)
+	case "update":
+		return runUpdate(args[1:], stdout, stderr)
 	}
 	_, _ = fmt.Fprintln(stderr, "unsupported operator command")
 	return 2
@@ -423,6 +434,15 @@ func runUp(args []string, stdout, stderr io.Writer) int {
 		return 1
 	default:
 		_, _ = fmt.Fprintf(stderr, "punaro up refused: schema is %s; follow the documented recovery procedure\n", state.Classification)
+		return 1
+	}
+	active, err := maintenanceActive(context.Background(), installation.AppDSNFile)
+	if err != nil {
+		_, _ = fmt.Fprintln(stderr, "punaro up refused: maintenance state is unavailable")
+		return 1
+	}
+	if active {
+		_, _ = fmt.Fprintln(stderr, "punaro up refused: an update transaction owns the maintenance fence; resume with punaro update")
 		return 1
 	}
 	if err := verifyInstallationPair(context.Background(), installation.AppDSNFile, installation.OwnerDSNFile); err != nil {
@@ -662,6 +682,7 @@ func runRestore(args []string, stdout, stderr io.Writer) int {
 	backupDir := flags.String("backup-dir", "", "existing private backup root for the restored stack")
 	ownerDSN := flags.String("owner-dsn-file", "", "protected target schema-owner DSN file")
 	appDSN := flags.String("app-dsn-file", "", "protected target application DSN file")
+	updateReceipt := flags.String("update-receipt", "", "protected host receipt for an update recovery backup")
 	if flags.Parse(args) != nil || flags.NArg() != 0 || *backupDirectory == "" || *directory == "" || *dataDir == "" || *backupDir == "" || *ownerDSN == "" || *appDSN == "" {
 		return 2
 	}
@@ -670,7 +691,10 @@ func runRestore(args []string, stdout, stderr io.Writer) int {
 			return 2
 		}
 	}
-	state, err := restoreOperatorBackup(context.Background(), restoreRequest{BackupDirectory: *backupDirectory, Directory: *directory, DataDir: *dataDir, BackupDir: *backupDir, OwnerDSNFile: *ownerDSN, AppDSNFile: *appDSN})
+	if *updateReceipt != "" && (!filepath.IsAbs(*updateReceipt) || filepath.Clean(*updateReceipt) != *updateReceipt) {
+		return 2
+	}
+	state, err := restoreOperatorBackup(context.Background(), restoreRequest{BackupDirectory: *backupDirectory, RecoveryReceipt: *updateReceipt, Directory: *directory, DataDir: *dataDir, BackupDir: *backupDir, OwnerDSNFile: *ownerDSN, AppDSNFile: *appDSN})
 	if err != nil {
 		var operationErr *punarobackup.OperationError
 		if errors.As(err, &operationErr) && operationErr.Phase != punarobackup.PhasePreflight {
@@ -684,30 +708,45 @@ func runRestore(args []string, stdout, stderr io.Writer) int {
 }
 
 func createBackup(ctx context.Context, installation operator.Installation) (punarobackup.Manifest, string, error) {
+	manifest, path, _, err := createBackupWithUpdate(ctx, installation, nil)
+	return manifest, path, err
+}
+
+func createUpdateBackup(ctx context.Context, installation operator.Installation, transaction punaropostgres.UpdateTransaction) (punarobackup.Manifest, string, punaropostgres.UpdateBackupMarker, error) {
+	return createBackupWithUpdate(ctx, installation, &transaction)
+}
+
+func createBackupWithUpdate(ctx context.Context, installation operator.Installation, transaction *punaropostgres.UpdateTransaction) (punarobackup.Manifest, string, punaropostgres.UpdateBackupMarker, error) {
 	if failures := operator.CheckPaths(installation); len(failures) != 0 {
-		return punarobackup.Manifest{}, "", errors.New("installation safety checks failed")
+		return punarobackup.Manifest{}, "", punaropostgres.UpdateBackupMarker{}, errors.New("installation safety checks failed")
 	}
 	state, err := inspectSchema(ctx, installation.AppDSNFile)
-	if err != nil || state.Classification != punaropostgres.Compatible {
-		return punarobackup.Manifest{}, "", errors.New("database schema is not compatible")
+	bridgeBackup := transaction != nil && transaction.Phase == punaropostgres.UpdateWritersStopped && state.Classification == punaropostgres.UpgradeRequired && state.Version == transaction.SourceSchema
+	if err != nil || (state.Classification != punaropostgres.Compatible && !bridgeBackup) {
+		return punarobackup.Manifest{}, "", punaropostgres.UpdateBackupMarker{}, errors.New("database schema is not compatible")
 	}
 	if err := verifyInstallationPair(ctx, installation.AppDSNFile, installation.OwnerDSNFile); err != nil {
-		return punarobackup.Manifest{}, "", err
+		return punarobackup.Manifest{}, "", punaropostgres.UpdateBackupMarker{}, err
 	}
 	owner, err := inspectOwner(ctx, installation.AppDSNFile)
 	if err != nil || owner.ID != installation.OwnerPrincipalID {
-		return punarobackup.Manifest{}, "", errors.New("installation owner does not match configuration")
+		return punarobackup.Manifest{}, "", punaropostgres.UpdateBackupMarker{}, errors.New("installation owner does not match configuration")
 	}
 	database, err := punaropostgres.OpenApplication(ctx, punaropostgres.Config{DSNFile: installation.AppDSNFile})
 	if err != nil {
-		return punarobackup.Manifest{}, "", err
+		return punarobackup.Manifest{}, "", punaropostgres.UpdateBackupMarker{}, err
 	}
 	defer func() { _ = database.Close() }()
-	source, err := punaropostgres.NewBackupSource(database, installation.OwnerDSNFile, pgDumpSnapshot)
-	if err != nil {
-		return punarobackup.Manifest{}, "", err
+	var source *punaropostgres.BackupSource
+	if transaction == nil {
+		source, err = punaropostgres.NewBackupSource(database, installation.OwnerDSNFile, pgDumpSnapshot)
+	} else {
+		source, err = punaropostgres.NewUpdateBackupSource(database, installation.OwnerDSNFile, transaction.UpdateID, pgDumpSnapshot)
 	}
-	return punarobackup.Create(ctx, punarobackup.CreateOptions{
+	if err != nil {
+		return punarobackup.Manifest{}, "", punaropostgres.UpdateBackupMarker{}, err
+	}
+	options := punarobackup.CreateOptions{
 		BackupRoot:       installation.BackupDir,
 		BlobRoot:         filepath.Join(installation.DataDir, "blobs"),
 		InstallationFile: operator.ConfigFile(installation.Directory),
@@ -715,7 +754,31 @@ func createBackup(ctx context.Context, installation operator.Installation) (puna
 		ComposeFile:      operator.OverrideFile(installation.Directory),
 		OwnerDSNFile:     installation.OwnerDSNFile,
 		AppDSNFile:       installation.AppDSNFile,
-	}, source)
+	}
+	if transaction != nil {
+		_, digest, found := strings.Cut(transaction.TargetImage, "@")
+		if !found {
+			return punarobackup.Manifest{}, "", punaropostgres.UpdateBackupMarker{}, errors.New("update target image is invalid")
+		}
+		options.Update = &punarobackup.UpdateTarget{UpdateID: transaction.UpdateID, TargetRelease: transaction.TargetRelease, TargetImageDigest: digest}
+	}
+	manifest, path, err := punarobackup.Create(ctx, options, source)
+	if err != nil || transaction == nil {
+		return manifest, path, punaropostgres.UpdateBackupMarker{}, err
+	}
+	binding, err := punarobackup.BuildUpdateBinding(path)
+	if err != nil {
+		return punarobackup.Manifest{}, "", punaropostgres.UpdateBackupMarker{}, err
+	}
+	if _, err := punarobackup.VerifyForUpdate(path, binding); err != nil {
+		return punarobackup.Manifest{}, "", punaropostgres.UpdateBackupMarker{}, err
+	}
+	return manifest, path, punaropostgres.UpdateBackupMarker{
+		UpdateID: binding.UpdateID, BackupID: manifest.BackupID, InstallationID: binding.InstallationID,
+		TimelineID: binding.TimelineID, ChangeSequence: binding.ChangeSequence, SourceSchema: binding.SourceSchema,
+		TargetRelease: binding.TargetRelease, TargetImageDigest: binding.TargetImageDigest,
+		ExportedSnapshotID: binding.ExportedSnapshotID, ManifestSHA256: binding.ManifestSHA256,
+	}, nil
 }
 
 func restoreBackup(ctx context.Context, request restoreRequest) (punarobackup.State, error) {
@@ -723,7 +786,38 @@ func restoreBackup(ctx context.Context, request restoreRequest) (punarobackup.St
 	if err != nil {
 		return punarobackup.State{}, err
 	}
-	if manifest.SchemaVersion != punaropostgres.CurrentManifest().MaxSupported {
+	var updateMarker *punaropostgres.UpdateBackupMarker
+	receiptDigest := ""
+	if manifest.Update != nil {
+		if request.RecoveryReceipt == "" {
+			return punarobackup.State{}, errors.New("update recovery requires an independent host receipt")
+		}
+		receipt, digest, receiptErr := operator.LoadUpdateRecoveryReceipt(request.RecoveryReceipt)
+		if receiptErr != nil {
+			return punarobackup.State{}, errors.New("update recovery receipt is unavailable or invalid")
+		}
+		binding, bindingErr := punarobackup.BuildUpdateBinding(request.BackupDirectory)
+		if bindingErr != nil {
+			return punarobackup.State{}, errors.New("update recovery binding is unavailable")
+		}
+		if _, verifyErr := punarobackup.VerifyForUpdate(request.BackupDirectory, binding); verifyErr != nil {
+			return punarobackup.State{}, errors.New("update recovery binding is invalid")
+		}
+		canonicalBackup, canonicalErr := filepath.EvalSymlinks(request.BackupDirectory)
+		if canonicalErr != nil || receipt.BackupDirectory != canonicalBackup || receipt.BackupID != manifest.BackupID || !receiptMatchesBinding(receipt, binding) {
+			return punarobackup.State{}, errors.New("update recovery receipt does not match the verified backup")
+		}
+		receiptDigest = digest
+		updateMarker = &punaropostgres.UpdateBackupMarker{
+			UpdateID: binding.UpdateID, BackupID: manifest.BackupID, InstallationID: binding.InstallationID,
+			TimelineID: binding.TimelineID, ChangeSequence: binding.ChangeSequence, SourceSchema: binding.SourceSchema,
+			TargetRelease: binding.TargetRelease, TargetImageDigest: binding.TargetImageDigest,
+			ExportedSnapshotID: binding.ExportedSnapshotID, ManifestSHA256: binding.ManifestSHA256,
+		}
+	} else if request.RecoveryReceipt != "" {
+		return punarobackup.State{}, errors.New("ordinary restore does not accept an update recovery receipt")
+	}
+	if manifest.SchemaVersion != punaropostgres.CurrentManifest().MaxSupported && (updateMarker == nil || manifest.SchemaVersion != updateMarker.SourceSchema) {
 		return punarobackup.State{}, errors.New("backup schema version is not exactly supported by this restore binary")
 	}
 	canonicalSource, err := filepath.EvalSymlinks(request.BackupDirectory)
@@ -781,6 +875,12 @@ func restoreBackup(ctx context.Context, request restoreRequest) (punarobackup.St
 		AppDSNFile:            canonicalAppDSN,
 		DatabaseIdentity:      targetIdentity,
 	}
+	if updateMarker != nil {
+		target.UpdateID = updateMarker.UpdateID
+		target.ManifestSHA256 = updateMarker.ManifestSHA256
+		target.RecoveryReceiptFile = request.RecoveryReceipt
+		target.RecoveryReceiptSHA256 = receiptDigest
+	}
 	finalizationStage := ""
 	state, err := punarobackup.Restore(ctx, punarobackup.RestoreOptions{
 		BackupDirectory: request.BackupDirectory,
@@ -817,7 +917,10 @@ func restoreBackup(ctx context.Context, request restoreRequest) (punarobackup.St
 					return err
 				}
 				return pgRestoreDump(restoreCtx, request.OwnerDSNFile, dump)
-			case punaropostgres.Compatible:
+			case punaropostgres.Compatible, punaropostgres.UpgradeRequired:
+				if targetState.Classification == punaropostgres.UpgradeRequired && (updateMarker == nil || targetState.Version != updateMarker.SourceSchema) {
+					break
+				}
 				database, openErr := punaropostgres.OpenApplication(restoreCtx, punaropostgres.Config{DSNFile: request.AppDSNFile})
 				if openErr != nil {
 					return openErr
@@ -836,14 +939,33 @@ func restoreBackup(ctx context.Context, request restoreRequest) (punarobackup.St
 				return punarobackup.State{}, openErr
 			}
 			defer func() { _ = admin.Close() }()
+			if updateMarker != nil {
+				rotated, _, rotateErr := admin.RestoreUpdateRecovery(rotateCtx, *updateMarker)
+				return punarobackup.State{InstallationID: rotated.InstallationID, TimelineID: rotated.TimelineID, ChangeSequence: rotated.ChangeSequence}, rotateErr
+			}
 			rotated, rotateErr := admin.RotateRestoredTimeline(rotateCtx, verified.BackupID, punaropostgres.InstallationState{InstallationID: verified.State.InstallationID, TimelineID: verified.State.TimelineID, ChangeSequence: verified.State.ChangeSequence})
 			return punarobackup.State{InstallationID: rotated.InstallationID, TimelineID: rotated.TimelineID, ChangeSequence: rotated.ChangeSequence}, rotateErr
 		},
 		Finalize: func(finalizeCtx context.Context, finalized punarobackup.State) error {
 			finalizationStage = "schema"
 			schema, inspectErr := inspectSchema(finalizeCtx, request.AppDSNFile)
-			if inspectErr != nil || schema.Classification != punaropostgres.Compatible || schema.Version != punaropostgres.CurrentManifest().MaxSupported || schema.Version != manifest.SchemaVersion {
+			schemaMatches := inspectErr == nil && schema.Version == manifest.SchemaVersion && schema.Classification == punaropostgres.Compatible
+			if updateMarker != nil {
+				schemaMatches = inspectErr == nil && schema.Version == updateMarker.SourceSchema && (schema.Classification == punaropostgres.Compatible || schema.Classification == punaropostgres.UpgradeRequired)
+			}
+			if !schemaMatches {
 				return errors.New("restored database schema is not the exact supported backup schema")
+			}
+			if updateMarker != nil {
+				admin, openErr := punaropostgres.OpenAdministration(finalizeCtx, punaropostgres.Config{DSNFile: request.OwnerDSNFile})
+				if openErr != nil {
+					return errors.New("restored update controls are unavailable")
+				}
+				active, activeErr := admin.ActiveUpdate(finalizeCtx)
+				closeErr := admin.Close()
+				if activeErr != nil || closeErr != nil || active.UpdateID != updateMarker.UpdateID || active.Phase != punaropostgres.UpdateRecoveryRequired || active.BackupManifestSHA256 != updateMarker.ManifestSHA256 {
+					return errors.New("restored update transaction does not match the backup")
+				}
 			}
 			finalizationStage = "roles"
 			if err := verifyInstallationPair(finalizeCtx, request.AppDSNFile, request.OwnerDSNFile); err != nil {
@@ -882,6 +1004,14 @@ func restoreBackup(ctx context.Context, request restoreRequest) (punarobackup.St
 		return punarobackup.State{}, errors.New("restored installation identity changed")
 	}
 	return state, nil
+}
+
+func receiptMatchesBinding(receipt operator.UpdateRecoveryReceipt, binding punarobackup.UpdateBinding) bool {
+	return receipt.UpdateID == binding.UpdateID && receipt.InstallationID == binding.InstallationID &&
+		receipt.TimelineID == binding.TimelineID && receipt.ChangeSequence == binding.ChangeSequence &&
+		receipt.SourceSchema == binding.SourceSchema && receipt.TargetRelease == binding.TargetRelease &&
+		receipt.TargetImageDigest == binding.TargetImageDigest && receipt.ExportedSnapshotID == binding.ExportedSnapshotID &&
+		receipt.ManifestSHA256 == binding.ManifestSHA256
 }
 
 func postgresDatabaseIdentity(ctx context.Context, appDSNFile string) (string, error) {

--- a/cmd/punaro/main_test.go
+++ b/cmd/punaro/main_test.go
@@ -136,6 +136,178 @@ func TestRealPostgresBackupRestoreCleanStackAndRetry(t *testing.T) {
 	}
 }
 
+func TestRealV5UpdateBackupReceiptRestoreAndRecoveryRetry(t *testing.T) {
+	sourceOwnerDSN := os.Getenv("PUNARO_TEST_UPDATE_SOURCE_OWNER_DSN")
+	sourceAppDSN := os.Getenv("PUNARO_TEST_UPDATE_SOURCE_APP_DSN")
+	targetOwnerDSN := os.Getenv("PUNARO_TEST_UPDATE_TARGET_OWNER_DSN")
+	targetAppDSN := os.Getenv("PUNARO_TEST_UPDATE_TARGET_APP_DSN")
+	if sourceOwnerDSN == "" || sourceAppDSN == "" || targetOwnerDSN == "" || targetAppDSN == "" {
+		t.Skip("set the PUNARO_TEST_UPDATE_* DSNs to run the v5 update recovery gate")
+	}
+	ctx := context.Background()
+	root := t.TempDir()
+	if err := os.Chmod(root, 0o700); err != nil { // #nosec G302 -- private integration-test root.
+		t.Fatal(err)
+	}
+	writeDSN := func(name, dsn string) string {
+		path := filepath.Join(root, name)
+		if err := os.WriteFile(path, []byte(dsn+"\n"), 0o600); err != nil { // #nosec G703 -- fixed fixture labels.
+			t.Fatal(err)
+		}
+		return path
+	}
+	sourceOwner := writeDSN("update-source-owner.dsn", sourceOwnerDSN)
+	sourceApp := writeDSN("update-source-app.dsn", sourceAppDSN)
+	targetOwner := writeDSN("update-target-owner.dsn", targetOwnerDSN)
+	targetApp := writeDSN("update-target-app.dsn", targetAppDSN)
+	stageV5Database(ctx, t, sourceOwnerDSN)
+
+	sourceData := filepath.Join(root, "update-source-data")
+	sourceBackups := filepath.Join(root, "update-source-backups")
+	targetBackups := filepath.Join(root, "update-target-backups")
+	for _, directory := range []string{filepath.Join(sourceData, "blobs", "ready"), sourceBackups, targetBackups} {
+		if err := os.MkdirAll(directory, 0o700); err != nil {
+			t.Fatal(err)
+		}
+	}
+	sourceInstallation, err := operator.Init(ctx, operator.InitOptions{
+		Directory: filepath.Join(root, "update-source-installation"), DataDir: sourceData, BackupDir: sourceBackups,
+		Image: cliTestImage, OwnerDSNFile: sourceOwner, AppDSNFile: sourceApp, OwnerName: "Update restore integration owner",
+		Ingress: ingress.Policy{Mode: ingress.Internet, ListenAddr: "127.0.0.1:8080", PublicURL: "https://punaro.example"},
+	}, func(initCtx context.Context, _ string, name string) (punaropostgres.Principal, error) {
+		database, openErr := sql.Open("pgx", sourceOwnerDSN)
+		if openErr != nil {
+			return punaropostgres.Principal{}, openErr
+		}
+		defer func() { _ = database.Close() }()
+		owner := punaropostgres.Principal{ID: "019b4eb0-c447-7c76-b73f-f442bab67061", Kind: punaropostgres.PrincipalKindOwner, DisplayName: name}
+		if _, insertErr := database.ExecContext(initCtx, `INSERT INTO auth.principals(id,kind,display_name) VALUES ($1,'owner',$2); INSERT INTO auth.installation_owner(principal_id) VALUES ($1)`, owner.ID, owner.DisplayName); insertErr != nil {
+			return punaropostgres.Principal{}, insertErr
+		}
+		return owner, nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	sourceDB, err := sql.Open("pgx", sourceOwnerDSN)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = sourceDB.Close() }()
+	var postgresMajor int
+	if err := sourceDB.QueryRowContext(ctx, `SELECT current_setting('server_version_num')::integer / 10000`).Scan(&postgresMajor); err != nil {
+		t.Fatal(err)
+	}
+	targetImage := "registry.example/punaro@sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+	updateRequest := punaropostgres.UpdateRequest{
+		UpdateID: "019b4eb0-798c-7a52-8d29-8560fcbb2083", SourceRelease: "v0.6.0", TargetRelease: "v0.7.0",
+		SourceImage: cliTestImage, TargetImage: targetImage, SourceSchema: 5, TargetSchema: 6, SchemaMin: 5, SchemaMax: 6, RollbackFloor: 5,
+		PostgresMajor: postgresMajor, ReleaseSHA256: strings.Repeat("b", 64), ComposeSHA256: strings.Repeat("c", 64),
+		MigrationManifestSHA256: punaropostgres.MigrationManifestSHA256(),
+	}
+	bridge, err := punaropostgres.BeginV5UpdateBridge(ctx, punaropostgres.Config{DSNFile: sourceOwner}, updateRequest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	transaction, err := bridge.CommitWritersStopped(ctx)
+	if err != nil || transaction.Phase != punaropostgres.UpdateWritersStopped {
+		t.Fatalf("v5 bridge transaction=%#v err=%v", transaction, err)
+	}
+	stage := operator.UpdateStage{Directory: sourceInstallation.Directory, UpdateID: updateRequest.UpdateID, PreviousRelease: updateRequest.SourceRelease, PreviousImage: updateRequest.SourceImage, TargetRelease: updateRequest.TargetRelease, TargetImage: updateRequest.TargetImage}
+	staged, err := operator.StageUpdate(stage)
+	if err != nil {
+		t.Fatal(err)
+	}
+	executor := &commandUpdateExecutor{installation: sourceInstallation, request: updateRequest, stage: stage, staged: staged}
+	marker, err := executor.Backup(ctx, transaction)
+	if err != nil {
+		t.Fatalf("v5 update backup: %v", err)
+	}
+	receiptFile := operator.UpdateRecoveryReceiptFile(sourceInstallation.Directory)
+	if _, _, err := operator.LoadUpdateRecoveryReceipt(receiptFile); err != nil {
+		t.Fatalf("independent recovery receipt: %v", err)
+	}
+	sourceAdmin, err := punaropostgres.OpenAdministration(ctx, punaropostgres.Config{DSNFile: sourceOwner})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if transaction, err = sourceAdmin.AdvanceUpdate(ctx, transaction.UpdateID, punaropostgres.UpdateWritersStopped, punaropostgres.UpdateBackupVerified, &marker); err != nil || transaction.Phase != punaropostgres.UpdateBackupVerified {
+		_ = sourceAdmin.Close()
+		t.Fatalf("record v5 backup marker transaction=%#v err=%v", transaction, err)
+	}
+	if err := sourceAdmin.Close(); err != nil {
+		t.Fatal(err)
+	}
+	receipt, _, err := operator.LoadUpdateRecoveryReceipt(receiptFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	restore := restoreRequest{
+		BackupDirectory: receipt.BackupDirectory, RecoveryReceipt: receiptFile,
+		Directory: filepath.Join(root, "update-target-installation"), DataDir: filepath.Join(root, "update-target-data"), BackupDir: targetBackups,
+		OwnerDSNFile: targetOwner, AppDSNFile: targetApp,
+	}
+	restored, err := restoreBackup(ctx, restore)
+	if err != nil {
+		t.Fatalf("receipt-bound v5 restore: %v", err)
+	}
+	if retried, retryErr := restoreBackup(ctx, restore); retryErr != nil || retried != restored {
+		t.Fatalf("receipt-bound restore retry=%#v err=%v", retried, retryErr)
+	}
+	targetAdmin, err := punaropostgres.OpenAdministration(ctx, punaropostgres.Config{DSNFile: targetOwner})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = targetAdmin.Close() }()
+	active, err := targetAdmin.ActiveUpdate(ctx)
+	if err != nil || active.UpdateID != updateRequest.UpdateID || active.Phase != punaropostgres.UpdateRecoveryRequired || active.BackupManifestSHA256 != marker.ManifestSHA256 {
+		t.Fatalf("restored active update=%#v err=%v", active, err)
+	}
+	for _, transition := range [][2]punaropostgres.UpdatePhase{{punaropostgres.UpdateRecoveryRequired, punaropostgres.UpdateRecoveryReady}, {punaropostgres.UpdateRecoveryReady, punaropostgres.UpdateRecoveryDoctor}, {punaropostgres.UpdateRecoveryDoctor, punaropostgres.UpdateRecoveryConfig}, {punaropostgres.UpdateRecoveryConfig, punaropostgres.UpdateRecovered}} {
+		active, err = targetAdmin.AdvanceUpdate(ctx, active.UpdateID, transition[0], transition[1], nil)
+		if err != nil || active.Phase != transition[1] {
+			t.Fatalf("recovery transition %s -> %s active=%#v err=%v", transition[0], transition[1], active, err)
+		}
+	}
+}
+
+func stageV5Database(ctx context.Context, t *testing.T, ownerDSN string) {
+	t.Helper()
+	database, err := sql.Open("pgx", ownerDSN)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = database.Close() }()
+	migrations := punaropostgres.CurrentManifest().Migrations[:5]
+	for index, migration := range migrations {
+		tx, beginErr := database.BeginTx(ctx, nil)
+		if beginErr != nil {
+			t.Fatal(beginErr)
+		}
+		if index == 0 {
+			_, err = tx.ExecContext(ctx, `CREATE SCHEMA jobs; CREATE TABLE jobs.schema_migrations (version bigint PRIMARY KEY,name text NOT NULL,checksum char(64) NOT NULL,compatibility_floor bigint NOT NULL,status text NOT NULL CHECK (status IN ('applying','applied')),started_at timestamptz NOT NULL DEFAULT statement_timestamp(),applied_at timestamptz)`)
+		} else {
+			_, err = tx.ExecContext(ctx, `INSERT INTO jobs.schema_migrations(version,name,checksum,compatibility_floor,status) VALUES ($1,$2,$3,$4,'applying')`, migration.Version, migration.Name, migration.Checksum, migration.CompatibilityFloor)
+		}
+		if err == nil && index == 0 {
+			_, err = tx.ExecContext(ctx, `INSERT INTO jobs.schema_migrations(version,name,checksum,compatibility_floor,status) VALUES ($1,$2,$3,$4,'applying')`, migration.Version, migration.Name, migration.Checksum, migration.CompatibilityFloor)
+		}
+		if err == nil {
+			_, err = tx.ExecContext(ctx, migration.SQL)
+		}
+		if err == nil {
+			_, err = tx.ExecContext(ctx, `UPDATE jobs.schema_migrations SET status='applied',applied_at=statement_timestamp() WHERE version=$1 AND status='applying'`, migration.Version)
+		}
+		if err != nil {
+			_ = tx.Rollback()
+			t.Fatalf("stage v5 migration %d: %v", migration.Version, err)
+		}
+		if err := tx.Commit(); err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
 func restoreTargetDiagnostic(ctx context.Context, ownerDSNFile, appDSNFile, sourceOwnerDSN, ownerDSN string) string {
 	db, err := sql.Open("pgx", ownerDSN)
 	if err != nil {
@@ -244,13 +416,13 @@ func testInstallation(t *testing.T) string {
 
 func preserveDependencies(t *testing.T) {
 	t.Helper()
-	originalInspect, originalOwner, originalMigrate := inspectSchema, inspectOwner, migratePristinePair
+	originalInspect, originalOwner, originalMigrate, originalMaintenance := inspectSchema, inspectOwner, migratePristinePair, maintenanceActive
 	originalCreate, originalRecover := createOwner, recoverInstallationOwner
 	originalVerify := verifyInstallationPair
 	originalStart, originalProbe, originalIssue := startServices, probe, issueEnrollment
 	originalBackup, originalListBackups, originalVerifyBackup, originalRestore := createOperatorBackup, listOperatorBackups, verifyOperatorBackup, restoreOperatorBackup
 	t.Cleanup(func() {
-		inspectSchema, inspectOwner, migratePristinePair = originalInspect, originalOwner, originalMigrate
+		inspectSchema, inspectOwner, migratePristinePair, maintenanceActive = originalInspect, originalOwner, originalMigrate, originalMaintenance
 		createOwner, recoverInstallationOwner = originalCreate, originalRecover
 		verifyInstallationPair = originalVerify
 		startServices, probe = originalStart, originalProbe
@@ -263,6 +435,22 @@ func preserveDependencies(t *testing.T) {
 	verifyInstallationPair = func(context.Context, string, string) error { return nil }
 	migratePristinePair = func(context.Context, string, string) (punaropostgres.SchemaState, error) {
 		return punaropostgres.SchemaState{Classification: punaropostgres.Compatible, Version: 5}, nil
+	}
+	maintenanceActive = func(context.Context, string) (bool, error) { return false, nil }
+}
+
+func TestUpRefusesActiveUpdateBeforeStartingWriters(t *testing.T) {
+	preserveDependencies(t)
+	directory := testInstallation(t)
+	inspectSchema = func(context.Context, string) (punaropostgres.SchemaState, error) {
+		return punaropostgres.SchemaState{Classification: punaropostgres.Compatible, Version: 6}, nil
+	}
+	maintenanceActive = func(context.Context, string) (bool, error) { return true, nil }
+	started := false
+	startServices = func(context.Context, operator.Installation) error { started = true; return nil }
+	var stderr bytes.Buffer
+	if code := run([]string{"up", "--directory", directory}, io.Discard, &stderr); code != 1 || started || !strings.Contains(stderr.String(), "punaro update") {
+		t.Fatalf("code=%d started=%t stderr=%q", code, started, stderr.String())
 	}
 }
 
@@ -327,6 +515,16 @@ func TestRestoreCommandRequiresExplicitNewStackInputs(t *testing.T) {
 	}
 	if code := run([]string{"restore", "--backup", backupPath}, io.Discard, io.Discard); code != 2 {
 		t.Fatalf("incomplete restore code=%d, want 2", code)
+	}
+}
+
+func TestRunRoutesUpdateCommand(t *testing.T) {
+	var stderr bytes.Buffer
+	if code := run([]string{"update"}, io.Discard, &stderr); code != 2 {
+		t.Fatalf("run(update) = %d, want 2", code)
+	}
+	if strings.Contains(stderr.String(), "unsupported operator command") {
+		t.Fatalf("update command was not routed: %q", stderr.String())
 	}
 }
 

--- a/cmd/punaro/main_test.go
+++ b/cmd/punaro/main_test.go
@@ -181,7 +181,10 @@ func TestRealV5UpdateBackupReceiptRestoreAndRecoveryRetry(t *testing.T) {
 		}
 		defer func() { _ = database.Close() }()
 		owner := punaropostgres.Principal{ID: "019b4eb0-c447-7c76-b73f-f442bab67061", Kind: punaropostgres.PrincipalKindOwner, DisplayName: name}
-		if _, insertErr := database.ExecContext(initCtx, `INSERT INTO auth.principals(id,kind,display_name) VALUES ($1,'owner',$2); INSERT INTO auth.installation_owner(principal_id) VALUES ($1)`, owner.ID, owner.DisplayName); insertErr != nil {
+		if _, insertErr := database.ExecContext(initCtx, `INSERT INTO auth.principals(id,kind,display_name) VALUES ($1,'owner',$2)`, owner.ID, owner.DisplayName); insertErr != nil {
+			return punaropostgres.Principal{}, insertErr
+		}
+		if _, insertErr := database.ExecContext(initCtx, `INSERT INTO auth.installation_owner(principal_id) VALUES ($1)`, owner.ID); insertErr != nil {
 			return punaropostgres.Principal{}, insertErr
 		}
 		return owner, nil

--- a/cmd/punaro/update_command.go
+++ b/cmd/punaro/update_command.go
@@ -1,0 +1,630 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	punarobackup "github.com/rock3r/punaro/internal/backup"
+	"github.com/rock3r/punaro/internal/operator"
+	punaropostgres "github.com/rock3r/punaro/internal/postgres"
+	punarorelease "github.com/rock3r/punaro/internal/release"
+)
+
+const minimumUpdateFreeBytes = uint64(512 << 20)
+
+const updateMigratorOwnerDSNPath = "/run/secrets/punaro-owner-dsn"
+
+var runUpdateDocker = func(ctx context.Context, directory string, environment []string, arguments ...string) ([]byte, error) {
+	command := exec.CommandContext(ctx, "docker", arguments...) // #nosec G204 -- fixed executable with validated generated paths and digest-pinned image arguments.
+	command.Dir = directory
+	command.Env = environment
+	return command.CombinedOutput()
+}
+
+type commandUpdateExecutor struct {
+	installation   operator.Installation
+	metadata       punarorelease.Metadata
+	request        punaropostgres.UpdateRequest
+	stage          operator.UpdateStage
+	staged         operator.StagedUpdate
+	bridge         *punaropostgres.V5UpdateBridge
+	recovery       *operator.Installation
+	recoverySchema int64
+}
+
+func runUpdate(args []string, stdout, stderr io.Writer) int {
+	flags := flag.NewFlagSet("update", flag.ContinueOnError)
+	flags.SetOutput(stderr)
+	directory := flags.String("directory", "", "absolute installation directory")
+	metadataPath := flags.String("release-metadata", "", "protected target release metadata JSON")
+	sourceRelease := flags.String("source-release", "", "current release name for installations predating release locks")
+	abort := flags.Bool("abort", false, "restart the previous image and abort before migration")
+	recovery := flags.String("recover", "", "post-migration recovery choice: compatible or restore")
+	if flags.Parse(args) != nil || flags.NArg() != 0 || *directory == "" || *metadataPath == "" || (*recovery != "" && *recovery != "compatible" && *recovery != "restore") || (*abort && *recovery != "") {
+		return 2
+	}
+	installation, err := operator.Load(*directory)
+	if err != nil {
+		_, _ = fmt.Fprintln(stderr, "punaro update refused: installation configuration is unavailable")
+		return 1
+	}
+	schema, err := inspectSchema(context.Background(), installation.AppDSNFile)
+	if err != nil || (schema.Classification != punaropostgres.Compatible && (schema.Classification != punaropostgres.UpgradeRequired || schema.Version != 5)) {
+		_, _ = fmt.Fprintln(stderr, "punaro update refused: source schema is not an intact supported update boundary")
+		return 1
+	}
+	major, err := updatePostgresMajor(context.Background(), installation.AppDSNFile)
+	if err != nil {
+		_, _ = fmt.Fprintln(stderr, "punaro update refused: PostgreSQL major is unavailable")
+		return 1
+	}
+	body, err := readReleaseMetadata(*metadataPath)
+	if err != nil {
+		_, _ = fmt.Fprintln(stderr, "punaro update refused: target release metadata is unavailable or unsafe")
+		return 1
+	}
+	metadata, err := punarorelease.Parse(body, punarorelease.Environment{CurrentSchema: schema.Version, PostgreSQLMajor: major})
+	if err != nil || metadata.MigrationManifestSHA256 != punaropostgres.MigrationManifestSHA256() {
+		_, _ = fmt.Fprintln(stderr, "punaro update refused: target release metadata does not match this updater")
+		return 1
+	}
+	active, activeErr := loadUpdateTransaction(context.Background(), installation, "")
+	if activeErr != nil && !errors.Is(activeErr, punaropostgres.ErrNotFound) {
+		_, _ = fmt.Fprintln(stderr, "punaro update refused: durable update state is unavailable")
+		return 1
+	}
+	var request punaropostgres.UpdateRequest
+	var stage operator.UpdateStage
+	if activeErr == nil {
+		if (*sourceRelease != "" && *sourceRelease != active.SourceRelease) || !metadataMatchesUpdateRequest(metadata, active.UpdateRequest) {
+			_, _ = fmt.Fprintln(stderr, "punaro update refused: supplied release does not match the active update transaction")
+			return 1
+		}
+		*sourceRelease = active.SourceRelease
+		request = active.UpdateRequest
+		stage = operator.UpdateStage{Directory: installation.Directory, UpdateID: active.UpdateID, PreviousRelease: active.SourceRelease, PreviousImage: active.SourceImage, TargetRelease: active.TargetRelease, TargetImage: active.TargetImage}
+	}
+	if errors.Is(activeErr, punaropostgres.ErrNotFound) {
+		latest, latestErr := loadLatestUpdateTransaction(context.Background(), installation)
+		if latestErr == nil && (*sourceRelease == "" || *sourceRelease == latest.SourceRelease) && completedUpdateMatches(latest, metadata, installation.Image, *abort, *recovery) {
+			stage := operator.UpdateStage{Directory: installation.Directory, UpdateID: latest.UpdateID, PreviousRelease: latest.SourceRelease, PreviousImage: latest.SourceImage, TargetRelease: latest.TargetRelease, TargetImage: latest.TargetImage}
+			if latest.Phase == punaropostgres.UpdateCommitted || latest.Phase == punaropostgres.UpdateRecovered || latest.Phase == punaropostgres.UpdateAborted {
+				cleanupErr := operator.AbortStage(stage)
+				if latest.Phase == punaropostgres.UpdateCommitted {
+					cleanupErr = operator.CompleteStage(stage)
+				}
+				if cleanupErr != nil {
+					_, _ = fmt.Fprintln(stderr, "punaro update reached a terminal outcome, but durable host-stage cleanup is incomplete; rerun the exact command")
+					return 1
+				}
+			}
+			return writeJSON(stdout, stderr, map[string]any{"status": latest.Phase, "update_id": latest.UpdateID, "target_release": latest.TargetRelease, "target_image": latest.TargetImage})
+		}
+		if latestErr == nil && *sourceRelease == "" {
+			switch {
+			case latest.Phase == punaropostgres.UpdateCommitted && installation.Image == latest.TargetImage:
+				*sourceRelease = latest.TargetRelease
+			case (latest.Phase == punaropostgres.UpdateRecovered || latest.Phase == punaropostgres.UpdateAborted) && installation.Image == latest.SourceImage:
+				*sourceRelease = latest.SourceRelease
+			}
+		}
+		existing, stageErr := operator.ExistingUpdateStage(installation.Directory)
+		if stageErr == nil {
+			if existing.PreviousImage != installation.Image || existing.TargetRelease != metadata.Release || existing.TargetImage != metadata.Image || (*sourceRelease != "" && *sourceRelease != existing.PreviousRelease) {
+				_, _ = fmt.Fprintln(stderr, "punaro update refused: durable host stage does not match the requested release")
+				return 1
+			}
+			*sourceRelease = existing.PreviousRelease
+			stage = existing
+		} else if !errors.Is(stageErr, operator.ErrUpdateStageNotFound) {
+			_, _ = fmt.Fprintln(stderr, "punaro update refused: durable host stage is unavailable")
+			return 1
+		}
+	}
+	if *sourceRelease == "" {
+		_, _ = fmt.Fprintln(stderr, "punaro update requires --source-release for this installation")
+		return 2
+	}
+	if request.UpdateID == "" {
+		updateID := uuid.NewString()
+		if stage.UpdateID != "" {
+			updateID = stage.UpdateID
+		}
+		request = punaropostgres.UpdateRequest{
+			UpdateID: updateID, SourceRelease: *sourceRelease, TargetRelease: metadata.Release,
+			SourceImage: installation.Image, TargetImage: metadata.Image,
+			SourceSchema: schema.Version, TargetSchema: metadata.Schema.Target,
+			SchemaMin: metadata.Schema.Min, SchemaMax: metadata.Schema.Max, RollbackFloor: metadata.Schema.RollbackFloor,
+			PostgresMajor: major, ReleaseSHA256: metadata.ReleaseSHA256, ComposeSHA256: metadata.ComposeSHA256,
+			MigrationManifestSHA256: metadata.MigrationManifestSHA256,
+		}
+	}
+	if stage.UpdateID == "" {
+		stage = operator.UpdateStage{Directory: installation.Directory, UpdateID: request.UpdateID, PreviousRelease: request.SourceRelease, PreviousImage: request.SourceImage, TargetRelease: request.TargetRelease, TargetImage: request.TargetImage}
+	}
+	executor := &commandUpdateExecutor{
+		installation: installation, metadata: metadata, request: request,
+		stage: stage,
+	}
+	transaction, err := executeUpdate(context.Background(), updateExecution{Request: request, Abort: *abort, RecoveryMode: *recovery}, executor)
+	if err != nil {
+		_, _ = fmt.Fprintf(stderr, "punaro update incomplete: phase=%s; reason=%v; rerun the exact command or select the documented recovery path\n", transaction.Phase, err)
+		return 1
+	}
+	return writeJSON(stdout, stderr, map[string]any{"status": transaction.Phase, "update_id": transaction.UpdateID, "target_release": transaction.TargetRelease, "target_image": transaction.TargetImage})
+}
+
+func updatePostgresMajor(ctx context.Context, dsnFile string) (int, error) {
+	database, err := punaropostgres.OpenApplication(ctx, punaropostgres.Config{DSNFile: dsnFile})
+	if err != nil {
+		return 0, err
+	}
+	defer func() { _ = database.Close() }()
+	return database.PostgreSQLMajor(ctx)
+}
+
+func readReleaseMetadata(path string) ([]byte, error) {
+	if !filepath.IsAbs(path) || filepath.Clean(path) != path {
+		return nil, errors.New("release metadata path is invalid")
+	}
+	info, err := os.Lstat(path)
+	if err != nil || !info.Mode().IsRegular() || info.Size() < 1 || info.Size() > punarorelease.MaximumMetadataBytes || info.Mode().Perm()&0o077 != 0 {
+		return nil, errors.New("release metadata file is unsafe")
+	}
+	file, err := os.Open(path) // #nosec G304 -- explicit protected release metadata path.
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = file.Close() }()
+	opened, err := file.Stat()
+	if err != nil || !os.SameFile(info, opened) {
+		return nil, errors.New("release metadata changed during open")
+	}
+	body, err := io.ReadAll(io.LimitReader(file, punarorelease.MaximumMetadataBytes+1))
+	if err != nil || len(body) > punarorelease.MaximumMetadataBytes {
+		return nil, errors.New("release metadata is too large")
+	}
+	return body, nil
+}
+
+func loadUpdateTransaction(ctx context.Context, installation operator.Installation, updateID string) (punaropostgres.UpdateTransaction, error) {
+	admin, err := punaropostgres.OpenAdministration(ctx, punaropostgres.Config{DSNFile: installation.OwnerDSNFile})
+	if err != nil {
+		state, inspectErr := inspectSchema(ctx, installation.AppDSNFile)
+		return punaropostgres.UpdateTransaction{}, classifyUpdateLookupOpenError(state, inspectErr, err)
+	}
+	defer func() { _ = admin.Close() }()
+	if updateID != "" {
+		return admin.Update(ctx, updateID)
+	}
+	return admin.ActiveUpdate(ctx)
+}
+
+func loadLatestUpdateTransaction(ctx context.Context, installation operator.Installation) (punaropostgres.UpdateTransaction, error) {
+	admin, err := punaropostgres.OpenAdministration(ctx, punaropostgres.Config{DSNFile: installation.OwnerDSNFile})
+	if err != nil {
+		state, inspectErr := inspectSchema(ctx, installation.AppDSNFile)
+		return punaropostgres.UpdateTransaction{}, classifyUpdateLookupOpenError(state, inspectErr, err)
+	}
+	defer func() { _ = admin.Close() }()
+	return admin.LatestUpdate(ctx)
+}
+
+func completedUpdateMatches(transaction punaropostgres.UpdateTransaction, metadata punarorelease.Metadata, publishedImage string, abort bool, recovery string) bool {
+	request := transaction.UpdateRequest
+	if !metadataMatchesUpdateRequest(metadata, request) {
+		return false
+	}
+	switch transaction.Phase {
+	case punaropostgres.UpdateCommitted:
+		return !abort && recovery == "" && publishedImage == request.TargetImage
+	case punaropostgres.UpdateRecovered:
+		return !abort && recovery != "" && publishedImage == request.SourceImage
+	case punaropostgres.UpdateAborted:
+		return abort && recovery == "" && publishedImage == request.SourceImage
+	default:
+		return false
+	}
+}
+
+func metadataMatchesUpdateRequest(metadata punarorelease.Metadata, request punaropostgres.UpdateRequest) bool {
+	return request.TargetRelease == metadata.Release && request.TargetImage == metadata.Image &&
+		request.SchemaMin == metadata.Schema.Min && request.SchemaMax == metadata.Schema.Max && request.TargetSchema == metadata.Schema.Target && request.RollbackFloor == metadata.Schema.RollbackFloor &&
+		request.PostgresMajor == metadata.PostgreSQLMajor && request.ReleaseSHA256 == metadata.ReleaseSHA256 && request.ComposeSHA256 == metadata.ComposeSHA256 && request.MigrationManifestSHA256 == metadata.MigrationManifestSHA256
+}
+
+func classifyUpdateLookupOpenError(state punaropostgres.SchemaState, inspectErr, openErr error) error {
+	if inspectErr == nil && state.Classification == punaropostgres.UpgradeRequired && state.Version == 5 {
+		return punaropostgres.ErrNotFound
+	}
+	return openErr
+}
+
+func (executor *commandUpdateExecutor) Active(ctx context.Context) (punaropostgres.UpdateTransaction, error) {
+	transaction, err := loadUpdateTransaction(ctx, executor.installation, executor.request.UpdateID)
+	if errors.Is(err, punaropostgres.ErrNotFound) {
+		return loadUpdateTransaction(ctx, executor.installation, "")
+	}
+	return transaction, err
+}
+
+func (executor *commandUpdateExecutor) PreflightAndPull(ctx context.Context) error {
+	if failures := operator.CheckPaths(executor.installation); len(failures) != 0 {
+		return errors.New("installation paths are unsafe")
+	}
+	base := strings.TrimRight(executor.installation.HealthURL, "/")
+	orphanedBridge := false
+	if probe(ctx, base+"/healthz") != nil || probe(ctx, base+"/readyz") != nil {
+		staged, stageErr := operator.ResumeUpdateStage(executor.stage)
+		stopped, stopErr := executor.configuredWritersStopped(ctx)
+		if stageErr != nil || stopErr != nil || !stopped {
+			return errors.New("current stack is unhealthy")
+		}
+		executor.staged = staged
+		orphanedBridge = true
+	}
+	appIdentity, appErr := postgresDatabaseIdentity(ctx, executor.installation.AppDSNFile)
+	ownerIdentity, ownerErr := postgresOwnerDatabaseIdentity(ctx, executor.installation.OwnerDSNFile)
+	owner, inspectErr := inspectOwner(ctx, executor.installation.AppDSNFile)
+	if appErr != nil || ownerErr != nil || appIdentity != ownerIdentity || inspectErr != nil || owner.ID != executor.installation.OwnerPrincipalID {
+		return errors.New("installation database identity changed")
+	}
+	for _, path := range []string{executor.installation.DataDir, executor.installation.BackupDir} {
+		available, err := operator.UpdateAvailableBytes(path)
+		if err != nil || available < minimumUpdateFreeBytes {
+			return errors.New("update disk capacity is insufficient")
+		}
+	}
+	return executor.prepareTarget(ctx, !orphanedBridge)
+}
+
+func (executor *commandUpdateExecutor) PrepareResume(ctx context.Context, transaction punaropostgres.UpdateTransaction) error {
+	if err := executor.prepareTarget(ctx, false); err != nil {
+		return err
+	}
+	if transaction.Phase == punaropostgres.UpdateCommitted || transaction.Phase == punaropostgres.UpdateRecovered {
+		_ = operator.CompleteStage(executor.stage)
+	}
+	return nil
+}
+
+func (executor *commandUpdateExecutor) prepareTarget(ctx context.Context, pull bool) error {
+	if pull {
+		_, err := runUpdateDocker(ctx, executor.installation.Directory, updateDockerEnvironment(os.Environ(), executor.installation.Directory), "pull", executor.request.TargetImage)
+		if err != nil {
+			return errors.New("target image pull failed")
+		}
+	}
+	output, err := runUpdateDocker(ctx, executor.installation.Directory, updateDockerEnvironment(os.Environ(), executor.installation.Directory), "image", "inspect", "--format", "{{json .RepoDigests}}", executor.request.TargetImage)
+	if err != nil || !bytes.Contains(output, []byte(strings.Split(executor.request.TargetImage, "@")[1])) {
+		return errors.New("pulled target digest cannot be verified locally")
+	}
+	staged, err := operator.StageUpdate(executor.stage)
+	if err != nil {
+		return err
+	}
+	executor.staged = staged
+	composeBody, err := os.ReadFile(operator.OverrideFile(staged.CandidateDirectory)) // #nosec G304 -- fixed file in validated operator stage.
+	if err != nil {
+		return errors.New("candidate Compose artifact is unavailable")
+	}
+	digest := sha256.Sum256(composeBody)
+	if hex.EncodeToString(digest[:]) != executor.metadata.ComposeSHA256 {
+		return errors.New("candidate Compose artifact does not match release metadata")
+	}
+	return nil
+}
+
+func (executor *commandUpdateExecutor) Fence(ctx context.Context, request punaropostgres.UpdateRequest) (punaropostgres.UpdateTransaction, error) {
+	if request.SourceSchema == 5 && request.TargetSchema == 6 {
+		bridge, err := punaropostgres.BeginV5UpdateBridge(ctx, punaropostgres.Config{DSNFile: executor.installation.OwnerDSNFile}, request)
+		if err != nil {
+			return punaropostgres.UpdateTransaction{}, err
+		}
+		executor.bridge = bridge
+		return bridge.Update(), nil
+	}
+	admin, err := punaropostgres.OpenAdministration(ctx, punaropostgres.Config{DSNFile: executor.installation.OwnerDSNFile})
+	if err != nil {
+		return punaropostgres.UpdateTransaction{}, err
+	}
+	defer func() { _ = admin.Close() }()
+	return admin.BeginUpdate(ctx, request)
+}
+
+func (executor *commandUpdateExecutor) StopWriters(ctx context.Context) error {
+	arguments, err := updateComposeArgs(executor.installation, "stop", "--timeout", "30", "punarod")
+	if err != nil {
+		return err
+	}
+	_, err = runUpdateDocker(ctx, executor.installation.Directory, updateDockerEnvironment(os.Environ(), executor.installation.Directory), arguments...)
+	if err != nil {
+		return errors.New("writer stop failed")
+	}
+	stopped, err := executor.configuredWritersStopped(ctx)
+	if err != nil || !stopped {
+		return errors.New("configured writer did not stop")
+	}
+	return nil
+}
+
+func (executor *commandUpdateExecutor) configuredWritersStopped(ctx context.Context) (bool, error) {
+	arguments, err := updateComposeArgs(executor.installation, "ps", "--status", "running", "--services")
+	if err != nil {
+		return false, err
+	}
+	output, err := runUpdateDocker(ctx, executor.installation.Directory, updateDockerEnvironment(os.Environ(), executor.installation.Directory), arguments...)
+	if err != nil {
+		return false, err
+	}
+	return strings.TrimSpace(string(output)) == "", nil
+}
+
+func updateComposeArgs(installation operator.Installation, tail ...string) ([]string, error) {
+	project, err := operator.ComposeProjectName(installation)
+	if err != nil {
+		return nil, err
+	}
+	arguments := []string{"compose", "--project-name", project, "--env-file", operator.EnvFile(installation.Directory), "-f", operator.OverrideFile(installation.Directory)}
+	return append(arguments, tail...), nil
+}
+
+func (executor *commandUpdateExecutor) Backup(ctx context.Context, transaction punaropostgres.UpdateTransaction) (punaropostgres.UpdateBackupMarker, error) {
+	receiptPath := operator.UpdateRecoveryReceiptFile(executor.installation.Directory)
+	if receipt, _, err := operator.LoadUpdateRecoveryReceipt(receiptPath); err == nil {
+		binding := receiptUpdateBinding(receipt)
+		manifest, verifyErr := punarobackup.VerifyForUpdate(receipt.BackupDirectory, binding)
+		marker := receiptUpdateMarker(receipt)
+		if verifyErr != nil || receipt.BackupID != manifest.BackupID || !updateBackupMarkerMatchesTransaction(marker, transaction) {
+			return punaropostgres.UpdateBackupMarker{}, errors.New("durable update recovery receipt does not match this transaction")
+		}
+		return marker, nil
+	} else if _, statErr := os.Lstat(receiptPath); !errors.Is(statErr, os.ErrNotExist) {
+		return punaropostgres.UpdateBackupMarker{}, errors.New("durable update recovery receipt is unavailable or unsafe")
+	}
+	_, path, marker, err := createUpdateBackup(ctx, executor.installation, transaction)
+	if err != nil {
+		return punaropostgres.UpdateBackupMarker{}, err
+	}
+	canonicalBackup, err := filepath.EvalSymlinks(path)
+	if err != nil {
+		return punaropostgres.UpdateBackupMarker{}, errors.New("verified update backup path cannot be resolved")
+	}
+	receipt := operator.UpdateRecoveryReceipt{
+		Version: 1, UpdateID: marker.UpdateID, BackupID: marker.BackupID, BackupDirectory: canonicalBackup,
+		InstallationID: marker.InstallationID, TimelineID: marker.TimelineID, ChangeSequence: marker.ChangeSequence,
+		SourceSchema: marker.SourceSchema, TargetRelease: marker.TargetRelease, TargetImageDigest: marker.TargetImageDigest,
+		ExportedSnapshotID: marker.ExportedSnapshotID, ManifestSHA256: marker.ManifestSHA256,
+	}
+	if _, err := operator.BindUpdateRecoveryReceipt(executor.stage, receipt); err != nil {
+		return punaropostgres.UpdateBackupMarker{}, err
+	}
+	return marker, nil
+}
+
+func receiptUpdateBinding(receipt operator.UpdateRecoveryReceipt) punarobackup.UpdateBinding {
+	return punarobackup.UpdateBinding{UpdateID: receipt.UpdateID, SourceSchema: receipt.SourceSchema, InstallationID: receipt.InstallationID, TimelineID: receipt.TimelineID, ChangeSequence: receipt.ChangeSequence, TargetRelease: receipt.TargetRelease, TargetImageDigest: receipt.TargetImageDigest, ExportedSnapshotID: receipt.ExportedSnapshotID, ManifestSHA256: receipt.ManifestSHA256}
+}
+
+func receiptUpdateMarker(receipt operator.UpdateRecoveryReceipt) punaropostgres.UpdateBackupMarker {
+	return punaropostgres.UpdateBackupMarker{UpdateID: receipt.UpdateID, BackupID: receipt.BackupID, InstallationID: receipt.InstallationID, TimelineID: receipt.TimelineID, ChangeSequence: receipt.ChangeSequence, SourceSchema: receipt.SourceSchema, TargetRelease: receipt.TargetRelease, TargetImageDigest: receipt.TargetImageDigest, ExportedSnapshotID: receipt.ExportedSnapshotID, ManifestSHA256: receipt.ManifestSHA256}
+}
+
+func updateBackupMarkerMatchesTransaction(marker punaropostgres.UpdateBackupMarker, transaction punaropostgres.UpdateTransaction) bool {
+	_, targetDigest, found := strings.Cut(transaction.TargetImage, "@")
+	return found && marker.UpdateID == transaction.UpdateID && marker.InstallationID != "" && marker.TimelineID != "" &&
+		marker.SourceSchema == transaction.SourceSchema && marker.TargetRelease == transaction.TargetRelease && marker.TargetImageDigest == targetDigest
+}
+
+func (executor *commandUpdateExecutor) Migrate(ctx context.Context, transaction punaropostgres.UpdateTransaction) error {
+	authorization := punaropostgres.UpdateMigrationAuthorization{UpdateID: transaction.UpdateID, BackupID: transaction.BackupID, TargetRelease: transaction.TargetRelease, TargetImage: transaction.TargetImage, TargetSchema: transaction.TargetSchema, ExportedSnapshotID: transaction.BackupSnapshotID, ManifestSHA256: transaction.BackupManifestSHA256}
+	arguments, err := updateMigratorContainerArgs(executor.installation, authorization)
+	if err != nil {
+		return err
+	}
+	migrateCtx, cancel := context.WithTimeout(ctx, 3*time.Minute)
+	defer cancel()
+	if _, err := runUpdateDocker(migrateCtx, executor.installation.Directory, updateDockerEnvironment(os.Environ(), executor.installation.Directory), arguments...); err != nil {
+		return errors.New("target migrator container failed")
+	}
+	return nil
+}
+
+func updateMigratorContainerArgs(installation operator.Installation, authorization punaropostgres.UpdateMigrationAuthorization) ([]string, error) {
+	if authorization.Validate() != nil || len(operator.CheckPaths(installation)) != 0 {
+		return nil, errors.New("target migrator inputs are unavailable or unsafe")
+	}
+	uid, uidErr := strconv.ParseUint(installation.RuntimeUID, 10, 32)
+	gid, gidErr := strconv.ParseUint(installation.RuntimeGID, 10, 32)
+	if uidErr != nil || gidErr != nil || uid == 0 || gid == 0 {
+		return nil, errors.New("target migrator runtime identity is invalid")
+	}
+	ownerDSNFile, err := filepath.EvalSymlinks(installation.OwnerDSNFile)
+	if err != nil || !filepath.IsAbs(ownerDSNFile) || strings.ContainsAny(ownerDSNFile, ",\r\n") {
+		return nil, errors.New("target migrator owner credential path is invalid")
+	}
+	return []string{
+		"run", "--rm", "--network", "host", "--read-only",
+		"--cap-drop", "ALL", "--security-opt", "no-new-privileges:true",
+		"--user", installation.RuntimeUID + ":" + installation.RuntimeGID,
+		"--mount", "type=bind,src=" + ownerDSNFile + ",dst=" + updateMigratorOwnerDSNPath + ",readonly",
+		"--entrypoint", "/usr/local/bin/punaro-migrate", authorization.TargetImage,
+		"--owner-dsn-file", updateMigratorOwnerDSNPath,
+		"--update-id", authorization.UpdateID,
+		"--backup-id", authorization.BackupID,
+		"--target-release", authorization.TargetRelease,
+		"--target-image", authorization.TargetImage,
+		"--target-schema", strconv.FormatInt(authorization.TargetSchema, 10),
+		"--exported-snapshot-id", authorization.ExportedSnapshotID,
+		"--manifest-sha256", authorization.ManifestSHA256,
+	}, nil
+}
+
+func updateDockerEnvironment(environment []string, directory string) []string {
+	sanitized := composeEnvironment(environment, directory)
+	result := make([]string, 0, len(sanitized))
+	for _, entry := range sanitized {
+		name, _, found := strings.Cut(entry, "=")
+		upper := strings.ToUpper(name)
+		if !found || strings.HasPrefix(upper, "PG") || strings.HasPrefix(upper, "DOCKER_") {
+			continue
+		}
+		result = append(result, entry)
+	}
+	return result
+}
+
+func (executor *commandUpdateExecutor) StartCandidate(ctx context.Context, _ punaropostgres.UpdateTransaction) error {
+	candidate, err := operator.Load(executor.staged.CandidateDirectory)
+	if err != nil {
+		return err
+	}
+	if err := startServices(ctx, candidate); err != nil {
+		return err
+	}
+	return waitForReady(ctx, candidate)
+}
+
+func waitForReady(ctx context.Context, installation operator.Installation) error {
+	deadline := time.Now().Add(30 * time.Second)
+	readyURL := strings.TrimRight(installation.HealthURL, "/") + "/readyz"
+	for {
+		if probe(ctx, readyURL) == nil {
+			return nil
+		}
+		if time.Now().After(deadline) {
+			return errors.New("candidate readiness deadline exceeded")
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(500 * time.Millisecond):
+		}
+	}
+}
+
+func (executor *commandUpdateExecutor) Doctor(ctx context.Context, _ punaropostgres.UpdateTransaction) error {
+	var candidate operator.Installation
+	if executor.recovery != nil {
+		candidate = *executor.recovery
+		state, err := inspectSchema(ctx, candidate.AppDSNFile)
+		active, maintenanceErr := maintenanceActive(ctx, candidate.AppDSNFile)
+		owner, ownerErr := inspectOwner(ctx, candidate.AppDSNFile)
+		base := strings.TrimRight(candidate.HealthURL, "/")
+		if err != nil || state.Version != executor.recoverySchema || maintenanceErr != nil || !active ||
+			len(operator.CheckPaths(candidate)) != 0 || verifyInstallationPair(ctx, candidate.AppDSNFile, candidate.OwnerDSNFile) != nil ||
+			ownerErr != nil || owner.ID != candidate.OwnerPrincipalID || probe(ctx, base+"/healthz") != nil || probe(ctx, base+"/readyz") != nil {
+			return errors.New("recovery doctor failed")
+		}
+		return nil
+	}
+	var err error
+	candidate, err = operator.Load(executor.staged.CandidateDirectory)
+	if err != nil {
+		return err
+	}
+	result := diagnose(ctx, candidate)
+	if !result.Healthy {
+		return errors.New("candidate doctor failed")
+	}
+	return nil
+}
+
+func (executor *commandUpdateExecutor) Publish(_ context.Context, _ punaropostgres.UpdateTransaction, recovery bool) error {
+	if recovery {
+		if executor.recovery == nil {
+			return errors.New("recovery installation is unavailable")
+		}
+		if executor.recovery.Directory == executor.stage.Directory {
+			return operator.PublishPreviousUpdate(executor.stage)
+		}
+		return nil
+	}
+	_, err := operator.PublishUpdate(executor.stage)
+	return err
+}
+
+func (executor *commandUpdateExecutor) AbortToPrevious(ctx context.Context, _ punaropostgres.UpdateTransaction) error {
+	if err := startServices(ctx, executor.installation); err != nil {
+		return err
+	}
+	if err := waitForReady(ctx, executor.installation); err != nil {
+		return err
+	}
+	if !diagnose(ctx, executor.installation).Healthy {
+		return errors.New("previous image doctor failed")
+	}
+	return operator.AbortStage(executor.stage)
+}
+
+func (executor *commandUpdateExecutor) Recover(ctx context.Context, transaction punaropostgres.UpdateTransaction, mode string) error {
+	switch mode {
+	case "compatible":
+		if executor.installation.Image != transaction.SourceImage && executor.installation.Image != transaction.TargetImage {
+			return errors.New("previous image is not schema-compatible; restore the bound backup")
+		}
+		executor.recoverySchema = transaction.TargetSchema
+	case "restore":
+		state, err := inspectSchema(ctx, executor.installation.AppDSNFile)
+		if err != nil || state.Version != transaction.SourceSchema || executor.installation.Image != transaction.SourceImage || transaction.BackupID == "" || transaction.BackupManifestSHA256 == "" {
+			return errors.New("restored installation does not match the bound update backup")
+		}
+		executor.recoverySchema = transaction.SourceSchema
+	default:
+		return errors.New("update recovery mode is invalid")
+	}
+	if err := operator.RestorePreviousUpdate(executor.stage); err != nil {
+		return err
+	}
+	previous, err := operator.Load(executor.stage.Directory)
+	if err != nil || previous.Image != transaction.SourceImage {
+		return errors.New("previous recovery configuration is unavailable")
+	}
+	executor.installation = previous
+	if err := startServices(ctx, executor.installation); err != nil {
+		return err
+	}
+	if err := waitForReady(ctx, executor.installation); err != nil {
+		return err
+	}
+	executor.recovery = &executor.installation
+	return nil
+}
+
+func (executor *commandUpdateExecutor) Advance(ctx context.Context, transaction punaropostgres.UpdateTransaction, to punaropostgres.UpdatePhase, marker *punaropostgres.UpdateBackupMarker) (punaropostgres.UpdateTransaction, error) {
+	if executor.bridge != nil && transaction.Phase == punaropostgres.UpdateFenced && to == punaropostgres.UpdateWritersStopped {
+		advanced, err := executor.bridge.CommitWritersStopped(ctx)
+		executor.bridge = nil
+		return advanced, err
+	}
+	admin, err := punaropostgres.OpenAdministration(ctx, punaropostgres.Config{DSNFile: executor.installation.OwnerDSNFile})
+	if err != nil {
+		return transaction, err
+	}
+	defer func() { _ = admin.Close() }()
+	advanced, err := admin.AdvanceUpdate(ctx, transaction.UpdateID, transaction.Phase, to, marker)
+	if err == nil && to == punaropostgres.UpdateCommitted {
+		if cleanupErr := operator.CompleteStage(executor.stage); cleanupErr != nil {
+			return advanced, cleanupErr
+		}
+	}
+	if err == nil && (to == punaropostgres.UpdateRecovered || to == punaropostgres.UpdateAborted) {
+		if cleanupErr := operator.AbortStage(executor.stage); cleanupErr != nil {
+			return advanced, cleanupErr
+		}
+	}
+	return advanced, err
+}

--- a/cmd/punaro/update_command_test.go
+++ b/cmd/punaro/update_command_test.go
@@ -1,0 +1,159 @@
+package main
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/rock3r/punaro/internal/operator"
+	punaropostgres "github.com/rock3r/punaro/internal/postgres"
+	punarorelease "github.com/rock3r/punaro/internal/release"
+)
+
+func TestUpdateLookupTreatsOnlyPreBridgeV5AsNoActiveUpdate(t *testing.T) {
+	openErr := errors.New("administration unavailable")
+	if err := classifyUpdateLookupOpenError(punaropostgres.SchemaState{Classification: punaropostgres.UpgradeRequired, Version: 5}, nil, openErr); !errors.Is(err, punaropostgres.ErrNotFound) {
+		t.Fatalf("pre-bridge v5 error = %v", err)
+	}
+	if err := classifyUpdateLookupOpenError(punaropostgres.SchemaState{Classification: punaropostgres.Compatible, Version: 6}, nil, openErr); !errors.Is(err, openErr) {
+		t.Fatalf("compatible schema hid administration error: %v", err)
+	}
+	inspectErr := errors.New("schema unavailable")
+	if err := classifyUpdateLookupOpenError(punaropostgres.SchemaState{}, inspectErr, openErr); !errors.Is(err, openErr) {
+		t.Fatalf("schema inspection error hid administration error: %v", err)
+	}
+}
+
+func TestCompletedUpdateReconciliationRequiresExactPublishedOutcome(t *testing.T) {
+	request := testUpdateRequest()
+	metadata := punarorelease.Metadata{
+		Release: request.TargetRelease, Image: request.TargetImage,
+		Schema:          punarorelease.SchemaRange{Min: request.SchemaMin, Max: request.SchemaMax, Target: request.TargetSchema, RollbackFloor: request.RollbackFloor},
+		PostgreSQLMajor: request.PostgresMajor, ReleaseSHA256: request.ReleaseSHA256,
+		ComposeSHA256: request.ComposeSHA256, MigrationManifestSHA256: request.MigrationManifestSHA256,
+	}
+	transaction := punaropostgres.UpdateTransaction{UpdateRequest: request, Phase: punaropostgres.UpdateCommitted}
+	if !completedUpdateMatches(transaction, metadata, request.TargetImage, false, "") {
+		t.Fatal("exact committed outcome was not reconciled")
+	}
+	if completedUpdateMatches(transaction, metadata, request.SourceImage, false, "") {
+		t.Fatal("committed outcome accepted unpublished target image")
+	}
+	metadata.ComposeSHA256 = "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+	if completedUpdateMatches(transaction, metadata, request.TargetImage, false, "") {
+		t.Fatal("committed outcome accepted changed release metadata")
+	}
+}
+
+func TestUpdateResumeUsesLocallyVerifiedTargetWithoutRegistryPull(t *testing.T) {
+	directory := testInstallation(t)
+	installation, err := operator.Load(directory)
+	if err != nil {
+		t.Fatal(err)
+	}
+	request := testUpdateRequest()
+	request.SourceImage = installation.Image
+	stage := operator.UpdateStage{Directory: directory, UpdateID: request.UpdateID, PreviousRelease: request.SourceRelease, PreviousImage: request.SourceImage, TargetRelease: request.TargetRelease, TargetImage: request.TargetImage}
+	staged, err := operator.StageUpdate(stage)
+	if err != nil {
+		t.Fatal(err)
+	}
+	compose, err := os.ReadFile(operator.OverrideFile(staged.CandidateDirectory))
+	if err != nil {
+		t.Fatal(err)
+	}
+	digest := sha256.Sum256(compose)
+	executor := &commandUpdateExecutor{installation: installation, request: request, stage: stage, metadata: punarorelease.Metadata{ComposeSHA256: hex.EncodeToString(digest[:])}}
+	originalDocker := runUpdateDocker
+	t.Cleanup(func() { runUpdateDocker = originalDocker })
+	pulled := false
+	runUpdateDocker = func(_ context.Context, _ string, _ []string, arguments ...string) ([]byte, error) {
+		if len(arguments) > 0 && arguments[0] == "pull" {
+			pulled = true
+		}
+		return []byte(request.TargetImage), nil
+	}
+	if err := executor.PrepareResume(context.Background(), punaropostgres.UpdateTransaction{UpdateRequest: request, Phase: punaropostgres.UpdateWritersStopped}); err != nil {
+		t.Fatal(err)
+	}
+	if pulled {
+		t.Fatal("durable update resume depended on a fresh registry pull")
+	}
+}
+
+func TestCompatibleRecoveryDoctorsPreviousInstallationBeforePublishing(t *testing.T) {
+	preserveDependencies(t)
+	directory := testInstallation(t)
+	installation, err := operator.Load(directory)
+	if err != nil {
+		t.Fatal(err)
+	}
+	request := testUpdateRequest()
+	request.SourceImage = installation.Image
+	stage := operator.UpdateStage{Directory: directory, UpdateID: request.UpdateID, PreviousRelease: request.SourceRelease, PreviousImage: request.SourceImage, TargetRelease: request.TargetRelease, TargetImage: request.TargetImage}
+	staged, err := operator.StageUpdate(stage)
+	if err != nil {
+		t.Fatal(err)
+	}
+	startServices = func(context.Context, operator.Installation) error { return nil }
+	probe = func(context.Context, string) error { return nil }
+	maintenanceActive = func(context.Context, string) (bool, error) { return true, nil }
+	inspectSchema = func(context.Context, string) (punaropostgres.SchemaState, error) {
+		return punaropostgres.SchemaState{Classification: punaropostgres.Compatible, Version: request.SourceSchema}, nil
+	}
+	executor := &commandUpdateExecutor{installation: installation, request: request, stage: stage, staged: staged}
+	transaction := punaropostgres.UpdateTransaction{UpdateRequest: request, Phase: punaropostgres.UpdateRecoveryRequired}
+	if err := executor.Recover(context.Background(), transaction, "compatible"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(filepath.Join(directory, ".update")); err != nil {
+		t.Fatalf("recovery removed stage before doctor: %v", err)
+	}
+	if err := executor.Doctor(context.Background(), transaction); err != nil {
+		t.Fatalf("previous-image doctor failed: %v", err)
+	}
+	if err := executor.Publish(context.Background(), transaction, true); err != nil {
+		t.Fatalf("compatible recovery publication failed: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(directory, ".update")); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("recovery stage remains after publication: %v", err)
+	}
+}
+
+func TestRestoredRecoveryDoctorsExactSourceSchemaBeforePublishing(t *testing.T) {
+	preserveDependencies(t)
+	directory := testInstallation(t)
+	installation, err := operator.Load(directory)
+	if err != nil {
+		t.Fatal(err)
+	}
+	request := testUpdateRequest()
+	request.SourceImage = installation.Image
+	request.SourceSchema, request.TargetSchema, request.SchemaMin, request.SchemaMax, request.RollbackFloor = 5, 6, 5, 6, 5
+	stage := operator.UpdateStage{Directory: directory, UpdateID: request.UpdateID, PreviousRelease: request.SourceRelease, PreviousImage: request.SourceImage, TargetRelease: request.TargetRelease, TargetImage: request.TargetImage}
+	staged, err := operator.StageUpdate(stage)
+	if err != nil {
+		t.Fatal(err)
+	}
+	startServices = func(context.Context, operator.Installation) error { return nil }
+	probe = func(context.Context, string) error { return nil }
+	maintenanceActive = func(context.Context, string) (bool, error) { return true, nil }
+	inspectSchema = func(context.Context, string) (punaropostgres.SchemaState, error) {
+		return punaropostgres.SchemaState{Classification: punaropostgres.UpgradeRequired, Version: 5}, nil
+	}
+	executor := &commandUpdateExecutor{installation: installation, request: request, stage: stage, staged: staged}
+	transaction := punaropostgres.UpdateTransaction{UpdateRequest: request, Phase: punaropostgres.UpdateRecoveryRequired, BackupID: "019b4eb0-5317-79a6-a0de-fd97719910fb", BackupManifestSHA256: "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"}
+	if err := executor.Recover(context.Background(), transaction, "restore"); err != nil {
+		t.Fatal(err)
+	}
+	if err := executor.Doctor(context.Background(), transaction); err != nil {
+		t.Fatalf("restored source-image doctor failed: %v", err)
+	}
+	if err := executor.Publish(context.Background(), transaction, true); err != nil {
+		t.Fatalf("restored recovery publication failed: %v", err)
+	}
+}

--- a/cmd/punaro/update_migrator_test.go
+++ b/cmd/punaro/update_migrator_test.go
@@ -1,0 +1,125 @@
+package main
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"slices"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/rock3r/punaro/internal/operator"
+	punaropostgres "github.com/rock3r/punaro/internal/postgres"
+)
+
+func migrationStartedTransaction() punaropostgres.UpdateTransaction {
+	request := testUpdateRequest()
+	return punaropostgres.UpdateTransaction{
+		UpdateRequest:        request,
+		Phase:                punaropostgres.UpdateMigrationStarted,
+		BackupID:             "019b4eb0-5317-79a6-a0de-fd97719910fb",
+		BackupSnapshotID:     "00000003-000001A0-1",
+		BackupManifestSHA256: "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+	}
+}
+
+func TestUpdateMigratorRunsOneShotInExactTargetDigestWithExactAuthorization(t *testing.T) {
+	directory := testInstallation(t)
+	installation, err := operator.Load(directory)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PGPASSWORD", "host-secret-must-not-propagate")
+	t.Setenv("PUNARO_OWNER_DSN", "postgres://owner-secret-must-not-propagate")
+	t.Setenv("COMPOSE_FILE", "/attacker/compose.yaml")
+	t.Setenv("DOCKER_HOST", "tcp://attacker.example:2375")
+
+	originalDocker := runUpdateDocker
+	t.Cleanup(func() { runUpdateDocker = originalDocker })
+	var gotDirectory string
+	var gotEnvironment, gotArguments []string
+	runUpdateDocker = func(_ context.Context, directory string, environment []string, arguments ...string) ([]byte, error) {
+		gotDirectory = directory
+		gotEnvironment = append([]string(nil), environment...)
+		gotArguments = append([]string(nil), arguments...)
+		return nil, nil
+	}
+
+	transaction := migrationStartedTransaction()
+	executor := &commandUpdateExecutor{installation: installation}
+	if err := executor.Migrate(context.Background(), transaction); err != nil {
+		t.Fatal(err)
+	}
+	canonicalOwnerDSN, err := filepath.EvalSymlinks(installation.OwnerDSNFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	containerDSNPath := "/run/secrets/punaro-owner-dsn"
+	want := []string{
+		"run", "--rm", "--network", "host", "--read-only",
+		"--cap-drop", "ALL", "--security-opt", "no-new-privileges:true",
+		"--user", installation.RuntimeUID + ":" + installation.RuntimeGID,
+		"--mount", "type=bind,src=" + canonicalOwnerDSN + ",dst=" + containerDSNPath + ",readonly",
+		"--entrypoint", "/usr/local/bin/punaro-migrate", transaction.TargetImage,
+		"--owner-dsn-file", containerDSNPath,
+		"--update-id", transaction.UpdateID,
+		"--backup-id", transaction.BackupID,
+		"--target-release", transaction.TargetRelease,
+		"--target-image", transaction.TargetImage,
+		"--target-schema", strconv.FormatInt(transaction.TargetSchema, 10),
+		"--exported-snapshot-id", transaction.BackupSnapshotID,
+		"--manifest-sha256", transaction.BackupManifestSHA256,
+	}
+	if gotDirectory != installation.Directory || !slices.Equal(gotArguments, want) {
+		t.Fatalf("directory=%q args=%v want=%v", gotDirectory, gotArguments, want)
+	}
+	for _, entry := range gotEnvironment {
+		name, _, _ := strings.Cut(entry, "=")
+		upper := strings.ToUpper(name)
+		if strings.HasPrefix(upper, "PG") || strings.HasPrefix(upper, "PUNARO_") || strings.HasPrefix(upper, "COMPOSE_") || strings.HasPrefix(upper, "DOCKER_") {
+			t.Fatalf("unsafe inherited migrator environment: %q", entry)
+		}
+	}
+	joined := strings.Join(append(append([]string(nil), gotEnvironment...), gotArguments...), "\n")
+	if strings.Contains(joined, "host-secret-must-not-propagate") || strings.Contains(joined, "owner-secret-must-not-propagate") || strings.Contains(joined, transaction.SourceImage) {
+		t.Fatalf("migrator command exposed a secret or source image: %s", joined)
+	}
+}
+
+func TestUpdateMigratorRefusesUnsafeOwnerPathAndUnpinnedTargetBeforeDocker(t *testing.T) {
+	for name, mutate := range map[string]func(*testing.T, *operator.Installation, *punaropostgres.UpdateTransaction){
+		"unsafe owner file": func(t *testing.T, installation *operator.Installation, _ *punaropostgres.UpdateTransaction) {
+			if err := os.Chmod(installation.OwnerDSNFile, 0o644); err != nil { // #nosec G302 -- deliberate unsafe permission drift.
+				t.Fatal(err)
+			}
+		},
+		"tagged target image": func(_ *testing.T, _ *operator.Installation, transaction *punaropostgres.UpdateTransaction) {
+			transaction.TargetImage = "registry.example/punaro:latest"
+		},
+		"missing authorization": func(_ *testing.T, _ *operator.Installation, transaction *punaropostgres.UpdateTransaction) {
+			transaction.BackupManifestSHA256 = ""
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			directory := testInstallation(t)
+			installation, err := operator.Load(directory)
+			if err != nil {
+				t.Fatal(err)
+			}
+			transaction := migrationStartedTransaction()
+			mutate(t, &installation, &transaction)
+			originalDocker := runUpdateDocker
+			t.Cleanup(func() { runUpdateDocker = originalDocker })
+			called := false
+			runUpdateDocker = func(context.Context, string, []string, ...string) ([]byte, error) {
+				called = true
+				return nil, nil
+			}
+			executor := &commandUpdateExecutor{installation: installation}
+			if err := executor.Migrate(context.Background(), transaction); err == nil || called {
+				t.Fatalf("err=%v dockerCalled=%t", err, called)
+			}
+		})
+	}
+}

--- a/cmd/punaro/update_orchestrator.go
+++ b/cmd/punaro/update_orchestrator.go
@@ -1,0 +1,147 @@
+package main
+
+import (
+	"context"
+	"errors"
+
+	punaropostgres "github.com/rock3r/punaro/internal/postgres"
+)
+
+type updateExecution struct {
+	Request      punaropostgres.UpdateRequest
+	Abort        bool
+	RecoveryMode string
+}
+
+type updateExecutor interface {
+	Active(context.Context) (punaropostgres.UpdateTransaction, error)
+	PreflightAndPull(context.Context) error
+	PrepareResume(context.Context, punaropostgres.UpdateTransaction) error
+	Fence(context.Context, punaropostgres.UpdateRequest) (punaropostgres.UpdateTransaction, error)
+	StopWriters(context.Context) error
+	Backup(context.Context, punaropostgres.UpdateTransaction) (punaropostgres.UpdateBackupMarker, error)
+	Migrate(context.Context, punaropostgres.UpdateTransaction) error
+	StartCandidate(context.Context, punaropostgres.UpdateTransaction) error
+	Doctor(context.Context, punaropostgres.UpdateTransaction) error
+	Publish(context.Context, punaropostgres.UpdateTransaction, bool) error
+	AbortToPrevious(context.Context, punaropostgres.UpdateTransaction) error
+	Recover(context.Context, punaropostgres.UpdateTransaction, string) error
+	Advance(context.Context, punaropostgres.UpdateTransaction, punaropostgres.UpdatePhase, *punaropostgres.UpdateBackupMarker) (punaropostgres.UpdateTransaction, error)
+}
+
+func executeUpdate(ctx context.Context, execution updateExecution, executor updateExecutor) (punaropostgres.UpdateTransaction, error) {
+	if executor == nil || execution.Request.Validate() != nil {
+		return punaropostgres.UpdateTransaction{}, errors.New("update execution is invalid")
+	}
+	transaction, err := executor.Active(ctx)
+	if errors.Is(err, punaropostgres.ErrNotFound) {
+		if execution.Abort || execution.RecoveryMode != "" {
+			return punaropostgres.UpdateTransaction{}, errors.New("no update transaction is active")
+		}
+		if err := executor.PreflightAndPull(ctx); err != nil {
+			return punaropostgres.UpdateTransaction{}, err
+		}
+		transaction, err = executor.Fence(ctx, execution.Request)
+	}
+	if err != nil {
+		return punaropostgres.UpdateTransaction{}, err
+	}
+	if transaction.UpdateRequest != execution.Request {
+		return transaction, errors.New("active update target does not match the requested release")
+	}
+	if execution.Abort {
+		switch transaction.Phase {
+		case punaropostgres.UpdateFenced, punaropostgres.UpdateWritersStopped, punaropostgres.UpdateBackupVerified:
+			if err := executor.AbortToPrevious(ctx, transaction); err != nil {
+				return transaction, err
+			}
+			return executor.Advance(ctx, transaction, punaropostgres.UpdateAborted, nil)
+		default:
+			return transaction, errors.New("update cannot be aborted after migration starts")
+		}
+	}
+	if execution.RecoveryMode != "" {
+		switch transaction.Phase {
+		case punaropostgres.UpdateMigrationStarted, punaropostgres.UpdateMigrated, punaropostgres.UpdateCandidateReady, punaropostgres.UpdateDoctorPassed:
+			transaction, err = executor.Advance(ctx, transaction, punaropostgres.UpdateRecoveryRequired, nil)
+			if err != nil {
+				return transaction, err
+			}
+		}
+	}
+	if execution.RecoveryMode == "" && transaction.Phase != punaropostgres.UpdateRecoveryRequired && transaction.Phase != punaropostgres.UpdateRecoveryReady && transaction.Phase != punaropostgres.UpdateRecoveryDoctor && transaction.Phase != punaropostgres.UpdateRecoveryConfig {
+		if err := executor.PrepareResume(ctx, transaction); err != nil {
+			return transaction, err
+		}
+	}
+	if execution.RecoveryMode == "" && (transaction.Phase == punaropostgres.UpdateRecoveryRequired || transaction.Phase == punaropostgres.UpdateRecoveryReady || transaction.Phase == punaropostgres.UpdateRecoveryDoctor) {
+		return transaction, errors.New("update recovery choice is required")
+	}
+
+	for {
+		switch transaction.Phase {
+		case punaropostgres.UpdateFenced:
+			if err := executor.StopWriters(ctx); err != nil {
+				return transaction, err
+			}
+			transaction, err = executor.Advance(ctx, transaction, punaropostgres.UpdateWritersStopped, nil)
+		case punaropostgres.UpdateWritersStopped:
+			var marker punaropostgres.UpdateBackupMarker
+			marker, err = executor.Backup(ctx, transaction)
+			if err == nil {
+				transaction, err = executor.Advance(ctx, transaction, punaropostgres.UpdateBackupVerified, &marker)
+			}
+		case punaropostgres.UpdateBackupVerified:
+			transaction, err = executor.Advance(ctx, transaction, punaropostgres.UpdateMigrationStarted, nil)
+		case punaropostgres.UpdateMigrationStarted:
+			if err = executor.Migrate(ctx, transaction); err != nil {
+				return transaction, err
+			}
+			transaction, err = executor.Advance(ctx, transaction, punaropostgres.UpdateMigrated, nil)
+		case punaropostgres.UpdateMigrated:
+			if err = executor.StartCandidate(ctx, transaction); err == nil {
+				transaction, err = executor.Advance(ctx, transaction, punaropostgres.UpdateCandidateReady, nil)
+			}
+		case punaropostgres.UpdateCandidateReady:
+			if err = executor.Doctor(ctx, transaction); err == nil {
+				transaction, err = executor.Advance(ctx, transaction, punaropostgres.UpdateDoctorPassed, nil)
+			}
+		case punaropostgres.UpdateDoctorPassed:
+			if err = executor.Publish(ctx, transaction, false); err == nil {
+				transaction, err = executor.Advance(ctx, transaction, punaropostgres.UpdateConfigPublished, nil)
+			}
+		case punaropostgres.UpdateConfigPublished:
+			transaction, err = executor.Advance(ctx, transaction, punaropostgres.UpdateCommitted, nil)
+		case punaropostgres.UpdateRecoveryRequired:
+			if execution.RecoveryMode == "" {
+				return transaction, errors.New("update recovery choice is required")
+			}
+			if err = executor.Recover(ctx, transaction, execution.RecoveryMode); err == nil {
+				transaction, err = executor.Advance(ctx, transaction, punaropostgres.UpdateRecoveryReady, nil)
+			}
+		case punaropostgres.UpdateRecoveryReady:
+			if err = executor.Recover(ctx, transaction, execution.RecoveryMode); err == nil {
+				err = executor.Doctor(ctx, transaction)
+			}
+			if err == nil {
+				transaction, err = executor.Advance(ctx, transaction, punaropostgres.UpdateRecoveryDoctor, nil)
+			}
+		case punaropostgres.UpdateRecoveryDoctor:
+			if err = executor.Recover(ctx, transaction, execution.RecoveryMode); err == nil {
+				err = executor.Publish(ctx, transaction, true)
+			}
+			if err == nil {
+				transaction, err = executor.Advance(ctx, transaction, punaropostgres.UpdateRecoveryConfig, nil)
+			}
+		case punaropostgres.UpdateRecoveryConfig:
+			transaction, err = executor.Advance(ctx, transaction, punaropostgres.UpdateRecovered, nil)
+		case punaropostgres.UpdateCommitted, punaropostgres.UpdateRecovered, punaropostgres.UpdateAborted:
+			return transaction, nil
+		default:
+			return transaction, errors.New("update transaction has an unsupported phase")
+		}
+		if err != nil {
+			return transaction, err
+		}
+	}
+}

--- a/cmd/punaro/update_orchestrator.go
+++ b/cmd/punaro/update_orchestrator.go
@@ -67,6 +67,10 @@ func executeUpdate(ctx context.Context, execution updateExecution, executor upda
 			if err != nil {
 				return transaction, err
 			}
+		case punaropostgres.UpdateRecoveryRequired, punaropostgres.UpdateRecoveryReady, punaropostgres.UpdateRecoveryDoctor, punaropostgres.UpdateRecoveryConfig:
+			// Resume the explicitly selected recovery path below.
+		default:
+			return transaction, errors.New("update recovery cannot start in the current phase")
 		}
 	}
 	if execution.RecoveryMode == "" && transaction.Phase != punaropostgres.UpdateRecoveryRequired && transaction.Phase != punaropostgres.UpdateRecoveryReady && transaction.Phase != punaropostgres.UpdateRecoveryDoctor && transaction.Phase != punaropostgres.UpdateRecoveryConfig {

--- a/cmd/punaro/update_orchestrator_test.go
+++ b/cmd/punaro/update_orchestrator_test.go
@@ -1,0 +1,169 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"testing"
+
+	punaropostgres "github.com/rock3r/punaro/internal/postgres"
+)
+
+type fakeUpdateExecutor struct {
+	active  punaropostgres.UpdateTransaction
+	actions []string
+	failAt  string
+}
+
+func (fake *fakeUpdateExecutor) action(name string) error {
+	fake.actions = append(fake.actions, name)
+	if fake.failAt == name {
+		return errors.New("injected failure")
+	}
+	return nil
+}
+
+func (fake *fakeUpdateExecutor) Active(context.Context) (punaropostgres.UpdateTransaction, error) {
+	if fake.active.UpdateID == "" {
+		return punaropostgres.UpdateTransaction{}, punaropostgres.ErrNotFound
+	}
+	return fake.active, nil
+}
+func (fake *fakeUpdateExecutor) PreflightAndPull(context.Context) error {
+	return fake.action("preflight_pull")
+}
+func (fake *fakeUpdateExecutor) PrepareResume(context.Context, punaropostgres.UpdateTransaction) error {
+	return fake.action("resume_preflight")
+}
+func (fake *fakeUpdateExecutor) Fence(_ context.Context, request punaropostgres.UpdateRequest) (punaropostgres.UpdateTransaction, error) {
+	if err := fake.action("fence"); err != nil {
+		return punaropostgres.UpdateTransaction{}, err
+	}
+	fake.active = punaropostgres.UpdateTransaction{UpdateRequest: request, Phase: punaropostgres.UpdateFenced}
+	return fake.active, nil
+}
+func (fake *fakeUpdateExecutor) StopWriters(context.Context) error {
+	return fake.action("stop_writers")
+}
+func (fake *fakeUpdateExecutor) Backup(context.Context, punaropostgres.UpdateTransaction) (punaropostgres.UpdateBackupMarker, error) {
+	if err := fake.action("backup"); err != nil {
+		return punaropostgres.UpdateBackupMarker{}, err
+	}
+	return punaropostgres.UpdateBackupMarker{UpdateID: fake.active.UpdateID}, nil
+}
+func (fake *fakeUpdateExecutor) Migrate(context.Context, punaropostgres.UpdateTransaction) error {
+	return fake.action("migrate")
+}
+func (fake *fakeUpdateExecutor) StartCandidate(context.Context, punaropostgres.UpdateTransaction) error {
+	return fake.action("candidate_ready")
+}
+func (fake *fakeUpdateExecutor) Doctor(context.Context, punaropostgres.UpdateTransaction) error {
+	return fake.action("doctor")
+}
+func (fake *fakeUpdateExecutor) Publish(context.Context, punaropostgres.UpdateTransaction, bool) error {
+	return fake.action("publish")
+}
+func (fake *fakeUpdateExecutor) AbortToPrevious(context.Context, punaropostgres.UpdateTransaction) error {
+	return fake.action("abort_previous")
+}
+func (fake *fakeUpdateExecutor) Recover(context.Context, punaropostgres.UpdateTransaction, string) error {
+	return fake.action("recover")
+}
+func (fake *fakeUpdateExecutor) Advance(_ context.Context, _ punaropostgres.UpdateTransaction, to punaropostgres.UpdatePhase, _ *punaropostgres.UpdateBackupMarker) (punaropostgres.UpdateTransaction, error) {
+	if err := fake.action("advance_" + string(to)); err != nil {
+		return fake.active, err
+	}
+	fake.active.Phase = to
+	return fake.active, nil
+}
+
+func testUpdateRequest() punaropostgres.UpdateRequest {
+	return punaropostgres.UpdateRequest{
+		UpdateID: "019b4eb0-21f8-7d93-84df-10e6cf05ce53", SourceRelease: "v0.6.0", TargetRelease: "v0.7.0",
+		SourceImage:  "ghcr.io/rock3r/punaro@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+		TargetImage:  "ghcr.io/rock3r/punaro@sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+		SourceSchema: 6, TargetSchema: 6, PostgresMajor: 17,
+		SchemaMin: 6, SchemaMax: 6, RollbackFloor: 6,
+		ReleaseSHA256:           "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+		ComposeSHA256:           "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+		MigrationManifestSHA256: "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+	}
+}
+
+func TestExecuteUpdateOrdersIrreversibleProofsBeforeCommit(t *testing.T) {
+	fake := &fakeUpdateExecutor{}
+	transaction, err := executeUpdate(context.Background(), updateExecution{Request: testUpdateRequest()}, fake)
+	if err != nil || transaction.Phase != punaropostgres.UpdateCommitted {
+		t.Fatalf("transaction=%#v err=%v", transaction, err)
+	}
+	want := []string{"preflight_pull", "fence", "resume_preflight", "stop_writers", "advance_writers_stopped", "backup", "advance_backup_verified", "advance_migration_started", "migrate", "advance_migrated", "candidate_ready", "advance_candidate_ready", "doctor", "advance_doctor_passed", "publish", "advance_config_published", "advance_committed"}
+	if !reflect.DeepEqual(fake.actions, want) {
+		t.Fatalf("actions=%v want=%v", fake.actions, want)
+	}
+}
+
+func TestExecuteUpdateResumesWithoutRepeatingCompletedExternalWork(t *testing.T) {
+	request := testUpdateRequest()
+	fake := &fakeUpdateExecutor{active: punaropostgres.UpdateTransaction{UpdateRequest: request, Phase: punaropostgres.UpdateMigrated}}
+	transaction, err := executeUpdate(context.Background(), updateExecution{Request: request}, fake)
+	if err != nil || transaction.Phase != punaropostgres.UpdateCommitted {
+		t.Fatalf("transaction=%#v err=%v", transaction, err)
+	}
+	if len(fake.actions) < 2 || fake.actions[0] != "resume_preflight" || fake.actions[1] != "candidate_ready" {
+		t.Fatalf("resume repeated prior work: %v", fake.actions)
+	}
+}
+
+func TestExecuteUpdateFailureNeverGuessesExternalSuccess(t *testing.T) {
+	request := testUpdateRequest()
+	fake := &fakeUpdateExecutor{active: punaropostgres.UpdateTransaction{UpdateRequest: request, Phase: punaropostgres.UpdateMigrated}, failAt: "candidate_ready"}
+	transaction, err := executeUpdate(context.Background(), updateExecution{Request: request}, fake)
+	if err == nil || transaction.Phase != punaropostgres.UpdateMigrated {
+		t.Fatalf("transaction=%#v err=%v", transaction, err)
+	}
+}
+
+func TestExecuteUpdateAmbiguousMigratorFailureRemainsExactlyResumable(t *testing.T) {
+	request := testUpdateRequest()
+	fake := &fakeUpdateExecutor{active: punaropostgres.UpdateTransaction{UpdateRequest: request, Phase: punaropostgres.UpdateMigrationStarted}, failAt: "migrate"}
+	transaction, err := executeUpdate(context.Background(), updateExecution{Request: request}, fake)
+	if err == nil || transaction.Phase != punaropostgres.UpdateMigrationStarted || !reflect.DeepEqual(fake.actions, []string{"resume_preflight", "migrate"}) {
+		t.Fatalf("transaction=%#v actions=%v err=%v", transaction, fake.actions, err)
+	}
+}
+
+func TestExecuteUpdateExplicitRecoveryMovesIrreversibleFailureIntoRecovery(t *testing.T) {
+	request := testUpdateRequest()
+	fake := &fakeUpdateExecutor{active: punaropostgres.UpdateTransaction{UpdateRequest: request, Phase: punaropostgres.UpdateMigrated}}
+	transaction, err := executeUpdate(context.Background(), updateExecution{Request: request, RecoveryMode: "compatible"}, fake)
+	if err != nil || transaction.Phase != punaropostgres.UpdateRecovered {
+		t.Fatalf("transaction=%#v err=%v", transaction, err)
+	}
+	want := []string{"advance_recovery_required", "recover", "advance_recovery_ready", "recover", "doctor", "advance_recovery_doctor_passed", "recover", "publish", "advance_recovery_config_published", "advance_recovered"}
+	if !reflect.DeepEqual(fake.actions, want) {
+		t.Fatalf("actions=%v want=%v", fake.actions, want)
+	}
+}
+
+func TestExecuteUpdateRejectsChangedResumeAndLateAbort(t *testing.T) {
+	request := testUpdateRequest()
+	changed := request
+	changed.TargetRelease = "v0.8.0"
+	fake := &fakeUpdateExecutor{active: punaropostgres.UpdateTransaction{UpdateRequest: request, Phase: punaropostgres.UpdateWritersStopped}}
+	if _, err := executeUpdate(context.Background(), updateExecution{Request: changed}, fake); err == nil {
+		t.Fatal("changed target resumed existing update")
+	}
+	fake = &fakeUpdateExecutor{active: punaropostgres.UpdateTransaction{UpdateRequest: request, Phase: punaropostgres.UpdateMigrationStarted}}
+	if _, err := executeUpdate(context.Background(), updateExecution{Request: request, Abort: true}, fake); err == nil {
+		t.Fatal("post-migration abort succeeded")
+	}
+}
+
+func TestExecuteUpdatePreMigrationAbortRestartsOldBeforeRelease(t *testing.T) {
+	request := testUpdateRequest()
+	fake := &fakeUpdateExecutor{active: punaropostgres.UpdateTransaction{UpdateRequest: request, Phase: punaropostgres.UpdateBackupVerified}}
+	transaction, err := executeUpdate(context.Background(), updateExecution{Request: request, Abort: true}, fake)
+	if err != nil || transaction.Phase != punaropostgres.UpdateAborted || !reflect.DeepEqual(fake.actions, []string{"abort_previous", "advance_aborted"}) {
+		t.Fatalf("transaction=%#v actions=%v err=%v", transaction, fake.actions, err)
+	}
+}

--- a/cmd/punaro/update_orchestrator_test.go
+++ b/cmd/punaro/update_orchestrator_test.go
@@ -145,6 +145,24 @@ func TestExecuteUpdateExplicitRecoveryMovesIrreversibleFailureIntoRecovery(t *te
 	}
 }
 
+func TestExecuteUpdateRejectsRecoveryOutsideRecoveryWindow(t *testing.T) {
+	request := testUpdateRequest()
+	for _, phase := range []punaropostgres.UpdatePhase{
+		punaropostgres.UpdateFenced,
+		punaropostgres.UpdateWritersStopped,
+		punaropostgres.UpdateBackupVerified,
+		punaropostgres.UpdateConfigPublished,
+	} {
+		t.Run(string(phase), func(t *testing.T) {
+			fake := &fakeUpdateExecutor{active: punaropostgres.UpdateTransaction{UpdateRequest: request, Phase: phase}}
+			transaction, err := executeUpdate(context.Background(), updateExecution{Request: request, RecoveryMode: "compatible"}, fake)
+			if err == nil || transaction.Phase != phase || len(fake.actions) != 0 {
+				t.Fatalf("transaction=%#v actions=%v err=%v", transaction, fake.actions, err)
+			}
+		})
+	}
+}
+
 func TestExecuteUpdateRejectsChangedResumeAndLateAbort(t *testing.T) {
 	request := testUpdateRequest()
 	changed := request

--- a/deploy/postgres-test-init.sql
+++ b/deploy/postgres-test-init.sql
@@ -10,3 +10,7 @@ CREATE DATABASE punaro_restore_source OWNER punaro_owner;
 GRANT CONNECT ON DATABASE punaro_restore_source TO punaro_app;
 CREATE DATABASE punaro_restore_target OWNER punaro_owner;
 GRANT CONNECT ON DATABASE punaro_restore_target TO punaro_app;
+CREATE DATABASE punaro_update_source OWNER punaro_owner;
+GRANT CONNECT ON DATABASE punaro_update_source TO punaro_app;
+CREATE DATABASE punaro_update_target OWNER punaro_owner;
+GRANT CONNECT ON DATABASE punaro_update_target TO punaro_app;

--- a/docker-compose.postgres-test.yml
+++ b/docker-compose.postgres-test.yml
@@ -36,6 +36,10 @@ services:
       PUNARO_TEST_RESTORE_SOURCE_APP_DSN: postgres://punaro_app@postgres:5432/punaro_restore_source?sslmode=disable
       PUNARO_TEST_RESTORE_TARGET_OWNER_DSN: postgres://punaro_owner@postgres:5432/punaro_restore_target?sslmode=disable
       PUNARO_TEST_RESTORE_TARGET_APP_DSN: postgres://punaro_app@postgres:5432/punaro_restore_target?sslmode=disable
+      PUNARO_TEST_UPDATE_SOURCE_OWNER_DSN: postgres://punaro_owner@postgres:5432/punaro_update_source?sslmode=disable
+      PUNARO_TEST_UPDATE_SOURCE_APP_DSN: postgres://punaro_app@postgres:5432/punaro_update_source?sslmode=disable
+      PUNARO_TEST_UPDATE_TARGET_OWNER_DSN: postgres://punaro_owner@postgres:5432/punaro_update_target?sslmode=disable
+      PUNARO_TEST_UPDATE_TARGET_APP_DSN: postgres://punaro_app@postgres:5432/punaro_update_target?sslmode=disable
     depends_on:
       postgres:
         condition: service_healthy

--- a/docs/operator-guide.md
+++ b/docs/operator-guide.md
@@ -425,23 +425,12 @@ create or repair schema objects. A pristine, dirty, upgrade-required, newer, or
 incompatible schema makes startup fail with a content-free classification. Do
 not grant DDL to `punaro_app` to bypass that refusal.
 
-M-1 through M-5 expose the schema-owner action directly for controlled development and
-integration use:
-
-```sh
-go run ./cmd/punaro-migrate -owner-dsn-file /absolute/private/owner.dsn
-```
-
-The same reviewed binary is present in the application image; because the
-alpha image still defaults to `punarod`, invoke the role explicitly and mount
-the protected file read-only:
-
-```sh
-docker run --rm --entrypoint /usr/local/bin/punaro-migrate \
-  --user "$(id -u):$(id -g)" \
-  --mount type=bind,src=/absolute/private/owner.dsn,dst=/run/secrets/owner.dsn,readonly \
-  PUNARO_IMAGE_BY_DIGEST -owner-dsn-file /run/secrets/owner.dsn
-```
+Existing-schema migration is available only through `punaro update`. The
+`punaro-migrate` image role requires the exact active update ID, verified backup
+marker, target release/image/schema, exported snapshot, and manifest digest.
+The host wrapper supplies those values to a hardened one-shot container and
+mounts the owner DSN read-only; invoking the role without that durable evidence
+fails closed. Pristine initialization remains part of `punaro init`.
 
 The role contract uses the exact roles `punaro_owner` and
 `punaro_app`. Provision `punaro_app` first as a login with no superuser,
@@ -453,19 +442,18 @@ read the caller-owned `0600` bind mount without weakening it; use an equivalent
 read-only secret mechanism in an orchestrator.
 Concurrent migrators serialize on a PostgreSQL advisory lock. A migration left
 in `applying` state is a dirty fence and is not silently repaired; preserve the
-database and investigate. Supported backup-gated production updates and dirty
-recovery arrive in later milestones, so this command is not yet a production
-update procedure. The digest-pinned `make test-postgres` stack is ephemeral
+database and investigate. The digest-pinned `make test-postgres` stack is ephemeral
 test infrastructure, publishes no database port, and deletes its volume on
 exit.
 
-The current binary requires schema version 5. Versions 1 through 4 are reported
+The current binary requires schema version 6. Versions 1 through 5 are reported
 as `upgrade_required`; damaged older objects remain `incompatible`. Migration 3 is
 additive and creates the host-local ownership, pending enrollment, device
 credential, cache/session generation, and Ed25519 migration-inventory records.
-There is still no relay cutover or production update wrapper. Do not
+Migration 6 adds the durable update coordinator, exact recovery evidence, and
+the mutation fence. There is still no relay cutover. Do not
 hand edit ownership, enrollment, credential, idempotency, capacity, lease,
-migration, or audit rows to bypass a failure.
+migration, update, restore, or audit rows to bypass a failure.
 Before any later authority cutover, rollback remains disabling the PostgreSQL
 opt-in and retaining SQLite as the unchanged active relay.
 
@@ -596,12 +584,11 @@ validated generated environment authoritative while retaining Docker connection
 settings. The operator-controlled Docker executable, CLI plugins, configuration,
 and selected daemon/context remain trusted dependencies; use a local daemon for
 this host-local wrapper because bind-path validation does not extend to a remote
-Docker host. It starts only a compatible schema;
+Docker host. It starts only a compatible schema and refuses while an update
+transaction owns the maintenance fence;
 a pristine database after initialization is treated as data loss, an old schema
-refuses startup and directs the operator to keep running the previous compatible
-release. This staged M-5 wrapper deliberately has no in-place update command;
-the separately reviewed M-7 durable update milestone adds that transaction after
-consistent backup/restore exists. Dirty/newer/incompatible state
+refuses startup and directs the operator to use the supported update or previous
+compatible release. Dirty/newer/incompatible state
 requires recovery. It waits up to 30 seconds for readiness and then runs the
 same checks as doctor. Raw `docker compose up` and `punarod` never migrate.
 
@@ -678,6 +665,17 @@ punaro restore \
   --app-dsn-file /absolute/private/restored-app.dsn
 ```
 
+For an update-bound recovery backup, the exact command must also name the
+independent receipt written by the failed update before migration:
+
+```text
+  --update-receipt /absolute/private/old-installation/.update/recovery.json
+```
+
+Keep that receipt until the update is committed, recovered, or aborted. It is
+deliberately outside the backup; a v2 update backup cannot authorize its own
+restore.
+
 Restore re-verifies the complete backup before mutation, stages and verifies
 all blobs, restores the database in one `pg_restore` transaction, preserves the
 installation ID, rotates the timeline, and publishes the new data and generated
@@ -691,9 +689,86 @@ unrotated timeline fail closed. Clients observing the new timeline must discard 
 cursors/caches and re-enumerate authoritative state. Optional gateways remain
 not ready until their external dependencies are supplied or re-enrolled.
 
-M-6 is not the M-7 production update transaction and does not make raw Compose
-or daemon startup migrate. Run restore drills and retain a verified off-host
-copy before admitting irreplaceable data.
+Update-created version 2 backups additionally bind the exact update ID, source
+schema and state coordinates, target release/image digest, exported snapshot,
+and raw manifest digest. Before the database accepts that backup marker, the
+host writes a protected receipt outside the backup. Restore requires both and
+binds the receipt path and digest into its resume journal before mutation.
+Restoring one automatically reconstructs the same fenced update transaction on
+the rotated timeline; it does not reopen writes.
+Run restore drills and retain a verified off-host copy before admitting
+irreplaceable data.
+
+### Supported update and rollback
+
+`punaro update` is the only supported existing-schema migration path. It manages
+the one generated `punarod` writer and the externally provisioned PostgreSQL
+database. Any additional writer using the same database is outside this
+generated-stack contract and must be stopped separately before adoption. The
+bundled production PostgreSQL/profile shape remains M-23.
+
+Run the host-side `punaro` wrapper shipped by the target release; its embedded
+migration manifest and generated Compose template are part of the target
+boundary and a source-release wrapper is intentionally rejected. Use the
+target release's published, protected metadata whose `image` is digest-pinned,
+`release_sha256` equals that image digest without the `sha256:` prefix,
+`compose_sha256` matches the generated Compose artifact, and migration-manifest,
+schema-range, rollback-floor, and PostgreSQL-major values match the target
+release. The file must be an absolute private regular file. On the first update
+from an installation without a release-name lock, supply the current release:
+
+```sh
+punaro update \
+  --directory /absolute/private/punaro-installation \
+  --release-metadata /absolute/private/releases/v0.7.0.json \
+  --source-release v0.6.0
+```
+
+Before maintenance, the wrapper checks private paths, current health and owner
+identity, disk capacity, PostgreSQL major, target compatibility, the exact
+pulled image digest, and the Compose hash. It then acquires the transactional
+database fence, drains earlier mutations, stops the configured writer, proves
+it stopped, creates and verifies the bound backup, and records that marker. The
+exact target image runs the one-shot migrator with a read-only owner DSN mount;
+the normal daemon never receives that credential. The target starts while the
+fence still rejects business writes and must pass readiness and doctor before
+configuration is published and the database commit reopens writes.
+
+Rerun the exact command after a crash or uncertain external command. It resumes
+the durable PostgreSQL phase and private host journal without repeating completed
+work or requiring another registry pull. Do not edit `.update`, the release
+metadata, database update rows, or the verified backup. A pre-migration failure
+may be abandoned only with the same arguments plus `--abort`; the previous
+digest must start and pass doctor before the fence is released:
+
+```sh
+punaro update \
+  --directory /absolute/private/punaro-installation \
+  --release-metadata /absolute/private/releases/v0.7.0.json \
+  --source-release v0.6.0 \
+  --abort
+```
+
+After migration starts, `--abort` is refused. Explicitly select `--recover
+compatible` only when the recorded previous image actually starts and passes
+readiness plus the recovery doctor against the migrated schema while still
+fenced. Otherwise restore the exact update-bound backup into a stopped,
+pristine database and new paths using the normal `punaro restore` command above
+with its `--update-receipt`. Then
+resume the reconstructed transaction from the restored installation:
+
+```sh
+punaro update \
+  --directory /absolute/private/restored-installation \
+  --release-metadata /absolute/private/releases/v0.7.0.json \
+  --recover restore
+```
+
+The restored source image, source schema, owner, installation/timeline state,
+backup marker, readiness, and doctor must all match before recovery commits and
+writes reopen. Keep the abandoned stack stopped. Raw `docker compose up`, raw
+`punarod`, and direct `punaro-migrate` invocation never clear or bypass a live
+fence.
 
 ## Operations and incident response
 

--- a/internal/backup/create.go
+++ b/internal/backup/create.go
@@ -51,6 +51,16 @@ type CreateOptions struct {
 	AppDSNFile       string
 	Now              func() time.Time
 	NewID            func() string
+	Update           *UpdateTarget
+}
+
+// UpdateTarget requests a v2 manifest for one update transaction. Source
+// coordinates are derived from the exported snapshot and cannot be supplied by
+// the caller.
+type UpdateTarget struct {
+	UpdateID          string
+	TargetRelease     string
+	TargetImageDigest string
 }
 
 // Create publishes a backup only after its exact snapshot dump, configuration,
@@ -85,9 +95,21 @@ func Create(ctx context.Context, options CreateOptions, source Source) (Manifest
 			_ = snapshot.Finish(abortCtx, false)
 		}
 	}()
-	manifest := Manifest{Version: 1, BackupID: backupID, CreatedAt: createdAt, SnapshotID: snapshot.ID, SchemaVersion: snapshot.SchemaVersion, State: snapshot.State, ExternalDependencies: []string{"host-tls", "oauth", "reverse-proxy", "telegram", "tunnel"}}
 	if err := validateSnapshot(snapshot); err != nil {
 		return Manifest{}, "", err
+	}
+	manifest := Manifest{Version: 1, BackupID: backupID, CreatedAt: createdAt, SnapshotID: snapshot.ID, SchemaVersion: snapshot.SchemaVersion, State: snapshot.State, ExternalDependencies: []string{"host-tls", "oauth", "reverse-proxy", "telegram", "tunnel"}}
+	if options.Update != nil {
+		manifest.Version = 2
+		manifest.Update = &UpdateMetadata{
+			UpdateID: options.Update.UpdateID, SourceSchema: snapshot.SchemaVersion,
+			InstallationID: snapshot.State.InstallationID, TimelineID: snapshot.State.TimelineID,
+			ChangeSequence: snapshot.State.ChangeSequence, TargetRelease: options.Update.TargetRelease,
+			TargetImageDigest: options.Update.TargetImageDigest, ExportedSnapshotID: snapshot.ID,
+		}
+		if err := validateUpdateMetadata(*manifest.Update); err != nil {
+			return Manifest{}, "", errors.New("backup update target is invalid")
+		}
 	}
 	if len(snapshot.ReadyBlobs) != 0 && trustedPrivateDirectory(options.BlobRoot) != nil {
 		return Manifest{}, "", errors.New("READY blob root is unavailable or unsafe")

--- a/internal/backup/create_test.go
+++ b/internal/backup/create_test.go
@@ -64,6 +64,38 @@ func TestCreatePublishesOnlyVerifiedSnapshot(t *testing.T) {
 	}
 }
 
+func TestCreatePublishesV2UpdateBoundSnapshot(t *testing.T) {
+	_, options := createTestInputs(t)
+	options.Update = &UpdateTarget{
+		UpdateID:          "0190ea2e-8a2d-7d42-b320-8515f7604bc1",
+		TargetRelease:     "v0.7.0",
+		TargetImageDigest: "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+	}
+	snapshot := &Snapshot{
+		ID:            "00000003-0000001B-1",
+		SchemaVersion: 5,
+		State:         State{InstallationID: "4e02b0e5-1934-4dda-9c4a-767c120c2fac", TimelineID: "797476ad-8fdc-4c05-b144-3ccbb92b54bf", ChangeSequence: 42},
+		Dump: func(_ context.Context, destination string) error {
+			return os.WriteFile(destination, []byte("database"), 0o600)
+		},
+		Finish: func(context.Context, bool) error { return nil },
+	}
+	manifest, directory, err := Create(context.Background(), options, fakeSource{snapshot: snapshot})
+	if err != nil {
+		t.Fatalf("create update backup: %v", err)
+	}
+	if manifest.Version != 2 || manifest.Update == nil || manifest.Update.SourceSchema != snapshot.SchemaVersion || manifest.Update.State() != snapshot.State || manifest.Update.ExportedSnapshotID != snapshot.ID {
+		t.Fatalf("update manifest did not bind exported source: %#v", manifest)
+	}
+	binding, err := BuildUpdateBinding(directory)
+	if err != nil {
+		t.Fatalf("build binding: %v", err)
+	}
+	if _, err := VerifyForUpdate(directory, binding); err != nil {
+		t.Fatalf("verify update backup: %v", err)
+	}
+}
+
 func TestCreateDoesNotPublishFailedOrUnverifiedBackup(t *testing.T) {
 	tests := []struct {
 		name   string

--- a/internal/backup/manifest.go
+++ b/internal/backup/manifest.go
@@ -50,16 +50,50 @@ type File struct {
 	SHA256 string `json:"sha256"`
 }
 
+// UpdateMetadata binds a v2 backup to the immutable source and target of one
+// update transaction. It deliberately contains identifiers only, never paths
+// or credentials.
+type UpdateMetadata struct {
+	UpdateID           string `json:"update_id"`
+	SourceSchema       int64  `json:"source_schema"`
+	InstallationID     string `json:"installation_id"`
+	TimelineID         string `json:"timeline_id"`
+	ChangeSequence     int64  `json:"change_sequence"`
+	TargetRelease      string `json:"target_release"`
+	TargetImageDigest  string `json:"target_image_digest"`
+	ExportedSnapshotID string `json:"exported_snapshot_id"`
+}
+
+// State returns the source-state coordinate recorded by the update metadata.
+func (metadata UpdateMetadata) State() State {
+	return State{InstallationID: metadata.InstallationID, TimelineID: metadata.TimelineID, ChangeSequence: metadata.ChangeSequence}
+}
+
+// UpdateBinding is the update marker persisted outside the backup. Its digest
+// binds the marker to the exact bytes of the verified manifest.json file.
+type UpdateBinding struct {
+	UpdateID           string `json:"update_id"`
+	SourceSchema       int64  `json:"source_schema"`
+	InstallationID     string `json:"installation_id"`
+	TimelineID         string `json:"timeline_id"`
+	ChangeSequence     int64  `json:"change_sequence"`
+	TargetRelease      string `json:"target_release"`
+	TargetImageDigest  string `json:"target_image_digest"`
+	ExportedSnapshotID string `json:"exported_snapshot_id"`
+	ManifestSHA256     string `json:"manifest_sha256"`
+}
+
 // Manifest is the single authoritative index for a published backup.
 type Manifest struct {
-	Version              int       `json:"version"`
-	BackupID             string    `json:"backup_id"`
-	CreatedAt            time.Time `json:"created_at"`
-	SnapshotID           string    `json:"snapshot_id"`
-	SchemaVersion        int64     `json:"schema_version"`
-	State                State     `json:"state"`
-	Files                []File    `json:"files"`
-	ExternalDependencies []string  `json:"external_dependencies"`
+	Version              int             `json:"version"`
+	BackupID             string          `json:"backup_id"`
+	CreatedAt            time.Time       `json:"created_at"`
+	SnapshotID           string          `json:"snapshot_id"`
+	SchemaVersion        int64           `json:"schema_version"`
+	State                State           `json:"state"`
+	Files                []File          `json:"files"`
+	ExternalDependencies []string        `json:"external_dependencies"`
+	Update               *UpdateMetadata `json:"update,omitempty"`
 }
 
 // Summary is safe, content-free metadata returned by backup list.
@@ -74,29 +108,34 @@ type Summary struct {
 // Verify strictly validates the manifest and every declared file without
 // following links. Undeclared regular files are rejected.
 func Verify(directory string) (Manifest, error) {
+	manifest, _, err := verify(directory)
+	return manifest, err
+}
+
+func verify(directory string) (Manifest, string, error) {
 	if err := trustedPrivateDirectory(directory); err != nil {
-		return Manifest{}, errors.New("backup directory is unavailable or unsafe")
+		return Manifest{}, "", errors.New("backup directory is unavailable or unsafe")
 	}
-	manifest, err := readManifest(filepath.Join(directory, manifestName))
+	manifest, manifestDigest, err := readManifest(filepath.Join(directory, manifestName))
 	if err != nil {
-		return Manifest{}, errors.New("backup manifest is unavailable or invalid")
+		return Manifest{}, "", errors.New("backup manifest is unavailable or invalid")
 	}
 	if err := validateManifest(manifest); err != nil {
-		return Manifest{}, err
+		return Manifest{}, "", err
 	}
 	declared := make(map[string]File, len(manifest.Files))
 	for _, entry := range manifest.Files {
 		if _, exists := declared[entry.Path]; exists {
-			return Manifest{}, errors.New("backup manifest contains duplicate files")
+			return Manifest{}, "", errors.New("backup manifest contains duplicate files")
 		}
 		declared[entry.Path] = entry
 		if err := verifyFile(directory, entry); err != nil {
-			return Manifest{}, fmt.Errorf("backup file %q failed verification", entry.Path)
+			return Manifest{}, "", fmt.Errorf("backup file %q failed verification", entry.Path)
 		}
 	}
 	for _, path := range requiredFiles {
 		if _, ok := declared[path]; !ok {
-			return Manifest{}, errors.New("backup manifest is missing required files")
+			return Manifest{}, "", errors.New("backup manifest is missing required files")
 		}
 	}
 	seen := map[string]bool{manifestName: true}
@@ -135,7 +174,45 @@ func Verify(directory string) (Manifest, error) {
 		return nil
 	})
 	if err != nil {
-		return Manifest{}, errors.New("backup filesystem contents are invalid")
+		return Manifest{}, "", errors.New("backup filesystem contents are invalid")
+	}
+	return manifest, manifestDigest, nil
+}
+
+// BuildUpdateBinding verifies a v2 backup and returns the complete marker that
+// must be recorded before an updater may consume it.
+func BuildUpdateBinding(directory string) (UpdateBinding, error) {
+	manifest, digest, err := verify(directory)
+	if err != nil || manifest.Version != 2 || manifest.Update == nil {
+		return UpdateBinding{}, errors.New("update backup is unavailable or invalid")
+	}
+	metadata := *manifest.Update
+	return UpdateBinding{
+		UpdateID: metadata.UpdateID, SourceSchema: metadata.SourceSchema,
+		InstallationID: metadata.InstallationID, TimelineID: metadata.TimelineID,
+		ChangeSequence: metadata.ChangeSequence, TargetRelease: metadata.TargetRelease,
+		TargetImageDigest: metadata.TargetImageDigest, ExportedSnapshotID: metadata.ExportedSnapshotID,
+		ManifestSHA256: digest,
+	}, nil
+}
+
+// VerifyForUpdate requires a complete marker matching both the decoded v2
+// metadata and the digest of the exact manifest bytes opened for verification.
+func VerifyForUpdate(directory string, binding UpdateBinding) (Manifest, error) {
+	if err := validateUpdateBinding(binding); err != nil {
+		return Manifest{}, err
+	}
+	manifest, digest, err := verify(directory)
+	if err != nil || manifest.Version != 2 || manifest.Update == nil {
+		return Manifest{}, errors.New("update backup is unavailable or invalid")
+	}
+	metadata := *manifest.Update
+	if binding.UpdateID != metadata.UpdateID || binding.SourceSchema != metadata.SourceSchema ||
+		binding.InstallationID != metadata.InstallationID || binding.TimelineID != metadata.TimelineID ||
+		binding.ChangeSequence != metadata.ChangeSequence || binding.TargetRelease != metadata.TargetRelease ||
+		binding.TargetImageDigest != metadata.TargetImageDigest || binding.ExportedSnapshotID != metadata.ExportedSnapshotID ||
+		binding.ManifestSHA256 != digest {
+		return Manifest{}, errors.New("update binding does not match the verified backup")
 	}
 	return manifest, nil
 }
@@ -170,36 +247,37 @@ func List(root string) ([]Summary, error) {
 	return result, nil
 }
 
-func readManifest(path string) (Manifest, error) {
+func readManifest(path string) (Manifest, string, error) {
 	info, err := os.Lstat(path)
 	if err != nil || !info.Mode().IsRegular() || info.Size() > maximumManifest || (runtime.GOOS != "windows" && info.Mode().Perm()&0o077 != 0) || trustedProtectedFile(path, maximumManifest) != nil {
-		return Manifest{}, errors.New("manifest file is unsafe")
+		return Manifest{}, "", errors.New("manifest file is unsafe")
 	}
 	file, err := os.Open(path) // #nosec G304 -- child of an explicit private backup directory.
 	if err != nil {
-		return Manifest{}, err
+		return Manifest{}, "", err
 	}
 	opened, statErr := file.Stat()
 	if statErr != nil || !os.SameFile(info, opened) {
 		_ = file.Close()
-		return Manifest{}, errors.New("manifest changed during open")
+		return Manifest{}, "", errors.New("manifest changed during open")
 	}
 	defer func() { _ = file.Close() }()
 	body, err := io.ReadAll(io.LimitReader(file, maximumManifest+1))
 	if err != nil || len(body) > maximumManifest || rejectDuplicateJSONKeys(body) != nil {
-		return Manifest{}, errors.New("manifest JSON is invalid")
+		return Manifest{}, "", errors.New("manifest JSON is invalid")
 	}
 	decoder := json.NewDecoder(bytes.NewReader(body))
 	decoder.DisallowUnknownFields()
 	var manifest Manifest
 	if err := decoder.Decode(&manifest); err != nil {
-		return Manifest{}, err
+		return Manifest{}, "", err
 	}
 	var trailing any
 	if err := decoder.Decode(&trailing); !errors.Is(err, io.EOF) {
-		return Manifest{}, errors.New("manifest has trailing JSON")
+		return Manifest{}, "", errors.New("manifest has trailing JSON")
 	}
-	return manifest, nil
+	digest := sha256.Sum256(body)
+	return manifest, hex.EncodeToString(digest[:]), nil
 }
 
 func rejectDuplicateJSONKeys(body []byte) error {
@@ -257,8 +335,16 @@ func rejectDuplicateJSONKeys(body []byte) error {
 }
 
 func validateManifest(manifest Manifest) error {
-	if manifest.Version != 1 || uuid.Validate(manifest.BackupID) != nil || manifest.CreatedAt.IsZero() || manifest.CreatedAt.Location() != time.UTC || manifest.SchemaVersion <= 0 || uuid.Validate(manifest.State.InstallationID) != nil || uuid.Validate(manifest.State.TimelineID) != nil || manifest.State.ChangeSequence < 0 || len(manifest.Files) == 0 || len(manifest.Files) > maximumFileCount {
+	if (manifest.Version != 1 && manifest.Version != 2) || uuid.Validate(manifest.BackupID) != nil || manifest.CreatedAt.IsZero() || manifest.CreatedAt.Location() != time.UTC || manifest.SchemaVersion <= 0 || uuid.Validate(manifest.State.InstallationID) != nil || uuid.Validate(manifest.State.TimelineID) != nil || manifest.State.ChangeSequence < 0 || len(manifest.Files) == 0 || len(manifest.Files) > maximumFileCount {
 		return errors.New("backup manifest metadata is invalid")
+	}
+	if manifest.Version == 1 && manifest.Update != nil {
+		return errors.New("v1 backup manifest cannot contain update metadata")
+	}
+	if manifest.Version == 2 {
+		if manifest.Update == nil || validateUpdateMetadata(*manifest.Update) != nil || manifest.Update.SourceSchema != manifest.SchemaVersion || manifest.Update.State() != manifest.State || manifest.Update.ExportedSnapshotID != manifest.SnapshotID {
+			return errors.New("v2 backup update metadata is invalid")
+		}
 	}
 	if !validSnapshotID(manifest.SnapshotID) {
 		return errors.New("backup snapshot identity is invalid")
@@ -296,6 +382,48 @@ func validateManifest(manifest Manifest) error {
 		}
 	}
 	return nil
+}
+
+func validateUpdateMetadata(metadata UpdateMetadata) error {
+	if uuid.Validate(metadata.UpdateID) != nil || metadata.SourceSchema <= 0 || uuid.Validate(metadata.InstallationID) != nil || uuid.Validate(metadata.TimelineID) != nil || metadata.ChangeSequence < 0 || !validRelease(metadata.TargetRelease) || !validImageDigest(metadata.TargetImageDigest) || !validSnapshotID(metadata.ExportedSnapshotID) {
+		return errors.New("update metadata is invalid")
+	}
+	return nil
+}
+
+func validateUpdateBinding(binding UpdateBinding) error {
+	metadata := UpdateMetadata{
+		UpdateID: binding.UpdateID, SourceSchema: binding.SourceSchema,
+		InstallationID: binding.InstallationID, TimelineID: binding.TimelineID,
+		ChangeSequence: binding.ChangeSequence, TargetRelease: binding.TargetRelease,
+		TargetImageDigest: binding.TargetImageDigest, ExportedSnapshotID: binding.ExportedSnapshotID,
+	}
+	if validateUpdateMetadata(metadata) != nil || !validSHA256(binding.ManifestSHA256) {
+		return errors.New("update binding is incomplete or invalid")
+	}
+	return nil
+}
+
+func validRelease(value string) bool {
+	if len(value) == 0 || len(value) > 128 {
+		return false
+	}
+	for index, character := range value {
+		alphaNumeric := character >= 'a' && character <= 'z' || character >= 'A' && character <= 'Z' || character >= '0' && character <= '9'
+		if !alphaNumeric && (index == 0 || character != '.' && character != '-' && character != '+' && character != '_') {
+			return false
+		}
+	}
+	return true
+}
+
+func validImageDigest(value string) bool {
+	return strings.HasPrefix(value, "sha256:") && len(value) == len("sha256:")+sha256.Size*2 && validSHA256(strings.TrimPrefix(value, "sha256:"))
+}
+
+func validSHA256(value string) bool {
+	decoded, err := hex.DecodeString(value)
+	return err == nil && len(decoded) == sha256.Size && hex.EncodeToString(decoded) == value
 }
 
 func maximumForPath(path string) (int64, bool) {

--- a/internal/backup/manifest_test.go
+++ b/internal/backup/manifest_test.go
@@ -28,6 +28,129 @@ func TestVerifyAcceptsExactPrivateBackup(t *testing.T) {
 	}
 }
 
+func TestVerifyForUpdateRequiresExactV2ManifestBinding(t *testing.T) {
+	directory := t.TempDir()
+	requirePrivate(t, directory)
+	paths := writeRequiredTestFiles(t, directory)
+	manifest := testManifest(t, directory, paths)
+	manifest.Version = 2
+	manifest.Update = &UpdateMetadata{
+		UpdateID:           "0190ea2e-8a2d-7d42-b320-8515f7604bc1",
+		SourceSchema:       manifest.SchemaVersion,
+		InstallationID:     manifest.State.InstallationID,
+		TimelineID:         manifest.State.TimelineID,
+		ChangeSequence:     manifest.State.ChangeSequence,
+		TargetRelease:      "v0.7.0-rc.1",
+		TargetImageDigest:  "sha256:" + strings.Repeat("a", 64),
+		ExportedSnapshotID: manifest.SnapshotID,
+	}
+	writeManifest(t, directory, manifest)
+
+	binding, err := BuildUpdateBinding(directory)
+	if err != nil {
+		t.Fatalf("build update binding: %v", err)
+	}
+	verified, err := VerifyForUpdate(directory, binding)
+	if err != nil {
+		t.Fatalf("verify for update: %v", err)
+	}
+	if verified.Update == nil || binding.UpdateID != verified.Update.UpdateID || len(binding.ManifestSHA256) != 64 {
+		t.Fatalf("unexpected verified binding: %#v, %#v", verified.Update, binding)
+	}
+
+	// The decoded manifest remains identical, but the marker must bind the exact
+	// published bytes rather than merely equivalent JSON values.
+	body, err := json.MarshalIndent(manifest, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	writeRawManifest(t, directory, append(body, '\n'))
+	if _, err := Verify(directory); err != nil {
+		t.Fatalf("ordinary verification after canonical rewrite: %v", err)
+	}
+	if _, err := VerifyForUpdate(directory, binding); err == nil {
+		t.Fatal("update verification accepted a replaced manifest")
+	}
+}
+
+func TestVerifyRejectsMalformedV2UpdateMetadata(t *testing.T) {
+	tests := []struct {
+		name   string
+		mutate func(*Manifest)
+	}{
+		{name: "missing metadata", mutate: func(manifest *Manifest) { manifest.Update = nil }},
+		{name: "partial metadata", mutate: func(manifest *Manifest) { manifest.Update.TargetRelease = "" }},
+		{name: "source schema mismatch", mutate: func(manifest *Manifest) { manifest.Update.SourceSchema++ }},
+		{name: "installation mismatch", mutate: func(manifest *Manifest) { manifest.Update.InstallationID = "5e02b0e5-1934-4dda-9c4a-767c120c2fac" }},
+		{name: "timeline mismatch", mutate: func(manifest *Manifest) { manifest.Update.TimelineID = "897476ad-8fdc-4c05-b144-3ccbb92b54bf" }},
+		{name: "change sequence mismatch", mutate: func(manifest *Manifest) { manifest.Update.ChangeSequence++ }},
+		{name: "snapshot mismatch", mutate: func(manifest *Manifest) { manifest.Update.ExportedSnapshotID = "00000003-0000001B-2" }},
+		{name: "release path", mutate: func(manifest *Manifest) { manifest.Update.TargetRelease = "../v0.7.0" }},
+		{name: "unpinned image", mutate: func(manifest *Manifest) { manifest.Update.TargetImageDigest = "registry.example/punaro:latest" }},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			directory := t.TempDir()
+			requirePrivate(t, directory)
+			paths := writeRequiredTestFiles(t, directory)
+			manifest := testManifest(t, directory, paths)
+			manifest.Version = 2
+			manifest.Update = &UpdateMetadata{
+				UpdateID: "0190ea2e-8a2d-7d42-b320-8515f7604bc1", SourceSchema: manifest.SchemaVersion,
+				InstallationID: manifest.State.InstallationID, TimelineID: manifest.State.TimelineID,
+				ChangeSequence: manifest.State.ChangeSequence, TargetRelease: "v0.7.0",
+				TargetImageDigest: "sha256:" + strings.Repeat("a", 64), ExportedSnapshotID: manifest.SnapshotID,
+			}
+			test.mutate(&manifest)
+			writeManifest(t, directory, manifest)
+			if _, err := Verify(directory); err == nil {
+				t.Fatal("malformed v2 manifest was accepted")
+			}
+		})
+	}
+}
+
+func TestVerifyForUpdateRejectsPartialOrMismatchedBinding(t *testing.T) {
+	directory := t.TempDir()
+	requirePrivate(t, directory)
+	paths := writeRequiredTestFiles(t, directory)
+	manifest := testManifest(t, directory, paths)
+	manifest.Version = 2
+	manifest.Update = &UpdateMetadata{
+		UpdateID: "0190ea2e-8a2d-7d42-b320-8515f7604bc1", SourceSchema: manifest.SchemaVersion,
+		InstallationID: manifest.State.InstallationID, TimelineID: manifest.State.TimelineID,
+		ChangeSequence: manifest.State.ChangeSequence, TargetRelease: "v0.7.0",
+		TargetImageDigest: "sha256:" + strings.Repeat("a", 64), ExportedSnapshotID: manifest.SnapshotID,
+	}
+	writeManifest(t, directory, manifest)
+	binding, err := BuildUpdateBinding(directory)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tests := []struct {
+		name   string
+		mutate func(*UpdateBinding)
+	}{
+		{name: "partial", mutate: func(binding *UpdateBinding) { binding.TargetRelease = "" }},
+		{name: "update ID", mutate: func(binding *UpdateBinding) { binding.UpdateID = "0290ea2e-8a2d-7d42-b320-8515f7604bc1" }},
+		{name: "source schema", mutate: func(binding *UpdateBinding) { binding.SourceSchema++ }},
+		{name: "state", mutate: func(binding *UpdateBinding) { binding.ChangeSequence++ }},
+		{name: "target", mutate: func(binding *UpdateBinding) { binding.TargetRelease = "v0.7.1" }},
+		{name: "image digest", mutate: func(binding *UpdateBinding) { binding.TargetImageDigest = "sha256:" + strings.Repeat("b", 64) }},
+		{name: "snapshot", mutate: func(binding *UpdateBinding) { binding.ExportedSnapshotID = "00000003-0000001B-2" }},
+		{name: "manifest digest", mutate: func(binding *UpdateBinding) { binding.ManifestSHA256 = strings.Repeat("b", 64) }},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			candidate := binding
+			test.mutate(&candidate)
+			if _, err := VerifyForUpdate(directory, candidate); err == nil {
+				t.Fatal("mismatched binding was accepted")
+			}
+		})
+	}
+}
+
 func TestReadVerifiedFileRejectsPathReplacementAfterManifestVerification(t *testing.T) {
 	directory := t.TempDir()
 	requirePrivate(t, directory)

--- a/internal/backup/restore.go
+++ b/internal/backup/restore.go
@@ -10,6 +10,8 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/google/uuid"
 )
 
 // OperationPhase identifies the last durable boundary reached by an operation.
@@ -52,6 +54,10 @@ type RestoreTarget struct {
 	OwnerDSNFile          string `json:"owner_dsn_file"`
 	AppDSNFile            string `json:"app_dsn_file"`
 	DatabaseIdentity      string `json:"database_identity"`
+	UpdateID              string `json:"update_id,omitempty"`
+	ManifestSHA256        string `json:"manifest_sha256,omitempty"`
+	RecoveryReceiptFile   string `json:"recovery_receipt_file,omitempty"`
+	RecoveryReceiptSHA256 string `json:"recovery_receipt_sha256,omitempty"`
 }
 
 type restoreRequest struct {
@@ -276,7 +282,17 @@ func validRestoreTarget(target RestoreTarget) bool {
 		}
 	}
 	decoded, err := hex.DecodeString(target.DatabaseIdentity)
-	return target.OwnerDSNFile != target.AppDSNFile && err == nil && len(decoded) == 32 && hex.EncodeToString(decoded) == target.DatabaseIdentity
+	if target.OwnerDSNFile == target.AppDSNFile || err != nil || len(decoded) != 32 || hex.EncodeToString(decoded) != target.DatabaseIdentity {
+		return false
+	}
+	if target.UpdateID == "" && target.ManifestSHA256 == "" && target.RecoveryReceiptFile == "" && target.RecoveryReceiptSHA256 == "" {
+		return true
+	}
+	manifestDigest, digestErr := hex.DecodeString(target.ManifestSHA256)
+	receiptDigest, receiptDigestErr := hex.DecodeString(target.RecoveryReceiptSHA256)
+	return uuid.Validate(target.UpdateID) == nil && digestErr == nil && len(manifestDigest) == 32 && hex.EncodeToString(manifestDigest) == target.ManifestSHA256 &&
+		filepath.IsAbs(target.RecoveryReceiptFile) && filepath.Clean(target.RecoveryReceiptFile) == target.RecoveryReceiptFile &&
+		receiptDigestErr == nil && len(receiptDigest) == 32 && hex.EncodeToString(receiptDigest) == target.RecoveryReceiptSHA256
 }
 
 func verifyManifestBlobs(root string, manifest Manifest) error {

--- a/internal/backup/restore_test.go
+++ b/internal/backup/restore_test.go
@@ -234,6 +234,24 @@ func restoreTargetFixture(parent string) RestoreTarget {
 	}
 }
 
+func TestRestoreTargetBindsUpdateManifestIdentityTogether(t *testing.T) {
+	target := restoreTargetFixture(t.TempDir())
+	target.UpdateID = "019b4eb0-21f8-7d93-84df-10e6cf05ce53"
+	if validRestoreTarget(target) {
+		t.Fatal("restore target accepted update identity without manifest digest")
+	}
+	target.ManifestSHA256 = strings.Repeat("b", 64)
+	target.RecoveryReceiptFile = filepath.Join(t.TempDir(), "recovery.json")
+	target.RecoveryReceiptSHA256 = strings.Repeat("c", 64)
+	if !validRestoreTarget(target) {
+		t.Fatal("restore target rejected exact update journal binding")
+	}
+	target.UpdateID = "invalid"
+	if validRestoreTarget(target) {
+		t.Fatal("restore target accepted invalid update identity")
+	}
+}
+
 func createRestoreFixture(t *testing.T, withBlob bool) (string, Manifest) {
 	t.Helper()
 	directory := filepath.Join(t.TempDir(), "backup")

--- a/internal/operator/update.go
+++ b/internal/operator/update.go
@@ -1,0 +1,600 @@
+package operator
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/google/uuid"
+)
+
+const (
+	updateStageDirectoryName = ".update"
+	updateCandidateName      = "candidate"
+	updateJournalName        = "journal.json"
+	updateRecoveryName       = "recovery.json"
+	updateJournalVersion     = 1
+
+	publishStepEnvironment  = "environment"
+	publishStepCompose      = "compose"
+	publishStepInstallation = "installation"
+)
+
+var (
+	updateReleasePattern  = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9._+-]{0,127}$`)
+	updateDigestPattern   = regexp.MustCompile(`^sha256:[0-9a-f]{64}$`)
+	updateSnapshotPattern = regexp.MustCompile(`^[0-9A-Z-]{1,200}$`)
+	updateHashPattern     = regexp.MustCompile(`^[0-9a-f]{64}$`)
+
+	// ErrUpdateStageConflict reports that the durable host stage belongs to a
+	// different update request or no longer matches the published installation.
+	ErrUpdateStageConflict = errors.New("update stage belongs to a different request")
+	// ErrUpdateAlreadyPublished reports an abort requested after the final
+	// installation marker became visible.
+	ErrUpdateAlreadyPublished = errors.New("update configuration is already published")
+	// ErrUpdateStageNotFound reports that no durable host-side update request
+	// exists. Resume inspection never creates one.
+	ErrUpdateStageNotFound = errors.New("update stage is not found")
+
+	// updatePublicationHook is test-only fault injection. Production leaves it
+	// nil; keeping it at the file boundary makes every durable rename testable.
+	updatePublicationHook func(string) error
+)
+
+// UpdateStage is the exact immutable request reserved by the host journal.
+// Previous fields are retained after publication as the compatible-image lock.
+type UpdateStage struct {
+	Directory       string
+	UpdateID        string
+	PreviousRelease string
+	PreviousImage   string
+	TargetRelease   string
+	TargetImage     string
+}
+
+// StagedUpdate is the content-free durable stage status returned on first use
+// and exact resume.
+type StagedUpdate struct {
+	Directory          string
+	CandidateDirectory string
+	UpdateID           string
+	PreviousRelease    string
+	PreviousImage      string
+	TargetRelease      string
+	TargetImage        string
+	Published          bool
+}
+
+// UpdateRecoveryReceipt is the independently durable host authorization for
+// restoring an update backup. It is written only after the backup has been
+// completely verified and must match both the host journal and backup.
+type UpdateRecoveryReceipt struct {
+	Version            int    `json:"version"`
+	UpdateID           string `json:"update_id"`
+	BackupID           string `json:"backup_id"`
+	BackupDirectory    string `json:"backup_directory"`
+	InstallationID     string `json:"installation_id"`
+	TimelineID         string `json:"timeline_id"`
+	ChangeSequence     int64  `json:"change_sequence"`
+	SourceSchema       int64  `json:"source_schema"`
+	TargetRelease      string `json:"target_release"`
+	TargetImageDigest  string `json:"target_image_digest"`
+	ExportedSnapshotID string `json:"exported_snapshot_id"`
+	ManifestSHA256     string `json:"manifest_sha256"`
+}
+
+type updateJournal struct {
+	Version              int          `json:"version"`
+	UpdateID             string       `json:"update_id"`
+	PreviousRelease      string       `json:"previous_release"`
+	PreviousImage        string       `json:"previous_image"`
+	TargetRelease        string       `json:"target_release"`
+	TargetImage          string       `json:"target_image"`
+	PreviousInstallation Installation `json:"previous_installation"`
+	Published            bool         `json:"published"`
+}
+
+// StageUpdate reserves one installation-local update request and durably
+// renders its candidate configuration without changing any published file.
+func StageUpdate(request UpdateStage) (StagedUpdate, error) {
+	if err := request.validate(); err != nil {
+		return StagedUpdate{}, err
+	}
+	if err := requireTrustedPrivateDirectory(request.Directory); err != nil {
+		return StagedUpdate{}, errors.New("installation directory is unavailable or unsafe")
+	}
+	root := updateStageRoot(request.Directory)
+	if _, err := os.Lstat(root); err == nil {
+		return resumeUpdateStage(request)
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return StagedUpdate{}, errors.New("update stage is unavailable or unsafe")
+	}
+
+	installation, err := Load(request.Directory)
+	if err != nil || installation.Image != request.PreviousImage || len(CheckPaths(installation)) != 0 {
+		return StagedUpdate{}, ErrUpdateStageConflict
+	}
+	if err := os.Mkdir(root, 0o700); err != nil {
+		return StagedUpdate{}, errors.New("update stage could not be reserved")
+	}
+	journalDurable := false
+	defer func() {
+		if !journalDurable {
+			_ = os.RemoveAll(root)
+		}
+	}()
+	if err := requireTrustedPrivateDirectory(root); err != nil {
+		return StagedUpdate{}, errors.New("update stage is unavailable or unsafe")
+	}
+	journal := newUpdateJournal(request, installation)
+	if err := writeExclusiveJSON(updateJournalPath(request.Directory), journal); err != nil || syncDirectory(root) != nil || syncDirectory(request.Directory) != nil {
+		return StagedUpdate{}, errors.New("update request could not be made durable")
+	}
+	journalDurable = true
+	if err := ensureUpdateCandidate(request.Directory, journal); err != nil {
+		return StagedUpdate{}, err
+	}
+	return journal.stage(request.Directory), nil
+}
+
+// ResumeUpdateStage opens only an already-durable exact stage. It is used to
+// recover a v5 bridge process crash without treating an unhealthy stack as
+// authority to begin a different update.
+func ResumeUpdateStage(request UpdateStage) (StagedUpdate, error) {
+	if err := request.validate(); err != nil {
+		return StagedUpdate{}, err
+	}
+	root := updateStageRoot(request.Directory)
+	if _, err := os.Lstat(root); errors.Is(err, os.ErrNotExist) {
+		return StagedUpdate{}, ErrUpdateStageNotFound
+	} else if err != nil {
+		return StagedUpdate{}, errors.New("update stage is unavailable or unsafe")
+	}
+	return resumeUpdateStage(request)
+}
+
+// ExistingUpdateStage returns the immutable request from an existing valid
+// host journal. It never creates or adopts a stage from caller-supplied fields.
+func ExistingUpdateStage(directory string) (UpdateStage, error) {
+	if !filepath.IsAbs(directory) || filepath.Clean(directory) != directory || !safeEnvPath(directory) {
+		return UpdateStage{}, errors.New("update stage directory is invalid")
+	}
+	root := updateStageRoot(directory)
+	if _, err := os.Lstat(root); errors.Is(err, os.ErrNotExist) {
+		return UpdateStage{}, ErrUpdateStageNotFound
+	} else if err != nil || requireTrustedPrivateDirectory(root) != nil {
+		return UpdateStage{}, errors.New("update stage is unavailable or unsafe")
+	}
+	journal, err := readUpdateJournal(directory)
+	if err != nil {
+		return UpdateStage{}, errors.New("update stage is unavailable or unsafe")
+	}
+	request := UpdateStage{Directory: directory, UpdateID: journal.UpdateID, PreviousRelease: journal.PreviousRelease, PreviousImage: journal.PreviousImage, TargetRelease: journal.TargetRelease, TargetImage: journal.TargetImage}
+	if _, err := ResumeUpdateStage(request); err != nil {
+		return UpdateStage{}, err
+	}
+	return request, nil
+}
+
+// UpdateRecoveryReceiptFile returns the fixed receipt path for an installation.
+func UpdateRecoveryReceiptFile(directory string) string {
+	return filepath.Join(updateStageRoot(directory), updateRecoveryName)
+}
+
+// BindUpdateRecoveryReceipt durably records an exact verified backup outside
+// that backup. Repeated calls are accepted only for byte-identical authority.
+func BindUpdateRecoveryReceipt(request UpdateStage, receipt UpdateRecoveryReceipt) (string, error) {
+	_, targetDigest, hasDigest := strings.Cut(request.TargetImage, "@")
+	if err := request.validate(); err != nil || !hasDigest || !receipt.valid() || receipt.UpdateID != request.UpdateID || receipt.TargetRelease != request.TargetRelease || receipt.TargetImageDigest != targetDigest {
+		return "", errors.New("update recovery receipt is invalid")
+	}
+	stage, err := ResumeUpdateStage(request)
+	if err != nil || stage.Published {
+		return "", errors.New("update recovery receipt cannot be bound to this stage")
+	}
+	body, err := indentedJSON(receipt)
+	if err != nil {
+		return "", errors.New("update recovery receipt cannot be encoded")
+	}
+	path := UpdateRecoveryReceiptFile(request.Directory)
+	if err := ensureExactProtectedFile(path, body); err != nil || syncDirectory(updateStageRoot(request.Directory)) != nil || syncDirectory(request.Directory) != nil {
+		return "", errors.New("update recovery receipt could not be made durable")
+	}
+	sum := sha256.Sum256(body)
+	return fmt.Sprintf("%x", sum[:]), nil
+}
+
+// LoadUpdateRecoveryReceipt strictly reads a protected receipt and returns the
+// digest used to bind an exact restore resume request.
+func LoadUpdateRecoveryReceipt(path string) (UpdateRecoveryReceipt, string, error) {
+	if !filepath.IsAbs(path) || filepath.Clean(path) != path || filepath.Base(path) != updateRecoveryName || requireTrustedProtectedFile(path, 64<<10) != nil {
+		return UpdateRecoveryReceipt{}, "", errors.New("update recovery receipt is unavailable or unsafe")
+	}
+	body, err := os.ReadFile(path) // #nosec G304 -- caller path is absolute and validated as a protected regular file.
+	if err != nil {
+		return UpdateRecoveryReceipt{}, "", errors.New("update recovery receipt is unavailable or unsafe")
+	}
+	decoder := json.NewDecoder(bytes.NewReader(body))
+	decoder.DisallowUnknownFields()
+	var receipt UpdateRecoveryReceipt
+	if decoder.Decode(&receipt) != nil || ensureJSONEOF(decoder) != nil || !receipt.valid() {
+		return UpdateRecoveryReceipt{}, "", errors.New("update recovery receipt is invalid")
+	}
+	sum := sha256.Sum256(body)
+	return receipt, fmt.Sprintf("%x", sum[:]), nil
+}
+
+func (receipt UpdateRecoveryReceipt) valid() bool {
+	return receipt.Version == 1 && uuid.Validate(receipt.UpdateID) == nil && uuid.Validate(receipt.BackupID) == nil &&
+		filepath.IsAbs(receipt.BackupDirectory) && filepath.Clean(receipt.BackupDirectory) == receipt.BackupDirectory && safeEnvPath(receipt.BackupDirectory) &&
+		uuid.Validate(receipt.InstallationID) == nil && uuid.Validate(receipt.TimelineID) == nil && receipt.ChangeSequence >= 0 && receipt.SourceSchema > 0 &&
+		updateReleasePattern.MatchString(receipt.TargetRelease) && updateDigestPattern.MatchString(receipt.TargetImageDigest) &&
+		updateSnapshotPattern.MatchString(receipt.ExportedSnapshotID) && updateHashPattern.MatchString(receipt.ManifestSHA256)
+}
+
+func resumeUpdateStage(request UpdateStage) (StagedUpdate, error) {
+	root := updateStageRoot(request.Directory)
+	if err := requireTrustedPrivateDirectory(root); err != nil {
+		return StagedUpdate{}, errors.New("update stage is unavailable or unsafe")
+	}
+	journal, err := readUpdateJournal(request.Directory)
+	if err != nil || !journal.matches(request) {
+		return StagedUpdate{}, ErrUpdateStageConflict
+	}
+	current, err := Load(request.Directory)
+	if err != nil {
+		return StagedUpdate{}, ErrUpdateStageConflict
+	}
+	previous := journal.previous(request.Directory)
+	candidate := journal.candidate(request.Directory)
+	switch current {
+	case previous:
+		if journal.Published {
+			return StagedUpdate{}, ErrUpdateStageConflict
+		}
+	case candidate:
+		if len(CheckPaths(current)) != 0 {
+			return StagedUpdate{}, ErrUpdateStageConflict
+		}
+		if !journal.Published {
+			journal.Published = true
+			if err := replaceUpdateJournal(request.Directory, journal); err != nil {
+				return StagedUpdate{}, errors.New("published update journal could not be reconciled")
+			}
+		}
+	default:
+		return StagedUpdate{}, ErrUpdateStageConflict
+	}
+	if err := ensureUpdateCandidate(request.Directory, journal); err != nil {
+		return StagedUpdate{}, err
+	}
+	return journal.stage(request.Directory), nil
+}
+
+// PublishUpdate atomically replaces the generated environment and Compose
+// files, then publishes installation.json last. Every boundary is idempotent.
+func PublishUpdate(request UpdateStage) (Installation, error) {
+	stage, err := StageUpdate(request)
+	if err != nil {
+		return Installation{}, err
+	}
+	journal, err := readUpdateJournal(request.Directory)
+	if err != nil || !journal.matches(request) {
+		return Installation{}, ErrUpdateStageConflict
+	}
+	candidate := journal.candidate(request.Directory)
+	if stage.Published {
+		if current, loadErr := Load(request.Directory); loadErr == nil && current == candidate && len(CheckPaths(current)) == 0 {
+			return current, nil
+		}
+		return Installation{}, ErrUpdateStageConflict
+	}
+
+	if err := replacePublishedFile(EnvFile(request.Directory), []byte(daemonEnv(candidate)), request.UpdateID); err != nil {
+		return Installation{}, errors.New("candidate environment could not be published")
+	}
+	if err := runUpdatePublicationHook(publishStepEnvironment); err != nil {
+		return Installation{}, errors.New("candidate publication was interrupted")
+	}
+	if err := replacePublishedFile(OverrideFile(request.Directory), []byte(composeOverride()), request.UpdateID); err != nil {
+		return Installation{}, errors.New("candidate Compose configuration could not be published")
+	}
+	if err := runUpdatePublicationHook(publishStepCompose); err != nil {
+		return Installation{}, errors.New("candidate publication was interrupted")
+	}
+	configBody, err := indentedJSON(candidate)
+	if err != nil || replacePublishedFile(ConfigFile(request.Directory), configBody, request.UpdateID) != nil {
+		return Installation{}, errors.New("candidate installation marker could not be published")
+	}
+	if err := runUpdatePublicationHook(publishStepInstallation); err != nil {
+		return Installation{}, errors.New("candidate publication was interrupted")
+	}
+	journal.Published = true
+	if err := replaceUpdateJournal(request.Directory, journal); err != nil {
+		return Installation{}, errors.New("candidate was published; rerun update publication to reconcile its journal")
+	}
+	return candidate, nil
+}
+
+// AbortStage removes only an unpublished stage. If publication stopped before
+// installation.json, it first restores the generated files for the previous
+// image so the old marker is internally consistent again.
+func AbortStage(request UpdateStage) error {
+	if err := request.validate(); err != nil {
+		return err
+	}
+	root := updateStageRoot(request.Directory)
+	if _, err := os.Lstat(root); errors.Is(err, os.ErrNotExist) {
+		current, loadErr := Load(request.Directory)
+		if loadErr == nil && current.Image == request.PreviousImage && len(CheckPaths(current)) == 0 {
+			if syncDirectory(request.Directory) == nil {
+				return nil
+			}
+			return errors.New("update stage removal durability could not be reconciled")
+		}
+		return ErrUpdateStageConflict
+	}
+	if err := requireTrustedPrivateDirectory(root); err != nil {
+		return errors.New("update stage is unavailable or unsafe")
+	}
+	journal, err := readUpdateJournal(request.Directory)
+	if err != nil || !journal.matches(request) {
+		return ErrUpdateStageConflict
+	}
+	current, err := Load(request.Directory)
+	if err != nil {
+		return ErrUpdateStageConflict
+	}
+	previous := journal.previous(request.Directory)
+	if journal.Published || current == journal.candidate(request.Directory) {
+		return ErrUpdateAlreadyPublished
+	}
+	if current != previous {
+		return ErrUpdateStageConflict
+	}
+	if err := replacePublishedFile(EnvFile(request.Directory), []byte(daemonEnv(previous)), request.UpdateID); err != nil || replacePublishedFile(OverrideFile(request.Directory), []byte(composeOverride()), request.UpdateID) != nil {
+		return errors.New("previous configuration could not be restored")
+	}
+	if err := os.RemoveAll(root); err != nil || syncDirectory(request.Directory) != nil {
+		return errors.New("update stage could not be removed durably")
+	}
+	return nil
+}
+
+// PublishPreviousUpdate restores the journaled previous generated
+// configuration for an explicitly selected fenced recovery. Unlike AbortStage,
+// it may reverse an already-published target marker and is marker-last and
+// idempotent across crashes.
+func PublishPreviousUpdate(request UpdateStage) error {
+	return restorePreviousUpdate(request, true)
+}
+
+// RestorePreviousUpdate publishes the previous marker and generated files but
+// retains the host journal until recovery doctor and final database transition
+// have succeeded.
+func RestorePreviousUpdate(request UpdateStage) error {
+	return restorePreviousUpdate(request, false)
+}
+
+func restorePreviousUpdate(request UpdateStage, complete bool) error {
+	if err := request.validate(); err != nil {
+		return err
+	}
+	root := updateStageRoot(request.Directory)
+	if _, err := os.Lstat(root); errors.Is(err, os.ErrNotExist) {
+		current, loadErr := Load(request.Directory)
+		if loadErr == nil && current.Image == request.PreviousImage && len(CheckPaths(current)) == 0 {
+			if !complete || syncDirectory(request.Directory) == nil {
+				return nil
+			}
+			return errors.New("previous recovery stage removal durability could not be reconciled")
+		}
+		return ErrUpdateStageConflict
+	}
+	journal, err := readUpdateJournal(request.Directory)
+	if err != nil || !journal.matches(request) {
+		return ErrUpdateStageConflict
+	}
+	previous := journal.previous(request.Directory)
+	if err := replacePublishedFile(EnvFile(request.Directory), []byte(daemonEnv(previous)), request.UpdateID); err != nil ||
+		replacePublishedFile(OverrideFile(request.Directory), []byte(composeOverride()), request.UpdateID) != nil {
+		return errors.New("previous recovery configuration could not be staged")
+	}
+	configBody, err := indentedJSON(previous)
+	if err != nil || replacePublishedFile(ConfigFile(request.Directory), configBody, request.UpdateID) != nil {
+		return errors.New("previous recovery marker could not be published")
+	}
+	if complete {
+		if err := os.RemoveAll(root); err != nil || syncDirectory(request.Directory) != nil {
+			return errors.New("previous recovery stage could not be removed durably")
+		}
+	}
+	return nil
+}
+
+// CompleteStage removes the host journal only after the target marker and all
+// generated files are published exactly. The durable database transaction is
+// the long-term update record; retaining .update would block the next update.
+func CompleteStage(request UpdateStage) error {
+	if err := request.validate(); err != nil {
+		return err
+	}
+	if _, err := os.Lstat(updateStageRoot(request.Directory)); errors.Is(err, os.ErrNotExist) {
+		current, loadErr := Load(request.Directory)
+		if loadErr == nil && current.Image == request.TargetImage && len(CheckPaths(current)) == 0 {
+			if syncDirectory(request.Directory) == nil {
+				return nil
+			}
+			return errors.New("completed update stage removal durability could not be reconciled")
+		}
+		return ErrUpdateStageConflict
+	}
+	journal, err := readUpdateJournal(request.Directory)
+	if err != nil || !journal.matches(request) || !journal.Published {
+		return ErrUpdateStageConflict
+	}
+	current, err := Load(request.Directory)
+	if err != nil || current != journal.candidate(request.Directory) || len(CheckPaths(current)) != 0 {
+		return ErrUpdateStageConflict
+	}
+	if err := os.RemoveAll(updateStageRoot(request.Directory)); err != nil || syncDirectory(request.Directory) != nil {
+		return errors.New("completed update stage could not be removed durably")
+	}
+	return nil
+}
+
+func (request UpdateStage) validate() error {
+	if !filepath.IsAbs(request.Directory) || filepath.Clean(request.Directory) != request.Directory || !safeEnvPath(request.Directory) || uuid.Validate(request.UpdateID) != nil || !updateReleasePattern.MatchString(request.PreviousRelease) || !updateReleasePattern.MatchString(request.TargetRelease) || request.PreviousRelease == request.TargetRelease || !validImageDigest(request.PreviousImage) || !validImageDigest(request.TargetImage) || request.PreviousImage == request.TargetImage {
+		return errors.New("update stage request is invalid")
+	}
+	return nil
+}
+
+func newUpdateJournal(request UpdateStage, installation Installation) updateJournal {
+	installation.Directory = ""
+	return updateJournal{Version: updateJournalVersion, UpdateID: request.UpdateID, PreviousRelease: request.PreviousRelease, PreviousImage: request.PreviousImage, TargetRelease: request.TargetRelease, TargetImage: request.TargetImage, PreviousInstallation: installation}
+}
+
+func (journal updateJournal) valid() bool {
+	request := UpdateStage{Directory: string(filepath.Separator), UpdateID: journal.UpdateID, PreviousRelease: journal.PreviousRelease, PreviousImage: journal.PreviousImage, TargetRelease: journal.TargetRelease, TargetImage: journal.TargetImage}
+	return journal.Version == updateJournalVersion && request.validate() == nil && journal.PreviousInstallation.Version == 1 && journal.PreviousInstallation.Image == journal.PreviousImage && journal.PreviousInstallation.Directory == ""
+}
+
+func (journal updateJournal) matches(request UpdateStage) bool {
+	return journal.valid() && journal.UpdateID == request.UpdateID && journal.PreviousRelease == request.PreviousRelease && journal.PreviousImage == request.PreviousImage && journal.TargetRelease == request.TargetRelease && journal.TargetImage == request.TargetImage
+}
+
+func (journal updateJournal) previous(directory string) Installation {
+	installation := journal.PreviousInstallation
+	installation.Directory = directory
+	return installation
+}
+
+func (journal updateJournal) candidate(directory string) Installation {
+	installation := journal.previous(directory)
+	installation.Image = journal.TargetImage
+	return installation
+}
+
+func (journal updateJournal) stage(directory string) StagedUpdate {
+	return StagedUpdate{Directory: directory, CandidateDirectory: updateCandidateDirectory(directory), UpdateID: journal.UpdateID, PreviousRelease: journal.PreviousRelease, PreviousImage: journal.PreviousImage, TargetRelease: journal.TargetRelease, TargetImage: journal.TargetImage, Published: journal.Published}
+}
+
+func updateStageRoot(directory string) string {
+	return filepath.Join(directory, updateStageDirectoryName)
+}
+
+func updateCandidateDirectory(directory string) string {
+	return filepath.Join(updateStageRoot(directory), updateCandidateName)
+}
+
+func updateJournalPath(directory string) string {
+	return filepath.Join(updateStageRoot(directory), updateJournalName)
+}
+
+func ensureUpdateCandidate(directory string, journal updateJournal) error {
+	candidateDirectory := updateCandidateDirectory(directory)
+	if _, err := os.Lstat(candidateDirectory); errors.Is(err, os.ErrNotExist) {
+		if err := os.Mkdir(candidateDirectory, 0o700); err != nil {
+			return errors.New("candidate configuration could not be reserved")
+		}
+	} else if err != nil {
+		return errors.New("candidate configuration is unavailable or unsafe")
+	}
+	if err := requireTrustedPrivateDirectory(candidateDirectory); err != nil {
+		return errors.New("candidate configuration is unavailable or unsafe")
+	}
+	candidate := journal.candidate(directory)
+	configBody, err := indentedJSON(candidate)
+	if err != nil || ensureExactProtectedFile(ConfigFile(candidateDirectory), configBody) != nil || ensureExactProtectedFile(EnvFile(candidateDirectory), []byte(daemonEnv(candidate))) != nil || ensureExactProtectedFile(OverrideFile(candidateDirectory), []byte(composeOverride())) != nil {
+		return errors.New("candidate configuration is incomplete or does not match the update request")
+	}
+	if syncDirectory(candidateDirectory) != nil || syncDirectory(updateStageRoot(directory)) != nil || syncDirectory(directory) != nil {
+		return errors.New("candidate configuration could not be made durable")
+	}
+	return nil
+}
+
+func ensureExactProtectedFile(path string, body []byte) error {
+	if _, err := os.Lstat(path); errors.Is(err, os.ErrNotExist) {
+		return writeExclusive(path, body)
+	} else if err != nil || requireTrustedProtectedFile(path, int64(len(body))+1) != nil {
+		return errors.New("protected staged file is unsafe")
+	}
+	existing, err := os.ReadFile(path) // #nosec G304 -- fixed file in a validated private stage.
+	if err != nil || !bytes.Equal(existing, body) {
+		return errors.New("protected staged file does not match")
+	}
+	return nil
+}
+
+func readUpdateJournal(directory string) (updateJournal, error) {
+	path := updateJournalPath(directory)
+	if err := requireTrustedProtectedFile(path, 64<<10); err != nil {
+		return updateJournal{}, err
+	}
+	file, err := os.Open(path) // #nosec G304 -- fixed journal below a validated private installation.
+	if err != nil {
+		return updateJournal{}, err
+	}
+	defer func() { _ = file.Close() }()
+	decoder := json.NewDecoder(io.LimitReader(file, 64<<10))
+	decoder.DisallowUnknownFields()
+	var journal updateJournal
+	if err := decoder.Decode(&journal); err != nil || ensureJSONEOF(decoder) != nil || !journal.valid() {
+		return updateJournal{}, errors.New("update journal is invalid")
+	}
+	return journal, nil
+}
+
+func indentedJSON(value any) ([]byte, error) {
+	body, err := json.MarshalIndent(value, "", "  ")
+	if err != nil {
+		return nil, err
+	}
+	return append(body, '\n'), nil
+}
+
+func replaceUpdateJournal(directory string, journal updateJournal) error {
+	body, err := indentedJSON(journal)
+	if err != nil {
+		return err
+	}
+	return replacePublishedFile(updateJournalPath(directory), body, journal.UpdateID)
+}
+
+func replacePublishedFile(path string, body []byte, updateID string) error {
+	if err := requireTrustedDirectoryAncestors(filepath.Dir(path)); err != nil {
+		return err
+	}
+	temporary := path + "." + updateID + ".pending"
+	if _, err := os.Lstat(temporary); err == nil {
+		if err := ensureExactProtectedFile(temporary, body); err != nil {
+			return err
+		}
+	} else if errors.Is(err, os.ErrNotExist) {
+		if err := writeExclusive(temporary, body); err != nil {
+			return err
+		}
+	} else {
+		return err
+	}
+	if err := os.Rename(temporary, path); err != nil {
+		return err
+	}
+	return syncDirectory(filepath.Dir(path))
+}
+
+func runUpdatePublicationHook(step string) error {
+	if updatePublicationHook == nil {
+		return nil
+	}
+	return updatePublicationHook(step)
+}

--- a/internal/operator/update_disk_unix.go
+++ b/internal/operator/update_disk_unix.go
@@ -1,0 +1,26 @@
+//go:build !windows
+
+package operator
+
+import (
+	"errors"
+	"math"
+
+	"golang.org/x/sys/unix"
+)
+
+// UpdateAvailableBytes returns filesystem capacity available to the operator.
+func UpdateAvailableBytes(path string) (uint64, error) {
+	var statistics unix.Statfs_t
+	if err := unix.Statfs(path, &statistics); err != nil {
+		return 0, errors.New("update disk capacity is unavailable")
+	}
+	if statistics.Bsize <= 0 {
+		return 0, errors.New("update disk capacity is invalid")
+	}
+	blockSize := uint64(statistics.Bsize) // #nosec G115 -- positivity is checked immediately above.
+	if statistics.Bavail > math.MaxUint64/blockSize {
+		return 0, errors.New("update disk capacity is invalid")
+	}
+	return statistics.Bavail * blockSize, nil
+}

--- a/internal/operator/update_disk_windows.go
+++ b/internal/operator/update_disk_windows.go
@@ -1,0 +1,22 @@
+//go:build windows
+
+package operator
+
+import (
+	"errors"
+
+	"golang.org/x/sys/windows"
+)
+
+// UpdateAvailableBytes returns filesystem capacity available to the operator.
+func UpdateAvailableBytes(path string) (uint64, error) {
+	root, err := windows.UTF16PtrFromString(path)
+	if err != nil {
+		return 0, errors.New("update disk capacity is unavailable")
+	}
+	var available uint64
+	if err := windows.GetDiskFreeSpaceEx(root, &available, nil, nil); err != nil {
+		return 0, errors.New("update disk capacity is unavailable")
+	}
+	return available, nil
+}

--- a/internal/operator/update_test.go
+++ b/internal/operator/update_test.go
@@ -1,0 +1,304 @@
+package operator
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	punaropostgres "github.com/rock3r/punaro/internal/postgres"
+)
+
+const updateTargetImage = "registry.example/punaro@sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+
+func installedUpdateRequest(t *testing.T) UpdateStage {
+	t.Helper()
+	options := validInitOptions(t)
+	if _, err := Init(context.Background(), options, func(context.Context, string, string) (punaropostgres.Principal, error) {
+		return punaropostgres.Principal{ID: "11111111-1111-4111-8111-111111111111", DisplayName: options.OwnerName}, nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	return UpdateStage{
+		Directory:       options.Directory,
+		UpdateID:        "019b4eb0-21f8-7d93-84df-10e6cf05ce53",
+		PreviousRelease: "v0.6.0",
+		PreviousImage:   testImage,
+		TargetRelease:   "v0.7.0",
+		TargetImage:     updateTargetImage,
+	}
+}
+
+func TestStageUpdateIsPrivateDurableAndDoesNotPublish(t *testing.T) {
+	request := installedUpdateRequest(t)
+	beforeConfig, err := os.ReadFile(ConfigFile(request.Directory))
+	if err != nil {
+		t.Fatal(err)
+	}
+	beforeEnv, err := os.ReadFile(EnvFile(request.Directory))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	stage, err := StageUpdate(request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stage.Published || stage.PreviousImage != request.PreviousImage || stage.TargetImage != request.TargetImage {
+		t.Fatalf("stage=%#v", stage)
+	}
+	if filepath.Dir(stage.CandidateDirectory) != filepath.Join(request.Directory, updateStageDirectoryName) {
+		t.Fatalf("candidate directory=%q", stage.CandidateDirectory)
+	}
+	for _, directory := range []string{filepath.Join(request.Directory, updateStageDirectoryName), stage.CandidateDirectory} {
+		info, statErr := os.Lstat(directory)
+		if statErr != nil || !info.IsDir() || info.Mode().Perm() != 0o700 {
+			t.Fatalf("directory=%q mode=%v err=%v", directory, info.Mode(), statErr)
+		}
+	}
+	candidate, err := readInstallation(ConfigFile(stage.CandidateDirectory))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if candidate.Image != request.TargetImage {
+		t.Fatalf("candidate image=%q", candidate.Image)
+	}
+	candidateEnv, err := os.ReadFile(EnvFile(stage.CandidateDirectory))
+	if err != nil || !strings.Contains(string(candidateEnv), "PUNARO_IMAGE="+request.TargetImage+"\n") {
+		t.Fatalf("candidate env=%q err=%v", candidateEnv, err)
+	}
+	if candidateCompose, readErr := os.ReadFile(OverrideFile(stage.CandidateDirectory)); readErr != nil || string(candidateCompose) != composeOverride() {
+		t.Fatalf("candidate compose invalid: %v", readErr)
+	}
+	afterConfig, _ := os.ReadFile(ConfigFile(request.Directory))
+	afterEnv, _ := os.ReadFile(EnvFile(request.Directory))
+	if string(afterConfig) != string(beforeConfig) || string(afterEnv) != string(beforeEnv) {
+		t.Fatal("staging changed published configuration")
+	}
+
+	resumed, err := StageUpdate(request)
+	if err != nil || resumed != stage {
+		t.Fatalf("resume=%#v err=%v", resumed, err)
+	}
+	changed := request
+	changed.TargetRelease = "v0.7.1"
+	if _, err := StageUpdate(changed); !errors.Is(err, ErrUpdateStageConflict) {
+		t.Fatalf("changed target error=%v", err)
+	}
+	other := request
+	other.UpdateID = "019b4eb0-5317-79a6-a0de-fd97719910fb"
+	if _, err := StageUpdate(other); !errors.Is(err, ErrUpdateStageConflict) {
+		t.Fatalf("second update error=%v", err)
+	}
+}
+
+func TestResumeUpdateStageNeverCreatesMissingAuthority(t *testing.T) {
+	request := installedUpdateRequest(t)
+	if _, err := ResumeUpdateStage(request); !errors.Is(err, ErrUpdateStageNotFound) {
+		t.Fatalf("missing stage error=%v", err)
+	}
+	if _, err := os.Stat(filepath.Join(request.Directory, updateStageDirectoryName)); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("resume created a stage: %v", err)
+	}
+	want, err := StageUpdate(request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := ResumeUpdateStage(request)
+	if err != nil || got != want {
+		t.Fatalf("resume=%#v err=%v want=%#v", got, err, want)
+	}
+	existing, err := ExistingUpdateStage(request.Directory)
+	if err != nil || existing != request {
+		t.Fatalf("existing request=%#v err=%v want=%#v", existing, err, request)
+	}
+}
+
+func TestUpdateRecoveryReceiptIsIndependentDurableAndExact(t *testing.T) {
+	request := installedUpdateRequest(t)
+	if _, err := StageUpdate(request); err != nil {
+		t.Fatal(err)
+	}
+	backupDirectory := filepath.Join(t.TempDir(), "verified-backup")
+	if err := os.Mkdir(backupDirectory, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	receipt := UpdateRecoveryReceipt{
+		Version: 1, UpdateID: request.UpdateID, BackupID: "019b4eb0-b9fb-761e-9c88-30f59a659aa8", BackupDirectory: backupDirectory,
+		InstallationID: "11111111-1111-4111-8111-111111111111", TimelineID: "22222222-2222-4222-8222-222222222222", ChangeSequence: 7,
+		SourceSchema: 5, TargetRelease: request.TargetRelease, TargetImageDigest: "sha256:" + strings.Repeat("b", 64),
+		ExportedSnapshotID: "000003A1-1", ManifestSHA256: strings.Repeat("c", 64),
+	}
+	digest, err := BindUpdateRecoveryReceipt(request, receipt)
+	if err != nil || len(digest) != 64 {
+		t.Fatalf("bind digest=%q err=%v", digest, err)
+	}
+	path := UpdateRecoveryReceiptFile(request.Directory)
+	loaded, loadedDigest, err := LoadUpdateRecoveryReceipt(path)
+	if err != nil || loaded != receipt || loadedDigest != digest {
+		t.Fatalf("loaded=%#v digest=%q err=%v", loaded, loadedDigest, err)
+	}
+	if digest2, err := BindUpdateRecoveryReceipt(request, receipt); err != nil || digest2 != digest {
+		t.Fatalf("idempotent bind digest=%q err=%v", digest2, err)
+	}
+	changed := receipt
+	changed.BackupID = "019b4eb1-a74a-77bd-9402-b8fa0532c44f"
+	if _, err := BindUpdateRecoveryReceipt(request, changed); err == nil {
+		t.Fatal("receipt authority was replaced")
+	}
+	info, err := os.Lstat(path)
+	if err != nil || !info.Mode().IsRegular() || info.Mode().Perm() != 0o600 {
+		t.Fatalf("receipt mode=%v err=%v", info.Mode(), err)
+	}
+}
+
+func TestPublishUpdateMarkerIsLastAndEveryBoundaryResumes(t *testing.T) {
+	for _, failAfter := range []string{publishStepEnvironment, publishStepCompose, publishStepInstallation} {
+		t.Run(failAfter, func(t *testing.T) {
+			request := installedUpdateRequest(t)
+			if _, err := StageUpdate(request); err != nil {
+				t.Fatal(err)
+			}
+			updatePublicationHook = func(step string) error {
+				loaded, loadErr := Load(request.Directory)
+				if loadErr != nil {
+					t.Fatalf("load at %s: %v", step, loadErr)
+				}
+				wantImage := request.PreviousImage
+				if step == publishStepInstallation {
+					wantImage = request.TargetImage
+				}
+				if loaded.Image != wantImage {
+					t.Fatalf("step=%s image=%q want=%q", step, loaded.Image, wantImage)
+				}
+				if step == failAfter {
+					return errors.New("simulated crash")
+				}
+				return nil
+			}
+			if _, err := PublishUpdate(request); err == nil {
+				t.Fatal("simulated publication crash was ignored")
+			}
+			updatePublicationHook = nil
+			t.Cleanup(func() { updatePublicationHook = nil })
+
+			published, err := PublishUpdate(request)
+			if err != nil || published.Image != request.TargetImage {
+				t.Fatalf("published=%#v err=%v", published, err)
+			}
+			if _, err := PublishUpdate(request); err != nil {
+				t.Fatalf("idempotent publish: %v", err)
+			}
+			loaded, err := Load(request.Directory)
+			if err != nil || loaded.Image != request.TargetImage || len(CheckPaths(loaded)) != 0 {
+				t.Fatalf("loaded=%#v failures=%v err=%v", loaded, CheckPaths(loaded), err)
+			}
+			journal, err := readUpdateJournal(request.Directory)
+			if err != nil || !journal.Published || journal.PreviousRelease != request.PreviousRelease || journal.PreviousImage != request.PreviousImage {
+				t.Fatalf("journal=%#v err=%v", journal, err)
+			}
+		})
+	}
+}
+
+func TestPublishPreviousUpdateReversesPublishedTargetForFencedRecovery(t *testing.T) {
+	request := installedUpdateRequest(t)
+	if _, err := PublishUpdate(request); err != nil {
+		t.Fatal(err)
+	}
+	if err := PublishPreviousUpdate(request); err != nil {
+		t.Fatal(err)
+	}
+	current, err := Load(request.Directory)
+	if err != nil || current.Image != request.PreviousImage || len(CheckPaths(current)) != 0 {
+		t.Fatalf("current=%#v err=%v", current, err)
+	}
+	if err := PublishPreviousUpdate(request); err != nil {
+		t.Fatalf("idempotent previous publication: %v", err)
+	}
+}
+
+func TestAbortStageRestoresPartialPublicationButRefusesPublishedUpdate(t *testing.T) {
+	request := installedUpdateRequest(t)
+	if _, err := StageUpdate(request); err != nil {
+		t.Fatal(err)
+	}
+	updatePublicationHook = func(step string) error {
+		if step == publishStepEnvironment {
+			return errors.New("simulated crash")
+		}
+		return nil
+	}
+	if _, err := PublishUpdate(request); err == nil {
+		t.Fatal("simulated crash was ignored")
+	}
+	updatePublicationHook = nil
+	t.Cleanup(func() { updatePublicationHook = nil })
+	if err := AbortStage(request); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Lstat(filepath.Join(request.Directory, updateStageDirectoryName)); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("stage survived abort: %v", err)
+	}
+	loaded, err := Load(request.Directory)
+	if err != nil || loaded.Image != request.PreviousImage || len(CheckPaths(loaded)) != 0 {
+		t.Fatalf("loaded=%#v failures=%v err=%v", loaded, CheckPaths(loaded), err)
+	}
+
+	if _, err := StageUpdate(request); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := PublishUpdate(request); err != nil {
+		t.Fatal(err)
+	}
+	if err := AbortStage(request); !errors.Is(err, ErrUpdateAlreadyPublished) {
+		t.Fatalf("published abort error=%v", err)
+	}
+}
+
+func TestStageUpdateStrictlyValidatesRequestAndPublishedSource(t *testing.T) {
+	base := installedUpdateRequest(t)
+	tests := map[string]func(*UpdateStage){
+		"relative directory": func(r *UpdateStage) { r.Directory = "relative" },
+		"invalid update id":  func(r *UpdateStage) { r.UpdateID = "not-a-uuid" },
+		"empty previous":     func(r *UpdateStage) { r.PreviousRelease = "" },
+		"unsafe target":      func(r *UpdateStage) { r.TargetRelease = "v0.7.0\nBAD=1" },
+		"same release":       func(r *UpdateStage) { r.TargetRelease = r.PreviousRelease },
+		"same image":         func(r *UpdateStage) { r.TargetImage = r.PreviousImage },
+		"tagged image":       func(r *UpdateStage) { r.TargetImage = "registry.example/punaro:latest" },
+		"wrong previous":     func(r *UpdateStage) { r.PreviousImage = updateTargetImage; r.TargetImage = testImage },
+	}
+	for name, mutate := range tests {
+		t.Run(name, func(t *testing.T) {
+			request := base
+			mutate(&request)
+			if _, err := StageUpdate(request); err == nil {
+				t.Fatal("invalid update stage accepted")
+			}
+		})
+	}
+}
+
+func TestCompleteStageRemovesOnlyPublishedExactJournal(t *testing.T) {
+	request := installedUpdateRequest(t)
+	if _, err := StageUpdate(request); err != nil {
+		t.Fatal(err)
+	}
+	if err := CompleteStage(request); err == nil {
+		t.Fatal("unpublished stage completed")
+	}
+	if _, err := PublishUpdate(request); err != nil {
+		t.Fatal(err)
+	}
+	if err := CompleteStage(request); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Lstat(filepath.Join(request.Directory, updateStageDirectoryName)); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("completed stage remains: %v", err)
+	}
+	if loaded, err := Load(request.Directory); err != nil || loaded.Image != request.TargetImage {
+		t.Fatalf("published installation changed: %#v err=%v", loaded, err)
+	}
+}

--- a/internal/postgres/backup.go
+++ b/internal/postgres/backup.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/google/uuid"
 	punarobackup "github.com/rock3r/punaro/internal/backup"
 )
 
@@ -23,6 +24,7 @@ type BackupSource struct {
 	dumpDSNFile      string
 	dump             DumpSnapshot
 	openFenceSession func(context.Context, string) (backupFenceSession, error)
+	updateID         string
 }
 
 type backupFenceSession interface {
@@ -154,6 +156,21 @@ func NewBackupSource(database *Database, dumpDSNFile string, dump DumpSnapshot) 
 	}, nil
 }
 
+// NewUpdateBackupSource binds backup creation to one exact active update. It
+// is required for the pre-update backup, including the one-time v5 bridge whose
+// additive controls intentionally remain unrecorded until after verification.
+func NewUpdateBackupSource(database *Database, dumpDSNFile, updateID string, dump DumpSnapshot) (*BackupSource, error) {
+	if uuid.Validate(updateID) != nil {
+		return nil, errors.New("PostgreSQL update backup identity is invalid")
+	}
+	source, err := NewBackupSource(database, dumpDSNFile, dump)
+	if err != nil {
+		return nil, err
+	}
+	source.updateID = updateID
+	return source, nil
+}
+
 // Begin acquires and commits a GC fence before exporting one repeatable-read
 // snapshot. READY blob metadata and server coordinates come from that snapshot.
 func (source *BackupSource) Begin(ctx context.Context) (*punarobackup.Snapshot, error) {
@@ -201,7 +218,13 @@ func (source *BackupSource) Begin(ctx context.Context) (*punarobackup.Snapshot, 
 		return nil, errors.New("PostgreSQL backup schema cannot be inspected")
 	}
 	schemaState := Classify(catalog, manifest)
-	if schemaState.Classification != Compatible || schemaState.Version != manifest.MaxSupported {
+	updateBackupAllowed := false
+	if source.updateID != "" {
+		active, activeErr := administration.ActiveUpdate(ctx)
+		controls, controlsErr := updateControlsAvailable(ctx, administration.db)
+		updateBackupAllowed = activeErr == nil && controlsErr == nil && controls && active.UpdateID == source.updateID && active.Phase == UpdateWritersStopped && active.SourceSchema == schemaState.Version
+	}
+	if (schemaState.Classification != Compatible || schemaState.Version != manifest.MaxSupported) && !updateBackupAllowed {
 		return nil, errors.New("PostgreSQL backup requires the exact current schema")
 	}
 	var state punarobackup.State

--- a/internal/postgres/backup_test.go
+++ b/internal/postgres/backup_test.go
@@ -2,11 +2,23 @@ package postgres
 
 import (
 	"context"
+	"database/sql"
 	"errors"
 	"reflect"
 	"sync"
 	"testing"
 )
+
+func TestNewUpdateBackupSourceRequiresExactUpdateIdentity(t *testing.T) {
+	database := &Database{db: &sql.DB{}}
+	dump := func(context.Context, string, string, string) error { return nil }
+	if _, err := NewUpdateBackupSource(database, "owner.dsn", "invalid", dump); err == nil {
+		t.Fatal("invalid update identity accepted")
+	}
+	if source, err := NewUpdateBackupSource(database, "owner.dsn", "019b4eb0-21f8-7d93-84df-10e6cf05ce53", dump); err != nil || source.updateID == "" {
+		t.Fatalf("valid update source=%#v err=%v", source, err)
+	}
+}
 
 func TestBackupSnapshotFinisherRetriesFailedReleaseAsAbort(t *testing.T) {
 	stopCalls := 0

--- a/internal/postgres/control_store.go
+++ b/internal/postgres/control_store.go
@@ -110,9 +110,9 @@ func (d *Database) CreatePrincipal(ctx context.Context, kind PrincipalKind, disp
 	if !validPrincipalKind(kind) || !validDisplayName(displayName) {
 		return Principal{}, errors.New("invalid principal")
 	}
-	tx, err := d.db.BeginTx(ctx, nil)
+	tx, err := beginMutation(ctx, d.db)
 	if err != nil {
-		return Principal{}, errors.New("principal transaction cannot start")
+		return Principal{}, mutationStartError(err, "principal transaction cannot start")
 	}
 	defer func() { _ = tx.Rollback() }()
 	var principal Principal
@@ -139,9 +139,9 @@ func (d *Database) GrantCapability(ctx context.Context, actorPrincipalID string,
 	if !validOpaqueID(actorPrincipalID) || grant.Validate() != nil {
 		return "", errors.New("invalid grant")
 	}
-	tx, err := d.db.BeginTx(ctx, nil)
+	tx, err := beginMutation(ctx, d.db)
 	if err != nil {
-		return "", errors.New("grant transaction cannot start")
+		return "", mutationStartError(err, "grant transaction cannot start")
 	}
 	defer func() { _ = tx.Rollback() }()
 	if err := lockGrantMutations(ctx, tx); err != nil {
@@ -202,9 +202,9 @@ func (d *Database) RevokeGrant(ctx context.Context, actorPrincipalID, grantID st
 	if !validOpaqueID(actorPrincipalID) || !validOpaqueID(grantID) {
 		return errors.New("invalid grant")
 	}
-	tx, err := d.db.BeginTx(ctx, nil)
+	tx, err := beginMutation(ctx, d.db)
 	if err != nil {
-		return errors.New("grant transaction cannot start")
+		return mutationStartError(err, "grant transaction cannot start")
 	}
 	defer func() { _ = tx.Rollback() }()
 	if err := lockGrantMutations(ctx, tx); err != nil {
@@ -427,9 +427,9 @@ func (d *Database) CreateProject(ctx context.Context, create ProjectCreate) (Pro
 	if err != nil {
 		return ProjectResult{}, errors.New("project create request cannot be encoded")
 	}
-	tx, err := d.db.BeginTx(ctx, nil)
+	tx, err := beginMutation(ctx, d.db)
 	if err != nil {
-		return ProjectResult{}, errors.New("project transaction cannot start")
+		return ProjectResult{}, mutationStartError(err, "project transaction cannot start")
 	}
 	defer func() { _ = tx.Rollback() }()
 	outcome, err := executeIdempotentTx(ctx, tx, IdempotencyRequest{PrincipalID: create.PrincipalID, Operation: "project.create", Key: create.IdempotencyKey, Body: body}, func(control *ControlTx) (IdempotencyOutcome, error) {
@@ -486,9 +486,9 @@ func (d *Database) executeIdempotent(ctx context.Context, request IdempotencyReq
 	if err := request.Validate(); err != nil {
 		return IdempotencyOutcome{}, err
 	}
-	tx, err := d.db.BeginTx(ctx, nil)
+	tx, err := beginMutation(ctx, d.db)
 	if err != nil {
-		return IdempotencyOutcome{}, errors.New("idempotency transaction cannot start")
+		return IdempotencyOutcome{}, mutationStartError(err, "idempotency transaction cannot start")
 	}
 	defer func() { _ = tx.Rollback() }()
 	outcome, err := executeIdempotentTx(ctx, tx, request, mutation)
@@ -622,9 +622,9 @@ func (d *Database) ClaimJobs(ctx context.Context, claim ClaimJobs) ([]LeasedJob,
 	if !knownKind {
 		return []LeasedJob{}, nil
 	}
-	tx, err := d.db.BeginTx(ctx, nil)
+	tx, err := beginMutation(ctx, d.db)
 	if err != nil {
-		return nil, errors.New("job claim transaction cannot start")
+		return nil, mutationStartError(err, "job claim transaction cannot start")
 	}
 	defer func() { _ = tx.Rollback() }()
 	if err := lockProjectJobMutations(ctx, tx, false); err != nil {
@@ -794,9 +794,9 @@ type authorizedJobLease struct {
 }
 
 func (d *Database) authorizedJobLeaseTx(ctx context.Context, lease JobLease) (authorizedJobLease, error) {
-	tx, err := d.db.BeginTx(ctx, nil)
+	tx, err := beginMutation(ctx, d.db)
 	if err != nil {
-		return authorizedJobLease{}, errors.New("job lease transaction cannot start")
+		return authorizedJobLease{}, mutationStartError(err, "job lease transaction cannot start")
 	}
 	if err := lockProjectJobMutations(ctx, tx, false); err != nil {
 		_ = tx.Rollback()
@@ -850,6 +850,9 @@ func (d *Database) PruneTerminalJobs(ctx context.Context, before time.Time, limi
 	}
 	var count int64
 	if err := d.db.QueryRowContext(ctx, `SELECT jobs.prune_terminal($1, $2)`, before, limit).Scan(&count); err != nil {
+		if isMaintenanceError(err) {
+			return 0, ErrMaintenance
+		}
 		return 0, errors.New("terminal jobs could not be pruned")
 	}
 	return count, nil
@@ -862,6 +865,9 @@ func (d *Database) PruneAuditEvents(ctx context.Context, before time.Time, limit
 	}
 	var count int64
 	if err := d.db.QueryRowContext(ctx, `SELECT audit.prune_events($1, $2)`, before, limit).Scan(&count); err != nil {
+		if isMaintenanceError(err) {
+			return 0, ErrMaintenance
+		}
 		return 0, errors.New("audit events could not be pruned")
 	}
 	return count, nil

--- a/internal/postgres/db.go
+++ b/internal/postgres/db.go
@@ -114,6 +114,15 @@ func (d *Database) InstallationState(ctx context.Context) (InstallationState, er
 	return state, nil
 }
 
+// PostgreSQLMajor returns the exact server major used by release preflight.
+func (d *Database) PostgreSQLMajor(ctx context.Context) (int, error) {
+	var major int
+	if err := d.db.QueryRowContext(ctx, `SELECT current_setting('server_version_num')::integer / 10000`).Scan(&major); err != nil || major < minimumSupportedPostgresMajor {
+		return 0, errors.New("PostgreSQL major version is unavailable")
+	}
+	return major, nil
+}
+
 // Identity returns a content-free fingerprint of the exact target database
 // within its PostgreSQL server. It is stable across schema restore operations.
 func (d *Database) Identity(ctx context.Context) (string, error) {
@@ -215,6 +224,9 @@ func (d *Database) AdvanceChange(ctx context.Context) (InstallationState, error)
 	var state InstallationState
 	err := d.db.QueryRowContext(ctx, `SELECT installation_id::text, timeline_id::text, change_sequence FROM jobs.advance_change_sequence()`).Scan(&state.InstallationID, &state.TimelineID, &state.ChangeSequence)
 	if err != nil {
+		if isMaintenanceError(err) {
+			return InstallationState{}, ErrMaintenance
+		}
 		return InstallationState{}, errors.New("PostgreSQL change sequence could not be advanced")
 	}
 	return state, nil
@@ -921,6 +933,13 @@ FROM objects, table_ownership, routine_safety, routine_acl, table_acl, schema_ac
 			return Snapshot{}, errors.New("PostgreSQL backup schema cannot be inspected")
 		}
 		snapshot.CurrentObjectsPresent = backupObjectsPresent
+	}
+	if snapshot.CurrentObjectsPresent && len(snapshot.Records) > 0 && snapshot.Records[len(snapshot.Records)-1].Version >= 6 {
+		updateObjectsPresent, err := updateControlsAvailable(ctx, q)
+		if err != nil {
+			return Snapshot{}, errors.New("PostgreSQL update-control schema cannot be inspected")
+		}
+		snapshot.CurrentObjectsPresent = updateObjectsPresent
 	}
 	return snapshot, nil
 }

--- a/internal/postgres/device_auth_store.go
+++ b/internal/postgres/device_auth_store.go
@@ -70,7 +70,15 @@ func OpenAdministration(ctx context.Context, cfg Config) (*Administration, error
 		_ = db.Close()
 		return nil, err
 	}
-	if state := Classify(snapshot, CurrentManifest()); state.Classification != Compatible {
+	state := Classify(snapshot, CurrentManifest())
+	bridgeControls, knownBridge := false, false
+	if state.Classification == UpgradeRequired && state.Version == 5 {
+		bridgeControls, err = updateControlsAvailable(ctx, db)
+		if err == nil && bridgeControls {
+			err = db.QueryRowContext(ctx, `SELECT EXISTS (SELECT 1 FROM jobs.update_transactions WHERE source_schema=5 AND target_schema=6)`).Scan(&knownBridge)
+		}
+	}
+	if err != nil || !administrationSchemaAllowed(state, bridgeControls, knownBridge) {
 		_ = db.Close()
 		return nil, contentFreeMigrationError(state.Classification)
 	}
@@ -184,9 +192,9 @@ func (a *Administration) BootstrapOwner(ctx context.Context, label string) (Prin
 	if !validDisplayName(label) {
 		return Principal{}, errors.New("invalid owner")
 	}
-	tx, err := a.db.BeginTx(ctx, nil)
+	tx, err := beginMutation(ctx, a.db)
 	if err != nil {
-		return Principal{}, errors.New("owner bootstrap cannot start")
+		return Principal{}, mutationStartError(err, "owner bootstrap cannot start")
 	}
 	defer func() { _ = tx.Rollback() }()
 	if _, err := tx.ExecContext(ctx, `SELECT pg_advisory_xact_lock($1)`, bootstrapLockKey); err != nil {
@@ -248,9 +256,9 @@ func (a *Administration) CreateEnrollment(ctx context.Context, actorPrincipalID 
 	code := base64.RawURLEncoding.EncodeToString(codeBytes)
 	codeDigest := sha256.Sum256(codeBytes)
 	previewDigest, _ := hex.DecodeString(previewHash)
-	tx, err := a.db.BeginTx(ctx, nil)
+	tx, err := beginMutation(ctx, a.db)
 	if err != nil {
-		return PendingEnrollment{}, errors.New("enrollment transaction cannot start")
+		return PendingEnrollment{}, mutationStartError(err, "enrollment transaction cannot start")
 	}
 	defer func() { _ = tx.Rollback() }()
 	if ok, err := lockInstallationOwner(ctx, tx, actorPrincipalID); err != nil || !ok {
@@ -348,9 +356,9 @@ func (d *Database) redeemEnrollment(ctx context.Context, redeem RedeemEnrollment
 	codeDigest := sha256.Sum256(codeBytes)
 	credentialSecret := deriveEnrollmentCredentialSecret(redeem, codeBytes)
 	secretDigest := sha256.Sum256(credentialSecret[:])
-	tx, err := d.db.BeginTx(ctx, nil)
+	tx, err := beginMutation(ctx, d.db)
 	if err != nil {
-		return DeviceCredential{}, errors.New("enrollment redemption cannot start")
+		return DeviceCredential{}, mutationStartError(err, "enrollment redemption cannot start")
 	}
 	defer func() { _ = tx.Rollback() }()
 	if err := lockGrantMutations(ctx, tx); err != nil {
@@ -520,9 +528,9 @@ func (a *Administration) BeginDeviceCredentialRotation(ctx context.Context, acto
 	}
 	code := base64.RawURLEncoding.EncodeToString(codeBytes)
 	digest := sha256.Sum256(codeBytes)
-	tx, err := a.db.BeginTx(ctx, nil)
+	tx, err := beginMutation(ctx, a.db)
 	if err != nil {
-		return PendingCredentialRotation{}, errors.New("credential rotation cannot start")
+		return PendingCredentialRotation{}, mutationStartError(err, "credential rotation cannot start")
 	}
 	defer func() { _ = tx.Rollback() }()
 	if ok, err := lockInstallationOwner(ctx, tx, actorPrincipalID); err != nil || !ok {
@@ -559,9 +567,9 @@ func (a *Administration) RotateDeviceCredential(ctx context.Context, actorPrinci
 	codeDigest := sha256.Sum256(codeBytes)
 	secret := deriveRotationCredentialSecret(rotate, codeBytes)
 	digest := sha256.Sum256(secret[:])
-	tx, err := a.db.BeginTx(ctx, nil)
+	tx, err := beginMutation(ctx, a.db)
 	if err != nil {
-		return DeviceCredential{}, errors.New("credential rotation cannot start")
+		return DeviceCredential{}, mutationStartError(err, "credential rotation cannot start")
 	}
 	defer func() { _ = tx.Rollback() }()
 	if ok, err := lockInstallationOwner(ctx, tx, actorPrincipalID); err != nil || !ok {
@@ -635,9 +643,9 @@ func (a *Administration) RevokeDeviceCredential(ctx context.Context, actorPrinci
 	if !validOpaqueID(actorPrincipalID) || !validOpaqueID(lookupID) {
 		return errors.New("invalid credential revocation")
 	}
-	tx, err := a.db.BeginTx(ctx, nil)
+	tx, err := beginMutation(ctx, a.db)
 	if err != nil {
-		return errors.New("credential revocation cannot start")
+		return mutationStartError(err, "credential revocation cannot start")
 	}
 	defer func() { _ = tx.Rollback() }()
 	if ok, err := lockInstallationOwner(ctx, tx, actorPrincipalID); err != nil || !ok {

--- a/internal/postgres/legacy_auth_store.go
+++ b/internal/postgres/legacy_auth_store.go
@@ -35,9 +35,9 @@ func (a *Administration) RegisterLegacyMachine(ctx context.Context, actorPrincip
 		return LegacyMachine{}, errors.New("invalid legacy machine")
 	}
 	digest := sha256.Sum256(publicKey)
-	tx, err := a.db.BeginTx(ctx, nil)
+	tx, err := beginMutation(ctx, a.db)
 	if err != nil {
-		return LegacyMachine{}, errors.New("legacy registration cannot start")
+		return LegacyMachine{}, mutationStartError(err, "legacy registration cannot start")
 	}
 	defer func() { _ = tx.Rollback() }()
 	if ok, err := lockInstallationOwner(ctx, tx, actorPrincipalID); err != nil || !ok {
@@ -134,9 +134,9 @@ func (a *Administration) RetireLegacyMachine(ctx context.Context, actorPrincipal
 	if !validOpaqueID(actorPrincipalID) || !validOpaqueID(legacyPrincipalID) {
 		return errors.New("invalid legacy retirement")
 	}
-	tx, err := a.db.BeginTx(ctx, nil)
+	tx, err := beginMutation(ctx, a.db)
 	if err != nil {
-		return errors.New("legacy retirement cannot start")
+		return mutationStartError(err, "legacy retirement cannot start")
 	}
 	defer func() { _ = tx.Rollback() }()
 	if ok, err := lockInstallationOwner(ctx, tx, actorPrincipalID); err != nil || !ok {
@@ -171,9 +171,9 @@ func (a *Administration) DisableLegacyAuthentication(ctx context.Context, actorP
 	if !validOpaqueID(actorPrincipalID) {
 		return errors.New("invalid legacy disable request")
 	}
-	tx, err := a.db.BeginTx(ctx, nil)
+	tx, err := beginMutation(ctx, a.db)
 	if err != nil {
-		return errors.New("legacy disable cannot start")
+		return mutationStartError(err, "legacy disable cannot start")
 	}
 	defer func() { _ = tx.Rollback() }()
 	if ok, err := lockInstallationOwner(ctx, tx, actorPrincipalID); err != nil || !ok {

--- a/internal/postgres/migrate.go
+++ b/internal/postgres/migrate.go
@@ -13,6 +13,17 @@ import (
 	"strings"
 )
 
+// MigrationManifestSHA256 binds release metadata and the update transaction to
+// the exact ordered embedded migration history without including SQL bodies.
+func MigrationManifestSHA256() string {
+	manifest := CurrentManifest()
+	hash := sha256.New()
+	for _, migration := range manifest.Migrations {
+		_, _ = hash.Write([]byte(strconv.FormatInt(migration.Version, 10) + "\x00" + migration.Name + "\x00" + migration.Checksum + "\x00" + strconv.FormatInt(migration.CompatibilityFloor, 10) + "\n"))
+	}
+	return hex.EncodeToString(hash.Sum(nil))
+}
+
 //go:embed migrations/*.sql
 var migrationFiles embed.FS
 
@@ -24,6 +35,7 @@ var migrationCompatibilityFloors = map[int64]int64{
 	3: 3,
 	4: 4,
 	5: 5,
+	6: 6,
 }
 
 // CurrentManifest returns the immutable migrations embedded in this binary.
@@ -72,7 +84,80 @@ func Migrate(ctx context.Context, cfg Config) (SchemaState, error) {
 		return SchemaState{}, err
 	}
 	defer func() { _ = db.Close() }()
+	if err := refuseOrdinaryUpgrade(ctx, db, CurrentManifest()); err != nil {
+		return SchemaState{}, err
+	}
 	return migrate(ctx, db, CurrentManifest())
+}
+
+// MigrateUpdate is the only existing-schema migrator. It binds the dedicated
+// owner session to one active, backup-verified update before taking the normal
+// migration advisory lock or staging schema history.
+func MigrateUpdate(ctx context.Context, cfg Config, authorization UpdateMigrationAuthorization) (SchemaState, error) {
+	manifest := CurrentManifest()
+	if authorization.Validate() != nil || authorization.TargetSchema != manifest.MaxSupported {
+		return SchemaState{}, errors.New("invalid update migration authorization")
+	}
+	dsn, err := ReadDSNFile(cfg.DSNFile)
+	if err != nil {
+		return SchemaState{}, err
+	}
+	db, err := open(ctx, dsn)
+	if err != nil {
+		return SchemaState{}, err
+	}
+	defer func() { _ = db.Close() }()
+	conn, err := db.Conn(ctx)
+	if err != nil {
+		return SchemaState{}, errors.New("PostgreSQL migration connection is unavailable")
+	}
+	defer func() { _ = conn.Close() }()
+	if err := verifyMigrationRoles(ctx, conn); err != nil {
+		return SchemaState{}, err
+	}
+	if _, err := conn.ExecContext(ctx, `SELECT pg_advisory_lock($1)`, updateCoordinatorLockKey); err != nil {
+		return SchemaState{}, errors.New("PostgreSQL update coordinator lock is unavailable")
+	}
+	defer func() {
+		unlockCtx, cancel := context.WithTimeout(context.Background(), operationTimeout)
+		defer cancel()
+		_, _ = conn.ExecContext(unlockCtx, `SELECT pg_advisory_unlock($1)`, updateCoordinatorLockKey)
+	}()
+	controls, err := updateControlsAvailable(ctx, conn)
+	if err != nil || !controls {
+		return SchemaState{}, errors.New("PostgreSQL update controls are unavailable")
+	}
+	var authorized bool
+	err = conn.QueryRowContext(ctx, `SELECT EXISTS (
+SELECT 1 FROM jobs.update_transactions
+WHERE update_id=$1::uuid AND phase='migration_started' AND backup_id=$2::uuid
+  AND target_release=$3 AND target_image=$4 AND target_schema=$5
+  AND migration_manifest_sha256=$6
+  AND backup_snapshot_id=$7 AND backup_manifest_sha256=$8
+)`, authorization.UpdateID, authorization.BackupID, authorization.TargetRelease, authorization.TargetImage, authorization.TargetSchema, MigrationManifestSHA256(), authorization.ExportedSnapshotID, authorization.ManifestSHA256).Scan(&authorized)
+	if err != nil || !authorized {
+		return SchemaState{}, errors.New("PostgreSQL update migration marker does not match")
+	}
+	if _, err := conn.ExecContext(ctx, `SELECT set_config('punaro.update_id',$1,false)`, authorization.UpdateID); err != nil {
+		return SchemaState{}, errors.New("PostgreSQL update migration session cannot be bound")
+	}
+	return migrateConnExpectedAppRole(ctx, conn, manifest, "punaro_app")
+}
+
+func refuseOrdinaryUpgrade(ctx context.Context, db *sql.DB, manifest Manifest) error {
+	conn, err := db.Conn(ctx)
+	if err != nil {
+		return errors.New("PostgreSQL schema state is unavailable")
+	}
+	defer func() { _ = conn.Close() }()
+	snapshot, err := inspect(ctx, conn)
+	if err != nil {
+		return err
+	}
+	if migrationAuthorizationRequired(Classify(snapshot, manifest)) {
+		return errors.New("PostgreSQL upgrade requires the supported update transaction")
+	}
+	return nil
 }
 
 func migrate(ctx context.Context, db *sql.DB, manifest Manifest) (SchemaState, error) {
@@ -140,6 +225,10 @@ func migrateConnExpectedAppRole(ctx context.Context, conn *sql.Conn, manifest Ma
 		return final, contentFreeMigrationError(final.Classification)
 	}
 	return final, nil
+}
+
+func migrationAuthorizationRequired(state SchemaState) bool {
+	return state.Classification == UpgradeRequired
 }
 
 func verifyMigrationRoles(ctx context.Context, conn *sql.Conn) error {
@@ -231,8 +320,24 @@ func applyMigration(ctx context.Context, conn *sql.Conn, migration Migration) er
 		return errors.New("PostgreSQL migration transaction could not start")
 	}
 	defer func() { _ = tx.Rollback() }()
-	if _, err := tx.ExecContext(ctx, migration.SQL); err != nil {
-		return errors.New("PostgreSQL migration failed")
+	controlsAlreadyInstalled := false
+	if migration.Version == 6 {
+		var err error
+		controlsAlreadyInstalled, err = updateControlsAvailable(ctx, tx)
+		if err != nil {
+			return err
+		}
+		if controlsAlreadyInstalled {
+			var authorized bool
+			if err := tx.QueryRowContext(ctx, `SELECT EXISTS (SELECT 1 FROM jobs.update_transactions WHERE phase='migration_started' AND source_schema=5 AND target_schema=6 AND backup_id IS NOT NULL)`).Scan(&authorized); err != nil || !authorized {
+				return errors.New("PostgreSQL update-control adoption lacks a verified active update")
+			}
+		}
+	}
+	if !controlsAlreadyInstalled {
+		if _, err := tx.ExecContext(ctx, migration.SQL); err != nil {
+			return errors.New("PostgreSQL migration failed")
+		}
 	}
 	result, err := tx.ExecContext(ctx, `UPDATE jobs.schema_migrations SET status = 'applied', applied_at = statement_timestamp() WHERE version = $1 AND status = 'applying'`, migration.Version)
 	if err != nil {

--- a/internal/postgres/migrations/006_transactional_update_fence.sql
+++ b/internal/postgres/migrations/006_transactional_update_fence.sql
@@ -1,0 +1,486 @@
+CREATE TABLE jobs.update_transactions (
+    update_id uuid PRIMARY KEY,
+    installation_id uuid NOT NULL,
+    timeline_id uuid NOT NULL,
+    owner_principal_id uuid NOT NULL REFERENCES auth.principals(id),
+    source_release text NOT NULL CHECK (source_release ~ '^[A-Za-z0-9][A-Za-z0-9._+\-]{0,127}$'),
+    target_release text NOT NULL CHECK (target_release ~ '^[A-Za-z0-9][A-Za-z0-9._+\-]{0,127}$' AND target_release <> source_release),
+    source_image text NOT NULL CHECK (source_image ~ '^[a-z0-9][a-z0-9./_:\-]*@sha256:[0-9a-f]{64}$'),
+    target_image text NOT NULL CHECK (target_image ~ '^[a-z0-9][a-z0-9./_:\-]*@sha256:[0-9a-f]{64}$' AND target_image <> source_image),
+    source_schema bigint NOT NULL CHECK (source_schema > 0),
+    target_schema bigint NOT NULL CHECK (target_schema >= source_schema),
+    schema_min bigint NOT NULL CHECK (schema_min > 0),
+    schema_max bigint NOT NULL CHECK (schema_max >= schema_min),
+    rollback_floor bigint NOT NULL CHECK (rollback_floor BETWEEN schema_min AND target_schema),
+    postgres_major integer NOT NULL CHECK (postgres_major >= 14),
+    release_sha256 char(64) NOT NULL CHECK (release_sha256 ~ '^[0-9a-f]{64}$'),
+    compose_sha256 char(64) NOT NULL CHECK (compose_sha256 ~ '^[0-9a-f]{64}$'),
+    migration_manifest_sha256 char(64) NOT NULL CHECK (migration_manifest_sha256 ~ '^[0-9a-f]{64}$'),
+    phase text NOT NULL CHECK (phase IN ('fenced','writers_stopped','backup_verified','migration_started','migrated','candidate_ready','doctor_passed','config_published','recovery_required','recovery_ready','recovery_doctor_passed','recovery_config_published','committed','recovered','aborted')),
+    backup_id uuid,
+    backup_installation_id uuid,
+    backup_timeline_id uuid,
+    backup_change_sequence bigint CHECK (backup_change_sequence >= 0),
+    backup_source_schema bigint CHECK (backup_source_schema > 0),
+    backup_snapshot_id text CHECK (backup_snapshot_id ~ '^[0-9A-Z-]{1,200}$'),
+    backup_manifest_sha256 char(64) CHECK (backup_manifest_sha256 ~ '^[0-9a-f]{64}$'),
+    created_at timestamptz NOT NULL DEFAULT statement_timestamp(),
+    updated_at timestamptz NOT NULL DEFAULT statement_timestamp(),
+    completed_at timestamptz,
+    CHECK (source_schema BETWEEN schema_min AND target_schema AND target_schema <= schema_max),
+    CHECK ((backup_id IS NULL) = (backup_installation_id IS NULL)),
+    CHECK ((backup_id IS NULL) = (backup_timeline_id IS NULL)),
+    CHECK ((backup_id IS NULL) = (backup_change_sequence IS NULL)),
+    CHECK ((backup_id IS NULL) = (backup_source_schema IS NULL)),
+    CHECK ((backup_id IS NULL) = (backup_snapshot_id IS NULL)),
+    CHECK ((backup_id IS NULL) = (backup_manifest_sha256 IS NULL)),
+    CHECK (phase IN ('fenced','writers_stopped','aborted') OR backup_id IS NOT NULL),
+    CHECK ((phase IN ('committed','recovered','aborted')) = (completed_at IS NOT NULL))
+);
+
+CREATE UNIQUE INDEX update_transactions_one_active
+ON jobs.update_transactions ((true))
+WHERE phase NOT IN ('committed','recovered','aborted');
+
+CREATE FUNCTION jobs.assert_application_mutation()
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog
+AS $function$
+BEGIN
+    -- The shared transaction lock makes a writer visible to fence acquisition
+    -- until its commit or rollback.
+    PERFORM pg_advisory_xact_lock_shared(579001230607);
+    IF EXISTS (
+        SELECT 1 FROM jobs.update_transactions
+        WHERE phase NOT IN ('committed','recovered','aborted')
+    ) THEN
+        RAISE EXCEPTION 'punaro maintenance in progress'
+            USING ERRCODE = '55P03';
+    END IF;
+END
+$function$;
+
+CREATE FUNCTION jobs.guard_application_mutation()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog
+AS $function$
+BEGIN
+	-- Only the dedicated migrator may write business tables as owner while a
+	-- fence is active. A custom GUC alone grants nothing: it must match the
+	-- durable transaction already in the irreversible migration phase.
+	IF session_user = 'punaro_owner'
+	   AND EXISTS (
+		SELECT 1 FROM jobs.update_transactions
+		WHERE update_id::text = current_setting('punaro.update_id', true)
+		  AND phase = 'migration_started'
+	   ) THEN
+		RETURN NULL;
+    END IF;
+	-- A restored pre-update snapshot still contains its writers_stopped row.
+	-- The dedicated recovery function inserts exact restore evidence before it
+	-- rotates server_state; this exception expires in the same statement when
+	-- that row moves to recovery_required.
+	IF session_user = 'punaro_owner'
+	   AND EXISTS (
+		SELECT 1
+		FROM jobs.update_transactions AS txn
+		JOIN jobs.restore_events AS event
+		  ON event.backup_id::text = current_setting('punaro.restore_backup_id', true)
+		 AND event.installation_id = txn.installation_id
+		 AND event.previous_timeline_id = txn.timeline_id
+		JOIN jobs.server_state AS state
+		  ON state.singleton
+		 AND state.installation_id = event.installation_id
+		 AND state.timeline_id = event.previous_timeline_id
+		 AND state.change_sequence = event.restored_change_sequence
+		WHERE txn.update_id::text = current_setting('punaro.restore_update_id', true)
+		  AND txn.phase = 'writers_stopped'
+	   ) THEN
+		RETURN NULL;
+	END IF;
+	PERFORM jobs.assert_application_mutation();
+    RETURN NULL;
+END
+$function$;
+
+CREATE FUNCTION jobs.restore_update_recovery(
+    requested_id uuid,
+    requested_backup_id uuid,
+    requested_installation_id uuid,
+    requested_timeline_id uuid,
+    requested_change_sequence bigint,
+    requested_source_schema bigint,
+    requested_target_release text,
+    requested_target_image_digest text,
+    requested_snapshot_id text,
+    requested_manifest_sha256 text
+)
+RETURNS SETOF jobs.update_transactions
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog
+AS $function$
+DECLARE
+    active jobs.update_transactions%ROWTYPE;
+    next_timeline uuid;
+BEGIN
+    IF session_user <> 'punaro_owner'
+       OR requested_id IS NULL OR requested_backup_id IS NULL
+       OR requested_installation_id IS NULL OR requested_timeline_id IS NULL
+       OR requested_change_sequence IS NULL OR requested_change_sequence < 0
+       OR requested_source_schema IS NULL OR requested_source_schema < 1
+	   OR requested_source_schema <> COALESCE((SELECT max(version) FROM jobs.schema_migrations WHERE status = 'applied'), 0)
+       OR requested_target_release IS NULL
+       OR requested_target_image_digest IS NULL
+       OR requested_snapshot_id IS NULL
+       OR requested_manifest_sha256 IS NULL
+       OR requested_target_release !~ '^[A-Za-z0-9][A-Za-z0-9._+\-]{0,127}$'
+       OR requested_target_image_digest !~ '^sha256:[0-9a-f]{64}$'
+       OR requested_snapshot_id !~ '^[0-9A-Z-]{1,200}$'
+       OR requested_manifest_sha256 !~ '^[0-9a-f]{64}$' THEN
+        RAISE EXCEPTION 'restored update authority is unavailable';
+    END IF;
+    PERFORM pg_advisory_xact_lock(579001230607);
+    SELECT * INTO active FROM jobs.update_transactions
+    WHERE update_id = requested_id
+    FOR UPDATE;
+    IF NOT FOUND THEN
+        RAISE EXCEPTION 'restored update is unavailable';
+    END IF;
+
+    SELECT event.restored_timeline_id INTO next_timeline
+    FROM jobs.restore_events AS event
+    WHERE event.backup_id = requested_backup_id
+      AND event.installation_id = requested_installation_id
+      AND event.previous_timeline_id = requested_timeline_id
+      AND event.restored_change_sequence = requested_change_sequence;
+    IF FOUND THEN
+        IF active.phase = 'recovery_required'
+           AND active.installation_id = requested_installation_id
+           AND active.timeline_id = next_timeline
+           AND active.source_schema = requested_source_schema
+           AND active.target_release = requested_target_release
+           AND split_part(active.target_image, '@', 2) = requested_target_image_digest
+           AND active.backup_id = requested_backup_id
+           AND active.backup_installation_id = requested_installation_id
+           AND active.backup_timeline_id = requested_timeline_id
+           AND active.backup_change_sequence = requested_change_sequence
+           AND active.backup_source_schema = requested_source_schema
+           AND active.backup_snapshot_id = requested_snapshot_id
+           AND active.backup_manifest_sha256 = requested_manifest_sha256
+           AND EXISTS (
+               SELECT 1 FROM jobs.server_state AS state
+               WHERE state.singleton
+                 AND state.installation_id = requested_installation_id
+                 AND state.timeline_id = next_timeline
+                 AND state.change_sequence = requested_change_sequence
+           ) THEN
+            RETURN NEXT active;
+            RETURN;
+        END IF;
+        RAISE EXCEPTION 'restored update retry evidence does not match';
+    END IF;
+
+    IF active.phase <> 'writers_stopped'
+       OR active.installation_id <> requested_installation_id
+       OR active.timeline_id <> requested_timeline_id
+       OR active.source_schema <> requested_source_schema
+       OR active.target_release <> requested_target_release
+       OR split_part(active.target_image, '@', 2) <> requested_target_image_digest
+       OR active.backup_id IS NOT NULL
+       OR NOT EXISTS (
+           SELECT 1 FROM jobs.server_state AS state
+           WHERE state.singleton
+             AND state.installation_id = requested_installation_id
+             AND state.timeline_id = requested_timeline_id
+             AND state.change_sequence = requested_change_sequence
+       ) THEN
+        RAISE EXCEPTION 'restored update boundary does not match';
+    END IF;
+
+    next_timeline := gen_random_uuid();
+    INSERT INTO jobs.restore_events (
+        restore_id, backup_id, installation_id, previous_timeline_id,
+        restored_timeline_id, restored_change_sequence
+    ) VALUES (
+        gen_random_uuid(), requested_backup_id, requested_installation_id,
+        requested_timeline_id, next_timeline, requested_change_sequence
+    );
+    PERFORM set_config('punaro.restore_update_id', requested_id::text, true);
+    PERFORM set_config('punaro.restore_backup_id', requested_backup_id::text, true);
+    UPDATE jobs.server_state AS state
+    SET timeline_id = next_timeline,
+        timeline_started_at = statement_timestamp()
+    WHERE state.singleton
+      AND state.installation_id = requested_installation_id
+      AND state.timeline_id = requested_timeline_id
+      AND state.change_sequence = requested_change_sequence;
+    IF NOT FOUND THEN
+        RAISE EXCEPTION 'restored timeline changed during recovery';
+    END IF;
+    UPDATE jobs.update_transactions
+    SET timeline_id = next_timeline,
+        phase = 'recovery_required',
+        backup_id = requested_backup_id,
+        backup_installation_id = requested_installation_id,
+        backup_timeline_id = requested_timeline_id,
+        backup_change_sequence = requested_change_sequence,
+        backup_source_schema = requested_source_schema,
+        backup_snapshot_id = requested_snapshot_id,
+        backup_manifest_sha256 = requested_manifest_sha256,
+        updated_at = statement_timestamp(),
+        completed_at = NULL
+    WHERE update_id = requested_id AND phase = 'writers_stopped'
+    RETURNING * INTO active;
+    IF NOT FOUND THEN
+        RAISE EXCEPTION 'restored update changed during recovery';
+    END IF;
+    RETURN NEXT active;
+END
+$function$;
+
+CREATE FUNCTION jobs.begin_update(
+    requested_id uuid,
+    requested_source_release text,
+    requested_target_release text,
+    requested_source_image text,
+    requested_target_image text,
+    requested_source_schema bigint,
+    requested_target_schema bigint,
+    requested_schema_min bigint,
+    requested_schema_max bigint,
+    requested_rollback_floor bigint,
+    requested_postgres_major integer,
+    requested_release_sha256 text,
+    requested_compose_sha256 text,
+    requested_migration_manifest_sha256 text
+)
+RETURNS SETOF jobs.update_transactions
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog
+AS $function$
+DECLARE
+    active jobs.update_transactions%ROWTYPE;
+BEGIN
+    IF session_user <> 'punaro_owner' OR requested_id IS NULL THEN
+        RAISE EXCEPTION 'update authority is unavailable';
+    END IF;
+    IF requested_source_schema <> (SELECT max(version) FROM jobs.schema_migrations WHERE status='applied')
+       OR requested_target_schema < requested_source_schema
+       OR requested_source_schema < requested_schema_min
+       OR requested_target_schema NOT BETWEEN requested_schema_min AND requested_schema_max
+       OR requested_rollback_floor NOT BETWEEN requested_schema_min AND requested_target_schema
+       OR requested_release_sha256 !~ '^[0-9a-f]{64}$'
+       OR requested_compose_sha256 !~ '^[0-9a-f]{64}$'
+       OR requested_migration_manifest_sha256 !~ '^[0-9a-f]{64}$'
+       OR requested_postgres_major <> current_setting('server_version_num')::integer / 10000 THEN
+        RAISE EXCEPTION 'update environment does not match the durable source';
+    END IF;
+    -- Wait for every transaction that has crossed a mutation trigger. Once the
+    -- exclusive lock is granted, its durable row is committed before later
+    -- writers can acquire their shared lock and reject.
+    PERFORM pg_advisory_xact_lock(579001230607);
+    SELECT * INTO active FROM jobs.update_transactions
+    WHERE phase NOT IN ('committed','recovered','aborted');
+    IF FOUND THEN
+        IF active.update_id = requested_id
+           AND active.source_release = requested_source_release
+           AND active.target_release = requested_target_release
+           AND active.source_image = requested_source_image
+           AND active.target_image = requested_target_image
+           AND active.source_schema = requested_source_schema
+           AND active.target_schema = requested_target_schema
+           AND active.schema_min = requested_schema_min
+           AND active.schema_max = requested_schema_max
+           AND active.rollback_floor = requested_rollback_floor
+           AND active.postgres_major = requested_postgres_major
+           AND active.release_sha256 = requested_release_sha256
+           AND active.compose_sha256 = requested_compose_sha256
+           AND active.migration_manifest_sha256 = requested_migration_manifest_sha256 THEN
+            RETURN NEXT active;
+            RETURN;
+        END IF;
+        RAISE EXCEPTION 'update fence is already owned';
+    END IF;
+    INSERT INTO jobs.update_transactions (
+        update_id, installation_id, timeline_id, owner_principal_id, source_release,
+        target_release, source_image, target_image, source_schema,
+        target_schema, schema_min, schema_max, rollback_floor, postgres_major,
+        release_sha256, compose_sha256, migration_manifest_sha256, phase
+    )
+    SELECT requested_id, state.installation_id, state.timeline_id, owner.principal_id,
+           requested_source_release, requested_target_release,
+           requested_source_image, requested_target_image,
+           requested_source_schema, requested_target_schema, requested_schema_min,
+           requested_schema_max, requested_rollback_floor, requested_postgres_major,
+           requested_release_sha256, requested_compose_sha256,
+           requested_migration_manifest_sha256, 'fenced'
+    FROM jobs.server_state AS state
+    JOIN auth.installation_owner AS owner ON owner.singleton
+    WHERE state.singleton
+    RETURNING * INTO active;
+    IF NOT FOUND THEN
+        RAISE EXCEPTION 'installation state is unavailable';
+    END IF;
+    RETURN NEXT active;
+END
+$function$;
+
+CREATE FUNCTION jobs.advance_update(
+    requested_id uuid,
+    expected_phase text,
+    requested_phase text,
+    requested_backup_id uuid,
+    requested_installation_id uuid,
+    requested_timeline_id uuid,
+    requested_change_sequence bigint,
+    requested_source_schema bigint,
+    requested_target_release text,
+    requested_target_image_digest text,
+    requested_snapshot_id text,
+    requested_manifest_sha256 text
+)
+RETURNS SETOF jobs.update_transactions
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog
+AS $function$
+DECLARE
+    active jobs.update_transactions%ROWTYPE;
+    transition_allowed boolean;
+BEGIN
+    IF session_user <> 'punaro_owner' THEN
+        RAISE EXCEPTION 'update authority is unavailable';
+    END IF;
+    transition_allowed := CASE expected_phase
+        WHEN 'fenced' THEN requested_phase IN ('writers_stopped','aborted')
+        WHEN 'writers_stopped' THEN requested_phase IN ('backup_verified','aborted')
+        WHEN 'backup_verified' THEN requested_phase IN ('migration_started','aborted')
+        WHEN 'migration_started' THEN requested_phase IN ('migrated','recovery_required')
+        WHEN 'migrated' THEN requested_phase IN ('candidate_ready','recovery_required')
+        WHEN 'candidate_ready' THEN requested_phase IN ('doctor_passed','recovery_required')
+        WHEN 'doctor_passed' THEN requested_phase IN ('config_published','recovery_required')
+        WHEN 'config_published' THEN requested_phase = 'committed'
+        WHEN 'recovery_required' THEN requested_phase = 'recovery_ready'
+        WHEN 'recovery_ready' THEN requested_phase = 'recovery_doctor_passed'
+        WHEN 'recovery_doctor_passed' THEN requested_phase = 'recovery_config_published'
+        WHEN 'recovery_config_published' THEN requested_phase = 'recovered'
+        ELSE false
+    END;
+    IF NOT transition_allowed THEN
+        RAISE EXCEPTION 'update phase transition is invalid';
+    END IF;
+    PERFORM pg_advisory_xact_lock(579001230607);
+    SELECT * INTO active FROM jobs.update_transactions
+    WHERE update_id = requested_id AND phase = expected_phase
+    FOR UPDATE;
+    IF NOT FOUND THEN
+        RAISE EXCEPTION 'update phase precondition changed';
+    END IF;
+    IF requested_phase = 'backup_verified' THEN
+        IF requested_backup_id IS NULL
+           OR requested_installation_id <> active.installation_id
+           OR requested_timeline_id <> active.timeline_id
+           OR requested_source_schema <> active.source_schema
+           OR requested_target_release <> active.target_release
+           OR requested_target_image_digest <> split_part(active.target_image, '@', 2)
+           OR requested_snapshot_id !~ '^[0-9A-Z-]{1,200}$'
+           OR requested_manifest_sha256 !~ '^[0-9a-f]{64}$'
+           OR requested_change_sequence IS NULL
+           OR NOT EXISTS (
+               SELECT 1 FROM jobs.server_state
+               WHERE singleton
+                 AND installation_id = requested_installation_id
+                 AND timeline_id = requested_timeline_id
+                 AND change_sequence = requested_change_sequence
+           ) THEN
+            RAISE EXCEPTION 'verified backup boundary does not match update';
+        END IF;
+    ELSIF requested_backup_id IS NOT NULL OR requested_installation_id IS NOT NULL
+       OR requested_timeline_id IS NOT NULL OR requested_change_sequence IS NOT NULL
+       OR requested_source_schema IS NOT NULL OR requested_target_release IS NOT NULL
+       OR requested_target_image_digest IS NOT NULL OR requested_snapshot_id IS NOT NULL
+       OR requested_manifest_sha256 IS NOT NULL THEN
+        RAISE EXCEPTION 'unexpected backup marker';
+    END IF;
+    UPDATE jobs.update_transactions
+    SET phase = requested_phase,
+        backup_id = COALESCE(requested_backup_id, backup_id),
+        backup_installation_id = COALESCE(requested_installation_id, backup_installation_id),
+        backup_timeline_id = COALESCE(requested_timeline_id, backup_timeline_id),
+        backup_change_sequence = COALESCE(requested_change_sequence, backup_change_sequence),
+        backup_source_schema = COALESCE(requested_source_schema, backup_source_schema),
+        backup_snapshot_id = COALESCE(requested_snapshot_id, backup_snapshot_id),
+        backup_manifest_sha256 = COALESCE(requested_manifest_sha256, backup_manifest_sha256),
+        updated_at = statement_timestamp(),
+        completed_at = CASE WHEN requested_phase IN ('committed','recovered','aborted') THEN statement_timestamp() ELSE NULL END
+    WHERE update_id = requested_id AND phase = expected_phase
+    RETURNING * INTO active;
+    IF NOT FOUND THEN
+        RAISE EXCEPTION 'update phase precondition changed';
+    END IF;
+    RETURN NEXT active;
+END
+$function$;
+
+CREATE FUNCTION jobs.maintenance_active()
+RETURNS boolean
+LANGUAGE sql
+SECURITY DEFINER
+STABLE
+SET search_path = pg_catalog
+AS $function$
+    SELECT EXISTS (
+        SELECT 1 FROM jobs.update_transactions
+        WHERE phase NOT IN ('committed','recovered','aborted')
+    )
+$function$;
+
+DO $block$
+DECLARE
+    target regclass;
+BEGIN
+    FOREACH target IN ARRAY ARRAY[
+        'jobs.server_state'::regclass,
+        'auth.principals'::regclass,
+        'relay.projects'::regclass,
+        'auth.capability_grants'::regclass,
+        'relay.idempotency_records'::regclass,
+        'audit.events'::regclass,
+        'jobs.queue_capacity'::regclass,
+        'jobs.outbox'::regclass,
+        'auth.installation_owner'::regclass,
+        'auth.pending_enrollments'::regclass,
+        'auth.pending_enrollment_grants'::regclass,
+        'auth.device_credentials'::regclass,
+        'auth.legacy_auth_state'::regclass,
+        'auth.legacy_machines'::regclass,
+        'auth.project_acl_state'::regclass,
+        'relay.project_identities'::regclass,
+        'relay.project_lookup_aliases'::regclass,
+        'relay.project_merge_previews'::regclass,
+        'attachment.ready_blob_manifest'::regclass
+    ]
+    LOOP
+        EXECUTE format(
+            'CREATE TRIGGER application_mutation_fence BEFORE INSERT OR UPDATE OR DELETE OR TRUNCATE ON %s FOR EACH STATEMENT EXECUTE FUNCTION jobs.guard_application_mutation()',
+            target
+        );
+    END LOOP;
+END
+$block$;
+
+REVOKE ALL ON jobs.update_transactions FROM PUBLIC, punaro_app;
+REVOKE ALL ON FUNCTION jobs.assert_application_mutation() FROM PUBLIC, punaro_app;
+REVOKE ALL ON FUNCTION jobs.guard_application_mutation() FROM PUBLIC, punaro_app;
+REVOKE ALL ON FUNCTION jobs.begin_update(uuid,text,text,text,text,bigint,bigint,bigint,bigint,bigint,integer,text,text,text) FROM PUBLIC, punaro_app;
+REVOKE ALL ON FUNCTION jobs.advance_update(uuid,text,text,uuid,uuid,uuid,bigint,bigint,text,text,text,text) FROM PUBLIC, punaro_app;
+REVOKE ALL ON FUNCTION jobs.restore_update_recovery(uuid,uuid,uuid,uuid,bigint,bigint,text,text,text,text) FROM PUBLIC, punaro_app;
+REVOKE ALL ON FUNCTION jobs.maintenance_active() FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION jobs.assert_application_mutation() TO punaro_app;
+GRANT EXECUTE ON FUNCTION jobs.maintenance_active() TO punaro_app;

--- a/internal/postgres/postgres_integration_test.go
+++ b/internal/postgres/postgres_integration_test.go
@@ -470,6 +470,13 @@ func testV5UpdateBridgeIntegration(ctx context.Context, t *testing.T, ownerDB *s
 	if state, err := migrate(ctx, ownerDB, v5Manifest); err != nil || state.Classification != Compatible || state.Version != 5 {
 		t.Fatalf("v5 staging state=%#v err=%v", state, err)
 	}
+	var bridgeOwnerID string
+	if err := ownerDB.QueryRowContext(ctx, `INSERT INTO auth.principals (kind,display_name) VALUES ('owner','v5 bridge owner') RETURNING id::text`).Scan(&bridgeOwnerID); err != nil {
+		t.Fatalf("stage v5 bridge owner: %v", err)
+	}
+	if _, err := ownerDB.ExecContext(ctx, `INSERT INTO auth.installation_owner (principal_id) VALUES ($1)`, bridgeOwnerID); err != nil {
+		t.Fatalf("install v5 bridge owner: %v", err)
+	}
 	if _, err := Migrate(ctx, Config{DSNFile: ownerFile}); err == nil || !strings.Contains(err.Error(), "supported update transaction") {
 		t.Fatalf("ordinary migrator accepted v5 upgrade: %v", err)
 	}
@@ -566,6 +573,15 @@ func testV5UpdateBridgeIntegration(ctx context.Context, t *testing.T, ownerDB *s
 		if err != nil || transaction.Phase != phases[1] {
 			t.Fatalf("bridge phase %s -> %s transaction=%#v err=%v", phases[0], phases[1], transaction, err)
 		}
+	}
+	if _, err := ownerDB.ExecContext(ctx, `DELETE FROM jobs.update_transactions`); err != nil {
+		t.Fatalf("remove v5 bridge transaction fixture: %v", err)
+	}
+	if _, err := ownerDB.ExecContext(ctx, `DELETE FROM auth.installation_owner WHERE principal_id=$1`, bridgeOwnerID); err != nil {
+		t.Fatalf("remove v5 bridge ownership fixture: %v", err)
+	}
+	if _, err := ownerDB.ExecContext(ctx, `DELETE FROM auth.principals WHERE id=$1`, bridgeOwnerID); err != nil {
+		t.Fatalf("remove v5 bridge principal fixture: %v", err)
 	}
 }
 

--- a/internal/postgres/postgres_integration_test.go
+++ b/internal/postgres/postgres_integration_test.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"sync"
 	"testing"
 	"time"
 )
@@ -108,31 +107,36 @@ func TestPostgresPlatformSubstrateIntegration(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	var wg sync.WaitGroup
-	errorsSeen := make(chan error, 2)
-	for range 2 {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			_, migrateErr := Migrate(ctx, Config{DSNFile: ownerFile})
-			errorsSeen <- migrateErr
-		}()
-	}
-	wg.Wait()
-	close(errorsSeen)
-	for migrateErr := range errorsSeen {
-		if migrateErr != nil {
-			logControlPlaneCatalog(ctx, t, ownerDB)
-			logDeviceAuthCatalog(ctx, t, ownerDB)
-			t.Fatalf("concurrent migration failed: %v", migrateErr)
-		}
-	}
+	testV5UpdateBridgeIntegration(ctx, t, ownerDB, ownerFile)
 
 	app, err = OpenApplication(ctx, Config{DSNFile: appFile})
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer func() { _ = app.Close() }()
+	if _, err := ownerDB.ExecContext(ctx, `ALTER FUNCTION jobs.maintenance_active() PARALLEL SAFE`); err != nil {
+		t.Fatal(err)
+	}
+	if drifted, driftErr := app.SchemaState(ctx); driftErr != nil || drifted.Classification != Incompatible {
+		t.Fatalf("drifted update routine state=%#v err=%v", drifted, driftErr)
+	}
+	if _, err := ownerDB.ExecContext(ctx, `ALTER FUNCTION jobs.maintenance_active() PARALLEL UNSAFE`); err != nil {
+		t.Fatal(err)
+	}
+	var phaseConstraint string
+	if err := ownerDB.QueryRowContext(ctx, `SELECT conname FROM pg_constraint WHERE conrelid='jobs.update_transactions'::regclass AND contype='c' AND conkey=ARRAY[18]::smallint[]`).Scan(&phaseConstraint); err != nil {
+		t.Fatal(err)
+	}
+	quotedConstraint := `"` + strings.ReplaceAll(phaseConstraint, `"`, `""`) + `"`
+	if _, err := ownerDB.ExecContext(ctx, `ALTER TABLE jobs.update_transactions DROP CONSTRAINT `+quotedConstraint+`; ALTER TABLE jobs.update_transactions ADD CONSTRAINT `+quotedConstraint+` CHECK (phase IS NOT NULL)`); err != nil { // #nosec G202 -- identifier is read from PostgreSQL and quoted.
+		t.Fatal(err)
+	}
+	if drifted, driftErr := app.SchemaState(ctx); driftErr != nil || drifted.Classification != Incompatible {
+		t.Fatalf("permissive update constraint state=%#v err=%v", drifted, driftErr)
+	}
+	if _, err := ownerDB.ExecContext(ctx, `ALTER TABLE jobs.update_transactions DROP CONSTRAINT `+quotedConstraint+`; ALTER TABLE jobs.update_transactions ADD CONSTRAINT `+quotedConstraint+` CHECK (phase IN ('fenced','writers_stopped','backup_verified','migration_started','migrated','candidate_ready','doctor_passed','config_published','recovery_required','recovery_ready','recovery_doctor_passed','recovery_config_published','committed','recovered','aborted'))`); err != nil { // #nosec G202 -- identifier is read from PostgreSQL and quoted.
+		t.Fatal(err)
+	}
 	if err := app.Ready(ctx); err != nil {
 		t.Fatalf("migrated application not ready: %v", err)
 	}
@@ -172,6 +176,7 @@ func TestPostgresPlatformSubstrateIntegration(t *testing.T) {
 	testDeviceAuthIntegration(ctx, t, app, ownerDB)
 	testProjectIdentityIntegration(ctx, t, app, ownerDB)
 	testBackupRestoreIntegration(ctx, t, app, ownerDB, ownerFile, appFile)
+	testTransactionalUpdateFenceIntegration(ctx, t, app, ownerDB)
 	if err := app.Close(); err != nil {
 		t.Fatal(err)
 	}
@@ -455,6 +460,292 @@ AS $function$ BEGIN RETURN NEW; END $function$`); err != nil {
 	var trackerExists bool
 	if err := ownerDB.QueryRowContext(ctx, `SELECT to_regclass('jobs.schema_migrations') IS NOT NULL`).Scan(&trackerExists); err != nil || trackerExists {
 		t.Fatalf("missing-role refusal mutated schema: tracker_exists=%t err=%v", trackerExists, err)
+	}
+}
+
+func testV5UpdateBridgeIntegration(ctx context.Context, t *testing.T, ownerDB *sql.DB, ownerFile string) {
+	t.Helper()
+	current := CurrentManifest()
+	v5Manifest := Manifest{MinSupported: 5, MaxSupported: 5, Migrations: append([]Migration(nil), current.Migrations[:5]...)}
+	if state, err := migrate(ctx, ownerDB, v5Manifest); err != nil || state.Classification != Compatible || state.Version != 5 {
+		t.Fatalf("v5 staging state=%#v err=%v", state, err)
+	}
+	if _, err := Migrate(ctx, Config{DSNFile: ownerFile}); err == nil || !strings.Contains(err.Error(), "supported update transaction") {
+		t.Fatalf("ordinary migrator accepted v5 upgrade: %v", err)
+	}
+	var postgresMajor int
+	if err := ownerDB.QueryRowContext(ctx, `SELECT current_setting('server_version_num')::integer / 10000`).Scan(&postgresMajor); err != nil {
+		t.Fatal(err)
+	}
+	request := UpdateRequest{
+		UpdateID:                "019b4eb0-798c-7a52-8d29-8560fcbb2083",
+		SourceRelease:           "v0.6.0",
+		TargetRelease:           "v0.7.0",
+		SourceImage:             "ghcr.io/rock3r/punaro@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+		TargetImage:             "ghcr.io/rock3r/punaro@sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+		SourceSchema:            5,
+		TargetSchema:            6,
+		SchemaMin:               5,
+		SchemaMax:               6,
+		RollbackFloor:           5,
+		PostgresMajor:           postgresMajor,
+		ReleaseSHA256:           "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+		ComposeSHA256:           "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+		MigrationManifestSHA256: MigrationManifestSHA256(),
+	}
+	bridge, err := BeginV5UpdateBridge(ctx, Config{DSNFile: ownerFile}, request)
+	if err != nil {
+		t.Fatalf("begin abortable bridge: %v", err)
+	}
+	if err := bridge.Abort(); err != nil {
+		t.Fatalf("abort uncommitted bridge: %v", err)
+	}
+	snapshot, err := inspect(ctx, ownerDB)
+	if err != nil || Classify(snapshot, v5Manifest).Classification != Compatible {
+		t.Fatalf("aborted bridge changed v5 compatibility: state=%#v err=%v", Classify(snapshot, v5Manifest), err)
+	}
+	bridge, err = BeginV5UpdateBridge(ctx, Config{DSNFile: ownerFile}, request)
+	if err != nil {
+		t.Fatalf("begin durable bridge: %v", err)
+	}
+	transaction, err := bridge.CommitWritersStopped(ctx)
+	if err != nil || transaction.Phase != UpdateWritersStopped {
+		t.Fatalf("commit bridge transaction=%#v err=%v", transaction, err)
+	}
+	snapshot, err = inspect(ctx, ownerDB)
+	if err != nil || Classify(snapshot, v5Manifest).Classification != Compatible {
+		t.Fatalf("active bridge broke old-image schema compatibility: state=%#v err=%v", Classify(snapshot, v5Manifest), err)
+	}
+	admin, err := OpenAdministration(ctx, Config{DSNFile: ownerFile})
+	if err != nil {
+		t.Fatalf("resume bridge administration: %v", err)
+	}
+	defer func() { _ = admin.Close() }()
+	if transaction, err = admin.AdvanceUpdate(ctx, request.UpdateID, UpdateWritersStopped, UpdateAborted, nil); err != nil || transaction.Phase != UpdateAborted {
+		t.Fatalf("abort durable bridge transaction=%#v err=%v", transaction, err)
+	}
+	request.UpdateID = "019b4eb0-798c-7a52-8d29-8560fcbb2084"
+	bridge, err = BeginV5UpdateBridge(ctx, Config{DSNFile: ownerFile}, request)
+	if err != nil {
+		t.Fatalf("retry bridge with exact installed controls: %v", err)
+	}
+	transaction, err = bridge.CommitWritersStopped(ctx)
+	if err != nil || transaction.Phase != UpdateWritersStopped {
+		t.Fatalf("commit retried bridge transaction=%#v err=%v", transaction, err)
+	}
+	var state InstallationState
+	if err := ownerDB.QueryRowContext(ctx, `SELECT installation_id::text,timeline_id::text,change_sequence FROM jobs.server_state WHERE singleton`).Scan(&state.InstallationID, &state.TimelineID, &state.ChangeSequence); err != nil {
+		t.Fatal(err)
+	}
+	marker := &UpdateBackupMarker{
+		UpdateID: request.UpdateID, BackupID: "019b4eb0-5317-79a6-a0de-fd97719910fb",
+		InstallationID: state.InstallationID, TimelineID: state.TimelineID, ChangeSequence: state.ChangeSequence,
+		SourceSchema: request.SourceSchema, TargetRelease: request.TargetRelease,
+		TargetImageDigest:  "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+		ExportedSnapshotID: "00000003-0000001B-1",
+		ManifestSHA256:     "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+	}
+	if transaction, err = admin.AdvanceUpdate(ctx, request.UpdateID, UpdateWritersStopped, UpdateBackupVerified, marker); err != nil || transaction.Phase != UpdateBackupVerified {
+		t.Fatalf("bind bridge backup transaction=%#v err=%v", transaction, err)
+	}
+	if transaction, err = admin.AdvanceUpdate(ctx, request.UpdateID, UpdateBackupVerified, UpdateMigrationStarted, nil); err != nil || transaction.Phase != UpdateMigrationStarted {
+		t.Fatalf("start bridge migration transaction=%#v err=%v", transaction, err)
+	}
+	authorization := UpdateMigrationAuthorization{
+		UpdateID: request.UpdateID, BackupID: marker.BackupID, TargetRelease: request.TargetRelease,
+		TargetImage: request.TargetImage, TargetSchema: request.TargetSchema,
+		ExportedSnapshotID: marker.ExportedSnapshotID, ManifestSHA256: marker.ManifestSHA256,
+	}
+	if state, err := MigrateUpdate(ctx, Config{DSNFile: ownerFile}, authorization); err != nil || state.Classification != Compatible || state.Version != 6 {
+		logControlPlaneCatalog(ctx, t, ownerDB)
+		logDeviceAuthCatalog(ctx, t, ownerDB)
+		t.Fatalf("bridge migration state=%#v err=%v", state, err)
+	}
+	for _, phases := range [][2]UpdatePhase{{UpdateMigrationStarted, UpdateMigrated}, {UpdateMigrated, UpdateCandidateReady}, {UpdateCandidateReady, UpdateDoctorPassed}, {UpdateDoctorPassed, UpdateConfigPublished}, {UpdateConfigPublished, UpdateCommitted}} {
+		transaction, err = admin.AdvanceUpdate(ctx, request.UpdateID, phases[0], phases[1], nil)
+		if err != nil || transaction.Phase != phases[1] {
+			t.Fatalf("bridge phase %s -> %s transaction=%#v err=%v", phases[0], phases[1], transaction, err)
+		}
+	}
+}
+
+func testTransactionalUpdateFenceIntegration(ctx context.Context, t *testing.T, app *Database, ownerDB *sql.DB) {
+	t.Helper()
+	admin := &Administration{db: ownerDB}
+	var postgresVersion int
+	if err := ownerDB.QueryRowContext(ctx, `SELECT current_setting('server_version_num')::integer / 10000`).Scan(&postgresVersion); err != nil {
+		t.Fatal(err)
+	}
+	request := UpdateRequest{
+		UpdateID:                "019b4eb0-21f8-7d93-84df-10e6cf05ce53",
+		SourceRelease:           "v0.6.0",
+		TargetRelease:           "v0.7.0",
+		SourceImage:             "ghcr.io/rock3r/punaro@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+		TargetImage:             "ghcr.io/rock3r/punaro@sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+		SourceSchema:            CurrentManifest().MaxSupported,
+		TargetSchema:            CurrentManifest().MaxSupported,
+		SchemaMin:               CurrentManifest().MaxSupported,
+		SchemaMax:               CurrentManifest().MaxSupported,
+		RollbackFloor:           CurrentManifest().MaxSupported,
+		PostgresMajor:           postgresVersion,
+		ReleaseSHA256:           "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+		ComposeSHA256:           "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+		MigrationManifestSHA256: MigrationManifestSHA256(),
+	}
+
+	// A writer that crossed the shared transaction gate must drain before the
+	// exclusive durable fence can be published.
+	writer, err := app.db.BeginTx(ctx, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := writer.ExecContext(ctx, `SELECT jobs.assert_application_mutation()`); err != nil {
+		_ = writer.Rollback()
+		t.Fatal(err)
+	}
+	result := make(chan struct {
+		transaction UpdateTransaction
+		err         error
+	}, 1)
+	go func() {
+		transaction, beginErr := admin.BeginUpdate(ctx, request)
+		result <- struct {
+			transaction UpdateTransaction
+			err         error
+		}{transaction, beginErr}
+	}()
+	select {
+	case early := <-result:
+		_ = writer.Rollback()
+		t.Fatalf("fence did not drain in-flight writer: %#v err=%v", early.transaction, early.err)
+	case <-time.After(100 * time.Millisecond):
+	}
+	if err := writer.Commit(); err != nil {
+		t.Fatal(err)
+	}
+	var transaction UpdateTransaction
+	select {
+	case completed := <-result:
+		transaction, err = completed.transaction, completed.err
+	case <-time.After(5 * time.Second):
+		t.Fatal("fence acquisition did not resume after writer commit")
+	}
+	if err != nil || transaction.Phase != UpdateFenced || transaction.UpdateID != request.UpdateID {
+		t.Fatalf("begin transaction=%#v err=%v", transaction, err)
+	}
+	if retried, err := admin.BeginUpdate(ctx, request); err != nil || retried != transaction {
+		t.Fatalf("exact begin retry=%#v err=%v", retried, err)
+	}
+	conflict := request
+	conflict.UpdateID = "019b4eb0-798c-7a52-8d29-8560fcbb2083"
+	if _, err := admin.BeginUpdate(ctx, conflict); !errors.Is(err, ErrUpdateConflict) {
+		t.Fatalf("concurrent update error=%v", err)
+	}
+	if _, err := app.AdvanceChange(ctx); !errors.Is(err, ErrMaintenance) {
+		t.Fatalf("fenced application mutation error=%v", err)
+	}
+	if _, err := app.CreatePrincipal(ctx, PrincipalKindService, "fenced"); !errors.Is(err, ErrMaintenance) {
+		t.Fatalf("fenced transaction mutation error=%v", err)
+	}
+
+	transaction, err = admin.AdvanceUpdate(ctx, request.UpdateID, UpdateFenced, UpdateWritersStopped, nil)
+	if err != nil || transaction.Phase != UpdateWritersStopped {
+		t.Fatalf("writers stopped=%#v err=%v", transaction, err)
+	}
+	state, err := app.InstallationState(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	marker := &UpdateBackupMarker{
+		UpdateID:           request.UpdateID,
+		BackupID:           "019b4eb0-a147-7d6c-8dc5-3824e816cc57",
+		InstallationID:     state.InstallationID,
+		TimelineID:         state.TimelineID,
+		ChangeSequence:     state.ChangeSequence,
+		SourceSchema:       request.SourceSchema,
+		TargetRelease:      request.TargetRelease,
+		TargetImageDigest:  "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+		ExportedSnapshotID: "00000003-0000001B-1",
+		ManifestSHA256:     "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+	}
+	transaction, err = admin.AdvanceUpdate(ctx, request.UpdateID, UpdateWritersStopped, UpdateBackupVerified, marker)
+	if err != nil || transaction.Phase != UpdateBackupVerified || transaction.BackupID != marker.BackupID {
+		t.Fatalf("backup marker=%#v err=%v", transaction, err)
+	}
+	if _, err := admin.AdvanceUpdate(ctx, request.UpdateID, UpdateBackupVerified, UpdateCommitted, nil); !errors.Is(err, ErrInvalidUpdateTransition) {
+		t.Fatalf("skipped migration error=%v", err)
+	}
+	for _, transition := range [][2]UpdatePhase{{UpdateBackupVerified, UpdateMigrationStarted}, {UpdateMigrationStarted, UpdateMigrated}, {UpdateMigrated, UpdateCandidateReady}, {UpdateCandidateReady, UpdateDoctorPassed}, {UpdateDoctorPassed, UpdateConfigPublished}, {UpdateConfigPublished, UpdateCommitted}} {
+		transaction, err = admin.AdvanceUpdate(ctx, request.UpdateID, transition[0], transition[1], nil)
+		if err != nil || transaction.Phase != transition[1] {
+			t.Fatalf("transition %s -> %s transaction=%#v err=%v", transition[0], transition[1], transaction, err)
+		}
+	}
+	if _, err := admin.ActiveUpdate(ctx); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("committed update remained active: %v", err)
+	}
+	latest, err := admin.LatestUpdate(ctx)
+	if err != nil || latest.UpdateID != request.UpdateID || latest.Phase != UpdateCommitted {
+		t.Fatalf("latest update=%#v err=%v", latest, err)
+	}
+	if _, err := app.AdvanceChange(ctx); err != nil {
+		t.Fatalf("mutation remained fenced after commit: %v", err)
+	}
+
+	// A pre-update dump contains the durable row at writers_stopped, before the
+	// external verified-backup marker can be recorded. This is the exact shape
+	// present after restoring that dump into a pristine stack.
+	recoveryRequest := request
+	recoveryRequest.UpdateID = "019b4eb0-798c-7a52-8d29-8560fcbb2083"
+	transaction, err = admin.BeginUpdate(ctx, recoveryRequest)
+	if err != nil {
+		t.Fatalf("begin recovery fixture: %v", err)
+	}
+	transaction, err = admin.AdvanceUpdate(ctx, recoveryRequest.UpdateID, UpdateFenced, UpdateWritersStopped, nil)
+	if err != nil || transaction.Phase != UpdateWritersStopped {
+		t.Fatalf("recovery fixture writers stopped=%#v err=%v", transaction, err)
+	}
+	beforeRestore, err := app.InstallationState(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	recoveryMarker := UpdateBackupMarker{
+		UpdateID: recoveryRequest.UpdateID, BackupID: "019b4eb0-c447-7c76-b73f-f442bab67061",
+		InstallationID: beforeRestore.InstallationID, TimelineID: beforeRestore.TimelineID,
+		ChangeSequence: beforeRestore.ChangeSequence, SourceSchema: recoveryRequest.SourceSchema,
+		TargetRelease:      recoveryRequest.TargetRelease,
+		TargetImageDigest:  "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+		ExportedSnapshotID: "00000003-0000001B-2",
+		ManifestSHA256:     "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+	}
+	mismatch := recoveryMarker
+	mismatch.TargetRelease = "v0.7.1"
+	if _, _, err := admin.RestoreUpdateRecovery(ctx, mismatch); err == nil {
+		t.Fatal("mismatched restored-backup evidence was accepted")
+	}
+	unchanged, err := app.InstallationState(ctx)
+	if err != nil || unchanged != beforeRestore {
+		t.Fatalf("failed recovery authorization mutated timeline: state=%#v err=%v", unchanged, err)
+	}
+	restored, transaction, err := admin.RestoreUpdateRecovery(ctx, recoveryMarker)
+	if err != nil || transaction.Phase != UpdateRecoveryRequired || restored.InstallationID != beforeRestore.InstallationID || restored.TimelineID == beforeRestore.TimelineID || restored.ChangeSequence != beforeRestore.ChangeSequence || transaction.BackupID != recoveryMarker.BackupID || transaction.BackupTimelineID != beforeRestore.TimelineID {
+		t.Fatalf("restored update state=%#v transaction=%#v err=%v", restored, transaction, err)
+	}
+	retriedState, retriedTransaction, err := admin.RestoreUpdateRecovery(ctx, recoveryMarker)
+	if err != nil || retriedState != restored || retriedTransaction != transaction {
+		t.Fatalf("restored update retry state=%#v transaction=%#v err=%v", retriedState, retriedTransaction, err)
+	}
+	if _, err := app.AdvanceChange(ctx); !errors.Is(err, ErrMaintenance) {
+		t.Fatalf("restored recovery did not retain maintenance fence: %v", err)
+	}
+	for _, transition := range [][2]UpdatePhase{{UpdateRecoveryRequired, UpdateRecoveryReady}, {UpdateRecoveryReady, UpdateRecoveryDoctor}, {UpdateRecoveryDoctor, UpdateRecoveryConfig}, {UpdateRecoveryConfig, UpdateRecovered}} {
+		transaction, err = admin.AdvanceUpdate(ctx, recoveryRequest.UpdateID, transition[0], transition[1], nil)
+		if err != nil || transaction.Phase != transition[1] {
+			t.Fatalf("restored recovery transition %s -> %s transaction=%#v err=%v", transition[0], transition[1], transaction, err)
+		}
+	}
+	if _, err := app.AdvanceChange(ctx); err != nil {
+		t.Fatalf("recovered update retained maintenance fence: %v", err)
 	}
 }
 

--- a/internal/postgres/postgres_integration_test.go
+++ b/internal/postgres/postgres_integration_test.go
@@ -495,7 +495,7 @@ func testV5UpdateBridgeIntegration(ctx context.Context, t *testing.T, ownerDB *s
 	}
 	bridge, err := BeginV5UpdateBridge(ctx, Config{DSNFile: ownerFile}, request)
 	if err != nil {
-		t.Fatalf("begin abortable bridge: %v", err)
+		t.Fatalf("begin abortable bridge: %v diagnostic=%s", err, v5BridgeDiagnostic(ctx, ownerDB, request))
 	}
 	if err := bridge.Abort(); err != nil {
 		t.Fatalf("abort uncommitted bridge: %v", err)
@@ -567,6 +567,22 @@ func testV5UpdateBridgeIntegration(ctx context.Context, t *testing.T, ownerDB *s
 			t.Fatalf("bridge phase %s -> %s transaction=%#v err=%v", phases[0], phases[1], transaction, err)
 		}
 	}
+}
+
+func v5BridgeDiagnostic(ctx context.Context, ownerDB *sql.DB, request UpdateRequest) string {
+	tx, err := ownerDB.BeginTx(ctx, nil)
+	if err != nil {
+		return "transaction-failed: " + err.Error()
+	}
+	defer func() { _ = tx.Rollback() }()
+	if _, err := tx.ExecContext(ctx, CurrentManifest().Migrations[5].SQL); err != nil {
+		return "migration-failed: " + err.Error()
+	}
+	_, err = scanUpdate(tx.QueryRowContext(ctx, `SELECT `+updateSelectColumns+` FROM jobs.begin_update($1::uuid,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14)`, request.UpdateID, request.SourceRelease, request.TargetRelease, request.SourceImage, request.TargetImage, request.SourceSchema, request.TargetSchema, request.SchemaMin, request.SchemaMax, request.RollbackFloor, request.PostgresMajor, request.ReleaseSHA256, request.ComposeSHA256, request.MigrationManifestSHA256))
+	if err != nil {
+		return "begin-failed: " + err.Error()
+	}
+	return "unexpected-success"
 }
 
 func testTransactionalUpdateFenceIntegration(ctx context.Context, t *testing.T, app *Database, ownerDB *sql.DB) {

--- a/internal/postgres/postgres_integration_test.go
+++ b/internal/postgres/postgres_integration_test.go
@@ -42,7 +42,7 @@ func TestPostgresPlatformSubstrateIntegration(t *testing.T) {
 		t.Fatalf("pristine DSN pair proof failed: %v", err)
 	}
 	if state, err := MigratePristinePair(ctx, Config{DSNFile: pairAppFile}, Config{DSNFile: pairOwnerFile}); err != nil || state.Classification != Compatible {
-		t.Fatalf("connection-bound pair migration state=%#v err=%v catalog=%s update=%s", state, err, m6CatalogDiagnostic(ctx, pairOwnerDSN), updateControlsDiagnostic(ctx, pairOwnerDSN))
+		t.Fatalf("connection-bound pair migration state=%#v err=%v catalog=%s", state, err, m6CatalogDiagnostic(ctx, pairOwnerDSN))
 	}
 	pairDB, err := open(ctx, pairOwnerDSN)
 	if err != nil {
@@ -502,7 +502,7 @@ func testV5UpdateBridgeIntegration(ctx context.Context, t *testing.T, ownerDB *s
 	}
 	bridge, err := BeginV5UpdateBridge(ctx, Config{DSNFile: ownerFile}, request)
 	if err != nil {
-		t.Fatalf("begin abortable bridge: %v diagnostic=%s", err, v5BridgeDiagnostic(ctx, ownerDB, request))
+		t.Fatalf("begin abortable bridge: %v", err)
 	}
 	if err := bridge.Abort(); err != nil {
 		t.Fatalf("abort uncommitted bridge: %v", err)
@@ -583,22 +583,6 @@ func testV5UpdateBridgeIntegration(ctx context.Context, t *testing.T, ownerDB *s
 	if _, err := ownerDB.ExecContext(ctx, `DELETE FROM auth.principals WHERE id=$1`, bridgeOwnerID); err != nil {
 		t.Fatalf("remove v5 bridge principal fixture: %v", err)
 	}
-}
-
-func v5BridgeDiagnostic(ctx context.Context, ownerDB *sql.DB, request UpdateRequest) string {
-	tx, err := ownerDB.BeginTx(ctx, nil)
-	if err != nil {
-		return "transaction-failed: " + err.Error()
-	}
-	defer func() { _ = tx.Rollback() }()
-	if _, err := tx.ExecContext(ctx, CurrentManifest().Migrations[5].SQL); err != nil {
-		return "migration-failed: " + err.Error()
-	}
-	_, err = scanUpdate(tx.QueryRowContext(ctx, `SELECT `+updateSelectColumns+` FROM jobs.begin_update($1::uuid,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14)`, request.UpdateID, request.SourceRelease, request.TargetRelease, request.SourceImage, request.TargetImage, request.SourceSchema, request.TargetSchema, request.SchemaMin, request.SchemaMax, request.RollbackFloor, request.PostgresMajor, request.ReleaseSHA256, request.ComposeSHA256, request.MigrationManifestSHA256))
-	if err != nil {
-		return "begin-failed: " + err.Error()
-	}
-	return "unexpected-success"
 }
 
 func testTransactionalUpdateFenceIntegration(ctx context.Context, t *testing.T, app *Database, ownerDB *sql.DB) {
@@ -812,46 +796,6 @@ func m6CatalogDiagnostic(ctx context.Context, ownerDSN string) string {
 		_ = rows.Close()
 	}
 	return diagnostic.String()
-}
-
-func updateControlsDiagnostic(ctx context.Context, ownerDSN string) string {
-	db, err := sql.Open("pgx", ownerDSN)
-	if err != nil {
-		return "open-failed: " + err.Error()
-	}
-	defer func() { _ = db.Close() }()
-	var available bool
-	if err := db.QueryRowContext(ctx, updateControlsInspectionSQL).Scan(&available); err != nil {
-		return "query-failed: " + err.Error()
-	}
-	if available {
-		return "available"
-	}
-	queries := []string{
-		`SELECT format('column:%s:%s:%s:%s:%s', attnum, attname, atttypid::regtype::text, atttypmod, attnotnull) FROM pg_attribute WHERE attrelid=to_regclass('jobs.update_transactions') AND attnum>0 AND NOT attisdropped ORDER BY attnum`,
-		`SELECT format('constraint:%s:%s:%s:%s', contype, conkey::text, convalidated, COALESCE(pg_get_expr(conbin,conrelid),'')) FROM pg_constraint WHERE conrelid=to_regclass('jobs.update_transactions') ORDER BY contype,conkey::text`,
-		`SELECT format('routine:%s:%s:%s:%s:%s:%s:%s:%s:%s', proc.oid::regprocedure::text, md5(btrim(proc.prosrc)), language.lanname, proc.provolatile, proc.prosecdef, pg_get_userbyid(proc.proowner), pg_get_function_result(proc.oid), COALESCE(array_to_string(proc.proconfig,','),''), COALESCE(proc.proargmodes::text,'')) FROM pg_proc AS proc JOIN pg_language AS language ON language.oid=proc.prolang WHERE proc.oid=ANY(ARRAY[to_regprocedure('jobs.assert_application_mutation()'),to_regprocedure('jobs.guard_application_mutation()'),to_regprocedure('jobs.begin_update(uuid,text,text,text,text,bigint,bigint,bigint,bigint,bigint,integer,text,text,text)'),to_regprocedure('jobs.advance_update(uuid,text,text,uuid,uuid,uuid,bigint,bigint,text,text,text,text)'),to_regprocedure('jobs.restore_update_recovery(uuid,uuid,uuid,uuid,bigint,bigint,text,text,text,text)'),to_regprocedure('jobs.maintenance_active()')]) ORDER BY proc.oid::regprocedure::text`,
-		`SELECT format('routine-acl:%s:%s:%s:%s', proc.oid::regprocedure::text, COALESCE(grantee.rolname,'PUBLIC'), acl.privilege_type, acl.is_grantable) FROM pg_proc AS proc CROSS JOIN LATERAL aclexplode(COALESCE(proc.proacl,acldefault('f',proc.proowner))) AS acl LEFT JOIN pg_roles AS grantee ON grantee.oid=acl.grantee WHERE proc.oid=ANY(ARRAY[to_regprocedure('jobs.assert_application_mutation()'),to_regprocedure('jobs.guard_application_mutation()'),to_regprocedure('jobs.begin_update(uuid,text,text,text,text,bigint,bigint,bigint,bigint,bigint,integer,text,text,text)'),to_regprocedure('jobs.advance_update(uuid,text,text,uuid,uuid,uuid,bigint,bigint,text,text,text,text)'),to_regprocedure('jobs.restore_update_recovery(uuid,uuid,uuid,uuid,bigint,bigint,text,text,text,text)'),to_regprocedure('jobs.maintenance_active()')]) ORDER BY proc.oid::regprocedure::text,grantee.rolname`,
-		`SELECT format('table:%s:%s:%s:%s:%s:%s', relkind, relpersistence, relrowsecurity, relforcerowsecurity, pg_get_userbyid(relowner), COALESCE(relacl::text,'')) FROM pg_class WHERE oid=to_regclass('jobs.update_transactions')`,
-		`SELECT format('index:%s:%s:%s:%s:%s:%s:%s:%s:%s', indisunique,indisvalid,indisready,indkey::text,indclass::text,indcollation::text,indoption::text,pg_get_expr(indexprs,indrelid),pg_get_expr(indpred,indrelid)) FROM pg_index WHERE indexrelid=to_regclass('jobs.update_transactions_one_active')`,
-		`SELECT format('trigger:%s:%s:%s:%s:%s:%s:%s', count(*),min(tgtype),max(tgtype),bool_and(tgenabled='O'),bool_and(NOT tgisinternal),bool_and(tgqual IS NULL),bool_and(tgattr::text='')) FROM pg_trigger WHERE tgname='application_mutation_fence' AND tgrelid=ANY(ARRAY['jobs.server_state'::regclass,'auth.principals'::regclass,'relay.projects'::regclass,'auth.capability_grants'::regclass,'relay.idempotency_records'::regclass,'audit.events'::regclass,'jobs.queue_capacity'::regclass,'jobs.outbox'::regclass,'auth.installation_owner'::regclass,'auth.pending_enrollments'::regclass,'auth.pending_enrollment_grants'::regclass,'auth.device_credentials'::regclass,'auth.legacy_auth_state'::regclass,'auth.legacy_machines'::regclass,'auth.project_acl_state'::regclass,'relay.project_identities'::regclass,'relay.project_lookup_aliases'::regclass,'relay.project_merge_previews'::regclass,'attachment.ready_blob_manifest'::regclass])`,
-	}
-	var diagnostic strings.Builder
-	for _, query := range queries {
-		rows, queryErr := db.QueryContext(ctx, query)
-		if queryErr != nil {
-			return "unavailable; diagnostic-query-failed: " + queryErr.Error()
-		}
-		for rows.Next() {
-			var line string
-			if rows.Scan(&line) == nil && diagnostic.Len()+len(line) < 16<<10 {
-				diagnostic.WriteString(line)
-				diagnostic.WriteByte(';')
-			}
-		}
-		_ = rows.Close()
-	}
-	return "unavailable; " + diagnostic.String()
 }
 
 func testBackupRestoreIntegration(ctx context.Context, t *testing.T, app *Database, ownerDB *sql.DB, ownerFile, appFile string) {

--- a/internal/postgres/postgres_integration_test.go
+++ b/internal/postgres/postgres_integration_test.go
@@ -42,7 +42,7 @@ func TestPostgresPlatformSubstrateIntegration(t *testing.T) {
 		t.Fatalf("pristine DSN pair proof failed: %v", err)
 	}
 	if state, err := MigratePristinePair(ctx, Config{DSNFile: pairAppFile}, Config{DSNFile: pairOwnerFile}); err != nil || state.Classification != Compatible {
-		t.Fatalf("connection-bound pair migration state=%#v err=%v catalog=%s", state, err, m6CatalogDiagnostic(ctx, pairOwnerDSN))
+		t.Fatalf("connection-bound pair migration state=%#v err=%v catalog=%s update=%s", state, err, m6CatalogDiagnostic(ctx, pairOwnerDSN), updateControlsDiagnostic(ctx, pairOwnerDSN))
 	}
 	pairDB, err := open(ctx, pairOwnerDSN)
 	if err != nil {
@@ -780,6 +780,22 @@ func m6CatalogDiagnostic(ctx context.Context, ownerDSN string) string {
 		_ = rows.Close()
 	}
 	return diagnostic.String()
+}
+
+func updateControlsDiagnostic(ctx context.Context, ownerDSN string) string {
+	db, err := sql.Open("pgx", ownerDSN)
+	if err != nil {
+		return "open-failed: " + err.Error()
+	}
+	defer func() { _ = db.Close() }()
+	var available bool
+	if err := db.QueryRowContext(ctx, updateControlsInspectionSQL).Scan(&available); err != nil {
+		return "query-failed: " + err.Error()
+	}
+	if available {
+		return "available"
+	}
+	return "unavailable"
 }
 
 func testBackupRestoreIntegration(ctx context.Context, t *testing.T, app *Database, ownerDB *sql.DB, ownerFile, appFile string) {

--- a/internal/postgres/postgres_integration_test.go
+++ b/internal/postgres/postgres_integration_test.go
@@ -795,7 +795,31 @@ func updateControlsDiagnostic(ctx context.Context, ownerDSN string) string {
 	if available {
 		return "available"
 	}
-	return "unavailable"
+	queries := []string{
+		`SELECT format('column:%s:%s:%s:%s:%s', attnum, attname, atttypid::regtype::text, atttypmod, attnotnull) FROM pg_attribute WHERE attrelid=to_regclass('jobs.update_transactions') AND attnum>0 AND NOT attisdropped ORDER BY attnum`,
+		`SELECT format('constraint:%s:%s:%s:%s', contype, conkey::text, convalidated, COALESCE(pg_get_expr(conbin,conrelid),'')) FROM pg_constraint WHERE conrelid=to_regclass('jobs.update_transactions') ORDER BY contype,conkey::text`,
+		`SELECT format('routine:%s:%s:%s:%s:%s:%s:%s:%s:%s', proc.oid::regprocedure::text, md5(btrim(proc.prosrc)), language.lanname, proc.provolatile, proc.prosecdef, pg_get_userbyid(proc.proowner), pg_get_function_result(proc.oid), COALESCE(array_to_string(proc.proconfig,','),''), COALESCE(proc.proargmodes::text,'')) FROM pg_proc AS proc JOIN pg_language AS language ON language.oid=proc.prolang WHERE proc.oid=ANY(ARRAY[to_regprocedure('jobs.assert_application_mutation()'),to_regprocedure('jobs.guard_application_mutation()'),to_regprocedure('jobs.begin_update(uuid,text,text,text,text,bigint,bigint,bigint,bigint,bigint,integer,text,text,text)'),to_regprocedure('jobs.advance_update(uuid,text,text,uuid,uuid,uuid,bigint,bigint,text,text,text,text)'),to_regprocedure('jobs.restore_update_recovery(uuid,uuid,uuid,uuid,bigint,bigint,text,text,text,text)'),to_regprocedure('jobs.maintenance_active()')]) ORDER BY proc.oid::regprocedure::text`,
+		`SELECT format('routine-acl:%s:%s:%s:%s', proc.oid::regprocedure::text, COALESCE(grantee.rolname,'PUBLIC'), acl.privilege_type, acl.is_grantable) FROM pg_proc AS proc CROSS JOIN LATERAL aclexplode(COALESCE(proc.proacl,acldefault('f',proc.proowner))) AS acl LEFT JOIN pg_roles AS grantee ON grantee.oid=acl.grantee WHERE proc.oid=ANY(ARRAY[to_regprocedure('jobs.assert_application_mutation()'),to_regprocedure('jobs.guard_application_mutation()'),to_regprocedure('jobs.begin_update(uuid,text,text,text,text,bigint,bigint,bigint,bigint,bigint,integer,text,text,text)'),to_regprocedure('jobs.advance_update(uuid,text,text,uuid,uuid,uuid,bigint,bigint,text,text,text,text)'),to_regprocedure('jobs.restore_update_recovery(uuid,uuid,uuid,uuid,bigint,bigint,text,text,text,text)'),to_regprocedure('jobs.maintenance_active()')]) ORDER BY proc.oid::regprocedure::text,grantee.rolname`,
+		`SELECT format('table:%s:%s:%s:%s:%s:%s', relkind, relpersistence, relrowsecurity, relforcerowsecurity, pg_get_userbyid(relowner), COALESCE(relacl::text,'')) FROM pg_class WHERE oid=to_regclass('jobs.update_transactions')`,
+		`SELECT format('index:%s:%s:%s:%s:%s:%s:%s:%s:%s', indisunique,indisvalid,indisready,indkey::text,indclass::text,indcollation::text,indoption::text,pg_get_expr(indexprs,indrelid),pg_get_expr(indpred,indrelid)) FROM pg_index WHERE indexrelid=to_regclass('jobs.update_transactions_one_active')`,
+		`SELECT format('trigger:%s:%s:%s:%s:%s:%s:%s', count(*),min(tgtype),max(tgtype),bool_and(tgenabled='O'),bool_and(NOT tgisinternal),bool_and(tgqual IS NULL),bool_and(tgattr::text='')) FROM pg_trigger WHERE tgname='application_mutation_fence' AND tgrelid=ANY(ARRAY['jobs.server_state'::regclass,'auth.principals'::regclass,'relay.projects'::regclass,'auth.capability_grants'::regclass,'relay.idempotency_records'::regclass,'audit.events'::regclass,'jobs.queue_capacity'::regclass,'jobs.outbox'::regclass,'auth.installation_owner'::regclass,'auth.pending_enrollments'::regclass,'auth.pending_enrollment_grants'::regclass,'auth.device_credentials'::regclass,'auth.legacy_auth_state'::regclass,'auth.legacy_machines'::regclass,'auth.project_acl_state'::regclass,'relay.project_identities'::regclass,'relay.project_lookup_aliases'::regclass,'relay.project_merge_previews'::regclass,'attachment.ready_blob_manifest'::regclass])`,
+	}
+	var diagnostic strings.Builder
+	for _, query := range queries {
+		rows, queryErr := db.QueryContext(ctx, query)
+		if queryErr != nil {
+			return "unavailable; diagnostic-query-failed: " + queryErr.Error()
+		}
+		for rows.Next() {
+			var line string
+			if rows.Scan(&line) == nil && diagnostic.Len()+len(line) < 16<<10 {
+				diagnostic.WriteString(line)
+				diagnostic.WriteByte(';')
+			}
+		}
+		_ = rows.Close()
+	}
+	return "unavailable; " + diagnostic.String()
 }
 
 func testBackupRestoreIntegration(ctx context.Context, t *testing.T, app *Database, ownerDB *sql.DB, ownerFile, appFile string) {

--- a/internal/postgres/project_identity_store.go
+++ b/internal/postgres/project_identity_store.go
@@ -119,9 +119,9 @@ func (d *Database) AttachProjectIdentity(ctx context.Context, request ProjectIde
 		Kind      ProjectIdentityKind `json:"kind"`
 		Locator   string              `json:"locator"`
 	}{request.ProjectID, request.Kind, locator})
-	tx, err := d.db.BeginTx(ctx, nil)
+	tx, err := beginMutation(ctx, d.db)
 	if err != nil {
-		return ProjectIdentityAttachment{}, errors.New("project identity transaction cannot start")
+		return ProjectIdentityAttachment{}, mutationStartError(err, "project identity transaction cannot start")
 	}
 	defer func() { _ = tx.Rollback() }()
 	outcome, err := executeIdempotentTx(ctx, tx, IdempotencyRequest{PrincipalID: request.ActorPrincipalID, Operation: "project.identity.attach", Key: request.IdempotencyKey, Body: body}, func(control *ControlTx) (IdempotencyOutcome, error) {
@@ -255,9 +255,9 @@ func (d *Database) PreviewProjectIdentityMerge(ctx context.Context, request Proj
 		Kind            ProjectIdentityKind `json:"kind"`
 		Locator         string              `json:"locator"`
 	}{request.SourceProjectID, request.Kind, locator})
-	tx, err := d.db.BeginTx(ctx, nil)
+	tx, err := beginMutation(ctx, d.db)
 	if err != nil {
-		return ProjectMergePreview{}, errors.New("project merge preview transaction cannot start")
+		return ProjectMergePreview{}, mutationStartError(err, "project merge preview transaction cannot start")
 	}
 	defer func() { _ = tx.Rollback() }()
 	outcome, err := executeIdempotentTx(ctx, tx, IdempotencyRequest{PrincipalID: request.ActorPrincipalID, Operation: "project.merge.preview", Key: request.IdempotencyKey, Body: body}, func(control *ControlTx) (IdempotencyOutcome, error) {
@@ -360,9 +360,9 @@ func (d *Database) ApproveProjectIdentityMerge(ctx context.Context, approval Pro
 	if !validOpaqueID(approval.ActorPrincipalID) || !validOpaqueID(approval.PreviewID) {
 		return ProjectMergeResult{}, errors.New("invalid project merge approval")
 	}
-	tx, err := d.db.BeginTx(ctx, nil)
+	tx, err := beginMutation(ctx, d.db)
 	if err != nil {
-		return ProjectMergeResult{}, errors.New("project merge transaction cannot start")
+		return ProjectMergeResult{}, mutationStartError(err, "project merge transaction cannot start")
 	}
 	defer func() { _ = tx.Rollback() }()
 	if err := lockProjectJobMutations(ctx, tx, true); err != nil {
@@ -732,9 +732,9 @@ func (d *Database) advanceProjectContentGeneration(ctx context.Context, actorPri
 	if !validOpaqueID(actorPrincipalID) || !validOpaqueID(projectID) {
 		return 0, errors.New("invalid project content mutation")
 	}
-	tx, err := d.db.BeginTx(ctx, nil)
+	tx, err := beginMutation(ctx, d.db)
 	if err != nil {
-		return 0, errors.New("project content transaction cannot start")
+		return 0, mutationStartError(err, "project content transaction cannot start")
 	}
 	defer func() { _ = tx.Rollback() }()
 	project, err := lockDirectActiveProject(ctx, tx, projectID)

--- a/internal/postgres/state_test.go
+++ b/internal/postgres/state_test.go
@@ -66,10 +66,10 @@ func TestManifestValidationRejectsMutableOrNonContiguousHistory(t *testing.T) {
 
 func TestCurrentManifestRequiresControlPlaneSchema(t *testing.T) {
 	manifest := CurrentManifest()
-	if manifest.MinSupported != 5 || manifest.MaxSupported != 5 || len(manifest.Migrations) != 5 {
-		t.Fatalf("manifest=%#v, want exact v5 compatibility window", manifest)
+	if manifest.MinSupported != 6 || manifest.MaxSupported != 6 || len(manifest.Migrations) != 6 {
+		t.Fatalf("manifest=%#v, want exact v6 compatibility window", manifest)
 	}
-	if manifest.Migrations[0].CompatibilityFloor != 1 || manifest.Migrations[1].CompatibilityFloor != 2 || manifest.Migrations[2].CompatibilityFloor != 3 || manifest.Migrations[3].CompatibilityFloor != 4 || manifest.Migrations[4].CompatibilityFloor != 5 {
+	if manifest.Migrations[0].CompatibilityFloor != 1 || manifest.Migrations[1].CompatibilityFloor != 2 || manifest.Migrations[2].CompatibilityFloor != 3 || manifest.Migrations[3].CompatibilityFloor != 4 || manifest.Migrations[4].CompatibilityFloor != 5 || manifest.Migrations[5].CompatibilityFloor != 6 {
 		t.Fatalf("migration floors=%d,%d,%d,%d,%d, want 1,2,3,4,5", manifest.Migrations[0].CompatibilityFloor, manifest.Migrations[1].CompatibilityFloor, manifest.Migrations[2].CompatibilityFloor, manifest.Migrations[3].CompatibilityFloor, manifest.Migrations[4].CompatibilityFloor)
 	}
 }

--- a/internal/postgres/update.go
+++ b/internal/postgres/update.go
@@ -330,14 +330,15 @@ WITH objects AS (
 		CROSS JOIN LATERAL aclexplode(COALESCE(proc.proacl,acldefault('f',proc.proowner))) AS acl
 		LEFT JOIN pg_roles AS grantee ON grantee.oid=acl.grantee
 	), table_safety AS (
-		SELECT relation.relkind='r' AND relation.relpersistence='p' AND NOT relation.relrowsecurity AND NOT relation.relforcerowsecurity
+		SELECT COALESCE((SELECT relation.relkind='r' AND relation.relpersistence='p' AND NOT relation.relrowsecurity AND NOT relation.relforcerowsecurity
 		   AND pg_get_userbyid(relation.relowner)='punaro_owner'
 		   AND (SELECT count(*)=CASE WHEN current_setting('server_version_num')::integer/10000 >= 15 THEN 8 ELSE 7 END
 		        AND bool_and(grantee.rolname='punaro_owner' AND NOT acl.is_grantable)
 		        FROM LATERAL aclexplode(COALESCE(relation.relacl,acldefault('r',relation.relowner))) AS acl
 		        LEFT JOIN pg_roles AS grantee ON grantee.oid=acl.grantee)
-		   AND NOT EXISTS (SELECT 1 FROM pg_attribute WHERE attrelid=relation.oid AND attnum>0 AND attacl IS NOT NULL) AS safe
-		FROM objects JOIN pg_class AS relation ON relation.oid=objects.updates_oid
+		   AND NOT EXISTS (SELECT 1 FROM pg_attribute WHERE attrelid=relation.oid AND attnum>0 AND attacl IS NOT NULL)
+		   FROM pg_class AS relation WHERE relation.oid=objects.updates_oid),false) AS safe
+		FROM objects
 	), trigger_safety AS (
 		SELECT count(*) = 19
 	       AND bool_and(trigger.tgenabled = 'O' AND NOT trigger.tgisinternal

--- a/internal/postgres/update.go
+++ b/internal/postgres/update.go
@@ -332,7 +332,8 @@ WITH objects AS (
 	), table_safety AS (
 		SELECT relation.relkind='r' AND relation.relpersistence='p' AND NOT relation.relrowsecurity AND NOT relation.relforcerowsecurity
 		   AND pg_get_userbyid(relation.relowner)='punaro_owner'
-		   AND (SELECT count(*)=7 AND bool_and(grantee.rolname='punaro_owner' AND NOT acl.is_grantable)
+		   AND (SELECT count(*)=CASE WHEN current_setting('server_version_num')::integer/10000 >= 15 THEN 8 ELSE 7 END
+		        AND bool_and(grantee.rolname='punaro_owner' AND NOT acl.is_grantable)
 		        FROM LATERAL aclexplode(COALESCE(relation.relacl,acldefault('r',relation.relowner))) AS acl
 		        LEFT JOIN pg_roles AS grantee ON grantee.oid=acl.grantee)
 		   AND NOT EXISTS (SELECT 1 FROM pg_attribute WHERE attrelid=relation.oid AND attnum>0 AND attacl IS NOT NULL) AS safe
@@ -357,7 +358,7 @@ SELECT updates_oid IS NOT NULL AND active_index_oid IS NOT NULL
 	        AND NOT index.indisprimary AND NOT index.indisexclusion AND NOT index.indisclustered
 	        AND index.indrelid = updates_oid AND index.indnkeyatts=1 AND index.indnatts=1 AND index.indkey::text='0'
 	        AND index.indcollation::text='0' AND index.indoption::text='0'
-	        AND index.indclass[0]=(SELECT oid FROM pg_opclass WHERE opcname='bool_ops' AND opcmethod=access_method.oid)
+	        AND index.indclass::oid[]=ARRAY[(SELECT oid FROM pg_opclass WHERE opcname='bool_ops' AND opcmethod=access_method.oid)]::oid[]
 	        AND index_relation.relkind='i' AND pg_get_userbyid(index_relation.relowner)='punaro_owner' AND access_method.amname='btree'
 	        AND pg_get_expr(index.indexprs,index.indrelid)='true'
 	        AND pg_get_expr(index.indpred,index.indrelid) = '(phase <> ALL (ARRAY[''committed''::text, ''recovered''::text, ''aborted''::text]))'

--- a/internal/postgres/update.go
+++ b/internal/postgres/update.go
@@ -233,12 +233,12 @@ WITH objects AS (
 	           to_regprocedure('jobs.maintenance_active()') AS active_oid
 	), expected_routines(oid, body_hash, language_name, volatility, result_type) AS (
 	    SELECT expected.* FROM objects, LATERAL (VALUES
-	        (assert_oid, '76bdbbc1411f2b9624c4730787ff75be', 'plpgsql', 'v'::"char", 'void'),
-			(guard_oid, 'f3339d7f9b6b1ebfec5172945f5c07ef', 'plpgsql', 'v'::"char", 'trigger'),
-			(begin_oid, '5f4cd7037a75c59ccea616622970d29e', 'plpgsql', 'v'::"char", 'SETOF jobs.update_transactions'),
-			(advance_oid, '4702d7cedcdf4b46e01beaf2b15e47cc', 'plpgsql', 'v'::"char", 'SETOF jobs.update_transactions'),
-			(restore_oid, '772d62b8629b384e84dc8a49c078be96', 'plpgsql', 'v'::"char", 'SETOF jobs.update_transactions'),
-	        (active_oid, 'e4475b6b4ac88f44927f2fc357f0ada3', 'sql', 's'::"char", 'boolean')
+	        (assert_oid, 'fc7543952561f0d5bc5113fcdaf813f9', 'plpgsql', 'v'::"char", 'void'),
+			(guard_oid, 'fcc654b13cfd4866c5b1a0197a7271cf', 'plpgsql', 'v'::"char", 'trigger'),
+			(begin_oid, 'c92d3f718820c5dbedafd741d922c6c0', 'plpgsql', 'v'::"char", 'SETOF jobs.update_transactions'),
+			(advance_oid, 'c32ff93b1819d456830727dcc5193a57', 'plpgsql', 'v'::"char", 'SETOF jobs.update_transactions'),
+			(restore_oid, 'e472e244c2979791f0b7fbfafd4f9b69', 'plpgsql', 'v'::"char", 'SETOF jobs.update_transactions'),
+	        (active_oid, 'f653ca3bdcc9dd7109d848c20264b546', 'sql', 's'::"char", 'boolean')
 	    ) AS expected(oid, body_hash, language_name, volatility, result_type)
 	), expected_tables(oid) AS (
     SELECT unnest(ARRAY[
@@ -308,10 +308,16 @@ WITH objects AS (
 		(ARRAY[18,19]::smallint[], '((phase = ANY (ARRAY[''fenced''::text, ''writers_stopped''::text, ''aborted''::text])) OR (backup_id IS NOT NULL))', '((phase = ANY (ARRAY[''fenced''::text, ''writers_stopped''::text, ''aborted''::text])) OR (backup_id IS NOT NULL))'),
 		(ARRAY[18,28]::smallint[], '((phase = ANY (ARRAY[''committed''::text, ''recovered''::text, ''aborted''::text])) = (completed_at IS NOT NULL))', '((phase = ANY (ARRAY[''committed''::text, ''recovered''::text, ''aborted''::text])) = (completed_at IS NOT NULL))')
 	), constraint_safety AS (
-		SELECT (SELECT count(*)=29 FROM pg_constraint,objects WHERE conrelid=updates_oid)
+		SELECT (SELECT count(*) FILTER (WHERE contype IN ('p','f','c'))=29
+		          AND count(*)=29+CASE WHEN current_setting('server_version_num')::integer/10000 >= 18 THEN 20 ELSE 0 END
+		        FROM pg_constraint,objects WHERE conrelid=updates_oid)
 		   AND (SELECT count(*)=1 FROM pg_constraint,objects WHERE conrelid=updates_oid AND contype='p' AND conkey=ARRAY[1]::smallint[] AND convalidated AND NOT condeferrable AND NOT condeferred)
 		   AND (SELECT count(*)=1 FROM pg_constraint,objects WHERE conrelid=updates_oid AND contype='f' AND conkey=ARRAY[4]::smallint[] AND confrelid='auth.principals'::regclass AND confkey=ARRAY[1]::smallint[] AND confupdtype='a' AND confdeltype='a' AND confmatchtype='s' AND convalidated AND NOT condeferrable AND NOT condeferred)
 		   AND (SELECT count(*)=27 FROM pg_constraint,objects WHERE conrelid=updates_oid AND contype='c' AND convalidated AND NOT condeferrable AND NOT condeferred)
+		   AND (current_setting('server_version_num')::integer/10000 < 18 OR NOT EXISTS (
+		       SELECT 1 FROM expected_columns,objects WHERE required AND NOT EXISTS (
+		           SELECT 1 FROM pg_constraint WHERE conrelid=updates_oid AND contype='n'
+		           AND conkey=ARRAY[expected_columns.attnum::smallint] AND convalidated AND NOT condeferrable AND NOT condeferred)))
 		   AND NOT EXISTS (SELECT 1 FROM expected_checks,objects WHERE NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conrelid=updates_oid AND contype='c' AND convalidated AND NOT condeferrable AND NOT condeferred AND conkey @> expected_checks.key AND conkey <@ expected_checks.key AND pg_get_expr(conbin,conrelid) IN (expected_checks.migration_expression,expected_checks.restored_expression))) AS safe
 	), routine_safety AS (
 	    SELECT count(*) = 6

--- a/internal/postgres/update.go
+++ b/internal/postgres/update.go
@@ -1,0 +1,498 @@
+package postgres
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"regexp"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgconn"
+)
+
+const minimumSupportedPostgresMajor = 14
+const updateCoordinatorLockKey int64 = 579001230607
+
+var (
+	updateReleasePattern  = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9._+-]{0,127}$`)
+	updateImagePattern    = regexp.MustCompile(`^[a-z0-9][a-z0-9./_:-]*@sha256:[0-9a-f]{64}$`)
+	updateDigestPattern   = regexp.MustCompile(`^sha256:[0-9a-f]{64}$`)
+	updateSnapshotPattern = regexp.MustCompile(`^[0-9A-Z-]{1,200}$`)
+	updateHashPattern     = regexp.MustCompile(`^[0-9a-f]{64}$`)
+
+	// ErrMaintenance is retryable: the mutation was rejected before acknowledgement.
+	ErrMaintenance = errors.New("installation is in maintenance mode; retry later")
+	// ErrUpdateConflict reports a different durable update already owning the fence.
+	ErrUpdateConflict = errors.New("another update transaction owns the maintenance fence")
+	// ErrInvalidUpdateTransition reports a fail-closed update state transition.
+	ErrInvalidUpdateTransition = errors.New("update phase transition is invalid")
+)
+
+// UpdatePhase is the durable, content-free phase of one update transaction.
+type UpdatePhase string
+
+const (
+	// UpdateFenced is the first durable phase after all earlier writers drain.
+	UpdateFenced UpdatePhase = "fenced"
+	// UpdateWritersStopped records proof that configured writers are stopped.
+	UpdateWritersStopped UpdatePhase = "writers_stopped"
+	// UpdateBackupVerified records the exact pre-update recovery point.
+	UpdateBackupVerified UpdatePhase = "backup_verified"
+	// UpdateMigrationStarted is the irreversible migration boundary.
+	UpdateMigrationStarted UpdatePhase = "migration_started"
+	// UpdateMigrated records successful target-schema migration.
+	UpdateMigrated UpdatePhase = "migrated"
+	// UpdateCandidateReady records deep readiness of the fenced target.
+	UpdateCandidateReady UpdatePhase = "candidate_ready"
+	// UpdateDoctorPassed records the target's non-mutating doctor result.
+	UpdateDoctorPassed UpdatePhase = "doctor_passed"
+	// UpdateConfigPublished records marker-last target publication.
+	UpdateConfigPublished UpdatePhase = "config_published"
+	// UpdateRecoveryRequired keeps an unsuccessful migrated update fenced.
+	UpdateRecoveryRequired UpdatePhase = "recovery_required"
+	// UpdateRecoveryReady records readiness of the selected recovery image.
+	UpdateRecoveryReady UpdatePhase = "recovery_ready"
+	// UpdateRecoveryDoctor records the recovery doctor result.
+	UpdateRecoveryDoctor UpdatePhase = "recovery_doctor_passed"
+	// UpdateRecoveryConfig records recovery configuration publication.
+	UpdateRecoveryConfig UpdatePhase = "recovery_config_published"
+	// UpdateCommitted is a successful target terminal outcome.
+	UpdateCommitted UpdatePhase = "committed"
+	// UpdateRecovered is a successful rollback terminal outcome.
+	UpdateRecovered UpdatePhase = "recovered"
+	// UpdateAborted is a pre-migration terminal outcome.
+	UpdateAborted UpdatePhase = "aborted"
+)
+
+// UpdateRequest immutably identifies the source and target update boundary.
+type UpdateRequest struct {
+	UpdateID                string
+	SourceRelease           string
+	TargetRelease           string
+	SourceImage             string
+	TargetImage             string
+	SourceSchema            int64
+	TargetSchema            int64
+	SchemaMin               int64
+	SchemaMax               int64
+	RollbackFloor           int64
+	PostgresMajor           int
+	ReleaseSHA256           string
+	ComposeSHA256           string
+	MigrationManifestSHA256 string
+}
+
+// Validate rejects a request that is not a complete immutable update boundary.
+func (r UpdateRequest) Validate() error {
+	if uuid.Validate(r.UpdateID) != nil || !updateReleasePattern.MatchString(r.SourceRelease) || !updateReleasePattern.MatchString(r.TargetRelease) || r.SourceRelease == r.TargetRelease || !updateImagePattern.MatchString(r.SourceImage) || !updateImagePattern.MatchString(r.TargetImage) || r.SourceImage == r.TargetImage || r.SourceSchema < 1 || r.SchemaMin < 1 || r.SchemaMax < r.SchemaMin || r.TargetSchema < r.SourceSchema || r.TargetSchema < r.SchemaMin || r.TargetSchema > r.SchemaMax || r.SourceSchema < r.SchemaMin || r.SourceSchema > r.TargetSchema || r.RollbackFloor < r.SchemaMin || r.RollbackFloor > r.TargetSchema || r.PostgresMajor < minimumSupportedPostgresMajor || !updateHashPattern.MatchString(r.ReleaseSHA256) || !updateHashPattern.MatchString(r.ComposeSHA256) || !updateHashPattern.MatchString(r.MigrationManifestSHA256) {
+		return errors.New("invalid update request")
+	}
+	return nil
+}
+
+// UpdateBackupMarker binds recovery to one exact verified snapshot boundary.
+type UpdateBackupMarker struct {
+	UpdateID           string
+	BackupID           string
+	InstallationID     string
+	TimelineID         string
+	ChangeSequence     int64
+	SourceSchema       int64
+	TargetRelease      string
+	TargetImageDigest  string
+	ExportedSnapshotID string
+	ManifestSHA256     string
+}
+
+// Validate rejects an incomplete or noncanonical backup binding.
+func (m UpdateBackupMarker) Validate() error {
+	if uuid.Validate(m.UpdateID) != nil || uuid.Validate(m.BackupID) != nil || uuid.Validate(m.InstallationID) != nil || uuid.Validate(m.TimelineID) != nil || m.ChangeSequence < 0 || m.SourceSchema < 1 || !updateReleasePattern.MatchString(m.TargetRelease) || !updateDigestPattern.MatchString(m.TargetImageDigest) || !updateSnapshotPattern.MatchString(m.ExportedSnapshotID) || !updateHashPattern.MatchString(m.ManifestSHA256) {
+		return errors.New("invalid update backup marker")
+	}
+	return nil
+}
+
+// UpdateTransaction is the resumable owner-side view. It contains no secrets.
+type UpdateTransaction struct {
+	UpdateRequest
+	Phase                UpdatePhase
+	BackupID             string
+	BackupInstallationID string
+	BackupTimelineID     string
+	BackupChangeSequence int64
+	BackupSourceSchema   int64
+	BackupSnapshotID     string
+	BackupManifestSHA256 string
+}
+
+const updateSelectColumns = `update_id::text,source_release,target_release,source_image,target_image,source_schema,target_schema,schema_min,schema_max,rollback_floor,postgres_major,release_sha256,compose_sha256,migration_manifest_sha256,phase,COALESCE(backup_id::text,''),COALESCE(backup_installation_id::text,''),COALESCE(backup_timeline_id::text,''),COALESCE(backup_change_sequence,0),COALESCE(backup_source_schema,0),COALESCE(backup_snapshot_id,''),COALESCE(backup_manifest_sha256::text,'')`
+
+type rowScanner interface{ Scan(...any) error }
+
+func scanUpdate(row rowScanner) (UpdateTransaction, error) {
+	var transaction UpdateTransaction
+	err := row.Scan(&transaction.UpdateID, &transaction.SourceRelease, &transaction.TargetRelease, &transaction.SourceImage, &transaction.TargetImage, &transaction.SourceSchema, &transaction.TargetSchema, &transaction.SchemaMin, &transaction.SchemaMax, &transaction.RollbackFloor, &transaction.PostgresMajor, &transaction.ReleaseSHA256, &transaction.ComposeSHA256, &transaction.MigrationManifestSHA256, &transaction.Phase, &transaction.BackupID, &transaction.BackupInstallationID, &transaction.BackupTimelineID, &transaction.BackupChangeSequence, &transaction.BackupSourceSchema, &transaction.BackupSnapshotID, &transaction.BackupManifestSHA256)
+	return transaction, err
+}
+
+// UpdateMigrationAuthorization is the exact durable evidence a one-shot owner
+// migrator must match before it may touch an existing schema.
+type UpdateMigrationAuthorization struct {
+	UpdateID           string
+	BackupID           string
+	TargetRelease      string
+	TargetImage        string
+	TargetSchema       int64
+	ExportedSnapshotID string
+	ManifestSHA256     string
+}
+
+// Validate rejects migration authority that is not bound to an exact update.
+func (authorization UpdateMigrationAuthorization) Validate() error {
+	if uuid.Validate(authorization.UpdateID) != nil || uuid.Validate(authorization.BackupID) != nil || !updateReleasePattern.MatchString(authorization.TargetRelease) || !updateImagePattern.MatchString(authorization.TargetImage) || authorization.TargetSchema < 1 || !updateSnapshotPattern.MatchString(authorization.ExportedSnapshotID) || !updateHashPattern.MatchString(authorization.ManifestSHA256) {
+		return errors.New("invalid update migration authorization")
+	}
+	return nil
+}
+
+func validateUpdateTransition(from, to UpdatePhase) error {
+	allowed := map[UpdatePhase]map[UpdatePhase]bool{
+		UpdateFenced:           {UpdateWritersStopped: true, UpdateAborted: true},
+		UpdateWritersStopped:   {UpdateBackupVerified: true, UpdateAborted: true},
+		UpdateBackupVerified:   {UpdateMigrationStarted: true, UpdateAborted: true},
+		UpdateMigrationStarted: {UpdateMigrated: true, UpdateRecoveryRequired: true},
+		UpdateMigrated:         {UpdateCandidateReady: true, UpdateRecoveryRequired: true},
+		UpdateCandidateReady:   {UpdateDoctorPassed: true, UpdateRecoveryRequired: true},
+		UpdateDoctorPassed:     {UpdateConfigPublished: true, UpdateRecoveryRequired: true},
+		UpdateConfigPublished:  {UpdateCommitted: true},
+		UpdateRecoveryRequired: {UpdateRecoveryReady: true},
+		UpdateRecoveryReady:    {UpdateRecoveryDoctor: true},
+		UpdateRecoveryDoctor:   {UpdateRecoveryConfig: true},
+		UpdateRecoveryConfig:   {UpdateRecovered: true},
+	}
+	if !allowed[from][to] {
+		return ErrInvalidUpdateTransition
+	}
+	return nil
+}
+
+func guardMutation(ctx context.Context, tx *sql.Tx) error {
+	if _, err := tx.ExecContext(ctx, `SELECT jobs.assert_application_mutation()`); err != nil {
+		if isMaintenanceError(err) {
+			return ErrMaintenance
+		}
+		return errors.New("mutation maintenance gate is unavailable")
+	}
+	return nil
+}
+
+// MaintenanceActive reports whether an unfinished update transaction owns the
+// installation write fence. It is safe for the application role to inspect.
+func (d *Database) MaintenanceActive(ctx context.Context) (bool, error) {
+	var active bool
+	if err := d.db.QueryRowContext(ctx, `SELECT jobs.maintenance_active()`).Scan(&active); err != nil {
+		return false, errors.New("maintenance state is unavailable")
+	}
+	return active, nil
+}
+
+func beginMutation(ctx context.Context, database *sql.DB) (*sql.Tx, error) {
+	tx, err := database.BeginTx(ctx, nil)
+	if err != nil {
+		return nil, err
+	}
+	if err := guardMutation(ctx, tx); err != nil {
+		_ = tx.Rollback()
+		return nil, err
+	}
+	return tx, nil
+}
+
+func mutationStartError(err error, fallback string) error {
+	if errors.Is(err, ErrMaintenance) {
+		return ErrMaintenance
+	}
+	return errors.New(fallback)
+}
+
+func isMaintenanceError(err error) bool {
+	var postgresError *pgconn.PgError
+	return errors.As(err, &postgresError) && postgresError.Code == "55P03" && postgresError.Message == "punaro maintenance in progress"
+}
+
+const updateControlsInspectionSQL = `
+WITH objects AS (
+    SELECT to_regclass('jobs.update_transactions') AS updates_oid,
+           to_regclass('jobs.update_transactions_one_active') AS active_index_oid,
+           to_regprocedure('jobs.assert_application_mutation()') AS assert_oid,
+           to_regprocedure('jobs.guard_application_mutation()') AS guard_oid,
+		   to_regprocedure('jobs.begin_update(uuid,text,text,text,text,bigint,bigint,bigint,bigint,bigint,integer,text,text,text)') AS begin_oid,
+		   to_regprocedure('jobs.advance_update(uuid,text,text,uuid,uuid,uuid,bigint,bigint,text,text,text,text)') AS advance_oid,
+			   to_regprocedure('jobs.restore_update_recovery(uuid,uuid,uuid,uuid,bigint,bigint,text,text,text,text)') AS restore_oid,
+	           to_regprocedure('jobs.maintenance_active()') AS active_oid
+	), expected_routines(oid, body_hash, language_name, volatility, result_type) AS (
+	    SELECT expected.* FROM objects, LATERAL (VALUES
+	        (assert_oid, '76bdbbc1411f2b9624c4730787ff75be', 'plpgsql', 'v'::"char", 'void'),
+			(guard_oid, 'f3339d7f9b6b1ebfec5172945f5c07ef', 'plpgsql', 'v'::"char", 'trigger'),
+			(begin_oid, '5f4cd7037a75c59ccea616622970d29e', 'plpgsql', 'v'::"char", 'SETOF jobs.update_transactions'),
+			(advance_oid, '4702d7cedcdf4b46e01beaf2b15e47cc', 'plpgsql', 'v'::"char", 'SETOF jobs.update_transactions'),
+			(restore_oid, '772d62b8629b384e84dc8a49c078be96', 'plpgsql', 'v'::"char", 'SETOF jobs.update_transactions'),
+	        (active_oid, 'e4475b6b4ac88f44927f2fc357f0ada3', 'sql', 's'::"char", 'boolean')
+	    ) AS expected(oid, body_hash, language_name, volatility, result_type)
+	), expected_tables(oid) AS (
+    SELECT unnest(ARRAY[
+        'jobs.server_state'::regclass, 'auth.principals'::regclass,
+        'relay.projects'::regclass, 'auth.capability_grants'::regclass,
+        'relay.idempotency_records'::regclass, 'audit.events'::regclass,
+        'jobs.queue_capacity'::regclass, 'jobs.outbox'::regclass,
+        'auth.installation_owner'::regclass, 'auth.pending_enrollments'::regclass,
+        'auth.pending_enrollment_grants'::regclass, 'auth.device_credentials'::regclass,
+        'auth.legacy_auth_state'::regclass, 'auth.legacy_machines'::regclass,
+        'auth.project_acl_state'::regclass, 'relay.project_identities'::regclass,
+        'relay.project_lookup_aliases'::regclass, 'relay.project_merge_previews'::regclass,
+        'attachment.ready_blob_manifest'::regclass
+    ])
+	), expected_columns(attnum, column_name, type_oid, type_modifier, required, default_expression) AS (
+		VALUES
+		(1,'update_id','uuid'::regtype,-1,true,''),(2,'installation_id','uuid'::regtype,-1,true,''),
+		(3,'timeline_id','uuid'::regtype,-1,true,''),(4,'owner_principal_id','uuid'::regtype,-1,true,''),
+		(5,'source_release','text'::regtype,-1,true,''),(6,'target_release','text'::regtype,-1,true,''),
+		(7,'source_image','text'::regtype,-1,true,''),(8,'target_image','text'::regtype,-1,true,''),
+		(9,'source_schema','bigint'::regtype,-1,true,''),(10,'target_schema','bigint'::regtype,-1,true,''),
+		(11,'schema_min','bigint'::regtype,-1,true,''),(12,'schema_max','bigint'::regtype,-1,true,''),
+		(13,'rollback_floor','bigint'::regtype,-1,true,''),(14,'postgres_major','integer'::regtype,-1,true,''),
+		(15,'release_sha256','character'::regtype,68,true,''),(16,'compose_sha256','character'::regtype,68,true,''),
+		(17,'migration_manifest_sha256','character'::regtype,68,true,''),(18,'phase','text'::regtype,-1,true,''),
+		(19,'backup_id','uuid'::regtype,-1,false,''),(20,'backup_installation_id','uuid'::regtype,-1,false,''),
+		(21,'backup_timeline_id','uuid'::regtype,-1,false,''),(22,'backup_change_sequence','bigint'::regtype,-1,false,''),
+		(23,'backup_source_schema','bigint'::regtype,-1,false,''),(24,'backup_snapshot_id','text'::regtype,-1,false,''),
+		(25,'backup_manifest_sha256','character'::regtype,68,false,''),(26,'created_at','timestamptz'::regtype,-1,true,'statement_timestamp()'),
+		(27,'updated_at','timestamptz'::regtype,-1,true,'statement_timestamp()'),(28,'completed_at','timestamptz'::regtype,-1,false,'')
+	), actual_columns AS (
+		SELECT attribute.attnum::integer, attribute.attname, attribute.atttypid, attribute.atttypmod,
+		       attribute.attnotnull, COALESCE(pg_get_expr(default_value.adbin,default_value.adrelid),'')
+		FROM objects JOIN pg_attribute AS attribute ON attribute.attrelid=objects.updates_oid
+		LEFT JOIN pg_attrdef AS default_value ON default_value.adrelid=attribute.attrelid AND default_value.adnum=attribute.attnum
+		WHERE attribute.attnum>0 AND NOT attribute.attisdropped
+	), column_safety AS (
+		SELECT NOT EXISTS (SELECT * FROM expected_columns EXCEPT SELECT * FROM actual_columns)
+		   AND NOT EXISTS (SELECT * FROM actual_columns EXCEPT SELECT * FROM expected_columns) AS safe
+	), expected_checks(key, migration_expression, restored_expression) AS (
+		VALUES
+		(ARRAY[5]::smallint[], '(source_release ~ ''^[A-Za-z0-9][A-Za-z0-9._+\-]{0,127}$''::text)', '(source_release ~ ''^[A-Za-z0-9][A-Za-z0-9._+\-]{0,127}$''::text)'),
+		(ARRAY[6,5]::smallint[], '((target_release ~ ''^[A-Za-z0-9][A-Za-z0-9._+\-]{0,127}$''::text) AND (target_release <> source_release))', '((target_release ~ ''^[A-Za-z0-9][A-Za-z0-9._+\-]{0,127}$''::text) AND (target_release <> source_release))'),
+		(ARRAY[7]::smallint[], '(source_image ~ ''^[a-z0-9][a-z0-9./_:\-]*@sha256:[0-9a-f]{64}$''::text)', '(source_image ~ ''^[a-z0-9][a-z0-9./_:\-]*@sha256:[0-9a-f]{64}$''::text)'),
+		(ARRAY[8,7]::smallint[], '((target_image ~ ''^[a-z0-9][a-z0-9./_:\-]*@sha256:[0-9a-f]{64}$''::text) AND (target_image <> source_image))', '((target_image ~ ''^[a-z0-9][a-z0-9./_:\-]*@sha256:[0-9a-f]{64}$''::text) AND (target_image <> source_image))'),
+		(ARRAY[9]::smallint[], '(source_schema > 0)', '(source_schema > 0)'),
+		(ARRAY[10,9]::smallint[], '(target_schema >= source_schema)', '(target_schema >= source_schema)'),
+		(ARRAY[11]::smallint[], '(schema_min > 0)', '(schema_min > 0)'),
+		(ARRAY[12,11]::smallint[], '(schema_max >= schema_min)', '(schema_max >= schema_min)'),
+		(ARRAY[13,11,10]::smallint[], '((rollback_floor >= schema_min) AND (rollback_floor <= target_schema))', '((rollback_floor >= schema_min) AND (rollback_floor <= target_schema))'),
+		(ARRAY[14]::smallint[], '(postgres_major >= 14)', '(postgres_major >= 14)'),
+		(ARRAY[15]::smallint[], '(release_sha256 ~ ''^[0-9a-f]{64}$''::text)', '(release_sha256 ~ ''^[0-9a-f]{64}$''::text)'),
+		(ARRAY[16]::smallint[], '(compose_sha256 ~ ''^[0-9a-f]{64}$''::text)', '(compose_sha256 ~ ''^[0-9a-f]{64}$''::text)'),
+		(ARRAY[17]::smallint[], '(migration_manifest_sha256 ~ ''^[0-9a-f]{64}$''::text)', '(migration_manifest_sha256 ~ ''^[0-9a-f]{64}$''::text)'),
+		(ARRAY[18]::smallint[], '(phase = ANY (ARRAY[''fenced''::text, ''writers_stopped''::text, ''backup_verified''::text, ''migration_started''::text, ''migrated''::text, ''candidate_ready''::text, ''doctor_passed''::text, ''config_published''::text, ''recovery_required''::text, ''recovery_ready''::text, ''recovery_doctor_passed''::text, ''recovery_config_published''::text, ''committed''::text, ''recovered''::text, ''aborted''::text]))', '(phase = ANY (ARRAY[''fenced''::text, ''writers_stopped''::text, ''backup_verified''::text, ''migration_started''::text, ''migrated''::text, ''candidate_ready''::text, ''doctor_passed''::text, ''config_published''::text, ''recovery_required''::text, ''recovery_ready''::text, ''recovery_doctor_passed''::text, ''recovery_config_published''::text, ''committed''::text, ''recovered''::text, ''aborted''::text]))'),
+		(ARRAY[22]::smallint[], '(backup_change_sequence >= 0)', '(backup_change_sequence >= 0)'),
+		(ARRAY[23]::smallint[], '(backup_source_schema > 0)', '(backup_source_schema > 0)'),
+		(ARRAY[24]::smallint[], '(backup_snapshot_id ~ ''^[0-9A-Z-]{1,200}$''::text)', '(backup_snapshot_id ~ ''^[0-9A-Z-]{1,200}$''::text)'),
+		(ARRAY[25]::smallint[], '(backup_manifest_sha256 ~ ''^[0-9a-f]{64}$''::text)', '(backup_manifest_sha256 ~ ''^[0-9a-f]{64}$''::text)'),
+		(ARRAY[9,11,10,12]::smallint[], '(((source_schema >= schema_min) AND (source_schema <= target_schema)) AND (target_schema <= schema_max))', '((source_schema >= schema_min) AND (source_schema <= target_schema) AND (target_schema <= schema_max))'),
+		(ARRAY[19,20]::smallint[], '((backup_id IS NULL) = (backup_installation_id IS NULL))', '((backup_id IS NULL) = (backup_installation_id IS NULL))'),
+		(ARRAY[19,21]::smallint[], '((backup_id IS NULL) = (backup_timeline_id IS NULL))', '((backup_id IS NULL) = (backup_timeline_id IS NULL))'),
+		(ARRAY[19,22]::smallint[], '((backup_id IS NULL) = (backup_change_sequence IS NULL))', '((backup_id IS NULL) = (backup_change_sequence IS NULL))'),
+		(ARRAY[19,23]::smallint[], '((backup_id IS NULL) = (backup_source_schema IS NULL))', '((backup_id IS NULL) = (backup_source_schema IS NULL))'),
+		(ARRAY[19,24]::smallint[], '((backup_id IS NULL) = (backup_snapshot_id IS NULL))', '((backup_id IS NULL) = (backup_snapshot_id IS NULL))'),
+		(ARRAY[19,25]::smallint[], '((backup_id IS NULL) = (backup_manifest_sha256 IS NULL))', '((backup_id IS NULL) = (backup_manifest_sha256 IS NULL))'),
+		(ARRAY[18,19]::smallint[], '((phase = ANY (ARRAY[''fenced''::text, ''writers_stopped''::text, ''aborted''::text])) OR (backup_id IS NOT NULL))', '((phase = ANY (ARRAY[''fenced''::text, ''writers_stopped''::text, ''aborted''::text])) OR (backup_id IS NOT NULL))'),
+		(ARRAY[18,28]::smallint[], '((phase = ANY (ARRAY[''committed''::text, ''recovered''::text, ''aborted''::text])) = (completed_at IS NOT NULL))', '((phase = ANY (ARRAY[''committed''::text, ''recovered''::text, ''aborted''::text])) = (completed_at IS NOT NULL))')
+	), constraint_safety AS (
+		SELECT (SELECT count(*)=29 FROM pg_constraint,objects WHERE conrelid=updates_oid)
+		   AND (SELECT count(*)=1 FROM pg_constraint,objects WHERE conrelid=updates_oid AND contype='p' AND conkey=ARRAY[1]::smallint[] AND convalidated AND NOT condeferrable AND NOT condeferred)
+		   AND (SELECT count(*)=1 FROM pg_constraint,objects WHERE conrelid=updates_oid AND contype='f' AND conkey=ARRAY[4]::smallint[] AND confrelid='auth.principals'::regclass AND confkey=ARRAY[1]::smallint[] AND confupdtype='a' AND confdeltype='a' AND confmatchtype='s' AND convalidated AND NOT condeferrable AND NOT condeferred)
+		   AND (SELECT count(*)=27 FROM pg_constraint,objects WHERE conrelid=updates_oid AND contype='c' AND convalidated AND NOT condeferrable AND NOT condeferred)
+		   AND NOT EXISTS (SELECT 1 FROM expected_checks,objects WHERE NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conrelid=updates_oid AND contype='c' AND convalidated AND NOT condeferrable AND NOT condeferred AND conkey @> expected_checks.key AND conkey <@ expected_checks.key AND pg_get_expr(conbin,conrelid) IN (expected_checks.migration_expression,expected_checks.restored_expression))) AS safe
+	), routine_safety AS (
+	    SELECT count(*) = 6
+	       AND bool_and(pg_get_userbyid(proc.proowner) = 'punaro_owner' AND proc.prosecdef AND proc.prokind = 'f')
+	       AND bool_and(COALESCE(proc.proconfig = ARRAY['search_path=pg_catalog']::text[], false))
+	       AND bool_and(md5(btrim(proc.prosrc)) = expected.body_hash AND language.lanname=expected.language_name
+	           AND proc.provolatile=expected.volatility AND pg_get_function_result(proc.oid)=expected.result_type
+	           AND NOT proc.proisstrict AND NOT proc.proleakproof AND proc.proparallel='u' AND proc.provariadic=0
+	           AND proc.proargmodes IS NULL AND proc.proallargtypes IS NULL) AS safe
+	    FROM expected_routines AS expected
+	    JOIN pg_proc AS proc ON proc.oid = expected.oid
+	    JOIN pg_language AS language ON language.oid=proc.prolang
+	), routine_acl AS (
+		SELECT count(*)=8 AND bool_and(NOT acl.is_grantable AND (grantee.rolname='punaro_owner' OR (grantee.rolname='punaro_app' AND proc.oid IN (objects.assert_oid,objects.active_oid)))) AS exact
+		FROM objects JOIN pg_proc AS proc ON proc.oid=ANY(ARRAY[assert_oid,guard_oid,begin_oid,advance_oid,restore_oid,active_oid])
+		CROSS JOIN LATERAL aclexplode(COALESCE(proc.proacl,acldefault('f',proc.proowner))) AS acl
+		LEFT JOIN pg_roles AS grantee ON grantee.oid=acl.grantee
+	), table_safety AS (
+		SELECT relation.relkind='r' AND relation.relpersistence='p' AND NOT relation.relrowsecurity AND NOT relation.relforcerowsecurity
+		   AND pg_get_userbyid(relation.relowner)='punaro_owner'
+		   AND (SELECT count(*)=7 AND bool_and(grantee.rolname='punaro_owner' AND NOT acl.is_grantable)
+		        FROM LATERAL aclexplode(COALESCE(relation.relacl,acldefault('r',relation.relowner))) AS acl
+		        LEFT JOIN pg_roles AS grantee ON grantee.oid=acl.grantee)
+		   AND NOT EXISTS (SELECT 1 FROM pg_attribute WHERE attrelid=relation.oid AND attnum>0 AND attacl IS NOT NULL) AS safe
+		FROM objects JOIN pg_class AS relation ON relation.oid=objects.updates_oid
+	), trigger_safety AS (
+		SELECT count(*) = 19
+	       AND bool_and(trigger.tgenabled = 'O' AND NOT trigger.tgisinternal
+	           AND trigger.tgtype = 62 AND trigger.tgfoid = objects.guard_oid AND trigger.tgconstraint=0
+	           AND NOT trigger.tgdeferrable AND NOT trigger.tginitdeferred AND trigger.tgnargs=0
+	           AND trigger.tgqual IS NULL AND trigger.tgnewtable IS NULL AND trigger.tgoldtable IS NULL
+	           AND trigger.tgattr::text='') AS safe
+	FROM expected_tables
+	JOIN pg_trigger AS trigger ON trigger.tgrelid = expected_tables.oid
+	   AND trigger.tgname = 'application_mutation_fence'
+	CROSS JOIN objects
+)
+SELECT updates_oid IS NOT NULL AND active_index_oid IS NOT NULL
+   AND assert_oid IS NOT NULL AND guard_oid IS NOT NULL AND begin_oid IS NOT NULL
+   AND advance_oid IS NOT NULL AND restore_oid IS NOT NULL AND active_oid IS NOT NULL
+	   AND column_safety.safe AND constraint_safety.safe AND routine_safety.safe AND routine_acl.exact AND table_safety.safe AND trigger_safety.safe
+	   AND (SELECT index.indisunique AND index.indisvalid AND index.indisready AND index.indislive AND index.indimmediate
+	        AND NOT index.indisprimary AND NOT index.indisexclusion AND NOT index.indisclustered
+	        AND index.indrelid = updates_oid AND index.indnkeyatts=1 AND index.indnatts=1 AND index.indkey::text='0'
+	        AND index.indcollation::text='0' AND index.indoption::text='0'
+	        AND index.indclass[0]=(SELECT oid FROM pg_opclass WHERE opcname='bool_ops' AND opcmethod=access_method.oid)
+	        AND index_relation.relkind='i' AND pg_get_userbyid(index_relation.relowner)='punaro_owner' AND access_method.amname='btree'
+	        AND pg_get_expr(index.indexprs,index.indrelid)='true'
+	        AND pg_get_expr(index.indpred,index.indrelid) = '(phase <> ALL (ARRAY[''committed''::text, ''recovered''::text, ''aborted''::text]))'
+	        FROM pg_index AS index JOIN pg_class AS index_relation ON index_relation.oid=index.indexrelid
+	        JOIN pg_am AS access_method ON access_method.oid=index_relation.relam WHERE index.indexrelid = active_index_oid)
+	FROM objects,column_safety,constraint_safety,routine_safety,routine_acl,table_safety,trigger_safety`
+
+func updateControlsAvailable(ctx context.Context, q queryer) (bool, error) {
+	var available bool
+	err := q.QueryRowContext(ctx, updateControlsInspectionSQL).Scan(&available)
+	if err != nil {
+		return false, errors.New("PostgreSQL update controls cannot be inspected")
+	}
+	return available, nil
+}
+
+func administrationSchemaAllowed(state SchemaState, bridgeControls, knownBridge bool) bool {
+	return state.Classification == Compatible || (state.Classification == UpgradeRequired && state.Version == 5 && bridgeControls && knownBridge)
+}
+
+// BeginUpdate drains mutation transactions through the database gate and then
+// publishes exactly one durable active owner. Exact retries return that owner.
+func (a *Administration) BeginUpdate(ctx context.Context, request UpdateRequest) (UpdateTransaction, error) {
+	if request.Validate() != nil {
+		return UpdateTransaction{}, errors.New("invalid update request")
+	}
+	transaction, err := scanUpdate(a.db.QueryRowContext(ctx, `SELECT `+updateSelectColumns+` FROM jobs.begin_update($1::uuid,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14)`, request.UpdateID, request.SourceRelease, request.TargetRelease, request.SourceImage, request.TargetImage, request.SourceSchema, request.TargetSchema, request.SchemaMin, request.SchemaMax, request.RollbackFloor, request.PostgresMajor, request.ReleaseSHA256, request.ComposeSHA256, request.MigrationManifestSHA256))
+	if err != nil {
+		if strings.Contains(err.Error(), "update fence is already owned") {
+			return UpdateTransaction{}, ErrUpdateConflict
+		}
+		return UpdateTransaction{}, errors.New("update transaction could not acquire the maintenance fence")
+	}
+	return transaction, nil
+}
+
+// ActiveUpdate returns the one unfinished durable update, if present.
+func (a *Administration) ActiveUpdate(ctx context.Context) (UpdateTransaction, error) {
+	transaction, err := scanUpdate(a.db.QueryRowContext(ctx, `SELECT `+updateSelectColumns+` FROM jobs.update_transactions WHERE phase NOT IN ('committed','recovered','aborted')`))
+	if errors.Is(err, sql.ErrNoRows) {
+		return UpdateTransaction{}, ErrNotFound
+	}
+	if err != nil {
+		return UpdateTransaction{}, errors.New("update transaction is unavailable")
+	}
+	return transaction, nil
+}
+
+// LatestUpdate returns the newest durable update outcome or active transaction.
+// It lets the host reconcile a lost final command response after the active
+// fence has already committed.
+func (a *Administration) LatestUpdate(ctx context.Context) (UpdateTransaction, error) {
+	transaction, err := scanUpdate(a.db.QueryRowContext(ctx, `SELECT `+updateSelectColumns+` FROM jobs.update_transactions ORDER BY created_at DESC, update_id DESC LIMIT 1`))
+	if errors.Is(err, sql.ErrNoRows) {
+		return UpdateTransaction{}, ErrNotFound
+	}
+	if err != nil {
+		return UpdateTransaction{}, errors.New("latest update transaction is unavailable")
+	}
+	return transaction, nil
+}
+
+// Update returns one exact durable transaction, including terminal outcomes.
+func (a *Administration) Update(ctx context.Context, updateID string) (UpdateTransaction, error) {
+	if uuid.Validate(updateID) != nil {
+		return UpdateTransaction{}, errors.New("invalid update identity")
+	}
+	transaction, err := scanUpdate(a.db.QueryRowContext(ctx, `SELECT `+updateSelectColumns+` FROM jobs.update_transactions WHERE update_id=$1::uuid`, updateID))
+	if errors.Is(err, sql.ErrNoRows) {
+		return UpdateTransaction{}, ErrNotFound
+	}
+	if err != nil {
+		return UpdateTransaction{}, errors.New("update transaction is unavailable")
+	}
+	return transaction, nil
+}
+
+// AdvanceUpdate performs one CAS phase transition. Backup verification requires
+// the exact marker; commit/abort are the only operations that release the gate.
+func (a *Administration) AdvanceUpdate(ctx context.Context, updateID string, from, to UpdatePhase, marker *UpdateBackupMarker) (UpdateTransaction, error) {
+	if uuid.Validate(updateID) != nil || validateUpdateTransition(from, to) != nil || (to == UpdateBackupVerified && (marker == nil || marker.Validate() != nil || marker.UpdateID != updateID)) || (to != UpdateBackupVerified && marker != nil) {
+		return UpdateTransaction{}, ErrInvalidUpdateTransition
+	}
+	var backupID any
+	if marker != nil {
+		backupID = marker.BackupID
+	}
+	transaction, err := scanUpdate(a.db.QueryRowContext(ctx, `SELECT `+updateSelectColumns+` FROM jobs.advance_update($1::uuid,$2,$3,$4::uuid,$5::uuid,$6::uuid,$7,$8,$9,$10,$11,$12)`, updateID, from, to, backupID, nullableText(marker, func(m *UpdateBackupMarker) string { return m.InstallationID }), nullableText(marker, func(m *UpdateBackupMarker) string { return m.TimelineID }), optionalInt64(marker, func(m *UpdateBackupMarker) int64 { return m.ChangeSequence }), optionalInt64(marker, func(m *UpdateBackupMarker) int64 { return m.SourceSchema }), nullableText(marker, func(m *UpdateBackupMarker) string { return m.TargetRelease }), nullableText(marker, func(m *UpdateBackupMarker) string { return m.TargetImageDigest }), nullableText(marker, func(m *UpdateBackupMarker) string { return m.ExportedSnapshotID }), nullableText(marker, func(m *UpdateBackupMarker) string { return m.ManifestSHA256 })))
+	if err != nil {
+		return UpdateTransaction{}, ErrInvalidUpdateTransition
+	}
+	return transaction, nil
+}
+
+// RestoreUpdateRecovery atomically rotates a restored pre-update timeline and
+// reconstructs the durable backup marker which, by design, was recorded only
+// after the exported snapshot. Exact retries return the same recovery state.
+func (a *Administration) RestoreUpdateRecovery(ctx context.Context, marker UpdateBackupMarker) (InstallationState, UpdateTransaction, error) {
+	if marker.Validate() != nil {
+		return InstallationState{}, UpdateTransaction{}, errors.New("invalid restored update authorization")
+	}
+	tx, err := a.db.BeginTx(ctx, nil)
+	if err != nil {
+		return InstallationState{}, UpdateTransaction{}, errors.New("restored update recovery could not start")
+	}
+	defer func() { _ = tx.Rollback() }()
+	transaction, err := scanUpdate(tx.QueryRowContext(ctx, `SELECT `+updateSelectColumns+` FROM jobs.restore_update_recovery($1::uuid,$2::uuid,$3::uuid,$4::uuid,$5,$6,$7,$8,$9,$10)`, marker.UpdateID, marker.BackupID, marker.InstallationID, marker.TimelineID, marker.ChangeSequence, marker.SourceSchema, marker.TargetRelease, marker.TargetImageDigest, marker.ExportedSnapshotID, marker.ManifestSHA256))
+	if err != nil {
+		return InstallationState{}, UpdateTransaction{}, errors.New("restored update evidence does not match")
+	}
+	var state InstallationState
+	if err := tx.QueryRowContext(ctx, `SELECT installation_id::text,timeline_id::text,change_sequence FROM jobs.server_state WHERE singleton`).Scan(&state.InstallationID, &state.TimelineID, &state.ChangeSequence); err != nil ||
+		state.InstallationID != marker.InstallationID || state.TimelineID == marker.TimelineID || state.ChangeSequence != marker.ChangeSequence ||
+		transaction.UpdateID != marker.UpdateID || transaction.Phase != UpdateRecoveryRequired || transaction.BackupID != marker.BackupID ||
+		transaction.TargetRelease != marker.TargetRelease || !strings.HasSuffix(transaction.TargetImage, "@"+marker.TargetImageDigest) ||
+		transaction.BackupInstallationID != marker.InstallationID || transaction.BackupTimelineID != marker.TimelineID || transaction.BackupChangeSequence != marker.ChangeSequence ||
+		transaction.BackupSourceSchema != marker.SourceSchema || transaction.BackupSnapshotID != marker.ExportedSnapshotID || transaction.BackupManifestSHA256 != marker.ManifestSHA256 {
+		return InstallationState{}, UpdateTransaction{}, errors.New("restored update recovery result is invalid")
+	}
+	if err := tx.Commit(); err != nil {
+		return InstallationState{}, UpdateTransaction{}, errors.New("restored update recovery could not be committed")
+	}
+	return state, transaction, nil
+}
+
+func nullableText[T any](value *T, field func(*T) string) any {
+	if value == nil {
+		return nil
+	}
+	return field(value)
+}
+
+func optionalInt64[T any](value *T, field func(*T) int64) any {
+	if value == nil {
+		return nil
+	}
+	return field(value)
+}

--- a/internal/postgres/update.go
+++ b/internal/postgres/update.go
@@ -358,7 +358,7 @@ SELECT updates_oid IS NOT NULL AND active_index_oid IS NOT NULL
 	        AND NOT index.indisprimary AND NOT index.indisexclusion AND NOT index.indisclustered
 	        AND index.indrelid = updates_oid AND index.indnkeyatts=1 AND index.indnatts=1 AND index.indkey::text='0'
 	        AND index.indcollation::text='0' AND index.indoption::text='0'
-	        AND index.indclass::oid[]=ARRAY[(SELECT oid FROM pg_opclass WHERE opcname='bool_ops' AND opcmethod=access_method.oid)]::oid[]
+	        AND index.indclass::text=(SELECT oid::text FROM pg_opclass WHERE opcname='bool_ops' AND opcmethod=access_method.oid)
 	        AND index_relation.relkind='i' AND pg_get_userbyid(index_relation.relowner)='punaro_owner' AND access_method.amname='btree'
 	        AND pg_get_expr(index.indexprs,index.indrelid)='true'
 	        AND pg_get_expr(index.indpred,index.indrelid) = '(phase <> ALL (ARRAY[''committed''::text, ''recovered''::text, ''aborted''::text]))'

--- a/internal/postgres/update.go
+++ b/internal/postgres/update.go
@@ -242,16 +242,16 @@ WITH objects AS (
 	    ) AS expected(oid, body_hash, language_name, volatility, result_type)
 	), expected_tables(oid) AS (
     SELECT unnest(ARRAY[
-        'jobs.server_state'::regclass, 'auth.principals'::regclass,
-        'relay.projects'::regclass, 'auth.capability_grants'::regclass,
-        'relay.idempotency_records'::regclass, 'audit.events'::regclass,
-        'jobs.queue_capacity'::regclass, 'jobs.outbox'::regclass,
-        'auth.installation_owner'::regclass, 'auth.pending_enrollments'::regclass,
-        'auth.pending_enrollment_grants'::regclass, 'auth.device_credentials'::regclass,
-        'auth.legacy_auth_state'::regclass, 'auth.legacy_machines'::regclass,
-        'auth.project_acl_state'::regclass, 'relay.project_identities'::regclass,
-        'relay.project_lookup_aliases'::regclass, 'relay.project_merge_previews'::regclass,
-        'attachment.ready_blob_manifest'::regclass
+        to_regclass('jobs.server_state'), to_regclass('auth.principals'),
+        to_regclass('relay.projects'), to_regclass('auth.capability_grants'),
+        to_regclass('relay.idempotency_records'), to_regclass('audit.events'),
+        to_regclass('jobs.queue_capacity'), to_regclass('jobs.outbox'),
+        to_regclass('auth.installation_owner'), to_regclass('auth.pending_enrollments'),
+        to_regclass('auth.pending_enrollment_grants'), to_regclass('auth.device_credentials'),
+        to_regclass('auth.legacy_auth_state'), to_regclass('auth.legacy_machines'),
+        to_regclass('auth.project_acl_state'), to_regclass('relay.project_identities'),
+        to_regclass('relay.project_lookup_aliases'), to_regclass('relay.project_merge_previews'),
+        to_regclass('attachment.ready_blob_manifest')
     ])
 	), expected_columns(attnum, column_name, type_oid, type_modifier, required, default_expression) AS (
 		VALUES
@@ -312,7 +312,7 @@ WITH objects AS (
 		          AND count(*)=29+CASE WHEN current_setting('server_version_num')::integer/10000 >= 18 THEN 20 ELSE 0 END
 		        FROM pg_constraint,objects WHERE conrelid=updates_oid)
 		   AND (SELECT count(*)=1 FROM pg_constraint,objects WHERE conrelid=updates_oid AND contype='p' AND conkey=ARRAY[1]::smallint[] AND convalidated AND NOT condeferrable AND NOT condeferred)
-		   AND (SELECT count(*)=1 FROM pg_constraint,objects WHERE conrelid=updates_oid AND contype='f' AND conkey=ARRAY[4]::smallint[] AND confrelid='auth.principals'::regclass AND confkey=ARRAY[1]::smallint[] AND confupdtype='a' AND confdeltype='a' AND confmatchtype='s' AND convalidated AND NOT condeferrable AND NOT condeferred)
+		   AND (SELECT count(*)=1 FROM pg_constraint,objects WHERE conrelid=updates_oid AND contype='f' AND conkey=ARRAY[4]::smallint[] AND confrelid=to_regclass('auth.principals') AND confkey=ARRAY[1]::smallint[] AND confupdtype='a' AND confdeltype='a' AND confmatchtype='s' AND convalidated AND NOT condeferrable AND NOT condeferred)
 		   AND (SELECT count(*)=27 FROM pg_constraint,objects WHERE conrelid=updates_oid AND contype='c' AND convalidated AND NOT condeferrable AND NOT condeferred)
 		   AND (current_setting('server_version_num')::integer/10000 < 18 OR NOT EXISTS (
 		       SELECT 1 FROM expected_columns,objects WHERE required AND NOT EXISTS (

--- a/internal/postgres/update_bridge.go
+++ b/internal/postgres/update_bridge.go
@@ -1,0 +1,175 @@
+package postgres
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"sync"
+)
+
+// V5UpdateBridge is the one-time transactional bridge from the last schema
+// that predates the durable mutation fence. Its transaction retains exclusive
+// locks on every v5 mutable relation until the caller has stopped all writers.
+type V5UpdateBridge struct {
+	mu          sync.Mutex
+	database    *sql.DB
+	connection  *sql.Conn
+	transaction *sql.Tx
+	update      UpdateTransaction
+	closed      bool
+}
+
+func validateV5BridgeRequest(request UpdateRequest) error {
+	if request.Validate() != nil || request.SourceSchema != 5 || request.TargetSchema != 6 {
+		return errors.New("v5 update bridge requires the exact v5 to v6 boundary")
+	}
+	return nil
+}
+
+// BeginV5UpdateBridge drains v5 writes under ACCESS EXCLUSIVE locks, installs
+// only the additive update-control migration, and stages the durable fence in
+// the same uncommitted owner transaction. The caller must stop every writer and
+// then call CommitWritersStopped; a crash or Abort rolls everything back.
+func BeginV5UpdateBridge(ctx context.Context, cfg Config, request UpdateRequest) (*V5UpdateBridge, error) {
+	if validateV5BridgeRequest(request) != nil {
+		return nil, errors.New("invalid v5 update bridge request")
+	}
+	dsn, err := ReadDSNFile(cfg.DSNFile)
+	if err != nil {
+		return nil, err
+	}
+	database, err := open(ctx, dsn)
+	if err != nil {
+		return nil, err
+	}
+	closeDatabase := true
+	defer func() {
+		if closeDatabase {
+			_ = database.Close()
+		}
+	}()
+	connection, err := database.Conn(ctx)
+	if err != nil {
+		return nil, errors.New("v5 update bridge connection is unavailable")
+	}
+	closeConnection := true
+	defer func() {
+		if closeConnection {
+			_ = connection.Close()
+		}
+	}()
+	if err := verifyMigrationRoles(ctx, connection); err != nil {
+		return nil, err
+	}
+	snapshot, err := inspect(ctx, connection)
+	if err != nil {
+		return nil, err
+	}
+	state := Classify(snapshot, CurrentManifest())
+	if state.Classification != UpgradeRequired || state.Version != 5 {
+		return nil, errors.New("v5 update bridge requires an intact v5 schema")
+	}
+	var postgresMajor int
+	if err := connection.QueryRowContext(ctx, `SELECT current_setting('server_version_num')::integer / 10000`).Scan(&postgresMajor); err != nil || postgresMajor != request.PostgresMajor {
+		return nil, errors.New("v5 update bridge PostgreSQL major does not match the target release")
+	}
+	existingControls, controlsErr := updateControlsAvailable(ctx, connection)
+	if controlsErr != nil {
+		return nil, controlsErr
+	}
+	tx, err := connection.BeginTx(ctx, nil)
+	if err != nil {
+		return nil, errors.New("v5 update bridge transaction cannot start")
+	}
+	rollback := true
+	defer func() {
+		if rollback {
+			_ = tx.Rollback()
+		}
+	}()
+	if _, err := tx.ExecContext(ctx, `SET LOCAL lock_timeout = '30s'`); err != nil {
+		return nil, errors.New("v5 update bridge lock timeout cannot be bounded")
+	}
+	if !existingControls {
+		if _, err := tx.ExecContext(ctx, `SELECT pg_advisory_xact_lock(579001230607)`); err != nil {
+			return nil, errors.New("v5 update bridge coordinator lock is unavailable")
+		}
+		if _, err := tx.ExecContext(ctx, `LOCK TABLE
+jobs.schema_migrations, jobs.server_state,
+auth.principals, relay.projects, auth.capability_grants,
+relay.idempotency_records, audit.events, jobs.queue_capacity, jobs.outbox,
+auth.installation_owner, auth.pending_enrollments, auth.pending_enrollment_grants,
+auth.device_credentials, auth.legacy_auth_state, auth.legacy_machines,
+auth.project_acl_state, relay.project_identities, relay.project_lookup_aliases,
+relay.project_merge_previews, attachment.ready_blob_manifest
+IN ACCESS EXCLUSIVE MODE`); err != nil {
+			return nil, errors.New("v5 application mutations could not be drained")
+		}
+		migration := CurrentManifest().Migrations[5]
+		if _, err := tx.ExecContext(ctx, migration.SQL); err != nil {
+			return nil, errors.New("v5 update bridge controls could not be installed")
+		}
+	}
+	update, err := scanUpdate(tx.QueryRowContext(ctx, `SELECT `+updateSelectColumns+` FROM jobs.begin_update($1::uuid,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14)`, request.UpdateID, request.SourceRelease, request.TargetRelease, request.SourceImage, request.TargetImage, request.SourceSchema, request.TargetSchema, request.SchemaMin, request.SchemaMax, request.RollbackFloor, request.PostgresMajor, request.ReleaseSHA256, request.ComposeSHA256, request.MigrationManifestSHA256))
+	if err != nil {
+		return nil, errors.New("v5 update bridge fence could not be staged")
+	}
+	rollback = false
+	closeConnection = false
+	closeDatabase = false
+	return &V5UpdateBridge{database: database, connection: connection, transaction: tx, update: update}, nil
+}
+
+// Update returns the immutable staged transaction identity.
+func (bridge *V5UpdateBridge) Update() UpdateTransaction {
+	bridge.mu.Lock()
+	defer bridge.mu.Unlock()
+	return bridge.update
+}
+
+// CommitWritersStopped durably publishes both the fence and the proof that the
+// old writer set was stopped while its relation locks were still held.
+func (bridge *V5UpdateBridge) CommitWritersStopped(ctx context.Context) (UpdateTransaction, error) {
+	bridge.mu.Lock()
+	defer bridge.mu.Unlock()
+	if bridge.closed || bridge.transaction == nil {
+		return UpdateTransaction{}, errors.New("v5 update bridge is closed")
+	}
+	update, err := scanUpdate(bridge.transaction.QueryRowContext(ctx, `SELECT `+updateSelectColumns+` FROM jobs.advance_update($1::uuid,'fenced','writers_stopped',NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL)`, bridge.update.UpdateID))
+	if err != nil {
+		return UpdateTransaction{}, errors.New("v5 update bridge writer stop could not be staged")
+	}
+	if err := bridge.transaction.Commit(); err != nil {
+		bridge.close()
+		return UpdateTransaction{}, errors.New("v5 update bridge outcome is uncertain; inspect the durable update transaction")
+	}
+	bridge.update = update
+	bridge.close()
+	return update, nil
+}
+
+// Abort rolls back the uncommitted bridge. It is safe only before the caller
+// reports writer shutdown as complete.
+func (bridge *V5UpdateBridge) Abort() error {
+	bridge.mu.Lock()
+	defer bridge.mu.Unlock()
+	if bridge.closed {
+		return nil
+	}
+	err := bridge.transaction.Rollback()
+	bridge.close()
+	return err
+}
+
+func (bridge *V5UpdateBridge) close() {
+	bridge.closed = true
+	bridge.transaction = nil
+	if bridge.connection != nil {
+		_ = bridge.connection.Close()
+		bridge.connection = nil
+	}
+	if bridge.database != nil {
+		_ = bridge.database.Close()
+		bridge.database = nil
+	}
+}

--- a/internal/postgres/update_bridge_test.go
+++ b/internal/postgres/update_bridge_test.go
@@ -1,0 +1,38 @@
+package postgres
+
+import "testing"
+
+func TestV5UpdateBridgeBoundary(t *testing.T) {
+	valid := UpdateRequest{
+		UpdateID:                "019b4eb0-21f8-7d93-84df-10e6cf05ce53",
+		SourceRelease:           "v0.6.0",
+		TargetRelease:           "v0.7.0",
+		SourceImage:             "ghcr.io/rock3r/punaro@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+		TargetImage:             "ghcr.io/rock3r/punaro@sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+		SourceSchema:            5,
+		TargetSchema:            6,
+		SchemaMin:               5,
+		SchemaMax:               6,
+		RollbackFloor:           5,
+		PostgresMajor:           17,
+		ReleaseSHA256:           "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+		ComposeSHA256:           "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+		MigrationManifestSHA256: "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+	}
+	if err := validateV5BridgeRequest(valid); err != nil {
+		t.Fatalf("valid bridge rejected: %v", err)
+	}
+	for name, mutate := range map[string]func(*UpdateRequest){
+		"wrong source": func(r *UpdateRequest) { r.SourceSchema = 4 },
+		"wrong target": func(r *UpdateRequest) { r.TargetSchema = 7 },
+		"image only":   func(r *UpdateRequest) { r.TargetSchema = 5 },
+	} {
+		t.Run(name, func(t *testing.T) {
+			request := valid
+			mutate(&request)
+			if validateV5BridgeRequest(request) == nil {
+				t.Fatal("unsafe bridge boundary accepted")
+			}
+		})
+	}
+}

--- a/internal/postgres/update_test.go
+++ b/internal/postgres/update_test.go
@@ -1,0 +1,151 @@
+package postgres
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestUpdateRequestValidation(t *testing.T) {
+	valid := UpdateRequest{
+		UpdateID:                "019b4eb0-21f8-7d93-84df-10e6cf05ce53",
+		SourceRelease:           "v0.6.0",
+		TargetRelease:           "v0.7.0",
+		SourceImage:             "ghcr.io/rock3r/punaro@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+		TargetImage:             "ghcr.io/rock3r/punaro@sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+		SourceSchema:            6,
+		TargetSchema:            7,
+		SchemaMin:               6,
+		SchemaMax:               7,
+		RollbackFloor:           6,
+		PostgresMajor:           17,
+		ReleaseSHA256:           "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+		ComposeSHA256:           "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+		MigrationManifestSHA256: "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+	}
+	if err := valid.Validate(); err != nil {
+		t.Fatalf("valid request rejected: %v", err)
+	}
+	for name, mutate := range map[string]func(*UpdateRequest){
+		"invalid id":        func(r *UpdateRequest) { r.UpdateID = "not-a-uuid" },
+		"same release":      func(r *UpdateRequest) { r.TargetRelease = r.SourceRelease },
+		"unpinned target":   func(r *UpdateRequest) { r.TargetImage = "ghcr.io/rock3r/punaro:latest" },
+		"schema downgrade":  func(r *UpdateRequest) { r.TargetSchema = r.SourceSchema - 1 },
+		"postgres too old":  func(r *UpdateRequest) { r.PostgresMajor = 13 },
+		"unbounded release": func(r *UpdateRequest) { r.TargetRelease = string(make([]byte, 129)) },
+	} {
+		t.Run(name, func(t *testing.T) {
+			request := valid
+			mutate(&request)
+			if request.Validate() == nil {
+				t.Fatal("invalid request accepted")
+			}
+		})
+	}
+}
+
+func TestUpdatePhaseTransitionsAreFailClosed(t *testing.T) {
+	allowed := []struct {
+		from UpdatePhase
+		to   UpdatePhase
+	}{
+		{UpdateFenced, UpdateWritersStopped},
+		{UpdateWritersStopped, UpdateBackupVerified},
+		{UpdateBackupVerified, UpdateMigrationStarted},
+		{UpdateBackupVerified, UpdateAborted},
+		{UpdateMigrationStarted, UpdateMigrated},
+		{UpdateMigrated, UpdateCandidateReady},
+		{UpdateCandidateReady, UpdateDoctorPassed},
+		{UpdateDoctorPassed, UpdateConfigPublished},
+		{UpdateConfigPublished, UpdateCommitted},
+		{UpdateFenced, UpdateAborted},
+		{UpdateWritersStopped, UpdateAborted},
+		{UpdateMigrationStarted, UpdateRecoveryRequired},
+		{UpdateMigrated, UpdateRecoveryRequired},
+		{UpdateRecoveryRequired, UpdateRecoveryReady},
+		{UpdateRecoveryReady, UpdateRecoveryDoctor},
+		{UpdateRecoveryDoctor, UpdateRecoveryConfig},
+		{UpdateRecoveryConfig, UpdateRecovered},
+	}
+	for _, transition := range allowed {
+		if err := validateUpdateTransition(transition.from, transition.to); err != nil {
+			t.Fatalf("transition %s -> %s rejected: %v", transition.from, transition.to, err)
+		}
+	}
+	for _, transition := range [][2]UpdatePhase{
+		{UpdateFenced, UpdateMigrationStarted},
+		{UpdateMigrated, UpdateCommitted},
+		{UpdateCommitted, UpdateFenced},
+		{UpdateAborted, UpdateFenced},
+		{"unknown", UpdateCommitted},
+	} {
+		if err := validateUpdateTransition(transition[0], transition[1]); !errors.Is(err, ErrInvalidUpdateTransition) {
+			t.Fatalf("transition %s -> %s error=%v", transition[0], transition[1], err)
+		}
+	}
+}
+
+func TestBackupMarkerBindsExactUpdateBoundary(t *testing.T) {
+	marker := UpdateBackupMarker{
+		UpdateID:           "019b4eb0-21f8-7d93-84df-10e6cf05ce53",
+		BackupID:           "019b4eb0-5317-79a6-a0de-fd97719910fb",
+		InstallationID:     "4e02b0e5-1934-4dda-9c4a-767c120c2fac",
+		TimelineID:         "797476ad-8fdc-4c05-b144-3ccbb92b54bf",
+		ChangeSequence:     42,
+		SourceSchema:       6,
+		TargetRelease:      "v0.7.0",
+		TargetImageDigest:  "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+		ExportedSnapshotID: "00000003-0000001B-1",
+		ManifestSHA256:     "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+	}
+	if err := marker.Validate(); err != nil {
+		t.Fatalf("valid marker rejected: %v", err)
+	}
+	marker.ChangeSequence = -1
+	if marker.Validate() == nil {
+		t.Fatal("negative backup boundary accepted")
+	}
+}
+
+func TestOrdinaryMigratorNeverPerformsUpgrade(t *testing.T) {
+	if migrationAuthorizationRequired(SchemaState{Classification: Pristine}) {
+		t.Fatal("pristine initialization unexpectedly requires update authorization")
+	}
+	if !migrationAuthorizationRequired(SchemaState{Classification: UpgradeRequired, Version: 5}) {
+		t.Fatal("existing schema upgrade did not require update authorization")
+	}
+	if migrationAuthorizationRequired(SchemaState{Classification: Compatible, Version: 6}) {
+		t.Fatal("compatible no-op migration unexpectedly requires authorization")
+	}
+}
+
+func TestUpdateMigrationAuthorizationValidation(t *testing.T) {
+	valid := UpdateMigrationAuthorization{
+		UpdateID:           "019b4eb0-21f8-7d93-84df-10e6cf05ce53",
+		BackupID:           "019b4eb0-5317-79a6-a0de-fd97719910fb",
+		TargetRelease:      "v0.7.0",
+		TargetImage:        "ghcr.io/rock3r/punaro@sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+		TargetSchema:       6,
+		ExportedSnapshotID: "00000003-0000001B-1",
+		ManifestSHA256:     "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+	}
+	if err := valid.Validate(); err != nil {
+		t.Fatalf("valid migration authorization rejected: %v", err)
+	}
+	valid.BackupID = "invalid"
+	if valid.Validate() == nil {
+		t.Fatal("invalid migration authorization accepted")
+	}
+}
+
+func TestAdministrationAllowsOnlyExactActiveBridge(t *testing.T) {
+	if !administrationSchemaAllowed(SchemaState{Classification: Compatible, Version: 6}, false, false) {
+		t.Fatal("compatible administration rejected")
+	}
+	bridge := SchemaState{Classification: UpgradeRequired, Version: 5}
+	if !administrationSchemaAllowed(bridge, true, true) {
+		t.Fatal("active exact bridge rejected")
+	}
+	if administrationSchemaAllowed(bridge, false, true) || administrationSchemaAllowed(bridge, true, false) {
+		t.Fatal("incomplete bridge evidence accepted")
+	}
+}

--- a/internal/release/metadata.go
+++ b/internal/release/metadata.go
@@ -1,0 +1,169 @@
+// Package release validates local target-release metadata. Validation binds
+// exact artifact digests and compatibility boundaries; it does not fetch
+// artifacts, access a network, or claim signature or provenance verification.
+package release
+
+import (
+	"bytes"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"io"
+	"regexp"
+	"strings"
+)
+
+// MaximumMetadataBytes bounds one target-release metadata document.
+const MaximumMetadataBytes = 64 << 10
+
+var (
+	releaseNamePattern     = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9._+-]{0,127}$`)
+	imageRepositoryPattern = regexp.MustCompile(`^(?:(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?)(?:\.(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?))*(?::[0-9]+)?/)?[a-z0-9]+(?:(?:[._]|__|-+)[a-z0-9]+)*(?:/[a-z0-9]+(?:(?:[._]|__|-+)[a-z0-9]+)*)*$`)
+)
+
+// Environment is the exact installed boundary against which a target release
+// is evaluated. Parse rejects PostgreSQL major drift and schema downgrades.
+type Environment struct {
+	CurrentSchema   int64
+	PostgreSQLMajor int
+}
+
+// SchemaRange declares the schema compatibility and migration boundary of one
+// release. RollbackFloor is metadata for the later recovery planner; Parse
+// validates its canonical relationship but does not promise in-place rollback.
+type SchemaRange struct {
+	Min           int64 `json:"min"`
+	Max           int64 `json:"max"`
+	Target        int64 `json:"target"`
+	RollbackFloor int64 `json:"rollback_floor"`
+}
+
+// Metadata binds one named release to immutable local artifact hashes and an
+// exact database compatibility boundary.
+type Metadata struct {
+	Release                 string      `json:"release"`
+	Image                   string      `json:"image"`
+	Schema                  SchemaRange `json:"schema"`
+	PostgreSQLMajor         int         `json:"postgres_major"`
+	ReleaseSHA256           string      `json:"release_sha256"`
+	ComposeSHA256           string      `json:"compose_sha256"`
+	MigrationManifestSHA256 string      `json:"migration_manifest_sha256"`
+}
+
+// Parse strictly parses and validates one bounded target-release metadata
+// document against the current installation. It performs no I/O or trust
+// verification beyond the supplied bytes.
+func Parse(body []byte, environment Environment) (Metadata, error) {
+	if len(body) == 0 || len(body) > MaximumMetadataBytes {
+		return Metadata{}, errors.New("release metadata is invalid")
+	}
+	if err := rejectDuplicateFields(body); err != nil {
+		return Metadata{}, errors.New("release metadata is invalid")
+	}
+	decoder := json.NewDecoder(bytes.NewReader(body))
+	decoder.DisallowUnknownFields()
+	var metadata Metadata
+	if err := decoder.Decode(&metadata); err != nil {
+		return Metadata{}, errors.New("release metadata is invalid")
+	}
+	var trailing any
+	if err := decoder.Decode(&trailing); !errors.Is(err, io.EOF) {
+		return Metadata{}, errors.New("release metadata is invalid")
+	}
+	if metadata.validate(environment) != nil {
+		return Metadata{}, errors.New("release metadata is invalid")
+	}
+	return metadata, nil
+}
+
+func (metadata Metadata) validate(environment Environment) error {
+	if !releaseNamePattern.MatchString(metadata.Release) || !validImageDigest(metadata.Image) || !validSHA256(metadata.ReleaseSHA256) || !validSHA256(metadata.ComposeSHA256) || !validSHA256(metadata.MigrationManifestSHA256) {
+		return errors.New("invalid release binding")
+	}
+	_, imageDigest, _ := strings.Cut(metadata.Image, "@sha256:")
+	if metadata.ReleaseSHA256 != imageDigest {
+		return errors.New("release artifact does not match image")
+	}
+	schema := metadata.Schema
+	if schema.Min < 1 || schema.Max < schema.Min || schema.Target < schema.Min || schema.Target > schema.Max || schema.RollbackFloor < schema.Min || schema.RollbackFloor > schema.Target {
+		return errors.New("invalid schema boundary")
+	}
+	if metadata.PostgreSQLMajor < 1 || environment.PostgreSQLMajor != metadata.PostgreSQLMajor {
+		return errors.New("PostgreSQL major mismatch")
+	}
+	if environment.CurrentSchema < schema.Min || environment.CurrentSchema > schema.Target {
+		return errors.New("schema target is incompatible")
+	}
+	return nil
+}
+
+func validImageDigest(value string) bool {
+	repository, digest, found := strings.Cut(value, "@sha256:")
+	return found && imageRepositoryPattern.MatchString(repository) && validSHA256(digest)
+}
+
+func validSHA256(value string) bool {
+	decoded, err := hex.DecodeString(value)
+	return err == nil && len(decoded) == 32 && hex.EncodeToString(decoded) == value
+}
+
+func rejectDuplicateFields(body []byte) error {
+	decoder := json.NewDecoder(bytes.NewReader(body))
+	decoder.UseNumber()
+	var visit func() error
+	visit = func() error {
+		token, err := decoder.Token()
+		if err != nil {
+			return err
+		}
+		delimiter, ok := token.(json.Delim)
+		if !ok {
+			return nil
+		}
+		switch delimiter {
+		case '{':
+			seen := map[string]struct{}{}
+			for decoder.More() {
+				keyToken, err := decoder.Token()
+				if err != nil {
+					return err
+				}
+				key, ok := keyToken.(string)
+				if !ok {
+					return errors.New("invalid object key")
+				}
+				if _, duplicate := seen[key]; duplicate {
+					return errors.New("duplicate object key")
+				}
+				seen[key] = struct{}{}
+				if err := visit(); err != nil {
+					return err
+				}
+			}
+			end, err := decoder.Token()
+			if err != nil || end != json.Delim('}') {
+				return errors.New("invalid object")
+			}
+		case '[':
+			for decoder.More() {
+				if err := visit(); err != nil {
+					return err
+				}
+			}
+			end, err := decoder.Token()
+			if err != nil || end != json.Delim(']') {
+				return errors.New("invalid array")
+			}
+		default:
+			return errors.New("invalid JSON delimiter")
+		}
+		return nil
+	}
+	if err := visit(); err != nil {
+		return err
+	}
+	if _, err := decoder.Token(); !errors.Is(err, io.EOF) {
+		return errors.New("trailing JSON value")
+	}
+	return nil
+}

--- a/internal/release/metadata_test.go
+++ b/internal/release/metadata_test.go
@@ -1,0 +1,118 @@
+package release
+
+import (
+	"bytes"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+const (
+	testDigestA = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	testDigestB = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+	testDigestC = "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+)
+
+func validMetadataJSON() string {
+	return `{
+  "release": "v0.7.0",
+  "image": "ghcr.io/rock3r/punaro@sha256:` + testDigestA + `",
+  "schema": {"min": 6, "max": 7, "target": 7, "rollback_floor": 6},
+  "postgres_major": 18,
+  "release_sha256": "` + testDigestA + `",
+  "compose_sha256": "` + testDigestB + `",
+  "migration_manifest_sha256": "` + testDigestC + `"
+}`
+}
+
+func TestParseBindsExactTargetReleaseMetadata(t *testing.T) {
+	for _, currentSchema := range []int64{6, 7} {
+		metadata, err := Parse([]byte(validMetadataJSON()), Environment{CurrentSchema: currentSchema, PostgreSQLMajor: 18})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if metadata.Release != "v0.7.0" || metadata.Image != "ghcr.io/rock3r/punaro@sha256:"+testDigestA || metadata.Schema != (SchemaRange{Min: 6, Max: 7, Target: 7, RollbackFloor: 6}) || metadata.PostgreSQLMajor != 18 {
+			t.Fatalf("metadata=%#v", metadata)
+		}
+		if metadata.ReleaseSHA256 != testDigestA || metadata.ComposeSHA256 != testDigestB || metadata.MigrationManifestSHA256 != testDigestC {
+			t.Fatalf("artifact hashes were not bound: %#v", metadata)
+		}
+	}
+}
+
+func TestParseRequiresReleaseArtifactHashToMatchImageDigest(t *testing.T) {
+	body := strings.Replace(validMetadataJSON(), `"release_sha256": "`+testDigestA+`"`, `"release_sha256": "`+testDigestB+`"`, 1)
+	if _, err := Parse([]byte(body), Environment{CurrentSchema: 6, PostgreSQLMajor: 18}); err == nil {
+		t.Fatal("release artifact hash was not bound to the pulled image digest")
+	}
+}
+
+func TestParseRejectsMalformedAndNonCanonicalMetadata(t *testing.T) {
+	valid := validMetadataJSON()
+	tests := map[string]string{
+		"empty":                  "",
+		"truncated":              `{"release":"v0.7.0"`,
+		"trailing value":         valid + ` {}`,
+		"unknown top-level":      strings.Replace(valid, `"release": "v0.7.0",`, `"release": "v0.7.0", "signature": "unverified",`, 1),
+		"unknown nested":         strings.Replace(valid, `"rollback_floor": 6`, `"rollback_floor": 6, "future": 7`, 1),
+		"duplicate release":      strings.Replace(valid, `"release": "v0.7.0",`, `"release": "v0.7.0", "release": "v0.8.0",`, 1),
+		"null":                   "null",
+		"noncanonical release":   strings.Replace(valid, "v0.7.0", " v0.7.0", 1),
+		"release too long":       strings.Replace(valid, "v0.7.0", strings.Repeat("r", 129), 1),
+		"tagged image":           strings.Replace(valid, "ghcr.io/rock3r/punaro@sha256:"+testDigestA, "ghcr.io/rock3r/punaro:latest", 1),
+		"uppercase image digest": strings.Replace(valid, testDigestA, strings.ToUpper(testDigestA), 1),
+		"short release hash":     strings.Replace(valid, `"release_sha256": "`+testDigestA+`"`, `"release_sha256": "abcd"`, 1),
+		"uppercase compose hash": strings.Replace(valid, testDigestB, strings.ToUpper(testDigestB), 1),
+		"nonhex migration hash":  strings.Replace(valid, testDigestC, strings.Repeat("g", 64), 1),
+		"zero schema min":        strings.Replace(valid, `"min": 6`, `"min": 0`, 1),
+		"max below min":          strings.Replace(valid, `"max": 7`, `"max": 5`, 1),
+		"target below min":       strings.Replace(valid, `"target": 7`, `"target": 5`, 1),
+		"target above max":       strings.Replace(valid, `"target": 7`, `"target": 8`, 1),
+		"rollback below min":     strings.Replace(valid, `"rollback_floor": 6`, `"rollback_floor": 5`, 1),
+		"rollback above target":  strings.Replace(valid, `"rollback_floor": 6`, `"rollback_floor": 8`, 1),
+		"zero postgres major":    strings.Replace(valid, `"postgres_major": 18`, `"postgres_major": 0`, 1),
+	}
+	for name, body := range tests {
+		t.Run(name, func(t *testing.T) {
+			if _, err := Parse([]byte(body), Environment{CurrentSchema: 6, PostgreSQLMajor: 18}); err == nil {
+				t.Fatal("invalid release metadata accepted")
+			}
+		})
+	}
+}
+
+func TestParseRejectsOversizedMetadata(t *testing.T) {
+	body := append([]byte(validMetadataJSON()), make([]byte, MaximumMetadataBytes)...)
+	if _, err := Parse(body, Environment{CurrentSchema: 6, PostgreSQLMajor: 18}); err == nil {
+		t.Fatal("oversized release metadata accepted")
+	}
+	bounded := []byte(validMetadataJSON())
+	bounded = append(bounded, bytes.Repeat([]byte(" "), MaximumMetadataBytes-len(bounded))...)
+	if _, err := Parse(bounded, Environment{CurrentSchema: 6, PostgreSQLMajor: 18}); err != nil {
+		t.Fatalf("exactly bounded metadata rejected: %v", err)
+	}
+}
+
+func TestParseRejectsSchemaDowngradeOrIncompatibleCurrentSchema(t *testing.T) {
+	for name, current := range map[string]int64{
+		"downgrade":       8,
+		"below minimum":   5,
+		"invalid current": 0,
+	} {
+		t.Run(name, func(t *testing.T) {
+			if _, err := Parse([]byte(validMetadataJSON()), Environment{CurrentSchema: current, PostgreSQLMajor: 18}); err == nil {
+				t.Fatal("incompatible schema boundary accepted")
+			}
+		})
+	}
+}
+
+func TestParseRequiresExactPostgreSQLMajor(t *testing.T) {
+	for _, major := range []int{0, 17, 19} {
+		t.Run(strconv.Itoa(major), func(t *testing.T) {
+			if _, err := Parse([]byte(validMetadataJSON()), Environment{CurrentSchema: 6, PostgreSQLMajor: major}); err == nil {
+				t.Fatalf("PostgreSQL major %d accepted", major)
+			}
+		})
+	}
+}

--- a/scripts/smoke-container-roles.sh
+++ b/scripts/smoke-container-roles.sh
@@ -8,7 +8,7 @@ if [ "$status" -ne 2 ]; then
 	echo "punaro-migrate container role returned $status, want explicit configuration refusal (2)" >&2
 	exit 1
 fi
-if ! printf '%s\n' "$output" | grep -Fq 'requires -owner-dsn-file'; then
+if ! printf '%s\n' "$output" | grep -Fq 'requires complete update authorization'; then
 	echo "punaro-migrate container role did not execute the expected command" >&2
 	exit 1
 fi
@@ -22,8 +22,15 @@ status=0
 output=$(docker run --rm --user "$(id -u):$(id -g)" \
 	--entrypoint /usr/local/bin/punaro-migrate \
 	--mount "type=bind,src=$dsn_file,dst=/run/secrets/owner.dsn,readonly" \
-	"$image" -owner-dsn-file /run/secrets/owner.dsn 2>&1) || status=$?
-if [ "$status" -ne 1 ] || ! printf '%s\n' "$output" | grep -Fq 'PostgreSQL is unavailable'; then
+	"$image" -owner-dsn-file /run/secrets/owner.dsn \
+	-update-id 019b4eb0-21f8-7d93-84df-10e6cf05ce53 \
+	-backup-id 019b4eb0-5317-79a6-a0de-fd97719910fb \
+	-target-release v0.7.0 \
+	-target-image ghcr.io/rock3r/punaro@sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb \
+	-target-schema 6 \
+	-exported-snapshot-id 00000003-0000001B-1 \
+	-manifest-sha256 cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc 2>&1) || status=$?
+if [ "$status" -ne 1 ] || ! printf '%s\n' "$output" | grep -Fq 'punaro-migrate failed'; then
 	echo "punaro-migrate container role could not read a protected mounted DSN" >&2
 	exit 1
 fi


### PR DESCRIPTION
## Summary

- add the durable PostgreSQL transactional maintenance fence and exact CAS update state machine
- add strict release metadata, digest-pinned host staging, one-shot owner migrator authorization, crash-safe resume, abort, compatible rollback, and verified-backup recovery
- bind update restores to an independently durable host receipt and exact PostgreSQL catalog fingerprints
- add the v5 bridge plus real v5 dump-to-fresh-target receipt-bound restore/retry coverage
- document the supported single-node update and rollback workflow

## Why

M7 requires one supported existing-schema update path that drains acknowledged mutations, proves every configured writer is stopped, records an exact verified recovery point before migration, and stays fenced until the target or an explicit recovery path passes readiness and doctor checks.

## Validation

- `make test`
- `make test-race`
- `make staticcheck`
- `make lint`
- `make security`
- independent adversarial, authorization, crash-resume, and operator-workflow reviews: no remaining P0/P1/P2 findings
- `make test-postgres` is wired with dedicated v5 source and fresh-target databases, but could not run locally because Docker Compose is not installed; hosted CI must exercise it
