### PR TITLE
M9b: add dormant credential transition

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -592,7 +592,8 @@ off by default and requires device auth plus the PostgreSQL relay, so this
 slice does not activate PostgreSQL mail authority or change the SQLite default.
 Long-lived notification sockets retain only a non-secret generation/gate fence,
 not the bearer credential. A check starts every second with a one-second
-deadline, bounding authority after the last successful check to two seconds. Gate
+deadline in a dedicated loop; wake writes cannot delay it, and fence failure
+cancels any blocked write. This bounds authority after the last successful check to two seconds. Gate
 closure, key retirement, credential rotation/revocation, principal disablement,
 mapping removal, timeout, or database failure closes the socket.
 

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -575,6 +575,27 @@ pending, migrated, or retired; the global legacy gate cannot close while any
 machine is pending. PostgreSQL remains dark for mail and SQLite routing is
 unchanged.
 
+The dormant M-9 credential-transition bridge does not duplicate relay
+authority in PostgreSQL. A successful proof-bound exchange already records the
+replacement credential lookup against the exact registered legacy public key.
+When the explicit transition switch is enabled, a current, unrevoked device
+credential follows that relationship back to the public key and selects the
+one matching static machine enrollment. The returned machine ID therefore has
+exactly the existing endpoint prefixes, exact endpoints, and attachment-device
+binding. Duplicate configured public keys fail startup. Ordinary device
+credentials, stale generations, retired mappings, and unavailable database
+state fail authentication without revealing which check failed. In the same
+mode every Ed25519 relay request consults the durable legacy gate after
+signature verification and before consuming its nonce; closing the gate blocks
+new legacy requests while migrated credentials remain usable. The switch is
+off by default and requires device auth plus the PostgreSQL relay, so this
+slice does not activate PostgreSQL mail authority or change the SQLite default.
+Long-lived notification sockets retain only a non-secret generation/gate fence,
+not the bearer credential. A check starts every second with a one-second
+deadline, bounding authority after the last successful check to two seconds. Gate
+closure, key retirement, credential rotation/revocation, principal disablement,
+mapping removal, timeout, or database failure closes the socket.
+
 The fourth dark foundation slice gives projects durable, credential-free
 identity claims. Conservative Git normalization strips credentials and only
 collapses well-known equivalent syntax; ambiguous locators fail closed.

--- a/README.md
+++ b/README.md
@@ -109,12 +109,13 @@ precedence over dotenv values.
 | `PUNARO_POSTGRES_ENABLED` | `false` | Opts into the PostgreSQL platform substrate. Ordinary startup only checks compatibility and never migrates. |
 | `PUNARO_POSTGRES_DSN_FILE` | unset | Required with PostgreSQL enabled: absolute path to a private application-role DSN file. The application role has no DDL authority. |
 | `PUNARO_DEVICE_AUTH_ENABLED` | `false` | Mounts bounded enrollment redemption and device-session authentication; requires PostgreSQL and a complete ingress policy. |
+| `PUNARO_CREDENTIAL_TRANSITION_ENABLED` | `false` | Dormant M-9 bridge. Requires device auth and the PostgreSQL relay. Legacy Ed25519 requests must pass the durable global gate; a migrated device bearer resolves through its proof-bound exchange to the exact static machine enrollment and inherits no additional endpoint authority. |
 | `PUNARO_INGRESS_MODE` | unset | Required with device auth: `lan`, `proxy`, or `internet`. Proxy and Internet origins bind loopback and require `PUNARO_PUBLIC_URL=https://...`. |
 | `PUNARO_PUBLIC_URL` | unset | Canonical HTTPS public URL for proxy/Internet mode. It does not make forwarded headers trustworthy. |
 | `PUNARO_TRUSTED_LAN_CIDR` | unset | Private/link-local CIDR containing the concrete LAN bind. Valid only in LAN mode. |
 | `PUNARO_TRUSTED_LAN_HTTP` | `false` | Explicit plaintext credential exception for observed peers inside the validated trusted LAN. Public peers never qualify. |
 | `PUNARO_RELAY_ENABLED` | `false` | Enables the loopback text relay; requires public machine enrollment records. |
-| `PUNARO_RELAY_STORE` | `sqlite` | Explicit relay backend selector. `postgres` requires PostgreSQL schema v8 and is for empty-destination parity/qualification before the M-9 one-shot cutover; it never imports or dual-writes SQLite. |
+| `PUNARO_RELAY_STORE` | `sqlite` | Explicit relay backend selector. `postgres` requires PostgreSQL schema v8 and is for empty-destination parity/qualification before the M-9 one-shot cutover; it never imports or dual-writes SQLite. Credential transition remains separately off by default. |
 | `PUNARO_RELAY_MACHINES_JSON` | unset | Explicit public-key machine enrollment records. `endpoint_prefixes` claims disjoint machine namespaces; `endpoints` can grant a named exact endpoint without creating a prefix. An issuer-capable machine additionally has canonical raw-base64url `attachment_device_id` (16 bytes), bound to exactly one directory device. |
 | `PUNARO_DIRECTORY_ENABLED` | `false` | Serves a current complete signed directory snapshot to authenticated enrolled machines; requires the relay. |
 | `PUNARO_DIRECTORY_SNAPSHOT_FILE` | unset | Absolute, root-owned and service-group-readable (`2750` parent, `0640` regular non-symlink) canonical directory snapshot publication file. |

--- a/cmd/punarod/main.go
+++ b/cmd/punarod/main.go
@@ -44,6 +44,55 @@ type deviceDatabase interface {
 	AuthenticateDevice(context.Context, string) (punaropostgres.AuthenticatedDevice, error)
 }
 
+type credentialTransitionDatabase interface {
+	deviceDatabase
+	DeviceSessionCurrent(context.Context, punaropostgres.AuthenticatedDevice) (bool, error)
+	ResolveLegacyMachine(context.Context, ed25519.PublicKey) (string, error)
+	ResolveMigratedLegacyPublicKey(context.Context, punaropostgres.AuthenticatedDevice) (ed25519.PublicKey, error)
+}
+
+type postgresTransitionAuthority struct {
+	database credentialTransitionDatabase
+}
+
+func (a postgresTransitionAuthority) AuthorizeTransition(ctx context.Context, credential string, legacyKey ed25519.PublicKey) (relay.TransitionAuthorization, error) {
+	if a.database == nil || (credential == "") == (len(legacyKey) == 0) {
+		return relay.TransitionAuthorization{}, relay.ErrForbidden
+	}
+	if credential == "" {
+		if _, err := a.database.ResolveLegacyMachine(ctx, legacyKey); err != nil {
+			return relay.TransitionAuthorization{}, relay.ErrForbidden
+		}
+		key := append(ed25519.PublicKey(nil), legacyKey...)
+		return relay.TransitionAuthorization{LegacyPublicKey: key, Current: func(currentCtx context.Context) error {
+			if _, err := a.database.ResolveLegacyMachine(currentCtx, key); err != nil {
+				return relay.ErrForbidden
+			}
+			return nil
+		}}, nil
+	}
+	authenticated, err := a.database.AuthenticateDevice(ctx, credential)
+	if err != nil {
+		return relay.TransitionAuthorization{}, relay.ErrForbidden
+	}
+	publicKey, err := a.database.ResolveMigratedLegacyPublicKey(ctx, authenticated)
+	if err != nil {
+		return relay.TransitionAuthorization{}, relay.ErrForbidden
+	}
+	key := append(ed25519.PublicKey(nil), publicKey...)
+	return relay.TransitionAuthorization{LegacyPublicKey: key, Current: func(currentCtx context.Context) error {
+		current, err := a.database.DeviceSessionCurrent(currentCtx, authenticated)
+		if err != nil || !current {
+			return relay.ErrForbidden
+		}
+		resolved, err := a.database.ResolveMigratedLegacyPublicKey(currentCtx, authenticated)
+		if err != nil || !bytes.Equal(resolved, key) {
+			return relay.ErrForbidden
+		}
+		return nil
+	}}, nil
+}
+
 var openPlatformDatabase = func(ctx context.Context, cfg punaropostgres.Config) (platformDatabase, error) {
 	return punaropostgres.OpenApplication(ctx, cfg)
 }
@@ -636,7 +685,19 @@ func buildRelayHandler(cfg config.Config, postgresBackends ...relay.Backend) (ht
 		}
 		backend = store
 	}
-	authenticator, err := relay.NewAuthenticator(backend, machines)
+	var authenticator *relay.Authenticator
+	if cfg.CredentialTransitionEnabled {
+		transitionDatabase, ok := backend.(credentialTransitionDatabase)
+		if !ok {
+			if store != nil {
+				_ = store.Close()
+			}
+			return nil, nil, errors.New("credential transition store is unavailable")
+		}
+		authenticator, err = relay.NewTransitionAuthenticator(backend, machines, postgresTransitionAuthority{database: transitionDatabase})
+	} else {
+		authenticator, err = relay.NewAuthenticator(backend, machines)
+	}
 	if err != nil {
 		if store != nil {
 			_ = store.Close()

--- a/cmd/punarod/relay_test.go
+++ b/cmd/punarod/relay_test.go
@@ -6,6 +6,7 @@ import (
 	"crypto/ed25519"
 	"crypto/rand"
 	"encoding/base64"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -16,8 +17,45 @@ import (
 	attachmentv2 "github.com/rock3r/punaro/internal/attachment/v2"
 	attachmentv3 "github.com/rock3r/punaro/internal/attachment/v3"
 	"github.com/rock3r/punaro/internal/config"
+	punaropostgres "github.com/rock3r/punaro/internal/postgres"
 	"github.com/rock3r/punaro/internal/relay"
 )
+
+type transitionDatabaseDouble struct {
+	legacyKey  ed25519.PublicKey
+	credential string
+	device     punaropostgres.AuthenticatedDevice
+	err        error
+}
+
+func (d *transitionDatabaseDouble) RedeemEnrollment(context.Context, punaropostgres.RedeemEnrollment) (punaropostgres.DeviceCredential, error) {
+	return punaropostgres.DeviceCredential{}, errors.New("not used")
+}
+
+func (d *transitionDatabaseDouble) AuthenticateDevice(_ context.Context, credential string) (punaropostgres.AuthenticatedDevice, error) {
+	if d.err != nil || credential != d.credential {
+		return punaropostgres.AuthenticatedDevice{}, punaropostgres.ErrUnauthenticated
+	}
+	return d.device, nil
+}
+
+func (d *transitionDatabaseDouble) DeviceSessionCurrent(_ context.Context, authenticated punaropostgres.AuthenticatedDevice) (bool, error) {
+	return d.err == nil && authenticated == d.device, d.err
+}
+
+func (d *transitionDatabaseDouble) ResolveLegacyMachine(_ context.Context, key ed25519.PublicKey) (string, error) {
+	if d.err != nil || !bytes.Equal(key, d.legacyKey) {
+		return "", punaropostgres.ErrUnauthenticated
+	}
+	return "11111111-1111-4111-8111-111111111111", nil
+}
+
+func (d *transitionDatabaseDouble) ResolveMigratedLegacyPublicKey(_ context.Context, authenticated punaropostgres.AuthenticatedDevice) (ed25519.PublicKey, error) {
+	if d.err != nil || authenticated != d.device {
+		return nil, punaropostgres.ErrUnauthenticated
+	}
+	return append(ed25519.PublicKey(nil), d.legacyKey...), nil
+}
 
 func TestBuildRelayHandlerRejectsInvalidEnrollment(t *testing.T) {
 	_, closeRelay, err := buildRelayHandler(config.Config{DataDir: t.TempDir(), RelayEnabled: true, RelayMachinesJSON: `[{"id":"machine-a","public_key":"invalid","endpoint_prefixes":["agent/"]}]`})
@@ -41,6 +79,34 @@ func TestBuildRelayCanSelectPostgresBackendWithoutOpeningSQLite(t *testing.T) {
 	}, backend)
 	if err != nil || handler == nil || sqliteStore != nil {
 		t.Fatalf("handler=%v sqlite=%v err=%v", handler, sqliteStore, err)
+	}
+}
+
+func TestPostgresTransitionAuthorityMapsBothPathsToExactLegacyKey(t *testing.T) {
+	public, _, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	database := &transitionDatabaseDouble{legacyKey: public, credential: "not-secret", device: punaropostgres.AuthenticatedDevice{PrincipalID: "11111111-1111-4111-8111-111111111111", LookupID: "22222222-2222-4222-8222-222222222222", Generation: 1}}
+	authority := postgresTransitionAuthority{database: database}
+	legacyResult, err := authority.AuthorizeTransition(t.Context(), "", public)
+	if err != nil || !bytes.Equal(legacyResult.LegacyPublicKey, public) || legacyResult.Current(t.Context()) != nil {
+		t.Fatalf("legacy result=%#v err=%v", legacyResult, err)
+	}
+	deviceResult, err := authority.AuthorizeTransition(t.Context(), database.credential, nil)
+	if err != nil || !bytes.Equal(deviceResult.LegacyPublicKey, public) || deviceResult.Current(t.Context()) != nil {
+		t.Fatalf("device result=%#v err=%v", deviceResult, err)
+	}
+	database.err = errors.New("revoked")
+	if err := legacyResult.Current(t.Context()); !errors.Is(err, relay.ErrForbidden) {
+		t.Fatalf("closed legacy session err=%v", err)
+	}
+	if err := deviceResult.Current(t.Context()); !errors.Is(err, relay.ErrForbidden) {
+		t.Fatalf("revoked device session err=%v", err)
+	}
+	database.err = nil
+	if _, err := authority.AuthorizeTransition(t.Context(), "wrong", nil); !errors.Is(err, relay.ErrForbidden) {
+		t.Fatalf("wrong credential err=%v", err)
 	}
 }
 

--- a/docs/platform-contracts.md
+++ b/docs/platform-contracts.md
@@ -131,6 +131,23 @@ server-constrained defaults, and coalesce `last_used_at`; it cannot rotate or
 revoke credentials. Host-local administration uses a direct `punaro_owner`
 connection and is not exposed as an HTTP route.
 
+The M-9 credential transition is a separate, off-by-default relay mode. It
+does not copy endpoint scopes into the auth schema. A replacement credential
+must authenticate as current and resolve through
+`migrated_credential_lookup_id` to the exact registered legacy public key;
+that key selects one non-ambiguous static relay machine enrollment. The device
+therefore receives precisely the old machine ID, endpoint prefixes, exact
+endpoints, and attachment-device binding. Every Ed25519 request in this mode
+also resolves its exact public key through `auth.legacy_auth_state`, so a closed
+gate fails legacy authentication. Database errors, revoked or stale device
+credentials, ordinary unenrolled device credentials, retired mappings, and
+duplicate configured keys all fail closed. Enabling the mode requires device
+auth and the PostgreSQL relay; it does not itself make PostgreSQL writable mail
+authority. A notification WebSocket retains only its non-secret session fence
+and revalidates the legacy gate or the exact device generation and migrated
+mapping every second under a one-second deadline; failure closes the socket,
+and the last successful durable check expires after at most two seconds.
+
 M-5 mounts only `POST /v1/enrollments/redeem` and authenticated
 `GET /v1/device/session`. Redemption requires exact `application/json`, a
 bounded object with four unique string fields, and the store's exact enrollment

--- a/docs/platform-contracts.md
+++ b/docs/platform-contracts.md
@@ -146,7 +146,9 @@ auth and the PostgreSQL relay; it does not itself make PostgreSQL writable mail
 authority. A notification WebSocket retains only its non-secret session fence
 and revalidates the legacy gate or the exact device generation and migrated
 mapping every second under a one-second deadline; failure closes the socket,
-and the last successful durable check expires after at most two seconds.
+and the last successful durable check expires after at most two seconds. The
+check loop is independent of wake writes and cancels their context on failure,
+so a slow or non-reading client cannot starve revalidation.
 
 M-5 mounts only `POST /v1/enrollments/redeem` and authenticated
 `GET /v1/device/session`. Redemption requires exact `application/json`, a

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -50,6 +50,7 @@ type Config struct {
 	PostgresEnabled             bool
 	PostgresDSNFile             string
 	DeviceAuthEnabled           bool
+	CredentialTransitionEnabled bool
 	IngressMode                 string
 	PublicURL                   string
 	TrustedLANCIDR              string
@@ -128,6 +129,10 @@ func Load(explicitEnvFile string) (Config, error) {
 	if err != nil {
 		return Config{}, fmt.Errorf("parse PUNARO_DEVICE_AUTH_ENABLED: %w", err)
 	}
+	credentialTransitionEnabled, err := strconv.ParseBool(value("PUNARO_CREDENTIAL_TRANSITION_ENABLED", "false"))
+	if err != nil {
+		return Config{}, fmt.Errorf("parse PUNARO_CREDENTIAL_TRANSITION_ENABLED: %w", err)
+	}
 	ingressMode := value("PUNARO_INGRESS_MODE", "")
 	publicURL := value("PUNARO_PUBLIC_URL", "")
 	trustedLANCIDR := value("PUNARO_TRUSTED_LAN_CIDR", "")
@@ -184,6 +189,9 @@ func Load(explicitEnvFile string) (Config, error) {
 	}
 	if relayStore == "postgres" && (directoryEnabled || permitIssuanceEnabled || attachmentV3Enabled || attachmentsEnabled) {
 		return Config{}, fmt.Errorf("PostgreSQL relay store cannot serve superseded attachment or directory routes")
+	}
+	if credentialTransitionEnabled && (!relayEnabled || relayStore != "postgres" || !postgresEnabled || !deviceAuthEnabled) {
+		return Config{}, fmt.Errorf("credential transition requires enabled PostgreSQL relay and device authentication")
 	}
 	if directoryEnabled && !relayEnabled {
 		return Config{}, fmt.Errorf("directory service requires PUNARO_RELAY_ENABLED")
@@ -255,7 +263,7 @@ func Load(explicitEnvFile string) (Config, error) {
 	if !postgresEnabled && postgresDSNFile != "" {
 		return Config{}, fmt.Errorf("PUNARO_POSTGRES_DSN_FILE requires PUNARO_POSTGRES_ENABLED")
 	}
-	return Config{ListenAddr: listenAddr, HealthListenAddr: healthListenAddr, DataDir: dataDir, LogLevel: level, AttachmentsEnabled: attachmentsEnabled, AttachmentDeviceKeysJSON: deviceKeys, AttachmentMembershipJSON: membership, AttachmentV3Enabled: attachmentV3Enabled, AttachmentV3SourceStoreFile: attachmentV3SourceStoreFile, DirectoryEnabled: directoryEnabled, DirectorySnapshotFile: directorySnapshotFile, PermitIssuanceEnabled: permitIssuanceEnabled, DirectoryAudience: audience, DirectoryRootKeyID: rootKeyID, DirectoryRootPublicKey: rootPublicKey, PermitIssuerKeyID: issuerKeyID, PermitIssuerPrivateKeyFile: permitIssuerPrivateKeyFile, PermitMaxLifetimeSeconds: maxLifetime, PermitMaxBytes: maxBytes, PermitMaxChunks: maxChunks, PermitMaxOperations: maxOperations, PermitMaxActive: maxActive, RelayEnabled: relayEnabled, RelayMachinesJSON: relayMachines, RelayStore: relayStore, AccessIssuer: accessIssuer, AccessAudience: accessAudience, AccessJWKSURL: accessJWKSURL, AccessJWKSFile: accessJWKSFile, PostgresEnabled: postgresEnabled, PostgresDSNFile: postgresDSNFile, DeviceAuthEnabled: deviceAuthEnabled, IngressMode: ingressMode, PublicURL: publicURL, TrustedLANCIDR: trustedLANCIDR, TrustedLANHTTP: trustedLANHTTP}, nil
+	return Config{ListenAddr: listenAddr, HealthListenAddr: healthListenAddr, DataDir: dataDir, LogLevel: level, AttachmentsEnabled: attachmentsEnabled, AttachmentDeviceKeysJSON: deviceKeys, AttachmentMembershipJSON: membership, AttachmentV3Enabled: attachmentV3Enabled, AttachmentV3SourceStoreFile: attachmentV3SourceStoreFile, DirectoryEnabled: directoryEnabled, DirectorySnapshotFile: directorySnapshotFile, PermitIssuanceEnabled: permitIssuanceEnabled, DirectoryAudience: audience, DirectoryRootKeyID: rootKeyID, DirectoryRootPublicKey: rootPublicKey, PermitIssuerKeyID: issuerKeyID, PermitIssuerPrivateKeyFile: permitIssuerPrivateKeyFile, PermitMaxLifetimeSeconds: maxLifetime, PermitMaxBytes: maxBytes, PermitMaxChunks: maxChunks, PermitMaxOperations: maxOperations, PermitMaxActive: maxActive, RelayEnabled: relayEnabled, RelayMachinesJSON: relayMachines, RelayStore: relayStore, AccessIssuer: accessIssuer, AccessAudience: accessAudience, AccessJWKSURL: accessJWKSURL, AccessJWKSFile: accessJWKSFile, PostgresEnabled: postgresEnabled, PostgresDSNFile: postgresDSNFile, DeviceAuthEnabled: deviceAuthEnabled, CredentialTransitionEnabled: credentialTransitionEnabled, IngressMode: ingressMode, PublicURL: publicURL, TrustedLANCIDR: trustedLANCIDR, TrustedLANHTTP: trustedLANHTTP}, nil
 }
 
 func decodeFixedBase64URL(name, value string, size int) ([32]byte, error) {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -329,6 +329,29 @@ func TestLoadAcceptsExplicitRelayMachineEnrollment(t *testing.T) {
 	}
 }
 
+func TestLoadCredentialTransitionIsOffByDefaultAndRequiresCompletePostgresRuntime(t *testing.T) {
+	config, err := Load("")
+	if err != nil || config.CredentialTransitionEnabled {
+		t.Fatalf("default config=%#v err=%v", config, err)
+	}
+	t.Setenv("PUNARO_CREDENTIAL_TRANSITION_ENABLED", "true")
+	if _, err := Load(""); err == nil {
+		t.Fatal("credential transition was enabled without its PostgreSQL relay dependencies")
+	}
+	t.Setenv("PUNARO_RELAY_ENABLED", "true")
+	t.Setenv("PUNARO_RELAY_MACHINES_JSON", `[{"id":"machine-a","public_key":"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA","endpoint_prefixes":["agent/a/"]}]`)
+	t.Setenv("PUNARO_RELAY_STORE", "postgres")
+	t.Setenv("PUNARO_POSTGRES_ENABLED", "true")
+	t.Setenv("PUNARO_POSTGRES_DSN_FILE", "/run/secrets/punaro-app-dsn")
+	t.Setenv("PUNARO_DEVICE_AUTH_ENABLED", "true")
+	t.Setenv("PUNARO_INGRESS_MODE", "proxy")
+	t.Setenv("PUNARO_PUBLIC_URL", "https://punaro.example.test")
+	config, err = Load("")
+	if err != nil || !config.CredentialTransitionEnabled {
+		t.Fatalf("complete transition config=%#v err=%v", config, err)
+	}
+}
+
 func TestLoadRejectsPartialCloudflareAccessVerifierConfiguration(t *testing.T) {
 	t.Setenv("PUNARO_ACCESS_ISSUER", "https://team.cloudflareaccess.com")
 	t.Setenv("PUNARO_ACCESS_AUDIENCE", "")

--- a/internal/postgres/device_auth_integration_test.go
+++ b/internal/postgres/device_auth_integration_test.go
@@ -1,6 +1,7 @@
 package postgres
 
 import (
+	"bytes"
 	"context"
 	"crypto/ed25519"
 	"crypto/rand"
@@ -287,6 +288,20 @@ WHERE id = $1`, legacyPending.ID, uuid.NewString(), owner.ID, credential.LookupI
 	if err != nil {
 		t.Fatal(err)
 	}
+	legacyAuthenticated, err := app.AuthenticateDevice(ctx, legacyCredential.Encoded)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resolvedPublicKey, err := app.ResolveMigratedLegacyPublicKey(ctx, legacyAuthenticated)
+	if err != nil || !bytes.Equal(resolvedPublicKey, legacyPublic) {
+		t.Fatalf("migrated legacy public key=%x err=%v", resolvedPublicKey, err)
+	}
+	if _, err := app.ResolveMigratedLegacyPublicKey(ctx, AuthenticatedDevice{PrincipalID: legacyAuthenticated.PrincipalID, LookupID: legacyAuthenticated.LookupID, Generation: legacyAuthenticated.Generation + 1}); !errors.Is(err, ErrUnauthenticated) {
+		t.Fatalf("forged migrated generation error=%v", err)
+	}
+	if _, err := app.ResolveMigratedLegacyPublicKey(ctx, authenticated); !errors.Is(err, ErrUnauthenticated) {
+		t.Fatalf("ordinary device acquired legacy relay authority error=%v", err)
+	}
 	legacyRetry, err := app.RedeemLegacyEnrollment(ctx, proof, legacyRedeem)
 	if err != nil || legacyRetry.Encoded != legacyCredential.Encoded || legacyRetry.LookupID != legacyCredential.LookupID {
 		t.Fatalf("exact legacy exchange retry=%#v err=%v", legacyRetry, err)
@@ -345,5 +360,8 @@ WHERE id = $1`, legacyPending.ID, uuid.NewString(), owner.ID, credential.LookupI
 	}
 	if _, err := app.AuthenticateDevice(ctx, legacyCredential.Encoded); err != nil {
 		t.Fatalf("new device credential failed after legacy disable: %v", err)
+	}
+	if resolvedPublicKey, err := app.ResolveMigratedLegacyPublicKey(ctx, legacyAuthenticated); err != nil || !bytes.Equal(resolvedPublicKey, legacyPublic) {
+		t.Fatalf("migrated relay authority failed after legacy disable: key=%x err=%v", resolvedPublicKey, err)
 	}
 }

--- a/internal/postgres/legacy_auth_store.go
+++ b/internal/postgres/legacy_auth_store.go
@@ -85,11 +85,35 @@ func (d *Database) ResolveLegacyMachine(ctx context.Context, publicKey ed25519.P
 FROM auth.legacy_machines AS machine
 JOIN auth.principals AS principal ON principal.id = machine.principal_id
 CROSS JOIN auth.legacy_auth_state AS state
-WHERE machine.public_key_digest = $1 AND machine.state <> 'retired' AND principal.disabled_at IS NULL AND state.singleton`, digest[:]).Scan(&principalID, &enabled)
+WHERE machine.public_key_digest = $1 AND machine.public_key = $2 AND machine.state <> 'retired' AND principal.disabled_at IS NULL AND state.singleton`, digest[:], []byte(publicKey)).Scan(&principalID, &enabled)
 	if err != nil || !enabled {
 		return "", ErrUnauthenticated
 	}
 	return principalID, nil
+}
+
+// ResolveMigratedLegacyPublicKey maps a currently valid device session back to
+// the exact Ed25519 enrollment it replaced. The public key is an opaque join
+// handle into the daemon's static machine configuration; endpoint authority is
+// never copied into PostgreSQL or reconstructed from labels and principal IDs.
+func (d *Database) ResolveMigratedLegacyPublicKey(ctx context.Context, authenticated AuthenticatedDevice) (ed25519.PublicKey, error) {
+	if !validOpaqueID(authenticated.PrincipalID) || !validOpaqueID(authenticated.LookupID) || authenticated.Generation < 1 {
+		return nil, ErrUnauthenticated
+	}
+	var publicKey []byte
+	err := d.db.QueryRowContext(ctx, `SELECT machine.public_key
+FROM auth.legacy_machines AS machine
+JOIN auth.device_credentials AS credential ON credential.lookup_id = machine.migrated_credential_lookup_id
+JOIN auth.principals AS principal ON principal.id = credential.principal_id
+WHERE machine.state = 'migrated'
+  AND credential.lookup_id = $1 AND credential.principal_id = $2 AND credential.generation = $3
+  AND credential.revoked_at IS NULL
+  AND (credential.expires_at IS NULL OR credential.expires_at > statement_timestamp())
+  AND principal.disabled_at IS NULL`, authenticated.LookupID, authenticated.PrincipalID, authenticated.Generation).Scan(&publicKey)
+	if err != nil || len(publicKey) != ed25519.PublicKeySize {
+		return nil, ErrUnauthenticated
+	}
+	return append(ed25519.PublicKey(nil), publicKey...), nil
 }
 
 // ListLegacyMachines returns bounded content-free migration inventory.

--- a/internal/relay/auth.go
+++ b/internal/relay/auth.go
@@ -2,6 +2,7 @@ package relay
 
 import (
 	"bytes"
+	"context"
 	"crypto/ed25519"
 	"crypto/sha256"
 	"encoding/base64"
@@ -60,14 +61,71 @@ type SignedRequest struct {
 // nonces in the relay database so a daemon restart cannot reopen a replay
 // window.
 type Authenticator struct {
-	store    NonceStore
-	machines map[string]Machine
+	store                NonceStore
+	machines             map[string]Machine
+	transition           TransitionAuthority
+	transitionMachineIDs map[[sha256.Size]byte]string
+}
+
+// TransitionAuthority is the dormant bridge between the durable PostgreSQL
+// migration inventory and the existing configured relay enrollment. For an
+// Ed25519 request credential is empty and legacyKey is the verified configured
+// key. For a device request credential is the opaque bearer and legacyKey is
+// nil. A successful result is always the exact registered legacy public key;
+// callers never accept a friendly label or principal ID as relay authority.
+type TransitionAuthority interface {
+	AuthorizeTransition(context.Context, string, ed25519.PublicKey) (TransitionAuthorization, error)
+}
+
+// TransitionAuthorization binds one successful request to its exact legacy
+// key and a non-secret current-session fence. Current must recheck the durable
+// gate or device generation without retaining bearer material.
+type TransitionAuthorization struct {
+	LegacyPublicKey ed25519.PublicKey
+	Current         func(context.Context) error
+}
+
+// MachineSession is the authenticated relay identity plus an optional durable
+// revalidation fence for long-lived transports.
+type MachineSession struct {
+	MachineID string
+	current   func(context.Context) error
+}
+
+// Current fails closed when the durable transition authority is no longer
+// current. Ordinary signed-request mode has no external transition fence.
+func (s MachineSession) Current(ctx context.Context) error {
+	if s.MachineID == "" {
+		return ErrForbidden
+	}
+	if s.current == nil {
+		return nil
+	}
+	if err := s.current(ctx); err != nil {
+		return ErrForbidden
+	}
+	return nil
 }
 
 // NewAuthenticator accepts a complete explicit enrollment set. Enrollment is
 // configuration-controlled, not message-controlled; duplicate IDs and unsafe
 // endpoint rules fail startup rather than picking an arbitrary credential.
 func NewAuthenticator(store NonceStore, machines []Machine) (*Authenticator, error) {
+	return newAuthenticator(store, machines, nil)
+}
+
+// NewTransitionAuthenticator enables the explicitly selected, dormant
+// Ed25519-to-device transition path. Static machine enrollments remain the sole
+// endpoint authority; PostgreSQL only proves whether the legacy key or its
+// exactly linked replacement credential may select that enrollment.
+func NewTransitionAuthenticator(store NonceStore, machines []Machine, transition TransitionAuthority) (*Authenticator, error) {
+	if transition == nil {
+		return nil, fmt.Errorf("relay transition authenticator requires durable authority")
+	}
+	return newAuthenticator(store, machines, transition)
+}
+
+func newAuthenticator(store NonceStore, machines []Machine, transition TransitionAuthority) (*Authenticator, error) {
 	if store == nil || len(machines) == 0 {
 		return nil, fmt.Errorf("relay authenticator requires enrolled machines")
 	}
@@ -130,7 +188,17 @@ func NewAuthenticator(store NonceStore, machines []Machine) (*Authenticator, err
 			}
 		}
 	}
-	return &Authenticator{store: store, machines: configured}, nil
+	transitionMachineIDs := make(map[[sha256.Size]byte]string, len(configured))
+	if transition != nil {
+		for machineID, machine := range configured {
+			digest := sha256.Sum256(machine.PublicKey)
+			if _, duplicate := transitionMachineIDs[digest]; duplicate {
+				return nil, fmt.Errorf("ambiguous public key for transition enrollment")
+			}
+			transitionMachineIDs[digest] = machineID
+		}
+	}
+	return &Authenticator{store: store, machines: configured, transition: transition, transitionMachineIDs: transitionMachineIDs}, nil
 }
 
 // validEndpointPrefix requires a complete mailbox path segment. Without the
@@ -160,11 +228,23 @@ func CanonicalRequest(request SignedRequest) []byte {
 // Verify rejects unknown machines, stale signatures, path/body tampering, and
 // replays. Errors intentionally use one authorization result at the boundary.
 func (a *Authenticator) Verify(request SignedRequest, now time.Time) error {
-	machine, found := a.machines[request.MachineID]
-	if !found || !ValidRequestToken(request.Nonce) || !validSignedRequest(request, now) || !ed25519.Verify(machine.PublicKey, CanonicalRequest(request), request.Signature) {
+	machine, err := a.verifySignature(request, now)
+	if err != nil {
 		return ErrForbidden
 	}
-	if err := a.store.ConsumeRequestNonce(request.MachineID, request.Nonce, now, request.Timestamp.UTC().Add(maxRequestAge)); err != nil {
+	return a.consumeNonce(machine.ID, request, now)
+}
+
+func (a *Authenticator) verifySignature(request SignedRequest, now time.Time) (Machine, error) {
+	machine, found := a.machines[request.MachineID]
+	if !found || !ValidRequestToken(request.Nonce) || !validSignedRequest(request, now) || !ed25519.Verify(machine.PublicKey, CanonicalRequest(request), request.Signature) {
+		return Machine{}, ErrForbidden
+	}
+	return machine, nil
+}
+
+func (a *Authenticator) consumeNonce(machineID string, request SignedRequest, now time.Time) error {
+	if err := a.store.ConsumeRequestNonce(machineID, request.Nonce, now, request.Timestamp.UTC().Add(maxRequestAge)); err != nil {
 		if errors.Is(err, ErrMaintenance) {
 			return ErrMaintenance
 		}
@@ -177,23 +257,66 @@ func (a *Authenticator) Verify(request SignedRequest, now time.Time) error {
 // body. Route handlers remain responsible for rejecting unsigned URL features
 // (query strings and alternate escaped paths) before calling this method.
 func (a *Authenticator) AuthenticateHTTP(request *http.Request, body []byte, now time.Time) (string, error) {
+	session, err := a.AuthenticateHTTPSession(request, body, now)
+	return session.MachineID, err
+}
+
+// AuthenticateHTTPSession authenticates one request and retains only the
+// non-secret durable fence needed to revalidate a long-lived transport.
+func (a *Authenticator) AuthenticateHTTPSession(request *http.Request, body []byte, now time.Time) (MachineSession, error) {
 	if a == nil || request == nil {
-		return "", ErrForbidden
+		return MachineSession{}, ErrForbidden
+	}
+	if authorization := request.Header.Get("Authorization"); authorization != "" {
+		return a.authenticateTransitionDevice(request, authorization)
 	}
 	timestamp, err := time.Parse(time.RFC3339Nano, request.Header.Get("X-Punaro-Timestamp"))
 	if err != nil {
-		return "", ErrForbidden
+		return MachineSession{}, ErrForbidden
 	}
 	signatureText := request.Header.Get("X-Punaro-Signature")
 	signature, err := base64.RawURLEncoding.DecodeString(signatureText)
 	if err != nil || base64.RawURLEncoding.EncodeToString(signature) != signatureText {
-		return "", ErrForbidden
+		return MachineSession{}, ErrForbidden
 	}
 	signed := SignedRequest{MachineID: request.Header.Get("X-Punaro-Machine"), Method: request.Method, Path: request.URL.Path, Body: body, Timestamp: timestamp, Nonce: request.Header.Get("X-Punaro-Nonce"), Signature: signature}
-	if err := a.Verify(signed, now.UTC()); err != nil {
-		return "", err
+	if a.transition == nil {
+		if err := a.Verify(signed, now.UTC()); err != nil {
+			return MachineSession{}, err
+		}
+		return MachineSession{MachineID: signed.MachineID}, nil
 	}
-	return signed.MachineID, nil
+	machine, err := a.verifySignature(signed, now.UTC())
+	if err != nil {
+		return MachineSession{}, err
+	}
+	authorization, err := a.transition.AuthorizeTransition(request.Context(), "", machine.PublicKey)
+	if err != nil || authorization.Current == nil || !bytes.Equal(authorization.LegacyPublicKey, machine.PublicKey) {
+		return MachineSession{}, ErrForbidden
+	}
+	if err := a.consumeNonce(machine.ID, signed, now.UTC()); err != nil {
+		return MachineSession{}, err
+	}
+	return MachineSession{MachineID: signed.MachineID, current: authorization.Current}, nil
+}
+
+func (a *Authenticator) authenticateTransitionDevice(request *http.Request, authorization string) (MachineSession, error) {
+	if a.transition == nil || len(request.Header.Values("Authorization")) != 1 || !strings.HasPrefix(authorization, "Bearer ") || strings.Count(authorization, " ") != 1 || request.Header.Get("X-Punaro-Machine") != "" || request.Header.Get("X-Punaro-Signature") != "" || request.Header.Get("X-Punaro-Timestamp") != "" || request.Header.Get("X-Punaro-Nonce") != "" {
+		return MachineSession{}, ErrForbidden
+	}
+	credential := strings.TrimPrefix(authorization, "Bearer ")
+	if credential == "" {
+		return MachineSession{}, ErrForbidden
+	}
+	transition, err := a.transition.AuthorizeTransition(request.Context(), credential, nil)
+	if err != nil || transition.Current == nil || len(transition.LegacyPublicKey) != ed25519.PublicKeySize {
+		return MachineSession{}, ErrForbidden
+	}
+	machineID, found := a.transitionMachineIDs[sha256.Sum256(transition.LegacyPublicKey)]
+	if !found || !bytes.Equal(a.machines[machineID].PublicKey, transition.LegacyPublicKey) {
+		return MachineSession{}, ErrForbidden
+	}
+	return MachineSession{MachineID: machineID, current: transition.Current}, nil
 }
 
 // AllowsEndpoint checks a configured endpoint namespace. It is used before an

--- a/internal/relay/auth_test.go
+++ b/internal/relay/auth_test.go
@@ -1,13 +1,25 @@
 package relay
 
 import (
+	"bytes"
+	"context"
 	"crypto/ed25519"
 	"crypto/rand"
+	"encoding/base64"
 	"errors"
+	"net/http"
 	"path/filepath"
 	"testing"
 	"time"
 )
+
+type transitionAuthorityFunc func(context.Context, string, ed25519.PublicKey) (TransitionAuthorization, error)
+
+const testTransitionToken = "not-secret"
+
+func (function transitionAuthorityFunc) AuthorizeTransition(ctx context.Context, credential string, legacyKey ed25519.PublicKey) (TransitionAuthorization, error) {
+	return function(ctx, credential, legacyKey)
+}
 
 type nonceStoreFunc func(string, string, time.Time, time.Time) error
 
@@ -196,6 +208,102 @@ func TestAuthenticatorRejectsExactEndpointOwnedByAnotherMachine(t *testing.T) {
 	}); err == nil {
 		t.Fatal("exact endpoint overlapping another machine namespace was accepted")
 	}
+}
+
+func TestTransitionAuthenticatorMakesLegacyGateAuthoritative(t *testing.T) {
+	public, private, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	store := nonceStoreFunc(func(string, string, time.Time, time.Time) error { return nil })
+	gateOpen := true
+	auth, err := NewTransitionAuthenticator(store, []Machine{{ID: "machine-a", PublicKey: public, EndpointPrefixes: []string{"agent/a/"}}}, transitionAuthorityFunc(func(_ context.Context, credential string, legacyKey ed25519.PublicKey) (TransitionAuthorization, error) {
+		if credential != "" || !gateOpen || !bytes.Equal(legacyKey, public) {
+			return TransitionAuthorization{}, ErrForbidden
+		}
+		return TransitionAuthorization{LegacyPublicKey: legacyKey, Current: func(context.Context) error {
+			if !gateOpen {
+				return ErrForbidden
+			}
+			return nil
+		}}, nil
+	}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	now := time.Date(2026, time.July, 20, 12, 0, 0, 0, time.UTC)
+	signed := signRequest(private, "machine-a", http.MethodPost, "/v1/conversations", []byte(`{"members":[]}`), now, "nonce-open")
+	request := signedHTTPRequest(t, signed)
+	session, err := auth.AuthenticateHTTPSession(request, signed.Body, now)
+	if err != nil || session.MachineID != "machine-a" {
+		t.Fatalf("open legacy gate session=%#v err=%v", session, err)
+	}
+	gateOpen = false
+	if err := session.Current(context.Background()); !errors.Is(err, ErrForbidden) {
+		t.Fatalf("closed legacy gate retained session err=%v", err)
+	}
+	signed = signRequest(private, "machine-a", http.MethodPost, "/v1/conversations", []byte(`{"members":[]}`), now, "nonce-closed")
+	request = signedHTTPRequest(t, signed)
+	if _, err := auth.AuthenticateHTTP(request, signed.Body, now); !errors.Is(err, ErrForbidden) {
+		t.Fatalf("closed legacy gate err=%v", err)
+	}
+}
+
+func TestTransitionAuthenticatorPreservesExactMachineAuthorityForMigratedCredential(t *testing.T) {
+	public, _, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	auth, err := NewTransitionAuthenticator(nonceStoreFunc(func(string, string, time.Time, time.Time) error { return nil }), []Machine{{ID: "machine-a", PublicKey: public, EndpointPrefixes: []string{"agent/a/"}, Endpoints: []string{"claude/exact"}}}, transitionAuthorityFunc(func(_ context.Context, credential string, legacyKey ed25519.PublicKey) (TransitionAuthorization, error) {
+		if credential != testTransitionToken || legacyKey != nil {
+			return TransitionAuthorization{}, ErrForbidden
+		}
+		return TransitionAuthorization{LegacyPublicKey: public, Current: func(context.Context) error { return nil }}, nil
+	}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	request, err := http.NewRequestWithContext(context.Background(), http.MethodPost, "http://localhost/v1/conversations", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	request.Header.Set("Authorization", "Bearer "+testTransitionToken)
+	machineID, err := auth.AuthenticateHTTP(request, nil, time.Now().UTC())
+	if err != nil || machineID != "machine-a" {
+		t.Fatalf("migrated credential machine=%q err=%v", machineID, err)
+	}
+	if !auth.AllowsEndpoint(machineID, "agent/a/session") || !auth.AllowsEndpoint(machineID, "claude/exact") || auth.AllowsEndpoint(machineID, "agent/b/session") || auth.AllowsEndpoint(machineID, "claude/exact-more") {
+		t.Fatal("migrated credential did not inherit the exact configured machine authority")
+	}
+}
+
+func TestTransitionAuthenticatorRejectsAmbiguousLegacyPublicKey(t *testing.T) {
+	public, _, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = NewTransitionAuthenticator(nonceStoreFunc(func(string, string, time.Time, time.Time) error { return nil }), []Machine{
+		{ID: "machine-a", PublicKey: public, EndpointPrefixes: []string{"agent/a/"}},
+		{ID: "machine-b", PublicKey: public, EndpointPrefixes: []string{"agent/b/"}},
+	}, transitionAuthorityFunc(func(context.Context, string, ed25519.PublicKey) (TransitionAuthorization, error) {
+		return TransitionAuthorization{LegacyPublicKey: public, Current: func(context.Context) error { return nil }}, nil
+	}))
+	if err == nil {
+		t.Fatal("transition authenticator accepted an ambiguous legacy public key")
+	}
+}
+
+func signedHTTPRequest(t *testing.T, signed SignedRequest) *http.Request {
+	t.Helper()
+	request, err := http.NewRequestWithContext(context.Background(), signed.Method, "http://localhost"+signed.Path, bytes.NewReader(signed.Body))
+	if err != nil {
+		t.Fatal(err)
+	}
+	request.Header.Set("X-Punaro-Machine", signed.MachineID)
+	request.Header.Set("X-Punaro-Timestamp", signed.Timestamp.Format(time.RFC3339Nano))
+	request.Header.Set("X-Punaro-Nonce", signed.Nonce)
+	request.Header.Set("X-Punaro-Signature", base64.RawURLEncoding.EncodeToString(signed.Signature))
+	return request
 }
 
 func signRequest(private ed25519.PrivateKey, machineID, method, path string, body []byte, timestamp time.Time, nonce string) SignedRequest {

--- a/internal/relay/http.go
+++ b/internal/relay/http.go
@@ -153,8 +153,9 @@ func (h *handler) notifications(w http.ResponseWriter, r *http.Request, session 
 	defer client.Close()
 	ctx, cancel := context.WithCancel(r.Context())
 	defer cancel()
-	revalidate := time.NewTicker(h.sessionRevalidateInterval)
-	defer revalidate.Stop()
+	authenticationExpired := make(chan struct{})
+	revalidationDone := make(chan struct{})
+	go h.revalidateNotificationSession(ctx, cancel, connection, session, authenticationExpired, revalidationDone)
 	go func() {
 		defer cancel()
 		for {
@@ -166,28 +167,54 @@ func (h *handler) notifications(w http.ResponseWriter, r *http.Request, session 
 	for {
 		select {
 		case <-ctx.Done():
+			waitForAuthenticationClose(authenticationExpired, revalidationDone)
 			return
-		case <-revalidate.C:
-			// A check starts halfway through the maximum fence age and receives
-			// only the remaining half as its deadline. A gate/database failure
-			// therefore cannot leave the socket authorized beyond two seconds
-			// after its last successful durable check.
-			checkCtx, checkCancel := context.WithTimeout(ctx, h.sessionRevalidateInterval)
-			err := session.Current(checkCtx)
-			checkCancel()
-			if err != nil {
-				_ = connection.Close(websocket.StatusPolicyViolation, "authentication expired")
-				return
-			}
 		case event := <-client.Events():
 			payload, err := json.Marshal(event)
 			if err != nil {
 				return
 			}
 			if err := connection.Write(ctx, websocket.MessageText, payload); err != nil {
+				waitForAuthenticationClose(authenticationExpired, revalidationDone)
 				return
 			}
 		}
+	}
+}
+
+func (h *handler) revalidateNotificationSession(ctx context.Context, cancel context.CancelFunc, connection *websocket.Conn, session MachineSession, authenticationExpired chan<- struct{}, done chan<- struct{}) {
+	defer close(done)
+	revalidate := time.NewTicker(h.sessionRevalidateInterval)
+	defer revalidate.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-revalidate.C:
+			// A check starts halfway through the maximum fence age and receives
+			// only the remaining half as its deadline. It runs independently of
+			// wake writes, and canceling ctx unblocks a slow/non-reading client.
+			checkCtx, checkCancel := context.WithTimeout(ctx, h.sessionRevalidateInterval)
+			err := session.Current(checkCtx)
+			checkCancel()
+			if err != nil {
+				close(authenticationExpired)
+				cancel()
+				// Cancel first to interrupt any blocked Read/Write, then close the
+				// transport immediately. A close-frame status is not an authority
+				// guarantee and cannot be delivered reliably to a non-reading peer.
+				_ = connection.CloseNow()
+				return
+			}
+		}
+	}
+}
+
+func waitForAuthenticationClose(authenticationExpired <-chan struct{}, revalidationDone <-chan struct{}) {
+	select {
+	case <-authenticationExpired:
+		<-revalidationDone
+	default:
 	}
 }
 

--- a/internal/relay/http.go
+++ b/internal/relay/http.go
@@ -14,18 +14,23 @@ import (
 	"github.com/coder/websocket"
 )
 
-const maxRequestBodyBytes = 64 << 10
+const (
+	maxRequestBodyBytes              = 64 << 10
+	maximumSessionFenceAge           = 2 * time.Second
+	defaultSessionRevalidateInterval = maximumSessionFenceAge / 2
+)
 
 // HandlerOptions make lease timing explicit and injectable for tests.
 type HandlerOptions struct {
-	Now              func() time.Time
-	EndpointLeaseTTL time.Duration
-	DeliveryLeaseTTL time.Duration
-	Notifier         *Notifier
+	Now                       func() time.Time
+	EndpointLeaseTTL          time.Duration
+	DeliveryLeaseTTL          time.Duration
+	Notifier                  *Notifier
+	SessionRevalidateInterval time.Duration
 }
 
-// NewHandler returns the authenticated relay API. It intentionally does not
-// mount WebSockets or attachment routes; those have separate release gates.
+// NewHandler returns the authenticated relay API, including the wake-metadata
+// notification WebSocket. Attachment routes remain separate release gates.
 func NewHandler(store Backend, auth *Authenticator, options HandlerOptions) http.Handler {
 	if options.Now == nil {
 		options.Now = time.Now
@@ -39,17 +44,21 @@ func NewHandler(store Backend, auth *Authenticator, options HandlerOptions) http
 	if options.Notifier == nil {
 		options.Notifier = NewNotifier()
 	}
-	h := &handler{store: store, auth: auth, notifier: options.Notifier, now: options.Now, endpointLeaseTTL: options.EndpointLeaseTTL, deliveryLeaseTTL: options.DeliveryLeaseTTL}
+	if options.SessionRevalidateInterval <= 0 || options.SessionRevalidateInterval > maximumSessionFenceAge/2 {
+		options.SessionRevalidateInterval = defaultSessionRevalidateInterval
+	}
+	h := &handler{store: store, auth: auth, notifier: options.Notifier, now: options.Now, endpointLeaseTTL: options.EndpointLeaseTTL, deliveryLeaseTTL: options.DeliveryLeaseTTL, sessionRevalidateInterval: options.SessionRevalidateInterval}
 	return http.HandlerFunc(h.serveHTTP)
 }
 
 type handler struct {
-	store            Backend
-	auth             *Authenticator
-	notifier         *Notifier
-	now              func() time.Time
-	endpointLeaseTTL time.Duration
-	deliveryLeaseTTL time.Duration
+	store                     Backend
+	auth                      *Authenticator
+	notifier                  *Notifier
+	now                       func() time.Time
+	endpointLeaseTTL          time.Duration
+	deliveryLeaseTTL          time.Duration
+	sessionRevalidateInterval time.Duration
 }
 
 func (h *handler) serveHTTP(w http.ResponseWriter, r *http.Request) {
@@ -62,7 +71,7 @@ func (h *handler) serveHTTP(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusRequestEntityTooLarge, "request body is too large")
 		return
 	}
-	machineID, err := h.authenticate(r, body)
+	session, err := h.authenticate(r, body)
 	if err != nil {
 		if errors.Is(err, ErrMaintenance) {
 			writeStoreError(w, err)
@@ -71,12 +80,13 @@ func (h *handler) serveHTTP(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusUnauthorized, "authentication required")
 		return
 	}
+	machineID := session.MachineID
 	now := h.now().UTC()
 	switch {
 	case r.Method == http.MethodGet && r.URL.Path == "/v1/conversations":
 		h.listConversations(w, machineID, now)
 	case r.Method == http.MethodGet && r.URL.Path == "/v1/notifications":
-		h.notifications(w, r, machineID)
+		h.notifications(w, r, session)
 	case r.Method == http.MethodPut && r.URL.Path == "/v1/machines/me/endpoints":
 		h.advertiseEndpoints(w, body, machineID, now)
 	case r.Method == http.MethodPost && r.URL.Path == "/v1/conversations":
@@ -133,16 +143,18 @@ func (h *handler) listConversations(w http.ResponseWriter, machineID string, now
 	writeJSON(w, http.StatusOK, map[string]any{"conversations": conversations})
 }
 
-func (h *handler) notifications(w http.ResponseWriter, r *http.Request, machineID string) {
+func (h *handler) notifications(w http.ResponseWriter, r *http.Request, session MachineSession) {
 	connection, err := websocket.Accept(w, r, &websocket.AcceptOptions{CompressionMode: websocket.CompressionDisabled})
 	if err != nil {
 		return
 	}
 	defer func() { _ = connection.Close(websocket.StatusNormalClosure, "") }()
-	client := h.notifier.Register(machineID)
+	client := h.notifier.Register(session.MachineID)
 	defer client.Close()
 	ctx, cancel := context.WithCancel(r.Context())
 	defer cancel()
+	revalidate := time.NewTicker(h.sessionRevalidateInterval)
+	defer revalidate.Stop()
 	go func() {
 		defer cancel()
 		for {
@@ -155,6 +167,18 @@ func (h *handler) notifications(w http.ResponseWriter, r *http.Request, machineI
 		select {
 		case <-ctx.Done():
 			return
+		case <-revalidate.C:
+			// A check starts halfway through the maximum fence age and receives
+			// only the remaining half as its deadline. A gate/database failure
+			// therefore cannot leave the socket authorized beyond two seconds
+			// after its last successful durable check.
+			checkCtx, checkCancel := context.WithTimeout(ctx, h.sessionRevalidateInterval)
+			err := session.Current(checkCtx)
+			checkCancel()
+			if err != nil {
+				_ = connection.Close(websocket.StatusPolicyViolation, "authentication expired")
+				return
+			}
 		case event := <-client.Events():
 			payload, err := json.Marshal(event)
 			if err != nil {
@@ -167,8 +191,8 @@ func (h *handler) notifications(w http.ResponseWriter, r *http.Request, machineI
 	}
 }
 
-func (h *handler) authenticate(r *http.Request, body []byte) (string, error) {
-	return h.auth.AuthenticateHTTP(r, body, h.now())
+func (h *handler) authenticate(r *http.Request, body []byte) (MachineSession, error) {
+	return h.auth.AuthenticateHTTPSession(r, body, h.now())
 }
 
 func (h *handler) advertiseEndpoints(w http.ResponseWriter, body []byte, machineID string, now time.Time) {

--- a/internal/relay/http_test.go
+++ b/internal/relay/http_test.go
@@ -331,6 +331,8 @@ func TestHTTPNotificationsCloseWithinFenceWhenTransitionAuthorityHangs(t *testin
 	defer cancel()
 	if _, _, err := connection.Read(readCtx); err == nil {
 		t.Fatal("unavailable transition authority left notification socket open")
+	} else if readCtx.Err() != nil {
+		t.Fatalf("notification socket did not close before the test deadline: %v", err)
 	}
 }
 

--- a/internal/relay/http_test.go
+++ b/internal/relay/http_test.go
@@ -11,6 +11,7 @@ import (
 	"net/http/httptest"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -279,6 +280,57 @@ func TestHTTPNotificationsAuthenticatesAndEmitsOnlyWakeMetadata(t *testing.T) {
 	}
 	if string(data) != `{"type":"wake","topic_id":"conversation-1","sequence":9}` {
 		t.Fatalf("wake payload=%s", data)
+	}
+}
+
+func TestHTTPNotificationsCloseWithinFenceWhenTransitionAuthorityHangs(t *testing.T) {
+	public, _, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	store, err := Open(filepath.Join(t.TempDir(), "relay.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	var current atomic.Int32
+	current.Store(1)
+	auth, err := NewTransitionAuthenticator(store, []Machine{{ID: "machine-a", PublicKey: public, EndpointPrefixes: []string{"agent/a/"}}}, transitionAuthorityFunc(func(_ context.Context, credential string, legacyKey ed25519.PublicKey) (TransitionAuthorization, error) {
+		if credential != testTransitionToken || legacyKey != nil {
+			return TransitionAuthorization{}, ErrForbidden
+		}
+		return TransitionAuthorization{LegacyPublicKey: public, Current: func(ctx context.Context) error {
+			switch current.Load() {
+			case 1:
+				return nil
+			case -1:
+				<-ctx.Done()
+				return ctx.Err()
+			default:
+				return ErrForbidden
+			}
+		}}, nil
+	}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	server := httptest.NewServer(NewHandler(store, auth, HandlerOptions{SessionRevalidateInterval: 10 * time.Millisecond}))
+	defer server.Close()
+	headers := http.Header{}
+	headers.Set("Authorization", "Bearer "+testTransitionToken)
+	connection, response, err := websocket.Dial(t.Context(), "ws"+strings.TrimPrefix(server.URL, "http")+"/v1/notifications", &websocket.DialOptions{HTTPHeader: headers})
+	if response != nil && response.Body != nil {
+		defer func() { _ = response.Body.Close() }()
+	}
+	if err != nil {
+		t.Fatalf("dial notifications status=%v err=%v", response, err)
+	}
+	defer func() { _ = connection.Close(websocket.StatusNormalClosure, "done") }()
+	current.Store(-1)
+	readCtx, cancel := context.WithTimeout(t.Context(), time.Second)
+	defer cancel()
+	if _, _, err := connection.Read(readCtx); websocket.CloseStatus(err) != websocket.StatusPolicyViolation {
+		t.Fatalf("revoked transition socket err=%v status=%v", err, websocket.CloseStatus(err))
 	}
 }
 

--- a/internal/relay/http_test.go
+++ b/internal/relay/http_test.go
@@ -329,8 +329,8 @@ func TestHTTPNotificationsCloseWithinFenceWhenTransitionAuthorityHangs(t *testin
 	current.Store(-1)
 	readCtx, cancel := context.WithTimeout(t.Context(), time.Second)
 	defer cancel()
-	if _, _, err := connection.Read(readCtx); websocket.CloseStatus(err) != websocket.StatusPolicyViolation {
-		t.Fatalf("revoked transition socket err=%v status=%v", err, websocket.CloseStatus(err))
+	if _, _, err := connection.Read(readCtx); err == nil {
+		t.Fatal("unavailable transition authority left notification socket open")
 	}
 }
 


### PR DESCRIPTION
## What changed

- add an off-by-default credential-transition runtime that requires device auth and the PostgreSQL relay
- resolve an authenticated migrated device back through the proof-bound credential lookup to its exact registered legacy public key
- make legacy Ed25519 relay requests consult the durable global legacy gate before nonce consumption
- bind both paths to the same static machine enrollment, preserving exact endpoint prefixes, exact endpoints, and attachment-device authority
- revalidate notification WebSocket session fences every second under a one-second deadline without retaining bearer material
- fail closed on ambiguous public keys, mixed auth envelopes, stale/revoked credentials, retired mappings, gate closure, timeout, and database failure

## Why

M3 recorded successful Ed25519-to-device exchanges, but the replacement credential could not recover the exact relay machine authority and the live Ed25519 verifier did not consult the durable global gate. M9b supplies those missing links while remaining dormant and leaving SQLite/default routing and mail authority unchanged.

## Security and review

The first adversarial review found that long-lived notification sockets were not revalidated. The remediation carries only a non-secret session fence and closes the socket after revocation, rotation, principal disablement, retirement, mapping loss, or gate closure. Alignment review then found that a two-second tick plus a two-second query timeout could approach four seconds; the final contract is a one-second tick plus a one-second deadline, covered by a hanging-authority regression test. PR review found that wake writes could starve that check; revalidation now runs independently, cancels blocked socket I/O on failure, and immediately closes the transport without promising a close frame to a non-reading peer.

- alignment review: PASS
- adversarial correctness/security review: PASS; no remaining P0/P1/P2 findings

## Validation

- `make test`
- `make test-race`
- `make staticcheck`
- `make lint`
- `make security`

All pass on exact head `98b18ff`. The live PostgreSQL credential-exchange assertions run in the hosted PostgreSQL integration job; local Docker is unavailable. Bugbot's test-coverage finding was fixed by making the hanging-authority regression test fail when its own read deadline expires; the focused test passed 20 normal runs and 5 race runs, and an independent adversarial re-review passed.

M9 remains in progress. This PR does not import SQLite, activate PostgreSQL mail authority, close the legacy gate, retire a source, or perform the irreversible M9c cutover.
