### PR TITLE
Add PostgreSQL relay parity

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,7 +2,8 @@
 # Production should use a secret manager, protected service credentials, Docker
 # secrets, Kubernetes secrets, or another environment-injection mechanism.
 PUNARO_LISTEN_ADDR=127.0.0.1:8080
-# SQLite relay state when PUNARO_RELAY_ENABLED=true.
+# SQLite relay state when PUNARO_RELAY_ENABLED=true and the default relay store
+# is selected.
 PUNARO_DATA_DIR=./data
 # Validated but not applied to the current standard logger.
 PUNARO_LOG_LEVEL=info
@@ -20,6 +21,9 @@ PUNARO_LOG_LEVEL=info
 # schema. Put the application DSN in an absolute 0600 file; never put it here.
 # PUNARO_POSTGRES_ENABLED=false
 # PUNARO_POSTGRES_DSN_FILE=/run/secrets/punaro-postgres-app-dsn
+# Explicit test/qualification selector. `postgres` requires the compatible
+# schema above and does not import or dual-write the existing SQLite relay.
+# PUNARO_RELAY_STORE=sqlite
 # Directory and permit-issuer values have no safe defaults. If exercising
 # permit issuance, inject all of these from protected service configuration;
 # all IDs/keys except the file path use canonical raw base64url without padding.

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -178,12 +178,14 @@ acknowledges each only after local acceptance succeeds.
 sender adapter  POST /v1/conversations/{id}/messages (Idempotency-Key)
 punarod         transaction: authorize, append message, create deliveries
 punarod         best-effort WebSocket hint: {type:"wake", topic_id, sequence}
-recipient       GET /v1/deliveries?topic_id=...&after=...
+recipient       POST /v1/deliveries/lease {endpoint, consumer_id, conversation_id?, limit?}
 recipient       inject into local agent_mailbox
 recipient       POST /v1/deliveries/{id}/ack
 ```
 
-The fetch response is the source of truth. Every recipient has an independent
+The lease response is the source of truth. It contains bounded durable
+deliveries plus a map of conversation IDs to the recipient's highest contiguous
+acknowledged sequence. Every recipient has an independent
 delivery stream; a delivery has a short server-enforced lease, lease generation,
 and lease token. A lease that expires without an acknowledgement becomes
 available again. The recipient must tolerate duplicate delivery by durably
@@ -196,7 +198,10 @@ credentials, or a machine no longer owning the endpoint are rejected. The relay
 advances its per-recipient cursor only across contiguous acknowledged sequences;
 it never skips a gap. Only one consumer holds an endpoint's renewable fencing
 lease at a time, preventing a stale adapter process from injecting alongside a
-replacement.
+replacement. `consumer_id` is a fresh opaque identity generated once per
+adapter process; repeated polls from that process renew its endpoint fence,
+while another process must wait for expiry before it can increment the fence
+and take over.
 
 ## WebSocket wake-up channel
 

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ precedence over dotenv values.
 | `PUNARO_DATA_DIR` | `./data` | Relay SQLite state location when `PUNARO_RELAY_ENABLED=true`. |
 | `PUNARO_LOG_LEVEL` | `info` | Validated reserved setting; current standard logging does not filter by it. |
 | `PUNARO_ENV_FILE` | unset | Optional dotenv file when no CLI flag is used. |
-| `PUNARO_POSTGRES_ENABLED` | `false` | Opts into the dark PostgreSQL platform substrate. It does not select PostgreSQL as the relay store. Ordinary startup only checks compatibility and never migrates. |
+| `PUNARO_POSTGRES_ENABLED` | `false` | Opts into the PostgreSQL platform substrate. Ordinary startup only checks compatibility and never migrates. |
 | `PUNARO_POSTGRES_DSN_FILE` | unset | Required with PostgreSQL enabled: absolute path to a private application-role DSN file. The application role has no DDL authority. |
 | `PUNARO_DEVICE_AUTH_ENABLED` | `false` | Mounts bounded enrollment redemption and device-session authentication; requires PostgreSQL and a complete ingress policy. |
 | `PUNARO_INGRESS_MODE` | unset | Required with device auth: `lan`, `proxy`, or `internet`. Proxy and Internet origins bind loopback and require `PUNARO_PUBLIC_URL=https://...`. |
@@ -114,6 +114,7 @@ precedence over dotenv values.
 | `PUNARO_TRUSTED_LAN_CIDR` | unset | Private/link-local CIDR containing the concrete LAN bind. Valid only in LAN mode. |
 | `PUNARO_TRUSTED_LAN_HTTP` | `false` | Explicit plaintext credential exception for observed peers inside the validated trusted LAN. Public peers never qualify. |
 | `PUNARO_RELAY_ENABLED` | `false` | Enables the loopback text relay; requires public machine enrollment records. |
+| `PUNARO_RELAY_STORE` | `sqlite` | Explicit relay backend selector. `postgres` requires PostgreSQL schema v7 and is for empty-destination parity/qualification before the M-9 one-shot cutover; it never imports or dual-writes SQLite. |
 | `PUNARO_RELAY_MACHINES_JSON` | unset | Explicit public-key machine enrollment records. `endpoint_prefixes` claims disjoint machine namespaces; `endpoints` can grant a named exact endpoint without creating a prefix. An issuer-capable machine additionally has canonical raw-base64url `attachment_device_id` (16 bytes), bound to exactly one directory device. |
 | `PUNARO_DIRECTORY_ENABLED` | `false` | Serves a current complete signed directory snapshot to authenticated enrolled machines; requires the relay. |
 | `PUNARO_DIRECTORY_SNAPSHOT_FILE` | unset | Absolute, root-owned and service-group-readable (`2750` parent, `0640` regular non-symlink) canonical directory snapshot publication file. |

--- a/cmd/punarod/main.go
+++ b/cmd/punarod/main.go
@@ -99,7 +99,16 @@ func run(args []string, stderr io.Writer) int {
 			return 2
 		}
 	}
-	relayHandler, relayStore, err := buildRelayHandler(cfg)
+	var postgresRelay relay.Backend
+	if cfg.RelayStore == "postgres" {
+		var ok bool
+		postgresRelay, ok = platformDB.(relay.Backend)
+		if !ok {
+			_, _ = fmt.Fprintln(stderr, "punarod relay configuration error: PostgreSQL relay store is unavailable")
+			return 2
+		}
+	}
+	relayHandler, relayStore, err := buildRelayHandler(cfg, postgresRelay)
 	if err != nil {
 		_, _ = fmt.Fprintf(stderr, "punarod relay configuration error: %v\n", err)
 		return 2
@@ -605,7 +614,7 @@ func buildDirectoryHandler(cfg config.Config, store *relay.Store) (http.Handler,
 	return handler, nil
 }
 
-func buildRelayHandler(cfg config.Config) (http.Handler, *relay.Store, error) {
+func buildRelayHandler(cfg config.Config, postgresBackends ...relay.Backend) (http.Handler, *relay.Store, error) {
 	if !cfg.RelayEnabled {
 		return nil, nil, nil
 	}
@@ -613,20 +622,34 @@ func buildRelayHandler(cfg config.Config) (http.Handler, *relay.Store, error) {
 	if err != nil {
 		return nil, nil, err
 	}
-	store, err := relay.Open(filepath.Join(cfg.DataDir, "relay.db"))
+	var backend relay.Backend
+	var store *relay.Store
+	if cfg.RelayStore == "postgres" {
+		if len(postgresBackends) != 1 || postgresBackends[0] == nil {
+			return nil, nil, errors.New("PostgreSQL relay store is unavailable")
+		}
+		backend = postgresBackends[0]
+	} else {
+		store, err = relay.Open(filepath.Join(cfg.DataDir, "relay.db"))
+		if err != nil {
+			return nil, nil, err
+		}
+		backend = store
+	}
+	authenticator, err := relay.NewAuthenticator(backend, machines)
 	if err != nil {
+		if store != nil {
+			_ = store.Close()
+		}
 		return nil, nil, err
 	}
-	authenticator, err := relay.NewAuthenticator(store, machines)
-	if err != nil {
-		_ = store.Close()
-		return nil, nil, err
-	}
-	handler := relay.NewHandler(store, authenticator, relay.HandlerOptions{})
+	handler := relay.NewHandler(backend, authenticator, relay.HandlerOptions{})
 	if cfg.AccessIssuer != "" {
 		verifier, err := newAccessVerifier(cfg)
 		if err != nil {
-			_ = store.Close()
+			if store != nil {
+				_ = store.Close()
+			}
 			return nil, nil, err
 		}
 		handler = verifier.Middleware(handler)

--- a/cmd/punarod/relay_test.go
+++ b/cmd/punarod/relay_test.go
@@ -29,6 +29,21 @@ func TestBuildRelayHandlerRejectsInvalidEnrollment(t *testing.T) {
 	}
 }
 
+func TestBuildRelayCanSelectPostgresBackendWithoutOpeningSQLite(t *testing.T) {
+	backend, err := relay.Open(filepath.Join(t.TempDir(), "postgres-backend-double.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = backend.Close() })
+	handler, sqliteStore, err := buildRelayHandler(config.Config{
+		DataDir: t.TempDir(), RelayEnabled: true, RelayStore: "postgres",
+		RelayMachinesJSON: `[{"id":"machine-a","public_key":"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA","endpoint_prefixes":["agent/a/"]}]`,
+	}, backend)
+	if err != nil || handler == nil || sqliteStore != nil {
+		t.Fatalf("handler=%v sqlite=%v err=%v", handler, sqliteStore, err)
+	}
+}
+
 func TestBuildPermitHandlerRequiresEnrolledAttachmentDeviceBinding(t *testing.T) {
 	privateDir := filepath.Join(t.TempDir(), "private")
 	if err := os.Mkdir(privateDir, 0o700); err != nil {

--- a/docs/operator-guide.md
+++ b/docs/operator-guide.md
@@ -413,7 +413,7 @@ under the target distribution, verify SQLite WAL behavior, and record
 loopback and use a separately reviewed ingress only after the applicable
 public-runtime release gate is complete.
 
-### Dark PostgreSQL substrate
+### PostgreSQL substrate and relay qualification
 
 PostgreSQL remains disabled unless both `PUNARO_POSTGRES_ENABLED=true` and an
 absolute `PUNARO_POSTGRES_DSN_FILE` are supplied. The DSN file must be a private
@@ -446,16 +446,29 @@ database and investigate. The digest-pinned `make test-postgres` stack is epheme
 test infrastructure, publishes no database port, and deletes its volume on
 exit.
 
-The current binary requires schema version 6. Versions 1 through 5 are reported
+The current binary requires schema version 7. Versions 1 through 6 are reported
 as `upgrade_required`; damaged older objects remain `incompatible`. Migration 3 is
 additive and creates the host-local ownership, pending enrollment, device
 credential, cache/session generation, and Ed25519 migration-inventory records.
 Migration 6 adds the durable update coordinator, exact recovery evidence, and
-the mutation fence. There is still no relay cutover. Do not
+the mutation fence. Migration 7 adds the PostgreSQL mail store, durable
+recipient cursors, replay protection, and relay-table mutation guards.
+PostgreSQL mail work uses a reserved four-connection application-role pool;
+each operation and lock wait is bounded to five seconds so platform work cannot
+consume the mail budget indefinitely.
+
+SQLite remains the default active relay. Maintainers may explicitly select an
+empty PostgreSQL relay with `PUNARO_RELAY_STORE=postgres` only after completing
+the supported v6-to-v7 update. This selector does not import the SQLite file,
+does not dual-write, and is incompatible with the superseded directory and
+attachment routes. Do not point an established installation at an empty
+PostgreSQL relay as a migration shortcut; the verified one-shot mail cutover is
+a separate release gate. Before that cutover, rollback is selecting `sqlite`
+again while retaining both stores unchanged.
+
+Do not
 hand edit ownership, enrollment, credential, idempotency, capacity, lease,
 migration, update, restore, or audit rows to bypass a failure.
-Before any later authority cutover, rollback remains disabling the PostgreSQL
-opt-in and retaining SQLite as the unchanged active relay.
 
 ### Host-local device enrollment
 

--- a/internal/adapter/client.go
+++ b/internal/adapter/client.go
@@ -37,6 +37,7 @@ type HTTPRelayClient struct {
 	machineID   string
 	privateKey  ed25519.PrivateKey
 	httpClient  *http.Client
+	consumerID  string
 	accessToken AccessServiceToken
 	access      *accessSession
 }
@@ -84,7 +85,11 @@ func NewHTTPRelayClient(rawURL, machineID string, privateKey ed25519.PrivateKey,
 		client = http.DefaultClient
 	}
 	clientCopy := *client
-	result := &HTTPRelayClient{baseURL: baseURL, machineID: machineID, privateKey: append(ed25519.PrivateKey(nil), privateKey...), httpClient: &clientCopy, accessToken: accessToken}
+	consumerID, err := randomConsumerID()
+	if err != nil {
+		return nil, fmt.Errorf("create relay consumer identity: %w", err)
+	}
+	result := &HTTPRelayClient{baseURL: baseURL, machineID: machineID, privateKey: append(ed25519.PrivateKey(nil), privateKey...), httpClient: &clientCopy, consumerID: consumerID, accessToken: accessToken}
 	if accessToken.ClientID != "" && !loopbackHost(baseURL.Hostname()) {
 		jar, err := cookiejar.New(nil)
 		if err != nil {
@@ -181,7 +186,7 @@ func (c *HTTPRelayClient) Lease(ctx context.Context, endpoint string) ([]relay.D
 	var response struct {
 		Deliveries []relay.Delivery `json:"deliveries"`
 	}
-	_, err := c.doJSON(ctx, http.MethodPost, "/v1/deliveries/lease", map[string]any{"endpoint": endpoint}, &response)
+	_, err := c.doJSON(ctx, http.MethodPost, "/v1/deliveries/lease", map[string]any{"endpoint": endpoint, "consumer_id": c.consumerID}, &response)
 	return response.Deliveries, err
 }
 
@@ -640,6 +645,14 @@ func randomNonce() (string, error) {
 	value := make([]byte, 24)
 	if _, err := rand.Read(value); err != nil {
 		return "", fmt.Errorf("generate request nonce: %w", err)
+	}
+	return base64.RawURLEncoding.EncodeToString(value), nil
+}
+
+func randomConsumerID() (string, error) {
+	value := make([]byte, 16)
+	if _, err := rand.Read(value); err != nil {
+		return "", err
 	}
 	return base64.RawURLEncoding.EncodeToString(value), nil
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -42,6 +42,7 @@ type Config struct {
 	PermitMaxActive             uint64
 	RelayEnabled                bool
 	RelayMachinesJSON           string
+	RelayStore                  string
 	AccessIssuer                string
 	AccessAudience              string
 	AccessJWKSURL               string
@@ -113,6 +114,7 @@ func Load(explicitEnvFile string) (Config, error) {
 	permitMaxActive := value("PUNARO_PERMIT_MAX_ACTIVE", "")
 	attachmentV3SourceStoreFile := value("PUNARO_ATTACHMENT_V3_SOURCE_STORE_FILE", "")
 	relayMachines := value("PUNARO_RELAY_MACHINES_JSON", "")
+	relayStore := strings.ToLower(value("PUNARO_RELAY_STORE", "sqlite"))
 	accessIssuer := value("PUNARO_ACCESS_ISSUER", "")
 	accessAudience := value("PUNARO_ACCESS_AUDIENCE", "")
 	accessJWKSURL := value("PUNARO_ACCESS_JWKS_URL", "")
@@ -173,6 +175,15 @@ func Load(explicitEnvFile string) (Config, error) {
 	}
 	if relayEnabled && relayMachines == "" {
 		return Config{}, fmt.Errorf("enabled relay requires PUNARO_RELAY_MACHINES_JSON")
+	}
+	if relayStore != "sqlite" && relayStore != "postgres" {
+		return Config{}, fmt.Errorf("PUNARO_RELAY_STORE must be sqlite or postgres")
+	}
+	if relayStore == "postgres" && (!relayEnabled || !postgresEnabled) {
+		return Config{}, fmt.Errorf("PostgreSQL relay store requires PUNARO_RELAY_ENABLED and PUNARO_POSTGRES_ENABLED")
+	}
+	if relayStore == "postgres" && (directoryEnabled || permitIssuanceEnabled || attachmentV3Enabled || attachmentsEnabled) {
+		return Config{}, fmt.Errorf("PostgreSQL relay store cannot serve superseded attachment or directory routes")
 	}
 	if directoryEnabled && !relayEnabled {
 		return Config{}, fmt.Errorf("directory service requires PUNARO_RELAY_ENABLED")
@@ -244,7 +255,7 @@ func Load(explicitEnvFile string) (Config, error) {
 	if !postgresEnabled && postgresDSNFile != "" {
 		return Config{}, fmt.Errorf("PUNARO_POSTGRES_DSN_FILE requires PUNARO_POSTGRES_ENABLED")
 	}
-	return Config{ListenAddr: listenAddr, HealthListenAddr: healthListenAddr, DataDir: dataDir, LogLevel: level, AttachmentsEnabled: attachmentsEnabled, AttachmentDeviceKeysJSON: deviceKeys, AttachmentMembershipJSON: membership, AttachmentV3Enabled: attachmentV3Enabled, AttachmentV3SourceStoreFile: attachmentV3SourceStoreFile, DirectoryEnabled: directoryEnabled, DirectorySnapshotFile: directorySnapshotFile, PermitIssuanceEnabled: permitIssuanceEnabled, DirectoryAudience: audience, DirectoryRootKeyID: rootKeyID, DirectoryRootPublicKey: rootPublicKey, PermitIssuerKeyID: issuerKeyID, PermitIssuerPrivateKeyFile: permitIssuerPrivateKeyFile, PermitMaxLifetimeSeconds: maxLifetime, PermitMaxBytes: maxBytes, PermitMaxChunks: maxChunks, PermitMaxOperations: maxOperations, PermitMaxActive: maxActive, RelayEnabled: relayEnabled, RelayMachinesJSON: relayMachines, AccessIssuer: accessIssuer, AccessAudience: accessAudience, AccessJWKSURL: accessJWKSURL, AccessJWKSFile: accessJWKSFile, PostgresEnabled: postgresEnabled, PostgresDSNFile: postgresDSNFile, DeviceAuthEnabled: deviceAuthEnabled, IngressMode: ingressMode, PublicURL: publicURL, TrustedLANCIDR: trustedLANCIDR, TrustedLANHTTP: trustedLANHTTP}, nil
+	return Config{ListenAddr: listenAddr, HealthListenAddr: healthListenAddr, DataDir: dataDir, LogLevel: level, AttachmentsEnabled: attachmentsEnabled, AttachmentDeviceKeysJSON: deviceKeys, AttachmentMembershipJSON: membership, AttachmentV3Enabled: attachmentV3Enabled, AttachmentV3SourceStoreFile: attachmentV3SourceStoreFile, DirectoryEnabled: directoryEnabled, DirectorySnapshotFile: directorySnapshotFile, PermitIssuanceEnabled: permitIssuanceEnabled, DirectoryAudience: audience, DirectoryRootKeyID: rootKeyID, DirectoryRootPublicKey: rootPublicKey, PermitIssuerKeyID: issuerKeyID, PermitIssuerPrivateKeyFile: permitIssuerPrivateKeyFile, PermitMaxLifetimeSeconds: maxLifetime, PermitMaxBytes: maxBytes, PermitMaxChunks: maxChunks, PermitMaxOperations: maxOperations, PermitMaxActive: maxActive, RelayEnabled: relayEnabled, RelayMachinesJSON: relayMachines, RelayStore: relayStore, AccessIssuer: accessIssuer, AccessAudience: accessAudience, AccessJWKSURL: accessJWKSURL, AccessJWKSFile: accessJWKSFile, PostgresEnabled: postgresEnabled, PostgresDSNFile: postgresDSNFile, DeviceAuthEnabled: deviceAuthEnabled, IngressMode: ingressMode, PublicURL: publicURL, TrustedLANCIDR: trustedLANCIDR, TrustedLANHTTP: trustedLANHTTP}, nil
 }
 
 func decodeFixedBase64URL(name, value string, size int) ([32]byte, error) {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -53,6 +53,21 @@ func TestLoadRequiresAbsolutePostgresDSNFileWhenEnabled(t *testing.T) {
 	}
 }
 
+func TestPostgresRelaySelectionIsExplicitAndRequiresPostgres(t *testing.T) {
+	t.Setenv("PUNARO_RELAY_ENABLED", "true")
+	t.Setenv("PUNARO_RELAY_MACHINES_JSON", `[{"id":"machine-a","public_key":"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA","endpoint_prefixes":["agent/a/"]}]`)
+	t.Setenv("PUNARO_RELAY_STORE", "postgres")
+	if _, err := Load(""); err == nil {
+		t.Fatal("PostgreSQL relay selection succeeded without PostgreSQL")
+	}
+	t.Setenv("PUNARO_POSTGRES_ENABLED", "true")
+	t.Setenv("PUNARO_POSTGRES_DSN_FILE", "/run/secrets/punaro-postgres-dsn")
+	cfg, err := Load("")
+	if err != nil || cfg.RelayStore != "postgres" {
+		t.Fatalf("config=%#v err=%v", cfg, err)
+	}
+}
+
 func TestLoadRejectsPostgresDSNFileWhileDisabled(t *testing.T) {
 	t.Setenv("PUNARO_POSTGRES_DSN_FILE", "/run/secrets/punaro-postgres-dsn")
 	if _, err := Load(""); err == nil {

--- a/internal/postgres/db.go
+++ b/internal/postgres/db.go
@@ -23,6 +23,7 @@ type Config struct {
 // Database is a least-privilege application connection to the platform substrate.
 type Database struct {
 	db       *sql.DB
+	relayDB  *sql.DB
 	manifest Manifest
 }
 
@@ -47,16 +48,30 @@ func OpenApplication(ctx context.Context, cfg Config) (*Database, error) {
 		_ = db.Close()
 		return nil, err
 	}
-	return &Database{db: db, manifest: CurrentManifest()}, nil
+	relayDB, err := openPool(ctx, dsn, 4, 1)
+	if err != nil {
+		_ = db.Close()
+		return nil, err
+	}
+	if err := verifyApplicationRole(ctx, relayDB); err != nil {
+		_ = relayDB.Close()
+		_ = db.Close()
+		return nil, err
+	}
+	return &Database{db: db, relayDB: relayDB, manifest: CurrentManifest()}, nil
 }
 
 func open(ctx context.Context, dsn string) (*sql.DB, error) {
+	return openPool(ctx, dsn, 8, 2)
+}
+
+func openPool(ctx context.Context, dsn string, maximumOpen, maximumIdle int) (*sql.DB, error) {
 	db, err := sql.Open("pgx", dsn)
 	if err != nil {
 		return nil, errors.New("PostgreSQL connection configuration is invalid")
 	}
-	db.SetMaxOpenConns(8)
-	db.SetMaxIdleConns(2)
+	db.SetMaxOpenConns(maximumOpen)
+	db.SetMaxIdleConns(maximumIdle)
 	pingCtx, cancel := context.WithTimeout(ctx, operationTimeout)
 	defer cancel()
 	if err := db.PingContext(pingCtx); err != nil {
@@ -66,8 +81,13 @@ func open(ctx context.Context, dsn string) (*sql.DB, error) {
 	return db, nil
 }
 
-// Close releases the application connection pool.
-func (d *Database) Close() error { return d.db.Close() }
+// Close releases both the general application and reserved relay pools.
+func (d *Database) Close() error {
+	if d.relayDB == nil {
+		return d.db.Close()
+	}
+	return errors.Join(d.relayDB.Close(), d.db.Close())
+}
 
 // SchemaState inspects schema history, required objects, and role safety atomically.
 func (d *Database) SchemaState(ctx context.Context) (SchemaState, error) {
@@ -940,6 +960,13 @@ FROM objects, table_ownership, routine_safety, routine_acl, table_acl, schema_ac
 			return Snapshot{}, errors.New("PostgreSQL update-control schema cannot be inspected")
 		}
 		snapshot.CurrentObjectsPresent = updateObjectsPresent
+	}
+	if snapshot.CurrentObjectsPresent && len(snapshot.Records) > 0 && snapshot.Records[len(snapshot.Records)-1].Version >= 7 {
+		relayObjectsPresent, err := relayControlsAvailable(ctx, q)
+		if err != nil {
+			return Snapshot{}, errors.New("PostgreSQL relay schema cannot be inspected")
+		}
+		snapshot.CurrentObjectsPresent = relayObjectsPresent
 	}
 	return snapshot, nil
 }

--- a/internal/postgres/migrate.go
+++ b/internal/postgres/migrate.go
@@ -16,7 +16,10 @@ import (
 // MigrationManifestSHA256 binds release metadata and the update transaction to
 // the exact ordered embedded migration history without including SQL bodies.
 func MigrationManifestSHA256() string {
-	manifest := CurrentManifest()
+	return migrationManifestSHA256(CurrentManifest())
+}
+
+func migrationManifestSHA256(manifest Manifest) string {
 	hash := sha256.New()
 	for _, migration := range manifest.Migrations {
 		_, _ = hash.Write([]byte(strconv.FormatInt(migration.Version, 10) + "\x00" + migration.Name + "\x00" + migration.Checksum + "\x00" + strconv.FormatInt(migration.CompatibilityFloor, 10) + "\n"))
@@ -36,6 +39,7 @@ var migrationCompatibilityFloors = map[int64]int64{
 	4: 4,
 	5: 5,
 	6: 6,
+	7: 7,
 }
 
 // CurrentManifest returns the immutable migrations embedded in this binary.
@@ -95,6 +99,10 @@ func Migrate(ctx context.Context, cfg Config) (SchemaState, error) {
 // migration advisory lock or staging schema history.
 func MigrateUpdate(ctx context.Context, cfg Config, authorization UpdateMigrationAuthorization) (SchemaState, error) {
 	manifest := CurrentManifest()
+	return migrateUpdateManifest(ctx, cfg, authorization, manifest)
+}
+
+func migrateUpdateManifest(ctx context.Context, cfg Config, authorization UpdateMigrationAuthorization, manifest Manifest) (SchemaState, error) {
 	if authorization.Validate() != nil || authorization.TargetSchema != manifest.MaxSupported {
 		return SchemaState{}, errors.New("invalid update migration authorization")
 	}
@@ -134,7 +142,7 @@ WHERE update_id=$1::uuid AND phase='migration_started' AND backup_id=$2::uuid
   AND target_release=$3 AND target_image=$4 AND target_schema=$5
   AND migration_manifest_sha256=$6
   AND backup_snapshot_id=$7 AND backup_manifest_sha256=$8
-)`, authorization.UpdateID, authorization.BackupID, authorization.TargetRelease, authorization.TargetImage, authorization.TargetSchema, MigrationManifestSHA256(), authorization.ExportedSnapshotID, authorization.ManifestSHA256).Scan(&authorized)
+)`, authorization.UpdateID, authorization.BackupID, authorization.TargetRelease, authorization.TargetImage, authorization.TargetSchema, migrationManifestSHA256(manifest), authorization.ExportedSnapshotID, authorization.ManifestSHA256).Scan(&authorized)
 	if err != nil || !authorized {
 		return SchemaState{}, errors.New("PostgreSQL update migration marker does not match")
 	}

--- a/internal/postgres/migrations/007_postgres_relay.sql
+++ b/internal/postgres/migrations/007_postgres_relay.sql
@@ -1,0 +1,180 @@
+CREATE TABLE relay.mail_endpoints (
+    endpoint text PRIMARY KEY CHECK (
+        char_length(endpoint) >= 1 AND char_length(endpoint) <= 512
+        AND octet_length(endpoint) <= 2048
+        AND endpoint !~ '[[:cntrl:]]'
+    ),
+    machine_id text NOT NULL CHECK (
+        char_length(machine_id) >= 1 AND char_length(machine_id) <= 128
+        AND octet_length(machine_id) <= 512
+        AND machine_id !~ '[[:cntrl:]]'
+    ),
+    lease_until timestamptz NOT NULL,
+    ownership_generation bigint NOT NULL DEFAULT 1 CHECK (ownership_generation > 0),
+    consumer_id text CHECK (consumer_id IS NULL OR (char_length(consumer_id) >= 1 AND char_length(consumer_id) <= 128 AND octet_length(consumer_id) <= 512 AND consumer_id !~ '[[:cntrl:]]')),
+    consumer_generation bigint NOT NULL DEFAULT 0 CHECK (consumer_generation >= 0),
+    consumer_lease_until timestamptz,
+    CHECK ((consumer_id IS NULL) = (consumer_lease_until IS NULL))
+);
+
+CREATE INDEX mail_endpoints_machine
+ON relay.mail_endpoints (machine_id, lease_until, endpoint);
+
+CREATE TABLE relay.mail_conversations (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    next_sequence bigint NOT NULL DEFAULT 0 CHECK (next_sequence >= 0),
+    created_at timestamptz NOT NULL DEFAULT statement_timestamp()
+);
+
+CREATE TABLE relay.mail_memberships (
+    conversation_id uuid NOT NULL REFERENCES relay.mail_conversations(id),
+    endpoint text NOT NULL REFERENCES relay.mail_endpoints(endpoint),
+    capabilities smallint NOT NULL CHECK (capabilities BETWEEN 1 AND 7),
+    PRIMARY KEY (conversation_id, endpoint)
+);
+
+CREATE TABLE relay.mail_messages (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    conversation_id uuid NOT NULL REFERENCES relay.mail_conversations(id),
+    sequence bigint NOT NULL CHECK (sequence > 0),
+    from_endpoint text NOT NULL REFERENCES relay.mail_endpoints(endpoint),
+    body text NOT NULL CHECK (octet_length(body) <= 32768),
+    created_at timestamptz NOT NULL,
+    UNIQUE (conversation_id, sequence)
+);
+
+CREATE TABLE relay.mail_deliveries (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    message_id uuid NOT NULL REFERENCES relay.mail_messages(id),
+    recipient_endpoint text NOT NULL REFERENCES relay.mail_endpoints(endpoint),
+    lease_machine_id text,
+    lease_token uuid,
+    lease_generation bigint NOT NULL DEFAULT 0 CHECK (lease_generation >= 0),
+    ownership_generation bigint,
+    consumer_generation bigint,
+    lease_until timestamptz,
+    acked_at timestamptz,
+    UNIQUE (message_id, recipient_endpoint),
+    CHECK (
+        (lease_machine_id IS NULL AND lease_token IS NULL AND ownership_generation IS NULL AND consumer_generation IS NULL AND lease_until IS NULL)
+        OR
+        (lease_machine_id IS NOT NULL AND lease_token IS NOT NULL AND ownership_generation IS NOT NULL AND consumer_generation IS NOT NULL AND lease_until IS NOT NULL)
+    )
+);
+
+CREATE INDEX mail_deliveries_pending
+ON relay.mail_deliveries (recipient_endpoint, acked_at, lease_until, id);
+
+CREATE TABLE relay.mail_recipient_cursors (
+    recipient_endpoint text NOT NULL REFERENCES relay.mail_endpoints(endpoint),
+    conversation_id uuid NOT NULL REFERENCES relay.mail_conversations(id),
+    sequence bigint NOT NULL DEFAULT 0 CHECK (sequence >= 0),
+    PRIMARY KEY (recipient_endpoint, conversation_id)
+);
+
+CREATE TABLE relay.mail_message_idempotency (
+    machine_id text NOT NULL,
+    key text NOT NULL CHECK (char_length(key) >= 1 AND char_length(key) <= 128 AND octet_length(key) <= 512 AND key !~ '[[:cntrl:]]'),
+    request_hash char(64) NOT NULL CHECK (request_hash ~ '^[0-9a-f]{64}$'),
+    message_id uuid NOT NULL UNIQUE REFERENCES relay.mail_messages(id),
+    created_at timestamptz NOT NULL,
+    PRIMARY KEY (machine_id, key)
+);
+
+CREATE TABLE relay.mail_conversation_idempotency (
+    machine_id text NOT NULL,
+    key text NOT NULL CHECK (char_length(key) >= 1 AND char_length(key) <= 128 AND octet_length(key) <= 512 AND key !~ '[[:cntrl:]]'),
+    request_hash char(64) NOT NULL CHECK (request_hash ~ '^[0-9a-f]{64}$'),
+    conversation_id uuid NOT NULL UNIQUE REFERENCES relay.mail_conversations(id),
+    created_at timestamptz NOT NULL,
+    PRIMARY KEY (machine_id, key)
+);
+
+CREATE TABLE relay.mail_request_nonces (
+    machine_id text NOT NULL,
+    nonce text NOT NULL CHECK (char_length(nonce) >= 1 AND char_length(nonce) <= 128 AND octet_length(nonce) <= 512 AND nonce !~ '[[:cntrl:]]'),
+    expires_at timestamptz NOT NULL,
+    PRIMARY KEY (machine_id, nonce)
+);
+
+CREATE INDEX mail_request_nonces_expiry
+ON relay.mail_request_nonces (expires_at, machine_id, nonce);
+
+CREATE FUNCTION relay.consume_mail_request_nonce(
+    requested_machine_id text,
+    requested_nonce text,
+    requested_now timestamptz,
+    requested_expires_at timestamptz
+)
+RETURNS boolean
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog
+AS $function$
+BEGIN
+    IF requested_machine_id IS NULL OR char_length(requested_machine_id) < 1 OR char_length(requested_machine_id) > 128
+       OR octet_length(requested_machine_id) > 512 OR requested_machine_id ~ '[[:cntrl:]]'
+       OR requested_nonce IS NULL OR char_length(requested_nonce) < 1 OR char_length(requested_nonce) > 128
+       OR octet_length(requested_nonce) > 512 OR requested_nonce ~ '[[:cntrl:]]'
+       OR requested_now IS NULL OR requested_expires_at IS NULL
+       OR requested_expires_at <= requested_now THEN
+        RETURN false;
+    END IF;
+    DELETE FROM relay.mail_request_nonces
+    WHERE (machine_id, nonce) IN (
+        SELECT machine_id, nonce FROM relay.mail_request_nonces
+        WHERE expires_at <= requested_now
+        ORDER BY expires_at, machine_id, nonce
+        LIMIT 256
+        FOR UPDATE SKIP LOCKED
+    );
+    INSERT INTO relay.mail_request_nonces(machine_id, nonce, expires_at)
+    VALUES (requested_machine_id, requested_nonce, requested_expires_at)
+    ON CONFLICT DO NOTHING;
+    RETURN FOUND;
+END
+$function$;
+
+CREATE TRIGGER mail_endpoints_mutation_guard
+BEFORE INSERT OR UPDATE OR DELETE ON relay.mail_endpoints
+FOR EACH STATEMENT EXECUTE FUNCTION jobs.guard_application_mutation();
+CREATE TRIGGER mail_conversations_mutation_guard
+BEFORE INSERT OR UPDATE OR DELETE ON relay.mail_conversations
+FOR EACH STATEMENT EXECUTE FUNCTION jobs.guard_application_mutation();
+CREATE TRIGGER mail_memberships_mutation_guard
+BEFORE INSERT OR UPDATE OR DELETE ON relay.mail_memberships
+FOR EACH STATEMENT EXECUTE FUNCTION jobs.guard_application_mutation();
+CREATE TRIGGER mail_messages_mutation_guard
+BEFORE INSERT OR UPDATE OR DELETE ON relay.mail_messages
+FOR EACH STATEMENT EXECUTE FUNCTION jobs.guard_application_mutation();
+CREATE TRIGGER mail_deliveries_mutation_guard
+BEFORE INSERT OR UPDATE OR DELETE ON relay.mail_deliveries
+FOR EACH STATEMENT EXECUTE FUNCTION jobs.guard_application_mutation();
+CREATE TRIGGER mail_recipient_cursors_mutation_guard
+BEFORE INSERT OR UPDATE OR DELETE ON relay.mail_recipient_cursors
+FOR EACH STATEMENT EXECUTE FUNCTION jobs.guard_application_mutation();
+CREATE TRIGGER mail_message_idempotency_mutation_guard
+BEFORE INSERT OR UPDATE OR DELETE ON relay.mail_message_idempotency
+FOR EACH STATEMENT EXECUTE FUNCTION jobs.guard_application_mutation();
+CREATE TRIGGER mail_conversation_idempotency_mutation_guard
+BEFORE INSERT OR UPDATE OR DELETE ON relay.mail_conversation_idempotency
+FOR EACH STATEMENT EXECUTE FUNCTION jobs.guard_application_mutation();
+CREATE TRIGGER mail_request_nonces_mutation_guard
+BEFORE INSERT OR UPDATE OR DELETE ON relay.mail_request_nonces
+FOR EACH STATEMENT EXECUTE FUNCTION jobs.guard_application_mutation();
+
+REVOKE ALL ON FUNCTION relay.consume_mail_request_nonce(text, text, timestamptz, timestamptz) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION relay.consume_mail_request_nonce(text, text, timestamptz, timestamptz) TO punaro_app;
+
+GRANT SELECT, INSERT ON relay.mail_endpoints TO punaro_app;
+GRANT UPDATE (machine_id, lease_until, ownership_generation, consumer_id, consumer_generation, consumer_lease_until) ON relay.mail_endpoints TO punaro_app;
+GRANT SELECT, INSERT ON relay.mail_conversations TO punaro_app;
+GRANT UPDATE (next_sequence) ON relay.mail_conversations TO punaro_app;
+GRANT SELECT, INSERT ON relay.mail_memberships TO punaro_app;
+GRANT SELECT, INSERT ON relay.mail_messages TO punaro_app;
+GRANT SELECT, INSERT ON relay.mail_deliveries TO punaro_app;
+GRANT UPDATE (lease_machine_id, lease_token, lease_generation, ownership_generation, consumer_generation, lease_until, acked_at) ON relay.mail_deliveries TO punaro_app;
+GRANT SELECT, INSERT ON relay.mail_recipient_cursors TO punaro_app;
+GRANT UPDATE (sequence) ON relay.mail_recipient_cursors TO punaro_app;
+GRANT SELECT, INSERT ON relay.mail_message_idempotency TO punaro_app;
+GRANT SELECT, INSERT ON relay.mail_conversation_idempotency TO punaro_app;

--- a/internal/postgres/postgres_integration_test.go
+++ b/internal/postgres/postgres_integration_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/rock3r/punaro/internal/relay"
 	"github.com/rock3r/punaro/internal/relay/contracttest"
 )
@@ -564,6 +565,73 @@ AS $function$ BEGIN RETURN NEW; END $function$`); err != nil {
 func testRelayIntegration(t *testing.T, app *Database) {
 	t.Helper()
 	contracttest.Run(t, app, "postgres-contract")
+	testRecipientCursorDoesNotCrossUncommittedAppend(t, app)
+}
+
+func testRecipientCursorDoesNotCrossUncommittedAppend(t *testing.T, app *Database) {
+	t.Helper()
+	now := time.Date(2026, time.July, 20, 15, 0, 0, 0, time.UTC)
+	const (
+		machineA  = "postgres-cursor-lock-machine-a"
+		machineB  = "postgres-cursor-lock-machine-b"
+		endpointA = "agent/postgres-cursor-lock/a"
+		endpointB = "agent/postgres-cursor-lock/b"
+	)
+	if err := app.AdvertiseEndpoints(machineA, []string{endpointA}, now, time.Hour); err != nil {
+		t.Fatal(err)
+	}
+	if err := app.AdvertiseEndpoints(machineB, []string{endpointB}, now, time.Hour); err != nil {
+		t.Fatal(err)
+	}
+	conversation, err := app.CreateConversationIdempotent(relay.CreateConversationInput{
+		MachineID: machineA, IdempotencyKey: "postgres-cursor-lock-create", CreatorEndpoint: endpointA, Now: now,
+		Members: []relay.Member{
+			{Endpoint: endpointA, Capabilities: relay.CapSend | relay.CapReceive | relay.CapAdmin},
+			{Endpoint: endpointB, Capabilities: relay.CapReceive},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	appendTx, appendCancel, err := app.beginRelayTransaction(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer appendCancel()
+	defer func() { _ = appendTx.Rollback() }()
+	messageID := uuid.NewString()
+	var sequence int64
+	if err := appendTx.QueryRowContext(context.Background(), `UPDATE relay.mail_conversations SET next_sequence=next_sequence+1 WHERE id=$1::uuid RETURNING next_sequence`, conversation.ID).Scan(&sequence); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := appendTx.ExecContext(context.Background(), `INSERT INTO relay.mail_messages(id,conversation_id,sequence,from_endpoint,body,created_at) VALUES($1::uuid,$2::uuid,$3,$4,$5,$6)`, messageID, conversation.ID, sequence, endpointA, "must remain pending", now); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := appendTx.ExecContext(context.Background(), `INSERT INTO relay.mail_deliveries(message_id,recipient_endpoint) VALUES($1::uuid,$2)`, messageID, endpointB); err != nil {
+		t.Fatal(err)
+	}
+	cursorTx, cursorCancel, err := app.beginRelayTransaction(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cursorCancel()
+	defer func() { _ = cursorTx.Rollback() }()
+	if err := postgresAdvanceRecipientCursor(cursorTx, endpointB, conversation.ID); err != nil {
+		t.Fatalf("advance cursor alongside uncommitted append: %v", err)
+	}
+	if err := cursorTx.Commit(); err != nil {
+		t.Fatal(err)
+	}
+	if err := appendTx.Commit(); err != nil {
+		t.Fatal(err)
+	}
+	if cursor, err := app.RecipientCursor(machineB, endpointB, conversation.ID, now); err != nil || cursor != 0 {
+		t.Fatalf("cursor crossed concurrent append: cursor=%d err=%v", cursor, err)
+	}
+	page, err := app.LeaseDeliveries(machineB, "postgres-cursor-lock-consumer", endpointB, conversation.ID, now, time.Minute, 10)
+	if err != nil || len(page.Deliveries) != 1 || page.Deliveries[0].Message.Sequence != 1 {
+		t.Fatalf("concurrent delivery page=%#v err=%v", page, err)
+	}
 }
 
 func testV5UpdateBridgeIntegration(ctx context.Context, t *testing.T, ownerDB *sql.DB, ownerFile string) {

--- a/internal/postgres/postgres_integration_test.go
+++ b/internal/postgres/postgres_integration_test.go
@@ -171,7 +171,7 @@ func TestPostgresPlatformSubstrateIntegration(t *testing.T) {
 	if err := ownerDB.QueryRowContext(ctx, `SELECT pg_get_functiondef('relay.consume_mail_request_nonce(text,text,timestamptz,timestamptz)'::regprocedure)`).Scan(&nonceDefinition); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := ownerDB.ExecContext(ctx, `CREATE OR REPLACE FUNCTION relay.consume_mail_request_nonce(text,text,timestamptz,timestamptz)
+	if _, err := ownerDB.ExecContext(ctx, `CREATE OR REPLACE FUNCTION relay.consume_mail_request_nonce(requested_machine_id text,requested_nonce text,requested_now timestamptz,requested_expires_at timestamptz)
 RETURNS boolean LANGUAGE plpgsql SECURITY DEFINER SET search_path=pg_catalog AS $function$ BEGIN RETURN true; END $function$`); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/postgres/postgres_integration_test.go
+++ b/internal/postgres/postgres_integration_test.go
@@ -10,6 +10,9 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/rock3r/punaro/internal/relay"
+	"github.com/rock3r/punaro/internal/relay/contracttest"
 )
 
 func TestPostgresPlatformSubstrateIntegration(t *testing.T) {
@@ -140,6 +143,100 @@ func TestPostgresPlatformSubstrateIntegration(t *testing.T) {
 	if err := app.Ready(ctx); err != nil {
 		t.Fatalf("migrated application not ready: %v", err)
 	}
+	if _, err := ownerDB.ExecContext(ctx, `ALTER TABLE relay.mail_messages DISABLE TRIGGER mail_messages_mutation_guard`); err != nil {
+		t.Fatal(err)
+	}
+	if drifted, driftErr := app.SchemaState(ctx); driftErr != nil || drifted.Classification != Incompatible {
+		t.Fatalf("disabled relay mutation guard state=%#v err=%v", drifted, driftErr)
+	}
+	if _, err := ownerDB.ExecContext(ctx, `ALTER TABLE relay.mail_messages ENABLE TRIGGER mail_messages_mutation_guard`); err != nil {
+		t.Fatal(err)
+	}
+	if err := app.Ready(ctx); err != nil {
+		t.Fatalf("relay guard restoration did not recover readiness: %v", err)
+	}
+	if _, err := ownerDB.ExecContext(ctx, `DROP TRIGGER mail_messages_mutation_guard ON relay.mail_messages; CREATE TRIGGER mail_messages_mutation_guard BEFORE INSERT OR UPDATE OR DELETE ON relay.mail_messages FOR EACH STATEMENT WHEN (false) EXECUTE FUNCTION jobs.guard_application_mutation()`); err != nil {
+		t.Fatal(err)
+	}
+	if drifted, driftErr := app.SchemaState(ctx); driftErr != nil || drifted.Classification != Incompatible {
+		t.Fatalf("conditional relay mutation guard state=%#v err=%v", drifted, driftErr)
+	}
+	if _, err := ownerDB.ExecContext(ctx, `DROP TRIGGER mail_messages_mutation_guard ON relay.mail_messages; CREATE TRIGGER mail_messages_mutation_guard BEFORE INSERT OR UPDATE OR DELETE ON relay.mail_messages FOR EACH STATEMENT EXECUTE FUNCTION jobs.guard_application_mutation()`); err != nil {
+		t.Fatal(err)
+	}
+	if err := app.Ready(ctx); err != nil {
+		t.Fatalf("unconditional relay guard restoration did not recover readiness: %v", err)
+	}
+	var nonceDefinition string
+	if err := ownerDB.QueryRowContext(ctx, `SELECT pg_get_functiondef('relay.consume_mail_request_nonce(text,text,timestamptz,timestamptz)'::regprocedure)`).Scan(&nonceDefinition); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ownerDB.ExecContext(ctx, `CREATE OR REPLACE FUNCTION relay.consume_mail_request_nonce(text,text,timestamptz,timestamptz)
+RETURNS boolean LANGUAGE plpgsql SECURITY DEFINER SET search_path=pg_catalog AS $function$ BEGIN RETURN true; END $function$`); err != nil {
+		t.Fatal(err)
+	}
+	if drifted, driftErr := app.SchemaState(ctx); driftErr != nil || drifted.Classification != Incompatible {
+		t.Fatalf("permissive relay nonce routine state=%#v err=%v", drifted, driftErr)
+	}
+	if _, err := ownerDB.ExecContext(ctx, nonceDefinition); err != nil {
+		t.Fatal(err)
+	}
+	if err := app.Ready(ctx); err != nil {
+		t.Fatalf("relay nonce routine restoration did not recover readiness: %v", err)
+	}
+	var bodyConstraint string
+	if err := ownerDB.QueryRowContext(ctx, `SELECT conname FROM pg_constraint WHERE conrelid='relay.mail_messages'::regclass AND contype='c' AND conkey=ARRAY[5]::smallint[]`).Scan(&bodyConstraint); err != nil {
+		t.Fatal(err)
+	}
+	quotedBodyConstraint := `"` + strings.ReplaceAll(bodyConstraint, `"`, `""`) + `"`
+	if _, err := ownerDB.ExecContext(ctx, `ALTER TABLE relay.mail_messages DROP CONSTRAINT `+quotedBodyConstraint+`; ALTER TABLE relay.mail_messages ADD CONSTRAINT `+quotedBodyConstraint+` CHECK (body IS NOT NULL)`); err != nil { // #nosec G202 -- catalog identifier is quoted.
+		t.Fatal(err)
+	}
+	if drifted, driftErr := app.SchemaState(ctx); driftErr != nil || drifted.Classification != Incompatible {
+		t.Fatalf("permissive relay body constraint state=%#v err=%v", drifted, driftErr)
+	}
+	if _, err := ownerDB.ExecContext(ctx, `ALTER TABLE relay.mail_messages DROP CONSTRAINT `+quotedBodyConstraint+`; ALTER TABLE relay.mail_messages ADD CONSTRAINT `+quotedBodyConstraint+` CHECK (octet_length(body) <= 32768)`); err != nil { // #nosec G202 -- catalog identifier is quoted.
+		t.Fatal(err)
+	}
+	if _, err := ownerDB.ExecContext(ctx, `GRANT SELECT ON relay.mail_messages TO pg_monitor`); err != nil {
+		t.Fatal(err)
+	}
+	if drifted, driftErr := app.SchemaState(ctx); driftErr != nil || drifted.Classification != Incompatible {
+		t.Fatalf("extra relay table grantee state=%#v err=%v", drifted, driftErr)
+	}
+	if _, err := ownerDB.ExecContext(ctx, `REVOKE SELECT ON relay.mail_messages FROM pg_monitor`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ownerDB.ExecContext(ctx, `GRANT SELECT ON relay.mail_messages TO PUBLIC`); err != nil {
+		t.Fatal(err)
+	}
+	if drifted, driftErr := app.SchemaState(ctx); driftErr != nil || drifted.Classification != Incompatible {
+		t.Fatalf("public relay table grant state=%#v err=%v", drifted, driftErr)
+	}
+	if _, err := ownerDB.ExecContext(ctx, `REVOKE SELECT ON relay.mail_messages FROM PUBLIC`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ownerDB.ExecContext(ctx, `GRANT UPDATE (body) ON relay.mail_messages TO punaro_app`); err != nil {
+		t.Fatal(err)
+	}
+	if drifted, driftErr := app.SchemaState(ctx); driftErr != nil || drifted.Classification != Incompatible {
+		t.Fatalf("extra relay column privilege state=%#v err=%v", drifted, driftErr)
+	}
+	if _, err := ownerDB.ExecContext(ctx, `REVOKE UPDATE (body) ON relay.mail_messages FROM punaro_app`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ownerDB.ExecContext(ctx, `REVOKE INSERT ON relay.mail_messages FROM punaro_app`); err != nil {
+		t.Fatal(err)
+	}
+	if drifted, driftErr := app.SchemaState(ctx); driftErr != nil || drifted.Classification != Incompatible {
+		t.Fatalf("missing relay insert privilege state=%#v err=%v", drifted, driftErr)
+	}
+	if _, err := ownerDB.ExecContext(ctx, `GRANT INSERT ON relay.mail_messages TO punaro_app`); err != nil {
+		t.Fatal(err)
+	}
+	if err := app.Ready(ctx); err != nil {
+		t.Fatalf("relay constraint and ACL restoration did not recover readiness: %v", err)
+	}
 	before, err := app.InstallationState(ctx)
 	if err != nil {
 		t.Fatal(err)
@@ -177,6 +274,7 @@ func TestPostgresPlatformSubstrateIntegration(t *testing.T) {
 	testProjectIdentityIntegration(ctx, t, app, ownerDB)
 	testBackupRestoreIntegration(ctx, t, app, ownerDB, ownerFile, appFile)
 	testTransactionalUpdateFenceIntegration(ctx, t, app, ownerDB)
+	testRelayIntegration(t, app)
 	if err := app.Close(); err != nil {
 		t.Fatal(err)
 	}
@@ -463,6 +561,11 @@ AS $function$ BEGIN RETURN NEW; END $function$`); err != nil {
 	}
 }
 
+func testRelayIntegration(t *testing.T, app *Database) {
+	t.Helper()
+	contracttest.Run(t, app, "postgres-contract")
+}
+
 func testV5UpdateBridgeIntegration(ctx context.Context, t *testing.T, ownerDB *sql.DB, ownerFile string) {
 	t.Helper()
 	current := CurrentManifest()
@@ -498,7 +601,7 @@ func testV5UpdateBridgeIntegration(ctx context.Context, t *testing.T, ownerDB *s
 		PostgresMajor:           postgresMajor,
 		ReleaseSHA256:           "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
 		ComposeSHA256:           "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
-		MigrationManifestSHA256: MigrationManifestSHA256(),
+		MigrationManifestSHA256: migrationManifestSHA256(Manifest{MinSupported: 6, MaxSupported: 6, Migrations: append([]Migration(nil), current.Migrations[:6]...)}),
 	}
 	bridge, err := BeginV5UpdateBridge(ctx, Config{DSNFile: ownerFile}, request)
 	if err != nil {
@@ -563,7 +666,8 @@ func testV5UpdateBridgeIntegration(ctx context.Context, t *testing.T, ownerDB *s
 		TargetImage: request.TargetImage, TargetSchema: request.TargetSchema,
 		ExportedSnapshotID: marker.ExportedSnapshotID, ManifestSHA256: marker.ManifestSHA256,
 	}
-	if state, err := MigrateUpdate(ctx, Config{DSNFile: ownerFile}, authorization); err != nil || state.Classification != Compatible || state.Version != 6 {
+	v6Manifest := Manifest{MinSupported: 6, MaxSupported: 6, Migrations: append([]Migration(nil), current.Migrations[:6]...)}
+	if state, err := migrateUpdateManifest(ctx, Config{DSNFile: ownerFile}, authorization, v6Manifest); err != nil || state.Classification != Compatible || state.Version != 6 {
 		logControlPlaneCatalog(ctx, t, ownerDB)
 		logDeviceAuthCatalog(ctx, t, ownerDB)
 		t.Fatalf("bridge migration state=%#v err=%v", state, err)
@@ -572,6 +676,63 @@ func testV5UpdateBridgeIntegration(ctx context.Context, t *testing.T, ownerDB *s
 		transaction, err = admin.AdvanceUpdate(ctx, request.UpdateID, phases[0], phases[1], nil)
 		if err != nil || transaction.Phase != phases[1] {
 			t.Fatalf("bridge phase %s -> %s transaction=%#v err=%v", phases[0], phases[1], transaction, err)
+		}
+	}
+	request = UpdateRequest{
+		UpdateID:                "019b4eb0-798c-7a52-8d29-8560fcbb2085",
+		SourceRelease:           "v0.7.0",
+		TargetRelease:           "v0.8.0",
+		SourceImage:             "ghcr.io/rock3r/punaro@sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+		TargetImage:             "ghcr.io/rock3r/punaro@sha256:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+		SourceSchema:            6,
+		TargetSchema:            7,
+		SchemaMin:               6,
+		SchemaMax:               7,
+		RollbackFloor:           6,
+		PostgresMajor:           postgresMajor,
+		ReleaseSHA256:           "abababababababababababababababababababababababababababababababab",
+		ComposeSHA256:           "cdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcd",
+		MigrationManifestSHA256: MigrationManifestSHA256(),
+	}
+	transaction, err = admin.BeginUpdate(ctx, request)
+	if err != nil || transaction.Phase != UpdateFenced {
+		t.Fatalf("begin v7 update transaction=%#v err=%v", transaction, err)
+	}
+	transaction, err = admin.AdvanceUpdate(ctx, request.UpdateID, UpdateFenced, UpdateWritersStopped, nil)
+	if err != nil || transaction.Phase != UpdateWritersStopped {
+		t.Fatalf("stop v7 writers transaction=%#v err=%v", transaction, err)
+	}
+	if err := ownerDB.QueryRowContext(ctx, `SELECT installation_id::text,timeline_id::text,change_sequence FROM jobs.server_state WHERE singleton`).Scan(&state.InstallationID, &state.TimelineID, &state.ChangeSequence); err != nil {
+		t.Fatal(err)
+	}
+	marker = &UpdateBackupMarker{
+		UpdateID: request.UpdateID, BackupID: "019b4eb0-5317-79a6-a0de-fd97719910fc",
+		InstallationID: state.InstallationID, TimelineID: state.TimelineID, ChangeSequence: state.ChangeSequence,
+		SourceSchema: request.SourceSchema, TargetRelease: request.TargetRelease,
+		TargetImageDigest:  "sha256:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+		ExportedSnapshotID: "00000003-0000001B-2",
+		ManifestSHA256:     "efefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefef",
+	}
+	transaction, err = admin.AdvanceUpdate(ctx, request.UpdateID, UpdateWritersStopped, UpdateBackupVerified, marker)
+	if err != nil || transaction.Phase != UpdateBackupVerified {
+		t.Fatalf("bind v7 backup transaction=%#v err=%v", transaction, err)
+	}
+	transaction, err = admin.AdvanceUpdate(ctx, request.UpdateID, UpdateBackupVerified, UpdateMigrationStarted, nil)
+	if err != nil || transaction.Phase != UpdateMigrationStarted {
+		t.Fatalf("start v7 migration transaction=%#v err=%v", transaction, err)
+	}
+	authorization = UpdateMigrationAuthorization{
+		UpdateID: request.UpdateID, BackupID: marker.BackupID, TargetRelease: request.TargetRelease,
+		TargetImage: request.TargetImage, TargetSchema: request.TargetSchema,
+		ExportedSnapshotID: marker.ExportedSnapshotID, ManifestSHA256: marker.ManifestSHA256,
+	}
+	if state, err := MigrateUpdate(ctx, Config{DSNFile: ownerFile}, authorization); err != nil || state.Classification != Compatible || state.Version != 7 {
+		t.Fatalf("v7 migration state=%#v err=%v", state, err)
+	}
+	for _, phases := range [][2]UpdatePhase{{UpdateMigrationStarted, UpdateMigrated}, {UpdateMigrated, UpdateCandidateReady}, {UpdateCandidateReady, UpdateDoctorPassed}, {UpdateDoctorPassed, UpdateConfigPublished}, {UpdateConfigPublished, UpdateCommitted}} {
+		transaction, err = admin.AdvanceUpdate(ctx, request.UpdateID, phases[0], phases[1], nil)
+		if err != nil || transaction.Phase != phases[1] {
+			t.Fatalf("v7 phase %s -> %s transaction=%#v err=%v", phases[0], phases[1], transaction, err)
 		}
 	}
 	if _, err := ownerDB.ExecContext(ctx, `DELETE FROM jobs.update_transactions`); err != nil {
@@ -662,6 +823,13 @@ func testTransactionalUpdateFenceIntegration(ctx context.Context, t *testing.T, 
 	}
 	if _, err := app.CreatePrincipal(ctx, PrincipalKindService, "fenced"); !errors.Is(err, ErrMaintenance) {
 		t.Fatalf("fenced transaction mutation error=%v", err)
+	}
+	if err := app.AdvertiseEndpoints("fenced-relay-machine", []string{"agent/fenced"}, time.Now().UTC(), time.Minute); !errors.Is(err, relay.ErrMaintenance) {
+		t.Fatalf("fenced relay mutation error=%v", err)
+	}
+	nonceNow := time.Now().UTC()
+	if err := app.ConsumeRequestNonce("fenced-relay-machine", "fenced-nonce", nonceNow, nonceNow.Add(time.Minute)); !errors.Is(err, relay.ErrMaintenance) {
+		t.Fatalf("fenced relay nonce error=%v", err)
 	}
 
 	transaction, err = admin.AdvanceUpdate(ctx, request.UpdateID, UpdateFenced, UpdateWritersStopped, nil)

--- a/internal/postgres/postgres_integration_test.go
+++ b/internal/postgres/postgres_integration_test.go
@@ -691,7 +691,7 @@ func testV5UpdateBridgeIntegration(ctx context.Context, t *testing.T, ownerDB *s
 		RollbackFloor:           6,
 		PostgresMajor:           postgresMajor,
 		ReleaseSHA256:           "abababababababababababababababababababababababababababababababab",
-		ComposeSHA256:           "cdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcd",
+		ComposeSHA256:           "cdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcd",
 		MigrationManifestSHA256: MigrationManifestSHA256(),
 	}
 	transaction, err = admin.BeginUpdate(ctx, request)

--- a/internal/postgres/postgres_integration_test.go
+++ b/internal/postgres/postgres_integration_test.go
@@ -566,6 +566,7 @@ func testRelayIntegration(t *testing.T, app *Database) {
 	t.Helper()
 	contracttest.Run(t, app, "postgres-contract")
 	testRecipientCursorDoesNotCrossUncommittedAppend(t, app)
+	testEndpointAdvertisementUsesCanonicalLockOrder(t, app)
 }
 
 func testRecipientCursorDoesNotCrossUncommittedAppend(t *testing.T, app *Database) {
@@ -631,6 +632,78 @@ func testRecipientCursorDoesNotCrossUncommittedAppend(t *testing.T, app *Databas
 	page, err := app.LeaseDeliveries(machineB, "postgres-cursor-lock-consumer", endpointB, conversation.ID, now, time.Minute, 10)
 	if err != nil || len(page.Deliveries) != 1 || page.Deliveries[0].Message.Sequence != 1 {
 		t.Fatalf("concurrent delivery page=%#v err=%v", page, err)
+	}
+}
+
+func testEndpointAdvertisementUsesCanonicalLockOrder(t *testing.T, app *Database) {
+	t.Helper()
+	now := time.Date(2026, time.July, 20, 16, 0, 0, 0, time.UTC)
+	const (
+		machineID = "postgres-advertisement-lock-machine"
+		endpointA = "agent/postgres-advertisement-lock/a"
+		endpointZ = "agent/postgres-advertisement-lock/z"
+	)
+	if err := app.AdvertiseEndpoints(machineID, []string{endpointA, endpointZ}, now, time.Hour); err != nil {
+		t.Fatal(err)
+	}
+	blocker, blockerCancel, err := app.beginRelayTransaction(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer blockerCancel()
+	defer func() { _ = blocker.Rollback() }()
+	if _, err := blocker.ExecContext(context.Background(), `SELECT endpoint FROM relay.mail_endpoints WHERE endpoint=$1 FOR UPDATE`, endpointA); err != nil {
+		t.Fatal(err)
+	}
+	advertisementResult := make(chan error, 1)
+	go func() {
+		advertisementResult <- app.AdvertiseEndpoints(machineID, []string{endpointA}, now.Add(time.Second), time.Hour)
+	}()
+	waitCtx, waitCancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer waitCancel()
+	for {
+		var waiting bool
+		err := app.relayPool().QueryRowContext(waitCtx, `SELECT EXISTS (
+			SELECT 1 FROM pg_stat_activity
+			WHERE datname=current_database() AND usename=current_user AND wait_event_type='Lock'
+			  AND query LIKE 'SELECT endpoint FROM relay.mail_endpoints%'
+		)`).Scan(&waiting)
+		if err != nil {
+			t.Fatalf("inspect advertisement lock wait: %v", err)
+		}
+		if waiting {
+			break
+		}
+		select {
+		case advertiseErr := <-advertisementResult:
+			t.Fatalf("advertisement escaped first endpoint lock: %v", advertiseErr)
+		case <-waitCtx.Done():
+			t.Fatal("advertisement did not wait on the first ordered endpoint")
+		case <-time.After(10 * time.Millisecond):
+		}
+	}
+	probe, probeCancel, err := app.beginRelayTransaction(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer probeCancel()
+	defer func() { _ = probe.Rollback() }()
+	if _, err := probe.ExecContext(context.Background(), `SELECT endpoint FROM relay.mail_endpoints WHERE endpoint=$1 FOR UPDATE NOWAIT`, endpointZ); err != nil {
+		t.Fatalf("advertisement locked a later endpoint before the first: %v", err)
+	}
+	if err := probe.Rollback(); err != nil {
+		t.Fatal(err)
+	}
+	if err := blocker.Commit(); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case err := <-advertisementResult:
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("ordered endpoint advertisement did not complete")
 	}
 }
 

--- a/internal/postgres/relay_store.go
+++ b/internal/postgres/relay_store.go
@@ -494,7 +494,7 @@ func (d *Database) ConversationsForMachine(machineID string, now time.Time) ([]r
 	rows, err := d.relayPool().QueryContext(ctx, `SELECT DISTINCT conversation.id::text FROM relay.mail_conversations AS conversation
 		JOIN relay.mail_memberships AS membership ON membership.conversation_id=conversation.id
 		JOIN relay.mail_endpoints AS endpoint ON endpoint.endpoint=membership.endpoint
-		WHERE endpoint.machine_id=$1 AND endpoint.lease_until>$2 ORDER BY conversation.id`, machineID, now.UTC())
+		WHERE endpoint.machine_id=$1 AND endpoint.lease_until>$2 ORDER BY conversation.id::text`, machineID, now.UTC())
 	if err != nil {
 		return nil, errors.New("machine conversations are unavailable")
 	}

--- a/internal/postgres/relay_store.go
+++ b/internal/postgres/relay_store.go
@@ -57,6 +57,9 @@ func (d *Database) AdvertiseEndpoints(machineID string, endpoints []string, now 
 	}
 	defer cancel()
 	defer func() { _ = tx.Rollback() }()
+	if endpoints == nil {
+		endpoints = []string{}
+	}
 	encodedEndpoints, err := json.Marshal(endpoints)
 	if err != nil {
 		return errors.New("endpoint advertisement is invalid")

--- a/internal/postgres/relay_store.go
+++ b/internal/postgres/relay_store.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"sort"
 	"strings"
 	"time"
 
@@ -57,12 +58,29 @@ func (d *Database) AdvertiseEndpoints(machineID string, endpoints []string, now 
 	}
 	defer cancel()
 	defer func() { _ = tx.Rollback() }()
-	if endpoints == nil {
-		endpoints = []string{}
-	}
-	encodedEndpoints, err := json.Marshal(endpoints)
+	orderedEndpoints := postgresSortedEndpoints(seen)
+	encodedEndpoints, err := json.Marshal(orderedEndpoints)
 	if err != nil {
 		return errors.New("endpoint advertisement is invalid")
+	}
+	rows, err := tx.QueryContext(context.Background(), `SELECT endpoint FROM relay.mail_endpoints
+		WHERE (machine_id=$1 AND lease_until>$2) OR endpoint IN (SELECT value FROM jsonb_array_elements_text($3::jsonb))
+		ORDER BY endpoint COLLATE "C" FOR UPDATE`, machineID, now.UTC(), string(encodedEndpoints))
+	if err != nil {
+		return relayDatabaseError(err, "lock endpoint advertisement")
+	}
+	for rows.Next() {
+		var endpoint string
+		if err := rows.Scan(&endpoint); err != nil {
+			_ = rows.Close()
+			return errors.New("endpoint advertisement lock is malformed")
+		}
+	}
+	if err := rows.Close(); err != nil {
+		return errors.New("endpoint advertisement locks are unavailable")
+	}
+	if err := rows.Err(); err != nil {
+		return errors.New("endpoint advertisement locks are unavailable")
 	}
 	if _, err := tx.ExecContext(context.Background(), `UPDATE relay.mail_endpoints
 		SET lease_until=$2,ownership_generation=ownership_generation+1,consumer_id=NULL,consumer_lease_until=NULL
@@ -70,7 +88,7 @@ func (d *Database) AdvertiseEndpoints(machineID string, endpoints []string, now 
 		return relayDatabaseError(err, "detach endpoints")
 	}
 	until := now.Add(ttl).UTC()
-	for endpoint := range seen {
+	for _, endpoint := range orderedEndpoints {
 		if _, err := tx.ExecContext(context.Background(), `INSERT INTO relay.mail_endpoints(endpoint,machine_id,lease_until) VALUES($1,$2,$3)
 			ON CONFLICT(endpoint) DO UPDATE SET
 				ownership_generation=CASE WHEN mail_endpoints.machine_id<>excluded.machine_id OR mail_endpoints.lease_until<=$4 THEN mail_endpoints.ownership_generation+1 ELSE mail_endpoints.ownership_generation END,
@@ -131,13 +149,13 @@ func (d *Database) CreateConversationIdempotent(input relay.CreateConversationIn
 	if _, err := tx.ExecContext(context.Background(), `SELECT pg_advisory_xact_lock(hashtextextended(jsonb_build_array($1::text,$2::text)::text, 579001230608))`, input.MachineID, input.IdempotencyKey); err != nil {
 		return relay.Conversation{}, errors.New("conversation retry lock is unavailable")
 	}
-	if _, err := postgresEndpointOwnershipLocked(tx, input.CreatorEndpoint, input.MachineID, input.Now); err != nil {
-		return relay.Conversation{}, err
-	}
 	hash := relay.CreateConversationRequestHash(input.CreatorEndpoint, input.Members)
 	var existingID, existingHash string
 	err = tx.QueryRowContext(context.Background(), `SELECT conversation_id::text,request_hash FROM relay.mail_conversation_idempotency WHERE machine_id=$1 AND key=$2`, input.MachineID, input.IdempotencyKey).Scan(&existingID, &existingHash)
 	if err == nil {
+		if _, err := postgresEndpointOwnershipLocked(tx, input.CreatorEndpoint, input.MachineID, input.Now); err != nil {
+			return relay.Conversation{}, err
+		}
 		if existingHash != hash {
 			return relay.Conversation{}, relay.ErrConflict
 		}
@@ -149,9 +167,18 @@ func (d *Database) CreateConversationIdempotent(input relay.CreateConversationIn
 	if !errors.Is(err, sql.ErrNoRows) {
 		return relay.Conversation{}, errors.New("conversation retry state is unavailable")
 	}
-	for endpoint := range seen {
-		if err := postgresEndpointActive(tx, endpoint, input.Now); err != nil {
-			return relay.Conversation{}, err
+	for _, endpoint := range postgresSortedEndpoints(seen) {
+		var owner string
+		var until time.Time
+		err := tx.QueryRowContext(context.Background(), `SELECT machine_id,lease_until FROM relay.mail_endpoints WHERE endpoint=$1 FOR UPDATE`, endpoint).Scan(&owner, &until)
+		if errors.Is(err, sql.ErrNoRows) {
+			return relay.Conversation{}, relay.ErrForbidden
+		}
+		if err != nil {
+			return relay.Conversation{}, errors.New("endpoint lease is unavailable")
+		}
+		if !until.After(input.Now) || endpoint == input.CreatorEndpoint && owner != input.MachineID {
+			return relay.Conversation{}, relay.ErrForbidden
 		}
 	}
 	conversation := relay.Conversation{ID: uuid.NewString()}
@@ -551,14 +578,13 @@ func (d *Database) ConversationsForMachine(machineID string, now time.Time) ([]r
 	return conversations, nil
 }
 
-func postgresEndpointActive(tx *sql.Tx, endpoint string, now time.Time) error {
-	var until time.Time
-	if err := tx.QueryRowContext(context.Background(), `SELECT lease_until FROM relay.mail_endpoints WHERE endpoint=$1 FOR UPDATE`, endpoint).Scan(&until); errors.Is(err, sql.ErrNoRows) || !until.After(now) {
-		return relay.ErrForbidden
-	} else if err != nil {
-		return errors.New("endpoint lease is unavailable")
+func postgresSortedEndpoints(endpoints map[string]struct{}) []string {
+	ordered := make([]string, 0, len(endpoints))
+	for endpoint := range endpoints {
+		ordered = append(ordered, endpoint)
 	}
-	return nil
+	sort.Strings(ordered)
+	return ordered
 }
 
 func postgresEndpointOwnedBy(tx *sql.Tx, endpoint, machineID string, now time.Time) error {

--- a/internal/postgres/relay_store.go
+++ b/internal/postgres/relay_store.go
@@ -125,7 +125,7 @@ func (d *Database) CreateConversationIdempotent(input relay.CreateConversationIn
 	}
 	defer cancel()
 	defer func() { _ = tx.Rollback() }()
-	if _, err := tx.ExecContext(context.Background(), `SELECT pg_advisory_xact_lock(hashtextextended($1, 579001230608))`, input.MachineID+"\x00"+input.IdempotencyKey); err != nil {
+	if _, err := tx.ExecContext(context.Background(), `SELECT pg_advisory_xact_lock(hashtextextended(jsonb_build_array($1::text,$2::text)::text, 579001230608))`, input.MachineID, input.IdempotencyKey); err != nil {
 		return relay.Conversation{}, errors.New("conversation retry lock is unavailable")
 	}
 	if _, err := postgresEndpointOwnershipLocked(tx, input.CreatorEndpoint, input.MachineID, input.Now); err != nil {
@@ -211,7 +211,7 @@ func (d *Database) AppendMessage(input relay.AppendInput) (relay.Message, bool, 
 	}
 	defer cancel()
 	defer func() { _ = tx.Rollback() }()
-	if _, err := tx.ExecContext(context.Background(), `SELECT pg_advisory_xact_lock(hashtextextended($1, 579001230609))`, input.SenderMachineID+"\x00"+input.IdempotencyKey); err != nil {
+	if _, err := tx.ExecContext(context.Background(), `SELECT pg_advisory_xact_lock(hashtextextended(jsonb_build_array($1::text,$2::text)::text, 579001230609))`, input.SenderMachineID, input.IdempotencyKey); err != nil {
 		return relay.Message{}, false, errors.New("message retry lock is unavailable")
 	}
 	if _, err := postgresEndpointOwnershipLocked(tx, input.FromEndpoint, input.SenderMachineID, input.Now); err != nil {

--- a/internal/postgres/relay_store.go
+++ b/internal/postgres/relay_store.go
@@ -765,7 +765,7 @@ WITH objects AS (
 	       AND NOT EXISTS (SELECT * FROM actual_keys EXCEPT SELECT * FROM expected_keys)
 	       AND NOT EXISTS (SELECT * FROM expected_foreign_keys EXCEPT SELECT * FROM actual_foreign_keys)
 	       AND NOT EXISTS (SELECT * FROM actual_foreign_keys EXCEPT SELECT * FROM expected_foreign_keys)
-	       AND check_expressions.exact AS exact
+	       AND bool_and(check_expressions.exact) AS exact
     FROM objects JOIN pg_constraint AS con
       ON con.conrelid=ANY(ARRAY[endpoints_oid,conversations_oid,memberships_oid,messages_oid,deliveries_oid,cursors_oid,message_idempotency_oid,conversation_idempotency_oid,nonces_oid])
      AND con.convalidated CROSS JOIN check_expressions

--- a/internal/postgres/relay_store.go
+++ b/internal/postgres/relay_store.go
@@ -1,0 +1,931 @@
+package postgres
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/rock3r/punaro/internal/relay"
+)
+
+var _ relay.Backend = (*Database)(nil)
+
+const postgresRelayMaxMessageBytes = 32 << 10
+
+// ConsumeRequestNonce atomically consumes one signed-request replay token
+// through the schema-owner routine. The application role cannot delete nonce
+// rows directly and therefore cannot reopen a replay window.
+func (d *Database) ConsumeRequestNonce(machineID, nonce string, now, expiresAt time.Time) error {
+	if !relay.ValidMachineID(machineID) || !relay.ValidRequestToken(nonce) || !expiresAt.After(now) {
+		return relay.ErrForbidden
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), operationTimeout)
+	defer cancel()
+	var consumed bool
+	if err := d.relayPool().QueryRowContext(ctx, `SELECT relay.consume_mail_request_nonce($1,$2,$3,$4)`, machineID, nonce, now.UTC(), expiresAt.UTC()).Scan(&consumed); err != nil {
+		return relayDatabaseError(err, "consume request nonce")
+	}
+	if !consumed {
+		return relay.ErrForbidden
+	}
+	return nil
+}
+
+// AdvertiseEndpoints atomically replaces one machine's active attachment set.
+func (d *Database) AdvertiseEndpoints(machineID string, endpoints []string, now time.Time, ttl time.Duration) error {
+	if !relay.ValidMachineID(machineID) || ttl <= 0 {
+		return errors.New("invalid endpoint lease")
+	}
+	seen := make(map[string]struct{}, len(endpoints))
+	for _, endpoint := range endpoints {
+		if !relay.ValidEndpoint(endpoint) {
+			return errors.New("endpoint is required")
+		}
+		if _, duplicate := seen[endpoint]; duplicate {
+			return errors.New("duplicate endpoint")
+		}
+		seen[endpoint] = struct{}{}
+	}
+	tx, cancel, err := d.beginRelayTransaction(nil)
+	if err != nil {
+		return errors.New("endpoint advertisement cannot start")
+	}
+	defer cancel()
+	defer func() { _ = tx.Rollback() }()
+	encodedEndpoints, err := json.Marshal(endpoints)
+	if err != nil {
+		return errors.New("endpoint advertisement is invalid")
+	}
+	if _, err := tx.ExecContext(context.Background(), `UPDATE relay.mail_endpoints
+		SET lease_until=$2,ownership_generation=ownership_generation+1,consumer_id=NULL,consumer_lease_until=NULL
+		WHERE machine_id=$1 AND lease_until>$2 AND endpoint NOT IN (SELECT value FROM jsonb_array_elements_text($3::jsonb))`, machineID, now.UTC(), string(encodedEndpoints)); err != nil {
+		return relayDatabaseError(err, "detach endpoints")
+	}
+	until := now.Add(ttl).UTC()
+	for endpoint := range seen {
+		if _, err := tx.ExecContext(context.Background(), `INSERT INTO relay.mail_endpoints(endpoint,machine_id,lease_until) VALUES($1,$2,$3)
+			ON CONFLICT(endpoint) DO UPDATE SET
+				ownership_generation=CASE WHEN mail_endpoints.machine_id<>excluded.machine_id OR mail_endpoints.lease_until<=$4 THEN mail_endpoints.ownership_generation+1 ELSE mail_endpoints.ownership_generation END,
+				consumer_id=CASE WHEN mail_endpoints.machine_id<>excluded.machine_id OR mail_endpoints.lease_until<=$4 THEN NULL ELSE mail_endpoints.consumer_id END,
+				consumer_lease_until=CASE WHEN mail_endpoints.machine_id<>excluded.machine_id OR mail_endpoints.lease_until<=$4 THEN NULL ELSE mail_endpoints.consumer_lease_until END,
+				machine_id=excluded.machine_id,lease_until=excluded.lease_until`, endpoint, machineID, until, now.UTC()); err != nil {
+			return relayDatabaseError(err, "advertise endpoint")
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		return relayDatabaseError(err, "commit endpoint advertisement")
+	}
+	return nil
+}
+
+// AssertEndpointOwnership verifies one live PostgreSQL endpoint lease.
+func (d *Database) AssertEndpointOwnership(machineID, endpoint string, now time.Time) error {
+	tx, cancel, err := d.beginRelayTransaction(&sql.TxOptions{ReadOnly: true})
+	if err != nil {
+		return errors.New("endpoint ownership cannot be inspected")
+	}
+	defer cancel()
+	defer func() { _ = tx.Rollback() }()
+	if err := postgresEndpointOwnedBy(tx, endpoint, machineID, now); err != nil {
+		return err
+	}
+	return tx.Commit()
+}
+
+// CreateConversationIdempotent creates one PostgreSQL relay conversation per retry key.
+func (d *Database) CreateConversationIdempotent(input relay.CreateConversationInput) (relay.Conversation, error) {
+	if !relay.ValidMachineID(input.MachineID) || !relay.ValidRequestToken(input.IdempotencyKey) || !relay.ValidEndpoint(input.CreatorEndpoint) || len(input.Members) == 0 || len(input.Members) > 256 {
+		return relay.Conversation{}, errors.New("invalid conversation request")
+	}
+	seen := make(map[string]struct{}, len(input.Members))
+	creatorAdmin := false
+	for _, member := range input.Members {
+		if !relay.ValidEndpoint(member.Endpoint) || member.Capabilities == 0 || member.Capabilities & ^(relay.CapSend|relay.CapReceive|relay.CapAdmin) != 0 {
+			return relay.Conversation{}, errors.New("invalid conversation member")
+		}
+		if _, duplicate := seen[member.Endpoint]; duplicate {
+			return relay.Conversation{}, errors.New("duplicate conversation member")
+		}
+		seen[member.Endpoint] = struct{}{}
+		if member.Endpoint == input.CreatorEndpoint && member.Capabilities&(relay.CapSend|relay.CapReceive|relay.CapAdmin) == relay.CapSend|relay.CapReceive|relay.CapAdmin {
+			creatorAdmin = true
+		}
+	}
+	if !creatorAdmin {
+		return relay.Conversation{}, relay.ErrForbidden
+	}
+	tx, cancel, err := d.beginRelayTransaction(nil)
+	if err != nil {
+		return relay.Conversation{}, errors.New("conversation transaction cannot start")
+	}
+	defer cancel()
+	defer func() { _ = tx.Rollback() }()
+	if _, err := tx.ExecContext(context.Background(), `SELECT pg_advisory_xact_lock(hashtextextended($1, 579001230608))`, input.MachineID+"\x00"+input.IdempotencyKey); err != nil {
+		return relay.Conversation{}, errors.New("conversation retry lock is unavailable")
+	}
+	if _, err := postgresEndpointOwnershipLocked(tx, input.CreatorEndpoint, input.MachineID, input.Now); err != nil {
+		return relay.Conversation{}, err
+	}
+	hash := relay.CreateConversationRequestHash(input.CreatorEndpoint, input.Members)
+	var existingID, existingHash string
+	err = tx.QueryRowContext(context.Background(), `SELECT conversation_id::text,request_hash FROM relay.mail_conversation_idempotency WHERE machine_id=$1 AND key=$2`, input.MachineID, input.IdempotencyKey).Scan(&existingID, &existingHash)
+	if err == nil {
+		if existingHash != hash {
+			return relay.Conversation{}, relay.ErrConflict
+		}
+		if err := tx.Commit(); err != nil {
+			return relay.Conversation{}, errors.New("conversation retry cannot commit")
+		}
+		return relay.Conversation{ID: existingID}, nil
+	}
+	if !errors.Is(err, sql.ErrNoRows) {
+		return relay.Conversation{}, errors.New("conversation retry state is unavailable")
+	}
+	for endpoint := range seen {
+		if err := postgresEndpointActive(tx, endpoint, input.Now); err != nil {
+			return relay.Conversation{}, err
+		}
+	}
+	conversation := relay.Conversation{ID: uuid.NewString()}
+	if _, err := tx.ExecContext(context.Background(), `INSERT INTO relay.mail_conversations(id,created_at) VALUES($1::uuid,$2)`, conversation.ID, input.Now.UTC()); err != nil {
+		return relay.Conversation{}, relayDatabaseError(err, "create conversation")
+	}
+	for _, member := range input.Members {
+		if _, err := tx.ExecContext(context.Background(), `INSERT INTO relay.mail_memberships(conversation_id,endpoint,capabilities) VALUES($1::uuid,$2,$3)`, conversation.ID, member.Endpoint, member.Capabilities); err != nil {
+			return relay.Conversation{}, relayDatabaseError(err, "add conversation member")
+		}
+	}
+	if _, err := tx.ExecContext(context.Background(), `INSERT INTO relay.mail_conversation_idempotency(machine_id,key,request_hash,conversation_id,created_at) VALUES($1,$2,$3,$4::uuid,$5)`, input.MachineID, input.IdempotencyKey, hash, conversation.ID, input.Now.UTC()); err != nil {
+		return relay.Conversation{}, relayDatabaseError(err, "record conversation retry")
+	}
+	if err := tx.Commit(); err != nil {
+		return relay.Conversation{}, relayDatabaseError(err, "commit conversation")
+	}
+	return conversation, nil
+}
+
+// AuthorizeSender verifies current PostgreSQL sender authority without mutation.
+func (d *Database) AuthorizeSender(conversationID, machineID, endpoint string, now time.Time) error {
+	if _, err := uuid.Parse(conversationID); err != nil {
+		return relay.ErrForbidden
+	}
+	tx, cancel, err := d.beginRelayTransaction(&sql.TxOptions{ReadOnly: true})
+	if err != nil {
+		return errors.New("sender authorization cannot start")
+	}
+	defer cancel()
+	defer func() { _ = tx.Rollback() }()
+	if err := postgresEndpointOwnedBy(tx, endpoint, machineID, now); err != nil {
+		return err
+	}
+	var capabilities relay.Capability
+	err = tx.QueryRowContext(context.Background(), `SELECT capabilities FROM relay.mail_memberships WHERE conversation_id=$1::uuid AND endpoint=$2`, conversationID, endpoint).Scan(&capabilities)
+	if errors.Is(err, sql.ErrNoRows) || capabilities&relay.CapSend == 0 {
+		return relay.ErrForbidden
+	}
+	if err != nil {
+		return errors.New("sender authorization is unavailable")
+	}
+	return tx.Commit()
+}
+
+// AppendMessage transactionally appends one immutable PostgreSQL relay message.
+func (d *Database) AppendMessage(input relay.AppendInput) (relay.Message, bool, error) {
+	if strings.TrimSpace(input.ConversationID) == "" || !relay.ValidMachineID(input.SenderMachineID) || !relay.ValidEndpoint(input.FromEndpoint) || !relay.ValidRequestToken(input.IdempotencyKey) {
+		return relay.Message{}, false, errors.New("invalid message request")
+	}
+	if len(input.Body) > postgresRelayMaxMessageBytes {
+		return relay.Message{}, false, errors.New("message body exceeds limit")
+	}
+	if _, err := uuid.Parse(input.ConversationID); err != nil {
+		return relay.Message{}, false, relay.ErrForbidden
+	}
+	tx, cancel, err := d.beginRelayTransaction(nil)
+	if err != nil {
+		return relay.Message{}, false, errors.New("message transaction cannot start")
+	}
+	defer cancel()
+	defer func() { _ = tx.Rollback() }()
+	if _, err := tx.ExecContext(context.Background(), `SELECT pg_advisory_xact_lock(hashtextextended($1, 579001230609))`, input.SenderMachineID+"\x00"+input.IdempotencyKey); err != nil {
+		return relay.Message{}, false, errors.New("message retry lock is unavailable")
+	}
+	if _, err := postgresEndpointOwnershipLocked(tx, input.FromEndpoint, input.SenderMachineID, input.Now); err != nil {
+		return relay.Message{}, false, err
+	}
+	var capabilities relay.Capability
+	err = tx.QueryRowContext(context.Background(), `SELECT capabilities FROM relay.mail_memberships WHERE conversation_id=$1::uuid AND endpoint=$2`, input.ConversationID, input.FromEndpoint).Scan(&capabilities)
+	if errors.Is(err, sql.ErrNoRows) || capabilities&relay.CapSend == 0 {
+		return relay.Message{}, false, relay.ErrForbidden
+	}
+	if err != nil {
+		return relay.Message{}, false, errors.New("message authorization is unavailable")
+	}
+	hash := relay.AppendRequestHash(input)
+	var existingID, existingHash string
+	err = tx.QueryRowContext(context.Background(), `SELECT message_id::text,request_hash FROM relay.mail_message_idempotency WHERE machine_id=$1 AND key=$2`, input.SenderMachineID, input.IdempotencyKey).Scan(&existingID, &existingHash)
+	if err == nil {
+		if existingHash != hash {
+			return relay.Message{}, false, relay.ErrConflict
+		}
+		message, err := postgresMessageByID(tx, existingID)
+		if err != nil {
+			return relay.Message{}, false, err
+		}
+		if err := tx.Commit(); err != nil {
+			return relay.Message{}, false, errors.New("message retry cannot commit")
+		}
+		return message, true, nil
+	}
+	if !errors.Is(err, sql.ErrNoRows) {
+		return relay.Message{}, false, errors.New("message retry state is unavailable")
+	}
+	message := relay.Message{ID: uuid.NewString(), ConversationID: input.ConversationID, FromEndpoint: input.FromEndpoint, Body: input.Body, CreatedAt: input.Now.UTC()}
+	if err := tx.QueryRowContext(context.Background(), `UPDATE relay.mail_conversations SET next_sequence=next_sequence+1 WHERE id=$1::uuid RETURNING next_sequence`, input.ConversationID).Scan(&message.Sequence); errors.Is(err, sql.ErrNoRows) {
+		return relay.Message{}, false, relay.ErrForbidden
+	} else if err != nil {
+		return relay.Message{}, false, relayDatabaseError(err, "allocate message sequence")
+	}
+	if _, err := tx.ExecContext(context.Background(), `INSERT INTO relay.mail_messages(id,conversation_id,sequence,from_endpoint,body,created_at) VALUES($1::uuid,$2::uuid,$3,$4,$5,$6)`, message.ID, message.ConversationID, message.Sequence, message.FromEndpoint, message.Body, message.CreatedAt); err != nil {
+		return relay.Message{}, false, relayDatabaseError(err, "append message")
+	}
+	if _, err := tx.ExecContext(context.Background(), `INSERT INTO relay.mail_deliveries(message_id,recipient_endpoint)
+		SELECT $1::uuid,endpoint FROM relay.mail_memberships WHERE conversation_id=$2::uuid AND (capabilities & $3) <> 0 AND endpoint<>$4`, message.ID, message.ConversationID, relay.CapReceive, message.FromEndpoint); err != nil {
+		return relay.Message{}, false, relayDatabaseError(err, "create recipient deliveries")
+	}
+	if capabilities&relay.CapReceive != 0 {
+		if err := postgresAdvanceRecipientCursor(tx, input.FromEndpoint, input.ConversationID); err != nil {
+			return relay.Message{}, false, err
+		}
+	}
+	if _, err := tx.ExecContext(context.Background(), `INSERT INTO relay.mail_message_idempotency(machine_id,key,request_hash,message_id,created_at) VALUES($1,$2,$3,$4::uuid,$5)`, input.SenderMachineID, input.IdempotencyKey, hash, message.ID, input.Now.UTC()); err != nil {
+		return relay.Message{}, false, relayDatabaseError(err, "record message retry")
+	}
+	if err := tx.Commit(); err != nil {
+		return relay.Message{}, false, relayDatabaseError(err, "commit message")
+	}
+	return message, false, nil
+}
+
+// LeaseDeliveries claims a bounded fenced PostgreSQL delivery page.
+func (d *Database) LeaseDeliveries(machineID, consumerID, endpoint, conversationID string, now time.Time, ttl time.Duration, limit int) ([]relay.Delivery, error) {
+	if !relay.ValidMachineID(machineID) || !relay.ValidRequestToken(consumerID) || !relay.ValidEndpoint(endpoint) || ttl <= 0 || limit < 1 || limit > 100 {
+		return nil, errors.New("invalid delivery lease request")
+	}
+	if conversationID != "" {
+		if _, err := uuid.Parse(conversationID); err != nil {
+			return nil, relay.ErrForbidden
+		}
+	}
+	tx, cancel, err := d.beginRelayTransaction(nil)
+	if err != nil {
+		return nil, errors.New("delivery lease transaction cannot start")
+	}
+	defer cancel()
+	defer func() { _ = tx.Rollback() }()
+	ownershipGeneration, err := postgresEndpointOwnershipLocked(tx, endpoint, machineID, now)
+	if err != nil {
+		return nil, err
+	}
+	var activeConsumer sql.NullString
+	var consumerGeneration int64
+	var consumerUntil sql.NullTime
+	if err := tx.QueryRowContext(context.Background(), `SELECT consumer_id,consumer_generation,consumer_lease_until FROM relay.mail_endpoints WHERE endpoint=$1`, endpoint).Scan(&activeConsumer, &consumerGeneration, &consumerUntil); err != nil {
+		return nil, errors.New("endpoint consumer lease is unavailable")
+	}
+	if activeConsumer.Valid && activeConsumer.String != consumerID && consumerUntil.Valid && consumerUntil.Time.After(now) {
+		return nil, relay.ErrConflict
+	}
+	if !activeConsumer.Valid || activeConsumer.String != consumerID || !consumerUntil.Valid || !consumerUntil.Time.After(now) {
+		consumerGeneration++
+	}
+	consumerLeaseUntil := now.Add(ttl).UTC()
+	if _, err := tx.ExecContext(context.Background(), `UPDATE relay.mail_endpoints SET consumer_id=$1,consumer_generation=$2,consumer_lease_until=$3 WHERE endpoint=$4 AND ownership_generation=$5`, consumerID, consumerGeneration, consumerLeaseUntil, endpoint, ownershipGeneration); err != nil {
+		return nil, relayDatabaseError(err, "claim endpoint consumer lease")
+	}
+	query := `SELECT delivery.id::text,delivery.lease_machine_id,delivery.lease_token::text,delivery.lease_generation,delivery.ownership_generation,delivery.consumer_generation,delivery.lease_until,
+		message.id::text,message.conversation_id::text,message.sequence,message.from_endpoint,message.body,message.created_at
+		FROM relay.mail_deliveries AS delivery JOIN relay.mail_messages AS message ON message.id=delivery.message_id
+		WHERE delivery.recipient_endpoint=$1 AND delivery.acked_at IS NULL
+		  AND (delivery.lease_until IS NULL OR delivery.lease_until<=$2 OR delivery.ownership_generation IS NULL OR delivery.ownership_generation<>$3 OR delivery.consumer_generation IS NULL OR delivery.consumer_generation<>$4 OR delivery.lease_machine_id=$5)`
+	args := []any{endpoint, now.UTC(), ownershipGeneration, consumerGeneration, machineID}
+	if conversationID != "" {
+		query += ` AND message.conversation_id=$6::uuid ORDER BY message.sequence,message.id LIMIT $7 FOR UPDATE OF delivery SKIP LOCKED`
+		args = append(args, conversationID, limit)
+	} else {
+		query += ` ORDER BY message.created_at,message.conversation_id,message.sequence LIMIT $6 FOR UPDATE OF delivery SKIP LOCKED`
+		args = append(args, limit)
+	}
+	rows, err := tx.QueryContext(context.Background(), query, args...)
+	if err != nil {
+		return nil, errors.New("pending deliveries are unavailable")
+	}
+	type leasedRow struct {
+		delivery       relay.Delivery
+		leaseMachine   sql.NullString
+		leaseToken     sql.NullString
+		leaseOwnership sql.NullInt64
+		leaseConsumer  sql.NullInt64
+		leaseUntil     sql.NullTime
+	}
+	var pending []leasedRow
+	for rows.Next() {
+		var row leasedRow
+		row.delivery.RecipientEndpoint = endpoint
+		if err := rows.Scan(&row.delivery.ID, &row.leaseMachine, &row.leaseToken, &row.delivery.LeaseGeneration, &row.leaseOwnership, &row.leaseConsumer, &row.leaseUntil, &row.delivery.Message.ID, &row.delivery.Message.ConversationID, &row.delivery.Message.Sequence, &row.delivery.Message.FromEndpoint, &row.delivery.Message.Body, &row.delivery.Message.CreatedAt); err != nil {
+			_ = rows.Close()
+			return nil, errors.New("pending delivery is malformed")
+		}
+		row.delivery.Message.CreatedAt = row.delivery.Message.CreatedAt.UTC()
+		pending = append(pending, row)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, errors.New("pending deliveries are unavailable")
+	}
+	if err := rows.Err(); err != nil {
+		return nil, errors.New("pending deliveries are unavailable")
+	}
+	deliveries := make([]relay.Delivery, 0, len(pending))
+	for _, row := range pending {
+		delivery := row.delivery
+		if row.leaseMachine.Valid && row.leaseMachine.String == machineID && row.leaseToken.Valid && row.leaseOwnership.Valid && row.leaseOwnership.Int64 == ownershipGeneration && row.leaseConsumer.Valid && row.leaseConsumer.Int64 == consumerGeneration && row.leaseUntil.Valid && row.leaseUntil.Time.After(now) {
+			delivery.LeaseToken = row.leaseToken.String
+			delivery.LeaseUntil = row.leaseUntil.Time.UTC()
+		} else {
+			delivery.LeaseGeneration++
+			delivery.LeaseToken = uuid.NewString()
+			delivery.LeaseUntil = now.Add(ttl).UTC()
+			if _, err := tx.ExecContext(context.Background(), `UPDATE relay.mail_deliveries SET lease_machine_id=$1,lease_token=$2::uuid,lease_generation=$3,ownership_generation=$4,consumer_generation=$5,lease_until=$6 WHERE id=$7::uuid`, machineID, delivery.LeaseToken, delivery.LeaseGeneration, ownershipGeneration, consumerGeneration, delivery.LeaseUntil, delivery.ID); err != nil {
+				return nil, relayDatabaseError(err, "lease delivery")
+			}
+		}
+		deliveries = append(deliveries, delivery)
+	}
+	if err := tx.Commit(); err != nil {
+		return nil, relayDatabaseError(err, "commit delivery lease")
+	}
+	return deliveries, nil
+}
+
+// AckDelivery conditionally acknowledges one fenced PostgreSQL delivery.
+func (d *Database) AckDelivery(machineID, endpoint, deliveryID, token string, generation int64, now time.Time) error {
+	if _, err := uuid.Parse(deliveryID); err != nil {
+		return relay.ErrForbidden
+	}
+	tx, cancel, err := d.beginRelayTransaction(nil)
+	if err != nil {
+		return errors.New("delivery acknowledgement cannot start")
+	}
+	defer cancel()
+	defer func() { _ = tx.Rollback() }()
+	ownershipGeneration, err := postgresEndpointOwnershipLocked(tx, endpoint, machineID, now)
+	if err != nil {
+		return err
+	}
+	var recipient string
+	var leaseMachine, leaseToken sql.NullString
+	var leaseGeneration int64
+	var leaseOwnership, leaseConsumer sql.NullInt64
+	var leaseUntil, acknowledged sql.NullTime
+	var conversationID string
+	err = tx.QueryRowContext(context.Background(), `SELECT delivery.recipient_endpoint,delivery.lease_machine_id,delivery.lease_token::text,
+		delivery.lease_generation,delivery.ownership_generation,delivery.consumer_generation,delivery.lease_until,delivery.acked_at,message.conversation_id::text
+		FROM relay.mail_deliveries AS delivery JOIN relay.mail_messages AS message ON message.id=delivery.message_id
+		WHERE delivery.id=$1::uuid FOR UPDATE OF delivery`, deliveryID).Scan(&recipient, &leaseMachine, &leaseToken, &leaseGeneration, &leaseOwnership, &leaseConsumer, &leaseUntil, &acknowledged, &conversationID)
+	if errors.Is(err, sql.ErrNoRows) || recipient != endpoint {
+		return relay.ErrForbidden
+	}
+	if err != nil {
+		return relay.ErrForbidden
+	}
+	if acknowledged.Valid && leaseToken.Valid && leaseToken.String == token && leaseGeneration == generation {
+		return tx.Commit()
+	}
+	var currentConsumerGeneration int64
+	if err := tx.QueryRowContext(context.Background(), `SELECT consumer_generation FROM relay.mail_endpoints WHERE endpoint=$1`, endpoint).Scan(&currentConsumerGeneration); err != nil {
+		return relay.ErrForbidden
+	}
+	if !leaseMachine.Valid || leaseMachine.String != machineID || !leaseToken.Valid || leaseToken.String != token || leaseGeneration != generation || !leaseOwnership.Valid || leaseOwnership.Int64 != ownershipGeneration || !leaseConsumer.Valid || leaseConsumer.Int64 != currentConsumerGeneration || !leaseUntil.Valid || !leaseUntil.Time.After(now) {
+		return relay.ErrForbidden
+	}
+	if _, err := tx.ExecContext(context.Background(), `UPDATE relay.mail_deliveries SET acked_at=$1 WHERE id=$2::uuid AND acked_at IS NULL`, now.UTC(), deliveryID); err != nil {
+		return relayDatabaseError(err, "acknowledge delivery")
+	}
+	if err := postgresAdvanceRecipientCursor(tx, endpoint, conversationID); err != nil {
+		return err
+	}
+	if err := tx.Commit(); err != nil {
+		return relayDatabaseError(err, "commit delivery acknowledgement")
+	}
+	return nil
+}
+
+// RecipientCursor reads one recipient's durable contiguous sequence.
+func (d *Database) RecipientCursor(machineID, endpoint, conversationID string, now time.Time) (int64, error) {
+	if _, err := uuid.Parse(conversationID); err != nil {
+		return 0, relay.ErrForbidden
+	}
+	tx, cancel, err := d.beginRelayTransaction(&sql.TxOptions{ReadOnly: true})
+	if err != nil {
+		return 0, errors.New("recipient cursor cannot be inspected")
+	}
+	defer cancel()
+	defer func() { _ = tx.Rollback() }()
+	if err := postgresEndpointOwnedBy(tx, endpoint, machineID, now); err != nil {
+		return 0, err
+	}
+	var capabilities relay.Capability
+	err = tx.QueryRowContext(context.Background(), `SELECT capabilities FROM relay.mail_memberships WHERE conversation_id=$1::uuid AND endpoint=$2`, conversationID, endpoint).Scan(&capabilities)
+	if errors.Is(err, sql.ErrNoRows) || capabilities&relay.CapReceive == 0 {
+		return 0, relay.ErrForbidden
+	}
+	if err != nil {
+		return 0, errors.New("recipient cursor authorization is unavailable")
+	}
+	var cursor int64
+	err = tx.QueryRowContext(context.Background(), `SELECT sequence FROM relay.mail_recipient_cursors WHERE recipient_endpoint=$1 AND conversation_id=$2::uuid`, endpoint, conversationID).Scan(&cursor)
+	if errors.Is(err, sql.ErrNoRows) {
+		cursor = 0
+	} else if err != nil {
+		return 0, errors.New("recipient cursor is unavailable")
+	}
+	if err := tx.Commit(); err != nil {
+		return 0, errors.New("recipient cursor snapshot cannot commit")
+	}
+	return cursor, nil
+}
+
+// RecipientMachines returns active machine owners for payload-free wake hints.
+func (d *Database) RecipientMachines(messageID string, now time.Time) ([]string, error) {
+	if _, err := uuid.Parse(messageID); err != nil {
+		return nil, relay.ErrForbidden
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), operationTimeout)
+	defer cancel()
+	rows, err := d.relayPool().QueryContext(ctx, `SELECT DISTINCT endpoint.machine_id FROM relay.mail_deliveries AS delivery
+		JOIN relay.mail_endpoints AS endpoint ON endpoint.endpoint=delivery.recipient_endpoint
+		WHERE delivery.message_id=$1::uuid AND endpoint.lease_until>$2 ORDER BY endpoint.machine_id`, messageID, now.UTC())
+	if err != nil {
+		return nil, errors.New("message recipients are unavailable")
+	}
+	defer func() { _ = rows.Close() }()
+	var machines []string
+	for rows.Next() {
+		var machineID string
+		if err := rows.Scan(&machineID); err != nil {
+			return nil, errors.New("message recipient is malformed")
+		}
+		machines = append(machines, machineID)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, errors.New("message recipients are unavailable")
+	}
+	return machines, nil
+}
+
+// ConversationsForMachine lists rooms visible through live machine endpoints.
+func (d *Database) ConversationsForMachine(machineID string, now time.Time) ([]relay.Conversation, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), operationTimeout)
+	defer cancel()
+	rows, err := d.relayPool().QueryContext(ctx, `SELECT DISTINCT conversation.id::text FROM relay.mail_conversations AS conversation
+		JOIN relay.mail_memberships AS membership ON membership.conversation_id=conversation.id
+		JOIN relay.mail_endpoints AS endpoint ON endpoint.endpoint=membership.endpoint
+		WHERE endpoint.machine_id=$1 AND endpoint.lease_until>$2 ORDER BY conversation.id`, machineID, now.UTC())
+	if err != nil {
+		return nil, errors.New("machine conversations are unavailable")
+	}
+	defer func() { _ = rows.Close() }()
+	var conversations []relay.Conversation
+	for rows.Next() {
+		var conversation relay.Conversation
+		if err := rows.Scan(&conversation.ID); err != nil {
+			return nil, errors.New("machine conversation is malformed")
+		}
+		conversations = append(conversations, conversation)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, errors.New("machine conversations are unavailable")
+	}
+	return conversations, nil
+}
+
+func postgresEndpointActive(tx *sql.Tx, endpoint string, now time.Time) error {
+	var until time.Time
+	if err := tx.QueryRowContext(context.Background(), `SELECT lease_until FROM relay.mail_endpoints WHERE endpoint=$1 FOR UPDATE`, endpoint).Scan(&until); errors.Is(err, sql.ErrNoRows) || !until.After(now) {
+		return relay.ErrForbidden
+	} else if err != nil {
+		return errors.New("endpoint lease is unavailable")
+	}
+	return nil
+}
+
+func postgresEndpointOwnedBy(tx *sql.Tx, endpoint, machineID string, now time.Time) error {
+	var owner string
+	var until time.Time
+	if err := tx.QueryRowContext(context.Background(), `SELECT machine_id,lease_until FROM relay.mail_endpoints WHERE endpoint=$1`, endpoint).Scan(&owner, &until); errors.Is(err, sql.ErrNoRows) || owner != machineID || !until.After(now) {
+		return relay.ErrForbidden
+	} else if err != nil {
+		return errors.New("endpoint ownership is unavailable")
+	}
+	return nil
+}
+
+func postgresEndpointOwnershipLocked(tx *sql.Tx, endpoint, machineID string, now time.Time) (int64, error) {
+	var owner string
+	var until time.Time
+	var generation int64
+	if err := tx.QueryRowContext(context.Background(), `SELECT machine_id,lease_until,ownership_generation FROM relay.mail_endpoints WHERE endpoint=$1 FOR UPDATE`, endpoint).Scan(&owner, &until, &generation); errors.Is(err, sql.ErrNoRows) || owner != machineID || !until.After(now) {
+		return 0, relay.ErrForbidden
+	} else if err != nil {
+		return 0, errors.New("endpoint ownership is unavailable")
+	}
+	return generation, nil
+}
+
+func postgresMessageByID(tx *sql.Tx, messageID string) (relay.Message, error) {
+	var message relay.Message
+	if err := tx.QueryRowContext(context.Background(), `SELECT id::text,conversation_id::text,sequence,from_endpoint,body,created_at FROM relay.mail_messages WHERE id=$1::uuid`, messageID).Scan(&message.ID, &message.ConversationID, &message.Sequence, &message.FromEndpoint, &message.Body, &message.CreatedAt); err != nil {
+		return relay.Message{}, errors.New("idempotent message is unavailable")
+	}
+	message.CreatedAt = message.CreatedAt.UTC()
+	return message, nil
+}
+
+func postgresAdvanceRecipientCursor(tx *sql.Tx, endpoint, conversationID string) error {
+	if _, err := tx.ExecContext(context.Background(), `INSERT INTO relay.mail_recipient_cursors(recipient_endpoint,conversation_id,sequence) VALUES($1,$2::uuid,0) ON CONFLICT DO NOTHING`, endpoint, conversationID); err != nil {
+		return relayDatabaseError(err, "initialize recipient cursor")
+	}
+	var cursor int64
+	if err := tx.QueryRowContext(context.Background(), `SELECT sequence FROM relay.mail_recipient_cursors WHERE recipient_endpoint=$1 AND conversation_id=$2::uuid FOR UPDATE`, endpoint, conversationID).Scan(&cursor); err != nil {
+		return errors.New("recipient cursor is unavailable")
+	}
+	var nextPending sql.NullInt64
+	if err := tx.QueryRowContext(context.Background(), `SELECT MIN(message.sequence) FROM relay.mail_deliveries AS delivery
+		JOIN relay.mail_messages AS message ON message.id=delivery.message_id
+		WHERE delivery.recipient_endpoint=$1 AND message.conversation_id=$2::uuid AND delivery.acked_at IS NULL AND message.sequence>$3`, endpoint, conversationID, cursor).Scan(&nextPending); err != nil {
+		return errors.New("recipient cursor gap is unavailable")
+	}
+	var target int64
+	if nextPending.Valid {
+		target = nextPending.Int64 - 1
+	} else {
+		var maximum int64
+		if err := tx.QueryRowContext(context.Background(), `SELECT next_sequence FROM relay.mail_conversations WHERE id=$1::uuid`, conversationID).Scan(&maximum); err != nil {
+			return errors.New("recipient cursor maximum is unavailable")
+		}
+		target = maximum
+	}
+	if target > cursor {
+		if _, err := tx.ExecContext(context.Background(), `UPDATE relay.mail_recipient_cursors SET sequence=$1 WHERE recipient_endpoint=$2 AND conversation_id=$3::uuid AND sequence=$4`, target, endpoint, conversationID, cursor); err != nil {
+			return relayDatabaseError(err, "advance recipient cursor")
+		}
+	}
+	return nil
+}
+
+func relayDatabaseError(err error, operation string) error {
+	if isMaintenanceError(err) {
+		return relay.ErrMaintenance
+	}
+	return fmt.Errorf("PostgreSQL relay %s failed", operation)
+}
+
+func (d *Database) beginRelayTransaction(options *sql.TxOptions) (*sql.Tx, context.CancelFunc, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), operationTimeout)
+	tx, err := d.relayPool().BeginTx(ctx, options)
+	if err != nil {
+		cancel()
+		return nil, nil, err
+	}
+	for _, statement := range []string{
+		`SET LOCAL statement_timeout = '5s'`,
+		`SET LOCAL lock_timeout = '5s'`,
+	} {
+		if _, err := tx.ExecContext(context.Background(), statement); err != nil {
+			_ = tx.Rollback()
+			cancel()
+			return nil, nil, err
+		}
+	}
+	return tx, cancel, nil
+}
+
+func (d *Database) relayPool() *sql.DB {
+	if d.relayDB != nil {
+		return d.relayDB
+	}
+	return d.db
+}
+
+func relayControlsAvailable(ctx context.Context, q queryer) (bool, error) {
+	var available bool
+	err := q.QueryRowContext(ctx, `
+WITH objects AS (
+    SELECT to_regclass('relay.mail_endpoints') AS endpoints_oid,
+           to_regclass('relay.mail_conversations') AS conversations_oid,
+           to_regclass('relay.mail_memberships') AS memberships_oid,
+           to_regclass('relay.mail_messages') AS messages_oid,
+           to_regclass('relay.mail_deliveries') AS deliveries_oid,
+           to_regclass('relay.mail_recipient_cursors') AS cursors_oid,
+           to_regclass('relay.mail_message_idempotency') AS message_idempotency_oid,
+           to_regclass('relay.mail_conversation_idempotency') AS conversation_idempotency_oid,
+           to_regclass('relay.mail_request_nonces') AS nonces_oid,
+           to_regclass('relay.mail_endpoints_machine') AS endpoints_index_oid,
+           to_regclass('relay.mail_deliveries_pending') AS deliveries_index_oid,
+           to_regclass('relay.mail_request_nonces_expiry') AS nonces_index_oid,
+           to_regprocedure('relay.consume_mail_request_nonce(text,text,timestamp with time zone,timestamp with time zone)') AS consume_oid,
+           to_regprocedure('jobs.guard_application_mutation()') AS guard_oid
+), table_ownership AS (
+    SELECT count(*)=9 AND bool_and(pg_get_userbyid(relation.relowner)='punaro_owner' AND relation.relkind='r' AND relation.relpersistence='p' AND NOT relation.relrowsecurity AND NOT relation.relforcerowsecurity) AS exact
+    FROM objects JOIN pg_class AS relation ON relation.oid=ANY(ARRAY[endpoints_oid,conversations_oid,memberships_oid,messages_oid,deliveries_oid,cursors_oid,message_idempotency_oid,conversation_idempotency_oid,nonces_oid])
+), expected_columns(table_oid,column_name,type_oid,required) AS (
+    SELECT expected.* FROM objects, LATERAL (VALUES
+        (endpoints_oid,'endpoint','text'::regtype,true),(endpoints_oid,'machine_id','text'::regtype,true),
+        (endpoints_oid,'lease_until','timestamptz'::regtype,true),(endpoints_oid,'ownership_generation','bigint'::regtype,true),
+        (endpoints_oid,'consumer_id','text'::regtype,false),(endpoints_oid,'consumer_generation','bigint'::regtype,true),
+        (endpoints_oid,'consumer_lease_until','timestamptz'::regtype,false),
+        (conversations_oid,'id','uuid'::regtype,true),(conversations_oid,'next_sequence','bigint'::regtype,true),(conversations_oid,'created_at','timestamptz'::regtype,true),
+        (memberships_oid,'conversation_id','uuid'::regtype,true),(memberships_oid,'endpoint','text'::regtype,true),(memberships_oid,'capabilities','smallint'::regtype,true),
+        (messages_oid,'id','uuid'::regtype,true),(messages_oid,'conversation_id','uuid'::regtype,true),(messages_oid,'sequence','bigint'::regtype,true),
+        (messages_oid,'from_endpoint','text'::regtype,true),(messages_oid,'body','text'::regtype,true),(messages_oid,'created_at','timestamptz'::regtype,true),
+        (deliveries_oid,'id','uuid'::regtype,true),(deliveries_oid,'message_id','uuid'::regtype,true),(deliveries_oid,'recipient_endpoint','text'::regtype,true),
+        (deliveries_oid,'lease_machine_id','text'::regtype,false),(deliveries_oid,'lease_token','uuid'::regtype,false),(deliveries_oid,'lease_generation','bigint'::regtype,true),
+        (deliveries_oid,'ownership_generation','bigint'::regtype,false),(deliveries_oid,'consumer_generation','bigint'::regtype,false),
+        (deliveries_oid,'lease_until','timestamptz'::regtype,false),(deliveries_oid,'acked_at','timestamptz'::regtype,false),
+        (cursors_oid,'recipient_endpoint','text'::regtype,true),(cursors_oid,'conversation_id','uuid'::regtype,true),(cursors_oid,'sequence','bigint'::regtype,true),
+        (message_idempotency_oid,'machine_id','text'::regtype,true),(message_idempotency_oid,'key','text'::regtype,true),(message_idempotency_oid,'request_hash','bpchar'::regtype,true),
+        (message_idempotency_oid,'message_id','uuid'::regtype,true),(message_idempotency_oid,'created_at','timestamptz'::regtype,true),
+        (conversation_idempotency_oid,'machine_id','text'::regtype,true),(conversation_idempotency_oid,'key','text'::regtype,true),(conversation_idempotency_oid,'request_hash','bpchar'::regtype,true),
+        (conversation_idempotency_oid,'conversation_id','uuid'::regtype,true),(conversation_idempotency_oid,'created_at','timestamptz'::regtype,true),
+        (nonces_oid,'machine_id','text'::regtype,true),(nonces_oid,'nonce','text'::regtype,true),(nonces_oid,'expires_at','timestamptz'::regtype,true)
+    ) AS expected(table_oid,column_name,type_oid,required)
+), actual_columns AS (
+    SELECT attribute.attrelid,attribute.attname,attribute.atttypid,attribute.attnotnull
+    FROM objects JOIN pg_attribute AS attribute
+      ON attribute.attrelid=ANY(ARRAY[endpoints_oid,conversations_oid,memberships_oid,messages_oid,deliveries_oid,cursors_oid,message_idempotency_oid,conversation_idempotency_oid,nonces_oid])
+     AND attribute.attnum>0 AND NOT attribute.attisdropped
+), columns AS (
+    SELECT NOT EXISTS (SELECT * FROM expected_columns EXCEPT SELECT * FROM actual_columns)
+       AND NOT EXISTS (SELECT * FROM actual_columns EXCEPT SELECT * FROM expected_columns)
+       AND (SELECT count(*)=2 FROM pg_attribute WHERE attrelid=ANY(ARRAY[message_idempotency_oid,conversation_idempotency_oid]) AND attname='request_hash' AND atttypid='bpchar'::regtype AND atttypmod=68)
+       AND NOT EXISTS (SELECT 1 FROM pg_attribute WHERE attrelid=ANY(ARRAY[endpoints_oid,conversations_oid,memberships_oid,messages_oid,deliveries_oid,cursors_oid,message_idempotency_oid,conversation_idempotency_oid,nonces_oid]) AND attnum>0 AND NOT attisdropped AND atttypid<>'bpchar'::regtype AND atttypmod<>-1) AS exact
+    FROM objects
+), expected_defaults(table_oid,column_name,expression) AS (
+    SELECT expected.* FROM objects, LATERAL (VALUES
+        (endpoints_oid,'ownership_generation','1'),(endpoints_oid,'consumer_generation','0'),
+        (conversations_oid,'id','gen_random_uuid()'),(conversations_oid,'next_sequence','0'),(conversations_oid,'created_at','statement_timestamp()'),
+        (messages_oid,'id','gen_random_uuid()'),(deliveries_oid,'id','gen_random_uuid()'),(deliveries_oid,'lease_generation','0'),
+        (cursors_oid,'sequence','0')
+    ) AS expected(table_oid,column_name,expression)
+), actual_defaults AS (
+    SELECT default_value.adrelid,attribute.attname,pg_get_expr(default_value.adbin,default_value.adrelid)
+    FROM objects JOIN pg_attrdef AS default_value
+      ON default_value.adrelid=ANY(ARRAY[endpoints_oid,conversations_oid,memberships_oid,messages_oid,deliveries_oid,cursors_oid,message_idempotency_oid,conversation_idempotency_oid,nonces_oid])
+    JOIN pg_attribute AS attribute ON attribute.attrelid=default_value.adrelid AND attribute.attnum=default_value.adnum
+), defaults AS (
+    SELECT NOT EXISTS (SELECT * FROM expected_defaults EXCEPT SELECT * FROM actual_defaults)
+       AND NOT EXISTS (SELECT * FROM actual_defaults EXCEPT SELECT * FROM expected_defaults) AS exact
+), expected_keys(table_oid,constraint_type,column_keys) AS (
+    SELECT expected.* FROM objects, LATERAL (VALUES
+        (endpoints_oid,'p'::"char",ARRAY[1]::smallint[]),(conversations_oid,'p'::"char",ARRAY[1]::smallint[]),
+        (memberships_oid,'p'::"char",ARRAY[1,2]::smallint[]),(messages_oid,'p'::"char",ARRAY[1]::smallint[]),
+        (deliveries_oid,'p'::"char",ARRAY[1]::smallint[]),(cursors_oid,'p'::"char",ARRAY[1,2]::smallint[]),
+        (message_idempotency_oid,'p'::"char",ARRAY[1,2]::smallint[]),(conversation_idempotency_oid,'p'::"char",ARRAY[1,2]::smallint[]),
+        (nonces_oid,'p'::"char",ARRAY[1,2]::smallint[]),
+        (messages_oid,'u'::"char",ARRAY[2,3]::smallint[]),(deliveries_oid,'u'::"char",ARRAY[2,3]::smallint[]),
+        (message_idempotency_oid,'u'::"char",ARRAY[4]::smallint[]),(conversation_idempotency_oid,'u'::"char",ARRAY[4]::smallint[])
+    ) AS expected(table_oid,constraint_type,column_keys)
+), actual_keys AS (
+    SELECT constraint.conrelid,constraint.contype,constraint.conkey
+    FROM objects JOIN pg_constraint AS constraint
+      ON constraint.conrelid=ANY(ARRAY[endpoints_oid,conversations_oid,memberships_oid,messages_oid,deliveries_oid,cursors_oid,message_idempotency_oid,conversation_idempotency_oid,nonces_oid])
+     AND constraint.contype IN ('p','u') AND constraint.convalidated AND NOT constraint.condeferrable AND NOT constraint.condeferred
+), expected_foreign_keys(table_oid,column_keys,foreign_table_oid,foreign_column_keys) AS (
+    SELECT expected.* FROM objects, LATERAL (VALUES
+        (memberships_oid,ARRAY[1]::smallint[],conversations_oid,ARRAY[1]::smallint[]),(memberships_oid,ARRAY[2]::smallint[],endpoints_oid,ARRAY[1]::smallint[]),
+        (messages_oid,ARRAY[2]::smallint[],conversations_oid,ARRAY[1]::smallint[]),(messages_oid,ARRAY[4]::smallint[],endpoints_oid,ARRAY[1]::smallint[]),
+        (deliveries_oid,ARRAY[2]::smallint[],messages_oid,ARRAY[1]::smallint[]),(deliveries_oid,ARRAY[3]::smallint[],endpoints_oid,ARRAY[1]::smallint[]),
+        (cursors_oid,ARRAY[1]::smallint[],endpoints_oid,ARRAY[1]::smallint[]),(cursors_oid,ARRAY[2]::smallint[],conversations_oid,ARRAY[1]::smallint[]),
+        (message_idempotency_oid,ARRAY[4]::smallint[],messages_oid,ARRAY[1]::smallint[]),(conversation_idempotency_oid,ARRAY[4]::smallint[],conversations_oid,ARRAY[1]::smallint[])
+    ) AS expected(table_oid,column_keys,foreign_table_oid,foreign_column_keys)
+), actual_foreign_keys AS (
+    SELECT constraint.conrelid,constraint.conkey,constraint.confrelid,constraint.confkey
+    FROM objects JOIN pg_constraint AS constraint
+      ON constraint.conrelid=ANY(ARRAY[memberships_oid,messages_oid,deliveries_oid,cursors_oid,message_idempotency_oid,conversation_idempotency_oid])
+     AND constraint.contype='f' AND constraint.convalidated AND NOT constraint.condeferrable AND NOT constraint.condeferred
+     AND constraint.confupdtype='a' AND constraint.confdeltype='a' AND constraint.confmatchtype='s'
+), expected_check_keys(table_oid,column_keys) AS (
+    SELECT expected.* FROM objects, LATERAL (VALUES
+        (endpoints_oid,ARRAY[1]::smallint[]),(endpoints_oid,ARRAY[2]::smallint[]),(endpoints_oid,ARRAY[4]::smallint[]),
+        (endpoints_oid,ARRAY[5]::smallint[]),(endpoints_oid,ARRAY[6]::smallint[]),(endpoints_oid,ARRAY[5,7]::smallint[]),
+        (conversations_oid,ARRAY[2]::smallint[]),(memberships_oid,ARRAY[3]::smallint[]),
+        (messages_oid,ARRAY[3]::smallint[]),(messages_oid,ARRAY[5]::smallint[]),
+        (deliveries_oid,ARRAY[6]::smallint[]),(deliveries_oid,ARRAY[4,5,7,8,9]::smallint[]),
+        (cursors_oid,ARRAY[3]::smallint[]),(message_idempotency_oid,ARRAY[2]::smallint[]),(message_idempotency_oid,ARRAY[3]::smallint[]),
+        (conversation_idempotency_oid,ARRAY[2]::smallint[]),(conversation_idempotency_oid,ARRAY[3]::smallint[]),(nonces_oid,ARRAY[2]::smallint[])
+    ) AS expected(table_oid,column_keys)
+), actual_check_keys AS (
+    SELECT constraint.conrelid,constraint.conkey
+    FROM objects JOIN pg_constraint AS constraint
+      ON constraint.conrelid=ANY(ARRAY[endpoints_oid,conversations_oid,memberships_oid,messages_oid,deliveries_oid,cursors_oid,message_idempotency_oid,conversation_idempotency_oid,nonces_oid])
+     AND constraint.contype='c' AND constraint.convalidated AND NOT constraint.condeferrable AND NOT constraint.condeferred
+), check_expressions AS (
+    SELECT NOT EXISTS (SELECT * FROM expected_check_keys EXCEPT ALL SELECT * FROM actual_check_keys)
+       AND NOT EXISTS (SELECT * FROM actual_check_keys EXCEPT ALL SELECT * FROM expected_check_keys)
+       AND NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conrelid=ANY(ARRAY[endpoints_oid,conversations_oid,memberships_oid,messages_oid,deliveries_oid,cursors_oid,message_idempotency_oid,conversation_idempotency_oid,nonces_oid]) AND contype='c' AND (NOT convalidated OR condeferrable OR condeferred))
+       AND EXISTS (SELECT 1 FROM pg_constraint WHERE conrelid=endpoints_oid AND contype='c' AND conkey=ARRAY[1]::smallint[] AND pg_get_expr(conbin,conrelid)='((char_length(endpoint) >= 1) AND (char_length(endpoint) <= 512) AND (octet_length(endpoint) <= 2048) AND (endpoint !~ ''[[:cntrl:]]''::text))')
+       AND EXISTS (SELECT 1 FROM pg_constraint WHERE conrelid=endpoints_oid AND contype='c' AND conkey=ARRAY[2]::smallint[] AND pg_get_expr(conbin,conrelid)='((char_length(machine_id) >= 1) AND (char_length(machine_id) <= 128) AND (octet_length(machine_id) <= 512) AND (machine_id !~ ''[[:cntrl:]]''::text))')
+       AND EXISTS (SELECT 1 FROM pg_constraint WHERE conrelid=endpoints_oid AND contype='c' AND conkey=ARRAY[4]::smallint[] AND pg_get_expr(conbin,conrelid)='(ownership_generation > 0)')
+       AND EXISTS (SELECT 1 FROM pg_constraint WHERE conrelid=endpoints_oid AND contype='c' AND conkey=ARRAY[6]::smallint[] AND pg_get_expr(conbin,conrelid)='(consumer_generation >= 0)')
+       AND EXISTS (SELECT 1 FROM pg_constraint WHERE conrelid=endpoints_oid AND contype='c' AND conkey=ARRAY[5]::smallint[] AND pg_get_expr(conbin,conrelid)='((consumer_id IS NULL) OR ((char_length(consumer_id) >= 1) AND (char_length(consumer_id) <= 128) AND (octet_length(consumer_id) <= 512) AND (consumer_id !~ ''[[:cntrl:]]''::text)))')
+       AND EXISTS (SELECT 1 FROM pg_constraint WHERE conrelid=endpoints_oid AND contype='c' AND conkey @> ARRAY[5,7]::smallint[] AND conkey <@ ARRAY[5,7]::smallint[] AND pg_get_expr(conbin,conrelid)='((consumer_id IS NULL) = (consumer_lease_until IS NULL))')
+       AND EXISTS (SELECT 1 FROM pg_constraint WHERE conrelid=conversations_oid AND contype='c' AND conkey=ARRAY[2]::smallint[] AND pg_get_expr(conbin,conrelid)='(next_sequence >= 0)')
+       AND EXISTS (SELECT 1 FROM pg_constraint WHERE conrelid=memberships_oid AND contype='c' AND conkey=ARRAY[3]::smallint[] AND pg_get_expr(conbin,conrelid)='((capabilities >= 1) AND (capabilities <= 7))')
+       AND EXISTS (SELECT 1 FROM pg_constraint WHERE conrelid=messages_oid AND contype='c' AND conkey=ARRAY[3]::smallint[] AND pg_get_expr(conbin,conrelid)='(sequence > 0)')
+       AND EXISTS (SELECT 1 FROM pg_constraint WHERE conrelid=messages_oid AND contype='c' AND conkey=ARRAY[5]::smallint[] AND pg_get_expr(conbin,conrelid)='(octet_length(body) <= 32768)')
+       AND EXISTS (SELECT 1 FROM pg_constraint WHERE conrelid=deliveries_oid AND contype='c' AND conkey=ARRAY[6]::smallint[] AND pg_get_expr(conbin,conrelid)='(lease_generation >= 0)')
+       AND EXISTS (SELECT 1 FROM pg_constraint WHERE conrelid=deliveries_oid AND contype='c' AND conkey @> ARRAY[4,5,7,8,9]::smallint[] AND conkey <@ ARRAY[4,5,7,8,9]::smallint[] AND pg_get_expr(conbin,conrelid)='(((lease_machine_id IS NULL) AND (lease_token IS NULL) AND (ownership_generation IS NULL) AND (consumer_generation IS NULL) AND (lease_until IS NULL)) OR ((lease_machine_id IS NOT NULL) AND (lease_token IS NOT NULL) AND (ownership_generation IS NOT NULL) AND (consumer_generation IS NOT NULL) AND (lease_until IS NOT NULL)))')
+       AND EXISTS (SELECT 1 FROM pg_constraint WHERE conrelid=cursors_oid AND contype='c' AND conkey=ARRAY[3]::smallint[] AND pg_get_expr(conbin,conrelid)='(sequence >= 0)')
+       AND EXISTS (SELECT 1 FROM pg_constraint WHERE conrelid=message_idempotency_oid AND contype='c' AND conkey=ARRAY[2]::smallint[] AND pg_get_expr(conbin,conrelid)='((char_length(key) >= 1) AND (char_length(key) <= 128) AND (octet_length(key) <= 512) AND (key !~ ''[[:cntrl:]]''::text))')
+       AND EXISTS (SELECT 1 FROM pg_constraint WHERE conrelid=message_idempotency_oid AND contype='c' AND conkey=ARRAY[3]::smallint[] AND pg_get_expr(conbin,conrelid)='(request_hash ~ ''^[0-9a-f]{64}$''::text)')
+       AND EXISTS (SELECT 1 FROM pg_constraint WHERE conrelid=conversation_idempotency_oid AND contype='c' AND conkey=ARRAY[2]::smallint[] AND pg_get_expr(conbin,conrelid)='((char_length(key) >= 1) AND (char_length(key) <= 128) AND (octet_length(key) <= 512) AND (key !~ ''[[:cntrl:]]''::text))')
+       AND EXISTS (SELECT 1 FROM pg_constraint WHERE conrelid=conversation_idempotency_oid AND contype='c' AND conkey=ARRAY[3]::smallint[] AND pg_get_expr(conbin,conrelid)='(request_hash ~ ''^[0-9a-f]{64}$''::text)')
+       AND EXISTS (SELECT 1 FROM pg_constraint WHERE conrelid=nonces_oid AND contype='c' AND conkey=ARRAY[2]::smallint[] AND pg_get_expr(conbin,conrelid)='((char_length(nonce) >= 1) AND (char_length(nonce) <= 128) AND (octet_length(nonce) <= 512) AND (nonce !~ ''[[:cntrl:]]''::text))') AS exact
+    FROM objects
+), constraints AS (
+    SELECT count(*) FILTER (WHERE constraint.contype='p')=9
+       AND count(*) FILTER (WHERE constraint.contype='u')=4
+	       AND count(*) FILTER (WHERE constraint.contype='f')=10
+	       AND count(*) FILTER (WHERE constraint.contype='c')=18
+	       AND NOT EXISTS (SELECT * FROM expected_keys EXCEPT SELECT * FROM actual_keys)
+	       AND NOT EXISTS (SELECT * FROM actual_keys EXCEPT SELECT * FROM expected_keys)
+	       AND NOT EXISTS (SELECT * FROM expected_foreign_keys EXCEPT SELECT * FROM actual_foreign_keys)
+	       AND NOT EXISTS (SELECT * FROM actual_foreign_keys EXCEPT SELECT * FROM expected_foreign_keys)
+	       AND check_expressions.exact AS exact
+    FROM objects JOIN pg_constraint AS constraint
+      ON constraint.conrelid=ANY(ARRAY[endpoints_oid,conversations_oid,memberships_oid,messages_oid,deliveries_oid,cursors_oid,message_idempotency_oid,conversation_idempotency_oid,nonces_oid])
+     AND constraint.convalidated CROSS JOIN check_expressions
+), expected_guards(table_oid, trigger_name) AS (
+    SELECT expected.* FROM objects, LATERAL (VALUES
+        (endpoints_oid, 'mail_endpoints_mutation_guard'),
+        (conversations_oid, 'mail_conversations_mutation_guard'),
+        (memberships_oid, 'mail_memberships_mutation_guard'),
+        (messages_oid, 'mail_messages_mutation_guard'),
+        (deliveries_oid, 'mail_deliveries_mutation_guard'),
+        (cursors_oid, 'mail_recipient_cursors_mutation_guard'),
+        (message_idempotency_oid, 'mail_message_idempotency_mutation_guard'),
+        (conversation_idempotency_oid, 'mail_conversation_idempotency_mutation_guard'),
+        (nonces_oid, 'mail_request_nonces_mutation_guard')
+    ) AS expected(table_oid, trigger_name)
+), guards AS (
+    SELECT count(*)=9
+       AND bool_and(trigger.tgfoid=objects.guard_oid AND trigger.tgenabled='O' AND NOT trigger.tgisinternal
+                    AND trigger.tgtype=30 AND trigger.tgconstraint=0
+                    AND NOT trigger.tgdeferrable AND NOT trigger.tginitdeferred AND trigger.tgnargs=0
+                    AND trigger.tgqual IS NULL AND trigger.tgnewtable IS NULL AND trigger.tgoldtable IS NULL
+                    AND trigger.tgattr::text='') AS exact
+    FROM objects JOIN expected_guards ON true
+    JOIN pg_trigger AS trigger
+      ON trigger.tgrelid=expected_guards.table_oid AND trigger.tgname=expected_guards.trigger_name
+), function_safety AS (
+    SELECT count(*)=1 AND bool_and(pg_get_userbyid(proc.proowner)='punaro_owner' AND proc.prosecdef
+       AND proc.prokind='f' AND proc.provolatile='v' AND NOT proc.proretset
+       AND proc.prorettype='boolean'::regtype AND proc.pronargs=4
+       AND COALESCE(proc.proconfig=ARRAY['search_path=pg_catalog']::text[],false)
+       AND md5(regexp_replace(proc.prosrc,'^\s+|\s+$','','g'))='4c348d98b79375c10c6c53728b7368fb') AS exact
+    FROM objects JOIN pg_proc AS proc ON proc.oid=consume_oid
+), index_safety AS (
+    SELECT count(*)=3 AND bool_and(index.indisvalid AND index.indisready AND index.indislive AND NOT index.indisunique
+       AND index.indnkeyatts=index.indnatts AND access_method.amname='btree'
+       AND pg_get_userbyid(relation.relowner)='punaro_owner'
+       AND CASE index.indexrelid
+           WHEN objects.endpoints_index_oid THEN index.indrelid=objects.endpoints_oid AND index.indkey::text='2 3 1'
+           WHEN objects.deliveries_index_oid THEN index.indrelid=objects.deliveries_oid AND index.indkey::text='3 10 9 1'
+           WHEN objects.nonces_index_oid THEN index.indrelid=objects.nonces_oid AND index.indkey::text='3 1 2'
+           ELSE false END) AS exact
+    FROM objects JOIN pg_index AS index ON index.indexrelid=ANY(ARRAY[endpoints_index_oid,deliveries_index_oid,nonces_index_oid])
+    JOIN pg_class AS relation ON relation.oid=index.indexrelid
+    JOIN pg_am AS access_method ON access_method.oid=relation.relam
+), expected_table_acl(table_oid,privilege_type) AS (
+    SELECT expected.* FROM objects, LATERAL (VALUES
+        (endpoints_oid,'SELECT'),(endpoints_oid,'INSERT'),(conversations_oid,'SELECT'),(conversations_oid,'INSERT'),
+        (memberships_oid,'SELECT'),(memberships_oid,'INSERT'),(messages_oid,'SELECT'),(messages_oid,'INSERT'),
+        (deliveries_oid,'SELECT'),(deliveries_oid,'INSERT'),(cursors_oid,'SELECT'),(cursors_oid,'INSERT'),
+        (message_idempotency_oid,'SELECT'),(message_idempotency_oid,'INSERT'),
+        (conversation_idempotency_oid,'SELECT'),(conversation_idempotency_oid,'INSERT')
+    ) AS expected(table_oid,privilege_type)
+), actual_table_acl AS (
+    SELECT relation.oid,acl.privilege_type
+    FROM objects JOIN pg_class AS relation
+      ON relation.oid=ANY(ARRAY[endpoints_oid,conversations_oid,memberships_oid,messages_oid,deliveries_oid,cursors_oid,message_idempotency_oid,conversation_idempotency_oid,nonces_oid])
+    CROSS JOIN LATERAL aclexplode(COALESCE(relation.relacl,acldefault('r',relation.relowner))) AS acl
+    JOIN pg_roles AS grantee ON grantee.oid=acl.grantee AND grantee.rolname='punaro_app'
+    WHERE NOT acl.is_grantable
+), table_acl AS (
+    SELECT NOT EXISTS (SELECT * FROM expected_table_acl EXCEPT SELECT * FROM actual_table_acl)
+       AND NOT EXISTS (SELECT * FROM actual_table_acl EXCEPT SELECT * FROM expected_table_acl) AS exact
+), expected_column_acl(table_oid,column_name,privilege_type) AS (
+    SELECT expected.* FROM objects, LATERAL (VALUES
+        (endpoints_oid,'machine_id','UPDATE'),(endpoints_oid,'lease_until','UPDATE'),(endpoints_oid,'ownership_generation','UPDATE'),
+        (endpoints_oid,'consumer_id','UPDATE'),(endpoints_oid,'consumer_generation','UPDATE'),(endpoints_oid,'consumer_lease_until','UPDATE'),
+        (conversations_oid,'next_sequence','UPDATE'),
+        (deliveries_oid,'lease_machine_id','UPDATE'),(deliveries_oid,'lease_token','UPDATE'),(deliveries_oid,'lease_generation','UPDATE'),
+        (deliveries_oid,'ownership_generation','UPDATE'),(deliveries_oid,'consumer_generation','UPDATE'),(deliveries_oid,'lease_until','UPDATE'),(deliveries_oid,'acked_at','UPDATE'),
+        (cursors_oid,'sequence','UPDATE')
+    ) AS expected(table_oid,column_name,privilege_type)
+), actual_column_acl AS (
+    SELECT attribute.attrelid,attribute.attname,acl.privilege_type
+    FROM objects JOIN pg_attribute AS attribute
+      ON attribute.attrelid=ANY(ARRAY[endpoints_oid,conversations_oid,memberships_oid,messages_oid,deliveries_oid,cursors_oid,message_idempotency_oid,conversation_idempotency_oid,nonces_oid])
+     AND attribute.attnum>0 AND attribute.attacl IS NOT NULL
+    CROSS JOIN LATERAL aclexplode(attribute.attacl) AS acl
+    JOIN pg_roles AS grantee ON grantee.oid=acl.grantee AND grantee.rolname='punaro_app'
+    WHERE NOT acl.is_grantable
+), column_acl AS (
+    SELECT NOT EXISTS (SELECT * FROM expected_column_acl EXCEPT SELECT * FROM actual_column_acl)
+       AND NOT EXISTS (SELECT * FROM actual_column_acl EXCEPT SELECT * FROM expected_column_acl) AS exact
+)
+SELECT endpoints_oid IS NOT NULL AND conversations_oid IS NOT NULL AND memberships_oid IS NOT NULL
+   AND messages_oid IS NOT NULL AND deliveries_oid IS NOT NULL AND cursors_oid IS NOT NULL
+   AND message_idempotency_oid IS NOT NULL AND conversation_idempotency_oid IS NOT NULL AND nonces_oid IS NOT NULL
+   AND endpoints_index_oid IS NOT NULL AND deliveries_index_oid IS NOT NULL AND nonces_index_oid IS NOT NULL
+   AND consume_oid IS NOT NULL AND guard_oid IS NOT NULL
+	   AND table_ownership.exact AND columns.exact AND defaults.exact AND constraints.exact AND guards.exact AND function_safety.exact AND index_safety.exact
+	   AND table_acl.exact AND column_acl.exact
+	   AND has_function_privilege('punaro_app',consume_oid,'EXECUTE')
+	   AND (SELECT count(*)=2 AND bool_and(NOT acl.is_grantable AND (grantee.rolname='punaro_owner' OR grantee.rolname='punaro_app'))
+	        FROM pg_proc AS routine
+	        CROSS JOIN LATERAL aclexplode(COALESCE(routine.proacl,acldefault('f',routine.proowner))) AS acl
+	        LEFT JOIN pg_roles AS grantee ON grantee.oid=acl.grantee
+	        WHERE routine.oid=consume_oid)
+	   AND NOT EXISTS (
+	       SELECT 1 FROM pg_class AS relation
+	       CROSS JOIN LATERAL aclexplode(COALESCE(relation.relacl,acldefault('r',relation.relowner))) AS acl
+	       LEFT JOIN pg_roles AS grantee ON grantee.oid=acl.grantee
+	       WHERE relation.oid=ANY(ARRAY[endpoints_oid,conversations_oid,memberships_oid,messages_oid,deliveries_oid,cursors_oid,message_idempotency_oid,conversation_idempotency_oid,nonces_oid])
+	         AND (acl.grantee=0 OR grantee.rolname IS NULL OR grantee.rolname NOT IN ('punaro_owner','punaro_app') OR (grantee.rolname='punaro_app' AND acl.is_grantable))
+	   )
+	   AND NOT EXISTS (
+	       SELECT 1 FROM pg_attribute AS attribute
+	       CROSS JOIN LATERAL aclexplode(attribute.attacl) AS acl
+	       LEFT JOIN pg_roles AS grantee ON grantee.oid=acl.grantee
+	       WHERE attribute.attrelid=ANY(ARRAY[endpoints_oid,conversations_oid,memberships_oid,messages_oid,deliveries_oid,cursors_oid,message_idempotency_oid,conversation_idempotency_oid,nonces_oid])
+	         AND attribute.attnum>0 AND attribute.attacl IS NOT NULL
+	         AND (acl.grantee=0 OR grantee.rolname IS NULL OR grantee.rolname NOT IN ('punaro_owner','punaro_app') OR (grantee.rolname='punaro_app' AND acl.is_grantable))
+	   )
+	   AND NOT EXISTS (
+	       SELECT 1 FROM pg_proc AS routine
+	       CROSS JOIN LATERAL aclexplode(COALESCE(routine.proacl,acldefault('f',routine.proowner))) AS acl
+	       WHERE routine.oid=consume_oid AND acl.grantee=0 AND acl.privilege_type='EXECUTE'
+	   )
+	   AND has_table_privilege('punaro_app',endpoints_oid,'SELECT') AND has_table_privilege('punaro_app',endpoints_oid,'INSERT')
+	   AND NOT has_table_privilege('punaro_app',endpoints_oid,'UPDATE')
+	   AND has_column_privilege('punaro_app',endpoints_oid,'machine_id','UPDATE')
+	   AND has_column_privilege('punaro_app',endpoints_oid,'lease_until','UPDATE')
+	   AND has_column_privilege('punaro_app',endpoints_oid,'ownership_generation','UPDATE')
+	   AND has_column_privilege('punaro_app',endpoints_oid,'consumer_id','UPDATE')
+	   AND has_column_privilege('punaro_app',endpoints_oid,'consumer_generation','UPDATE')
+	   AND has_column_privilege('punaro_app',endpoints_oid,'consumer_lease_until','UPDATE')
+	   AND NOT has_column_privilege('punaro_app',endpoints_oid,'endpoint','UPDATE')
+	   AND has_table_privilege('punaro_app',conversations_oid,'SELECT') AND has_table_privilege('punaro_app',conversations_oid,'INSERT')
+	   AND NOT has_table_privilege('punaro_app',conversations_oid,'UPDATE')
+	   AND has_column_privilege('punaro_app',conversations_oid,'next_sequence','UPDATE')
+	   AND NOT has_column_privilege('punaro_app',conversations_oid,'id','UPDATE')
+	   AND NOT has_column_privilege('punaro_app',conversations_oid,'created_at','UPDATE')
+   AND has_table_privilege('punaro_app',memberships_oid,'SELECT') AND has_table_privilege('punaro_app',memberships_oid,'INSERT')
+   AND has_table_privilege('punaro_app',messages_oid,'SELECT') AND has_table_privilege('punaro_app',messages_oid,'INSERT')
+	   AND has_table_privilege('punaro_app',deliveries_oid,'SELECT') AND has_table_privilege('punaro_app',deliveries_oid,'INSERT')
+	   AND NOT has_table_privilege('punaro_app',deliveries_oid,'UPDATE')
+	   AND has_column_privilege('punaro_app',deliveries_oid,'lease_machine_id','UPDATE')
+	   AND has_column_privilege('punaro_app',deliveries_oid,'lease_token','UPDATE')
+	   AND has_column_privilege('punaro_app',deliveries_oid,'lease_generation','UPDATE')
+	   AND has_column_privilege('punaro_app',deliveries_oid,'ownership_generation','UPDATE')
+	   AND has_column_privilege('punaro_app',deliveries_oid,'consumer_generation','UPDATE')
+	   AND has_column_privilege('punaro_app',deliveries_oid,'lease_until','UPDATE')
+	   AND has_column_privilege('punaro_app',deliveries_oid,'acked_at','UPDATE')
+	   AND NOT has_column_privilege('punaro_app',deliveries_oid,'id','UPDATE')
+	   AND NOT has_column_privilege('punaro_app',deliveries_oid,'message_id','UPDATE')
+	   AND NOT has_column_privilege('punaro_app',deliveries_oid,'recipient_endpoint','UPDATE')
+	   AND has_table_privilege('punaro_app',cursors_oid,'SELECT') AND has_table_privilege('punaro_app',cursors_oid,'INSERT')
+	   AND NOT has_table_privilege('punaro_app',cursors_oid,'UPDATE')
+	   AND has_column_privilege('punaro_app',cursors_oid,'sequence','UPDATE')
+	   AND NOT has_column_privilege('punaro_app',cursors_oid,'recipient_endpoint','UPDATE')
+	   AND NOT has_column_privilege('punaro_app',cursors_oid,'conversation_id','UPDATE')
+   AND has_table_privilege('punaro_app',message_idempotency_oid,'SELECT') AND has_table_privilege('punaro_app',message_idempotency_oid,'INSERT')
+   AND has_table_privilege('punaro_app',conversation_idempotency_oid,'SELECT') AND has_table_privilege('punaro_app',conversation_idempotency_oid,'INSERT')
+   AND NOT has_table_privilege('punaro_app',nonces_oid,'SELECT,INSERT,UPDATE,DELETE,TRUNCATE,REFERENCES,TRIGGER')
+   AND NOT has_table_privilege('punaro_app',endpoints_oid,'DELETE,TRUNCATE,REFERENCES,TRIGGER')
+   AND NOT has_table_privilege('punaro_app',conversations_oid,'DELETE,TRUNCATE,REFERENCES,TRIGGER')
+   AND NOT has_table_privilege('punaro_app',memberships_oid,'UPDATE,DELETE,TRUNCATE,REFERENCES,TRIGGER')
+   AND NOT has_table_privilege('punaro_app',messages_oid,'UPDATE,DELETE,TRUNCATE,REFERENCES,TRIGGER')
+   AND NOT has_table_privilege('punaro_app',deliveries_oid,'DELETE,TRUNCATE,REFERENCES,TRIGGER')
+   AND NOT has_table_privilege('punaro_app',cursors_oid,'DELETE,TRUNCATE,REFERENCES,TRIGGER')
+   AND NOT has_table_privilege('punaro_app',message_idempotency_oid,'UPDATE,DELETE,TRUNCATE,REFERENCES,TRIGGER')
+   AND NOT has_table_privilege('punaro_app',conversation_idempotency_oid,'UPDATE,DELETE,TRUNCATE,REFERENCES,TRIGGER')
+FROM objects,table_ownership,columns,defaults,constraints,guards,function_safety,index_safety,table_acl,column_acl`).Scan(&available)
+	return available, err
+}

--- a/internal/postgres/relay_store.go
+++ b/internal/postgres/relay_store.go
@@ -247,7 +247,7 @@ func (d *Database) AppendMessage(input relay.AppendInput) (relay.Message, bool, 
 	if !errors.Is(err, sql.ErrNoRows) {
 		return relay.Message{}, false, errors.New("message retry state is unavailable")
 	}
-	message := relay.Message{ID: uuid.NewString(), ConversationID: input.ConversationID, FromEndpoint: input.FromEndpoint, Body: input.Body, CreatedAt: input.Now.UTC()}
+	message := relay.Message{ID: uuid.NewString(), ConversationID: input.ConversationID, FromEndpoint: input.FromEndpoint, Body: input.Body, CreatedAt: input.Now.UTC().Truncate(time.Millisecond)}
 	if err := tx.QueryRowContext(context.Background(), `UPDATE relay.mail_conversations SET next_sequence=next_sequence+1 WHERE id=$1::uuid RETURNING next_sequence`, input.ConversationID).Scan(&message.Sequence); errors.Is(err, sql.ErrNoRows) {
 		return relay.Message{}, false, relay.ErrForbidden
 	} else if err != nil {
@@ -275,40 +275,40 @@ func (d *Database) AppendMessage(input relay.AppendInput) (relay.Message, bool, 
 }
 
 // LeaseDeliveries claims a bounded fenced PostgreSQL delivery page.
-func (d *Database) LeaseDeliveries(machineID, consumerID, endpoint, conversationID string, now time.Time, ttl time.Duration, limit int) ([]relay.Delivery, error) {
+func (d *Database) LeaseDeliveries(machineID, consumerID, endpoint, conversationID string, now time.Time, ttl time.Duration, limit int) (relay.DeliveryLeasePage, error) {
 	if !relay.ValidMachineID(machineID) || !relay.ValidRequestToken(consumerID) || !relay.ValidEndpoint(endpoint) || ttl <= 0 || limit < 1 || limit > 100 {
-		return nil, errors.New("invalid delivery lease request")
+		return relay.DeliveryLeasePage{}, errors.New("invalid delivery lease request")
 	}
 	if conversationID != "" {
 		if _, err := uuid.Parse(conversationID); err != nil {
-			return nil, relay.ErrForbidden
+			return relay.DeliveryLeasePage{}, relay.ErrForbidden
 		}
 	}
 	tx, cancel, err := d.beginRelayTransaction(nil)
 	if err != nil {
-		return nil, errors.New("delivery lease transaction cannot start")
+		return relay.DeliveryLeasePage{}, errors.New("delivery lease transaction cannot start")
 	}
 	defer cancel()
 	defer func() { _ = tx.Rollback() }()
 	ownershipGeneration, err := postgresEndpointOwnershipLocked(tx, endpoint, machineID, now)
 	if err != nil {
-		return nil, err
+		return relay.DeliveryLeasePage{}, err
 	}
 	var activeConsumer sql.NullString
 	var consumerGeneration int64
 	var consumerUntil sql.NullTime
 	if err := tx.QueryRowContext(context.Background(), `SELECT consumer_id,consumer_generation,consumer_lease_until FROM relay.mail_endpoints WHERE endpoint=$1`, endpoint).Scan(&activeConsumer, &consumerGeneration, &consumerUntil); err != nil {
-		return nil, errors.New("endpoint consumer lease is unavailable")
+		return relay.DeliveryLeasePage{}, errors.New("endpoint consumer lease is unavailable")
 	}
 	if activeConsumer.Valid && activeConsumer.String != consumerID && consumerUntil.Valid && consumerUntil.Time.After(now) {
-		return nil, relay.ErrConflict
+		return relay.DeliveryLeasePage{}, relay.ErrConflict
 	}
 	if !activeConsumer.Valid || activeConsumer.String != consumerID || !consumerUntil.Valid || !consumerUntil.Time.After(now) {
 		consumerGeneration++
 	}
 	consumerLeaseUntil := now.Add(ttl).UTC()
 	if _, err := tx.ExecContext(context.Background(), `UPDATE relay.mail_endpoints SET consumer_id=$1,consumer_generation=$2,consumer_lease_until=$3 WHERE endpoint=$4 AND ownership_generation=$5`, consumerID, consumerGeneration, consumerLeaseUntil, endpoint, ownershipGeneration); err != nil {
-		return nil, relayDatabaseError(err, "claim endpoint consumer lease")
+		return relay.DeliveryLeasePage{}, relayDatabaseError(err, "claim endpoint consumer lease")
 	}
 	query := `SELECT delivery.id::text,delivery.lease_machine_id,delivery.lease_token::text,delivery.lease_generation,delivery.ownership_generation,delivery.consumer_generation,delivery.lease_until,
 		message.id::text,message.conversation_id::text,message.sequence,message.from_endpoint,message.body,message.created_at
@@ -320,12 +320,12 @@ func (d *Database) LeaseDeliveries(machineID, consumerID, endpoint, conversation
 		query += ` AND message.conversation_id=$6::uuid ORDER BY message.sequence,message.id LIMIT $7 FOR UPDATE OF delivery SKIP LOCKED`
 		args = append(args, conversationID, limit)
 	} else {
-		query += ` ORDER BY message.created_at,message.conversation_id,message.sequence LIMIT $6 FOR UPDATE OF delivery SKIP LOCKED`
+		query += ` ORDER BY message.created_at,message.conversation_id,message.sequence,message.id LIMIT $6 FOR UPDATE OF delivery SKIP LOCKED`
 		args = append(args, limit)
 	}
 	rows, err := tx.QueryContext(context.Background(), query, args...)
 	if err != nil {
-		return nil, errors.New("pending deliveries are unavailable")
+		return relay.DeliveryLeasePage{}, errors.New("pending deliveries are unavailable")
 	}
 	type leasedRow struct {
 		delivery       relay.Delivery
@@ -341,16 +341,16 @@ func (d *Database) LeaseDeliveries(machineID, consumerID, endpoint, conversation
 		row.delivery.RecipientEndpoint = endpoint
 		if err := rows.Scan(&row.delivery.ID, &row.leaseMachine, &row.leaseToken, &row.delivery.LeaseGeneration, &row.leaseOwnership, &row.leaseConsumer, &row.leaseUntil, &row.delivery.Message.ID, &row.delivery.Message.ConversationID, &row.delivery.Message.Sequence, &row.delivery.Message.FromEndpoint, &row.delivery.Message.Body, &row.delivery.Message.CreatedAt); err != nil {
 			_ = rows.Close()
-			return nil, errors.New("pending delivery is malformed")
+			return relay.DeliveryLeasePage{}, errors.New("pending delivery is malformed")
 		}
 		row.delivery.Message.CreatedAt = row.delivery.Message.CreatedAt.UTC()
 		pending = append(pending, row)
 	}
 	if err := rows.Close(); err != nil {
-		return nil, errors.New("pending deliveries are unavailable")
+		return relay.DeliveryLeasePage{}, errors.New("pending deliveries are unavailable")
 	}
 	if err := rows.Err(); err != nil {
-		return nil, errors.New("pending deliveries are unavailable")
+		return relay.DeliveryLeasePage{}, errors.New("pending deliveries are unavailable")
 	}
 	deliveries := make([]relay.Delivery, 0, len(pending))
 	for _, row := range pending {
@@ -363,15 +363,50 @@ func (d *Database) LeaseDeliveries(machineID, consumerID, endpoint, conversation
 			delivery.LeaseToken = uuid.NewString()
 			delivery.LeaseUntil = now.Add(ttl).UTC()
 			if _, err := tx.ExecContext(context.Background(), `UPDATE relay.mail_deliveries SET lease_machine_id=$1,lease_token=$2::uuid,lease_generation=$3,ownership_generation=$4,consumer_generation=$5,lease_until=$6 WHERE id=$7::uuid`, machineID, delivery.LeaseToken, delivery.LeaseGeneration, ownershipGeneration, consumerGeneration, delivery.LeaseUntil, delivery.ID); err != nil {
-				return nil, relayDatabaseError(err, "lease delivery")
+				return relay.DeliveryLeasePage{}, relayDatabaseError(err, "lease delivery")
 			}
 		}
 		deliveries = append(deliveries, delivery)
 	}
-	if err := tx.Commit(); err != nil {
-		return nil, relayDatabaseError(err, "commit delivery lease")
+	conversationIDs := make(map[string]struct{})
+	if conversationID != "" {
+		conversationIDs[conversationID] = struct{}{}
 	}
-	return deliveries, nil
+	for _, delivery := range deliveries {
+		conversationIDs[delivery.Message.ConversationID] = struct{}{}
+	}
+	cursors := make(map[string]int64, len(conversationIDs))
+	for id := range conversationIDs {
+		cursor, err := postgresRecipientCursorForLease(tx, endpoint, id)
+		if err != nil {
+			return relay.DeliveryLeasePage{}, err
+		}
+		cursors[id] = cursor
+	}
+	if err := tx.Commit(); err != nil {
+		return relay.DeliveryLeasePage{}, relayDatabaseError(err, "commit delivery lease")
+	}
+	return relay.DeliveryLeasePage{Deliveries: deliveries, Cursors: cursors}, nil
+}
+
+func postgresRecipientCursorForLease(tx *sql.Tx, endpoint, conversationID string) (int64, error) {
+	var capabilities relay.Capability
+	err := tx.QueryRowContext(context.Background(), `SELECT capabilities FROM relay.mail_memberships WHERE conversation_id=$1::uuid AND endpoint=$2`, conversationID, endpoint).Scan(&capabilities)
+	if errors.Is(err, sql.ErrNoRows) || capabilities&relay.CapReceive == 0 {
+		return 0, relay.ErrForbidden
+	}
+	if err != nil {
+		return 0, errors.New("recipient cursor authorization is unavailable")
+	}
+	var cursor int64
+	err = tx.QueryRowContext(context.Background(), `SELECT sequence FROM relay.mail_recipient_cursors WHERE recipient_endpoint=$1 AND conversation_id=$2::uuid`, endpoint, conversationID).Scan(&cursor)
+	if errors.Is(err, sql.ErrNoRows) {
+		return 0, nil
+	}
+	if err != nil {
+		return 0, errors.New("recipient cursor is unavailable")
+	}
+	return cursor, nil
 }
 
 // AckDelivery conditionally acknowledges one fenced PostgreSQL delivery.
@@ -559,6 +594,10 @@ func postgresMessageByID(tx *sql.Tx, messageID string) (relay.Message, error) {
 }
 
 func postgresAdvanceRecipientCursor(tx *sql.Tx, endpoint, conversationID string) error {
+	var maximum int64
+	if err := tx.QueryRowContext(context.Background(), `SELECT next_sequence FROM relay.mail_conversations WHERE id=$1::uuid`, conversationID).Scan(&maximum); err != nil {
+		return errors.New("recipient cursor maximum is unavailable")
+	}
 	if _, err := tx.ExecContext(context.Background(), `INSERT INTO relay.mail_recipient_cursors(recipient_endpoint,conversation_id,sequence) VALUES($1,$2::uuid,0) ON CONFLICT DO NOTHING`, endpoint, conversationID); err != nil {
 		return relayDatabaseError(err, "initialize recipient cursor")
 	}
@@ -576,10 +615,6 @@ func postgresAdvanceRecipientCursor(tx *sql.Tx, endpoint, conversationID string)
 	if nextPending.Valid {
 		target = nextPending.Int64 - 1
 	} else {
-		var maximum int64
-		if err := tx.QueryRowContext(context.Background(), `SELECT next_sequence FROM relay.mail_conversations WHERE id=$1::uuid`, conversationID).Scan(&maximum); err != nil {
-			return errors.New("recipient cursor maximum is unavailable")
-		}
 		target = maximum
 	}
 	if target > cursor {

--- a/internal/postgres/relay_store.go
+++ b/internal/postgres/relay_store.go
@@ -700,10 +700,10 @@ WITH objects AS (
         (message_idempotency_oid,'u'::"char",ARRAY[4]::smallint[]),(conversation_idempotency_oid,'u'::"char",ARRAY[4]::smallint[])
     ) AS expected(table_oid,constraint_type,column_keys)
 ), actual_keys AS (
-    SELECT constraint.conrelid,constraint.contype,constraint.conkey
-    FROM objects JOIN pg_constraint AS constraint
-      ON constraint.conrelid=ANY(ARRAY[endpoints_oid,conversations_oid,memberships_oid,messages_oid,deliveries_oid,cursors_oid,message_idempotency_oid,conversation_idempotency_oid,nonces_oid])
-     AND constraint.contype IN ('p','u') AND constraint.convalidated AND NOT constraint.condeferrable AND NOT constraint.condeferred
+    SELECT con.conrelid,con.contype,con.conkey
+    FROM objects JOIN pg_constraint AS con
+      ON con.conrelid=ANY(ARRAY[endpoints_oid,conversations_oid,memberships_oid,messages_oid,deliveries_oid,cursors_oid,message_idempotency_oid,conversation_idempotency_oid,nonces_oid])
+     AND con.contype IN ('p','u') AND con.convalidated AND NOT con.condeferrable AND NOT con.condeferred
 ), expected_foreign_keys(table_oid,column_keys,foreign_table_oid,foreign_column_keys) AS (
     SELECT expected.* FROM objects, LATERAL (VALUES
         (memberships_oid,ARRAY[1]::smallint[],conversations_oid,ARRAY[1]::smallint[]),(memberships_oid,ARRAY[2]::smallint[],endpoints_oid,ARRAY[1]::smallint[]),
@@ -713,11 +713,11 @@ WITH objects AS (
         (message_idempotency_oid,ARRAY[4]::smallint[],messages_oid,ARRAY[1]::smallint[]),(conversation_idempotency_oid,ARRAY[4]::smallint[],conversations_oid,ARRAY[1]::smallint[])
     ) AS expected(table_oid,column_keys,foreign_table_oid,foreign_column_keys)
 ), actual_foreign_keys AS (
-    SELECT constraint.conrelid,constraint.conkey,constraint.confrelid,constraint.confkey
-    FROM objects JOIN pg_constraint AS constraint
-      ON constraint.conrelid=ANY(ARRAY[memberships_oid,messages_oid,deliveries_oid,cursors_oid,message_idempotency_oid,conversation_idempotency_oid])
-     AND constraint.contype='f' AND constraint.convalidated AND NOT constraint.condeferrable AND NOT constraint.condeferred
-     AND constraint.confupdtype='a' AND constraint.confdeltype='a' AND constraint.confmatchtype='s'
+    SELECT con.conrelid,con.conkey,con.confrelid,con.confkey
+    FROM objects JOIN pg_constraint AS con
+      ON con.conrelid=ANY(ARRAY[memberships_oid,messages_oid,deliveries_oid,cursors_oid,message_idempotency_oid,conversation_idempotency_oid])
+     AND con.contype='f' AND con.convalidated AND NOT con.condeferrable AND NOT con.condeferred
+     AND con.confupdtype='a' AND con.confdeltype='a' AND con.confmatchtype='s'
 ), expected_check_keys(table_oid,column_keys) AS (
     SELECT expected.* FROM objects, LATERAL (VALUES
         (endpoints_oid,ARRAY[1]::smallint[]),(endpoints_oid,ARRAY[2]::smallint[]),(endpoints_oid,ARRAY[4]::smallint[]),
@@ -729,10 +729,10 @@ WITH objects AS (
         (conversation_idempotency_oid,ARRAY[2]::smallint[]),(conversation_idempotency_oid,ARRAY[3]::smallint[]),(nonces_oid,ARRAY[2]::smallint[])
     ) AS expected(table_oid,column_keys)
 ), actual_check_keys AS (
-    SELECT constraint.conrelid,constraint.conkey
-    FROM objects JOIN pg_constraint AS constraint
-      ON constraint.conrelid=ANY(ARRAY[endpoints_oid,conversations_oid,memberships_oid,messages_oid,deliveries_oid,cursors_oid,message_idempotency_oid,conversation_idempotency_oid,nonces_oid])
-     AND constraint.contype='c' AND constraint.convalidated AND NOT constraint.condeferrable AND NOT constraint.condeferred
+    SELECT con.conrelid,con.conkey
+    FROM objects JOIN pg_constraint AS con
+      ON con.conrelid=ANY(ARRAY[endpoints_oid,conversations_oid,memberships_oid,messages_oid,deliveries_oid,cursors_oid,message_idempotency_oid,conversation_idempotency_oid,nonces_oid])
+     AND con.contype='c' AND con.convalidated AND NOT con.condeferrable AND NOT con.condeferred
 ), check_expressions AS (
     SELECT NOT EXISTS (SELECT * FROM expected_check_keys EXCEPT ALL SELECT * FROM actual_check_keys)
        AND NOT EXISTS (SELECT * FROM actual_check_keys EXCEPT ALL SELECT * FROM expected_check_keys)
@@ -757,18 +757,18 @@ WITH objects AS (
        AND EXISTS (SELECT 1 FROM pg_constraint WHERE conrelid=nonces_oid AND contype='c' AND conkey=ARRAY[2]::smallint[] AND pg_get_expr(conbin,conrelid)='((char_length(nonce) >= 1) AND (char_length(nonce) <= 128) AND (octet_length(nonce) <= 512) AND (nonce !~ ''[[:cntrl:]]''::text))') AS exact
     FROM objects
 ), constraints AS (
-    SELECT count(*) FILTER (WHERE constraint.contype='p')=9
-       AND count(*) FILTER (WHERE constraint.contype='u')=4
-	       AND count(*) FILTER (WHERE constraint.contype='f')=10
-	       AND count(*) FILTER (WHERE constraint.contype='c')=18
+    SELECT count(*) FILTER (WHERE con.contype='p')=9
+       AND count(*) FILTER (WHERE con.contype='u')=4
+	       AND count(*) FILTER (WHERE con.contype='f')=10
+	       AND count(*) FILTER (WHERE con.contype='c')=18
 	       AND NOT EXISTS (SELECT * FROM expected_keys EXCEPT SELECT * FROM actual_keys)
 	       AND NOT EXISTS (SELECT * FROM actual_keys EXCEPT SELECT * FROM expected_keys)
 	       AND NOT EXISTS (SELECT * FROM expected_foreign_keys EXCEPT SELECT * FROM actual_foreign_keys)
 	       AND NOT EXISTS (SELECT * FROM actual_foreign_keys EXCEPT SELECT * FROM expected_foreign_keys)
 	       AND check_expressions.exact AS exact
-    FROM objects JOIN pg_constraint AS constraint
-      ON constraint.conrelid=ANY(ARRAY[endpoints_oid,conversations_oid,memberships_oid,messages_oid,deliveries_oid,cursors_oid,message_idempotency_oid,conversation_idempotency_oid,nonces_oid])
-     AND constraint.convalidated CROSS JOIN check_expressions
+    FROM objects JOIN pg_constraint AS con
+      ON con.conrelid=ANY(ARRAY[endpoints_oid,conversations_oid,memberships_oid,messages_oid,deliveries_oid,cursors_oid,message_idempotency_oid,conversation_idempotency_oid,nonces_oid])
+     AND con.convalidated CROSS JOIN check_expressions
 ), expected_guards(table_oid, trigger_name) AS (
     SELECT expected.* FROM objects, LATERAL (VALUES
         (endpoints_oid, 'mail_endpoints_mutation_guard'),
@@ -783,14 +783,14 @@ WITH objects AS (
     ) AS expected(table_oid, trigger_name)
 ), guards AS (
     SELECT count(*)=9
-       AND bool_and(trigger.tgfoid=objects.guard_oid AND trigger.tgenabled='O' AND NOT trigger.tgisinternal
-                    AND trigger.tgtype=30 AND trigger.tgconstraint=0
-                    AND NOT trigger.tgdeferrable AND NOT trigger.tginitdeferred AND trigger.tgnargs=0
-                    AND trigger.tgqual IS NULL AND trigger.tgnewtable IS NULL AND trigger.tgoldtable IS NULL
-                    AND trigger.tgattr::text='') AS exact
+       AND bool_and(trg.tgfoid=objects.guard_oid AND trg.tgenabled='O' AND NOT trg.tgisinternal
+                    AND trg.tgtype=30 AND trg.tgconstraint=0
+                    AND NOT trg.tgdeferrable AND NOT trg.tginitdeferred AND trg.tgnargs=0
+                    AND trg.tgqual IS NULL AND trg.tgnewtable IS NULL AND trg.tgoldtable IS NULL
+                    AND trg.tgattr::text='') AS exact
     FROM objects JOIN expected_guards ON true
-    JOIN pg_trigger AS trigger
-      ON trigger.tgrelid=expected_guards.table_oid AND trigger.tgname=expected_guards.trigger_name
+    JOIN pg_trigger AS trg
+      ON trg.tgrelid=expected_guards.table_oid AND trg.tgname=expected_guards.trigger_name
 ), function_safety AS (
     SELECT count(*)=1 AND bool_and(pg_get_userbyid(proc.proowner)='punaro_owner' AND proc.prosecdef
        AND proc.prokind='f' AND proc.provolatile='v' AND NOT proc.proretset

--- a/internal/postgres/relay_store_test.go
+++ b/internal/postgres/relay_store_test.go
@@ -1,0 +1,18 @@
+package postgres
+
+import (
+	"slices"
+	"testing"
+)
+
+func TestPostgresConversationEndpointLockOrder(t *testing.T) {
+	endpoints := map[string]struct{}{
+		"agent/z": {},
+		"agent/a": {},
+		"agent/m": {},
+	}
+	want := []string{"agent/a", "agent/m", "agent/z"}
+	if got := postgresSortedEndpoints(endpoints); !slices.Equal(got, want) {
+		t.Fatalf("endpoint lock order=%v, want %v", got, want)
+	}
+}

--- a/internal/postgres/state_test.go
+++ b/internal/postgres/state_test.go
@@ -66,10 +66,12 @@ func TestManifestValidationRejectsMutableOrNonContiguousHistory(t *testing.T) {
 
 func TestCurrentManifestRequiresControlPlaneSchema(t *testing.T) {
 	manifest := CurrentManifest()
-	if manifest.MinSupported != 6 || manifest.MaxSupported != 6 || len(manifest.Migrations) != 6 {
-		t.Fatalf("manifest=%#v, want exact v6 compatibility window", manifest)
+	if manifest.MinSupported != 7 || manifest.MaxSupported != 7 || len(manifest.Migrations) != 7 {
+		t.Fatalf("manifest=%#v, want exact v7 compatibility window", manifest)
 	}
-	if manifest.Migrations[0].CompatibilityFloor != 1 || manifest.Migrations[1].CompatibilityFloor != 2 || manifest.Migrations[2].CompatibilityFloor != 3 || manifest.Migrations[3].CompatibilityFloor != 4 || manifest.Migrations[4].CompatibilityFloor != 5 || manifest.Migrations[5].CompatibilityFloor != 6 {
-		t.Fatalf("migration floors=%d,%d,%d,%d,%d, want 1,2,3,4,5", manifest.Migrations[0].CompatibilityFloor, manifest.Migrations[1].CompatibilityFloor, manifest.Migrations[2].CompatibilityFloor, manifest.Migrations[3].CompatibilityFloor, manifest.Migrations[4].CompatibilityFloor)
+	for index, migration := range manifest.Migrations {
+		if migration.CompatibilityFloor != int64(index+1) {
+			t.Fatalf("migration %d floor=%d, want %d", index+1, migration.CompatibilityFloor, index+1)
+		}
 	}
 }

--- a/internal/relay/auth.go
+++ b/internal/relay/auth.go
@@ -2,10 +2,10 @@ package relay
 
 import (
 	"bytes"
-	"context"
 	"crypto/ed25519"
 	"crypto/sha256"
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"net/http"
 	"strings"
@@ -60,21 +60,21 @@ type SignedRequest struct {
 // nonces in the relay database so a daemon restart cannot reopen a replay
 // window.
 type Authenticator struct {
-	store    *Store
+	store    NonceStore
 	machines map[string]Machine
 }
 
 // NewAuthenticator accepts a complete explicit enrollment set. Enrollment is
 // configuration-controlled, not message-controlled; duplicate IDs and unsafe
 // endpoint rules fail startup rather than picking an arbitrary credential.
-func NewAuthenticator(store *Store, machines []Machine) (*Authenticator, error) {
+func NewAuthenticator(store NonceStore, machines []Machine) (*Authenticator, error) {
 	if store == nil || len(machines) == 0 {
 		return nil, fmt.Errorf("relay authenticator requires enrolled machines")
 	}
 	configured := make(map[string]Machine, len(machines))
 	attachmentDevices := make(map[[16]byte]string, len(machines))
 	for _, machine := range machines {
-		if strings.TrimSpace(machine.ID) == "" || len(machine.PublicKey) != ed25519.PublicKeySize || (len(machine.EndpointPrefixes) == 0 && len(machine.Endpoints) == 0) {
+		if !ValidMachineID(machine.ID) || len(machine.PublicKey) != ed25519.PublicKeySize || (len(machine.EndpointPrefixes) == 0 && len(machine.Endpoints) == 0) {
 			return nil, fmt.Errorf("invalid machine enrollment")
 		}
 		if _, exists := configured[machine.ID]; exists {
@@ -93,7 +93,7 @@ func NewAuthenticator(store *Store, machines []Machine) (*Authenticator, error) 
 		}
 		exact := make(map[string]struct{}, len(machine.Endpoints))
 		for _, endpoint := range machine.Endpoints {
-			if endpoint == "" || strings.TrimSpace(endpoint) != endpoint {
+			if !ValidEndpoint(endpoint) {
 				return nil, fmt.Errorf("invalid exact endpoint for machine %q", machine.ID)
 			}
 			if _, duplicate := exact[endpoint]; duplicate {
@@ -137,7 +137,7 @@ func NewAuthenticator(store *Store, machines []Machine) (*Authenticator, error) 
 // trailing slash, a raw prefix comparison could let `agent/a` claim
 // `agent/abuse`; prefixes are authority boundaries, not friendly labels.
 func validEndpointPrefix(prefix string) bool {
-	return prefix == strings.TrimSpace(prefix) && prefix != "/" && strings.HasSuffix(prefix, "/") && !strings.Contains(prefix, "//")
+	return ValidEndpoint(prefix) && prefix != "/" && strings.HasSuffix(prefix, "/") && !strings.Contains(prefix, "//")
 }
 
 // CanonicalRequest returns the stable, unambiguous byte sequence signed by a
@@ -161,22 +161,16 @@ func CanonicalRequest(request SignedRequest) []byte {
 // replays. Errors intentionally use one authorization result at the boundary.
 func (a *Authenticator) Verify(request SignedRequest, now time.Time) error {
 	machine, found := a.machines[request.MachineID]
-	if !found || !validSignedRequest(request, now) || !ed25519.Verify(machine.PublicKey, CanonicalRequest(request), request.Signature) {
+	if !found || !ValidRequestToken(request.Nonce) || !validSignedRequest(request, now) || !ed25519.Verify(machine.PublicKey, CanonicalRequest(request), request.Signature) {
 		return ErrForbidden
 	}
-	tx, err := a.store.db.BeginTx(context.Background(), nil)
-	if err != nil {
-		return fmt.Errorf("begin request replay transaction: %w", err)
-	}
-	defer rollback(tx)
-	if _, err := tx.ExecContext(context.Background(), "DELETE FROM request_nonces WHERE expires_at <= ?", now.UnixMilli()); err != nil {
-		return fmt.Errorf("prune request nonces: %w", err)
-	}
-	_, err = tx.ExecContext(context.Background(), "INSERT INTO request_nonces(machine_id, nonce, expires_at) VALUES (?, ?, ?)", request.MachineID, request.Nonce, request.Timestamp.UTC().Add(maxRequestAge).UnixMilli())
-	if err != nil {
+	if err := a.store.ConsumeRequestNonce(request.MachineID, request.Nonce, now, request.Timestamp.UTC().Add(maxRequestAge)); err != nil {
+		if errors.Is(err, ErrMaintenance) {
+			return ErrMaintenance
+		}
 		return ErrForbidden
 	}
-	return tx.Commit()
+	return nil
 }
 
 // AuthenticateHTTP authenticates a request over its exact already-bounded

--- a/internal/relay/auth_test.go
+++ b/internal/relay/auth_test.go
@@ -3,10 +3,33 @@ package relay
 import (
 	"crypto/ed25519"
 	"crypto/rand"
+	"errors"
 	"path/filepath"
 	"testing"
 	"time"
 )
+
+type nonceStoreFunc func(string, string, time.Time, time.Time) error
+
+func (function nonceStoreFunc) ConsumeRequestNonce(machineID, nonce string, now, expiresAt time.Time) error {
+	return function(machineID, nonce, now, expiresAt)
+}
+
+func TestAuthenticatorPreservesMaintenanceRefusal(t *testing.T) {
+	public, private, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	auth, err := NewAuthenticator(nonceStoreFunc(func(string, string, time.Time, time.Time) error { return ErrMaintenance }), []Machine{{ID: "machine-a", PublicKey: public, EndpointPrefixes: []string{"agent/"}}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	now := time.Date(2026, time.July, 20, 12, 0, 0, 0, time.UTC)
+	request := signRequest(private, "machine-a", "GET", "/v1/conversations", nil, now, "nonce")
+	if err := auth.Verify(request, now); !errors.Is(err, ErrMaintenance) {
+		t.Fatalf("maintenance authentication err=%v", err)
+	}
+}
 
 func TestAuthenticatorVerifiesRequestAndRejectsReplayAfterRestart(t *testing.T) {
 	t.Parallel()

--- a/internal/relay/backend.go
+++ b/internal/relay/backend.go
@@ -49,7 +49,7 @@ type Backend interface {
 	CreateConversationIdempotent(CreateConversationInput) (Conversation, error)
 	AuthorizeSender(conversationID, machineID, endpoint string, now time.Time) error
 	AppendMessage(AppendInput) (Message, bool, error)
-	LeaseDeliveries(machineID, consumerID, endpoint, conversationID string, now time.Time, ttl time.Duration, limit int) ([]Delivery, error)
+	LeaseDeliveries(machineID, consumerID, endpoint, conversationID string, now time.Time, ttl time.Duration, limit int) (DeliveryLeasePage, error)
 	AckDelivery(machineID, endpoint, deliveryID, token string, generation int64, now time.Time) error
 	RecipientCursor(machineID, endpoint, conversationID string, now time.Time) (int64, error)
 	RecipientMachines(messageID string, now time.Time) ([]string, error)

--- a/internal/relay/backend.go
+++ b/internal/relay/backend.go
@@ -1,0 +1,66 @@
+package relay
+
+import (
+	"strings"
+	"time"
+	"unicode"
+	"unicode/utf8"
+)
+
+func validBoundedText(value string, maxCharacters, maxBytes int) bool {
+	if value == "" || strings.TrimSpace(value) != value || len(value) > maxBytes || utf8.RuneCountInString(value) > maxCharacters {
+		return false
+	}
+	for _, character := range value {
+		if unicode.IsControl(character) {
+			return false
+		}
+	}
+	return true
+}
+
+// ValidMachineID reports whether an enrolled machine identifier has portable
+// SQLite/PostgreSQL representation.
+func ValidMachineID(value string) bool { return validBoundedText(value, 128, 512) }
+
+// ValidEndpoint reports whether a mailbox address has portable durable bounds.
+func ValidEndpoint(value string) bool { return validBoundedText(value, 512, 2048) }
+
+// ValidRequestToken bounds nonces, idempotency keys, and consumer identities.
+func ValidRequestToken(value string) bool { return validBoundedText(value, 128, 512) }
+
+// AppendRequestHash binds a message idempotency key to its immutable request.
+func AppendRequestHash(input AppendInput) string { return appendHash(input) }
+
+// CreateConversationRequestHash binds a conversation idempotency key to the
+// normalized creator and membership set.
+func CreateConversationRequestHash(creatorEndpoint string, members []Member) string {
+	return createConversationHash(creatorEndpoint, members)
+}
+
+// Backend is the complete durable mail boundary shared by the SQLite parity
+// store and the selectable PostgreSQL implementation. HTTP authentication and
+// authorization remain outside this interface; every method still rechecks
+// the durable ownership needed for its own operation.
+type Backend interface {
+	NonceStore
+	AdvertiseEndpoints(machineID string, endpoints []string, now time.Time, ttl time.Duration) error
+	AssertEndpointOwnership(machineID, endpoint string, now time.Time) error
+	CreateConversationIdempotent(CreateConversationInput) (Conversation, error)
+	AuthorizeSender(conversationID, machineID, endpoint string, now time.Time) error
+	AppendMessage(AppendInput) (Message, bool, error)
+	LeaseDeliveries(machineID, consumerID, endpoint, conversationID string, now time.Time, ttl time.Duration, limit int) ([]Delivery, error)
+	AckDelivery(machineID, endpoint, deliveryID, token string, generation int64, now time.Time) error
+	RecipientCursor(machineID, endpoint, conversationID string, now time.Time) (int64, error)
+	RecipientMachines(messageID string, now time.Time) ([]string, error)
+	ConversationsForMachine(machineID string, now time.Time) ([]Conversation, error)
+}
+
+// NonceStore atomically consumes one signed-request nonce until its expiry.
+// It is intentionally smaller than Backend so attachment-only handlers can
+// share authentication without receiving mail mutation authority.
+type NonceStore interface {
+	ConsumeRequestNonce(machineID, nonce string, now, expiresAt time.Time) error
+}
+
+var _ Backend = (*Store)(nil)

--- a/internal/relay/contracttest/contract.go
+++ b/internal/relay/contracttest/contract.go
@@ -5,6 +5,7 @@ package contracttest
 import (
 	"errors"
 	"fmt"
+	"sort"
 	"sync"
 	"testing"
 	"time"
@@ -77,9 +78,10 @@ func Run(t *testing.T, backend relay.Backend, namespace string) {
 	if err != nil || len(recipients) != 1 || recipients[0] != machineB {
 		t.Fatalf("recipient machines=%#v err=%v", recipients, err)
 	}
-	deliveries, err := backend.LeaseDeliveries(machineB, consumerB, endpointB, conversation.ID, now, time.Minute, 10)
-	if err != nil || len(deliveries) != 2 {
-		t.Fatalf("deliveries=%#v err=%v", deliveries, err)
+	page, err := backend.LeaseDeliveries(machineB, consumerB, endpointB, conversation.ID, now, time.Minute, 10)
+	deliveries := page.Deliveries
+	if err != nil || len(deliveries) != 2 || page.Cursors[conversation.ID] != 0 {
+		t.Fatalf("page=%#v err=%v", page, err)
 	}
 	if err := backend.AdvertiseEndpoints(machineB, []string{endpointB}, now.Add(time.Second), time.Hour); err != nil {
 		t.Fatal(err)
@@ -107,7 +109,8 @@ func Run(t *testing.T, backend relay.Backend, namespace string) {
 	}
 
 	third := appendMessage("send-3", "third")
-	thirdLease, err := backend.LeaseDeliveries(machineB, consumerB, endpointB, conversation.ID, now, time.Minute, 10)
+	thirdPage, err := backend.LeaseDeliveries(machineB, consumerB, endpointB, conversation.ID, now, time.Minute, 10)
+	thirdLease := thirdPage.Deliveries
 	if err != nil || len(thirdLease) != 1 || thirdLease[0].Message.ID != third.ID {
 		t.Fatalf("third lease=%#v err=%v", thirdLease, err)
 	}
@@ -121,7 +124,8 @@ func Run(t *testing.T, backend relay.Backend, namespace string) {
 	if err := backend.AdvertiseEndpoints(machineB, []string{endpointB}, reclaimAt, time.Hour); err != nil {
 		t.Fatal(err)
 	}
-	reclaimed, err := backend.LeaseDeliveries(machineB, consumerB, endpointB, conversation.ID, reclaimAt, time.Minute, 10)
+	reclaimedPage, err := backend.LeaseDeliveries(machineB, consumerB, endpointB, conversation.ID, reclaimAt, time.Minute, 10)
+	reclaimed := reclaimedPage.Deliveries
 	if err != nil || len(reclaimed) != 1 || reclaimed[0].LeaseGeneration <= thirdLease[0].LeaseGeneration || reclaimed[0].LeaseToken == thirdLease[0].LeaseToken {
 		t.Fatalf("reclaimed=%#v original=%#v err=%v", reclaimed, thirdLease, err)
 	}
@@ -149,7 +153,8 @@ func Run(t *testing.T, backend relay.Backend, namespace string) {
 	if afterSelf.Sequence != 5 {
 		t.Fatalf("post-self sequence=%d", afterSelf.Sequence)
 	}
-	afterSelfLease, err := backend.LeaseDeliveries(machineB, consumerB, endpointB, conversation.ID, reclaimAt, time.Minute, 10)
+	afterSelfPage, err := backend.LeaseDeliveries(machineB, consumerB, endpointB, conversation.ID, reclaimAt, time.Minute, 10)
+	afterSelfLease := afterSelfPage.Deliveries
 	if err != nil || len(afterSelfLease) != 1 || afterSelfLease[0].Message.ID != afterSelf.ID {
 		t.Fatalf("post-self lease=%#v err=%v", afterSelfLease, err)
 	}
@@ -200,7 +205,8 @@ func Run(t *testing.T, backend relay.Backend, namespace string) {
 	}
 
 	abaMessage := appendMessage("aba", "aba")
-	abaLease, err := backend.LeaseDeliveries(machineB, consumerB, endpointB, conversation.ID, reclaimAt, time.Minute, 100)
+	abaPage, err := backend.LeaseDeliveries(machineB, consumerB, endpointB, conversation.ID, reclaimAt, time.Minute, 100)
+	abaLease := abaPage.Deliveries
 	if err != nil || len(abaLease) == 0 || abaLease[len(abaLease)-1].Message.ID != abaMessage.ID {
 		t.Fatalf("aba lease=%#v err=%v", abaLease, err)
 	}
@@ -216,7 +222,8 @@ func Run(t *testing.T, backend relay.Backend, namespace string) {
 	if err := backend.AckDelivery(machineB, endpointB, abaLease[len(abaLease)-1].ID, abaLease[len(abaLease)-1].LeaseToken, abaLease[len(abaLease)-1].LeaseGeneration, reclaimAt.Add(2*time.Second)); !errors.Is(err, relay.ErrForbidden) {
 		t.Fatalf("ABA-stale acknowledgement err=%v", err)
 	}
-	releasedAfterABA, err := backend.LeaseDeliveries(machineB, consumerB, endpointB, conversation.ID, reclaimAt.Add(2*time.Second), time.Minute, 100)
+	releasedAfterABAPage, err := backend.LeaseDeliveries(machineB, consumerB, endpointB, conversation.ID, reclaimAt.Add(2*time.Second), time.Minute, 100)
+	releasedAfterABA := releasedAfterABAPage.Deliveries
 	if err != nil || len(releasedAfterABA) == 0 || releasedAfterABA[len(releasedAfterABA)-1].LeaseGeneration <= abaLease[len(abaLease)-1].LeaseGeneration {
 		t.Fatalf("post-ABA lease=%#v err=%v", releasedAfterABA, err)
 	}
@@ -233,5 +240,88 @@ func Run(t *testing.T, backend relay.Backend, namespace string) {
 	}
 	if err := backend.ConsumeRequestNonce(machineA, namespace+"-nonce", now, expires); !errors.Is(err, relay.ErrForbidden) {
 		t.Fatalf("replayed nonce err=%v", err)
+	}
+	runLeasePageContract(t, backend, namespace, now)
+}
+
+func runLeasePageContract(t *testing.T, backend relay.Backend, namespace string, now time.Time) {
+	t.Helper()
+	senderMachine, recipientMachine := namespace+"-page-sender", namespace+"-page-recipient"
+	senderEndpoint, recipientEndpoint := "agent/"+namespace+"/page-sender", "agent/"+namespace+"/page-recipient"
+	if err := backend.AdvertiseEndpoints(senderMachine, []string{senderEndpoint}, now, time.Hour); err != nil {
+		t.Fatal(err)
+	}
+	if err := backend.AdvertiseEndpoints(recipientMachine, []string{recipientEndpoint}, now, time.Hour); err != nil {
+		t.Fatal(err)
+	}
+	members := []relay.Member{
+		{Endpoint: senderEndpoint, Capabilities: relay.CapSend | relay.CapReceive | relay.CapAdmin},
+		{Endpoint: recipientEndpoint, Capabilities: relay.CapReceive},
+	}
+	createConversation := func(key string, members []relay.Member) relay.Conversation {
+		t.Helper()
+		conversation, err := backend.CreateConversationIdempotent(relay.CreateConversationInput{
+			MachineID: senderMachine, IdempotencyKey: namespace + "-" + key,
+			CreatorEndpoint: senderEndpoint, Members: members, Now: now,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		return conversation
+	}
+	firstConversation := createConversation("page-first", members)
+	secondConversation := createConversation("page-second", members)
+	unauthorizedConversation := createConversation("page-unauthorized", members[:1])
+	if _, err := backend.LeaseDeliveries(recipientMachine, namespace+"-failed-consumer", recipientEndpoint, unauthorizedConversation.ID, now, time.Minute, 1); !errors.Is(err, relay.ErrForbidden) {
+		t.Fatalf("unauthorized filtered lease err=%v", err)
+	}
+	appendMessage := func(conversation relay.Conversation, key string, createdAt time.Time) relay.Message {
+		t.Helper()
+		message, duplicate, err := backend.AppendMessage(relay.AppendInput{
+			ConversationID: conversation.ID, SenderMachineID: senderMachine, FromEndpoint: senderEndpoint,
+			Body: key, IdempotencyKey: namespace + "-" + key, Now: createdAt,
+		})
+		if err != nil || duplicate {
+			t.Fatalf("append %s message=%#v duplicate=%t err=%v", key, message, duplicate, err)
+		}
+		return message
+	}
+	lexicallyEarlier, lexicallyLater := firstConversation, secondConversation
+	if lexicallyEarlier.ID > lexicallyLater.ID {
+		lexicallyEarlier, lexicallyLater = lexicallyLater, lexicallyEarlier
+	}
+	chronologicallyEarlier := appendMessage(lexicallyLater, "page-submillisecond-earlier", now.Add(100*time.Microsecond))
+	chronologicallyLater := appendMessage(lexicallyEarlier, "page-submillisecond-later", now.Add(900*time.Microsecond))
+	if !chronologicallyEarlier.CreatedAt.Equal(now) || !chronologicallyLater.CreatedAt.Equal(now) {
+		t.Fatalf("message timestamps were not normalized to milliseconds: earlier=%s later=%s", chronologicallyEarlier.CreatedAt, chronologicallyLater.CreatedAt)
+	}
+	expected := []relay.Message{
+		chronologicallyEarlier,
+		chronologicallyLater,
+		appendMessage(firstConversation, "page-first-2", now.Add(-time.Second)),
+	}
+	sort.Slice(expected, func(left, right int) bool {
+		if !expected[left].CreatedAt.Equal(expected[right].CreatedAt) {
+			return expected[left].CreatedAt.Before(expected[right].CreatedAt)
+		}
+		if expected[left].ConversationID != expected[right].ConversationID {
+			return expected[left].ConversationID < expected[right].ConversationID
+		}
+		if expected[left].Sequence != expected[right].Sequence {
+			return expected[left].Sequence < expected[right].Sequence
+		}
+		return expected[left].ID < expected[right].ID
+	})
+	page, err := backend.LeaseDeliveries(recipientMachine, namespace+"-page-consumer", recipientEndpoint, "", now, time.Minute, 2)
+	if err != nil || len(page.Deliveries) != 2 {
+		t.Fatalf("ordered lease page=%#v err=%v", page, err)
+	}
+	for index := range page.Deliveries {
+		if page.Deliveries[index].Message.ID != expected[index].ID {
+			t.Fatalf("ordered lease page=%#v expected=%#v", page.Deliveries, expected[:2])
+		}
+		if page.Cursors[page.Deliveries[index].Message.ConversationID] != 0 {
+			t.Fatalf("lease page cursors=%#v", page.Cursors)
+		}
 	}
 }

--- a/internal/relay/contracttest/contract.go
+++ b/internal/relay/contracttest/contract.go
@@ -1,0 +1,237 @@
+// Package contracttest contains the storage-independent durable mail contract.
+// It is imported only by SQLite and PostgreSQL tests.
+package contracttest
+
+import (
+	"errors"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/rock3r/punaro/internal/relay"
+)
+
+// Run exercises the same authorization, idempotency, delivery, lease, and
+// cursor contract against one otherwise-empty backend namespace.
+func Run(t *testing.T, backend relay.Backend, namespace string) {
+	t.Helper()
+	now := time.Date(2026, time.July, 20, 12, 0, 0, 0, time.UTC)
+	machineA, machineB := namespace+"-machine-a", namespace+"-machine-b"
+	consumerB := namespace + "-consumer-b"
+	endpointA, endpointB := "agent/"+namespace+"/a", "agent/"+namespace+"/b"
+	if err := backend.AdvertiseEndpoints(machineA, []string{endpointA}, now, time.Hour); err != nil {
+		t.Fatal(err)
+	}
+	if err := backend.AdvertiseEndpoints(machineB, []string{endpointB}, now, time.Hour); err != nil {
+		t.Fatal(err)
+	}
+	members := []relay.Member{
+		{Endpoint: endpointA, Capabilities: relay.CapSend | relay.CapReceive | relay.CapAdmin},
+		{Endpoint: endpointB, Capabilities: relay.CapSend | relay.CapReceive},
+	}
+	create := relay.CreateConversationInput{MachineID: machineA, IdempotencyKey: namespace + "-create", CreatorEndpoint: endpointA, Members: members, Now: now}
+	conversation, err := backend.CreateConversationIdempotent(create)
+	if err != nil {
+		t.Fatal(err)
+	}
+	repeated, err := backend.CreateConversationIdempotent(create)
+	if err != nil || repeated != conversation {
+		t.Fatalf("repeated conversation=%#v err=%v", repeated, err)
+	}
+	changedCreate := create
+	changedCreate.Members = append([]relay.Member(nil), members...)
+	changedCreate.Members[1].Capabilities |= relay.CapAdmin
+	if _, err := backend.CreateConversationIdempotent(changedCreate); !errors.Is(err, relay.ErrConflict) {
+		t.Fatalf("changed conversation retry err=%v", err)
+	}
+	listed, err := backend.ConversationsForMachine(machineB, now)
+	if err != nil || len(listed) != 1 || listed[0] != conversation {
+		t.Fatalf("listed=%#v err=%v", listed, err)
+	}
+
+	appendMessage := func(key, body string) relay.Message {
+		t.Helper()
+		input := relay.AppendInput{ConversationID: conversation.ID, SenderMachineID: machineA, FromEndpoint: endpointA, Body: body, IdempotencyKey: namespace + "-" + key, Now: now}
+		message, duplicate, err := backend.AppendMessage(input)
+		if err != nil || duplicate {
+			t.Fatalf("append message=%#v duplicate=%t err=%v", message, duplicate, err)
+		}
+		repeated, duplicate, err := backend.AppendMessage(input)
+		if err != nil || !duplicate || repeated != message {
+			t.Fatalf("repeated message=%#v duplicate=%t err=%v", repeated, duplicate, err)
+		}
+		changed := input
+		changed.Body += " changed"
+		if _, _, err := backend.AppendMessage(changed); !errors.Is(err, relay.ErrConflict) {
+			t.Fatalf("changed message retry err=%v", err)
+		}
+		return message
+	}
+	first := appendMessage("send-1", "first")
+	second := appendMessage("send-2", "second")
+	if first.Sequence != 1 || second.Sequence != 2 {
+		t.Fatalf("message sequences=%d,%d", first.Sequence, second.Sequence)
+	}
+	recipients, err := backend.RecipientMachines(first.ID, now)
+	if err != nil || len(recipients) != 1 || recipients[0] != machineB {
+		t.Fatalf("recipient machines=%#v err=%v", recipients, err)
+	}
+	deliveries, err := backend.LeaseDeliveries(machineB, consumerB, endpointB, conversation.ID, now, time.Minute, 10)
+	if err != nil || len(deliveries) != 2 {
+		t.Fatalf("deliveries=%#v err=%v", deliveries, err)
+	}
+	if err := backend.AdvertiseEndpoints(machineB, []string{endpointB}, now.Add(time.Second), time.Hour); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := backend.LeaseDeliveries(machineB, namespace+"-consumer-b-rival", endpointB, conversation.ID, now, time.Minute, 10); !errors.Is(err, relay.ErrConflict) {
+		t.Fatalf("concurrent consumer lease err=%v", err)
+	}
+	if err := backend.AckDelivery(machineA, endpointB, deliveries[0].ID, deliveries[0].LeaseToken, deliveries[0].LeaseGeneration, now); !errors.Is(err, relay.ErrForbidden) {
+		t.Fatalf("wrong-owner ack err=%v", err)
+	}
+	if err := backend.AckDelivery(machineB, endpointB, deliveries[1].ID, deliveries[1].LeaseToken, deliveries[1].LeaseGeneration, now); err != nil {
+		t.Fatal(err)
+	}
+	if cursor, err := backend.RecipientCursor(machineB, endpointB, conversation.ID, now); err != nil || cursor != 0 {
+		t.Fatalf("gapped cursor=%d err=%v", cursor, err)
+	}
+	if err := backend.AckDelivery(machineB, endpointB, deliveries[0].ID, deliveries[0].LeaseToken, deliveries[0].LeaseGeneration, now); err != nil {
+		t.Fatal(err)
+	}
+	if err := backend.AckDelivery(machineB, endpointB, deliveries[0].ID, deliveries[0].LeaseToken, deliveries[0].LeaseGeneration, now); err != nil {
+		t.Fatalf("idempotent ack err=%v", err)
+	}
+	if cursor, err := backend.RecipientCursor(machineB, endpointB, conversation.ID, now); err != nil || cursor != 2 {
+		t.Fatalf("contiguous cursor=%d err=%v", cursor, err)
+	}
+
+	third := appendMessage("send-3", "third")
+	thirdLease, err := backend.LeaseDeliveries(machineB, consumerB, endpointB, conversation.ID, now, time.Minute, 10)
+	if err != nil || len(thirdLease) != 1 || thirdLease[0].Message.ID != third.ID {
+		t.Fatalf("third lease=%#v err=%v", thirdLease, err)
+	}
+	if err := backend.AdvertiseEndpoints(machineB, nil, now.Add(time.Second), time.Hour); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := backend.LeaseDeliveries(machineB, consumerB, endpointB, conversation.ID, now.Add(time.Second), time.Minute, 10); !errors.Is(err, relay.ErrForbidden) {
+		t.Fatalf("detached lease err=%v", err)
+	}
+	reclaimAt := now.Add(2 * time.Minute)
+	if err := backend.AdvertiseEndpoints(machineB, []string{endpointB}, reclaimAt, time.Hour); err != nil {
+		t.Fatal(err)
+	}
+	reclaimed, err := backend.LeaseDeliveries(machineB, consumerB, endpointB, conversation.ID, reclaimAt, time.Minute, 10)
+	if err != nil || len(reclaimed) != 1 || reclaimed[0].LeaseGeneration <= thirdLease[0].LeaseGeneration || reclaimed[0].LeaseToken == thirdLease[0].LeaseToken {
+		t.Fatalf("reclaimed=%#v original=%#v err=%v", reclaimed, thirdLease, err)
+	}
+	if err := backend.AckDelivery(machineB, endpointB, thirdLease[0].ID, thirdLease[0].LeaseToken, thirdLease[0].LeaseGeneration, reclaimAt); !errors.Is(err, relay.ErrForbidden) {
+		t.Fatalf("stale ack err=%v", err)
+	}
+	if err := backend.AckDelivery(machineB, endpointB, reclaimed[0].ID, reclaimed[0].LeaseToken, reclaimed[0].LeaseGeneration, reclaimAt); err != nil {
+		t.Fatal(err)
+	}
+	if cursor, err := backend.RecipientCursor(machineB, endpointB, conversation.ID, reclaimAt); err != nil || cursor != 3 {
+		t.Fatalf("recovered cursor=%d err=%v", cursor, err)
+	}
+	selfInput := relay.AppendInput{
+		ConversationID: conversation.ID, SenderMachineID: machineB, FromEndpoint: endpointB,
+		Body: "recipient-authored", IdempotencyKey: namespace + "-recipient-send", Now: reclaimAt,
+	}
+	selfMessage, duplicate, err := backend.AppendMessage(selfInput)
+	if err != nil || duplicate || selfMessage.Sequence != 4 {
+		t.Fatalf("recipient-authored message=%#v duplicate=%t err=%v", selfMessage, duplicate, err)
+	}
+	if cursor, err := backend.RecipientCursor(machineB, endpointB, conversation.ID, reclaimAt); err != nil || cursor != 4 {
+		t.Fatalf("cursor across trailing self sequence=%d err=%v", cursor, err)
+	}
+	afterSelf := appendMessage("send-after-self", "after self")
+	if afterSelf.Sequence != 5 {
+		t.Fatalf("post-self sequence=%d", afterSelf.Sequence)
+	}
+	afterSelfLease, err := backend.LeaseDeliveries(machineB, consumerB, endpointB, conversation.ID, reclaimAt, time.Minute, 10)
+	if err != nil || len(afterSelfLease) != 1 || afterSelfLease[0].Message.ID != afterSelf.ID {
+		t.Fatalf("post-self lease=%#v err=%v", afterSelfLease, err)
+	}
+	if err := backend.AckDelivery(machineB, endpointB, afterSelfLease[0].ID, afterSelfLease[0].LeaseToken, afterSelfLease[0].LeaseGeneration, reclaimAt); err != nil {
+		t.Fatal(err)
+	}
+	if cursor, err := backend.RecipientCursor(machineB, endpointB, conversation.ID, reclaimAt); err != nil || cursor != 5 {
+		t.Fatalf("cursor across non-recipient sequence=%d err=%v", cursor, err)
+	}
+
+	const concurrentMessages = 8
+	sequences := make(chan int64, concurrentMessages)
+	errorsSeen := make(chan error, concurrentMessages)
+	var writers sync.WaitGroup
+	for index := 0; index < concurrentMessages; index++ {
+		writers.Add(1)
+		go func(index int) {
+			defer writers.Done()
+			message, duplicate, err := backend.AppendMessage(relay.AppendInput{
+				ConversationID: conversation.ID, SenderMachineID: machineA, FromEndpoint: endpointA,
+				Body: fmt.Sprintf("concurrent-%d", index), IdempotencyKey: fmt.Sprintf("%s-concurrent-%d", namespace, index), Now: reclaimAt,
+			})
+			if err != nil {
+				errorsSeen <- err
+				return
+			}
+			if duplicate {
+				errorsSeen <- errors.New("concurrent first append reported duplicate")
+				return
+			}
+			sequences <- message.Sequence
+		}(index)
+	}
+	writers.Wait()
+	close(sequences)
+	close(errorsSeen)
+	for err := range errorsSeen {
+		t.Fatalf("concurrent append: %v", err)
+	}
+	seenSequences := make(map[int64]struct{}, concurrentMessages)
+	for sequence := range sequences {
+		seenSequences[sequence] = struct{}{}
+	}
+	for sequence := int64(6); sequence < 6+concurrentMessages; sequence++ {
+		if _, found := seenSequences[sequence]; !found {
+			t.Fatalf("concurrent sequences=%v, missing %d", seenSequences, sequence)
+		}
+	}
+
+	abaMessage := appendMessage("aba", "aba")
+	abaLease, err := backend.LeaseDeliveries(machineB, consumerB, endpointB, conversation.ID, reclaimAt, time.Minute, 100)
+	if err != nil || len(abaLease) == 0 || abaLease[len(abaLease)-1].Message.ID != abaMessage.ID {
+		t.Fatalf("aba lease=%#v err=%v", abaLease, err)
+	}
+	if err := backend.AdvertiseEndpoints(machineA, []string{endpointA, endpointB}, reclaimAt.Add(time.Second), time.Hour); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := backend.AppendMessage(selfInput); !errors.Is(err, relay.ErrForbidden) {
+		t.Fatalf("detached exact message retry err=%v", err)
+	}
+	if err := backend.AdvertiseEndpoints(machineB, []string{endpointB}, reclaimAt.Add(2*time.Second), time.Hour); err != nil {
+		t.Fatal(err)
+	}
+	if err := backend.AckDelivery(machineB, endpointB, abaLease[len(abaLease)-1].ID, abaLease[len(abaLease)-1].LeaseToken, abaLease[len(abaLease)-1].LeaseGeneration, reclaimAt.Add(2*time.Second)); !errors.Is(err, relay.ErrForbidden) {
+		t.Fatalf("ABA-stale acknowledgement err=%v", err)
+	}
+	releasedAfterABA, err := backend.LeaseDeliveries(machineB, consumerB, endpointB, conversation.ID, reclaimAt.Add(2*time.Second), time.Minute, 100)
+	if err != nil || len(releasedAfterABA) == 0 || releasedAfterABA[len(releasedAfterABA)-1].LeaseGeneration <= abaLease[len(abaLease)-1].LeaseGeneration {
+		t.Fatalf("post-ABA lease=%#v err=%v", releasedAfterABA, err)
+	}
+	if err := backend.AdvertiseEndpoints(machineB, []string{endpointA, endpointB}, reclaimAt.Add(3*time.Second), time.Hour); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := backend.CreateConversationIdempotent(create); !errors.Is(err, relay.ErrForbidden) {
+		t.Fatalf("detached exact conversation retry err=%v", err)
+	}
+
+	expires := now.Add(5 * time.Minute)
+	if err := backend.ConsumeRequestNonce(machineA, namespace+"-nonce", now, expires); err != nil {
+		t.Fatal(err)
+	}
+	if err := backend.ConsumeRequestNonce(machineA, namespace+"-nonce", now, expires); !errors.Is(err, relay.ErrForbidden) {
+		t.Fatalf("replayed nonce err=%v", err)
+	}
+}

--- a/internal/relay/http.go
+++ b/internal/relay/http.go
@@ -294,28 +294,12 @@ func (h *handler) leaseDeliveries(w http.ResponseWriter, body []byte, machineID 
 	if request.Limit == 0 {
 		request.Limit = 50
 	}
-	deliveries, err := h.store.LeaseDeliveries(machineID, request.ConsumerID, request.Endpoint, request.ConversationID, now, h.deliveryLeaseTTL, request.Limit)
+	page, err := h.store.LeaseDeliveries(machineID, request.ConsumerID, request.Endpoint, request.ConversationID, now, h.deliveryLeaseTTL, request.Limit)
 	if err != nil {
 		writeStoreError(w, err)
 		return
 	}
-	conversationIDs := make(map[string]struct{})
-	if request.ConversationID != "" {
-		conversationIDs[request.ConversationID] = struct{}{}
-	}
-	for _, delivery := range deliveries {
-		conversationIDs[delivery.Message.ConversationID] = struct{}{}
-	}
-	cursors := make(map[string]int64, len(conversationIDs))
-	for conversationID := range conversationIDs {
-		cursor, err := h.store.RecipientCursor(machineID, request.Endpoint, conversationID, now)
-		if err != nil {
-			writeStoreError(w, err)
-			return
-		}
-		cursors[conversationID] = cursor
-	}
-	writeJSON(w, http.StatusOK, map[string]any{"deliveries": deliveries, "cursors": cursors})
+	writeJSON(w, http.StatusOK, page)
 }
 
 func (h *handler) ackDelivery(w http.ResponseWriter, body []byte, machineID, deliveryID string, now time.Time) {

--- a/internal/relay/http.go
+++ b/internal/relay/http.go
@@ -26,7 +26,7 @@ type HandlerOptions struct {
 
 // NewHandler returns the authenticated relay API. It intentionally does not
 // mount WebSockets or attachment routes; those have separate release gates.
-func NewHandler(store *Store, auth *Authenticator, options HandlerOptions) http.Handler {
+func NewHandler(store Backend, auth *Authenticator, options HandlerOptions) http.Handler {
 	if options.Now == nil {
 		options.Now = time.Now
 	}
@@ -44,7 +44,7 @@ func NewHandler(store *Store, auth *Authenticator, options HandlerOptions) http.
 }
 
 type handler struct {
-	store            *Store
+	store            Backend
 	auth             *Authenticator
 	notifier         *Notifier
 	now              func() time.Time
@@ -64,6 +64,10 @@ func (h *handler) serveHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 	machineID, err := h.authenticate(r, body)
 	if err != nil {
+		if errors.Is(err, ErrMaintenance) {
+			writeStoreError(w, err)
+			return
+		}
 		writeError(w, http.StatusUnauthorized, "authentication required")
 		return
 	}
@@ -189,7 +193,7 @@ func (h *handler) advertiseEndpoints(w http.ResponseWriter, body []byte, machine
 }
 
 func (h *handler) createConversation(w http.ResponseWriter, body []byte, machineID string, now time.Time, idempotencyKey string) {
-	if idempotencyKey == "" {
+	if !ValidRequestToken(idempotencyKey) {
 		writeError(w, http.StatusBadRequest, "Idempotency-Key is required")
 		return
 	}
@@ -230,7 +234,7 @@ func (h *handler) createConversation(w http.ResponseWriter, body []byte, machine
 }
 
 func (h *handler) appendMessage(w http.ResponseWriter, body []byte, machineID, conversationID string, now time.Time, idempotencyKey string) {
-	if idempotencyKey == "" {
+	if !ValidRequestToken(idempotencyKey) {
 		writeError(w, http.StatusBadRequest, "Idempotency-Key is required")
 		return
 	}
@@ -271,10 +275,15 @@ func (h *handler) appendMessage(w http.ResponseWriter, body []byte, machineID, c
 func (h *handler) leaseDeliveries(w http.ResponseWriter, body []byte, machineID string, now time.Time) {
 	var request struct {
 		Endpoint       string `json:"endpoint"`
+		ConsumerID     string `json:"consumer_id"`
 		ConversationID string `json:"conversation_id"`
 		Limit          int    `json:"limit"`
 	}
 	if err := decodeJSON(body, &request); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid delivery lease request")
+		return
+	}
+	if !ValidRequestToken(request.ConsumerID) {
 		writeError(w, http.StatusBadRequest, "invalid delivery lease request")
 		return
 	}
@@ -285,12 +294,28 @@ func (h *handler) leaseDeliveries(w http.ResponseWriter, body []byte, machineID 
 	if request.Limit == 0 {
 		request.Limit = 50
 	}
-	deliveries, err := h.store.LeaseDeliveries(machineID, request.Endpoint, request.ConversationID, now, h.deliveryLeaseTTL, request.Limit)
+	deliveries, err := h.store.LeaseDeliveries(machineID, request.ConsumerID, request.Endpoint, request.ConversationID, now, h.deliveryLeaseTTL, request.Limit)
 	if err != nil {
 		writeStoreError(w, err)
 		return
 	}
-	writeJSON(w, http.StatusOK, map[string]any{"deliveries": deliveries})
+	conversationIDs := make(map[string]struct{})
+	if request.ConversationID != "" {
+		conversationIDs[request.ConversationID] = struct{}{}
+	}
+	for _, delivery := range deliveries {
+		conversationIDs[delivery.Message.ConversationID] = struct{}{}
+	}
+	cursors := make(map[string]int64, len(conversationIDs))
+	for conversationID := range conversationIDs {
+		cursor, err := h.store.RecipientCursor(machineID, request.Endpoint, conversationID, now)
+		if err != nil {
+			writeStoreError(w, err)
+			return
+		}
+		cursors[conversationID] = cursor
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"deliveries": deliveries, "cursors": cursors})
 }
 
 func (h *handler) ackDelivery(w http.ResponseWriter, body []byte, machineID, deliveryID string, now time.Time) {
@@ -364,6 +389,9 @@ func writeStoreError(w http.ResponseWriter, err error) {
 		writeError(w, http.StatusForbidden, "authorization denied")
 	case errors.Is(err, ErrConflict):
 		writeError(w, http.StatusConflict, "request conflicts with durable state")
+	case errors.Is(err, ErrMaintenance):
+		w.Header().Set("Retry-After", "5")
+		writeError(w, http.StatusServiceUnavailable, "relay maintenance in progress")
 	default:
 		writeError(w, http.StatusBadRequest, "invalid request")
 	}

--- a/internal/relay/http_test.go
+++ b/internal/relay/http_test.go
@@ -58,11 +58,12 @@ func TestHTTPDurableMessageFlowRequiresSignedMachineRequests(t *testing.T) {
 	if message.Code != http.StatusCreated {
 		t.Fatalf("message status=%d body=%s", message.Code, message.Body.String())
 	}
-	lease := serveSigned(t, handler, privateB, "machine-b", http.MethodPost, "/v1/deliveries/lease", `{"endpoint":"agent/b/session"}`, "lease", "")
+	lease := serveSigned(t, handler, privateB, "machine-b", http.MethodPost, "/v1/deliveries/lease", `{"endpoint":"agent/b/session","consumer_id":"consumer-b"}`, "lease", "")
 	if lease.Code != http.StatusOK {
 		t.Fatalf("lease status=%d body=%s", lease.Code, lease.Body.String())
 	}
 	var leased struct {
+		Cursors    map[string]int64 `json:"cursors"`
 		Deliveries []struct {
 			ID              string `json:"id"`
 			LeaseToken      string `json:"lease_token"`
@@ -75,7 +76,7 @@ func TestHTTPDurableMessageFlowRequiresSignedMachineRequests(t *testing.T) {
 	if err := json.NewDecoder(lease.Body).Decode(&leased); err != nil {
 		t.Fatal(err)
 	}
-	if len(leased.Deliveries) != 1 || leased.Deliveries[0].Message.Body != "review complete" {
+	if len(leased.Deliveries) != 1 || leased.Deliveries[0].Message.Body != "review complete" || leased.Cursors[conversation.ID] != 0 {
 		t.Fatalf("leased=%+v", leased)
 	}
 	ackBody, err := json.Marshal(map[string]any{"endpoint": "agent/b/session", "lease_token": leased.Deliveries[0].LeaseToken, "lease_generation": leased.Deliveries[0].LeaseGeneration})
@@ -85,6 +86,13 @@ func TestHTTPDurableMessageFlowRequiresSignedMachineRequests(t *testing.T) {
 	ack := serveSigned(t, handler, privateB, "machine-b", http.MethodPost, "/v1/deliveries/"+leased.Deliveries[0].ID+"/ack", string(ackBody), "ack", "")
 	if ack.Code != http.StatusNoContent {
 		t.Fatalf("ack status=%d body=%s", ack.Code, ack.Body.String())
+	}
+	afterAck := serveSigned(t, handler, privateB, "machine-b", http.MethodPost, "/v1/deliveries/lease", `{"endpoint":"agent/b/session","consumer_id":"consumer-b","conversation_id":"`+conversation.ID+`"}`, "lease-after-ack", "")
+	var caughtUp struct {
+		Cursors map[string]int64 `json:"cursors"`
+	}
+	if afterAck.Code != http.StatusOK || json.NewDecoder(afterAck.Body).Decode(&caughtUp) != nil || caughtUp.Cursors[conversation.ID] != 1 {
+		t.Fatalf("caught-up status=%d body=%s cursors=%v", afterAck.Code, afterAck.Body.String(), caughtUp.Cursors)
 	}
 }
 
@@ -205,6 +213,28 @@ func TestHTTPRejectsUnsignedEndpointClaimsAndUnknownJSON(t *testing.T) {
 	handler.ServeHTTP(response, unsigned)
 	if response.Code != http.StatusUnauthorized {
 		t.Fatalf("unsigned status=%d body=%s", response.Code, response.Body.String())
+	}
+}
+
+func TestHTTPRelayReportsMaintenanceDuringAuthentication(t *testing.T) {
+	public, private, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	store, err := Open(filepath.Join(t.TempDir(), "relay.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	auth, err := NewAuthenticator(nonceStoreFunc(func(string, string, time.Time, time.Time) error { return ErrMaintenance }), []Machine{{ID: "machine-a", PublicKey: public, EndpointPrefixes: []string{"agent/a/"}}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	now := time.Date(2026, time.July, 13, 12, 0, 0, 0, time.UTC)
+	handler := NewHandler(store, auth, HandlerOptions{Now: func() time.Time { return now }})
+	response := serveSigned(t, handler, private, "machine-a", http.MethodGet, "/v1/conversations", "", "maintenance", "")
+	if response.Code != http.StatusServiceUnavailable || response.Header().Get("Retry-After") != "5" {
+		t.Fatalf("maintenance status=%d retry-after=%q body=%s", response.Code, response.Header().Get("Retry-After"), response.Body.String())
 	}
 }
 

--- a/internal/relay/store.go
+++ b/internal/relay/store.go
@@ -82,6 +82,13 @@ type Delivery struct {
 	LeaseUntil        time.Time `json:"lease_until"`
 }
 
+// DeliveryLeasePage atomically binds leased delivery fences to the durable
+// cursors returned in the same HTTP response.
+type DeliveryLeasePage struct {
+	Deliveries []Delivery       `json:"deliveries"`
+	Cursors    map[string]int64 `json:"cursors"`
+}
+
 // AppendInput contains one client retry domain. IdempotencyKey is scoped to
 // SenderMachineID and may only be reused with identical message data.
 type AppendInput struct {
@@ -532,7 +539,7 @@ func (s *Store) AppendMessage(input AppendInput) (Message, bool, error) {
 	if !errors.Is(err, sql.ErrNoRows) {
 		return Message{}, false, fmt.Errorf("read idempotency key: %w", err)
 	}
-	message := Message{ID: uuid.NewString(), ConversationID: input.ConversationID, FromEndpoint: input.FromEndpoint, Body: input.Body, CreatedAt: input.Now.UTC()}
+	message := Message{ID: uuid.NewString(), ConversationID: input.ConversationID, FromEndpoint: input.FromEndpoint, Body: input.Body, CreatedAt: input.Now.UTC().Truncate(time.Millisecond)}
 	if err := tx.QueryRowContext(context.Background(), "UPDATE conversations SET next_sequence = next_sequence + 1 WHERE id = ? RETURNING next_sequence", input.ConversationID).Scan(&message.Sequence); errors.Is(err, sql.ErrNoRows) {
 		return Message{}, false, ErrForbidden
 	} else if err != nil {
@@ -579,34 +586,34 @@ func (s *Store) AppendMessage(input AppendInput) (Message, bool, error) {
 // LeaseDeliveries leases a bounded page of pending deliveries for one active
 // endpoint. A retry by the same machine receives its current lease; an expired
 // lease receives a new token and monotonically increasing fence generation.
-func (s *Store) LeaseDeliveries(machineID, consumerID, endpoint, conversationID string, now time.Time, ttl time.Duration, limit int) ([]Delivery, error) {
+func (s *Store) LeaseDeliveries(machineID, consumerID, endpoint, conversationID string, now time.Time, ttl time.Duration, limit int) (DeliveryLeasePage, error) {
 	if !ValidMachineID(machineID) || !ValidRequestToken(consumerID) || !ValidEndpoint(endpoint) || ttl <= 0 || limit < 1 || limit > 100 {
-		return nil, fmt.Errorf("invalid delivery lease request")
+		return DeliveryLeasePage{}, fmt.Errorf("invalid delivery lease request")
 	}
 	tx, err := s.db.BeginTx(context.Background(), nil)
 	if err != nil {
-		return nil, err
+		return DeliveryLeasePage{}, err
 	}
 	defer rollback(tx)
 	ownershipGeneration, err := endpointOwnership(tx, endpoint, machineID, now)
 	if err != nil {
-		return nil, err
+		return DeliveryLeasePage{}, err
 	}
 	var activeConsumer sql.NullString
 	var consumerGeneration int64
 	var consumerUntil sql.NullInt64
 	if err := tx.QueryRowContext(context.Background(), `SELECT consumer_id, consumer_generation, consumer_lease_until FROM endpoints WHERE endpoint = ?`, endpoint).Scan(&activeConsumer, &consumerGeneration, &consumerUntil); err != nil {
-		return nil, fmt.Errorf("read endpoint consumer lease: %w", err)
+		return DeliveryLeasePage{}, fmt.Errorf("read endpoint consumer lease: %w", err)
 	}
 	if activeConsumer.Valid && activeConsumer.String != consumerID && consumerUntil.Valid && consumerUntil.Int64 > now.UnixMilli() {
-		return nil, ErrConflict
+		return DeliveryLeasePage{}, ErrConflict
 	}
 	if !activeConsumer.Valid || activeConsumer.String != consumerID || !consumerUntil.Valid || consumerUntil.Int64 <= now.UnixMilli() {
 		consumerGeneration++
 	}
 	consumerLeaseUntil := now.Add(ttl).UTC()
 	if _, err := tx.ExecContext(context.Background(), `UPDATE endpoints SET consumer_id = ?, consumer_generation = ?, consumer_lease_until = ? WHERE endpoint = ? AND ownership_generation = ?`, consumerID, consumerGeneration, consumerLeaseUntil.UnixMilli(), endpoint, ownershipGeneration); err != nil {
-		return nil, fmt.Errorf("claim endpoint consumer lease: %w", err)
+		return DeliveryLeasePage{}, fmt.Errorf("claim endpoint consumer lease: %w", err)
 	}
 	query := `SELECT d.id, d.lease_machine_id, d.lease_token, d.lease_generation, d.ownership_generation, d.consumer_generation, d.lease_until,
 		m.id, m.conversation_id, m.sequence, m.from_endpoint, m.body, m.created_at
@@ -615,14 +622,16 @@ func (s *Store) LeaseDeliveries(machineID, consumerID, endpoint, conversationID 
 		AND (d.lease_until IS NULL OR d.lease_until <= ? OR d.ownership_generation IS NULL OR d.ownership_generation <> ? OR d.consumer_generation IS NULL OR d.consumer_generation <> ? OR d.lease_machine_id = ?)`
 	args := []any{endpoint, now.UnixMilli(), ownershipGeneration, consumerGeneration, machineID}
 	if conversationID != "" {
-		query += " AND m.conversation_id = ?"
+		query += " AND m.conversation_id = ? ORDER BY m.sequence, m.id"
 		args = append(args, conversationID)
+	} else {
+		query += " ORDER BY m.created_at, m.conversation_id, m.sequence, m.id"
 	}
-	query += " ORDER BY m.sequence ASC LIMIT ?"
+	query += " LIMIT ?"
 	args = append(args, limit)
 	rows, err := tx.QueryContext(context.Background(), query, args...)
 	if err != nil {
-		return nil, fmt.Errorf("find deliveries: %w", err)
+		return DeliveryLeasePage{}, fmt.Errorf("find deliveries: %w", err)
 	}
 	defer func() { _ = rows.Close() }()
 	var deliveries []Delivery
@@ -633,7 +642,7 @@ func (s *Store) LeaseDeliveries(machineID, consumerID, endpoint, conversationID 
 		var createdAt int64
 		delivery.RecipientEndpoint = endpoint
 		if err := rows.Scan(&delivery.ID, &leaseMachine, &leaseToken, &delivery.LeaseGeneration, &leaseOwnership, &leaseConsumer, &leaseUntil, &delivery.Message.ID, &delivery.Message.ConversationID, &delivery.Message.Sequence, &delivery.Message.FromEndpoint, &delivery.Message.Body, &createdAt); err != nil {
-			return nil, err
+			return DeliveryLeasePage{}, err
 		}
 		delivery.Message.CreatedAt = fromMillis(createdAt)
 		if leaseMachine.Valid && leaseMachine.String == machineID && leaseToken.Valid && leaseOwnership.Valid && leaseOwnership.Int64 == ownershipGeneration && leaseConsumer.Valid && leaseConsumer.Int64 == consumerGeneration && leaseUntil.Valid && leaseUntil.Int64 > now.UnixMilli() {
@@ -642,24 +651,62 @@ func (s *Store) LeaseDeliveries(machineID, consumerID, endpoint, conversationID 
 		} else {
 			token, err := randomToken()
 			if err != nil {
-				return nil, err
+				return DeliveryLeasePage{}, err
 			}
 			delivery.LeaseGeneration++
 			delivery.LeaseToken = token
 			delivery.LeaseUntil = now.Add(ttl).UTC()
 			if _, err := tx.ExecContext(context.Background(), `UPDATE deliveries SET lease_machine_id = ?, lease_token = ?, lease_generation = ?, ownership_generation = ?, consumer_generation = ?, lease_until = ? WHERE id = ?`, machineID, token, delivery.LeaseGeneration, ownershipGeneration, consumerGeneration, delivery.LeaseUntil.UnixMilli(), delivery.ID); err != nil {
-				return nil, fmt.Errorf("lease delivery: %w", err)
+				return DeliveryLeasePage{}, fmt.Errorf("lease delivery: %w", err)
 			}
 		}
 		deliveries = append(deliveries, delivery)
 	}
 	if err := rows.Err(); err != nil {
-		return nil, err
+		return DeliveryLeasePage{}, err
+	}
+	if err := rows.Close(); err != nil {
+		return DeliveryLeasePage{}, err
+	}
+	conversationIDs := make(map[string]struct{})
+	if conversationID != "" {
+		conversationIDs[conversationID] = struct{}{}
+	}
+	for _, delivery := range deliveries {
+		conversationIDs[delivery.Message.ConversationID] = struct{}{}
+	}
+	cursors := make(map[string]int64, len(conversationIDs))
+	for id := range conversationIDs {
+		cursor, err := recipientCursorForLease(tx, endpoint, id)
+		if err != nil {
+			return DeliveryLeasePage{}, err
+		}
+		cursors[id] = cursor
 	}
 	if err := tx.Commit(); err != nil {
-		return nil, err
+		return DeliveryLeasePage{}, err
 	}
-	return deliveries, nil
+	return DeliveryLeasePage{Deliveries: deliveries, Cursors: cursors}, nil
+}
+
+func recipientCursorForLease(tx *sql.Tx, endpoint, conversationID string) (int64, error) {
+	var capabilities Capability
+	err := tx.QueryRowContext(context.Background(), "SELECT capabilities FROM memberships WHERE conversation_id = ? AND endpoint = ?", conversationID, endpoint).Scan(&capabilities)
+	if errors.Is(err, sql.ErrNoRows) || capabilities&CapReceive == 0 {
+		return 0, ErrForbidden
+	}
+	if err != nil {
+		return 0, fmt.Errorf("authorize recipient cursor: %w", err)
+	}
+	var cursor int64
+	err = tx.QueryRowContext(context.Background(), "SELECT sequence FROM recipient_cursors WHERE recipient_endpoint = ? AND conversation_id = ?", endpoint, conversationID).Scan(&cursor)
+	if errors.Is(err, sql.ErrNoRows) {
+		return 0, nil
+	}
+	if err != nil {
+		return 0, fmt.Errorf("read recipient cursor: %w", err)
+	}
+	return cursor, nil
 }
 
 // AckDelivery acknowledges a local mailbox handoff. It is idempotent after a

--- a/internal/relay/store.go
+++ b/internal/relay/store.go
@@ -33,6 +33,9 @@ var (
 	// ErrConflict denotes a valid request that conflicts with durable state,
 	// such as reusing an idempotency key with another request body.
 	ErrConflict = errors.New("relay state conflict")
+	// ErrMaintenance is a retryable, payload-free refusal while the durable
+	// update fence owns application mutations.
+	ErrMaintenance = errors.New("relay maintenance in progress")
 )
 
 // Capability controls an endpoint's membership in a conversation.
@@ -118,6 +121,11 @@ func Open(database string) (*Store, error) {
 	if err != nil {
 		return nil, fmt.Errorf("open relay database: %w", err)
 	}
+	// SQLite has one writer. Keeping one pooled connection makes that boundary
+	// explicit and prevents connection-local PRAGMAs or concurrent BEGIN calls
+	// from surfacing SQLITE_BUSY instead of orderly transactional serialization.
+	db.SetMaxOpenConns(1)
+	db.SetMaxIdleConns(1)
 	store := &Store{db: db}
 	if err := store.migrate(context.Background()); err != nil {
 		_ = db.Close()
@@ -129,6 +137,27 @@ func Open(database string) (*Store, error) {
 // Close closes the durable state database.
 func (s *Store) Close() error { return s.db.Close() }
 
+// ConsumeRequestNonce atomically prunes expired replay records and records one
+// signed request nonce. A duplicate is intentionally indistinguishable from
+// another authentication failure.
+func (s *Store) ConsumeRequestNonce(machineID, nonce string, now, expiresAt time.Time) error {
+	if !ValidMachineID(machineID) || !ValidRequestToken(nonce) || !expiresAt.After(now) {
+		return ErrForbidden
+	}
+	tx, err := s.db.BeginTx(context.Background(), nil)
+	if err != nil {
+		return err
+	}
+	defer rollback(tx)
+	if _, err := tx.ExecContext(context.Background(), "DELETE FROM request_nonces WHERE expires_at <= ?", now.UnixMilli()); err != nil {
+		return fmt.Errorf("prune request nonces: %w", err)
+	}
+	if _, err := tx.ExecContext(context.Background(), "INSERT INTO request_nonces(machine_id, nonce, expires_at) VALUES (?, ?, ?)", machineID, nonce, expiresAt.UnixMilli()); err != nil {
+		return ErrForbidden
+	}
+	return tx.Commit()
+}
+
 func (s *Store) migrate(ctx context.Context) error {
 	for _, statement := range []string{
 		"PRAGMA foreign_keys = ON",
@@ -137,7 +166,11 @@ func (s *Store) migrate(ctx context.Context) error {
 		`CREATE TABLE IF NOT EXISTS endpoints (
 			endpoint TEXT PRIMARY KEY,
 			machine_id TEXT NOT NULL,
-			lease_until INTEGER NOT NULL
+			lease_until INTEGER NOT NULL,
+			ownership_generation INTEGER NOT NULL DEFAULT 1,
+			consumer_id TEXT,
+			consumer_generation INTEGER NOT NULL DEFAULT 0,
+			consumer_lease_until INTEGER
 		)`,
 		`CREATE TABLE IF NOT EXISTS conversations (
 			id TEXT PRIMARY KEY,
@@ -166,9 +199,17 @@ func (s *Store) migrate(ctx context.Context) error {
 			lease_machine_id TEXT,
 			lease_token TEXT,
 			lease_generation INTEGER NOT NULL DEFAULT 0,
+			ownership_generation INTEGER,
+			consumer_generation INTEGER,
 			lease_until INTEGER,
 			acked_at INTEGER,
 			UNIQUE (message_id, recipient_endpoint)
+		)`,
+		`CREATE TABLE IF NOT EXISTS recipient_cursors (
+			recipient_endpoint TEXT NOT NULL,
+			conversation_id TEXT NOT NULL REFERENCES conversations(id) ON DELETE CASCADE,
+			sequence INTEGER NOT NULL DEFAULT 0 CHECK (sequence >= 0),
+			PRIMARY KEY (recipient_endpoint, conversation_id)
 		)`,
 		`CREATE TABLE IF NOT EXISTS idempotency (
 			machine_id TEXT NOT NULL,
@@ -199,6 +240,52 @@ func (s *Store) migrate(ctx context.Context) error {
 			return fmt.Errorf("migrate relay database: %w", err)
 		}
 	}
+	for _, column := range []struct {
+		table, name, definition string
+	}{
+		{"endpoints", "ownership_generation", "INTEGER NOT NULL DEFAULT 1"},
+		{"endpoints", "consumer_id", "TEXT"},
+		{"endpoints", "consumer_generation", "INTEGER NOT NULL DEFAULT 0"},
+		{"endpoints", "consumer_lease_until", "INTEGER"},
+		{"deliveries", "ownership_generation", "INTEGER"},
+		{"deliveries", "consumer_generation", "INTEGER"},
+	} {
+		if err := ensureSQLiteColumn(ctx, s.db, column.table, column.name, column.definition); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func ensureSQLiteColumn(ctx context.Context, db *sql.DB, table, name, definition string) error {
+	if table != "endpoints" && table != "deliveries" {
+		return errors.New("invalid relay migration table")
+	}
+	rows, err := db.QueryContext(ctx, "PRAGMA table_info("+table+")") // #nosec G202 -- table is restricted above to fixed internal names.
+	if err != nil {
+		return fmt.Errorf("inspect relay table %s: %w", table, err)
+	}
+	found := false
+	for rows.Next() {
+		var sequence int
+		var columnName, columnType string
+		var required, primaryKey int
+		var defaultValue sql.NullString
+		if err := rows.Scan(&sequence, &columnName, &columnType, &required, &defaultValue, &primaryKey); err != nil {
+			_ = rows.Close()
+			return fmt.Errorf("inspect relay table %s: %w", table, err)
+		}
+		found = found || columnName == name
+	}
+	if err := rows.Close(); err != nil {
+		return fmt.Errorf("inspect relay table %s: %w", table, err)
+	}
+	if found {
+		return nil
+	}
+	if _, err := db.ExecContext(ctx, "ALTER TABLE "+table+" ADD COLUMN "+name+" "+definition); err != nil { // #nosec G202 -- all values come from the fixed migration list above.
+		return fmt.Errorf("upgrade relay table %s: %w", table, err)
+	}
 	return nil
 }
 
@@ -206,12 +293,12 @@ func (s *Store) migrate(ctx context.Context) error {
 // endpoints. Detached endpoints cannot fetch or acknowledge deliveries until
 // their owning machine advertises them again.
 func (s *Store) AdvertiseEndpoints(machineID string, endpoints []string, now time.Time, ttl time.Duration) error {
-	if strings.TrimSpace(machineID) == "" || ttl <= 0 {
+	if !ValidMachineID(machineID) || ttl <= 0 {
 		return fmt.Errorf("invalid endpoint lease")
 	}
 	seen := make(map[string]struct{}, len(endpoints))
 	for _, endpoint := range endpoints {
-		if strings.TrimSpace(endpoint) == "" {
+		if !ValidEndpoint(endpoint) {
 			return fmt.Errorf("endpoint is required")
 		}
 		if _, duplicate := seen[endpoint]; duplicate {
@@ -224,13 +311,40 @@ func (s *Store) AdvertiseEndpoints(machineID string, endpoints []string, now tim
 		return err
 	}
 	defer rollback(tx)
-	if _, err := tx.ExecContext(context.Background(), "DELETE FROM endpoints WHERE machine_id = ?", machineID); err != nil {
-		return fmt.Errorf("detach endpoints: %w", err)
+	rows, err := tx.QueryContext(context.Background(), `SELECT endpoint FROM endpoints WHERE machine_id = ? AND lease_until > ?`, machineID, now.UnixMilli())
+	if err != nil {
+		return fmt.Errorf("find attached endpoints: %w", err)
+	}
+	var detached []string
+	for rows.Next() {
+		var endpoint string
+		if err := rows.Scan(&endpoint); err != nil {
+			_ = rows.Close()
+			return fmt.Errorf("read attached endpoint: %w", err)
+		}
+		if _, retained := seen[endpoint]; !retained {
+			detached = append(detached, endpoint)
+		}
+	}
+	if err := rows.Close(); err != nil {
+		return fmt.Errorf("find attached endpoints: %w", err)
+	}
+	for _, endpoint := range detached {
+		if _, err := tx.ExecContext(context.Background(), `UPDATE endpoints
+			SET lease_until = ?, ownership_generation = ownership_generation + 1,
+			    consumer_id = NULL, consumer_lease_until = NULL
+			WHERE endpoint = ? AND machine_id = ? AND lease_until > ?`, now.UnixMilli(), endpoint, machineID, now.UnixMilli()); err != nil {
+			return fmt.Errorf("detach endpoint: %w", err)
+		}
 	}
 	until := now.Add(ttl).UnixMilli()
 	for endpoint := range seen {
 		if _, err := tx.ExecContext(context.Background(), `INSERT INTO endpoints(endpoint, machine_id, lease_until) VALUES (?, ?, ?)
-			ON CONFLICT(endpoint) DO UPDATE SET machine_id = excluded.machine_id, lease_until = excluded.lease_until`, endpoint, machineID, until); err != nil {
+			ON CONFLICT(endpoint) DO UPDATE SET
+				ownership_generation = CASE WHEN endpoints.machine_id <> excluded.machine_id OR endpoints.lease_until <= ? THEN endpoints.ownership_generation + 1 ELSE endpoints.ownership_generation END,
+				consumer_id = CASE WHEN endpoints.machine_id <> excluded.machine_id OR endpoints.lease_until <= ? THEN NULL ELSE endpoints.consumer_id END,
+				consumer_lease_until = CASE WHEN endpoints.machine_id <> excluded.machine_id OR endpoints.lease_until <= ? THEN NULL ELSE endpoints.consumer_lease_until END,
+				machine_id = excluded.machine_id, lease_until = excluded.lease_until`, endpoint, machineID, until, now.UnixMilli(), now.UnixMilli(), now.UnixMilli()); err != nil {
 			return fmt.Errorf("advertise endpoint: %w", err)
 		}
 	}
@@ -262,7 +376,7 @@ func (s *Store) CreateConversation(creatorEndpoint string, members []Member, now
 // CreateConversationIdempotent creates a room once for a signed machine retry
 // domain. A repeated key with a different normalized request is a conflict.
 func (s *Store) CreateConversationIdempotent(input CreateConversationInput) (Conversation, error) {
-	if strings.TrimSpace(input.MachineID) == "" || strings.TrimSpace(input.IdempotencyKey) == "" {
+	if !ValidMachineID(input.MachineID) || !ValidRequestToken(input.IdempotencyKey) {
 		return Conversation{}, fmt.Errorf("machine and idempotency key are required")
 	}
 	return s.createConversation(input)
@@ -272,13 +386,13 @@ func (s *Store) createConversation(input CreateConversationInput) (Conversation,
 	creatorEndpoint := input.CreatorEndpoint
 	members := input.Members
 	now := input.Now
-	if strings.TrimSpace(creatorEndpoint) == "" || len(members) == 0 {
+	if !ValidEndpoint(creatorEndpoint) || len(members) == 0 || len(members) > 256 {
 		return Conversation{}, fmt.Errorf("creator and members are required")
 	}
 	seen := make(map[string]struct{}, len(members))
 	creatorAdmin := false
 	for _, member := range members {
-		if strings.TrimSpace(member.Endpoint) == "" || member.Capabilities == 0 || member.Capabilities & ^(CapSend|CapReceive|CapAdmin) != 0 {
+		if !ValidEndpoint(member.Endpoint) || member.Capabilities == 0 || member.Capabilities & ^(CapSend|CapReceive|CapAdmin) != 0 {
 			return Conversation{}, fmt.Errorf("invalid conversation member")
 		}
 		if _, duplicate := seen[member.Endpoint]; duplicate {
@@ -297,6 +411,11 @@ func (s *Store) createConversation(input CreateConversationInput) (Conversation,
 		return Conversation{}, err
 	}
 	defer rollback(tx)
+	if input.MachineID != "" {
+		if err := endpointOwnedBy(tx, creatorEndpoint, input.MachineID, now); err != nil {
+			return Conversation{}, err
+		}
+	}
 	if input.MachineID != "" {
 		requestHash := createConversationHash(creatorEndpoint, members)
 		var existingID, existingHash string
@@ -372,7 +491,7 @@ func (s *Store) AuthorizeSender(conversationID, machineID, endpoint string, now 
 // AppendMessage accepts one immutable, authorized message and creates one
 // independent durable delivery per receiving endpoint, excluding the sender.
 func (s *Store) AppendMessage(input AppendInput) (Message, bool, error) {
-	if strings.TrimSpace(input.ConversationID) == "" || strings.TrimSpace(input.SenderMachineID) == "" || strings.TrimSpace(input.FromEndpoint) == "" || strings.TrimSpace(input.IdempotencyKey) == "" {
+	if strings.TrimSpace(input.ConversationID) == "" || !ValidMachineID(input.SenderMachineID) || !ValidEndpoint(input.FromEndpoint) || !ValidRequestToken(input.IdempotencyKey) {
 		return Message{}, false, fmt.Errorf("conversation, machine, endpoint, and idempotency key are required")
 	}
 	if len(input.Body) > maxMessageBodyBytes {
@@ -384,6 +503,17 @@ func (s *Store) AppendMessage(input AppendInput) (Message, bool, error) {
 		return Message{}, false, err
 	}
 	defer rollback(tx)
+	if err := endpointOwnedBy(tx, input.FromEndpoint, input.SenderMachineID, input.Now); err != nil {
+		return Message{}, false, err
+	}
+	var capabilities Capability
+	err = tx.QueryRowContext(context.Background(), "SELECT capabilities FROM memberships WHERE conversation_id = ? AND endpoint = ?", input.ConversationID, input.FromEndpoint).Scan(&capabilities)
+	if errors.Is(err, sql.ErrNoRows) || capabilities&CapSend == 0 {
+		return Message{}, false, ErrForbidden
+	}
+	if err != nil {
+		return Message{}, false, fmt.Errorf("authorize message sender: %w", err)
+	}
 	var existingID, existingHash string
 	err = tx.QueryRowContext(context.Background(), "SELECT message_id, request_hash FROM idempotency WHERE machine_id = ? AND key = ?", input.SenderMachineID, input.IdempotencyKey).Scan(&existingID, &existingHash)
 	if err == nil {
@@ -401,17 +531,6 @@ func (s *Store) AppendMessage(input AppendInput) (Message, bool, error) {
 	}
 	if !errors.Is(err, sql.ErrNoRows) {
 		return Message{}, false, fmt.Errorf("read idempotency key: %w", err)
-	}
-	if err := endpointOwnedBy(tx, input.FromEndpoint, input.SenderMachineID, input.Now); err != nil {
-		return Message{}, false, err
-	}
-	var capabilities Capability
-	err = tx.QueryRowContext(context.Background(), "SELECT capabilities FROM memberships WHERE conversation_id = ? AND endpoint = ?", input.ConversationID, input.FromEndpoint).Scan(&capabilities)
-	if errors.Is(err, sql.ErrNoRows) || capabilities&CapSend == 0 {
-		return Message{}, false, ErrForbidden
-	}
-	if err != nil {
-		return Message{}, false, fmt.Errorf("authorize message sender: %w", err)
 	}
 	message := Message{ID: uuid.NewString(), ConversationID: input.ConversationID, FromEndpoint: input.FromEndpoint, Body: input.Body, CreatedAt: input.Now.UTC()}
 	if err := tx.QueryRowContext(context.Background(), "UPDATE conversations SET next_sequence = next_sequence + 1 WHERE id = ? RETURNING next_sequence", input.ConversationID).Scan(&message.Sequence); errors.Is(err, sql.ErrNoRows) {
@@ -443,6 +562,11 @@ func (s *Store) AppendMessage(input AppendInput) (Message, bool, error) {
 			return Message{}, false, fmt.Errorf("create delivery: %w", err)
 		}
 	}
+	if capabilities&CapReceive != 0 {
+		if err := advanceRecipientCursor(tx, input.FromEndpoint, input.ConversationID); err != nil {
+			return Message{}, false, err
+		}
+	}
 	if _, err := tx.ExecContext(context.Background(), "INSERT INTO idempotency(machine_id, key, request_hash, message_id, created_at) VALUES (?, ?, ?, ?, ?)", input.SenderMachineID, input.IdempotencyKey, requestHash, message.ID, input.Now.UnixMilli()); err != nil {
 		return Message{}, false, fmt.Errorf("record idempotency key: %w", err)
 	}
@@ -455,8 +579,8 @@ func (s *Store) AppendMessage(input AppendInput) (Message, bool, error) {
 // LeaseDeliveries leases a bounded page of pending deliveries for one active
 // endpoint. A retry by the same machine receives its current lease; an expired
 // lease receives a new token and monotonically increasing fence generation.
-func (s *Store) LeaseDeliveries(machineID, endpoint, conversationID string, now time.Time, ttl time.Duration, limit int) ([]Delivery, error) {
-	if ttl <= 0 || limit < 1 || limit > 100 {
+func (s *Store) LeaseDeliveries(machineID, consumerID, endpoint, conversationID string, now time.Time, ttl time.Duration, limit int) ([]Delivery, error) {
+	if !ValidMachineID(machineID) || !ValidRequestToken(consumerID) || !ValidEndpoint(endpoint) || ttl <= 0 || limit < 1 || limit > 100 {
 		return nil, fmt.Errorf("invalid delivery lease request")
 	}
 	tx, err := s.db.BeginTx(context.Background(), nil)
@@ -464,15 +588,32 @@ func (s *Store) LeaseDeliveries(machineID, endpoint, conversationID string, now 
 		return nil, err
 	}
 	defer rollback(tx)
-	if err := endpointOwnedBy(tx, endpoint, machineID, now); err != nil {
+	ownershipGeneration, err := endpointOwnership(tx, endpoint, machineID, now)
+	if err != nil {
 		return nil, err
 	}
-	query := `SELECT d.id, d.lease_machine_id, d.lease_token, d.lease_generation, d.lease_until,
+	var activeConsumer sql.NullString
+	var consumerGeneration int64
+	var consumerUntil sql.NullInt64
+	if err := tx.QueryRowContext(context.Background(), `SELECT consumer_id, consumer_generation, consumer_lease_until FROM endpoints WHERE endpoint = ?`, endpoint).Scan(&activeConsumer, &consumerGeneration, &consumerUntil); err != nil {
+		return nil, fmt.Errorf("read endpoint consumer lease: %w", err)
+	}
+	if activeConsumer.Valid && activeConsumer.String != consumerID && consumerUntil.Valid && consumerUntil.Int64 > now.UnixMilli() {
+		return nil, ErrConflict
+	}
+	if !activeConsumer.Valid || activeConsumer.String != consumerID || !consumerUntil.Valid || consumerUntil.Int64 <= now.UnixMilli() {
+		consumerGeneration++
+	}
+	consumerLeaseUntil := now.Add(ttl).UTC()
+	if _, err := tx.ExecContext(context.Background(), `UPDATE endpoints SET consumer_id = ?, consumer_generation = ?, consumer_lease_until = ? WHERE endpoint = ? AND ownership_generation = ?`, consumerID, consumerGeneration, consumerLeaseUntil.UnixMilli(), endpoint, ownershipGeneration); err != nil {
+		return nil, fmt.Errorf("claim endpoint consumer lease: %w", err)
+	}
+	query := `SELECT d.id, d.lease_machine_id, d.lease_token, d.lease_generation, d.ownership_generation, d.consumer_generation, d.lease_until,
 		m.id, m.conversation_id, m.sequence, m.from_endpoint, m.body, m.created_at
 		FROM deliveries d JOIN messages m ON m.id = d.message_id
 		WHERE d.recipient_endpoint = ? AND d.acked_at IS NULL
-		AND (d.lease_until IS NULL OR d.lease_until <= ? OR d.lease_machine_id = ?)`
-	args := []any{endpoint, now.UnixMilli(), machineID}
+		AND (d.lease_until IS NULL OR d.lease_until <= ? OR d.ownership_generation IS NULL OR d.ownership_generation <> ? OR d.consumer_generation IS NULL OR d.consumer_generation <> ? OR d.lease_machine_id = ?)`
+	args := []any{endpoint, now.UnixMilli(), ownershipGeneration, consumerGeneration, machineID}
 	if conversationID != "" {
 		query += " AND m.conversation_id = ?"
 		args = append(args, conversationID)
@@ -488,14 +629,14 @@ func (s *Store) LeaseDeliveries(machineID, endpoint, conversationID string, now 
 	for rows.Next() {
 		var delivery Delivery
 		var leaseMachine, leaseToken sql.NullString
-		var leaseUntil sql.NullInt64
+		var leaseUntil, leaseOwnership, leaseConsumer sql.NullInt64
 		var createdAt int64
 		delivery.RecipientEndpoint = endpoint
-		if err := rows.Scan(&delivery.ID, &leaseMachine, &leaseToken, &delivery.LeaseGeneration, &leaseUntil, &delivery.Message.ID, &delivery.Message.ConversationID, &delivery.Message.Sequence, &delivery.Message.FromEndpoint, &delivery.Message.Body, &createdAt); err != nil {
+		if err := rows.Scan(&delivery.ID, &leaseMachine, &leaseToken, &delivery.LeaseGeneration, &leaseOwnership, &leaseConsumer, &leaseUntil, &delivery.Message.ID, &delivery.Message.ConversationID, &delivery.Message.Sequence, &delivery.Message.FromEndpoint, &delivery.Message.Body, &createdAt); err != nil {
 			return nil, err
 		}
 		delivery.Message.CreatedAt = fromMillis(createdAt)
-		if leaseMachine.Valid && leaseMachine.String == machineID && leaseToken.Valid && leaseUntil.Valid && leaseUntil.Int64 > now.UnixMilli() {
+		if leaseMachine.Valid && leaseMachine.String == machineID && leaseToken.Valid && leaseOwnership.Valid && leaseOwnership.Int64 == ownershipGeneration && leaseConsumer.Valid && leaseConsumer.Int64 == consumerGeneration && leaseUntil.Valid && leaseUntil.Int64 > now.UnixMilli() {
 			delivery.LeaseToken = leaseToken.String
 			delivery.LeaseUntil = fromMillis(leaseUntil.Int64)
 		} else {
@@ -506,7 +647,7 @@ func (s *Store) LeaseDeliveries(machineID, endpoint, conversationID string, now 
 			delivery.LeaseGeneration++
 			delivery.LeaseToken = token
 			delivery.LeaseUntil = now.Add(ttl).UTC()
-			if _, err := tx.ExecContext(context.Background(), `UPDATE deliveries SET lease_machine_id = ?, lease_token = ?, lease_generation = ?, lease_until = ? WHERE id = ?`, machineID, token, delivery.LeaseGeneration, delivery.LeaseUntil.UnixMilli(), delivery.ID); err != nil {
+			if _, err := tx.ExecContext(context.Background(), `UPDATE deliveries SET lease_machine_id = ?, lease_token = ?, lease_generation = ?, ownership_generation = ?, consumer_generation = ?, lease_until = ? WHERE id = ?`, machineID, token, delivery.LeaseGeneration, ownershipGeneration, consumerGeneration, delivery.LeaseUntil.UnixMilli(), delivery.ID); err != nil {
 				return nil, fmt.Errorf("lease delivery: %w", err)
 			}
 		}
@@ -530,29 +671,112 @@ func (s *Store) AckDelivery(machineID, endpoint, deliveryID, token string, gener
 		return err
 	}
 	defer rollback(tx)
-	if err := endpointOwnedBy(tx, endpoint, machineID, now); err != nil {
+	ownershipGeneration, err := endpointOwnership(tx, endpoint, machineID, now)
+	if err != nil {
 		return err
 	}
 	var recipient, leaseMachine, leaseToken sql.NullString
 	var leaseGeneration int64
+	var leaseOwnership, leaseConsumer sql.NullInt64
 	var leaseUntil, acknowledged sql.NullInt64
-	err = tx.QueryRowContext(context.Background(), "SELECT recipient_endpoint, lease_machine_id, lease_token, lease_generation, lease_until, acked_at FROM deliveries WHERE id = ?", deliveryID).Scan(&recipient, &leaseMachine, &leaseToken, &leaseGeneration, &leaseUntil, &acknowledged)
+	err = tx.QueryRowContext(context.Background(), "SELECT recipient_endpoint, lease_machine_id, lease_token, lease_generation, ownership_generation, consumer_generation, lease_until, acked_at FROM deliveries WHERE id = ?", deliveryID).Scan(&recipient, &leaseMachine, &leaseToken, &leaseGeneration, &leaseOwnership, &leaseConsumer, &leaseUntil, &acknowledged)
 	if errors.Is(err, sql.ErrNoRows) || !recipient.Valid || recipient.String != endpoint {
 		return ErrForbidden
 	}
 	if err != nil {
 		return fmt.Errorf("read delivery acknowledgement state: %w", err)
 	}
-	if acknowledged.Valid {
+	if acknowledged.Valid && leaseToken.Valid && token == leaseToken.String && leaseGeneration == generation {
 		return tx.Commit()
 	}
-	if !leaseMachine.Valid || leaseMachine.String != machineID || !leaseToken.Valid || token != leaseToken.String || leaseGeneration != generation || !leaseUntil.Valid || leaseUntil.Int64 <= now.UnixMilli() {
+	var currentConsumerGeneration int64
+	if err := tx.QueryRowContext(context.Background(), `SELECT consumer_generation FROM endpoints WHERE endpoint = ?`, endpoint).Scan(&currentConsumerGeneration); err != nil {
+		return ErrForbidden
+	}
+	if !leaseMachine.Valid || leaseMachine.String != machineID || !leaseToken.Valid || token != leaseToken.String || leaseGeneration != generation || !leaseOwnership.Valid || leaseOwnership.Int64 != ownershipGeneration || !leaseConsumer.Valid || leaseConsumer.Int64 != currentConsumerGeneration || !leaseUntil.Valid || leaseUntil.Int64 <= now.UnixMilli() {
 		return ErrForbidden
 	}
 	if _, err := tx.ExecContext(context.Background(), "UPDATE deliveries SET acked_at = ? WHERE id = ? AND acked_at IS NULL", now.UnixMilli(), deliveryID); err != nil {
 		return fmt.Errorf("acknowledge delivery: %w", err)
 	}
+	var conversationID string
+	if err := tx.QueryRowContext(context.Background(), `SELECT message.conversation_id
+		FROM deliveries AS delivery JOIN messages AS message ON message.id = delivery.message_id
+		WHERE delivery.id = ?`, deliveryID).Scan(&conversationID); err != nil {
+		return fmt.Errorf("read delivery conversation: %w", err)
+	}
+	if err := advanceRecipientCursor(tx, endpoint, conversationID); err != nil {
+		return err
+	}
 	return tx.Commit()
+}
+
+// RecipientCursor returns the highest conversation sequence for which this
+// recipient has no earlier unacknowledged delivery. Sequences not addressed to
+// the recipient do not create gaps.
+func (s *Store) RecipientCursor(machineID, endpoint, conversationID string, now time.Time) (int64, error) {
+	tx, err := s.db.BeginTx(context.Background(), nil)
+	if err != nil {
+		return 0, err
+	}
+	defer rollback(tx)
+	if err := endpointOwnedBy(tx, endpoint, machineID, now); err != nil {
+		return 0, err
+	}
+	var capabilities Capability
+	err = tx.QueryRowContext(context.Background(), "SELECT capabilities FROM memberships WHERE conversation_id = ? AND endpoint = ?", conversationID, endpoint).Scan(&capabilities)
+	if errors.Is(err, sql.ErrNoRows) || capabilities&CapReceive == 0 {
+		return 0, ErrForbidden
+	}
+	if err != nil {
+		return 0, fmt.Errorf("authorize recipient cursor: %w", err)
+	}
+	var cursor int64
+	err = tx.QueryRowContext(context.Background(), "SELECT sequence FROM recipient_cursors WHERE recipient_endpoint = ? AND conversation_id = ?", endpoint, conversationID).Scan(&cursor)
+	if errors.Is(err, sql.ErrNoRows) {
+		cursor = 0
+	} else if err != nil {
+		return 0, fmt.Errorf("read recipient cursor: %w", err)
+	}
+	if err := tx.Commit(); err != nil {
+		return 0, err
+	}
+	return cursor, nil
+}
+
+func advanceRecipientCursor(tx *sql.Tx, endpoint, conversationID string) error {
+	if _, err := tx.ExecContext(context.Background(), `INSERT INTO recipient_cursors(recipient_endpoint, conversation_id, sequence)
+		VALUES (?, ?, 0) ON CONFLICT(recipient_endpoint, conversation_id) DO NOTHING`, endpoint, conversationID); err != nil {
+		return fmt.Errorf("initialize recipient cursor: %w", err)
+	}
+	var cursor int64
+	if err := tx.QueryRowContext(context.Background(), "SELECT sequence FROM recipient_cursors WHERE recipient_endpoint = ? AND conversation_id = ?", endpoint, conversationID).Scan(&cursor); err != nil {
+		return fmt.Errorf("read recipient cursor: %w", err)
+	}
+	var nextPending sql.NullInt64
+	if err := tx.QueryRowContext(context.Background(), `SELECT MIN(message.sequence)
+		FROM deliveries AS delivery JOIN messages AS message ON message.id = delivery.message_id
+		WHERE delivery.recipient_endpoint = ? AND message.conversation_id = ?
+		  AND delivery.acked_at IS NULL AND message.sequence > ?`, endpoint, conversationID, cursor).Scan(&nextPending); err != nil {
+		return fmt.Errorf("find recipient cursor gap: %w", err)
+	}
+	var target int64
+	if nextPending.Valid {
+		target = nextPending.Int64 - 1
+	} else {
+		var maximum int64
+		if err := tx.QueryRowContext(context.Background(), `SELECT next_sequence FROM conversations WHERE id = ?`, conversationID).Scan(&maximum); err != nil {
+			return fmt.Errorf("find recipient cursor maximum: %w", err)
+		}
+		target = maximum
+	}
+	if target > cursor {
+		if _, err := tx.ExecContext(context.Background(), `UPDATE recipient_cursors SET sequence = ?
+			WHERE recipient_endpoint = ? AND conversation_id = ? AND sequence = ?`, target, endpoint, conversationID, cursor); err != nil {
+			return fmt.Errorf("advance recipient cursor: %w", err)
+		}
+	}
+	return nil
 }
 
 // RecipientMachines returns active machine owners for a message's recipient
@@ -619,16 +843,22 @@ func endpointActive(tx *sql.Tx, endpoint string, now time.Time) error {
 }
 
 func endpointOwnedBy(tx *sql.Tx, endpoint, machineID string, now time.Time) error {
+	_, err := endpointOwnership(tx, endpoint, machineID, now)
+	return err
+}
+
+func endpointOwnership(tx *sql.Tx, endpoint, machineID string, now time.Time) (int64, error) {
 	var owner string
 	var until int64
-	err := tx.QueryRowContext(context.Background(), "SELECT machine_id, lease_until FROM endpoints WHERE endpoint = ?", endpoint).Scan(&owner, &until)
+	var generation int64
+	err := tx.QueryRowContext(context.Background(), "SELECT machine_id, lease_until, ownership_generation FROM endpoints WHERE endpoint = ?", endpoint).Scan(&owner, &until, &generation)
 	if errors.Is(err, sql.ErrNoRows) || owner != machineID || until <= now.UnixMilli() {
-		return ErrForbidden
+		return 0, ErrForbidden
 	}
 	if err != nil {
-		return fmt.Errorf("read endpoint ownership: %w", err)
+		return 0, fmt.Errorf("read endpoint ownership: %w", err)
 	}
-	return nil
+	return generation, nil
 }
 
 func messageByID(tx *sql.Tx, messageID string) (Message, error) {

--- a/internal/relay/store_conformance_test.go
+++ b/internal/relay/store_conformance_test.go
@@ -1,0 +1,18 @@
+package relay_test
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/rock3r/punaro/internal/relay"
+	"github.com/rock3r/punaro/internal/relay/contracttest"
+)
+
+func TestSQLiteStoreConformance(t *testing.T) {
+	store, err := relay.Open(filepath.Join(t.TempDir(), "relay.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	contracttest.Run(t, store, "sqlite-contract")
+}

--- a/internal/relay/store_test.go
+++ b/internal/relay/store_test.go
@@ -67,10 +67,11 @@ func TestStoreProvidesDurableAtLeastOnceDelivery(t *testing.T) {
 		t.Fatalf("recipient machines = %#v", recipients)
 	}
 
-	leased, err := store.LeaseDeliveries("machine-b", "consumer-b", "agent/b", "", clock, time.Minute, 10)
+	page, err := store.LeaseDeliveries("machine-b", "consumer-b", "agent/b", "", clock, time.Minute, 10)
 	if err != nil {
 		t.Fatal(err)
 	}
+	leased := page.Deliveries
 	if len(leased) != 1 || leased[0].Message.ID != first.ID || leased[0].Message.Body != "ready for review" {
 		t.Fatalf("leased = %#v", leased)
 	}
@@ -109,7 +110,8 @@ func TestStoreRejectsStaleLeaseAfterRedeliveryAndSurvivesRestart(t *testing.T) {
 	if _, _, err := store.AppendMessage(AppendInput{ConversationID: conversation.ID, SenderMachineID: "machine-a", FromEndpoint: "agent/a", Body: "one", IdempotencyKey: "send-1", Now: clock}); err != nil {
 		t.Fatal(err)
 	}
-	firstLease, err := store.LeaseDeliveries("machine-b", "consumer-b", "agent/b", "", clock, time.Minute, 10)
+	firstPage, err := store.LeaseDeliveries("machine-b", "consumer-b", "agent/b", "", clock, time.Minute, 10)
+	firstLease := firstPage.Deliveries
 	if err != nil || len(firstLease) != 1 {
 		t.Fatalf("first lease = %#v, %v", firstLease, err)
 	}
@@ -121,7 +123,8 @@ func TestStoreRejectsStaleLeaseAfterRedeliveryAndSurvivesRestart(t *testing.T) {
 		t.Fatal(err)
 	}
 	t.Cleanup(func() { _ = store.Close() })
-	secondLease, err := store.LeaseDeliveries("machine-b", "consumer-b", "agent/b", "", clock.Add(time.Minute+time.Second), time.Minute, 10)
+	secondPage, err := store.LeaseDeliveries("machine-b", "consumer-b", "agent/b", "", clock.Add(time.Minute+time.Second), time.Minute, 10)
+	secondLease := secondPage.Deliveries
 	if err != nil || len(secondLease) != 1 {
 		t.Fatalf("second lease = %#v, %v", secondLease, err)
 	}
@@ -162,7 +165,8 @@ func TestStoreRecipientCursorNeverSkipsAcknowledgementGap(t *testing.T) {
 			t.Fatal(err)
 		}
 	}
-	deliveries, err := store.LeaseDeliveries("machine-b", "consumer-b", "agent/b", conversation.ID, now, time.Minute, 10)
+	page, err := store.LeaseDeliveries("machine-b", "consumer-b", "agent/b", conversation.ID, now, time.Minute, 10)
+	deliveries := page.Deliveries
 	if err != nil || len(deliveries) != 2 {
 		t.Fatalf("deliveries=%#v err=%v", deliveries, err)
 	}

--- a/internal/relay/store_test.go
+++ b/internal/relay/store_test.go
@@ -1,6 +1,7 @@
 package relay
 
 import (
+	"fmt"
 	"path/filepath"
 	"testing"
 	"time"
@@ -66,7 +67,7 @@ func TestStoreProvidesDurableAtLeastOnceDelivery(t *testing.T) {
 		t.Fatalf("recipient machines = %#v", recipients)
 	}
 
-	leased, err := store.LeaseDeliveries("machine-b", "agent/b", "", clock, time.Minute, 10)
+	leased, err := store.LeaseDeliveries("machine-b", "consumer-b", "agent/b", "", clock, time.Minute, 10)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -108,7 +109,7 @@ func TestStoreRejectsStaleLeaseAfterRedeliveryAndSurvivesRestart(t *testing.T) {
 	if _, _, err := store.AppendMessage(AppendInput{ConversationID: conversation.ID, SenderMachineID: "machine-a", FromEndpoint: "agent/a", Body: "one", IdempotencyKey: "send-1", Now: clock}); err != nil {
 		t.Fatal(err)
 	}
-	firstLease, err := store.LeaseDeliveries("machine-b", "agent/b", "", clock, time.Minute, 10)
+	firstLease, err := store.LeaseDeliveries("machine-b", "consumer-b", "agent/b", "", clock, time.Minute, 10)
 	if err != nil || len(firstLease) != 1 {
 		t.Fatalf("first lease = %#v, %v", firstLease, err)
 	}
@@ -120,7 +121,7 @@ func TestStoreRejectsStaleLeaseAfterRedeliveryAndSurvivesRestart(t *testing.T) {
 		t.Fatal(err)
 	}
 	t.Cleanup(func() { _ = store.Close() })
-	secondLease, err := store.LeaseDeliveries("machine-b", "agent/b", "", clock.Add(time.Minute+time.Second), time.Minute, 10)
+	secondLease, err := store.LeaseDeliveries("machine-b", "consumer-b", "agent/b", "", clock.Add(time.Minute+time.Second), time.Minute, 10)
 	if err != nil || len(secondLease) != 1 {
 		t.Fatalf("second lease = %#v, %v", secondLease, err)
 	}
@@ -132,6 +133,50 @@ func TestStoreRejectsStaleLeaseAfterRedeliveryAndSurvivesRestart(t *testing.T) {
 	}
 	if err := store.AckDelivery("machine-b", "agent/b", secondLease[0].ID, secondLease[0].LeaseToken, secondLease[0].LeaseGeneration, clock.Add(time.Minute+time.Second)); err != nil {
 		t.Fatal(err)
+	}
+}
+
+func TestStoreRecipientCursorNeverSkipsAcknowledgementGap(t *testing.T) {
+	t.Parallel()
+	store, err := Open(filepath.Join(t.TempDir(), "relay.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	now := time.Date(2026, time.July, 20, 12, 0, 0, 0, time.UTC)
+	if err := store.AdvertiseEndpoints("machine-a", []string{"agent/a"}, now, time.Hour); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.AdvertiseEndpoints("machine-b", []string{"agent/b"}, now, time.Hour); err != nil {
+		t.Fatal(err)
+	}
+	conversation, err := store.CreateConversation("agent/a", []Member{
+		{Endpoint: "agent/a", Capabilities: CapSend | CapReceive | CapAdmin},
+		{Endpoint: "agent/b", Capabilities: CapReceive},
+	}, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for index, body := range []string{"first", "second"} {
+		if _, _, err := store.AppendMessage(AppendInput{ConversationID: conversation.ID, SenderMachineID: "machine-a", FromEndpoint: "agent/a", Body: body, IdempotencyKey: fmt.Sprintf("send-%d", index), Now: now}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	deliveries, err := store.LeaseDeliveries("machine-b", "consumer-b", "agent/b", conversation.ID, now, time.Minute, 10)
+	if err != nil || len(deliveries) != 2 {
+		t.Fatalf("deliveries=%#v err=%v", deliveries, err)
+	}
+	if err := store.AckDelivery("machine-b", "agent/b", deliveries[1].ID, deliveries[1].LeaseToken, deliveries[1].LeaseGeneration, now); err != nil {
+		t.Fatal(err)
+	}
+	if cursor, err := store.RecipientCursor("machine-b", "agent/b", conversation.ID, now); err != nil || cursor != 0 {
+		t.Fatalf("cursor=%d err=%v, want gap-preserving zero", cursor, err)
+	}
+	if err := store.AckDelivery("machine-b", "agent/b", deliveries[0].ID, deliveries[0].LeaseToken, deliveries[0].LeaseGeneration, now); err != nil {
+		t.Fatal(err)
+	}
+	if cursor, err := store.RecipientCursor("machine-b", "agent/b", conversation.ID, now); err != nil || cursor != 2 {
+		t.Fatalf("cursor=%d err=%v, want contiguous two", cursor, err)
 	}
 }
 


### PR DESCRIPTION
## Summary
- add a PostgreSQL relay backend and schema v7 with transactional sequences, durable deliveries, gap-safe cursors, and ownership/consumer fencing
- run SQLite and PostgreSQL through one shared relay conformance suite
- add an explicit PUNARO_RELAY_STORE selector while keeping SQLite as the default
- document the bounded reserved PostgreSQL pool and rollback boundary

## Scope
This is M8 only. It does not add M9 import, dual-write, or cutover behavior, and it does not include Compose Pi integration.

## Validation
- make test
- make test-race
- make lint
- make security
- git diff --check