### PR TITLE
M9a: add dark mail cutover substrate

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -537,6 +537,18 @@ dirty, old, newer, or incompatible schemas without performing DDL. The normal
 application role is distinct from the schema owner. SQLite remains the active
 and default relay authority until the later fenced mail cutover.
 
+The first mail-cutover slice remains dark and stops before authority transfer.
+SQLite can be inspected read-only into a deterministic logical manifest; its
+prepare barrier expires endpoint ownership, clears consumers and delivery
+leases, advances their generations, and installs a durable write fence that
+also stops already-open older daemons. PostgreSQL schema v8 can durably record
+one owner-authorized import epoch plus bounded staging/checkpoint state and
+fences application-role mail writes while that epoch is importing or verified.
+It has no canonical-row importer or activation transition, so it cannot create
+a dual-authority state. A prepared SQLite source may be reopened only before it
+is permanently retired; retirement and PostgreSQL activation belong to the
+later irreversible executor slice.
+
 The second dark foundation slice adds opaque principals/projects, explicit
 selected-project and dynamic all-project capability grants, globally unique
 operation-bound idempotency keys, closed content-free audit events, and a

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ precedence over dotenv values.
 | `PUNARO_TRUSTED_LAN_CIDR` | unset | Private/link-local CIDR containing the concrete LAN bind. Valid only in LAN mode. |
 | `PUNARO_TRUSTED_LAN_HTTP` | `false` | Explicit plaintext credential exception for observed peers inside the validated trusted LAN. Public peers never qualify. |
 | `PUNARO_RELAY_ENABLED` | `false` | Enables the loopback text relay; requires public machine enrollment records. |
-| `PUNARO_RELAY_STORE` | `sqlite` | Explicit relay backend selector. `postgres` requires PostgreSQL schema v7 and is for empty-destination parity/qualification before the M-9 one-shot cutover; it never imports or dual-writes SQLite. |
+| `PUNARO_RELAY_STORE` | `sqlite` | Explicit relay backend selector. `postgres` requires PostgreSQL schema v8 and is for empty-destination parity/qualification before the M-9 one-shot cutover; it never imports or dual-writes SQLite. |
 | `PUNARO_RELAY_MACHINES_JSON` | unset | Explicit public-key machine enrollment records. `endpoint_prefixes` claims disjoint machine namespaces; `endpoints` can grant a named exact endpoint without creating a prefix. An issuer-capable machine additionally has canonical raw-base64url `attachment_device_id` (16 bytes), bound to exactly one directory device. |
 | `PUNARO_DIRECTORY_ENABLED` | `false` | Serves a current complete signed directory snapshot to authenticated enrolled machines; requires the relay. |
 | `PUNARO_DIRECTORY_SNAPSHOT_FILE` | unset | Absolute, root-owned and service-group-readable (`2750` parent, `0640` regular non-symlink) canonical directory snapshot publication file. |

--- a/docs/operator-guide.md
+++ b/docs/operator-guide.md
@@ -446,20 +446,25 @@ database and investigate. The digest-pinned `make test-postgres` stack is epheme
 test infrastructure, publishes no database port, and deletes its volume on
 exit.
 
-The current binary requires schema version 7. Versions 1 through 6 are reported
+The current binary requires schema version 8. Versions 1 through 7 are reported
 as `upgrade_required`; damaged older objects remain `incompatible`. Migration 3 is
 additive and creates the host-local ownership, pending enrollment, device
 credential, cache/session generation, and Ed25519 migration-inventory records.
 Migration 6 adds the durable update coordinator, exact recovery evidence, and
 the mutation fence. Migration 7 adds the PostgreSQL mail store, durable
 recipient cursors, replay protection, and relay-table mutation guards.
+Migration 8 adds the dark M-9 cutover substrate: owner-only migration epochs,
+bounded staging rows and checkpoints, and an application-role mail-write fence
+for an importing or verified epoch. It does not import rows, activate
+PostgreSQL mail authority, retire SQLite, or change the default relay. Those
+irreversible operations remain disabled until the later M-9 executor slice.
 PostgreSQL mail work uses a reserved four-connection application-role pool;
 each operation and lock wait is bounded to five seconds so platform work cannot
 consume the mail budget indefinitely.
 
 SQLite remains the default active relay. Maintainers may explicitly select an
 empty PostgreSQL relay with `PUNARO_RELAY_STORE=postgres` only after completing
-the supported v6-to-v7 update. This selector does not import the SQLite file,
+the supported update to schema v8. This selector does not import the SQLite file,
 does not dual-write, and is incompatible with the superseded directory and
 attachment routes. Do not point an established installation at an empty
 PostgreSQL relay as a migration shortcut; the verified one-shot mail cutover is

--- a/docs/operator-guide.md
+++ b/docs/operator-guide.md
@@ -458,6 +458,9 @@ bounded staging rows and checkpoints, and an application-role mail-write fence
 for an importing or verified epoch. It does not import rows, activate
 PostgreSQL mail authority, retire SQLite, or change the default relay. Those
 irreversible operations remain disabled until the later M-9 executor slice.
+That executor must take the canonical SQLite source path from Punaro's private,
+service-owned relay data directory. The source-path argument is a privileged
+operator boundary, not a filesystem sandbox for untrusted paths.
 PostgreSQL mail work uses a reserved four-connection application-role pool;
 each operation and lock wait is bounded to five seconds so platform work cannot
 consume the mail budget indefinitely.

--- a/internal/postgres/db.go
+++ b/internal/postgres/db.go
@@ -968,6 +968,13 @@ FROM objects, table_ownership, routine_safety, routine_acl, table_acl, schema_ac
 		}
 		snapshot.CurrentObjectsPresent = relayObjectsPresent
 	}
+	if snapshot.CurrentObjectsPresent && len(snapshot.Records) > 0 && snapshot.Records[len(snapshot.Records)-1].Version >= 8 {
+		cutoverObjectsPresent, err := mailCutoverControlsAvailable(ctx, q)
+		if err != nil {
+			return Snapshot{}, errors.New("PostgreSQL mail-cutover schema cannot be inspected")
+		}
+		snapshot.CurrentObjectsPresent = cutoverObjectsPresent
+	}
 	return snapshot, nil
 }
 

--- a/internal/postgres/mail_cutover.go
+++ b/internal/postgres/mail_cutover.go
@@ -8,6 +8,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"regexp"
 	"time"
@@ -235,6 +236,7 @@ func (a *Administration) AbortMailCutover(ctx context.Context, actorPrincipalID,
 
 func mailCutoverControlsAvailable(ctx context.Context, q queryer) (bool, error) {
 	var available bool
+	var diagnostic string
 	err := q.QueryRowContext(ctx, `
 WITH objects AS (
     SELECT to_regclass('relay.mail_cutover_epochs') AS epochs_oid,
@@ -391,7 +393,23 @@ WITH objects AS (
 SELECT objects.epochs_oid IS NOT NULL AND objects.staging_oid IS NOT NULL AND objects.checkpoints_oid IS NOT NULL
    AND objects.active_index_oid IS NOT NULL AND objects.guard_oid IS NOT NULL
    AND ownership.exact AND columns.exact AND defaults.exact AND constraints.exact AND active_index.exact AND routine.exact AND guards.exact AND table_acl.exact
-   AND NOT has_function_privilege('punaro_app',objects.guard_oid,'EXECUTE')
-FROM objects,ownership,columns,defaults,constraints,active_index,routine,guards,table_acl`).Scan(&available)
+   AND NOT has_function_privilege('punaro_app',objects.guard_oid,'EXECUTE'),
+   concat_ws(',',
+       CASE WHEN objects.epochs_oid IS NOT NULL AND objects.staging_oid IS NOT NULL AND objects.checkpoints_oid IS NOT NULL THEN NULL ELSE 'objects' END,
+       CASE WHEN objects.active_index_oid IS NOT NULL THEN NULL ELSE 'index-object' END,
+       CASE WHEN objects.guard_oid IS NOT NULL THEN NULL ELSE 'routine-object' END,
+       CASE WHEN ownership.exact THEN NULL ELSE 'ownership' END,
+       CASE WHEN columns.exact THEN NULL ELSE 'columns' END,
+       CASE WHEN defaults.exact THEN NULL ELSE 'defaults' END,
+       CASE WHEN constraints.exact THEN NULL ELSE 'constraints' END,
+       CASE WHEN active_index.exact THEN NULL ELSE 'active-index' END,
+       CASE WHEN routine.exact THEN NULL ELSE 'routine' END,
+       CASE WHEN guards.exact THEN NULL ELSE 'guards' END,
+       CASE WHEN table_acl.exact THEN NULL ELSE 'table-acl' END,
+       CASE WHEN NOT has_function_privilege('punaro_app',objects.guard_oid,'EXECUTE') THEN NULL ELSE 'routine-acl' END)
+FROM objects,ownership,columns,defaults,constraints,active_index,routine,guards,table_acl`).Scan(&available, &diagnostic)
+	if err == nil && !available {
+		return false, fmt.Errorf("mail cutover catalog mismatch: %s", diagnostic)
+	}
 	return available, err
 }

--- a/internal/postgres/mail_cutover.go
+++ b/internal/postgres/mail_cutover.go
@@ -162,7 +162,12 @@ const mailCutoverSelect = `SELECT epoch_id::text,source_id::text,target_identity
 type mailCutoverRowScanner interface{ Scan(...any) error }
 
 func scanMailCutover(row mailCutoverRowScanner, epoch *MailCutoverEpoch) error {
-	return row.Scan(&epoch.EpochID, &epoch.SourceID, &epoch.TargetIdentity, &epoch.SourceFingerprint, &epoch.Manifest, &epoch.ManifestSHA256, &epoch.Phase, &epoch.CreatedAt, &epoch.UpdatedAt, &epoch.VerifiedAt, &epoch.ActivatedAt, &epoch.AbortedAt)
+	var manifest string
+	if err := row.Scan(&epoch.EpochID, &epoch.SourceID, &epoch.TargetIdentity, &epoch.SourceFingerprint, &manifest, &epoch.ManifestSHA256, &epoch.Phase, &epoch.CreatedAt, &epoch.UpdatedAt, &epoch.VerifiedAt, &epoch.ActivatedAt, &epoch.AbortedAt); err != nil {
+		return err
+	}
+	epoch.Manifest = json.RawMessage(manifest)
+	return nil
 }
 
 func sameMailCutoverRequest(left, right MailCutoverRequest) bool {

--- a/internal/postgres/mail_cutover.go
+++ b/internal/postgres/mail_cutover.go
@@ -1,0 +1,397 @@
+package postgres
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"database/sql"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"io"
+	"regexp"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/rock3r/punaro/internal/relay"
+)
+
+const mailCutoverLockKey int64 = 0x50554e414d41494c
+
+var mailCutoverDigestPattern = regexp.MustCompile(`^[0-9a-f]{64}$`)
+
+// MailCutoverPhase is the durable PostgreSQL-side authority staging phase.
+type MailCutoverPhase string
+
+const (
+	// MailCutoverImporting fences application mail writes during staging.
+	MailCutoverImporting MailCutoverPhase = "importing"
+	// MailCutoverVerified records a fully verified but inactive epoch.
+	MailCutoverVerified MailCutoverPhase = "verified"
+	// MailCutoverActive records PostgreSQL as the published mail authority.
+	MailCutoverActive MailCutoverPhase = "active"
+	// MailCutoverAborted is the terminal pre-activation rollback outcome.
+	MailCutoverAborted MailCutoverPhase = "aborted"
+)
+
+// MailCutoverRequest binds one typed SQLite manifest to one PostgreSQL target.
+type MailCutoverRequest struct {
+	EpochID           string
+	SourceID          string
+	TargetIdentity    string
+	SourceFingerprint string
+	Manifest          json.RawMessage
+	ManifestSHA256    string
+}
+
+// Validate rejects incomplete, noncanonical, or internally inconsistent bindings.
+func (r MailCutoverRequest) Validate() error {
+	if _, err := canonicalMailCutoverManifest(r); err != nil {
+		return errors.New("invalid mail cutover request")
+	}
+	return nil
+}
+
+func canonicalMailCutoverManifest(request MailCutoverRequest) ([]byte, error) {
+	if uuid.Validate(request.EpochID) != nil || uuid.Validate(request.SourceID) != nil || !mailCutoverDigestPattern.MatchString(request.TargetIdentity) || !mailCutoverDigestPattern.MatchString(request.SourceFingerprint) || !mailCutoverDigestPattern.MatchString(request.ManifestSHA256) || len(request.Manifest) == 0 || len(request.Manifest) > 8192 {
+		return nil, errors.New("invalid mail cutover request")
+	}
+	decoder := json.NewDecoder(bytes.NewReader(request.Manifest))
+	decoder.DisallowUnknownFields()
+	var manifest relay.MigrationSourceManifest
+	if err := decoder.Decode(&manifest); err != nil {
+		return nil, errors.New("invalid mail cutover manifest")
+	}
+	if err := decoder.Decode(&struct{}{}); !errors.Is(err, io.EOF) {
+		return nil, errors.New("invalid mail cutover manifest")
+	}
+	counts := []int64{manifest.Counts.Endpoints, manifest.Counts.Conversations, manifest.Counts.Memberships, manifest.Counts.Messages, manifest.Counts.Deliveries, manifest.Counts.RecipientCursors, manifest.Counts.MessageIdempotency, manifest.Counts.ConversationIdempotency, manifest.Counts.RequestNonces}
+	hashes := []string{manifest.TableSHA256.Endpoints, manifest.TableSHA256.Conversations, manifest.TableSHA256.Memberships, manifest.TableSHA256.Messages, manifest.TableSHA256.Deliveries, manifest.TableSHA256.RecipientCursors, manifest.TableSHA256.MessageIdempotency, manifest.TableSHA256.ConversationIdempotency, manifest.TableSHA256.RequestNonces}
+	if manifest.Version != 1 || manifest.SourceID != request.SourceID || manifest.Phase != relay.MigrationSourcePrepared || manifest.EpochID != request.EpochID || manifest.TargetIdentity != request.TargetIdentity || manifest.Fingerprint != request.SourceFingerprint {
+		return nil, errors.New("mail cutover manifest binding does not match")
+	}
+	for _, count := range counts {
+		if count < 0 {
+			return nil, errors.New("mail cutover manifest count is invalid")
+		}
+	}
+	for _, hash := range hashes {
+		if !mailCutoverDigestPattern.MatchString(hash) {
+			return nil, errors.New("mail cutover manifest hash is invalid")
+		}
+	}
+	canonical, err := json.Marshal(manifest)
+	if err != nil || len(canonical) > 8192 {
+		return nil, errors.New("mail cutover manifest is too large")
+	}
+	digest := sha256.Sum256(canonical)
+	if hex.EncodeToString(digest[:]) != request.ManifestSHA256 {
+		return nil, errors.New("mail cutover manifest digest does not match")
+	}
+	return canonical, nil
+}
+
+// MailCutoverEpoch is the owner-side durable view of one cutover attempt.
+type MailCutoverEpoch struct {
+	MailCutoverRequest
+	Phase       MailCutoverPhase
+	CreatedAt   time.Time
+	UpdatedAt   time.Time
+	VerifiedAt  sql.NullTime
+	ActivatedAt sql.NullTime
+	AbortedAt   sql.NullTime
+}
+
+// BeginMailCutover drains application writers and creates one dark import epoch.
+func (a *Administration) BeginMailCutover(ctx context.Context, actorPrincipalID string, request MailCutoverRequest) (MailCutoverEpoch, error) {
+	if !validOpaqueID(actorPrincipalID) || request.Validate() != nil {
+		return MailCutoverEpoch{}, errors.New("invalid mail cutover request")
+	}
+	canonicalManifest, err := canonicalMailCutoverManifest(request)
+	if err != nil {
+		return MailCutoverEpoch{}, errors.New("invalid mail cutover request")
+	}
+	request.Manifest = canonicalManifest
+	tx, err := a.db.BeginTx(ctx, nil)
+	if err != nil {
+		return MailCutoverEpoch{}, errors.New("mail cutover cannot start")
+	}
+	defer func() { _ = tx.Rollback() }()
+	if err := guardMutation(ctx, tx); err != nil {
+		return MailCutoverEpoch{}, err
+	}
+	if ok, err := lockInstallationOwner(ctx, tx, actorPrincipalID); err != nil || !ok {
+		return MailCutoverEpoch{}, errors.New("mail cutover is not authorized")
+	}
+	if _, err := tx.ExecContext(ctx, `SELECT pg_advisory_xact_lock($1)`, mailCutoverLockKey); err != nil {
+		return MailCutoverEpoch{}, errors.New("mail cutover cannot be serialized")
+	}
+	identity, err := databaseIdentity(ctx, tx)
+	if err != nil || identity != request.TargetIdentity {
+		return MailCutoverEpoch{}, errors.New("mail cutover target identity does not match")
+	}
+	var existing MailCutoverEpoch
+	err = scanMailCutover(tx.QueryRowContext(ctx, mailCutoverSelect+` WHERE epoch_id=$1`, request.EpochID), &existing)
+	if err == nil {
+		if !sameMailCutoverRequest(existing.MailCutoverRequest, request) {
+			return MailCutoverEpoch{}, ErrIdempotencyConflict
+		}
+		if err := tx.Commit(); err != nil {
+			return MailCutoverEpoch{}, errors.New("mail cutover retry cannot commit")
+		}
+		return existing, nil
+	}
+	if !errors.Is(err, sql.ErrNoRows) {
+		return MailCutoverEpoch{}, errors.New("mail cutover state is unavailable")
+	}
+	var rows int64
+	if err := tx.QueryRowContext(ctx, `SELECT (SELECT count(*) FROM relay.mail_endpoints)+(SELECT count(*) FROM relay.mail_conversations)+(SELECT count(*) FROM relay.mail_memberships)+(SELECT count(*) FROM relay.mail_messages)+(SELECT count(*) FROM relay.mail_deliveries)+(SELECT count(*) FROM relay.mail_recipient_cursors)+(SELECT count(*) FROM relay.mail_message_idempotency)+(SELECT count(*) FROM relay.mail_conversation_idempotency)+(SELECT count(*) FROM relay.mail_request_nonces)`).Scan(&rows); err != nil || rows != 0 {
+		return MailCutoverEpoch{}, errors.New("mail cutover target is not empty")
+	}
+	if err := scanMailCutover(tx.QueryRowContext(ctx, `INSERT INTO relay.mail_cutover_epochs(epoch_id,source_id,target_identity,source_fingerprint,source_manifest,manifest_sha256,phase) VALUES($1,$2,$3,$4,$5,$6,'importing') RETURNING epoch_id::text,source_id::text,target_identity,source_fingerprint,source_manifest,manifest_sha256,phase,created_at,updated_at,verified_at,activated_at,aborted_at`, request.EpochID, request.SourceID, request.TargetIdentity, request.SourceFingerprint, string(request.Manifest), request.ManifestSHA256), &existing); err != nil {
+		return MailCutoverEpoch{}, errors.New("mail cutover cannot be recorded")
+	}
+	if err := tx.Commit(); err != nil {
+		return MailCutoverEpoch{}, errors.New("mail cutover cannot commit")
+	}
+	return existing, nil
+}
+
+const mailCutoverSelect = `SELECT epoch_id::text,source_id::text,target_identity,source_fingerprint,source_manifest,manifest_sha256,phase,created_at,updated_at,verified_at,activated_at,aborted_at FROM relay.mail_cutover_epochs`
+
+type mailCutoverRowScanner interface{ Scan(...any) error }
+
+func scanMailCutover(row mailCutoverRowScanner, epoch *MailCutoverEpoch) error {
+	return row.Scan(&epoch.EpochID, &epoch.SourceID, &epoch.TargetIdentity, &epoch.SourceFingerprint, &epoch.Manifest, &epoch.ManifestSHA256, &epoch.Phase, &epoch.CreatedAt, &epoch.UpdatedAt, &epoch.VerifiedAt, &epoch.ActivatedAt, &epoch.AbortedAt)
+}
+
+func sameMailCutoverRequest(left, right MailCutoverRequest) bool {
+	return left.EpochID == right.EpochID && left.SourceID == right.SourceID && left.TargetIdentity == right.TargetIdentity && left.SourceFingerprint == right.SourceFingerprint && left.ManifestSHA256 == right.ManifestSHA256
+}
+
+// MailCutoverStatus returns one epoch to the installation owner.
+func (a *Administration) MailCutoverStatus(ctx context.Context, actorPrincipalID, epochID string) (MailCutoverEpoch, error) {
+	if !validOpaqueID(actorPrincipalID) || uuid.Validate(epochID) != nil {
+		return MailCutoverEpoch{}, errors.New("invalid mail cutover status request")
+	}
+	tx, err := a.db.BeginTx(ctx, nil)
+	if err != nil {
+		return MailCutoverEpoch{}, errors.New("mail cutover status is unavailable")
+	}
+	defer func() { _ = tx.Rollback() }()
+	if ok, err := lockInstallationOwner(ctx, tx, actorPrincipalID); err != nil || !ok {
+		return MailCutoverEpoch{}, errors.New("mail cutover status is not authorized")
+	}
+	var epoch MailCutoverEpoch
+	if err := scanMailCutover(tx.QueryRowContext(ctx, mailCutoverSelect+` WHERE epoch_id=$1`, epochID), &epoch); err != nil {
+		return MailCutoverEpoch{}, errors.New("mail cutover status is unavailable")
+	}
+	if err := tx.Commit(); err != nil {
+		return MailCutoverEpoch{}, errors.New("mail cutover status cannot commit")
+	}
+	return epoch, nil
+}
+
+// AbortMailCutover reopens PostgreSQL mail writes before activation.
+func (a *Administration) AbortMailCutover(ctx context.Context, actorPrincipalID, epochID, sourceFingerprint string) error {
+	if !validOpaqueID(actorPrincipalID) || uuid.Validate(epochID) != nil || !mailCutoverDigestPattern.MatchString(sourceFingerprint) {
+		return errors.New("invalid mail cutover abort request")
+	}
+	tx, err := a.db.BeginTx(ctx, nil)
+	if err != nil {
+		return errors.New("mail cutover abort cannot start")
+	}
+	defer func() { _ = tx.Rollback() }()
+	if err := guardMutation(ctx, tx); err != nil {
+		return err
+	}
+	if ok, err := lockInstallationOwner(ctx, tx, actorPrincipalID); err != nil || !ok {
+		return errors.New("mail cutover abort is not authorized")
+	}
+	if _, err := tx.ExecContext(ctx, `SELECT pg_advisory_xact_lock($1)`, mailCutoverLockKey); err != nil {
+		return errors.New("mail cutover abort cannot be serialized")
+	}
+	var phase MailCutoverPhase
+	var fingerprint string
+	if err := tx.QueryRowContext(ctx, `SELECT phase,source_fingerprint FROM relay.mail_cutover_epochs WHERE epoch_id=$1 FOR UPDATE`, epochID).Scan(&phase, &fingerprint); err != nil {
+		return errors.New("mail cutover epoch is unavailable")
+	}
+	if fingerprint != sourceFingerprint {
+		return ErrIdempotencyConflict
+	}
+	if phase == MailCutoverActive {
+		return errors.New("active mail cutover cannot be aborted")
+	}
+	if phase != MailCutoverAborted {
+		if _, err := tx.ExecContext(ctx, `DELETE FROM relay.mail_cutover_staging WHERE epoch_id=$1; DELETE FROM relay.mail_cutover_checkpoints WHERE epoch_id=$1; UPDATE relay.mail_cutover_epochs SET phase='aborted',updated_at=statement_timestamp(),verified_at=NULL,aborted_at=statement_timestamp() WHERE epoch_id=$1`, epochID); err != nil {
+			return errors.New("mail cutover cannot be aborted")
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		return errors.New("mail cutover abort cannot commit")
+	}
+	return nil
+}
+
+func mailCutoverControlsAvailable(ctx context.Context, q queryer) (bool, error) {
+	var available bool
+	err := q.QueryRowContext(ctx, `
+WITH objects AS (
+    SELECT to_regclass('relay.mail_cutover_epochs') AS epochs_oid,
+           to_regclass('relay.mail_cutover_staging') AS staging_oid,
+           to_regclass('relay.mail_cutover_checkpoints') AS checkpoints_oid,
+		   to_regclass('relay.mail_cutover_epochs_one_authority') AS active_index_oid,
+           to_regprocedure('relay.guard_mail_mutation()') AS guard_oid
+), expected_columns(table_oid,column_name,type_oid,required) AS (
+    SELECT expected.* FROM objects, LATERAL (VALUES
+        (epochs_oid,'epoch_id','uuid'::regtype,true),(epochs_oid,'source_id','uuid'::regtype,true),
+        (epochs_oid,'target_identity','bpchar'::regtype,true),(epochs_oid,'source_fingerprint','bpchar'::regtype,true),
+		(epochs_oid,'source_manifest','text'::regtype,true),(epochs_oid,'manifest_sha256','bpchar'::regtype,true),
+        (epochs_oid,'phase','text'::regtype,true),(epochs_oid,'created_at','timestamptz'::regtype,true),
+        (epochs_oid,'updated_at','timestamptz'::regtype,true),(epochs_oid,'verified_at','timestamptz'::regtype,false),
+        (epochs_oid,'activated_at','timestamptz'::regtype,false),(epochs_oid,'aborted_at','timestamptz'::regtype,false),
+        (staging_oid,'epoch_id','uuid'::regtype,true),(staging_oid,'table_name','text'::regtype,true),
+        (staging_oid,'row_key','text'::regtype,true),(staging_oid,'payload','jsonb'::regtype,true),(staging_oid,'row_sha256','bpchar'::regtype,true),
+        (checkpoints_oid,'epoch_id','uuid'::regtype,true),(checkpoints_oid,'table_name','text'::regtype,true),
+        (checkpoints_oid,'last_key','text'::regtype,false),(checkpoints_oid,'row_count','bigint'::regtype,true),
+        (checkpoints_oid,'rolling_sha256','bpchar'::regtype,true),(checkpoints_oid,'updated_at','timestamptz'::regtype,true)
+    ) AS expected(table_oid,column_name,type_oid,required)
+), actual_columns AS (
+    SELECT attribute.attrelid,attribute.attname,attribute.atttypid,attribute.attnotnull
+    FROM objects JOIN pg_attribute AS attribute
+      ON attribute.attrelid=ANY(ARRAY[epochs_oid,staging_oid,checkpoints_oid])
+     AND attribute.attnum>0 AND NOT attribute.attisdropped
+), columns AS (
+    SELECT NOT EXISTS (SELECT * FROM expected_columns EXCEPT SELECT * FROM actual_columns)
+       AND NOT EXISTS (SELECT * FROM actual_columns EXCEPT SELECT * FROM expected_columns)
+		AND (SELECT count(*)=5 FROM pg_attribute WHERE attrelid=ANY(ARRAY[epochs_oid,staging_oid,checkpoints_oid]) AND atttypid='bpchar'::regtype AND atttypmod=68)
+       AND NOT EXISTS (SELECT 1 FROM pg_attribute WHERE attrelid=ANY(ARRAY[epochs_oid,staging_oid,checkpoints_oid]) AND attnum>0 AND NOT attisdropped AND atttypid<>'bpchar'::regtype AND atttypmod<>-1) AS exact
+    FROM objects
+), ownership AS (
+    SELECT count(*)=3 AND bool_and(pg_get_userbyid(relation.relowner)='punaro_owner' AND relation.relkind='r' AND relation.relpersistence='p' AND NOT relation.relrowsecurity AND NOT relation.relforcerowsecurity) AS exact
+    FROM objects JOIN pg_class AS relation ON relation.oid=ANY(ARRAY[epochs_oid,staging_oid,checkpoints_oid])
+), expected_defaults(table_oid,column_name,expression) AS (
+    SELECT expected.* FROM objects, LATERAL (VALUES
+        (epochs_oid,'created_at','statement_timestamp()'),(epochs_oid,'updated_at','statement_timestamp()'),
+        (checkpoints_oid,'row_count','0'),(checkpoints_oid,'updated_at','statement_timestamp()')
+    ) AS expected(table_oid,column_name,expression)
+), actual_defaults AS (
+    SELECT default_value.adrelid,attribute.attname,pg_get_expr(default_value.adbin,default_value.adrelid)
+    FROM objects JOIN pg_attrdef AS default_value ON default_value.adrelid=ANY(ARRAY[epochs_oid,staging_oid,checkpoints_oid])
+    JOIN pg_attribute AS attribute ON attribute.attrelid=default_value.adrelid AND attribute.attnum=default_value.adnum
+), defaults AS (
+    SELECT NOT EXISTS (SELECT * FROM expected_defaults EXCEPT SELECT * FROM actual_defaults)
+       AND NOT EXISTS (SELECT * FROM actual_defaults EXCEPT SELECT * FROM expected_defaults) AS exact
+), expected_constraints(table_oid,constraint_name,constraint_type,column_keys,foreign_table_oid,foreign_column_keys) AS (
+    SELECT expected.* FROM objects, LATERAL (VALUES
+        (epochs_oid,'mail_cutover_epochs_pkey','p'::"char",ARRAY[1]::smallint[],0::oid,'{}'::smallint[]),
+        (epochs_oid,'mail_cutover_epochs_target_identity_check','c'::"char",ARRAY[3]::smallint[],0::oid,'{}'::smallint[]),
+        (epochs_oid,'mail_cutover_epochs_source_fingerprint_check','c'::"char",ARRAY[4]::smallint[],0::oid,'{}'::smallint[]),
+        (epochs_oid,'mail_cutover_epochs_source_manifest_check','c'::"char",ARRAY[5]::smallint[],0::oid,'{}'::smallint[]),
+        (epochs_oid,'mail_cutover_epochs_manifest_sha256_check','c'::"char",ARRAY[6]::smallint[],0::oid,'{}'::smallint[]),
+        (epochs_oid,'mail_cutover_epochs_phase_check','c'::"char",ARRAY[7]::smallint[],0::oid,'{}'::smallint[]),
+        (epochs_oid,'mail_cutover_epochs_verified_at_check','c'::"char",ARRAY[7,10]::smallint[],0::oid,'{}'::smallint[]),
+        (epochs_oid,'mail_cutover_epochs_activated_at_check','c'::"char",ARRAY[7,11]::smallint[],0::oid,'{}'::smallint[]),
+        (epochs_oid,'mail_cutover_epochs_aborted_at_check','c'::"char",ARRAY[7,12]::smallint[],0::oid,'{}'::smallint[]),
+        (staging_oid,'mail_cutover_staging_pkey','p'::"char",ARRAY[1,2,3]::smallint[],0::oid,'{}'::smallint[]),
+        (staging_oid,'mail_cutover_staging_epoch_fkey','f'::"char",ARRAY[1]::smallint[],epochs_oid,ARRAY[1]::smallint[]),
+        (staging_oid,'mail_cutover_staging_table_name_check','c'::"char",ARRAY[2]::smallint[],0::oid,'{}'::smallint[]),
+        (staging_oid,'mail_cutover_staging_row_key_check','c'::"char",ARRAY[3]::smallint[],0::oid,'{}'::smallint[]),
+        (staging_oid,'mail_cutover_staging_payload_check','c'::"char",ARRAY[4]::smallint[],0::oid,'{}'::smallint[]),
+        (staging_oid,'mail_cutover_staging_row_sha256_check','c'::"char",ARRAY[5]::smallint[],0::oid,'{}'::smallint[]),
+        (checkpoints_oid,'mail_cutover_checkpoints_pkey','p'::"char",ARRAY[1,2]::smallint[],0::oid,'{}'::smallint[]),
+        (checkpoints_oid,'mail_cutover_checkpoints_epoch_fkey','f'::"char",ARRAY[1]::smallint[],epochs_oid,ARRAY[1]::smallint[]),
+        (checkpoints_oid,'mail_cutover_checkpoints_table_name_check','c'::"char",ARRAY[2]::smallint[],0::oid,'{}'::smallint[]),
+        (checkpoints_oid,'mail_cutover_checkpoints_last_key_check','c'::"char",ARRAY[3]::smallint[],0::oid,'{}'::smallint[]),
+        (checkpoints_oid,'mail_cutover_checkpoints_row_count_check','c'::"char",ARRAY[4]::smallint[],0::oid,'{}'::smallint[]),
+        (checkpoints_oid,'mail_cutover_checkpoints_rolling_sha256_check','c'::"char",ARRAY[5]::smallint[],0::oid,'{}'::smallint[])
+    ) AS expected(table_oid,constraint_name,constraint_type,column_keys,foreign_table_oid,foreign_column_keys)
+), actual_constraints AS (
+    SELECT con.conrelid,con.conname,con.contype,con.conkey,con.confrelid,COALESCE(con.confkey,'{}'::smallint[])
+    FROM objects JOIN pg_constraint AS con ON con.conrelid=ANY(ARRAY[epochs_oid,staging_oid,checkpoints_oid])
+), constraints AS (
+    SELECT NOT EXISTS (SELECT * FROM expected_constraints EXCEPT SELECT * FROM actual_constraints)
+       AND NOT EXISTS (SELECT * FROM actual_constraints EXCEPT SELECT * FROM expected_constraints)
+       AND (SELECT count(*)=21 AND bool_and(con.convalidated AND NOT con.condeferrable AND NOT con.condeferred
+           AND (con.contype<>'f' OR (con.confupdtype='a' AND con.confdeltype='a' AND con.confmatchtype='s')))
+           FROM objects JOIN pg_constraint AS con ON con.conrelid=ANY(ARRAY[epochs_oid,staging_oid,checkpoints_oid]))
+       AND (SELECT bool_and(CASE con.conname
+           WHEN 'mail_cutover_epochs_target_identity_check' THEN pg_get_expr(con.conbin,con.conrelid)='(target_identity ~ ''^[0-9a-f]{64}$''::text)'
+           WHEN 'mail_cutover_epochs_source_fingerprint_check' THEN pg_get_expr(con.conbin,con.conrelid)='(source_fingerprint ~ ''^[0-9a-f]{64}$''::text)'
+		WHEN 'mail_cutover_epochs_source_manifest_check' THEN pg_get_expr(con.conbin,con.conrelid)='((jsonb_typeof((source_manifest)::jsonb) = ''object''::text) AND (octet_length(source_manifest) <= 8192))'
+           WHEN 'mail_cutover_epochs_manifest_sha256_check' THEN pg_get_expr(con.conbin,con.conrelid)='(manifest_sha256 ~ ''^[0-9a-f]{64}$''::text)'
+           WHEN 'mail_cutover_epochs_phase_check' THEN pg_get_expr(con.conbin,con.conrelid)='(phase = ANY (ARRAY[''importing''::text, ''verified''::text, ''active''::text, ''aborted''::text]))'
+           WHEN 'mail_cutover_epochs_verified_at_check' THEN pg_get_expr(con.conbin,con.conrelid)='((phase = ANY (ARRAY[''verified''::text, ''active''::text])) = (verified_at IS NOT NULL))'
+           WHEN 'mail_cutover_epochs_activated_at_check' THEN pg_get_expr(con.conbin,con.conrelid)='((phase = ''active''::text) = (activated_at IS NOT NULL))'
+           WHEN 'mail_cutover_epochs_aborted_at_check' THEN pg_get_expr(con.conbin,con.conrelid)='((phase = ''aborted''::text) = (aborted_at IS NOT NULL))'
+           WHEN 'mail_cutover_staging_table_name_check' THEN pg_get_expr(con.conbin,con.conrelid)='(table_name = ANY (ARRAY[''mail_endpoints''::text, ''mail_conversations''::text, ''mail_memberships''::text, ''mail_messages''::text, ''mail_deliveries''::text, ''mail_recipient_cursors''::text, ''mail_message_idempotency''::text, ''mail_conversation_idempotency''::text, ''mail_request_nonces''::text]))'
+           WHEN 'mail_cutover_staging_row_key_check' THEN pg_get_expr(con.conbin,con.conrelid)='((octet_length(row_key) >= 1) AND (octet_length(row_key) <= 4096))'
+           WHEN 'mail_cutover_staging_payload_check' THEN pg_get_expr(con.conbin,con.conrelid)='((jsonb_typeof(payload) = ''object''::text) AND (octet_length((payload)::text) <= 65536))'
+           WHEN 'mail_cutover_staging_row_sha256_check' THEN pg_get_expr(con.conbin,con.conrelid)='(row_sha256 ~ ''^[0-9a-f]{64}$''::text)'
+           WHEN 'mail_cutover_checkpoints_table_name_check' THEN pg_get_expr(con.conbin,con.conrelid)='(table_name = ANY (ARRAY[''mail_endpoints''::text, ''mail_conversations''::text, ''mail_memberships''::text, ''mail_messages''::text, ''mail_deliveries''::text, ''mail_recipient_cursors''::text, ''mail_message_idempotency''::text, ''mail_conversation_idempotency''::text, ''mail_request_nonces''::text]))'
+           WHEN 'mail_cutover_checkpoints_last_key_check' THEN pg_get_expr(con.conbin,con.conrelid)='((last_key IS NULL) OR ((octet_length(last_key) >= 1) AND (octet_length(last_key) <= 4096)))'
+           WHEN 'mail_cutover_checkpoints_row_count_check' THEN pg_get_expr(con.conbin,con.conrelid)='(row_count >= 0)'
+           WHEN 'mail_cutover_checkpoints_rolling_sha256_check' THEN pg_get_expr(con.conbin,con.conrelid)='(rolling_sha256 ~ ''^[0-9a-f]{64}$''::text)'
+           ELSE con.contype<>'c' END)
+           FROM objects JOIN pg_constraint AS con ON con.conrelid=ANY(ARRAY[epochs_oid,staging_oid,checkpoints_oid])) AS exact
+), active_index AS (
+    SELECT count(*)=1 AND bool_and(index.indrelid=objects.epochs_oid AND index.indisunique AND index.indisvalid AND index.indisready AND index.indislive
+       AND index.indnkeyatts=1 AND index.indnatts=1 AND pg_get_expr(index.indexprs,index.indrelid)='true'
+		AND pg_get_expr(index.indpred,index.indrelid)='(phase = ANY (ARRAY[''importing''::text, ''verified''::text, ''active''::text]))'
+       AND pg_get_userbyid(relation.relowner)='punaro_owner' AND access_method.amname='btree') AS exact
+    FROM objects JOIN pg_index AS index ON index.indexrelid=objects.active_index_oid
+	JOIN pg_class AS relation ON relation.oid=index.indexrelid
+	JOIN pg_am AS access_method ON access_method.oid=relation.relam
+), routine AS (
+    SELECT count(*)=1 AND bool_and(pg_get_userbyid(proc.proowner)='punaro_owner' AND NOT proc.prosecdef AND proc.prokind='f'
+       AND proc.provolatile='v' AND NOT proc.proretset AND proc.prorettype='trigger'::regtype AND proc.pronargs=0
+		AND COALESCE(proc.proconfig=ARRAY['search_path=pg_catalog']::text[],false)
+		AND md5(regexp_replace(proc.prosrc,'^\s+|\s+$','','g'))='a272f27743f82a8cfcf434328ed10180'
+       AND NOT EXISTS (SELECT 1 FROM aclexplode(COALESCE(proc.proacl,acldefault('f',proc.proowner))) AS acl WHERE acl.grantee<>proc.proowner)) AS exact
+    FROM objects JOIN pg_proc AS proc ON proc.oid=guard_oid
+), expected_guards(table_oid,trigger_name) AS (
+    SELECT expected.* FROM objects, LATERAL (VALUES
+        (to_regclass('relay.mail_endpoints'),'mail_endpoints_mutation_guard'),
+        (to_regclass('relay.mail_conversations'),'mail_conversations_mutation_guard'),
+        (to_regclass('relay.mail_memberships'),'mail_memberships_mutation_guard'),
+        (to_regclass('relay.mail_messages'),'mail_messages_mutation_guard'),
+        (to_regclass('relay.mail_deliveries'),'mail_deliveries_mutation_guard'),
+        (to_regclass('relay.mail_recipient_cursors'),'mail_recipient_cursors_mutation_guard'),
+        (to_regclass('relay.mail_message_idempotency'),'mail_message_idempotency_mutation_guard'),
+        (to_regclass('relay.mail_conversation_idempotency'),'mail_conversation_idempotency_mutation_guard'),
+        (to_regclass('relay.mail_request_nonces'),'mail_request_nonces_mutation_guard')
+    ) AS expected(table_oid,trigger_name)
+), guards AS (
+    SELECT count(*)=9 AND count(DISTINCT trigger.tgrelid)=9
+       AND bool_and(trigger.tgfoid=objects.guard_oid AND trigger.tgenabled='O' AND NOT trigger.tgisinternal
+       AND trigger.tgtype=30 AND trigger.tgconstraint=0 AND NOT trigger.tgdeferrable AND NOT trigger.tginitdeferred
+       AND trigger.tgnargs=0 AND trigger.tgqual IS NULL AND trigger.tgnewtable IS NULL AND trigger.tgoldtable IS NULL AND trigger.tgattr::text='') AS exact
+    FROM objects JOIN expected_guards ON true
+    JOIN pg_trigger AS trigger ON trigger.tgrelid=expected_guards.table_oid AND trigger.tgname=expected_guards.trigger_name
+	HAVING (SELECT count(*) FROM pg_trigger AS inventory
+			WHERE inventory.tgrelid IN (SELECT table_oid FROM expected_guards) AND NOT inventory.tgisinternal)=9
+	   AND (SELECT count(*) FROM pg_trigger AS inventory
+			WHERE inventory.tgrelid=ANY(ARRAY[to_regclass('relay.mail_cutover_epochs'),to_regclass('relay.mail_cutover_staging'),to_regclass('relay.mail_cutover_checkpoints')]) AND NOT inventory.tgisinternal)=0
+), table_acl AS (
+    SELECT has_table_privilege('punaro_app',epochs_oid,'SELECT')
+       AND NOT has_table_privilege('punaro_app',epochs_oid,'INSERT,UPDATE,DELETE,TRUNCATE,REFERENCES,TRIGGER')
+       AND NOT has_any_column_privilege('punaro_app',epochs_oid,'INSERT,UPDATE,REFERENCES')
+       AND NOT has_table_privilege('punaro_app',staging_oid,'SELECT,INSERT,UPDATE,DELETE,TRUNCATE,REFERENCES,TRIGGER')
+       AND NOT has_any_column_privilege('punaro_app',staging_oid,'INSERT,UPDATE,REFERENCES')
+       AND NOT has_table_privilege('punaro_app',checkpoints_oid,'SELECT,INSERT,UPDATE,DELETE,TRUNCATE,REFERENCES,TRIGGER')
+       AND NOT has_any_column_privilege('punaro_app',checkpoints_oid,'INSERT,UPDATE,REFERENCES')
+       AND NOT EXISTS (
+           SELECT 1 FROM pg_class AS relation
+           CROSS JOIN LATERAL aclexplode(COALESCE(relation.relacl,acldefault('r',relation.relowner))) AS acl
+           WHERE relation.oid=ANY(ARRAY[epochs_oid,staging_oid,checkpoints_oid])
+             AND acl.grantee NOT IN (relation.relowner,(SELECT oid FROM pg_roles WHERE rolname='punaro_app'))
+       ) AS exact
+    FROM objects
+)
+SELECT objects.epochs_oid IS NOT NULL AND objects.staging_oid IS NOT NULL AND objects.checkpoints_oid IS NOT NULL
+   AND objects.active_index_oid IS NOT NULL AND objects.guard_oid IS NOT NULL
+   AND ownership.exact AND columns.exact AND defaults.exact AND constraints.exact AND active_index.exact AND routine.exact AND guards.exact AND table_acl.exact
+   AND NOT has_function_privilege('punaro_app',objects.guard_oid,'EXECUTE')
+FROM objects,ownership,columns,defaults,constraints,active_index,routine,guards,table_acl`).Scan(&available)
+	return available, err
+}

--- a/internal/postgres/mail_cutover.go
+++ b/internal/postgres/mail_cutover.go
@@ -365,13 +365,13 @@ WITH objects AS (
     SELECT count(*)=9 AND count(DISTINCT trigger.tgrelid)=9
        AND bool_and(trigger.tgfoid=objects.guard_oid AND trigger.tgenabled='O' AND NOT trigger.tgisinternal
        AND trigger.tgtype=30 AND trigger.tgconstraint=0 AND NOT trigger.tgdeferrable AND NOT trigger.tginitdeferred
-       AND trigger.tgnargs=0 AND trigger.tgqual IS NULL AND trigger.tgnewtable IS NULL AND trigger.tgoldtable IS NULL AND trigger.tgattr::text='') AS exact
-    FROM objects JOIN expected_guards ON true
-    JOIN pg_trigger AS trigger ON trigger.tgrelid=expected_guards.table_oid AND trigger.tgname=expected_guards.trigger_name
-	HAVING (SELECT count(*) FROM pg_trigger AS inventory
+       AND trigger.tgnargs=0 AND trigger.tgqual IS NULL AND trigger.tgnewtable IS NULL AND trigger.tgoldtable IS NULL AND trigger.tgattr::text='')
+       AND (SELECT count(*) FROM pg_trigger AS inventory
 			WHERE inventory.tgrelid IN (SELECT table_oid FROM expected_guards) AND NOT inventory.tgisinternal)=9
 	   AND (SELECT count(*) FROM pg_trigger AS inventory
-			WHERE inventory.tgrelid=ANY(ARRAY[to_regclass('relay.mail_cutover_epochs'),to_regclass('relay.mail_cutover_staging'),to_regclass('relay.mail_cutover_checkpoints')]) AND NOT inventory.tgisinternal)=0
+			WHERE inventory.tgrelid=ANY(ARRAY[to_regclass('relay.mail_cutover_epochs'),to_regclass('relay.mail_cutover_staging'),to_regclass('relay.mail_cutover_checkpoints')]) AND NOT inventory.tgisinternal)=0 AS exact
+    FROM objects JOIN expected_guards ON true
+    JOIN pg_trigger AS trigger ON trigger.tgrelid=expected_guards.table_oid AND trigger.tgname=expected_guards.trigger_name
 ), table_acl AS (
     SELECT has_table_privilege('punaro_app',epochs_oid,'SELECT')
        AND NOT has_table_privilege('punaro_app',epochs_oid,'INSERT,UPDATE,DELETE,TRUNCATE,REFERENCES,TRIGGER')

--- a/internal/postgres/mail_cutover.go
+++ b/internal/postgres/mail_cutover.go
@@ -8,7 +8,6 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"io"
 	"regexp"
 	"time"
@@ -236,7 +235,6 @@ func (a *Administration) AbortMailCutover(ctx context.Context, actorPrincipalID,
 
 func mailCutoverControlsAvailable(ctx context.Context, q queryer) (bool, error) {
 	var available bool
-	var diagnostic string
 	err := q.QueryRowContext(ctx, `
 WITH objects AS (
     SELECT to_regclass('relay.mail_cutover_epochs') AS epochs_oid,
@@ -310,13 +308,13 @@ WITH objects AS (
     ) AS expected(table_oid,constraint_name,constraint_type,column_keys,foreign_table_oid,foreign_column_keys)
 ), actual_constraints AS (
     SELECT con.conrelid,con.conname,con.contype,con.conkey,con.confrelid,COALESCE(con.confkey,'{}'::smallint[])
-    FROM objects JOIN pg_constraint AS con ON con.conrelid=ANY(ARRAY[epochs_oid,staging_oid,checkpoints_oid])
+    FROM objects JOIN pg_constraint AS con ON con.conrelid=ANY(ARRAY[epochs_oid,staging_oid,checkpoints_oid]) AND con.contype<>'n'
 ), constraints AS (
     SELECT NOT EXISTS (SELECT * FROM expected_constraints EXCEPT SELECT * FROM actual_constraints)
        AND NOT EXISTS (SELECT * FROM actual_constraints EXCEPT SELECT * FROM expected_constraints)
        AND (SELECT count(*)=21 AND bool_and(con.convalidated AND NOT con.condeferrable AND NOT con.condeferred
            AND (con.contype<>'f' OR (con.confupdtype='a' AND con.confdeltype='a' AND con.confmatchtype='s')))
-           FROM objects JOIN pg_constraint AS con ON con.conrelid=ANY(ARRAY[epochs_oid,staging_oid,checkpoints_oid]))
+           FROM objects JOIN pg_constraint AS con ON con.conrelid=ANY(ARRAY[epochs_oid,staging_oid,checkpoints_oid]) AND con.contype<>'n')
        AND (SELECT bool_and(CASE con.conname
            WHEN 'mail_cutover_epochs_target_identity_check' THEN pg_get_expr(con.conbin,con.conrelid)='(target_identity ~ ''^[0-9a-f]{64}$''::text)'
            WHEN 'mail_cutover_epochs_source_fingerprint_check' THEN pg_get_expr(con.conbin,con.conrelid)='(source_fingerprint ~ ''^[0-9a-f]{64}$''::text)'
@@ -393,23 +391,7 @@ WITH objects AS (
 SELECT objects.epochs_oid IS NOT NULL AND objects.staging_oid IS NOT NULL AND objects.checkpoints_oid IS NOT NULL
    AND objects.active_index_oid IS NOT NULL AND objects.guard_oid IS NOT NULL
    AND ownership.exact AND columns.exact AND defaults.exact AND constraints.exact AND active_index.exact AND routine.exact AND guards.exact AND table_acl.exact
-   AND NOT has_function_privilege('punaro_app',objects.guard_oid,'EXECUTE'),
-   concat_ws(',',
-       CASE WHEN objects.epochs_oid IS NOT NULL AND objects.staging_oid IS NOT NULL AND objects.checkpoints_oid IS NOT NULL THEN NULL ELSE 'objects' END,
-       CASE WHEN objects.active_index_oid IS NOT NULL THEN NULL ELSE 'index-object' END,
-       CASE WHEN objects.guard_oid IS NOT NULL THEN NULL ELSE 'routine-object' END,
-       CASE WHEN ownership.exact THEN NULL ELSE 'ownership' END,
-       CASE WHEN columns.exact THEN NULL ELSE 'columns' END,
-       CASE WHEN defaults.exact THEN NULL ELSE 'defaults' END,
-       CASE WHEN constraints.exact THEN NULL ELSE 'constraints' END,
-       CASE WHEN active_index.exact THEN NULL ELSE 'active-index' END,
-       CASE WHEN routine.exact THEN NULL ELSE 'routine' END,
-       CASE WHEN guards.exact THEN NULL ELSE 'guards' END,
-       CASE WHEN table_acl.exact THEN NULL ELSE 'table-acl' END,
-       CASE WHEN NOT has_function_privilege('punaro_app',objects.guard_oid,'EXECUTE') THEN NULL ELSE 'routine-acl' END)
-FROM objects,ownership,columns,defaults,constraints,active_index,routine,guards,table_acl`).Scan(&available, &diagnostic)
-	if err == nil && !available {
-		return false, fmt.Errorf("mail cutover catalog mismatch: %s", diagnostic)
-	}
+   AND NOT has_function_privilege('punaro_app',objects.guard_oid,'EXECUTE')
+FROM objects,ownership,columns,defaults,constraints,active_index,routine,guards,table_acl`).Scan(&available)
 	return available, err
 }

--- a/internal/postgres/mail_cutover.go
+++ b/internal/postgres/mail_cutover.go
@@ -228,7 +228,13 @@ func (a *Administration) AbortMailCutover(ctx context.Context, actorPrincipalID,
 		return errors.New("active mail cutover cannot be aborted")
 	}
 	if phase != MailCutoverAborted {
-		if _, err := tx.ExecContext(ctx, `DELETE FROM relay.mail_cutover_staging WHERE epoch_id=$1; DELETE FROM relay.mail_cutover_checkpoints WHERE epoch_id=$1; UPDATE relay.mail_cutover_epochs SET phase='aborted',updated_at=statement_timestamp(),verified_at=NULL,aborted_at=statement_timestamp() WHERE epoch_id=$1`, epochID); err != nil {
+		if _, err := tx.ExecContext(ctx, `DELETE FROM relay.mail_cutover_staging WHERE epoch_id=$1`, epochID); err != nil {
+			return errors.New("mail cutover cannot be aborted")
+		}
+		if _, err := tx.ExecContext(ctx, `DELETE FROM relay.mail_cutover_checkpoints WHERE epoch_id=$1`, epochID); err != nil {
+			return errors.New("mail cutover cannot be aborted")
+		}
+		if _, err := tx.ExecContext(ctx, `UPDATE relay.mail_cutover_epochs SET phase='aborted',updated_at=statement_timestamp(),verified_at=NULL,aborted_at=statement_timestamp() WHERE epoch_id=$1`, epochID); err != nil {
 			return errors.New("mail cutover cannot be aborted")
 		}
 	}

--- a/internal/postgres/mail_cutover_test.go
+++ b/internal/postgres/mail_cutover_test.go
@@ -1,0 +1,60 @@
+package postgres
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/rock3r/punaro/internal/relay"
+)
+
+func TestMailCutoverRequestValidation(t *testing.T) {
+	t.Parallel()
+	valid := MailCutoverRequest{
+		EpochID:           "019f7f07-4b88-7c12-a394-b663274a6555",
+		SourceID:          "019f7f07-5b88-7c12-a394-b663274a6555",
+		TargetIdentity:    "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+		SourceFingerprint: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+	}
+	manifest := relay.MigrationSourceManifest{
+		Version: 1, SourceID: valid.SourceID, Phase: relay.MigrationSourcePrepared, EpochID: valid.EpochID,
+		TargetIdentity: valid.TargetIdentity, Fingerprint: valid.SourceFingerprint,
+		TableSHA256: relay.MigrationSourceHashes{
+			Endpoints: strings.Repeat("c", 64), Conversations: strings.Repeat("c", 64), Memberships: strings.Repeat("c", 64),
+			Messages: strings.Repeat("c", 64), Deliveries: strings.Repeat("c", 64), RecipientCursors: strings.Repeat("c", 64),
+			MessageIdempotency: strings.Repeat("c", 64), ConversationIdempotency: strings.Repeat("c", 64), RequestNonces: strings.Repeat("c", 64),
+		},
+	}
+	valid.Manifest, _ = json.Marshal(manifest)
+	digest := sha256.Sum256(valid.Manifest)
+	valid.ManifestSHA256 = hex.EncodeToString(digest[:])
+	if err := valid.Validate(); err != nil {
+		t.Fatal(err)
+	}
+	invalid := []MailCutoverRequest{
+		{},
+		func() MailCutoverRequest { changed := valid; changed.EpochID = "bad"; return changed }(),
+		func() MailCutoverRequest { changed := valid; changed.SourceID = "bad"; return changed }(),
+		func() MailCutoverRequest { changed := valid; changed.TargetIdentity = "bad"; return changed }(),
+		func() MailCutoverRequest { changed := valid; changed.SourceFingerprint = "bad"; return changed }(),
+		func() MailCutoverRequest { changed := valid; changed.Manifest = json.RawMessage(`[]`); return changed }(),
+		func() MailCutoverRequest {
+			changed := valid
+			changed.Manifest = json.RawMessage(`{"padding":"` + strings.Repeat("x", 9000) + `"}`)
+			return changed
+		}(),
+		func() MailCutoverRequest { changed := valid; changed.ManifestSHA256 = "bad"; return changed }(),
+		func() MailCutoverRequest {
+			changed := valid
+			changed.SourceFingerprint = strings.Repeat("d", 64)
+			return changed
+		}(),
+	}
+	for index, request := range invalid {
+		if err := request.Validate(); err == nil {
+			t.Fatalf("invalid request %d accepted: %#v", index, request)
+		}
+	}
+}

--- a/internal/postgres/mail_cutover_test.go
+++ b/internal/postgres/mail_cutover_test.go
@@ -10,6 +10,30 @@ import (
 	"github.com/rock3r/punaro/internal/relay"
 )
 
+type mailCutoverScannerFunc func(...any) error
+
+func (f mailCutoverScannerFunc) Scan(destinations ...any) error { return f(destinations...) }
+
+func TestScanMailCutoverPreservesManifestText(t *testing.T) {
+	t.Parallel()
+	const manifest = `{"version":1,"source_id":"exact-bytes"}`
+	row := mailCutoverScannerFunc(func(destinations ...any) error {
+		text, ok := destinations[4].(*string)
+		if !ok {
+			t.Fatalf("manifest destination=%T, want *string", destinations[4])
+		}
+		*text = manifest
+		return nil
+	})
+	var epoch MailCutoverEpoch
+	if err := scanMailCutover(row, &epoch); err != nil {
+		t.Fatal(err)
+	}
+	if string(epoch.Manifest) != manifest {
+		t.Fatalf("manifest=%q, want exact text %q", epoch.Manifest, manifest)
+	}
+}
+
 func TestMailCutoverRequestValidation(t *testing.T) {
 	t.Parallel()
 	valid := MailCutoverRequest{

--- a/internal/postgres/migrate.go
+++ b/internal/postgres/migrate.go
@@ -40,6 +40,7 @@ var migrationCompatibilityFloors = map[int64]int64{
 	5: 5,
 	6: 6,
 	7: 7,
+	8: 8,
 }
 
 // CurrentManifest returns the immutable migrations embedded in this binary.

--- a/internal/postgres/migrations/008_mail_cutover_substrate.sql
+++ b/internal/postgres/migrations/008_mail_cutover_substrate.sql
@@ -1,0 +1,83 @@
+CREATE TABLE relay.mail_cutover_epochs (
+    epoch_id uuid CONSTRAINT mail_cutover_epochs_pkey PRIMARY KEY,
+    source_id uuid NOT NULL,
+    target_identity char(64) NOT NULL CONSTRAINT mail_cutover_epochs_target_identity_check CHECK (target_identity ~ '^[0-9a-f]{64}$'),
+    source_fingerprint char(64) NOT NULL CONSTRAINT mail_cutover_epochs_source_fingerprint_check CHECK (source_fingerprint ~ '^[0-9a-f]{64}$'),
+    source_manifest text NOT NULL CONSTRAINT mail_cutover_epochs_source_manifest_check CHECK (jsonb_typeof(source_manifest::jsonb) = 'object' AND octet_length(source_manifest) <= 8192),
+    manifest_sha256 char(64) NOT NULL CONSTRAINT mail_cutover_epochs_manifest_sha256_check CHECK (manifest_sha256 ~ '^[0-9a-f]{64}$'),
+    phase text NOT NULL CONSTRAINT mail_cutover_epochs_phase_check CHECK (phase IN ('importing','verified','active','aborted')),
+    created_at timestamptz NOT NULL DEFAULT statement_timestamp(),
+    updated_at timestamptz NOT NULL DEFAULT statement_timestamp(),
+    verified_at timestamptz,
+    activated_at timestamptz,
+    aborted_at timestamptz,
+    CONSTRAINT mail_cutover_epochs_verified_at_check CHECK ((phase IN ('verified','active')) = (verified_at IS NOT NULL)),
+    CONSTRAINT mail_cutover_epochs_activated_at_check CHECK ((phase = 'active') = (activated_at IS NOT NULL)),
+    CONSTRAINT mail_cutover_epochs_aborted_at_check CHECK ((phase = 'aborted') = (aborted_at IS NOT NULL))
+);
+
+CREATE UNIQUE INDEX mail_cutover_epochs_one_authority
+ON relay.mail_cutover_epochs ((true))
+WHERE phase IN ('importing','verified','active');
+
+CREATE TABLE relay.mail_cutover_staging (
+    epoch_id uuid NOT NULL CONSTRAINT mail_cutover_staging_epoch_fkey REFERENCES relay.mail_cutover_epochs(epoch_id),
+    table_name text NOT NULL CONSTRAINT mail_cutover_staging_table_name_check CHECK (table_name IN ('mail_endpoints','mail_conversations','mail_memberships','mail_messages','mail_deliveries','mail_recipient_cursors','mail_message_idempotency','mail_conversation_idempotency','mail_request_nonces')),
+    row_key text NOT NULL CONSTRAINT mail_cutover_staging_row_key_check CHECK (octet_length(row_key) BETWEEN 1 AND 4096),
+    payload jsonb NOT NULL CONSTRAINT mail_cutover_staging_payload_check CHECK (jsonb_typeof(payload) = 'object' AND octet_length(payload::text) <= 65536),
+    row_sha256 char(64) NOT NULL CONSTRAINT mail_cutover_staging_row_sha256_check CHECK (row_sha256 ~ '^[0-9a-f]{64}$'),
+    CONSTRAINT mail_cutover_staging_pkey PRIMARY KEY (epoch_id, table_name, row_key)
+);
+
+CREATE TABLE relay.mail_cutover_checkpoints (
+    epoch_id uuid NOT NULL CONSTRAINT mail_cutover_checkpoints_epoch_fkey REFERENCES relay.mail_cutover_epochs(epoch_id),
+    table_name text NOT NULL CONSTRAINT mail_cutover_checkpoints_table_name_check CHECK (table_name IN ('mail_endpoints','mail_conversations','mail_memberships','mail_messages','mail_deliveries','mail_recipient_cursors','mail_message_idempotency','mail_conversation_idempotency','mail_request_nonces')),
+    last_key text CONSTRAINT mail_cutover_checkpoints_last_key_check CHECK (last_key IS NULL OR octet_length(last_key) BETWEEN 1 AND 4096),
+    row_count bigint NOT NULL DEFAULT 0 CONSTRAINT mail_cutover_checkpoints_row_count_check CHECK (row_count >= 0),
+    rolling_sha256 char(64) NOT NULL CONSTRAINT mail_cutover_checkpoints_rolling_sha256_check CHECK (rolling_sha256 ~ '^[0-9a-f]{64}$'),
+    updated_at timestamptz NOT NULL DEFAULT statement_timestamp(),
+    CONSTRAINT mail_cutover_checkpoints_pkey PRIMARY KEY (epoch_id, table_name)
+);
+
+CREATE FUNCTION relay.guard_mail_mutation()
+RETURNS trigger
+LANGUAGE plpgsql
+SET search_path = pg_catalog
+AS $function$
+BEGIN
+    PERFORM jobs.assert_application_mutation();
+    PERFORM pg_advisory_xact_lock_shared(5788618938430605644);
+    IF session_user = 'punaro_app' AND EXISTS (
+        SELECT 1 FROM relay.mail_cutover_epochs WHERE phase IN ('importing','verified')
+    ) THEN
+        RAISE EXCEPTION USING ERRCODE = '55P03', MESSAGE = 'punaro maintenance in progress';
+    END IF;
+    RETURN NULL;
+END
+$function$;
+
+DO $do$
+DECLARE
+    target regclass;
+    trigger_name text;
+BEGIN
+    FOR target, trigger_name IN VALUES
+        ('relay.mail_endpoints'::regclass, 'mail_endpoints_mutation_guard'),
+        ('relay.mail_conversations'::regclass, 'mail_conversations_mutation_guard'),
+        ('relay.mail_memberships'::regclass, 'mail_memberships_mutation_guard'),
+        ('relay.mail_messages'::regclass, 'mail_messages_mutation_guard'),
+        ('relay.mail_deliveries'::regclass, 'mail_deliveries_mutation_guard'),
+        ('relay.mail_recipient_cursors'::regclass, 'mail_recipient_cursors_mutation_guard'),
+        ('relay.mail_message_idempotency'::regclass, 'mail_message_idempotency_mutation_guard'),
+        ('relay.mail_conversation_idempotency'::regclass, 'mail_conversation_idempotency_mutation_guard'),
+        ('relay.mail_request_nonces'::regclass, 'mail_request_nonces_mutation_guard')
+    LOOP
+        EXECUTE format('DROP TRIGGER %I ON %s', trigger_name, target);
+        EXECUTE format('CREATE TRIGGER %I BEFORE INSERT OR UPDATE OR DELETE ON %s FOR EACH STATEMENT EXECUTE FUNCTION relay.guard_mail_mutation()', trigger_name, target);
+    END LOOP;
+END
+$do$;
+
+REVOKE ALL ON relay.mail_cutover_epochs, relay.mail_cutover_staging, relay.mail_cutover_checkpoints FROM PUBLIC, punaro_app;
+GRANT SELECT ON relay.mail_cutover_epochs TO punaro_app;
+REVOKE ALL ON FUNCTION relay.guard_mail_mutation() FROM PUBLIC, punaro_app;

--- a/internal/postgres/postgres_integration_test.go
+++ b/internal/postgres/postgres_integration_test.go
@@ -49,7 +49,14 @@ func TestPostgresPlatformSubstrateIntegration(t *testing.T) {
 		t.Fatalf("pristine DSN pair proof failed: %v", err)
 	}
 	if state, err := MigratePristinePair(ctx, Config{DSNFile: pairAppFile}, Config{DSNFile: pairOwnerFile}); err != nil || state.Classification != Compatible {
-		t.Fatalf("connection-bound pair migration state=%#v err=%v catalog=%s", state, err, m6CatalogDiagnostic(ctx, pairOwnerDSN))
+		pairDB, openErr := open(ctx, pairOwnerDSN)
+		var cutoverAvailable bool
+		var cutoverErr error
+		if openErr == nil {
+			cutoverAvailable, cutoverErr = mailCutoverControlsAvailable(ctx, pairDB)
+			_ = pairDB.Close()
+		}
+		t.Fatalf("connection-bound pair migration state=%#v err=%v catalog=%s cutover_available=%t cutover_err=%v diagnostic_open_err=%v", state, err, m6CatalogDiagnostic(ctx, pairOwnerDSN), cutoverAvailable, cutoverErr, openErr)
 	}
 	pairDB, err := open(ctx, pairOwnerDSN)
 	if err != nil {

--- a/internal/postgres/postgres_integration_test.go
+++ b/internal/postgres/postgres_integration_test.go
@@ -739,6 +739,12 @@ func testMailCutoverSubstrate(ctx context.Context, t *testing.T, app *Database, 
 	}
 	changed := request
 	changed.SourceFingerprint = "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
+	changedManifest := manifest
+	changedManifest.Fingerprint = changed.SourceFingerprint
+	changedCanonical, _ := json.Marshal(changedManifest)
+	changed.Manifest = changedCanonical
+	changedDigest := sha256.Sum256(changedCanonical)
+	changed.ManifestSHA256 = hex.EncodeToString(changedDigest[:])
 	if _, err := admin.BeginMailCutover(ctx, actor, changed); !errors.Is(err, ErrIdempotencyConflict) {
 		t.Fatalf("changed cutover retry err=%v", err)
 	}
@@ -773,10 +779,10 @@ func testMailCutoverSubstrate(ctx context.Context, t *testing.T, app *Database, 
 	changedEpoch := request
 	changedEpoch.EpochID = "019f7f07-7b88-7c12-a394-b663274a6555"
 	manifest.EpochID = changedEpoch.EpochID
-	changedCanonical, _ := json.Marshal(manifest)
-	changedEpoch.Manifest = changedCanonical
-	changedDigest := sha256.Sum256(changedCanonical)
-	changedEpoch.ManifestSHA256 = hex.EncodeToString(changedDigest[:])
+	changedEpochCanonical, _ := json.Marshal(manifest)
+	changedEpoch.Manifest = changedEpochCanonical
+	changedEpochDigest := sha256.Sum256(changedEpochCanonical)
+	changedEpoch.ManifestSHA256 = hex.EncodeToString(changedEpochDigest[:])
 	if _, err := admin.BeginMailCutover(ctx, actor, changedEpoch); !errors.Is(err, ErrMaintenance) {
 		t.Fatalf("mail begin overlapped active update: %v", err)
 	}

--- a/internal/postgres/postgres_integration_test.go
+++ b/internal/postgres/postgres_integration_test.go
@@ -2,11 +2,14 @@ package postgres
 
 import (
 	"context"
+	"crypto/sha256"
 	"database/sql"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -156,17 +159,65 @@ func TestPostgresPlatformSubstrateIntegration(t *testing.T) {
 	if err := app.Ready(ctx); err != nil {
 		t.Fatalf("relay guard restoration did not recover readiness: %v", err)
 	}
-	if _, err := ownerDB.ExecContext(ctx, `DROP TRIGGER mail_messages_mutation_guard ON relay.mail_messages; CREATE TRIGGER mail_messages_mutation_guard BEFORE INSERT OR UPDATE OR DELETE ON relay.mail_messages FOR EACH STATEMENT WHEN (false) EXECUTE FUNCTION jobs.guard_application_mutation()`); err != nil {
+	if _, err := ownerDB.ExecContext(ctx, `DROP TRIGGER mail_messages_mutation_guard ON relay.mail_messages; CREATE TRIGGER mail_messages_mutation_guard BEFORE INSERT OR UPDATE OR DELETE ON relay.mail_messages FOR EACH STATEMENT WHEN (false) EXECUTE FUNCTION relay.guard_mail_mutation()`); err != nil {
 		t.Fatal(err)
 	}
 	if drifted, driftErr := app.SchemaState(ctx); driftErr != nil || drifted.Classification != Incompatible {
 		t.Fatalf("conditional relay mutation guard state=%#v err=%v", drifted, driftErr)
 	}
-	if _, err := ownerDB.ExecContext(ctx, `DROP TRIGGER mail_messages_mutation_guard ON relay.mail_messages; CREATE TRIGGER mail_messages_mutation_guard BEFORE INSERT OR UPDATE OR DELETE ON relay.mail_messages FOR EACH STATEMENT EXECUTE FUNCTION jobs.guard_application_mutation()`); err != nil {
+	if _, err := ownerDB.ExecContext(ctx, `DROP TRIGGER mail_messages_mutation_guard ON relay.mail_messages; CREATE TRIGGER mail_messages_mutation_guard BEFORE INSERT OR UPDATE OR DELETE ON relay.mail_messages FOR EACH STATEMENT EXECUTE FUNCTION relay.guard_mail_mutation()`); err != nil {
 		t.Fatal(err)
 	}
 	if err := app.Ready(ctx); err != nil {
 		t.Fatalf("unconditional relay guard restoration did not recover readiness: %v", err)
+	}
+	if _, err := ownerDB.ExecContext(ctx, `ALTER TABLE relay.mail_cutover_epochs DROP CONSTRAINT mail_cutover_epochs_phase_check; ALTER TABLE relay.mail_cutover_epochs ADD CONSTRAINT mail_cutover_epochs_phase_check CHECK (phase IS NOT NULL)`); err != nil {
+		t.Fatal(err)
+	}
+	if drifted, driftErr := app.SchemaState(ctx); driftErr != nil || drifted.Classification != Incompatible {
+		t.Fatalf("permissive mail-cutover phase constraint state=%#v err=%v", drifted, driftErr)
+	}
+	if _, err := ownerDB.ExecContext(ctx, `ALTER TABLE relay.mail_cutover_epochs DROP CONSTRAINT mail_cutover_epochs_phase_check; ALTER TABLE relay.mail_cutover_epochs ADD CONSTRAINT mail_cutover_epochs_phase_check CHECK (phase IN ('importing','verified','active','aborted'))`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ownerDB.ExecContext(ctx, `DROP INDEX relay.mail_cutover_epochs_one_authority; CREATE UNIQUE INDEX mail_cutover_epochs_one_authority ON relay.mail_cutover_epochs ((true)) WHERE phase='importing'`); err != nil {
+		t.Fatal(err)
+	}
+	if drifted, driftErr := app.SchemaState(ctx); driftErr != nil || drifted.Classification != Incompatible {
+		t.Fatalf("weakened mail-cutover authority index state=%#v err=%v", drifted, driftErr)
+	}
+	if _, err := ownerDB.ExecContext(ctx, `DROP INDEX relay.mail_cutover_epochs_one_authority; CREATE UNIQUE INDEX mail_cutover_epochs_one_authority ON relay.mail_cutover_epochs ((true)) WHERE phase IN ('importing','verified','active')`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ownerDB.ExecContext(ctx, `GRANT SELECT ON relay.mail_cutover_staging TO PUBLIC`); err != nil {
+		t.Fatal(err)
+	}
+	if drifted, driftErr := app.SchemaState(ctx); driftErr != nil || drifted.Classification != Incompatible {
+		t.Fatalf("mail-cutover extra grantee state=%#v err=%v", drifted, driftErr)
+	}
+	if _, err := ownerDB.ExecContext(ctx, `REVOKE SELECT ON relay.mail_cutover_staging FROM PUBLIC`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ownerDB.ExecContext(ctx, `ALTER TABLE relay.mail_cutover_epochs ADD CONSTRAINT mail_cutover_epochs_unexpected_unique UNIQUE(epoch_id,source_id) DEFERRABLE`); err != nil {
+		t.Fatal(err)
+	}
+	if drifted, driftErr := app.SchemaState(ctx); driftErr != nil || drifted.Classification != Incompatible {
+		t.Fatalf("mail-cutover extra constraint state=%#v err=%v", drifted, driftErr)
+	}
+	if _, err := ownerDB.ExecContext(ctx, `ALTER TABLE relay.mail_cutover_epochs DROP CONSTRAINT mail_cutover_epochs_unexpected_unique`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ownerDB.ExecContext(ctx, `CREATE TRIGGER mail_endpoints_unexpected_guard BEFORE INSERT ON relay.mail_endpoints FOR EACH STATEMENT EXECUTE FUNCTION relay.guard_mail_mutation()`); err != nil {
+		t.Fatal(err)
+	}
+	if drifted, driftErr := app.SchemaState(ctx); driftErr != nil || drifted.Classification != Incompatible {
+		t.Fatalf("mail-cutover extra trigger state=%#v err=%v", drifted, driftErr)
+	}
+	if _, err := ownerDB.ExecContext(ctx, `DROP TRIGGER mail_endpoints_unexpected_guard ON relay.mail_endpoints`); err != nil {
+		t.Fatal(err)
+	}
+	if err := app.Ready(ctx); err != nil {
+		t.Fatalf("mail-cutover catalog restoration did not recover readiness: %v", err)
 	}
 	var nonceDefinition string
 	if err := ownerDB.QueryRowContext(ctx, `SELECT pg_get_functiondef('relay.consume_mail_request_nonce(text,text,timestamptz,timestamptz)'::regprocedure)`).Scan(&nonceDefinition); err != nil {
@@ -275,6 +326,7 @@ RETURNS boolean LANGUAGE plpgsql SECURITY DEFINER SET search_path=pg_catalog AS 
 	testProjectIdentityIntegration(ctx, t, app, ownerDB)
 	testBackupRestoreIntegration(ctx, t, app, ownerDB, ownerFile, appFile)
 	testTransactionalUpdateFenceIntegration(ctx, t, app, ownerDB)
+	testMailCutoverSubstrate(ctx, t, app, ownerDB)
 	testRelayIntegration(t, app)
 	if err := app.Close(); err != nil {
 		t.Fatal(err)
@@ -562,6 +614,183 @@ AS $function$ BEGIN RETURN NEW; END $function$`); err != nil {
 	}
 }
 
+func testMailCutoverSubstrate(ctx context.Context, t *testing.T, app *Database, ownerDB *sql.DB) {
+	t.Helper()
+	admin := &Administration{db: ownerDB}
+	var actor string
+	if err := ownerDB.QueryRowContext(ctx, `SELECT principal_id::text FROM auth.installation_owner`).Scan(&actor); err != nil {
+		t.Fatal(err)
+	}
+	targetIdentity, err := app.Identity(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	request := MailCutoverRequest{
+		EpochID:           "019f7f07-4b88-7c12-a394-b663274a6555",
+		SourceID:          "019f7f07-5b88-7c12-a394-b663274a6555",
+		TargetIdentity:    targetIdentity,
+		SourceFingerprint: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+	}
+	manifest := relay.MigrationSourceManifest{
+		Version: 1, SourceID: request.SourceID, Phase: relay.MigrationSourcePrepared, EpochID: request.EpochID,
+		TargetIdentity: request.TargetIdentity, Fingerprint: request.SourceFingerprint,
+		TableSHA256: relay.MigrationSourceHashes{
+			Endpoints: strings.Repeat("e", 64), Conversations: strings.Repeat("e", 64), Memberships: strings.Repeat("e", 64),
+			Messages: strings.Repeat("e", 64), Deliveries: strings.Repeat("e", 64), RecipientCursors: strings.Repeat("e", 64),
+			MessageIdempotency: strings.Repeat("e", 64), ConversationIdempotency: strings.Repeat("e", 64), RequestNonces: strings.Repeat("e", 64),
+		},
+	}
+	canonicalManifest, _ := json.Marshal(manifest)
+	request.Manifest, _ = json.MarshalIndent(manifest, "", "  ")
+	manifestDigest := sha256.Sum256(canonicalManifest)
+	request.ManifestSHA256 = hex.EncodeToString(manifestDigest[:])
+	if _, err := admin.BeginMailCutover(ctx, uuid.NewString(), request); err == nil {
+		t.Fatal("non-owner began mail cutover")
+	}
+	wrongTarget := request
+	wrongTarget.TargetIdentity = strings.Repeat("f", 64)
+	manifest.TargetIdentity = wrongTarget.TargetIdentity
+	wrongCanonical, _ := json.Marshal(manifest)
+	wrongTarget.Manifest = wrongCanonical
+	wrongDigest := sha256.Sum256(wrongCanonical)
+	wrongTarget.ManifestSHA256 = hex.EncodeToString(wrongDigest[:])
+	if _, err := admin.BeginMailCutover(ctx, actor, wrongTarget); err == nil {
+		t.Fatal("mail cutover accepted the wrong target identity")
+	}
+	manifest.TargetIdentity = request.TargetIdentity
+	var rejectedEpochs int
+	if err := ownerDB.QueryRowContext(ctx, `SELECT count(*) FROM relay.mail_cutover_epochs`).Scan(&rejectedEpochs); err != nil || rejectedEpochs != 0 {
+		t.Fatalf("rejected cutover created epochs=%d err=%v", rejectedEpochs, err)
+	}
+	writer, err := app.relayPool().BeginTx(ctx, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := writer.ExecContext(ctx, `INSERT INTO relay.mail_endpoints(endpoint,machine_id,lease_until) VALUES('agent/cutover/draining','cutover-draining-machine',statement_timestamp()+interval '1 minute')`); err != nil {
+		_ = writer.Rollback()
+		t.Fatal(err)
+	}
+	type beginResult struct {
+		epoch MailCutoverEpoch
+		err   error
+	}
+	beginDone := make(chan beginResult, 1)
+	go func() {
+		epoch, err := admin.BeginMailCutover(ctx, actor, request)
+		beginDone <- beginResult{epoch: epoch, err: err}
+	}()
+	waitDeadline := time.Now().Add(2 * time.Second)
+	for {
+		var waiting bool
+		if err := ownerDB.QueryRowContext(ctx, `SELECT EXISTS (SELECT 1 FROM pg_stat_activity WHERE usename='punaro_owner' AND wait_event='advisory' AND query LIKE 'SELECT pg_advisory_xact_lock(%')`).Scan(&waiting); err != nil {
+			_ = writer.Rollback()
+			t.Fatal(err)
+		}
+		if waiting {
+			break
+		}
+		select {
+		case result := <-beginDone:
+			_ = writer.Rollback()
+			t.Fatalf("cutover begin escaped an uncommitted application writer: epoch=%#v err=%v", result.epoch, result.err)
+		default:
+		}
+		if time.Now().After(waitDeadline) {
+			_ = writer.Rollback()
+			t.Fatal("cutover begin did not wait for the application writer")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if err := writer.Commit(); err != nil {
+		t.Fatal(err)
+	}
+	result := <-beginDone
+	if result.err == nil {
+		t.Fatalf("cutover accepted a target populated by a drained writer: %#v", result.epoch)
+	}
+	if _, err := ownerDB.ExecContext(ctx, `DELETE FROM relay.mail_endpoints WHERE endpoint='agent/cutover/draining'`); err != nil {
+		t.Fatal(err)
+	}
+	epoch, err := admin.BeginMailCutover(ctx, actor, request)
+	if err != nil || epoch.Phase != MailCutoverImporting || epoch.EpochID != request.EpochID {
+		t.Fatalf("begin cutover epoch=%#v err=%v", epoch, err)
+	}
+	durableDigest := sha256.Sum256(epoch.Manifest)
+	if hex.EncodeToString(durableDigest[:]) != request.ManifestSHA256 || string(epoch.Manifest) != string(canonicalManifest) {
+		t.Fatalf("durable manifest=%s digest=%x", epoch.Manifest, durableDigest)
+	}
+	var postgresMajor int
+	if err := ownerDB.QueryRowContext(ctx, `SELECT current_setting('server_version_num')::integer / 10000`).Scan(&postgresMajor); err != nil {
+		t.Fatal(err)
+	}
+	updateRequest := UpdateRequest{
+		UpdateID: "019f7f07-6b88-7c12-a394-b663274a6555", SourceRelease: "cutover-source", TargetRelease: "cutover-target",
+		SourceImage:  "ghcr.io/rock3r/punaro@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+		TargetImage:  "ghcr.io/rock3r/punaro@sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+		SourceSchema: 8, TargetSchema: 8, SchemaMin: 8, SchemaMax: 8, RollbackFloor: 8, PostgresMajor: postgresMajor,
+		ReleaseSHA256: strings.Repeat("1", 64), ComposeSHA256: strings.Repeat("2", 64), MigrationManifestSHA256: MigrationManifestSHA256(),
+	}
+	if _, err := admin.BeginUpdate(ctx, updateRequest); !errors.Is(err, ErrUpdateConflict) {
+		t.Fatalf("update overlapped importing mail epoch: %v", err)
+	}
+	repeated, err := admin.BeginMailCutover(ctx, actor, request)
+	if err != nil || !reflect.DeepEqual(repeated, epoch) {
+		t.Fatalf("repeat cutover epoch=%#v err=%v", repeated, err)
+	}
+	changed := request
+	changed.SourceFingerprint = "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
+	if _, err := admin.BeginMailCutover(ctx, actor, changed); !errors.Is(err, ErrIdempotencyConflict) {
+		t.Fatalf("changed cutover retry err=%v", err)
+	}
+	if err := app.AdvertiseEndpoints("cutover-fenced-machine", []string{"agent/cutover/fenced"}, time.Now().UTC(), time.Minute); !errors.Is(err, relay.ErrMaintenance) {
+		t.Fatalf("application mail write during inactive cutover err=%v", err)
+	}
+	for _, table := range []string{"mail_endpoints", "mail_conversations", "mail_memberships", "mail_messages", "mail_deliveries", "mail_recipient_cursors", "mail_message_idempotency", "mail_conversation_idempotency"} {
+		if _, err := app.relayPool().ExecContext(ctx, `INSERT INTO relay.`+table+` DEFAULT VALUES`); !isMaintenanceError(err) { // #nosec G202 -- table comes only from the fixed test allowlist.
+			t.Fatalf("application cutover guard table=%s err=%v", table, err)
+		}
+	}
+	if err := app.ConsumeRequestNonce("cutover-fenced-machine", "cutover-fenced-nonce", time.Now().UTC(), time.Now().UTC().Add(time.Minute)); !errors.Is(err, relay.ErrMaintenance) {
+		t.Fatalf("application nonce write during cutover err=%v", err)
+	}
+	if err := admin.AbortMailCutover(ctx, actor, request.EpochID, request.SourceFingerprint); err != nil {
+		t.Fatal(err)
+	}
+	if err := admin.AbortMailCutover(ctx, actor, request.EpochID, request.SourceFingerprint); err != nil {
+		t.Fatalf("idempotent cutover abort err=%v", err)
+	}
+	status, err := admin.MailCutoverStatus(ctx, actor, request.EpochID)
+	if err != nil || status.Phase != MailCutoverAborted {
+		t.Fatalf("aborted cutover status=%#v err=%v", status, err)
+	}
+	update, err := admin.BeginUpdate(ctx, updateRequest)
+	if err != nil || update.Phase != UpdateFenced {
+		t.Fatalf("begin update after mail abort=%#v err=%v", update, err)
+	}
+	if err := admin.AbortMailCutover(ctx, actor, request.EpochID, request.SourceFingerprint); !errors.Is(err, ErrMaintenance) {
+		t.Fatalf("mail abort overlapped active update: %v", err)
+	}
+	changedEpoch := request
+	changedEpoch.EpochID = "019f7f07-7b88-7c12-a394-b663274a6555"
+	manifest.EpochID = changedEpoch.EpochID
+	changedCanonical, _ := json.Marshal(manifest)
+	changedEpoch.Manifest = changedCanonical
+	changedDigest := sha256.Sum256(changedCanonical)
+	changedEpoch.ManifestSHA256 = hex.EncodeToString(changedDigest[:])
+	if _, err := admin.BeginMailCutover(ctx, actor, changedEpoch); !errors.Is(err, ErrMaintenance) {
+		t.Fatalf("mail begin overlapped active update: %v", err)
+	}
+	if update, err = admin.AdvanceUpdate(ctx, updateRequest.UpdateID, UpdateFenced, UpdateAborted, nil); err != nil || update.Phase != UpdateAborted {
+		t.Fatalf("abort update after cutover exclusion=%#v err=%v", update, err)
+	}
+	if err := app.AdvertiseEndpoints("cutover-unfenced-machine", []string{"agent/cutover/unfenced"}, time.Now().UTC(), time.Minute); err != nil {
+		t.Fatalf("mail write after abort: %v", err)
+	}
+	if _, err := ownerDB.ExecContext(ctx, `DELETE FROM relay.mail_endpoints WHERE endpoint='agent/cutover/unfenced'`); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func testRelayIntegration(t *testing.T, app *Database) {
 	t.Helper()
 	contracttest.Run(t, app, "postgres-contract")
@@ -819,6 +1048,7 @@ func testV5UpdateBridgeIntegration(ctx context.Context, t *testing.T, ownerDB *s
 			t.Fatalf("bridge phase %s -> %s transaction=%#v err=%v", phases[0], phases[1], transaction, err)
 		}
 	}
+	v7Manifest := Manifest{MinSupported: 7, MaxSupported: 7, Migrations: append([]Migration(nil), current.Migrations[:7]...)}
 	request = UpdateRequest{
 		UpdateID:                "019b4eb0-798c-7a52-8d29-8560fcbb2085",
 		SourceRelease:           "v0.7.0",
@@ -833,7 +1063,7 @@ func testV5UpdateBridgeIntegration(ctx context.Context, t *testing.T, ownerDB *s
 		PostgresMajor:           postgresMajor,
 		ReleaseSHA256:           "abababababababababababababababababababababababababababababababab",
 		ComposeSHA256:           "cdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcd",
-		MigrationManifestSHA256: MigrationManifestSHA256(),
+		MigrationManifestSHA256: migrationManifestSHA256(v7Manifest),
 	}
 	transaction, err = admin.BeginUpdate(ctx, request)
 	if err != nil || transaction.Phase != UpdateFenced {
@@ -867,13 +1097,70 @@ func testV5UpdateBridgeIntegration(ctx context.Context, t *testing.T, ownerDB *s
 		TargetImage: request.TargetImage, TargetSchema: request.TargetSchema,
 		ExportedSnapshotID: marker.ExportedSnapshotID, ManifestSHA256: marker.ManifestSHA256,
 	}
-	if state, err := MigrateUpdate(ctx, Config{DSNFile: ownerFile}, authorization); err != nil || state.Classification != Compatible || state.Version != 7 {
+	if state, err := migrateUpdateManifest(ctx, Config{DSNFile: ownerFile}, authorization, v7Manifest); err != nil || state.Classification != Compatible || state.Version != 7 {
 		t.Fatalf("v7 migration state=%#v err=%v", state, err)
 	}
 	for _, phases := range [][2]UpdatePhase{{UpdateMigrationStarted, UpdateMigrated}, {UpdateMigrated, UpdateCandidateReady}, {UpdateCandidateReady, UpdateDoctorPassed}, {UpdateDoctorPassed, UpdateConfigPublished}, {UpdateConfigPublished, UpdateCommitted}} {
 		transaction, err = admin.AdvanceUpdate(ctx, request.UpdateID, phases[0], phases[1], nil)
 		if err != nil || transaction.Phase != phases[1] {
 			t.Fatalf("v7 phase %s -> %s transaction=%#v err=%v", phases[0], phases[1], transaction, err)
+		}
+	}
+	request = UpdateRequest{
+		UpdateID:                "019b4eb0-798c-7a52-8d29-8560fcbb2086",
+		SourceRelease:           "v0.8.0",
+		TargetRelease:           "v0.9.0",
+		SourceImage:             "ghcr.io/rock3r/punaro@sha256:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+		TargetImage:             "ghcr.io/rock3r/punaro@sha256:eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+		SourceSchema:            7,
+		TargetSchema:            8,
+		SchemaMin:               7,
+		SchemaMax:               8,
+		RollbackFloor:           7,
+		PostgresMajor:           postgresMajor,
+		ReleaseSHA256:           "1212121212121212121212121212121212121212121212121212121212121212",
+		ComposeSHA256:           "3434343434343434343434343434343434343434343434343434343434343434",
+		MigrationManifestSHA256: MigrationManifestSHA256(),
+	}
+	transaction, err = admin.BeginUpdate(ctx, request)
+	if err != nil || transaction.Phase != UpdateFenced {
+		t.Fatalf("begin v8 update transaction=%#v err=%v", transaction, err)
+	}
+	transaction, err = admin.AdvanceUpdate(ctx, request.UpdateID, UpdateFenced, UpdateWritersStopped, nil)
+	if err != nil || transaction.Phase != UpdateWritersStopped {
+		t.Fatalf("stop v8 writers transaction=%#v err=%v", transaction, err)
+	}
+	if err := ownerDB.QueryRowContext(ctx, `SELECT installation_id::text,timeline_id::text,change_sequence FROM jobs.server_state WHERE singleton`).Scan(&state.InstallationID, &state.TimelineID, &state.ChangeSequence); err != nil {
+		t.Fatal(err)
+	}
+	marker = &UpdateBackupMarker{
+		UpdateID: request.UpdateID, BackupID: "019b4eb0-5317-79a6-a0de-fd97719910fd",
+		InstallationID: state.InstallationID, TimelineID: state.TimelineID, ChangeSequence: state.ChangeSequence,
+		SourceSchema: request.SourceSchema, TargetRelease: request.TargetRelease,
+		TargetImageDigest:  "sha256:eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+		ExportedSnapshotID: "00000003-0000001B-3",
+		ManifestSHA256:     "5656565656565656565656565656565656565656565656565656565656565656",
+	}
+	transaction, err = admin.AdvanceUpdate(ctx, request.UpdateID, UpdateWritersStopped, UpdateBackupVerified, marker)
+	if err != nil || transaction.Phase != UpdateBackupVerified {
+		t.Fatalf("bind v8 backup transaction=%#v err=%v", transaction, err)
+	}
+	transaction, err = admin.AdvanceUpdate(ctx, request.UpdateID, UpdateBackupVerified, UpdateMigrationStarted, nil)
+	if err != nil || transaction.Phase != UpdateMigrationStarted {
+		t.Fatalf("start v8 migration transaction=%#v err=%v", transaction, err)
+	}
+	authorization = UpdateMigrationAuthorization{
+		UpdateID: request.UpdateID, BackupID: marker.BackupID, TargetRelease: request.TargetRelease,
+		TargetImage: request.TargetImage, TargetSchema: request.TargetSchema,
+		ExportedSnapshotID: marker.ExportedSnapshotID, ManifestSHA256: marker.ManifestSHA256,
+	}
+	if state, err := MigrateUpdate(ctx, Config{DSNFile: ownerFile}, authorization); err != nil || state.Classification != Compatible || state.Version != 8 {
+		t.Fatalf("v8 migration state=%#v err=%v", state, err)
+	}
+	for _, phases := range [][2]UpdatePhase{{UpdateMigrationStarted, UpdateMigrated}, {UpdateMigrated, UpdateCandidateReady}, {UpdateCandidateReady, UpdateDoctorPassed}, {UpdateDoctorPassed, UpdateConfigPublished}, {UpdateConfigPublished, UpdateCommitted}} {
+		transaction, err = admin.AdvanceUpdate(ctx, request.UpdateID, phases[0], phases[1], nil)
+		if err != nil || transaction.Phase != phases[1] {
+			t.Fatalf("v8 phase %s -> %s transaction=%#v err=%v", phases[0], phases[1], transaction, err)
 		}
 	}
 	if _, err := ownerDB.ExecContext(ctx, `DELETE FROM jobs.update_transactions`); err != nil {

--- a/internal/postgres/postgres_integration_test.go
+++ b/internal/postgres/postgres_integration_test.go
@@ -56,7 +56,7 @@ func TestPostgresPlatformSubstrateIntegration(t *testing.T) {
 			cutoverAvailable, cutoverErr = mailCutoverControlsAvailable(ctx, pairDB)
 			_ = pairDB.Close()
 		}
-		t.Fatalf("connection-bound pair migration state=%#v err=%v catalog=%s cutover_available=%t cutover_err=%v diagnostic_open_err=%v", state, err, m6CatalogDiagnostic(ctx, pairOwnerDSN), cutoverAvailable, cutoverErr, openErr)
+		t.Fatalf("connection-bound pair migration state=%#v err=%v catalog=%s cutover_constraints=%s cutover_available=%t cutover_err=%v diagnostic_open_err=%v", state, err, m6CatalogDiagnostic(ctx, pairOwnerDSN), mailCutoverConstraintDiagnostic(ctx, pairOwnerDSN), cutoverAvailable, cutoverErr, openErr)
 	}
 	pairDB, err := open(ctx, pairOwnerDSN)
 	if err != nil {
@@ -1397,6 +1397,28 @@ func m6CatalogDiagnostic(ctx context.Context, ownerDSN string) string {
 			}
 		}
 		_ = rows.Close()
+	}
+	return diagnostic.String()
+}
+
+func mailCutoverConstraintDiagnostic(ctx context.Context, ownerDSN string) string {
+	db, err := sql.Open("pgx", ownerDSN)
+	if err != nil {
+		return "open-failed"
+	}
+	defer func() { _ = db.Close() }()
+	rows, err := db.QueryContext(ctx, `SELECT format('%s:%s:%s:%s:%s:%s:%s:%s:%s', conname, contype, conkey::text, confrelid::regclass::text, COALESCE(confkey,'{}'::smallint[])::text, convalidated, condeferrable, condeferred, COALESCE(pg_get_expr(conbin,conrelid),'')) FROM pg_constraint WHERE conrelid=ANY(ARRAY[to_regclass('relay.mail_cutover_epochs'),to_regclass('relay.mail_cutover_staging'),to_regclass('relay.mail_cutover_checkpoints')]) ORDER BY conrelid::regclass::text,conname`)
+	if err != nil {
+		return "query-failed"
+	}
+	defer func() { _ = rows.Close() }()
+	var diagnostic strings.Builder
+	for rows.Next() {
+		var line string
+		if rows.Scan(&line) == nil && diagnostic.Len()+len(line) < 16<<10 {
+			diagnostic.WriteString(line)
+			diagnostic.WriteByte(';')
+		}
 	}
 	return diagnostic.String()
 }

--- a/internal/postgres/postgres_integration_test.go
+++ b/internal/postgres/postgres_integration_test.go
@@ -49,14 +49,7 @@ func TestPostgresPlatformSubstrateIntegration(t *testing.T) {
 		t.Fatalf("pristine DSN pair proof failed: %v", err)
 	}
 	if state, err := MigratePristinePair(ctx, Config{DSNFile: pairAppFile}, Config{DSNFile: pairOwnerFile}); err != nil || state.Classification != Compatible {
-		pairDB, openErr := open(ctx, pairOwnerDSN)
-		var cutoverAvailable bool
-		var cutoverErr error
-		if openErr == nil {
-			cutoverAvailable, cutoverErr = mailCutoverControlsAvailable(ctx, pairDB)
-			_ = pairDB.Close()
-		}
-		t.Fatalf("connection-bound pair migration state=%#v err=%v catalog=%s cutover_constraints=%s cutover_available=%t cutover_err=%v diagnostic_open_err=%v", state, err, m6CatalogDiagnostic(ctx, pairOwnerDSN), mailCutoverConstraintDiagnostic(ctx, pairOwnerDSN), cutoverAvailable, cutoverErr, openErr)
+		t.Fatalf("connection-bound pair migration state=%#v err=%v catalog=%s", state, err, m6CatalogDiagnostic(ctx, pairOwnerDSN))
 	}
 	pairDB, err := open(ctx, pairOwnerDSN)
 	if err != nil {
@@ -1397,28 +1390,6 @@ func m6CatalogDiagnostic(ctx context.Context, ownerDSN string) string {
 			}
 		}
 		_ = rows.Close()
-	}
-	return diagnostic.String()
-}
-
-func mailCutoverConstraintDiagnostic(ctx context.Context, ownerDSN string) string {
-	db, err := sql.Open("pgx", ownerDSN)
-	if err != nil {
-		return "open-failed"
-	}
-	defer func() { _ = db.Close() }()
-	rows, err := db.QueryContext(ctx, `SELECT format('%s:%s:%s:%s:%s:%s:%s:%s:%s', conname, contype, conkey::text, confrelid::regclass::text, COALESCE(confkey,'{}'::smallint[])::text, convalidated, condeferrable, condeferred, COALESCE(pg_get_expr(conbin,conrelid),'')) FROM pg_constraint WHERE conrelid=ANY(ARRAY[to_regclass('relay.mail_cutover_epochs'),to_regclass('relay.mail_cutover_staging'),to_regclass('relay.mail_cutover_checkpoints')]) ORDER BY conrelid::regclass::text,conname`)
-	if err != nil {
-		return "query-failed"
-	}
-	defer func() { _ = rows.Close() }()
-	var diagnostic strings.Builder
-	for rows.Next() {
-		var line string
-		if rows.Scan(&line) == nil && diagnostic.Len()+len(line) < 16<<10 {
-			diagnostic.WriteString(line)
-			diagnostic.WriteByte(';')
-		}
 	}
 	return diagnostic.String()
 }

--- a/internal/postgres/relay_store.go
+++ b/internal/postgres/relay_store.go
@@ -702,7 +702,8 @@ WITH objects AS (
            to_regclass('relay.mail_deliveries_pending') AS deliveries_index_oid,
            to_regclass('relay.mail_request_nonces_expiry') AS nonces_index_oid,
            to_regprocedure('relay.consume_mail_request_nonce(text,text,timestamp with time zone,timestamp with time zone)') AS consume_oid,
-           to_regprocedure('jobs.guard_application_mutation()') AS guard_oid
+           to_regprocedure('jobs.guard_application_mutation()') AS legacy_guard_oid,
+           to_regprocedure('relay.guard_mail_mutation()') AS cutover_guard_oid
 ), table_ownership AS (
     SELECT count(*)=9 AND bool_and(pg_get_userbyid(relation.relowner)='punaro_owner' AND relation.relkind='r' AND relation.relpersistence='p' AND NOT relation.relrowsecurity AND NOT relation.relforcerowsecurity) AS exact
     FROM objects JOIN pg_class AS relation ON relation.oid=ANY(ARRAY[endpoints_oid,conversations_oid,memberships_oid,messages_oid,deliveries_oid,cursors_oid,message_idempotency_oid,conversation_idempotency_oid,nonces_oid])
@@ -847,7 +848,7 @@ WITH objects AS (
     ) AS expected(table_oid, trigger_name)
 ), guards AS (
     SELECT count(*)=9
-       AND bool_and(trg.tgfoid=objects.guard_oid AND trg.tgenabled='O' AND NOT trg.tgisinternal
+       AND bool_and(trg.tgfoid IN (objects.legacy_guard_oid, objects.cutover_guard_oid) AND trg.tgenabled='O' AND NOT trg.tgisinternal
                     AND trg.tgtype=30 AND trg.tgconstraint=0
                     AND NOT trg.tgdeferrable AND NOT trg.tginitdeferred AND trg.tgnargs=0
                     AND trg.tgqual IS NULL AND trg.tgnewtable IS NULL AND trg.tgoldtable IS NULL

--- a/internal/postgres/relay_store.go
+++ b/internal/postgres/relay_store.go
@@ -918,7 +918,7 @@ SELECT endpoints_oid IS NOT NULL AND conversations_oid IS NOT NULL AND membershi
    AND messages_oid IS NOT NULL AND deliveries_oid IS NOT NULL AND cursors_oid IS NOT NULL
    AND message_idempotency_oid IS NOT NULL AND conversation_idempotency_oid IS NOT NULL AND nonces_oid IS NOT NULL
    AND endpoints_index_oid IS NOT NULL AND deliveries_index_oid IS NOT NULL AND nonces_index_oid IS NOT NULL
-   AND consume_oid IS NOT NULL AND guard_oid IS NOT NULL
+   AND consume_oid IS NOT NULL AND (legacy_guard_oid IS NOT NULL OR cutover_guard_oid IS NOT NULL)
 	   AND table_ownership.exact AND columns.exact AND defaults.exact AND constraints.exact AND guards.exact AND function_safety.exact AND index_safety.exact
 	   AND table_acl.exact AND column_acl.exact
 	   AND has_function_privilege('punaro_app',consume_oid,'EXECUTE')

--- a/internal/postgres/state_test.go
+++ b/internal/postgres/state_test.go
@@ -66,8 +66,8 @@ func TestManifestValidationRejectsMutableOrNonContiguousHistory(t *testing.T) {
 
 func TestCurrentManifestRequiresControlPlaneSchema(t *testing.T) {
 	manifest := CurrentManifest()
-	if manifest.MinSupported != 7 || manifest.MaxSupported != 7 || len(manifest.Migrations) != 7 {
-		t.Fatalf("manifest=%#v, want exact v7 compatibility window", manifest)
+	if manifest.MinSupported != 8 || manifest.MaxSupported != 8 || len(manifest.Migrations) != 8 {
+		t.Fatalf("manifest=%#v, want exact v8 compatibility window", manifest)
 	}
 	for index, migration := range manifest.Migrations {
 		if migration.CompatibilityFloor != int64(index+1) {

--- a/internal/postgres/update.go
+++ b/internal/postgres/update.go
@@ -392,12 +392,34 @@ func (a *Administration) BeginUpdate(ctx context.Context, request UpdateRequest)
 	if request.Validate() != nil {
 		return UpdateTransaction{}, errors.New("invalid update request")
 	}
-	transaction, err := scanUpdate(a.db.QueryRowContext(ctx, `SELECT `+updateSelectColumns+` FROM jobs.begin_update($1::uuid,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14)`, request.UpdateID, request.SourceRelease, request.TargetRelease, request.SourceImage, request.TargetImage, request.SourceSchema, request.TargetSchema, request.SchemaMin, request.SchemaMax, request.RollbackFloor, request.PostgresMajor, request.ReleaseSHA256, request.ComposeSHA256, request.MigrationManifestSHA256))
+	tx, err := a.db.BeginTx(ctx, nil)
+	if err != nil {
+		return UpdateTransaction{}, errors.New("update transaction could not acquire the maintenance fence")
+	}
+	defer func() { _ = tx.Rollback() }()
+	transaction, err := scanUpdate(tx.QueryRowContext(ctx, `SELECT `+updateSelectColumns+` FROM jobs.begin_update($1::uuid,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14)`, request.UpdateID, request.SourceRelease, request.TargetRelease, request.SourceImage, request.TargetImage, request.SourceSchema, request.TargetSchema, request.SchemaMin, request.SchemaMax, request.RollbackFloor, request.PostgresMajor, request.ReleaseSHA256, request.ComposeSHA256, request.MigrationManifestSHA256))
 	if err != nil {
 		if strings.Contains(err.Error(), "update fence is already owned") {
 			return UpdateTransaction{}, ErrUpdateConflict
 		}
 		return UpdateTransaction{}, errors.New("update transaction could not acquire the maintenance fence")
+	}
+	if transaction.Phase != UpdateCommitted && transaction.Phase != UpdateRecovered && transaction.Phase != UpdateAborted {
+		if _, err := tx.ExecContext(ctx, `SELECT pg_advisory_xact_lock($1)`, mailCutoverLockKey); err != nil {
+			return UpdateTransaction{}, errors.New("update transaction could not acquire the mail cutover fence")
+		}
+		var cutoverControls, cutoverActive bool
+		if err := tx.QueryRowContext(ctx, `SELECT to_regclass('relay.mail_cutover_epochs') IS NOT NULL`).Scan(&cutoverControls); err != nil {
+			return UpdateTransaction{}, errors.New("update transaction could not inspect the mail cutover fence")
+		}
+		if cutoverControls {
+			if err := tx.QueryRowContext(ctx, `SELECT EXISTS (SELECT 1 FROM relay.mail_cutover_epochs WHERE phase IN ('importing','verified'))`).Scan(&cutoverActive); err != nil || cutoverActive {
+				return UpdateTransaction{}, ErrUpdateConflict
+			}
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		return UpdateTransaction{}, errors.New("update transaction could not commit the maintenance fence")
 	}
 	return transaction, nil
 }

--- a/internal/relay/migration_source.go
+++ b/internal/relay/migration_source.go
@@ -631,8 +631,11 @@ func openMigrationSourceDatabase(path string, readOnly bool) (*sql.DB, error) {
 	}
 	directoryInfo, err := os.Lstat(filepath.Dir(path))
 	if err != nil || !directoryInfo.IsDir() || directoryInfo.Mode()&os.ModeSymlink != 0 {
-		return nil, errors.New("relay migration source path must not traverse symlinks")
+		return nil, errors.New("relay migration source parent must be a real directory")
 	}
+	// The later host-local executor supplies this privileged path from Punaro's
+	// private relay data directory; it is not a caller-selected confinement root.
+	// Reject last-hop redirection while allowing platform aliases in ancestors.
 	mode := "rw"
 	if readOnly {
 		mode = "ro"

--- a/internal/relay/migration_source.go
+++ b/internal/relay/migration_source.go
@@ -629,16 +629,8 @@ func openMigrationSourceDatabase(path string, readOnly bool) (*sql.DB, error) {
 	if err != nil || !info.Mode().IsRegular() || info.Mode()&os.ModeSymlink != 0 {
 		return nil, errors.New("relay migration source must be an existing regular file")
 	}
-	directory := filepath.Dir(path)
-	resolvedDirectory, err := filepath.EvalSymlinks(directory)
-	canonicalDirectory := directory
-	for alias, target := range map[string]string{"/var": "/private/var", "/tmp": "/private/tmp"} {
-		if directory == alias || strings.HasPrefix(directory, alias+string(filepath.Separator)) {
-			canonicalDirectory = target + strings.TrimPrefix(directory, alias)
-			break
-		}
-	}
-	if err != nil || resolvedDirectory != canonicalDirectory {
+	directoryInfo, err := os.Lstat(filepath.Dir(path))
+	if err != nil || !directoryInfo.IsDir() || directoryInfo.Mode()&os.ModeSymlink != 0 {
 		return nil, errors.New("relay migration source path must not traverse symlinks")
 	}
 	mode := "rw"

--- a/internal/relay/migration_source.go
+++ b/internal/relay/migration_source.go
@@ -1,0 +1,674 @@
+package relay
+
+import (
+	"context"
+	"crypto/sha256"
+	"database/sql"
+	"encoding/binary"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"hash"
+	"net/url"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// MigrationSourcePhase is the durable SQLite authority boundary.
+type MigrationSourcePhase string
+
+const (
+	// MigrationSourceActive permits ordinary SQLite relay writes.
+	MigrationSourceActive MigrationSourcePhase = "active"
+	// MigrationSourcePrepared is the abortable durable write barrier.
+	MigrationSourcePrepared MigrationSourcePhase = "prepared"
+	// MigrationSourceRetired is the irreversible forensic-only barrier.
+	MigrationSourceRetired MigrationSourcePhase = "retired"
+)
+
+// MigrationSourceCounts are the exact logical row counts bound into a source
+// manifest. Cutover metadata is intentionally excluded.
+type MigrationSourceCounts struct {
+	Endpoints               int64 `json:"endpoints"`
+	Conversations           int64 `json:"conversations"`
+	Memberships             int64 `json:"memberships"`
+	Messages                int64 `json:"messages"`
+	Deliveries              int64 `json:"deliveries"`
+	RecipientCursors        int64 `json:"recipient_cursors"`
+	MessageIdempotency      int64 `json:"message_idempotency"`
+	ConversationIdempotency int64 `json:"conversation_idempotency"`
+	RequestNonces           int64 `json:"request_nonces"`
+}
+
+// MigrationSourceHashes are per-table hashes over canonical ordered rows.
+type MigrationSourceHashes struct {
+	Endpoints               string `json:"endpoints"`
+	Conversations           string `json:"conversations"`
+	Memberships             string `json:"memberships"`
+	Messages                string `json:"messages"`
+	Deliveries              string `json:"deliveries"`
+	RecipientCursors        string `json:"recipient_cursors"`
+	MessageIdempotency      string `json:"message_idempotency"`
+	ConversationIdempotency string `json:"conversation_idempotency"`
+	RequestNonces           string `json:"request_nonces"`
+}
+
+// MigrationSourceManifest is a content-addressed logical view of one SQLite
+// relay. It never includes file bytes, page order, WAL state, or secrets.
+type MigrationSourceManifest struct {
+	Version                 int                   `json:"version"`
+	SourceID                string                `json:"source_id"`
+	Phase                   MigrationSourcePhase  `json:"phase"`
+	EpochID                 string                `json:"epoch_id,omitempty"`
+	TargetIdentity          string                `json:"target_identity,omitempty"`
+	Counts                  MigrationSourceCounts `json:"counts"`
+	TableSHA256             MigrationSourceHashes `json:"table_sha256"`
+	Fingerprint             string                `json:"fingerprint"`
+	lastEpochID             string
+	lastTargetIdentity      string
+	lastExpectedFingerprint string
+	lastResultFingerprint   string
+	lastCutoff              int64
+	lastTransition          string
+}
+
+type migrationTableSpec struct {
+	name, columns, order string
+}
+
+var migrationTableSpecs = []migrationTableSpec{
+	{"endpoints", "endpoint,machine_id,lease_until,ownership_generation,consumer_id,consumer_generation,consumer_lease_until", "endpoint"},
+	{"conversations", "id,next_sequence,created_at", "id"},
+	{"memberships", "conversation_id,endpoint,capabilities", "conversation_id,endpoint"},
+	{"messages", "id,conversation_id,sequence,from_endpoint,body,created_at", "id"},
+	{"deliveries", "id,message_id,recipient_endpoint,lease_machine_id,lease_token,lease_generation,ownership_generation,consumer_generation,lease_until,acked_at", "id"},
+	{"recipient_cursors", "recipient_endpoint,conversation_id,sequence", "recipient_endpoint,conversation_id"},
+	{"idempotency", "machine_id,key,request_hash,message_id,created_at", "machine_id,key"},
+	{"conversation_idempotency", "machine_id,key,request_hash,conversation_id,created_at", "machine_id,key"},
+	{"request_nonces", "machine_id,nonce,expires_at", "machine_id,nonce"},
+}
+
+const migrationSourceSchema = "punaro-relay-sqlite-v1:endpoints;conversations;memberships;messages;deliveries;recipient_cursors;idempotency;conversation_idempotency;request_nonces"
+
+// InspectMigrationSource reads an existing source without creating, migrating,
+// checkpointing, or changing its logical cutover state.
+func InspectMigrationSource(ctx context.Context, path string) (MigrationSourceManifest, error) {
+	db, err := openMigrationSourceDatabase(path, true)
+	if err != nil {
+		return MigrationSourceManifest{}, err
+	}
+	defer func() { _ = db.Close() }()
+	tx, err := db.BeginTx(ctx, &sql.TxOptions{ReadOnly: true})
+	if err != nil {
+		return MigrationSourceManifest{}, errors.New("relay migration source snapshot cannot start")
+	}
+	defer func() { _ = tx.Rollback() }()
+	manifest, err := inspectMigrationSource(ctx, tx)
+	if err != nil {
+		return MigrationSourceManifest{}, err
+	}
+	if err := tx.Commit(); err != nil {
+		return MigrationSourceManifest{}, errors.New("relay migration source snapshot cannot commit")
+	}
+	return manifest, nil
+}
+
+// PrepareMigrationSource fences every SQLite relay mutation, advances all
+// carried lease fences, and records the exact post-fence logical fingerprint.
+func PrepareMigrationSource(ctx context.Context, path, epochID, targetIdentity, expectedFingerprint string, now time.Time) (MigrationSourceManifest, error) {
+	if uuid.Validate(epochID) != nil || !validMigrationDigest(targetIdentity) || !validMigrationDigest(expectedFingerprint) || now.IsZero() {
+		return MigrationSourceManifest{}, errors.New("invalid relay migration preparation")
+	}
+	return mutateMigrationSource(ctx, path, func(conn *sql.Conn, current MigrationSourceManifest) (MigrationSourceManifest, error) {
+		if current.Phase == MigrationSourcePrepared && current.EpochID == epochID && current.TargetIdentity == targetIdentity && current.lastEpochID == epochID && current.lastTargetIdentity == targetIdentity && current.lastExpectedFingerprint == expectedFingerprint && current.lastResultFingerprint == current.Fingerprint && current.lastCutoff == now.UTC().UnixMilli() && current.lastTransition == "prepared" {
+			return current, nil
+		}
+		if current.Phase != MigrationSourceActive || current.Fingerprint != expectedFingerprint {
+			return MigrationSourceManifest{}, errors.New("relay migration source changed before preparation")
+		}
+		if _, err := conn.ExecContext(ctx, `UPDATE endpoints SET lease_until=?,ownership_generation=ownership_generation+1,
+			consumer_id=NULL,consumer_generation=consumer_generation+CASE WHEN consumer_id IS NULL THEN 0 ELSE 1 END,consumer_lease_until=NULL`, now.UTC().UnixMilli()); err != nil {
+			return MigrationSourceManifest{}, errors.New("relay migration endpoint fencing failed")
+		}
+		if _, err := conn.ExecContext(ctx, `UPDATE deliveries SET lease_machine_id=NULL,lease_token=NULL,
+			lease_generation=lease_generation+CASE WHEN lease_token IS NULL THEN 0 ELSE 1 END,
+			ownership_generation=NULL,consumer_generation=NULL,lease_until=NULL`); err != nil {
+			return MigrationSourceManifest{}, errors.New("relay migration delivery fencing failed")
+		}
+		prepared, err := inspectMigrationSource(ctx, conn)
+		if err != nil {
+			return MigrationSourceManifest{}, err
+		}
+		if _, err := conn.ExecContext(ctx, `UPDATE relay_migration_control SET phase='prepared',epoch_id=?,target_identity=?,fingerprint=?,last_epoch_id=?,last_target_identity=?,last_expected_fingerprint=?,last_result_fingerprint=?,last_cutoff=?,last_transition='prepared',changed_at=? WHERE singleton=1 AND phase='active'`, epochID, targetIdentity, prepared.Fingerprint, epochID, targetIdentity, expectedFingerprint, prepared.Fingerprint, now.UTC().UnixMilli(), now.UTC().UnixMilli()); err != nil {
+			return MigrationSourceManifest{}, errors.New("relay migration source cannot be prepared")
+		}
+		prepared.Phase = MigrationSourcePrepared
+		prepared.EpochID = epochID
+		prepared.TargetIdentity = targetIdentity
+		prepared.lastEpochID = epochID
+		prepared.lastTargetIdentity = targetIdentity
+		prepared.lastExpectedFingerprint = expectedFingerprint
+		prepared.lastResultFingerprint = prepared.Fingerprint
+		prepared.lastCutoff = now.UTC().UnixMilli()
+		prepared.lastTransition = "prepared"
+		return prepared, nil
+	})
+}
+
+// AbortPreparedMigrationSource reopens SQLite only before the permanent retire
+// boundary and only for the exact prepared epoch/source/target binding.
+func AbortPreparedMigrationSource(ctx context.Context, path, epochID, targetIdentity, fingerprint string) (MigrationSourceManifest, error) {
+	return transitionPreparedMigrationSource(ctx, path, epochID, targetIdentity, fingerprint, MigrationSourceActive)
+}
+
+// RetirePreparedMigrationSource permanently marks SQLite forensic-only.
+func RetirePreparedMigrationSource(ctx context.Context, path, epochID, targetIdentity, fingerprint string) (MigrationSourceManifest, error) {
+	return transitionPreparedMigrationSource(ctx, path, epochID, targetIdentity, fingerprint, MigrationSourceRetired)
+}
+
+func transitionPreparedMigrationSource(ctx context.Context, path, epochID, targetIdentity, fingerprint string, target MigrationSourcePhase) (MigrationSourceManifest, error) {
+	if uuid.Validate(epochID) != nil || !validMigrationDigest(targetIdentity) || !validMigrationDigest(fingerprint) || target != MigrationSourceActive && target != MigrationSourceRetired {
+		return MigrationSourceManifest{}, errors.New("invalid relay migration transition")
+	}
+	return mutateMigrationSource(ctx, path, func(conn *sql.Conn, current MigrationSourceManifest) (MigrationSourceManifest, error) {
+		if current.Phase == MigrationSourceRetired {
+			if target == MigrationSourceRetired && current.EpochID == epochID && current.TargetIdentity == targetIdentity && current.Fingerprint == fingerprint && current.lastEpochID == epochID && current.lastTargetIdentity == targetIdentity && current.lastResultFingerprint == fingerprint && current.lastTransition == "retired" {
+				return current, nil
+			}
+			return MigrationSourceManifest{}, ErrMigrationSourceRetired
+		}
+		if current.Phase == MigrationSourceActive && target == MigrationSourceActive && current.Fingerprint == fingerprint && current.lastEpochID == epochID && current.lastTargetIdentity == targetIdentity && current.lastResultFingerprint == fingerprint && current.lastTransition == "aborted" {
+			return current, nil
+		}
+		if current.Phase != MigrationSourcePrepared || current.EpochID != epochID || current.TargetIdentity != targetIdentity || current.Fingerprint != fingerprint {
+			return MigrationSourceManifest{}, errors.New("relay migration source binding does not match")
+		}
+		if target == MigrationSourceActive {
+			if _, err := conn.ExecContext(ctx, `UPDATE relay_migration_control SET phase='active',epoch_id=NULL,target_identity=NULL,fingerprint=NULL,last_transition='aborted',changed_at=? WHERE singleton=1 AND phase='prepared'`, time.Now().UTC().UnixMilli()); err != nil {
+				return MigrationSourceManifest{}, errors.New("relay migration source cannot be reopened")
+			}
+			current.Phase, current.EpochID, current.TargetIdentity = MigrationSourceActive, "", ""
+			current.lastTransition = "aborted"
+			return current, nil
+		}
+		if _, err := conn.ExecContext(ctx, `UPDATE relay_migration_control SET phase='retired',last_transition='retired',changed_at=? WHERE singleton=1 AND phase='prepared'`, time.Now().UTC().UnixMilli()); err != nil {
+			return MigrationSourceManifest{}, errors.New("relay migration source cannot be retired")
+		}
+		current.Phase = MigrationSourceRetired
+		current.lastTransition = "retired"
+		return current, nil
+	})
+}
+
+func mutateMigrationSource(ctx context.Context, path string, mutation func(*sql.Conn, MigrationSourceManifest) (MigrationSourceManifest, error)) (MigrationSourceManifest, error) {
+	db, err := openMigrationSourceDatabase(path, false)
+	if err != nil {
+		return MigrationSourceManifest{}, err
+	}
+	defer func() { _ = db.Close() }()
+	conn, err := db.Conn(ctx)
+	if err != nil {
+		return MigrationSourceManifest{}, errors.New("relay migration source connection is unavailable")
+	}
+	defer func() { _ = conn.Close() }()
+	if _, err := conn.ExecContext(ctx, "PRAGMA busy_timeout = 5000"); err != nil {
+		return MigrationSourceManifest{}, errors.New("relay migration source timeout cannot be configured")
+	}
+	if _, err := conn.ExecContext(ctx, "BEGIN IMMEDIATE"); err != nil {
+		return MigrationSourceManifest{}, errors.New("relay migration source writer barrier is unavailable")
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_, _ = conn.ExecContext(context.Background(), "ROLLBACK")
+		}
+	}()
+	current, err := inspectMigrationSource(ctx, conn)
+	if err != nil {
+		return MigrationSourceManifest{}, err
+	}
+	result, err := mutation(conn, current)
+	if err != nil {
+		return MigrationSourceManifest{}, err
+	}
+	if _, err := conn.ExecContext(ctx, "COMMIT"); err != nil {
+		return MigrationSourceManifest{}, errors.New("relay migration source transition cannot commit")
+	}
+	committed = true
+	return result, nil
+}
+
+type migrationQueryer interface {
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
+}
+
+func inspectMigrationSource(ctx context.Context, q migrationQueryer) (MigrationSourceManifest, error) {
+	manifest := MigrationSourceManifest{Version: 1}
+	var storedFingerprint sql.NullString
+	var controlRows int
+	if err := q.QueryRowContext(ctx, `SELECT count(*) FROM relay_migration_control`).Scan(&controlRows); err != nil || controlRows != 1 {
+		return MigrationSourceManifest{}, errors.New("relay migration source control is unavailable")
+	}
+	if err := q.QueryRowContext(ctx, `SELECT source_id,phase,COALESCE(epoch_id,''),COALESCE(target_identity,''),fingerprint,COALESCE(last_epoch_id,''),COALESCE(last_target_identity,''),COALESCE(last_expected_fingerprint,''),COALESCE(last_result_fingerprint,''),COALESCE(last_cutoff,0),COALESCE(last_transition,'') FROM relay_migration_control WHERE singleton=1`).Scan(&manifest.SourceID, &manifest.Phase, &manifest.EpochID, &manifest.TargetIdentity, &storedFingerprint, &manifest.lastEpochID, &manifest.lastTargetIdentity, &manifest.lastExpectedFingerprint, &manifest.lastResultFingerprint, &manifest.lastCutoff, &manifest.lastTransition); err != nil || uuid.Validate(manifest.SourceID) != nil {
+		return MigrationSourceManifest{}, errors.New("relay migration source control is unavailable")
+	}
+	if manifest.Phase != MigrationSourceActive && manifest.Phase != MigrationSourcePrepared && manifest.Phase != MigrationSourceRetired {
+		return MigrationSourceManifest{}, errors.New("relay migration source phase is invalid")
+	}
+	if manifest.Phase == MigrationSourceActive {
+		if manifest.EpochID != "" || manifest.TargetIdentity != "" || storedFingerprint.Valid {
+			return MigrationSourceManifest{}, errors.New("relay migration active binding is invalid")
+		}
+	} else if uuid.Validate(manifest.EpochID) != nil || !validMigrationDigest(manifest.TargetIdentity) || !storedFingerprint.Valid || !validMigrationDigest(storedFingerprint.String) {
+		return MigrationSourceManifest{}, errors.New("relay migration durable binding is invalid")
+	}
+	if manifest.lastTransition != "" && manifest.lastTransition != "prepared" && manifest.lastTransition != "aborted" && manifest.lastTransition != "retired" {
+		return MigrationSourceManifest{}, errors.New("relay migration transition journal is invalid")
+	}
+	if err := verifyMigrationSourceSchema(ctx, q); err != nil {
+		return MigrationSourceManifest{}, err
+	}
+	overall := sha256.New()
+	if err := writeMigrationHashValue(overall, migrationSourceSchema); err != nil {
+		return MigrationSourceManifest{}, err
+	}
+	if err := writeMigrationHashValue(overall, manifest.SourceID); err != nil {
+		return MigrationSourceManifest{}, err
+	}
+	for _, spec := range migrationTableSpecs {
+		tableHash := sha256.New()
+		query := fmt.Sprintf("SELECT %s FROM %s ORDER BY %s", spec.columns, spec.name, spec.order)
+		rows, err := q.QueryContext(ctx, query) // #nosec G202 -- query fragments come only from the fixed migrationTableSpecs allowlist.
+		if err != nil {
+			return MigrationSourceManifest{}, errors.New("relay migration source rows are unavailable")
+		}
+		columns, err := rows.Columns()
+		if err != nil {
+			_ = rows.Close()
+			return MigrationSourceManifest{}, errors.New("relay migration source columns are unavailable")
+		}
+		var count int64
+		for rows.Next() {
+			values := make([]any, len(columns))
+			destinations := make([]any, len(columns))
+			for index := range values {
+				destinations[index] = &values[index]
+			}
+			if err := rows.Scan(destinations...); err != nil {
+				_ = rows.Close()
+				return MigrationSourceManifest{}, errors.New("relay migration source row is malformed")
+			}
+			for _, value := range values {
+				if err := writeMigrationHashValue(tableHash, value); err != nil {
+					_ = rows.Close()
+					return MigrationSourceManifest{}, err
+				}
+			}
+			count++
+		}
+		if err := rows.Close(); err != nil {
+			return MigrationSourceManifest{}, errors.New("relay migration source rows cannot close")
+		}
+		if err := rows.Err(); err != nil {
+			return MigrationSourceManifest{}, errors.New("relay migration source rows are unavailable")
+		}
+		digest := hex.EncodeToString(tableHash.Sum(nil))
+		setMigrationTableEvidence(&manifest, spec.name, count, digest)
+		if err := writeMigrationHashValue(overall, spec.name); err != nil {
+			return MigrationSourceManifest{}, err
+		}
+		if err := writeMigrationHashValue(overall, count); err != nil {
+			return MigrationSourceManifest{}, err
+		}
+		if err := writeMigrationHashValue(overall, digest); err != nil {
+			return MigrationSourceManifest{}, err
+		}
+	}
+	manifest.Fingerprint = hex.EncodeToString(overall.Sum(nil))
+	if manifest.Phase != MigrationSourceActive && (!storedFingerprint.Valid || storedFingerprint.String != manifest.Fingerprint) {
+		return MigrationSourceManifest{}, errors.New("relay migration source fingerprint does not match its durable barrier")
+	}
+	return manifest, nil
+}
+
+func verifyMigrationSourceSchema(ctx context.Context, q migrationQueryer) error {
+	rows, err := q.QueryContext(ctx, `SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%' ORDER BY name`)
+	if err != nil {
+		return errors.New("relay migration source schema is unavailable")
+	}
+	defer func() { _ = rows.Close() }()
+	var names []string
+	for rows.Next() {
+		var name string
+		if err := rows.Scan(&name); err != nil {
+			return errors.New("relay migration source schema is malformed")
+		}
+		names = append(names, name)
+	}
+	want := []string{"conversation_idempotency", "conversations", "deliveries", "endpoints", "idempotency", "memberships", "messages", "recipient_cursors", "relay_migration_control", "request_nonces"}
+	if strings.Join(names, "\x00") != strings.Join(want, "\x00") {
+		return errors.New("relay migration source has an unexpected schema")
+	}
+	expectedColumns := map[string][]string{
+		"endpoints":                {"endpoint:TEXT:0:1:-", "machine_id:TEXT:1:0:-", "lease_until:INTEGER:1:0:-", "ownership_generation:INTEGER:1:0:1", "consumer_id:TEXT:0:0:-", "consumer_generation:INTEGER:1:0:0", "consumer_lease_until:INTEGER:0:0:-"},
+		"conversations":            {"id:TEXT:0:1:-", "next_sequence:INTEGER:1:0:0", "created_at:INTEGER:1:0:-"},
+		"memberships":              {"conversation_id:TEXT:1:1:-", "endpoint:TEXT:1:2:-", "capabilities:INTEGER:1:0:-"},
+		"messages":                 {"id:TEXT:0:1:-", "conversation_id:TEXT:1:0:-", "sequence:INTEGER:1:0:-", "from_endpoint:TEXT:1:0:-", "body:TEXT:1:0:-", "created_at:INTEGER:1:0:-"},
+		"deliveries":               {"id:TEXT:0:1:-", "message_id:TEXT:1:0:-", "recipient_endpoint:TEXT:1:0:-", "lease_machine_id:TEXT:0:0:-", "lease_token:TEXT:0:0:-", "lease_generation:INTEGER:1:0:0", "ownership_generation:INTEGER:0:0:-", "consumer_generation:INTEGER:0:0:-", "lease_until:INTEGER:0:0:-", "acked_at:INTEGER:0:0:-"},
+		"recipient_cursors":        {"recipient_endpoint:TEXT:1:1:-", "conversation_id:TEXT:1:2:-", "sequence:INTEGER:1:0:0"},
+		"idempotency":              {"machine_id:TEXT:1:1:-", "key:TEXT:1:2:-", "request_hash:TEXT:1:0:-", "message_id:TEXT:1:0:-", "created_at:INTEGER:1:0:-"},
+		"conversation_idempotency": {"machine_id:TEXT:1:1:-", "key:TEXT:1:2:-", "request_hash:TEXT:1:0:-", "conversation_id:TEXT:1:0:-", "created_at:INTEGER:1:0:-"},
+		"request_nonces":           {"machine_id:TEXT:1:1:-", "nonce:TEXT:1:2:-", "expires_at:INTEGER:1:0:-"},
+		"relay_migration_control":  {"singleton:INTEGER:0:1:-", "source_id:TEXT:1:0:-", "phase:TEXT:1:0:'active'", "epoch_id:TEXT:0:0:-", "target_identity:TEXT:0:0:-", "fingerprint:TEXT:0:0:-", "last_epoch_id:TEXT:0:0:-", "last_target_identity:TEXT:0:0:-", "last_expected_fingerprint:TEXT:0:0:-", "last_result_fingerprint:TEXT:0:0:-", "last_cutoff:INTEGER:0:0:-", "last_transition:TEXT:0:0:-", "changed_at:INTEGER:1:0:-"},
+	}
+	for table, expected := range expectedColumns {
+		columns, err := q.QueryContext(ctx, fmt.Sprintf("PRAGMA table_info(%s)", table)) // #nosec G202 -- table comes only from the fixed expectedColumns allowlist.
+		if err != nil {
+			return errors.New("relay migration source columns are unavailable")
+		}
+		var actual []string
+		for columns.Next() {
+			var ordinal, notNull, primaryKey int
+			var name, columnType string
+			var defaultValue sql.NullString
+			if err := columns.Scan(&ordinal, &name, &columnType, &notNull, &defaultValue, &primaryKey); err != nil {
+				_ = columns.Close()
+				return errors.New("relay migration source columns are malformed")
+			}
+			encodedDefault := "-"
+			if defaultValue.Valid {
+				encodedDefault = defaultValue.String
+			}
+			actual = append(actual, fmt.Sprintf("%s:%s:%d:%d:%s", name, strings.ToUpper(columnType), notNull, primaryKey, encodedDefault))
+		}
+		sort.Strings(actual)
+		sort.Strings(expected)
+		if err := columns.Close(); err != nil || columns.Err() != nil || strings.Join(actual, "\x00") != strings.Join(expected, "\x00") {
+			return errors.New("relay migration source has unexpected columns")
+		}
+	}
+	expectedForeignKeys := map[string][]string{
+		"memberships":              {"conversations:conversation_id:id:NO ACTION:CASCADE:NONE"},
+		"messages":                 {"conversations:conversation_id:id:NO ACTION:CASCADE:NONE"},
+		"deliveries":               {"messages:message_id:id:NO ACTION:CASCADE:NONE"},
+		"recipient_cursors":        {"conversations:conversation_id:id:NO ACTION:CASCADE:NONE"},
+		"idempotency":              {"messages:message_id:id:NO ACTION:CASCADE:NONE"},
+		"conversation_idempotency": {"conversations:conversation_id:id:NO ACTION:CASCADE:NONE"},
+	}
+	for table := range expectedColumns {
+		foreignKeys, err := q.QueryContext(ctx, fmt.Sprintf("PRAGMA foreign_key_list(%s)", table)) // #nosec G202 -- table comes only from the fixed expectedColumns allowlist.
+		if err != nil {
+			return errors.New("relay migration source foreign key schema is unavailable")
+		}
+		var actual []string
+		for foreignKeys.Next() {
+			var id, sequence int
+			var foreignTable, from, to, onUpdate, onDelete, match string
+			if err := foreignKeys.Scan(&id, &sequence, &foreignTable, &from, &to, &onUpdate, &onDelete, &match); err != nil {
+				_ = foreignKeys.Close()
+				return errors.New("relay migration source foreign key schema is malformed")
+			}
+			actual = append(actual, strings.Join([]string{foreignTable, from, to, onUpdate, onDelete, match}, ":"))
+		}
+		expected := append([]string(nil), expectedForeignKeys[table]...)
+		sort.Strings(actual)
+		sort.Strings(expected)
+		if err := foreignKeys.Close(); err != nil || foreignKeys.Err() != nil || strings.Join(actual, "\x00") != strings.Join(expected, "\x00") {
+			return errors.New("relay migration source has unexpected foreign keys")
+		}
+	}
+	expectedIndexes := []string{
+		"endpoints:1:pk:0:endpoint",
+		"conversations:1:pk:0:id",
+		"memberships:1:pk:0:conversation_id,endpoint",
+		"messages:1:pk:0:id", "messages:1:u:0:conversation_id,sequence",
+		"deliveries:1:pk:0:id", "deliveries:1:u:0:message_id,recipient_endpoint", "deliveries:0:c:0:recipient_endpoint,acked_at,lease_until",
+		"recipient_cursors:1:pk:0:recipient_endpoint,conversation_id",
+		"idempotency:1:pk:0:machine_id,key",
+		"conversation_idempotency:1:pk:0:machine_id,key",
+		"request_nonces:1:pk:0:machine_id,nonce", "request_nonces:0:c:0:expires_at",
+	}
+	var actualIndexes []string
+	for table := range expectedColumns {
+		indexes, err := q.QueryContext(ctx, fmt.Sprintf("PRAGMA index_list(%s)", table)) // #nosec G202 -- table comes only from the fixed expectedColumns allowlist.
+		if err != nil {
+			return errors.New("relay migration source index schema is unavailable")
+		}
+		type indexMetadata struct {
+			name, origin    string
+			unique, partial int
+		}
+		var metadata []indexMetadata
+		for indexes.Next() {
+			var sequence, unique, partial int
+			var name, origin string
+			if err := indexes.Scan(&sequence, &name, &unique, &origin, &partial); err != nil {
+				_ = indexes.Close()
+				return errors.New("relay migration source index schema is malformed")
+			}
+			metadata = append(metadata, indexMetadata{name: name, origin: origin, unique: unique, partial: partial})
+		}
+		if err := indexes.Close(); err != nil || indexes.Err() != nil {
+			return errors.New("relay migration source index schema is unavailable")
+		}
+		for _, index := range metadata {
+			escapedName := strings.ReplaceAll(index.name, "'", "''")
+			indexColumns, err := q.QueryContext(ctx, "PRAGMA index_info('"+escapedName+"')") // #nosec G202 -- SQLite quotes are escaped before inspecting an existing schema object.
+			if err != nil {
+				return errors.New("relay migration source index columns are unavailable")
+			}
+			var columns []string
+			for indexColumns.Next() {
+				var ordinal, columnID int
+				var column string
+				if err := indexColumns.Scan(&ordinal, &columnID, &column); err != nil {
+					_ = indexColumns.Close()
+					return errors.New("relay migration source index columns are malformed")
+				}
+				columns = append(columns, column)
+			}
+			if err := indexColumns.Close(); err != nil || indexColumns.Err() != nil {
+				return errors.New("relay migration source index columns are unavailable")
+			}
+			actualIndexes = append(actualIndexes, fmt.Sprintf("%s:%d:%s:%d:%s", table, index.unique, index.origin, index.partial, strings.Join(columns, ",")))
+		}
+	}
+	sort.Strings(expectedIndexes)
+	sort.Strings(actualIndexes)
+	if strings.Join(actualIndexes, "\x00") != strings.Join(expectedIndexes, "\x00") {
+		return errors.New("relay migration source has unexpected indexes")
+	}
+	triggerRows, err := q.QueryContext(ctx, `SELECT name,tbl_name,sql FROM sqlite_master WHERE type='trigger' ORDER BY name`)
+	if err != nil {
+		return errors.New("relay migration source guards are unavailable")
+	}
+	seenTriggers := make(map[string]struct{}, 27)
+	for triggerRows.Next() {
+		var name, table, statement string
+		if err := triggerRows.Scan(&name, &table, &statement); err != nil {
+			_ = triggerRows.Close()
+			return errors.New("relay migration source guard is malformed")
+		}
+		matched := false
+		for _, operation := range []string{"insert", "update", "delete"} {
+			expectedName := "relay_migration_guard_" + table + "_" + operation
+			if name != expectedName {
+				continue
+			}
+			normalized := strings.ToLower(strings.Join(strings.Fields(statement), " "))
+			normalized = strings.Replace(normalized, "create trigger if not exists ", "create trigger ", 1)
+			expectedStatement := fmt.Sprintf("create trigger %s before %s on %s when coalesce((select phase from relay_migration_control where singleton=1), 'missing') <> 'active' begin select raise(abort, 'relay migration source is not writable'); end", name, operation, table)
+			if normalized != expectedStatement {
+				_ = triggerRows.Close()
+				return errors.New("relay migration source guard definition is unexpected")
+			}
+			matched = true
+			seenTriggers[name] = struct{}{}
+			break
+		}
+		if !matched {
+			_ = triggerRows.Close()
+			return errors.New("relay migration source has an unexpected trigger")
+		}
+	}
+	if err := triggerRows.Close(); err != nil || triggerRows.Err() != nil || len(seenTriggers) != 27 {
+		return errors.New("relay migration source guard inventory is incomplete")
+	}
+	var integrity string
+	if err := q.QueryRowContext(ctx, `PRAGMA quick_check`).Scan(&integrity); err != nil || integrity != "ok" {
+		return errors.New("relay migration source integrity check failed")
+	}
+	foreignKeyRows, err := q.QueryContext(ctx, `PRAGMA foreign_key_check`)
+	if err != nil {
+		return errors.New("relay migration source foreign keys cannot be checked")
+	}
+	defer func() { _ = foreignKeyRows.Close() }()
+	if foreignKeyRows.Next() || foreignKeyRows.Err() != nil {
+		return errors.New("relay migration source foreign keys are invalid")
+	}
+	var invalidLogicalState bool
+	if err := q.QueryRowContext(ctx, `WITH uuid_values(value) AS (
+		SELECT id FROM conversations UNION ALL SELECT conversation_id FROM memberships
+		UNION ALL SELECT id FROM messages UNION ALL SELECT conversation_id FROM messages
+		UNION ALL SELECT id FROM deliveries UNION ALL SELECT message_id FROM deliveries
+		UNION ALL SELECT conversation_id FROM recipient_cursors
+		UNION ALL SELECT message_id FROM idempotency
+		UNION ALL SELECT conversation_id FROM conversation_idempotency
+	)
+	SELECT
+        EXISTS (SELECT 1 FROM endpoints WHERE ownership_generation<1 OR consumer_generation<0 OR (consumer_id IS NULL)<>(consumer_lease_until IS NULL))
+        OR EXISTS (SELECT 1 FROM conversations WHERE next_sequence<0)
+        OR EXISTS (SELECT 1 FROM memberships WHERE capabilities<1 OR capabilities>7)
+        OR EXISTS (SELECT 1 FROM memberships AS membership LEFT JOIN endpoints AS endpoint ON endpoint.endpoint=membership.endpoint WHERE endpoint.endpoint IS NULL)
+        OR EXISTS (SELECT 1 FROM messages WHERE sequence<1 OR length(CAST(body AS blob))>32768)
+        OR EXISTS (SELECT 1 FROM messages AS message LEFT JOIN endpoints AS endpoint ON endpoint.endpoint=message.from_endpoint WHERE endpoint.endpoint IS NULL)
+        OR EXISTS (SELECT 1 FROM messages AS message JOIN conversations AS conversation ON conversation.id=message.conversation_id WHERE message.sequence>conversation.next_sequence)
+        OR EXISTS (SELECT 1 FROM deliveries WHERE lease_generation<0 OR (lease_token IS NOT NULL AND (ownership_generation<1 OR consumer_generation<0)) OR (acked_at IS NOT NULL AND lease_token IS NOT NULL) OR ((lease_machine_id IS NULL OR lease_token IS NULL OR ownership_generation IS NULL OR consumer_generation IS NULL OR lease_until IS NULL) AND NOT (lease_machine_id IS NULL AND lease_token IS NULL AND ownership_generation IS NULL AND consumer_generation IS NULL AND lease_until IS NULL)))
+        OR EXISTS (SELECT 1 FROM deliveries AS delivery LEFT JOIN endpoints AS endpoint ON endpoint.endpoint=delivery.recipient_endpoint WHERE endpoint.endpoint IS NULL)
+        OR EXISTS (SELECT 1 FROM recipient_cursors AS cursor JOIN conversations AS conversation ON conversation.id=cursor.conversation_id WHERE cursor.sequence<0 OR cursor.sequence>conversation.next_sequence)
+        OR EXISTS (SELECT 1 FROM recipient_cursors AS cursor LEFT JOIN endpoints AS endpoint ON endpoint.endpoint=cursor.recipient_endpoint WHERE endpoint.endpoint IS NULL)
+        OR EXISTS (SELECT 1 FROM idempotency WHERE length(request_hash)<>64 OR request_hash GLOB '*[^0-9a-f]*')
+		OR EXISTS (SELECT 1 FROM idempotency GROUP BY message_id HAVING count(*)<>1)
+        OR EXISTS (SELECT 1 FROM conversation_idempotency WHERE length(request_hash)<>64 OR request_hash GLOB '*[^0-9a-f]*')
+		OR EXISTS (SELECT 1 FROM conversation_idempotency GROUP BY conversation_id HAVING count(*)<>1)
+		OR EXISTS (SELECT 1 FROM uuid_values WHERE typeof(value)<>'text' OR length(value)<>36 OR substr(value,9,1)<>'-' OR substr(value,14,1)<>'-' OR substr(value,19,1)<>'-' OR substr(value,24,1)<>'-' OR lower(replace(value,'-','')) GLOB '*[^0-9a-f]*')
+		OR EXISTS (SELECT 1 FROM endpoints WHERE typeof(endpoint)<>'text' OR typeof(machine_id)<>'text' OR typeof(lease_until)<>'integer' OR typeof(ownership_generation)<>'integer' OR (consumer_id IS NOT NULL AND typeof(consumer_id)<>'text') OR typeof(consumer_generation)<>'integer' OR (consumer_lease_until IS NOT NULL AND typeof(consumer_lease_until)<>'integer'))
+		OR EXISTS (SELECT 1 FROM conversations WHERE typeof(next_sequence)<>'integer' OR typeof(created_at)<>'integer')
+		OR EXISTS (SELECT 1 FROM memberships WHERE typeof(endpoint)<>'text' OR typeof(capabilities)<>'integer')
+		OR EXISTS (SELECT 1 FROM messages WHERE typeof(sequence)<>'integer' OR typeof(from_endpoint)<>'text' OR typeof(body)<>'text' OR typeof(created_at)<>'integer')
+		OR EXISTS (SELECT 1 FROM deliveries WHERE typeof(recipient_endpoint)<>'text' OR (lease_machine_id IS NOT NULL AND typeof(lease_machine_id)<>'text') OR typeof(lease_generation)<>'integer' OR (lease_token IS NOT NULL AND (typeof(lease_token)<>'text' OR length(lease_token)<>64 OR lease_token GLOB '*[^0-9a-f]*')) OR (ownership_generation IS NOT NULL AND typeof(ownership_generation)<>'integer') OR (consumer_generation IS NOT NULL AND typeof(consumer_generation)<>'integer') OR (lease_until IS NOT NULL AND typeof(lease_until)<>'integer') OR (acked_at IS NOT NULL AND typeof(acked_at)<>'integer'))
+		OR EXISTS (SELECT 1 FROM recipient_cursors WHERE typeof(recipient_endpoint)<>'text' OR typeof(sequence)<>'integer')
+		OR EXISTS (SELECT 1 FROM idempotency WHERE typeof(machine_id)<>'text' OR typeof(key)<>'text' OR typeof(request_hash)<>'text' OR typeof(created_at)<>'integer')
+		OR EXISTS (SELECT 1 FROM conversation_idempotency WHERE typeof(machine_id)<>'text' OR typeof(key)<>'text' OR typeof(request_hash)<>'text' OR typeof(created_at)<>'integer')
+		OR EXISTS (SELECT 1 FROM request_nonces WHERE typeof(machine_id)<>'text' OR typeof(nonce)<>'text' OR typeof(expires_at)<>'integer')
+		OR EXISTS (SELECT 1 FROM relay_migration_control WHERE typeof(source_id)<>'text' OR typeof(phase)<>'text' OR (epoch_id IS NOT NULL AND typeof(epoch_id)<>'text') OR (target_identity IS NOT NULL AND typeof(target_identity)<>'text') OR (fingerprint IS NOT NULL AND typeof(fingerprint)<>'text') OR (last_epoch_id IS NOT NULL AND typeof(last_epoch_id)<>'text') OR (last_target_identity IS NOT NULL AND typeof(last_target_identity)<>'text') OR (last_expected_fingerprint IS NOT NULL AND typeof(last_expected_fingerprint)<>'text') OR (last_result_fingerprint IS NOT NULL AND typeof(last_result_fingerprint)<>'text') OR (last_cutoff IS NOT NULL AND typeof(last_cutoff)<>'integer') OR (last_transition IS NOT NULL AND typeof(last_transition)<>'text') OR typeof(changed_at)<>'integer')`).Scan(&invalidLogicalState); err != nil || invalidLogicalState {
+		return errors.New("relay migration source logical constraints are invalid")
+	}
+	return nil
+}
+
+func writeMigrationHashValue(destination hash.Hash, value any) error {
+	var kind byte
+	var body []byte
+	switch typed := value.(type) {
+	case nil:
+		kind = 0
+	case int64:
+		kind = 1
+		body = make([]byte, 8)
+		binary.BigEndian.PutUint64(body, uint64(typed)) // #nosec G115 -- two's-complement bits are the canonical signed-int encoding.
+	case string:
+		kind, body = 2, []byte(typed)
+	case []byte:
+		kind, body = 3, typed
+	default:
+		return errors.New("relay migration source contains an unsupported value")
+	}
+	_, _ = destination.Write([]byte{kind})
+	length := make([]byte, 8)
+	binary.BigEndian.PutUint64(length, uint64(len(body)))
+	_, _ = destination.Write(length)
+	_, _ = destination.Write(body)
+	return nil
+}
+
+func setMigrationTableEvidence(manifest *MigrationSourceManifest, table string, count int64, digest string) {
+	switch table {
+	case "endpoints":
+		manifest.Counts.Endpoints, manifest.TableSHA256.Endpoints = count, digest
+	case "conversations":
+		manifest.Counts.Conversations, manifest.TableSHA256.Conversations = count, digest
+	case "memberships":
+		manifest.Counts.Memberships, manifest.TableSHA256.Memberships = count, digest
+	case "messages":
+		manifest.Counts.Messages, manifest.TableSHA256.Messages = count, digest
+	case "deliveries":
+		manifest.Counts.Deliveries, manifest.TableSHA256.Deliveries = count, digest
+	case "recipient_cursors":
+		manifest.Counts.RecipientCursors, manifest.TableSHA256.RecipientCursors = count, digest
+	case "idempotency":
+		manifest.Counts.MessageIdempotency, manifest.TableSHA256.MessageIdempotency = count, digest
+	case "conversation_idempotency":
+		manifest.Counts.ConversationIdempotency, manifest.TableSHA256.ConversationIdempotency = count, digest
+	case "request_nonces":
+		manifest.Counts.RequestNonces, manifest.TableSHA256.RequestNonces = count, digest
+	}
+}
+
+func openMigrationSourceDatabase(path string, readOnly bool) (*sql.DB, error) {
+	if !filepath.IsAbs(path) || filepath.Clean(path) != path {
+		return nil, errors.New("relay migration source path must be clean and absolute")
+	}
+	info, err := os.Lstat(path)
+	if err != nil || !info.Mode().IsRegular() || info.Mode()&os.ModeSymlink != 0 {
+		return nil, errors.New("relay migration source must be an existing regular file")
+	}
+	directory := filepath.Dir(path)
+	resolvedDirectory, err := filepath.EvalSymlinks(directory)
+	canonicalDirectory := directory
+	for alias, target := range map[string]string{"/var": "/private/var", "/tmp": "/private/tmp"} {
+		if directory == alias || strings.HasPrefix(directory, alias+string(filepath.Separator)) {
+			canonicalDirectory = target + strings.TrimPrefix(directory, alias)
+			break
+		}
+	}
+	if err != nil || resolvedDirectory != canonicalDirectory {
+		return nil, errors.New("relay migration source path must not traverse symlinks")
+	}
+	mode := "rw"
+	if readOnly {
+		mode = "ro"
+	}
+	sourceURL := &url.URL{Scheme: "file", Path: path, RawQuery: "mode=" + mode}
+	dsn := sourceURL.String()
+	db, err := sql.Open("sqlite", dsn)
+	if err != nil {
+		return nil, errors.New("relay migration source cannot open")
+	}
+	db.SetMaxOpenConns(1)
+	db.SetMaxIdleConns(1)
+	if err := db.PingContext(context.Background()); err != nil {
+		_ = db.Close()
+		return nil, errors.New("relay migration source is unavailable")
+	}
+	openedInfo, err := os.Stat(path)
+	if err != nil || !os.SameFile(info, openedInfo) {
+		_ = db.Close()
+		return nil, errors.New("relay migration source changed while opening")
+	}
+	return db, nil
+}
+
+func validMigrationDigest(value string) bool {
+	if len(value) != sha256.Size*2 {
+		return false
+	}
+	_, err := hex.DecodeString(value)
+	return err == nil && value == strings.ToLower(value)
+}

--- a/internal/relay/migration_source_test.go
+++ b/internal/relay/migration_source_test.go
@@ -1,0 +1,351 @@
+package relay
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+func TestMigrationSourceManifestAndBarrier(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	now := time.Date(2026, time.July, 21, 9, 0, 0, 0, time.UTC)
+	path := filepath.Join(t.TempDir(), "relay.db")
+	store, err := Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	if err := store.AdvertiseEndpoints("machine-a", []string{"agent/source/a"}, now, time.Hour); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.AdvertiseEndpoints("machine-b", []string{"agent/source/b"}, now, time.Hour); err != nil {
+		t.Fatal(err)
+	}
+	conversation, err := store.CreateConversationIdempotent(CreateConversationInput{
+		MachineID: "machine-a", IdempotencyKey: "source-create", CreatorEndpoint: "agent/source/a", Now: now,
+		Members: []Member{
+			{Endpoint: "agent/source/a", Capabilities: CapSend | CapReceive | CapAdmin},
+			{Endpoint: "agent/source/b", Capabilities: CapReceive},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	message, duplicate, err := store.AppendMessage(AppendInput{
+		ConversationID: conversation.ID, SenderMachineID: "machine-a", FromEndpoint: "agent/source/a",
+		Body: "migration body", IdempotencyKey: "source-message", Now: now,
+	})
+	if err != nil || duplicate {
+		t.Fatalf("append=%#v duplicate=%t err=%v", message, duplicate, err)
+	}
+	page, err := store.LeaseDeliveries("machine-b", "source-consumer", "agent/source/b", conversation.ID, now, time.Minute, 10)
+	if err != nil || len(page.Deliveries) != 1 {
+		t.Fatalf("lease page=%#v err=%v", page, err)
+	}
+
+	beforePhase := migrationSourcePhase(t, store)
+	first, err := InspectMigrationSource(ctx, path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := InspectMigrationSource(ctx, path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first != second || first.Version != 1 || first.SourceID == "" || first.Phase != MigrationSourceActive || first.Fingerprint == "" {
+		t.Fatalf("unstable manifest first=%#v second=%#v", first, second)
+	}
+	if first.Counts.Endpoints != 2 || first.Counts.Conversations != 1 || first.Counts.Messages != 1 || first.Counts.Deliveries != 1 || first.Counts.MessageIdempotency != 1 || first.Counts.ConversationIdempotency != 1 {
+		t.Fatalf("manifest counts=%#v", first.Counts)
+	}
+	if got := migrationSourcePhase(t, store); got != beforePhase {
+		t.Fatalf("read-only inspection changed phase from %q to %q", beforePhase, got)
+	}
+
+	epochID := uuid.NewString()
+	targetID := "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+	if _, err := PrepareMigrationSource(ctx, path, epochID, targetID, strings.Repeat("f", 64), now.Add(time.Minute)); err == nil {
+		t.Fatal("wrong source fingerprint was accepted")
+	}
+	afterRejectedPrepare, err := InspectMigrationSource(ctx, path)
+	if err != nil || afterRejectedPrepare != first {
+		t.Fatalf("rejected prepare mutated source=%#v err=%v", afterRejectedPrepare, err)
+	}
+	prepared, err := PrepareMigrationSource(ctx, path, epochID, targetID, first.Fingerprint, now.Add(time.Minute))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if prepared.Phase != MigrationSourcePrepared || prepared.EpochID != epochID || prepared.TargetIdentity != targetID || prepared.Fingerprint == first.Fingerprint {
+		t.Fatalf("prepared manifest=%#v active=%#v", prepared, first)
+	}
+	preparedRetry, err := PrepareMigrationSource(ctx, path, epochID, targetID, first.Fingerprint, now.Add(time.Minute))
+	if err != nil || preparedRetry != prepared {
+		t.Fatalf("exact prepare retry=%#v err=%v, want %#v", preparedRetry, err, prepared)
+	}
+	if _, err := PrepareMigrationSource(ctx, path, epochID, targetID, first.Fingerprint, now.Add(2*time.Minute)); err == nil {
+		t.Fatal("changed prepare cutoff was accepted as an exact retry")
+	}
+	if _, err := store.db.ExecContext(ctx, `INSERT INTO request_nonces(machine_id,nonce,expires_at) VALUES('old-daemon','blocked-direct-write',?)`, now.Add(time.Hour).UnixMilli()); err == nil || !strings.Contains(err.Error(), "relay migration source is not writable") {
+		t.Fatalf("persisted mutation trigger err=%v", err)
+	}
+	if _, _, err := store.AppendMessage(AppendInput{
+		ConversationID: conversation.ID, SenderMachineID: "machine-a", FromEndpoint: "agent/source/a",
+		Body: "blocked", IdempotencyKey: "source-blocked", Now: now.Add(time.Minute),
+	}); err == nil {
+		t.Fatalf("existing writable store after prepare err=%v", err)
+	}
+	if reopened, err := Open(path); !errors.Is(err, ErrMigrationSourcePrepared) {
+		if reopened != nil {
+			_ = reopened.Close()
+		}
+		t.Fatalf("new writable store after prepare err=%v", err)
+	}
+	var endpointUntil, ownershipGeneration, consumerGeneration int64
+	var consumerID, consumerUntil any
+	if err := store.db.QueryRowContext(ctx, `SELECT lease_until,ownership_generation,consumer_id,consumer_generation,consumer_lease_until FROM endpoints WHERE endpoint='agent/source/b'`).Scan(&endpointUntil, &ownershipGeneration, &consumerID, &consumerGeneration, &consumerUntil); err != nil {
+		t.Fatal(err)
+	}
+	if endpointUntil > now.Add(time.Minute).UnixMilli() || ownershipGeneration != 2 || consumerID != nil || consumerGeneration != 2 || consumerUntil != nil {
+		t.Fatalf("prepared endpoint until=%d ownership=%d consumer=%v generation=%d consumer_until=%v", endpointUntil, ownershipGeneration, consumerID, consumerGeneration, consumerUntil)
+	}
+	var leaseMachine, leaseToken, leaseOwnership, leaseConsumer, leaseUntil any
+	var leaseGeneration int64
+	if err := store.db.QueryRowContext(ctx, `SELECT lease_machine_id,lease_token,lease_generation,ownership_generation,consumer_generation,lease_until FROM deliveries WHERE id=?`, page.Deliveries[0].ID).Scan(&leaseMachine, &leaseToken, &leaseGeneration, &leaseOwnership, &leaseConsumer, &leaseUntil); err != nil {
+		t.Fatal(err)
+	}
+	if leaseMachine != nil || leaseToken != nil || leaseGeneration != page.Deliveries[0].LeaseGeneration+1 || leaseOwnership != nil || leaseConsumer != nil || leaseUntil != nil {
+		t.Fatalf("prepared delivery machine=%v token=%v generation=%d ownership=%v consumer=%v until=%v", leaseMachine, leaseToken, leaseGeneration, leaseOwnership, leaseConsumer, leaseUntil)
+	}
+
+	active, err := AbortPreparedMigrationSource(ctx, path, epochID, targetID, prepared.Fingerprint)
+	if err != nil || active.Phase != MigrationSourceActive || active.EpochID != "" || active.TargetIdentity != "" {
+		t.Fatalf("aborted manifest=%#v err=%v", active, err)
+	}
+	activeRetry, err := AbortPreparedMigrationSource(ctx, path, epochID, targetID, prepared.Fingerprint)
+	if err != nil || activeRetry.Fingerprint != active.Fingerprint || activeRetry.Phase != MigrationSourceActive {
+		t.Fatalf("exact abort retry=%#v err=%v", activeRetry, err)
+	}
+	if err := store.ConsumeRequestNonce("machine-a", "post-abort-write", now.Add(2*time.Minute), now.Add(3*time.Minute)); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := AbortPreparedMigrationSource(ctx, path, epochID, targetID, prepared.Fingerprint); err == nil {
+		t.Fatal("stale abort retry accepted a changed active source")
+	}
+	active, err = InspectMigrationSource(ctx, path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	reopened, err := Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = reopened.Close()
+
+	prepared, err = PrepareMigrationSource(ctx, path, uuid.NewString(), targetID, active.Fingerprint, now.Add(2*time.Minute))
+	if err != nil {
+		t.Fatal(err)
+	}
+	retired, err := RetirePreparedMigrationSource(ctx, path, prepared.EpochID, targetID, prepared.Fingerprint)
+	if err != nil || retired.Phase != MigrationSourceRetired {
+		t.Fatalf("retired manifest=%#v err=%v", retired, err)
+	}
+	retiredRetry, err := RetirePreparedMigrationSource(ctx, path, prepared.EpochID, targetID, prepared.Fingerprint)
+	if err != nil || retiredRetry != retired {
+		t.Fatalf("exact retire retry=%#v err=%v", retiredRetry, err)
+	}
+	if _, err := AbortPreparedMigrationSource(ctx, path, prepared.EpochID, targetID, prepared.Fingerprint); !errors.Is(err, ErrMigrationSourceRetired) {
+		t.Fatalf("abort retired source err=%v", err)
+	}
+	if reopened, err := Open(path); !errors.Is(err, ErrMigrationSourceRetired) {
+		if reopened != nil {
+			_ = reopened.Close()
+		}
+		t.Fatalf("new writable store after retirement err=%v", err)
+	}
+}
+
+func TestMigrationSourceRefusesMissingOrPermissiveGuard(t *testing.T) {
+	t.Parallel()
+	for _, test := range []struct {
+		name   string
+		tamper string
+	}{
+		{name: "missing", tamper: `DROP TRIGGER relay_migration_guard_request_nonces_insert`},
+		{name: "permissive", tamper: `DROP TRIGGER relay_migration_guard_request_nonces_insert; CREATE TRIGGER relay_migration_guard_request_nonces_insert BEFORE INSERT ON request_nonces BEGIN SELECT 1; END`},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "relay.db")
+			store, err := Open(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if _, err := store.db.ExecContext(context.Background(), test.tamper); err != nil {
+				_ = store.Close()
+				t.Fatal(err)
+			}
+			_ = store.Close()
+			if _, err := InspectMigrationSource(context.Background(), path); err == nil {
+				t.Fatal("tampered mutation guard was accepted")
+			}
+		})
+	}
+}
+
+func TestMigrationSourceGuardFailsClosedWithoutControlRow(t *testing.T) {
+	t.Parallel()
+	path := filepath.Join(t.TempDir(), "relay.db")
+	store, err := Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = store.Close() }()
+	if _, err := store.db.ExecContext(context.Background(), `DELETE FROM relay_migration_control`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.db.ExecContext(context.Background(), `INSERT INTO request_nonces(machine_id,nonce,expires_at) VALUES('machine','nonce',1)`); err == nil || !strings.Contains(err.Error(), "relay migration source is not writable") {
+		t.Fatalf("write without control singleton err=%v", err)
+	}
+}
+
+func TestMigrationSourceRefusesUnexpectedIndex(t *testing.T) {
+	t.Parallel()
+	path := filepath.Join(t.TempDir(), "relay.db")
+	store, err := Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.db.ExecContext(context.Background(), `CREATE INDEX unexpected_endpoint_index ON endpoints(lease_until)`); err != nil {
+		_ = store.Close()
+		t.Fatal(err)
+	}
+	_ = store.Close()
+	if _, err := InspectMigrationSource(context.Background(), path); err == nil {
+		t.Fatal("unexpected source index was accepted")
+	}
+}
+
+func TestMigrationSourceRefusesMalformedRuntimeType(t *testing.T) {
+	t.Parallel()
+	path := filepath.Join(t.TempDir(), "relay.db")
+	store, err := Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	now := time.Now().UTC()
+	if err := store.AdvertiseEndpoints("runtime-type-machine", []string{"agent/runtime-type"}, now, time.Hour); err != nil {
+		t.Fatal(err)
+	}
+	conversation, err := store.CreateConversationIdempotent(CreateConversationInput{
+		MachineID: "runtime-type-machine", IdempotencyKey: "runtime-type-conversation", CreatorEndpoint: "agent/runtime-type", Now: now,
+		Members: []Member{{Endpoint: "agent/runtime-type", Capabilities: CapSend | CapReceive | CapAdmin}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.db.ExecContext(context.Background(), `UPDATE conversations SET created_at='bad-timestamp' WHERE id=?`, conversation.ID); err != nil {
+		t.Fatal(err)
+	}
+	_ = store.Close()
+	if _, err := InspectMigrationSource(context.Background(), path); err == nil {
+		t.Fatal("malformed SQLite runtime type was accepted")
+	}
+}
+
+func TestMigrationSourceConcurrentPreparersSingleWinner(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	path := filepath.Join(t.TempDir(), "relay.db")
+	store, err := Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatal(err)
+	}
+	manifest, err := InspectMigrationSource(ctx, path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	target := strings.Repeat("a", 64)
+	type result struct {
+		manifest MigrationSourceManifest
+		err      error
+	}
+	results := make(chan result, 2)
+	for range 2 {
+		epoch := uuid.NewString()
+		go func() {
+			prepared, err := PrepareMigrationSource(ctx, path, epoch, target, manifest.Fingerprint, time.Now().UTC())
+			results <- result{manifest: prepared, err: err}
+		}()
+	}
+	var successes int
+	for range 2 {
+		outcome := <-results
+		if outcome.err == nil {
+			successes++
+		}
+	}
+	if successes != 1 {
+		t.Fatalf("concurrent prepare successes=%d, want 1", successes)
+	}
+}
+
+func TestInspectMigrationSourceRefusesMissingAndSymlink(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	directory := t.TempDir()
+	missing := filepath.Join(directory, "missing.db")
+	if _, err := InspectMigrationSource(ctx, missing); err == nil {
+		t.Fatal("missing source was created or accepted")
+	}
+	target := filepath.Join(directory, "target.db")
+	store, err := Open(target)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = store.Close()
+	link := filepath.Join(directory, "source-link.db")
+	if err := os.Symlink(target, link); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := InspectMigrationSource(ctx, link); err == nil {
+		t.Fatal("symlink source was accepted")
+	}
+	linkedDirectory := filepath.Join(directory, "linked-directory")
+	if err := os.Symlink(directory, linkedDirectory); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := InspectMigrationSource(ctx, filepath.Join(linkedDirectory, "target.db")); err == nil {
+		t.Fatal("source beneath symlinked directory was accepted")
+	}
+	specialSource := filepath.Join(directory, "special-source.db")
+	specialStore, err := Open(specialSource)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = specialStore.Close()
+	special := filepath.Join(directory, "relay?#.db")
+	if err := os.Rename(specialSource, special); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := InspectMigrationSource(ctx, special); err != nil {
+		t.Fatalf("literal special-character source path: %v", err)
+	}
+}
+
+func migrationSourcePhase(t *testing.T, store *Store) MigrationSourcePhase {
+	t.Helper()
+	var phase MigrationSourcePhase
+	if err := store.db.QueryRowContext(context.Background(), `SELECT phase FROM relay_migration_control WHERE singleton=1`).Scan(&phase); err != nil {
+		t.Fatal(err)
+	}
+	return phase
+}

--- a/internal/relay/migration_source_test.go
+++ b/internal/relay/migration_source_test.go
@@ -205,12 +205,20 @@ func TestMigrationSourceGuardFailsClosedWithoutControlRow(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer func() { _ = store.Close() }()
 	if _, err := store.db.ExecContext(context.Background(), `DELETE FROM relay_migration_control`); err != nil {
+		_ = store.Close()
 		t.Fatal(err)
 	}
 	if _, err := store.db.ExecContext(context.Background(), `INSERT INTO request_nonces(machine_id,nonce,expires_at) VALUES('machine','nonce',1)`); err == nil || !strings.Contains(err.Error(), "relay migration source is not writable") {
+		_ = store.Close()
 		t.Fatalf("write without control singleton err=%v", err)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if reopened, err := Open(path); err == nil {
+		_ = reopened.Close()
+		t.Fatal("ordinary startup recreated the missing migration-control singleton")
 	}
 }
 

--- a/internal/relay/store.go
+++ b/internal/relay/store.go
@@ -189,6 +189,10 @@ func (s *Store) ConsumeRequestNonce(machineID, nonce string, now, expiresAt time
 }
 
 func (s *Store) migrate(ctx context.Context) error {
+	var migrationControlExisted bool
+	if err := s.db.QueryRowContext(ctx, `SELECT EXISTS (SELECT 1 FROM sqlite_schema WHERE type='table' AND name='relay_migration_control')`).Scan(&migrationControlExisted); err != nil {
+		return fmt.Errorf("inspect relay migration control: %w", err)
+	}
 	for _, statement := range []string{
 		"PRAGMA foreign_keys = ON",
 		"PRAGMA journal_mode = WAL",
@@ -289,8 +293,10 @@ func (s *Store) migrate(ctx context.Context) error {
 			return fmt.Errorf("migrate relay database: %w", err)
 		}
 	}
-	if _, err := s.db.ExecContext(ctx, `INSERT OR IGNORE INTO relay_migration_control(singleton,source_id,changed_at) VALUES(1,?,?)`, uuid.NewString(), time.Now().UTC().UnixMilli()); err != nil {
-		return fmt.Errorf("initialize relay migration control: %w", err)
+	if !migrationControlExisted {
+		if _, err := s.db.ExecContext(ctx, `INSERT INTO relay_migration_control(singleton,source_id,changed_at) VALUES(1,?,?)`, uuid.NewString(), time.Now().UTC().UnixMilli()); err != nil {
+			return fmt.Errorf("initialize relay migration control: %w", err)
+		}
 	}
 	for _, table := range []string{"endpoints", "conversations", "memberships", "messages", "deliveries", "recipient_cursors", "idempotency", "conversation_idempotency", "request_nonces"} {
 		for _, operation := range []string{"INSERT", "UPDATE", "DELETE"} {

--- a/internal/relay/store.go
+++ b/internal/relay/store.go
@@ -36,6 +36,12 @@ var (
 	// ErrMaintenance is a retryable, payload-free refusal while the durable
 	// update fence owns application mutations.
 	ErrMaintenance = errors.New("relay maintenance in progress")
+	// ErrMigrationSourcePrepared means the SQLite relay is fenced for a
+	// resumable PostgreSQL cutover epoch and cannot accept writes.
+	ErrMigrationSourcePrepared = errors.New("relay migration source is prepared")
+	// ErrMigrationSourceRetired means PostgreSQL cutover crossed the permanent
+	// source-retirement boundary. The SQLite file is forensic evidence only.
+	ErrMigrationSourceRetired = errors.New("relay migration source is retired")
 )
 
 // Capability controls an endpoint's membership in a conversation.
@@ -137,6 +143,23 @@ func Open(database string) (*Store, error) {
 	if err := store.migrate(context.Background()); err != nil {
 		_ = db.Close()
 		return nil, err
+	}
+	var migrationPhase MigrationSourcePhase
+	if err := db.QueryRowContext(context.Background(), `SELECT phase FROM relay_migration_control WHERE singleton=1`).Scan(&migrationPhase); err != nil {
+		_ = db.Close()
+		return nil, errors.New("relay migration source state is unavailable")
+	}
+	switch migrationPhase {
+	case MigrationSourceActive:
+	case MigrationSourcePrepared:
+		_ = db.Close()
+		return nil, ErrMigrationSourcePrepared
+	case MigrationSourceRetired:
+		_ = db.Close()
+		return nil, ErrMigrationSourceRetired
+	default:
+		_ = db.Close()
+		return nil, errors.New("relay migration source control is invalid")
 	}
 	return store, nil
 }
@@ -240,11 +263,44 @@ func (s *Store) migrate(ctx context.Context) error {
 			expires_at INTEGER NOT NULL,
 			PRIMARY KEY (machine_id, nonce)
 		)`,
+		`CREATE TABLE IF NOT EXISTS relay_migration_control (
+			singleton INTEGER PRIMARY KEY CHECK (singleton = 1),
+			source_id TEXT NOT NULL,
+			phase TEXT NOT NULL DEFAULT 'active' CHECK (phase IN ('active', 'prepared', 'retired')),
+			epoch_id TEXT,
+			target_identity TEXT,
+			fingerprint TEXT,
+			last_epoch_id TEXT,
+			last_target_identity TEXT,
+			last_expected_fingerprint TEXT,
+			last_result_fingerprint TEXT,
+			last_cutoff INTEGER,
+			last_transition TEXT CHECK (last_transition IS NULL OR last_transition IN ('prepared', 'aborted', 'retired')),
+			changed_at INTEGER NOT NULL,
+			CHECK (
+				(phase = 'active' AND epoch_id IS NULL AND target_identity IS NULL AND fingerprint IS NULL)
+				OR (phase IN ('prepared', 'retired') AND epoch_id IS NOT NULL AND target_identity IS NOT NULL AND fingerprint IS NOT NULL)
+			)
+		)`,
 		"CREATE INDEX IF NOT EXISTS deliveries_recipient_pending ON deliveries(recipient_endpoint, acked_at, lease_until)",
 		"CREATE INDEX IF NOT EXISTS request_nonces_expiry ON request_nonces(expires_at)",
 	} {
 		if _, err := s.db.ExecContext(ctx, statement); err != nil {
 			return fmt.Errorf("migrate relay database: %w", err)
+		}
+	}
+	if _, err := s.db.ExecContext(ctx, `INSERT OR IGNORE INTO relay_migration_control(singleton,source_id,changed_at) VALUES(1,?,?)`, uuid.NewString(), time.Now().UTC().UnixMilli()); err != nil {
+		return fmt.Errorf("initialize relay migration control: %w", err)
+	}
+	for _, table := range []string{"endpoints", "conversations", "memberships", "messages", "deliveries", "recipient_cursors", "idempotency", "conversation_idempotency", "request_nonces"} {
+		for _, operation := range []string{"INSERT", "UPDATE", "DELETE"} {
+			name := "relay_migration_guard_" + table + "_" + strings.ToLower(operation)
+			statement := fmt.Sprintf(`CREATE TRIGGER IF NOT EXISTS %s BEFORE %s ON %s
+				WHEN COALESCE((SELECT phase FROM relay_migration_control WHERE singleton=1), 'missing') <> 'active'
+				BEGIN SELECT RAISE(ABORT, 'relay migration source is not writable'); END`, name, operation, table) // #nosec G201 -- identifiers come only from fixed internal allowlists.
+			if _, err := s.db.ExecContext(ctx, statement); err != nil { // #nosec G202 -- identifiers come only from fixed internal allowlists above.
+				return fmt.Errorf("install relay migration guard: %w", err)
+			}
 		}
 	}
 	for _, column := range []struct {
@@ -256,6 +312,12 @@ func (s *Store) migrate(ctx context.Context) error {
 		{"endpoints", "consumer_lease_until", "INTEGER"},
 		{"deliveries", "ownership_generation", "INTEGER"},
 		{"deliveries", "consumer_generation", "INTEGER"},
+		{"relay_migration_control", "last_epoch_id", "TEXT"},
+		{"relay_migration_control", "last_target_identity", "TEXT"},
+		{"relay_migration_control", "last_expected_fingerprint", "TEXT"},
+		{"relay_migration_control", "last_result_fingerprint", "TEXT"},
+		{"relay_migration_control", "last_cutoff", "INTEGER"},
+		{"relay_migration_control", "last_transition", "TEXT"},
 	} {
 		if err := ensureSQLiteColumn(ctx, s.db, column.table, column.name, column.definition); err != nil {
 			return err
@@ -265,7 +327,7 @@ func (s *Store) migrate(ctx context.Context) error {
 }
 
 func ensureSQLiteColumn(ctx context.Context, db *sql.DB, table, name, definition string) error {
-	if table != "endpoints" && table != "deliveries" {
+	if table != "endpoints" && table != "deliveries" && table != "relay_migration_control" {
 		return errors.New("invalid relay migration table")
 	}
 	rows, err := db.QueryContext(ctx, "PRAGMA table_info("+table+")") // #nosec G202 -- table is restricted above to fixed internal names.


### PR DESCRIPTION
## Summary

- add the dark M-9A SQLite cutover substrate: deterministic logical manifests, exact schema/runtime validation, lease fencing, durable fail-closed write guards, and resumable prepare/abort/retire transitions
- add PostgreSQL schema v8 owner-only cutover epochs, bounded staging/checkpoints, exact catalog readiness, application writer draining, and mutual exclusion with platform updates
- keep SQLite as the default authority; this slice has no canonical importer, PostgreSQL activation transition, routing change, dual writes, or Compose Pi work

## Safety and review

- alignment review: PASS
- adversarial correctness/security review: PASS (no remaining P0/P1 findings)
- application and cutover advisory locks linearize the empty-target proof against in-flight writers
- old SQLite connections are fenced by 27 persisted database triggers; missing/drifted controls fail closed
- typed manifests are canonicalized before hashing and stored byte-exactly

## Validation

- `make test`
- `make test-race`
- `make lint`
- `make security`

`make test-postgres` could not run locally because this Mac has no Docker binary. The required digest-pinned PostgreSQL integration job must pass on this PR before merge.
