### PR TITLE
M9c: add irreversible mail cutover

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -544,6 +544,8 @@ leases, advances their generations, and installs a durable write fence that
 also stops already-open older daemons. PostgreSQL schema v8 can durably record
 one owner-authorized import epoch plus bounded staging/checkpoint state and
 fences application-role mail writes while that epoch is importing or verified.
+Schema v9 expands only the staging payload bound to cover worst-case JSON
+escaping for every valid 32 KiB message body while retaining the same ACLs.
 The one-shot executor now consumes that substrate. It exports canonical rows in
 bounded order-preserving pages, durably checkpoints exact idempotent staging,
 streams every table back through the source-manifest hash, and materializes all
@@ -612,7 +614,10 @@ The supported cutover action is `punaro mail cutover`. Its dry-run reads the
 service-owned `relay.db` from the installation data directory and prints the
 source fingerprint, exact counts, and PostgreSQL target identity without a
 mutation. Execution accepts no arbitrary source path and requires a caller
-chosen epoch UUID, the dry-run fingerprint, and `--yes`. SQLite prepare fences
+chosen epoch UUID, the dry-run fingerprint, `--yes`, and a complete validated
+public static relay enrollment on first execution. That enrollment is published
+marker-last before SQLite prepare, remains the canonical endpoint authority
+after cutover, and cannot be changed by a recovery retry. SQLite prepare fences
 old daemons and clears every lease holder while advancing fences. Staging is
 bounded to 128 rows per page and resumes from durable PostgreSQL checkpoints.
 Verification rejects any missing, extra, reordered, malformed, or changed row.

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -537,17 +537,28 @@ dirty, old, newer, or incompatible schemas without performing DDL. The normal
 application role is distinct from the schema owner. SQLite remains the active
 and default relay authority until the later fenced mail cutover.
 
-The first mail-cutover slice remains dark and stops before authority transfer.
+The first mail-cutover slice was dark and stopped before authority transfer.
 SQLite can be inspected read-only into a deterministic logical manifest; its
 prepare barrier expires endpoint ownership, clears consumers and delivery
 leases, advances their generations, and installs a durable write fence that
 also stops already-open older daemons. PostgreSQL schema v8 can durably record
 one owner-authorized import epoch plus bounded staging/checkpoint state and
 fences application-role mail writes while that epoch is importing or verified.
-It has no canonical-row importer or activation transition, so it cannot create
-a dual-authority state. A prepared SQLite source may be reopened only before it
-is permanently retired; retirement and PostgreSQL activation belong to the
-later irreversible executor slice.
+The one-shot executor now consumes that substrate. It exports canonical rows in
+bounded order-preserving pages, durably checkpoints exact idempotent staging,
+streams every table back through the source-manifest hash, and materializes all
+canonical PostgreSQL tables in one verified transaction. Before source
+retirement an explicit abort deletes any materialized destination rows, reopens
+SQLite first, and marks the destination epoch aborted. If PostgreSQL rejected
+before recording the epoch, abort first records an exact terminal tombstone so
+a delayed begin cannot resurrect the import fence, then reopens SQLite.
+Retirement is permanent.
+Only after it succeeds may one owner transaction prove that no intended legacy
+machine remains pending, close the legacy gate, and mark PostgreSQL active.
+The generated environment, Compose input, and installation marker are then
+published locally with `installation.json` last. A crash can therefore resume
+at prepare, staging, verification, retirement, activation, or publication
+without dual writes or rollback across the seal.
 
 The second dark foundation slice adds opaque principals/projects, explicit
 selected-project and dynamic all-project capability grants, globally unique
@@ -596,6 +607,17 @@ deadline in a dedicated loop; wake writes cannot delay it, and fence failure
 cancels any blocked write. This bounds authority after the last successful check to two seconds. Gate
 closure, key retirement, credential rotation/revocation, principal disablement,
 mapping removal, timeout, or database failure closes the socket.
+
+The supported cutover action is `punaro mail cutover`. Its dry-run reads the
+service-owned `relay.db` from the installation data directory and prints the
+source fingerprint, exact counts, and PostgreSQL target identity without a
+mutation. Execution accepts no arbitrary source path and requires a caller
+chosen epoch UUID, the dry-run fingerprint, and `--yes`. SQLite prepare fences
+old daemons and clears every lease holder while advancing fences. Staging is
+bounded to 128 rows per page and resumes from durable PostgreSQL checkpoints.
+Verification rejects any missing, extra, reordered, malformed, or changed row.
+`--abort` is available only before SQLite retirement; after activation the old
+file is forensic evidence and recovery is PostgreSQL backup or forward repair.
 
 The fourth dark foundation slice gives projects durable, credential-free
 identity claims. Conservative Git normalization strips credentials and only

--- a/README.md
+++ b/README.md
@@ -58,9 +58,11 @@ make operator-binary
 ```
 
 The host wrapper also provides exported-snapshot `backup`, strict `backup
-verify`, clean-stack `restore --into-new-stack`, and the durable backup-gated
-`update` path; see the operator guide for private-path, PostgreSQL-role,
-rollback, recovery, external-dependency, and restore-drill rules.
+verify`, clean-stack `restore --into-new-stack`, the durable backup-gated
+`update` path, and the explicit one-shot `mail cutover` path. Mail cutover is
+always dry-run first, imports in bounded resumable pages, and requires the
+printed source fingerprint plus an explicit epoch and `--yes`. See the operator
+guide for the pre-seal abort and irreversible recovery boundaries.
 
 ```sh
 cp .env.example .env
@@ -115,7 +117,7 @@ precedence over dotenv values.
 | `PUNARO_TRUSTED_LAN_CIDR` | unset | Private/link-local CIDR containing the concrete LAN bind. Valid only in LAN mode. |
 | `PUNARO_TRUSTED_LAN_HTTP` | `false` | Explicit plaintext credential exception for observed peers inside the validated trusted LAN. Public peers never qualify. |
 | `PUNARO_RELAY_ENABLED` | `false` | Enables the loopback text relay; requires public machine enrollment records. |
-| `PUNARO_RELAY_STORE` | `sqlite` | Explicit relay backend selector. `postgres` requires PostgreSQL schema v8 and is for empty-destination parity/qualification before the M-9 one-shot cutover; it never imports or dual-writes SQLite. Credential transition remains separately off by default. |
+| `PUNARO_RELAY_STORE` | `sqlite` | Explicit relay backend selector. Before cutover, `postgres` is limited to empty-destination parity/qualification. The supported one-shot executor publishes `postgres` marker-last only after verified import, SQLite retirement, legacy-gate closure, and PostgreSQL activation. It never dual-writes. |
 | `PUNARO_RELAY_MACHINES_JSON` | unset | Explicit public-key machine enrollment records. `endpoint_prefixes` claims disjoint machine namespaces; `endpoints` can grant a named exact endpoint without creating a prefix. An issuer-capable machine additionally has canonical raw-base64url `attachment_device_id` (16 bytes), bound to exactly one directory device. |
 | `PUNARO_DIRECTORY_ENABLED` | `false` | Serves a current complete signed directory snapshot to authenticated enrolled machines; requires the relay. |
 | `PUNARO_DIRECTORY_SNAPSHOT_FILE` | unset | Absolute, root-owned and service-group-readable (`2750` parent, `0640` regular non-symlink) canonical directory snapshot publication file. |

--- a/cmd/punaro/mail_cutover_command.go
+++ b/cmd/punaro/mail_cutover_command.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"path/filepath"
+	"time"
+
+	"github.com/rock3r/punaro/internal/cutover"
+	"github.com/rock3r/punaro/internal/operator"
+	punaropostgres "github.com/rock3r/punaro/internal/postgres"
+)
+
+type mailCutoverCommand func(context.Context, operator.Installation, bool, bool, cutover.Request) (any, error)
+
+func runMailCutover(args []string, stdout, stderr io.Writer, execute mailCutoverCommand) int {
+	flags := flag.NewFlagSet("mail cutover", flag.ContinueOnError)
+	flags.SetOutput(stderr)
+	directory := flags.String("directory", "", "absolute Punaro installation directory")
+	dryRun := flags.Bool("dry-run", false, "inspect source and target without changing either authority")
+	abort := flags.Bool("abort", false, "abort the exact prepared epoch before source retirement")
+	epochID := flags.String("epoch-id", "", "explicit cutover epoch UUID")
+	expectedFingerprint := flags.String("expected-source-fingerprint", "", "exact fingerprint printed by dry-run")
+	confirmed := flags.Bool("yes", false, "confirm the irreversible source retirement and PostgreSQL activation")
+	if flags.Parse(args) != nil || flags.NArg() != 0 || *directory == "" || execute == nil {
+		return 2
+	}
+	if !*dryRun && !*abort && (!*confirmed || *epochID == "" || *expectedFingerprint == "") {
+		_, _ = fmt.Fprintln(stderr, "mail cutover execution requires --epoch-id, --expected-source-fingerprint, and --yes")
+		return 2
+	}
+	if *dryRun && (*abort || *confirmed || *epochID != "" || *expectedFingerprint != "") {
+		_, _ = fmt.Fprintln(stderr, "mail cutover dry-run does not accept execution authorization")
+		return 2
+	}
+	if *abort && (!*confirmed || *epochID == "" || *expectedFingerprint != "") {
+		_, _ = fmt.Fprintln(stderr, "mail cutover abort requires --epoch-id and --yes")
+		return 2
+	}
+	var installation operator.Installation
+	var err error
+	if !*dryRun && !*abort {
+		installation, err = operator.LoadMailCutoverRecovery(*directory)
+	} else {
+		installation, err = operator.Load(*directory)
+	}
+	if err != nil {
+		_, _ = fmt.Fprintln(stderr, "mail cutover installation is unavailable")
+		return 1
+	}
+	if (*dryRun || *abort) && len(operator.CheckPaths(installation)) != 0 {
+		_, _ = fmt.Fprintln(stderr, "mail cutover installation paths are not ready")
+		return 1
+	}
+	request := cutover.Request{ActorPrincipalID: installation.OwnerPrincipalID, EpochID: *epochID, ExpectedSourceFingerprint: *expectedFingerprint, Cutoff: time.Now().UTC()}
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Hour)
+	defer cancel()
+	value, err := execute(ctx, installation, *dryRun, *abort, request)
+	if err != nil {
+		_, _ = fmt.Fprintln(stderr, "mail cutover failed")
+		return 1
+	}
+	return writeJSON(stdout, stderr, value)
+}
+
+func executeMailCutover(ctx context.Context, installation operator.Installation, dryRun, abort bool, request cutover.Request) (any, error) {
+	admin, err := punaropostgres.OpenAdministration(ctx, punaropostgres.Config{DSNFile: installation.OwnerDSNFile})
+	if err != nil {
+		return nil, errors.New("mail cutover administration is unavailable")
+	}
+	defer func() { _ = admin.Close() }()
+	executor := cutover.Executor{
+		Source: cutover.FileSource{Path: filepath.Join(installation.DataDir, "relay.db")}, Destination: admin, BatchSize: 128,
+		Publish: func(_ context.Context, publication operator.MailCutoverPublication) error {
+			_, err := operator.PublishMailCutover(installation.Directory, publication)
+			return err
+		},
+	}
+	if dryRun {
+		return executor.DryRun(ctx)
+	}
+	if abort {
+		return executor.Abort(ctx, request.ActorPrincipalID, request.EpochID)
+	}
+	return executor.Execute(ctx, request)
+}

--- a/cmd/punaro/mail_cutover_command.go
+++ b/cmd/punaro/mail_cutover_command.go
@@ -24,6 +24,7 @@ func runMailCutover(args []string, stdout, stderr io.Writer, execute mailCutover
 	abort := flags.Bool("abort", false, "abort the exact prepared epoch before source retirement")
 	epochID := flags.String("epoch-id", "", "explicit cutover epoch UUID")
 	expectedFingerprint := flags.String("expected-source-fingerprint", "", "exact fingerprint printed by dry-run")
+	relayMachinesFile := flags.String("relay-machines-file", "", "protected static relay enrollment JSON to persist before execution")
 	confirmed := flags.Bool("yes", false, "confirm the irreversible source retirement and PostgreSQL activation")
 	if flags.Parse(args) != nil || flags.NArg() != 0 || *directory == "" || execute == nil {
 		return 2
@@ -32,11 +33,11 @@ func runMailCutover(args []string, stdout, stderr io.Writer, execute mailCutover
 		_, _ = fmt.Fprintln(stderr, "mail cutover execution requires --epoch-id, --expected-source-fingerprint, and --yes")
 		return 2
 	}
-	if *dryRun && (*abort || *confirmed || *epochID != "" || *expectedFingerprint != "") {
+	if *dryRun && (*abort || *confirmed || *epochID != "" || *expectedFingerprint != "" || *relayMachinesFile != "") {
 		_, _ = fmt.Fprintln(stderr, "mail cutover dry-run does not accept execution authorization")
 		return 2
 	}
-	if *abort && (!*confirmed || *epochID == "" || *expectedFingerprint != "") {
+	if *abort && (!*confirmed || *epochID == "" || *expectedFingerprint != "" || *relayMachinesFile != "") {
 		_, _ = fmt.Fprintln(stderr, "mail cutover abort requires --epoch-id and --yes")
 		return 2
 	}
@@ -50,6 +51,19 @@ func runMailCutover(args []string, stdout, stderr io.Writer, execute mailCutover
 	if err != nil {
 		_, _ = fmt.Fprintln(stderr, "mail cutover installation is unavailable")
 		return 1
+	}
+	if !*dryRun && !*abort {
+		if *relayMachinesFile != "" {
+			installation, err = operator.ConfigureMailCutoverRelayMachines(*directory, *relayMachinesFile)
+			if err != nil {
+				_, _ = fmt.Fprintln(stderr, "mail cutover relay enrollment is unavailable")
+				return 1
+			}
+		}
+		if installation.RelayMachinesJSON == "" {
+			_, _ = fmt.Fprintln(stderr, "mail cutover execution requires --relay-machines-file")
+			return 2
+		}
 	}
 	if (*dryRun || *abort) && len(operator.CheckPaths(installation)) != 0 {
 		_, _ = fmt.Fprintln(stderr, "mail cutover installation paths are not ready")

--- a/cmd/punaro/mail_cutover_command.go
+++ b/cmd/punaro/mail_cutover_command.go
@@ -88,6 +88,7 @@ func executeMailCutover(ctx context.Context, installation operator.Installation,
 	defer func() { _ = admin.Close() }()
 	executor := cutover.Executor{
 		Source: cutover.FileSource{Path: filepath.Join(installation.DataDir, "relay.db")}, Destination: admin, BatchSize: 128,
+		Enrollment: installation.RelayMachinesJSON,
 		Publish: func(_ context.Context, publication operator.MailCutoverPublication) error {
 			_, err := operator.PublishMailCutover(installation.Directory, publication)
 			return err

--- a/cmd/punaro/mail_cutover_command_test.go
+++ b/cmd/punaro/mail_cutover_command_test.go
@@ -1,0 +1,67 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/rock3r/punaro/internal/cutover"
+	"github.com/rock3r/punaro/internal/operator"
+	"github.com/rock3r/punaro/internal/postgres"
+	"github.com/rock3r/punaro/internal/relay"
+)
+
+func TestMailCutoverCommandRequiresDryRunBindingAndExplicitConfirmation(t *testing.T) {
+	directory := testInstallation(t)
+	called := false
+	execute := func(_ context.Context, _ operator.Installation, dryRun, abort bool, request cutover.Request) (any, error) {
+		called = true
+		if !dryRun || abort || request.EpochID != "" || request.ExpectedSourceFingerprint != "" {
+			t.Fatalf("dry-run request=%#v dry=%t abort=%t", request, dryRun, abort)
+		}
+		return cutover.Plan{SourcePhase: relay.MigrationSourceActive, SourceFingerprint: strings.Repeat("a", 64), TargetIdentity: strings.Repeat("b", 64)}, nil
+	}
+	var stdout, stderr bytes.Buffer
+	if code := runMailCutover([]string{"--directory", directory, "--dry-run"}, &stdout, &stderr, execute); code != 0 || !called || !strings.Contains(stdout.String(), `"source_fingerprint"`) {
+		t.Fatalf("dry-run code=%d called=%t stdout=%q stderr=%q", code, called, stdout.String(), stderr.String())
+	}
+	called = false
+	stdout.Reset()
+	stderr.Reset()
+	if code := runMailCutover([]string{"--directory", directory, "--epoch-id", "019f7f07-8b88-7c12-a394-b663274a6555", "--expected-source-fingerprint", strings.Repeat("a", 64)}, &stdout, &stderr, execute); code != 2 || called {
+		t.Fatalf("unconfirmed code=%d called=%t stderr=%q", code, called, stderr.String())
+	}
+}
+
+func TestMailCutoverCommandPassesExactIrreversibleAuthorization(t *testing.T) {
+	directory := testInstallation(t)
+	epoch := "019f7f07-8b88-7c12-a394-b663274a6555"
+	fingerprint := strings.Repeat("a", 64)
+	execute := func(_ context.Context, installation operator.Installation, dryRun, abort bool, request cutover.Request) (any, error) {
+		if dryRun || abort || request.ActorPrincipalID != installation.OwnerPrincipalID || request.EpochID != epoch || request.ExpectedSourceFingerprint != fingerprint || request.Cutoff.IsZero() {
+			t.Fatalf("installation=%#v request=%#v dry=%t abort=%t", installation, request, dryRun, abort)
+		}
+		return cutover.Result{EpochID: epoch, SourceFingerprint: fingerprint, SourcePhase: relay.MigrationSourceRetired, Phase: postgres.MailCutoverActive}, nil
+	}
+	var stdout, stderr bytes.Buffer
+	args := []string{"--directory", directory, "--epoch-id", epoch, "--expected-source-fingerprint", fingerprint, "--yes"}
+	if code := runMailCutover(args, &stdout, &stderr, execute); code != 0 || !strings.Contains(stdout.String(), `"phase": "active"`) {
+		t.Fatalf("code=%d stdout=%q stderr=%q", code, stdout.String(), stderr.String())
+	}
+}
+
+func TestMailCutoverCommandPassesExplicitAbort(t *testing.T) {
+	directory := testInstallation(t)
+	epoch := "019f7f07-8b88-7c12-a394-b663274a6555"
+	execute := func(_ context.Context, installation operator.Installation, dryRun, abort bool, request cutover.Request) (any, error) {
+		if dryRun || !abort || request.ActorPrincipalID != installation.OwnerPrincipalID || request.EpochID != epoch || request.ExpectedSourceFingerprint != "" {
+			t.Fatalf("request=%#v dry=%t abort=%t", request, dryRun, abort)
+		}
+		return cutover.Result{EpochID: epoch, SourcePhase: relay.MigrationSourceActive, Phase: postgres.MailCutoverAborted}, nil
+	}
+	var stdout, stderr bytes.Buffer
+	if code := runMailCutover([]string{"--directory", directory, "--abort", "--epoch-id", epoch, "--yes"}, &stdout, &stderr, execute); code != 0 || !strings.Contains(stdout.String(), `"phase": "aborted"`) {
+		t.Fatalf("code=%d stdout=%q stderr=%q", code, stdout.String(), stderr.String())
+	}
+}

--- a/cmd/punaro/mail_cutover_command_test.go
+++ b/cmd/punaro/mail_cutover_command_test.go
@@ -3,6 +3,8 @@ package main
 import (
 	"bytes"
 	"context"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -36,16 +38,21 @@ func TestMailCutoverCommandRequiresDryRunBindingAndExplicitConfirmation(t *testi
 
 func TestMailCutoverCommandPassesExactIrreversibleAuthorization(t *testing.T) {
 	directory := testInstallation(t)
+	relayMachines := filepath.Join(filepath.Dir(directory), "relay-machines.json")
+	const relayMachinesJSON = `[{"id":"machine-a","public_key":"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA","endpoint_prefixes":["agent/a/"],"endpoints":[],"attachment_device_id":""}]`
+	if err := os.WriteFile(relayMachines, []byte(relayMachinesJSON), 0o600); err != nil {
+		t.Fatal(err)
+	}
 	epoch := "019f7f07-8b88-7c12-a394-b663274a6555"
 	fingerprint := strings.Repeat("a", 64)
 	execute := func(_ context.Context, installation operator.Installation, dryRun, abort bool, request cutover.Request) (any, error) {
-		if dryRun || abort || request.ActorPrincipalID != installation.OwnerPrincipalID || request.EpochID != epoch || request.ExpectedSourceFingerprint != fingerprint || request.Cutoff.IsZero() {
+		if dryRun || abort || installation.RelayMachinesJSON != relayMachinesJSON || request.ActorPrincipalID != installation.OwnerPrincipalID || request.EpochID != epoch || request.ExpectedSourceFingerprint != fingerprint || request.Cutoff.IsZero() {
 			t.Fatalf("installation=%#v request=%#v dry=%t abort=%t", installation, request, dryRun, abort)
 		}
 		return cutover.Result{EpochID: epoch, SourceFingerprint: fingerprint, SourcePhase: relay.MigrationSourceRetired, Phase: postgres.MailCutoverActive}, nil
 	}
 	var stdout, stderr bytes.Buffer
-	args := []string{"--directory", directory, "--epoch-id", epoch, "--expected-source-fingerprint", fingerprint, "--yes"}
+	args := []string{"--directory", directory, "--relay-machines-file", relayMachines, "--epoch-id", epoch, "--expected-source-fingerprint", fingerprint, "--yes"}
 	if code := runMailCutover(args, &stdout, &stderr, execute); code != 0 || !strings.Contains(stdout.String(), `"phase": "active"`) {
 		t.Fatalf("code=%d stdout=%q stderr=%q", code, stdout.String(), stderr.String())
 	}

--- a/cmd/punaro/main.go
+++ b/cmd/punaro/main.go
@@ -319,7 +319,7 @@ func main() { os.Exit(run(os.Args[1:], os.Stdout, os.Stderr)) }
 
 func run(args []string, stdout, stderr io.Writer) int {
 	if len(args) == 0 {
-		_, _ = fmt.Fprintln(stderr, "usage: punaro init|up|status|doctor|client|backup|restore|update")
+		_, _ = fmt.Fprintln(stderr, "usage: punaro init|up|status|doctor|client|mail|backup|restore|update")
 		return 2
 	}
 	switch args[0] {
@@ -334,6 +334,10 @@ func run(args []string, stdout, stderr io.Writer) int {
 	case "client":
 		if len(args) > 1 && args[1] == "add" {
 			return runClientAdd(args[2:], stdout, stderr)
+		}
+	case "mail":
+		if len(args) > 1 && args[1] == "cutover" {
+			return runMailCutover(args[2:], stdout, stderr, executeMailCutover)
 		}
 	case "backup":
 		return runBackup(args[1:], stdout, stderr)

--- a/docs/operator-guide.md
+++ b/docs/operator-guide.md
@@ -465,7 +465,7 @@ consume the mail budget indefinitely.
 
 SQLite remains the default active relay. Maintainers may explicitly select an
 empty PostgreSQL relay with `PUNARO_RELAY_STORE=postgres` only after completing
-the supported update to schema v8. This selector does not import the SQLite file,
+the supported update through schema v9. This selector does not import the SQLite file,
 does not dual-write, and is incompatible with the superseded directory and
 attachment routes. Do not point an established installation at an empty
 PostgreSQL relay as a migration shortcut; the verified one-shot mail cutover is
@@ -481,19 +481,24 @@ First stop ordinary operator changes, confirm every intended legacy machine is
 punaro mail cutover --directory /absolute/private/punaro --dry-run
 ```
 
-Record the printed `source_fingerprint` and `target_identity`. Choose one UUID
-for the durable epoch, then execute exactly that binding:
+Record the printed `source_fingerprint` and `target_identity`. Prepare one
+protected JSON file containing the complete public static relay enrollment;
+private keys and device bearer credentials must never appear in it. Choose one
+UUID for the durable epoch, then execute exactly that binding:
 
 ```sh
 punaro mail cutover --directory /absolute/private/punaro \
+  --relay-machines-file /absolute/private/relay-machines.json \
   --epoch-id 019f7f07-8b88-7c12-a394-b663274a6555 \
   --expected-source-fingerprint SOURCE_SHA256 --yes
 ```
 
-The same command is the crash-recovery command. It resumes the exact prepared
-source, checkpointed staging, verified destination, retired source, active
-database, or marker-last publication. Before source retirement only, abort the
-same epoch explicitly:
+Punaro validates and durably publishes that public authority before preparing
+the SQLite source. Exact retries may omit `--relay-machines-file` after this
+publication; a different enrollment is rejected. The same command is the
+crash-recovery command. It resumes the exact prepared source, checkpointed
+staging, verified destination, retired source, active database, or marker-last
+publication. Before source retirement only, abort the same epoch explicitly:
 
 ```sh
 punaro mail cutover --directory /absolute/private/punaro \

--- a/docs/operator-guide.md
+++ b/docs/operator-guide.md
@@ -453,14 +453,12 @@ credential, cache/session generation, and Ed25519 migration-inventory records.
 Migration 6 adds the durable update coordinator, exact recovery evidence, and
 the mutation fence. Migration 7 adds the PostgreSQL mail store, durable
 recipient cursors, replay protection, and relay-table mutation guards.
-Migration 8 adds the dark M-9 cutover substrate: owner-only migration epochs,
+Migration 8 adds the M-9 cutover substrate: owner-only migration epochs,
 bounded staging rows and checkpoints, and an application-role mail-write fence
-for an importing or verified epoch. It does not import rows, activate
-PostgreSQL mail authority, retire SQLite, or change the default relay. Those
-irreversible operations remain disabled until the later M-9 executor slice.
-That executor must take the canonical SQLite source path from Punaro's private,
-service-owned relay data directory. The source-path argument is a privileged
-operator boundary, not a filesystem sandbox for untrusted paths.
+for an importing or verified epoch. The host wrapper's one-shot executor is the
+only supported authority transition. It always reads `relay.db` from Punaro's
+validated private service data directory; there is no caller-selected source
+path.
 PostgreSQL mail work uses a reserved four-connection application-role pool;
 each operation and lock wait is bounded to five seconds so platform work cannot
 consume the mail budget indefinitely.
@@ -473,6 +471,43 @@ attachment routes. Do not point an established installation at an empty
 PostgreSQL relay as a migration shortcut; the verified one-shot mail cutover is
 a separate release gate. Before that cutover, rollback is selecting `sqlite`
 again while retaining both stores unchanged.
+
+### One-shot mail cutover
+
+First stop ordinary operator changes, confirm every intended legacy machine is
+`migrated` or explicitly `retired`, and run the read-only preview:
+
+```sh
+punaro mail cutover --directory /absolute/private/punaro --dry-run
+```
+
+Record the printed `source_fingerprint` and `target_identity`. Choose one UUID
+for the durable epoch, then execute exactly that binding:
+
+```sh
+punaro mail cutover --directory /absolute/private/punaro \
+  --epoch-id 019f7f07-8b88-7c12-a394-b663274a6555 \
+  --expected-source-fingerprint SOURCE_SHA256 --yes
+```
+
+The same command is the crash-recovery command. It resumes the exact prepared
+source, checkpointed staging, verified destination, retired source, active
+database, or marker-last publication. Before source retirement only, abort the
+same epoch explicitly:
+
+```sh
+punaro mail cutover --directory /absolute/private/punaro \
+  --abort --epoch-id 019f7f07-8b88-7c12-a394-b663274a6555 --yes
+```
+
+Abort is itself crash-safe. If PostgreSQL rejected the begin before creating
+the epoch, Punaro first records an exact terminal abort reservation; a delayed
+begin can then only observe that tombstone and cannot recreate an import fence.
+
+After success, run `punaro up --directory /absolute/private/punaro` to recreate
+the daemon from the published PostgreSQL and credential-transition settings.
+Never reopen or replace the retired SQLite file. Once PostgreSQL accepts new
+mail, recovery uses a PostgreSQL backup or forward repair.
 
 Do not
 hand edit ownership, enrollment, credential, idempotency, capacity, lease,

--- a/docs/operator-guide.md
+++ b/docs/operator-guide.md
@@ -474,7 +474,9 @@ again while retaining both stores unchanged.
 
 ### One-shot mail cutover
 
-First stop ordinary operator changes, confirm every intended legacy machine is
+First complete the supported update through the exact current schema v9; the
+preview and execution both fail closed on runtime-compatible schema v8 before
+inspecting or preparing SQLite. Then stop ordinary operator changes, confirm every intended legacy machine is
 `migrated` or explicitly `retired`, and run the read-only preview:
 
 ```sh

--- a/docs/platform-contracts.md
+++ b/docs/platform-contracts.md
@@ -150,6 +150,21 @@ and the last successful durable check expires after at most two seconds. The
 check loop is independent of wake writes and cancels their context on failure,
 so a slow or non-reading client cannot starve revalidation.
 
+The M-9 executor is the only supported mail authority switch. A dry-run is
+read-only. Execution binds one caller-chosen epoch to the exact SQLite source
+fingerprint and PostgreSQL installation identity, prepares SQLite, stages at
+most 128 canonical rows per page, and resumes from owner-only checkpoints.
+Every staged table must reproduce the manifest count and SHA-256 before one
+transaction materializes the canonical relay tables and records `verified`.
+SQLite retirement precedes PostgreSQL activation. Activation refuses any
+pending legacy inventory and closes the global legacy gate in the same owner
+transaction that publishes the PostgreSQL authority. The local generated files
+selecting PostgreSQL and credential transition are published afterward with
+`installation.json` last. Abort is possible only before retirement; active
+epochs and retired SQLite sources are permanently non-abortable. A begin that
+failed before epoch insertion is aborted by durably reserving the exact epoch
+as terminal before SQLite reopens, fencing every delayed retry of that begin.
+
 M-5 mounts only `POST /v1/enrollments/redeem` and authenticated
 `GET /v1/device/session`. Redemption requires exact `application/json`, a
 bounded object with four unique string fields, and the store's exact enrollment

--- a/docs/platform-contracts.md
+++ b/docs/platform-contracts.md
@@ -156,8 +156,9 @@ fingerprint and PostgreSQL installation identity, prepares SQLite, stages at
 most 128 canonical rows per page, and resumes from owner-only checkpoints.
 Every staged table must reproduce the manifest count and SHA-256 before one
 transaction materializes the canonical relay tables and records `verified`.
-SQLite retirement precedes PostgreSQL activation. Activation refuses any
-pending legacy inventory and closes the global legacy gate in the same owner
+SQLite retirement precedes PostgreSQL activation. Activation refuses pending
+legacy inventory, requires every migrated key in the static relay enrollment,
+and permits only known retired keys in addition before retirement. It closes the gate in the same owner
 transaction that publishes the PostgreSQL authority. The local generated files
 selecting PostgreSQL and credential transition are published afterward with
 `installation.json` last. Abort is possible only before retirement; active

--- a/internal/cutover/executor.go
+++ b/internal/cutover/executor.go
@@ -35,6 +35,7 @@ type Source interface {
 
 // Destination is the schema-owner PostgreSQL cutover surface.
 type Destination interface {
+	CheckMailCutoverSchemaReadiness(context.Context) error
 	Identity(context.Context) (string, error)
 	BeginMailCutover(context.Context, string, postgres.MailCutoverRequest) (postgres.MailCutoverEpoch, error)
 	MailCutoverStatus(context.Context, string, string) (postgres.MailCutoverEpoch, error)
@@ -89,6 +90,9 @@ func (e Executor) DryRun(ctx context.Context) (Plan, error) {
 	if e.Source == nil || e.Destination == nil {
 		return Plan{}, errors.New("mail cutover executor is incomplete")
 	}
+	if err := e.Destination.CheckMailCutoverSchemaReadiness(ctx); err != nil {
+		return Plan{}, err
+	}
 	target, err := e.Destination.Identity(ctx)
 	if err != nil {
 		return Plan{}, errors.New("mail cutover target identity is unavailable")
@@ -106,6 +110,9 @@ func (e Executor) DryRun(ctx context.Context) (Plan, error) {
 func (e Executor) Execute(ctx context.Context, request Request) (Result, error) {
 	if e.Source == nil || e.Destination == nil || e.Publish == nil || uuid.Validate(request.ActorPrincipalID) != nil || uuid.Validate(request.EpochID) != nil || !digestPattern.MatchString(request.ExpectedSourceFingerprint) || request.Cutoff.IsZero() {
 		return Result{}, errors.New("mail cutover execution request is invalid")
+	}
+	if err := e.Destination.CheckMailCutoverSchemaReadiness(ctx); err != nil {
+		return Result{}, err
 	}
 	batchSize := e.BatchSize
 	if batchSize < 1 || batchSize > 256 {

--- a/internal/cutover/executor.go
+++ b/internal/cutover/executor.go
@@ -42,6 +42,7 @@ type Destination interface {
 	MailCutoverCheckpoint(context.Context, string, string, string) (postgres.MailCutoverCheckpoint, error)
 	StageMailCutoverBatch(context.Context, string, postgres.MailCutoverBatch) (postgres.MailCutoverCheckpoint, error)
 	VerifyMailCutover(context.Context, string, string, string) (postgres.MailCutoverEpoch, error)
+	CheckMailCutoverActivationReadiness(context.Context, string, string, string) error
 	ActivateMailCutover(context.Context, string, string, string, relay.MigrationSourceManifest) (postgres.MailCutoverEpoch, error)
 	AbortMailCutover(context.Context, string, string, string) error
 }
@@ -192,6 +193,9 @@ func (e Executor) Execute(ctx context.Context, request Request) (Result, error) 
 	}
 	if epoch.Phase == postgres.MailCutoverVerified {
 		if manifest.Phase == relay.MigrationSourcePrepared {
+			if err := e.Destination.CheckMailCutoverActivationReadiness(ctx, request.ActorPrincipalID, request.EpochID, prepared.Fingerprint); err != nil {
+				return Result{}, err
+			}
 			manifest, err = e.Source.Retire(ctx, request.EpochID, target, prepared.Fingerprint)
 			if err != nil {
 				return Result{}, err

--- a/internal/cutover/executor.go
+++ b/internal/cutover/executor.go
@@ -1,0 +1,340 @@
+// Package cutover coordinates Punaro's one irreversible SQLite-to-PostgreSQL
+// mail authority transition without introducing a dual-write state.
+package cutover
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"regexp"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/rock3r/punaro/internal/operator"
+	"github.com/rock3r/punaro/internal/postgres"
+	"github.com/rock3r/punaro/internal/relay"
+)
+
+var tables = []string{
+	"mail_endpoints", "mail_conversations", "mail_memberships", "mail_messages", "mail_deliveries",
+	"mail_recipient_cursors", "mail_message_idempotency", "mail_conversation_idempotency", "mail_request_nonces",
+}
+
+var digestPattern = regexp.MustCompile(`^[0-9a-f]{64}$`)
+
+// Source is the privileged, service-owned SQLite cutover surface.
+type Source interface {
+	Inspect(context.Context) (relay.MigrationSourceManifest, error)
+	Prepare(context.Context, string, string, string, time.Time) (relay.MigrationSourceManifest, error)
+	ReadBatch(context.Context, string, string, int) (relay.MigrationSourceBatch, error)
+	Abort(context.Context, string, string, string) (relay.MigrationSourceManifest, error)
+	Retire(context.Context, string, string, string) (relay.MigrationSourceManifest, error)
+}
+
+// Destination is the schema-owner PostgreSQL cutover surface.
+type Destination interface {
+	Identity(context.Context) (string, error)
+	BeginMailCutover(context.Context, string, postgres.MailCutoverRequest) (postgres.MailCutoverEpoch, error)
+	MailCutoverStatus(context.Context, string, string) (postgres.MailCutoverEpoch, error)
+	ReserveMailCutoverAbort(context.Context, string, postgres.MailCutoverRequest) (postgres.MailCutoverEpoch, error)
+	MailCutoverCheckpoint(context.Context, string, string, string) (postgres.MailCutoverCheckpoint, error)
+	StageMailCutoverBatch(context.Context, string, postgres.MailCutoverBatch) (postgres.MailCutoverCheckpoint, error)
+	VerifyMailCutover(context.Context, string, string, string) (postgres.MailCutoverEpoch, error)
+	ActivateMailCutover(context.Context, string, string, string, relay.MigrationSourceManifest) (postgres.MailCutoverEpoch, error)
+	AbortMailCutover(context.Context, string, string, string) error
+}
+
+// Publisher makes the already-active database selection visible locally.
+type Publisher func(context.Context, operator.MailCutoverPublication) error
+
+// Executor composes independently durable source, destination, and publication
+// boundaries. BatchSize is clamped to the supported 1-256 range.
+type Executor struct {
+	Source      Source
+	Destination Destination
+	Publish     Publisher
+	BatchSize   int
+}
+
+// Request is the explicit irreversible execution authorization.
+type Request struct {
+	ActorPrincipalID          string
+	EpochID                   string
+	ExpectedSourceFingerprint string
+	Cutoff                    time.Time
+}
+
+// Plan is a read-only dry-run view.
+type Plan struct {
+	SourceID          string                      `json:"source_id"`
+	SourcePhase       relay.MigrationSourcePhase  `json:"source_phase"`
+	SourceFingerprint string                      `json:"source_fingerprint"`
+	TargetIdentity    string                      `json:"target_identity"`
+	Counts            relay.MigrationSourceCounts `json:"counts"`
+}
+
+// Result is the durable final authority binding.
+type Result struct {
+	EpochID           string                     `json:"epoch_id"`
+	SourceFingerprint string                     `json:"source_fingerprint"`
+	SourcePhase       relay.MigrationSourcePhase `json:"source_phase"`
+	Phase             postgres.MailCutoverPhase  `json:"phase"`
+}
+
+// DryRun inspects both authorities without fencing or mutating either one.
+func (e Executor) DryRun(ctx context.Context) (Plan, error) {
+	if e.Source == nil || e.Destination == nil {
+		return Plan{}, errors.New("mail cutover executor is incomplete")
+	}
+	target, err := e.Destination.Identity(ctx)
+	if err != nil {
+		return Plan{}, errors.New("mail cutover target identity is unavailable")
+	}
+	manifest, err := e.Source.Inspect(ctx)
+	if err != nil {
+		return Plan{}, err
+	}
+	return Plan{SourceID: manifest.SourceID, SourcePhase: manifest.Phase, SourceFingerprint: manifest.Fingerprint, TargetIdentity: target, Counts: manifest.Counts}, nil
+}
+
+// Execute resumes from every durable boundary. It retires SQLite only after
+// PostgreSQL verification, activates PostgreSQL only after retirement, and
+// publishes the runtime marker only after database activation.
+func (e Executor) Execute(ctx context.Context, request Request) (Result, error) {
+	if e.Source == nil || e.Destination == nil || e.Publish == nil || uuid.Validate(request.ActorPrincipalID) != nil || uuid.Validate(request.EpochID) != nil || !digestPattern.MatchString(request.ExpectedSourceFingerprint) || request.Cutoff.IsZero() {
+		return Result{}, errors.New("mail cutover execution request is invalid")
+	}
+	batchSize := e.BatchSize
+	if batchSize < 1 || batchSize > 256 {
+		batchSize = 128
+	}
+	target, err := e.Destination.Identity(ctx)
+	if err != nil {
+		return Result{}, errors.New("mail cutover target identity is unavailable")
+	}
+	manifest, err := e.Source.Inspect(ctx)
+	if err != nil {
+		return Result{}, err
+	}
+	switch manifest.Phase {
+	case relay.MigrationSourceActive:
+		if manifest.Fingerprint != request.ExpectedSourceFingerprint {
+			return Result{}, errors.New("mail cutover source changed after dry-run")
+		}
+		manifest, err = e.Source.Prepare(ctx, request.EpochID, target, request.ExpectedSourceFingerprint, request.Cutoff)
+		if err != nil {
+			return Result{}, err
+		}
+	case relay.MigrationSourcePrepared, relay.MigrationSourceRetired:
+		if manifest.EpochID != request.EpochID || manifest.TargetIdentity != target || manifest.ExpectedFingerprint != request.ExpectedSourceFingerprint {
+			return Result{}, errors.New("mail cutover source is bound to another execution")
+		}
+	default:
+		return Result{}, errors.New("mail cutover source phase is invalid")
+	}
+	prepared := manifest
+	prepared.Phase = relay.MigrationSourcePrepared
+	cutoverRequest, err := destinationRequest(prepared, request.EpochID, target)
+	if err != nil {
+		return Result{}, err
+	}
+	epoch, err := e.Destination.BeginMailCutover(ctx, request.ActorPrincipalID, cutoverRequest)
+	if err != nil {
+		return Result{}, err
+	}
+	if epoch.Phase == postgres.MailCutoverImporting {
+		if manifest.Phase != relay.MigrationSourcePrepared {
+			return Result{}, errors.New("retired source has an incomplete destination import")
+		}
+		for _, table := range tables {
+			checkpoint, err := e.Destination.MailCutoverCheckpoint(ctx, request.ActorPrincipalID, request.EpochID, table)
+			if err != nil {
+				return Result{}, err
+			}
+			expected, _ := tableEvidence(prepared, table)
+			if checkpoint.RowCount > expected {
+				return Result{}, errors.New("mail cutover checkpoint exceeds the source manifest")
+			}
+			if checkpoint.RowCount == expected && (expected > 0 || !checkpoint.UpdatedAt.IsZero()) {
+				continue
+			}
+			after := ""
+			if checkpoint.LastKey.Valid {
+				after = checkpoint.LastKey.String
+			}
+			for {
+				batch, err := e.Source.ReadBatch(ctx, table, after, batchSize)
+				if err != nil {
+					return Result{}, err
+				}
+				checkpoint, err = e.Destination.StageMailCutoverBatch(ctx, request.ActorPrincipalID, postgres.MailCutoverBatch{EpochID: request.EpochID, Table: table, AfterKey: after, Rows: batch.Rows, Done: batch.Done})
+				if err != nil {
+					return Result{}, err
+				}
+				if batch.Done {
+					break
+				}
+				if batch.NextKey == "" || batch.NextKey == after {
+					return Result{}, errors.New("mail cutover source pagination did not advance")
+				}
+				after = batch.NextKey
+			}
+			if checkpoint.RowCount != expected {
+				return Result{}, errors.New("mail cutover checkpoint does not reach the source manifest")
+			}
+		}
+		epoch, err = e.Destination.VerifyMailCutover(ctx, request.ActorPrincipalID, request.EpochID, prepared.Fingerprint)
+		if err != nil {
+			return Result{}, err
+		}
+	}
+	if epoch.Phase == postgres.MailCutoverVerified {
+		if manifest.Phase == relay.MigrationSourcePrepared {
+			manifest, err = e.Source.Retire(ctx, request.EpochID, target, prepared.Fingerprint)
+			if err != nil {
+				return Result{}, err
+			}
+		}
+		if manifest.Phase != relay.MigrationSourceRetired {
+			return Result{}, errors.New("mail cutover source is not retired")
+		}
+		epoch, err = e.Destination.ActivateMailCutover(ctx, request.ActorPrincipalID, request.EpochID, prepared.Fingerprint, manifest)
+		if err != nil {
+			return Result{}, err
+		}
+	}
+	if epoch.Phase != postgres.MailCutoverActive || manifest.Phase != relay.MigrationSourceRetired {
+		return Result{}, errors.New("mail cutover did not reach the active authority boundary")
+	}
+	publication := operator.MailCutoverPublication{Version: 1, EpochID: request.EpochID, TargetIdentity: target, SourceFingerprint: prepared.Fingerprint}
+	if err := e.Publish(ctx, publication); err != nil {
+		return Result{}, err
+	}
+	return Result{EpochID: request.EpochID, SourceFingerprint: prepared.Fingerprint, SourcePhase: manifest.Phase, Phase: epoch.Phase}, nil
+}
+
+// Abort reopens the prepared SQLite source and leaves the destination dark. It
+// rechecks the destination before touching SQLite and can never cross or undo
+// the source-retirement/active-PostgreSQL barrier.
+func (e Executor) Abort(ctx context.Context, actorPrincipalID, epochID string) (Result, error) {
+	if e.Source == nil || e.Destination == nil || uuid.Validate(actorPrincipalID) != nil || uuid.Validate(epochID) != nil {
+		return Result{}, errors.New("mail cutover abort request is invalid")
+	}
+	target, err := e.Destination.Identity(ctx)
+	if err != nil {
+		return Result{}, errors.New("mail cutover target identity is unavailable")
+	}
+	manifest, err := e.Source.Inspect(ctx)
+	if err != nil {
+		return Result{}, err
+	}
+	if manifest.Phase == relay.MigrationSourceRetired {
+		return Result{}, errors.New("retired mail cutover cannot be aborted")
+	}
+	status, err := e.Destination.MailCutoverStatus(ctx, actorPrincipalID, epochID)
+	destinationAbsent := errors.Is(err, postgres.ErrNotFound)
+	if err != nil && !destinationAbsent {
+		return Result{}, err
+	}
+	if !destinationAbsent && status.Phase == postgres.MailCutoverActive {
+		return Result{}, errors.New("active mail cutover cannot be aborted")
+	}
+	fingerprint := status.SourceFingerprint
+	if destinationAbsent {
+		if manifest.Phase != relay.MigrationSourcePrepared || manifest.EpochID != epochID || manifest.TargetIdentity != target {
+			return Result{}, errors.New("mail cutover source cannot prove an abort binding")
+		}
+		fingerprint = manifest.Fingerprint
+		cutoverRequest, requestErr := destinationRequest(manifest, epochID, target)
+		if requestErr != nil {
+			return Result{}, requestErr
+		}
+		status, err = e.Destination.ReserveMailCutoverAbort(ctx, actorPrincipalID, cutoverRequest)
+		if err != nil || status.Phase != postgres.MailCutoverAborted || status.SourceFingerprint != fingerprint {
+			if err != nil {
+				return Result{}, err
+			}
+			return Result{}, errors.New("mail cutover abort reservation is unavailable")
+		}
+	}
+	if manifest.Phase == relay.MigrationSourcePrepared && (manifest.EpochID != epochID || manifest.TargetIdentity != target || manifest.Fingerprint != fingerprint) {
+		return Result{}, errors.New("mail cutover source binding does not match")
+	}
+	manifest, err = e.Source.Abort(ctx, epochID, target, fingerprint)
+	if err != nil {
+		return Result{}, err
+	}
+	if err := e.Destination.AbortMailCutover(ctx, actorPrincipalID, epochID, fingerprint); err != nil {
+		return Result{}, err
+	}
+	return Result{EpochID: epochID, SourceFingerprint: fingerprint, SourcePhase: manifest.Phase, Phase: postgres.MailCutoverAborted}, nil
+}
+
+func destinationRequest(manifest relay.MigrationSourceManifest, epochID, target string) (postgres.MailCutoverRequest, error) {
+	prepared := manifest
+	prepared.Phase, prepared.EpochID, prepared.TargetIdentity = relay.MigrationSourcePrepared, epochID, target
+	manifestBody, err := json.Marshal(prepared)
+	if err != nil {
+		return postgres.MailCutoverRequest{}, errors.New("mail cutover manifest cannot be encoded")
+	}
+	manifestDigest := sha256.Sum256(manifestBody)
+	return postgres.MailCutoverRequest{
+		EpochID: epochID, SourceID: prepared.SourceID, TargetIdentity: target, SourceFingerprint: prepared.Fingerprint,
+		Manifest: manifestBody, ManifestSHA256: hex.EncodeToString(manifestDigest[:]),
+	}, nil
+}
+
+func tableEvidence(manifest relay.MigrationSourceManifest, table string) (int64, string) {
+	switch table {
+	case "mail_endpoints":
+		return manifest.Counts.Endpoints, manifest.TableSHA256.Endpoints
+	case "mail_conversations":
+		return manifest.Counts.Conversations, manifest.TableSHA256.Conversations
+	case "mail_memberships":
+		return manifest.Counts.Memberships, manifest.TableSHA256.Memberships
+	case "mail_messages":
+		return manifest.Counts.Messages, manifest.TableSHA256.Messages
+	case "mail_deliveries":
+		return manifest.Counts.Deliveries, manifest.TableSHA256.Deliveries
+	case "mail_recipient_cursors":
+		return manifest.Counts.RecipientCursors, manifest.TableSHA256.RecipientCursors
+	case "mail_message_idempotency":
+		return manifest.Counts.MessageIdempotency, manifest.TableSHA256.MessageIdempotency
+	case "mail_conversation_idempotency":
+		return manifest.Counts.ConversationIdempotency, manifest.TableSHA256.ConversationIdempotency
+	case "mail_request_nonces":
+		return manifest.Counts.RequestNonces, manifest.TableSHA256.RequestNonces
+	default:
+		return -1, ""
+	}
+}
+
+// FileSource binds the executor to one explicit canonical service-owned file.
+type FileSource struct{ Path string }
+
+// Inspect returns the current durable SQLite source manifest.
+func (s FileSource) Inspect(ctx context.Context) (relay.MigrationSourceManifest, error) {
+	return relay.InspectMigrationSource(ctx, s.Path)
+}
+
+// Prepare installs the exact SQLite write barrier.
+func (s FileSource) Prepare(ctx context.Context, epoch, target, expected string, cutoff time.Time) (relay.MigrationSourceManifest, error) {
+	return relay.PrepareMigrationSource(ctx, s.Path, epoch, target, expected, cutoff)
+}
+
+// ReadBatch exports one bounded canonical source page.
+func (s FileSource) ReadBatch(ctx context.Context, table, after string, limit int) (relay.MigrationSourceBatch, error) {
+	return relay.ReadMigrationSourceBatch(ctx, s.Path, table, after, limit)
+}
+
+// Abort reopens the exact prepared source before retirement.
+func (s FileSource) Abort(ctx context.Context, epoch, target, fingerprint string) (relay.MigrationSourceManifest, error) {
+	return relay.AbortPreparedMigrationSource(ctx, s.Path, epoch, target, fingerprint)
+}
+
+// Retire permanently seals the exact prepared source.
+func (s FileSource) Retire(ctx context.Context, epoch, target, fingerprint string) (relay.MigrationSourceManifest, error) {
+	return relay.RetirePreparedMigrationSource(ctx, s.Path, epoch, target, fingerprint)
+}

--- a/internal/cutover/executor.go
+++ b/internal/cutover/executor.go
@@ -27,6 +27,7 @@ var digestPattern = regexp.MustCompile(`^[0-9a-f]{64}$`)
 // Source is the privileged, service-owned SQLite cutover surface.
 type Source interface {
 	Inspect(context.Context) (relay.MigrationSourceManifest, error)
+	CheckEnrollmentCoverage(context.Context, string) error
 	Prepare(context.Context, string, string, string, time.Time) (relay.MigrationSourceManifest, error)
 	ReadBatch(context.Context, string, string, int) (relay.MigrationSourceBatch, error)
 	Abort(context.Context, string, string, string) (relay.MigrationSourceManifest, error)
@@ -43,7 +44,7 @@ type Destination interface {
 	MailCutoverCheckpoint(context.Context, string, string, string) (postgres.MailCutoverCheckpoint, error)
 	StageMailCutoverBatch(context.Context, string, postgres.MailCutoverBatch) (postgres.MailCutoverCheckpoint, error)
 	VerifyMailCutover(context.Context, string, string, string) (postgres.MailCutoverEpoch, error)
-	CheckMailCutoverActivationReadiness(context.Context, string, string, string) error
+	CheckMailCutoverActivationReadiness(context.Context, string, string, string, string) error
 	ActivateMailCutover(context.Context, string, string, string, relay.MigrationSourceManifest) (postgres.MailCutoverEpoch, error)
 	AbortMailCutover(context.Context, string, string, string) error
 }
@@ -58,6 +59,7 @@ type Executor struct {
 	Destination Destination
 	Publish     Publisher
 	BatchSize   int
+	Enrollment  string
 }
 
 // Request is the explicit irreversible execution authorization.
@@ -108,7 +110,7 @@ func (e Executor) DryRun(ctx context.Context) (Plan, error) {
 // PostgreSQL verification, activates PostgreSQL only after retirement, and
 // publishes the runtime marker only after database activation.
 func (e Executor) Execute(ctx context.Context, request Request) (Result, error) {
-	if e.Source == nil || e.Destination == nil || e.Publish == nil || uuid.Validate(request.ActorPrincipalID) != nil || uuid.Validate(request.EpochID) != nil || !digestPattern.MatchString(request.ExpectedSourceFingerprint) || request.Cutoff.IsZero() {
+	if e.Source == nil || e.Destination == nil || e.Publish == nil || e.Enrollment == "" || uuid.Validate(request.ActorPrincipalID) != nil || uuid.Validate(request.EpochID) != nil || !digestPattern.MatchString(request.ExpectedSourceFingerprint) || request.Cutoff.IsZero() {
 		return Result{}, errors.New("mail cutover execution request is invalid")
 	}
 	if err := e.Destination.CheckMailCutoverSchemaReadiness(ctx); err != nil {
@@ -126,6 +128,9 @@ func (e Executor) Execute(ctx context.Context, request Request) (Result, error) 
 	if err != nil {
 		return Result{}, err
 	}
+	if err := e.Source.CheckEnrollmentCoverage(ctx, e.Enrollment); err != nil {
+		return Result{}, err
+	}
 	switch manifest.Phase {
 	case relay.MigrationSourceActive:
 		if manifest.Fingerprint != request.ExpectedSourceFingerprint {
@@ -133,6 +138,9 @@ func (e Executor) Execute(ctx context.Context, request Request) (Result, error) 
 		}
 		manifest, err = e.Source.Prepare(ctx, request.EpochID, target, request.ExpectedSourceFingerprint, request.Cutoff)
 		if err != nil {
+			return Result{}, err
+		}
+		if err := e.Source.CheckEnrollmentCoverage(ctx, e.Enrollment); err != nil {
 			return Result{}, err
 		}
 	case relay.MigrationSourcePrepared, relay.MigrationSourceRetired:
@@ -200,7 +208,7 @@ func (e Executor) Execute(ctx context.Context, request Request) (Result, error) 
 	}
 	if epoch.Phase == postgres.MailCutoverVerified {
 		if manifest.Phase == relay.MigrationSourcePrepared {
-			if err := e.Destination.CheckMailCutoverActivationReadiness(ctx, request.ActorPrincipalID, request.EpochID, prepared.Fingerprint); err != nil {
+			if err := e.Destination.CheckMailCutoverActivationReadiness(ctx, request.ActorPrincipalID, request.EpochID, prepared.Fingerprint, e.Enrollment); err != nil {
 				return Result{}, err
 			}
 			manifest, err = e.Source.Retire(ctx, request.EpochID, target, prepared.Fingerprint)
@@ -328,6 +336,11 @@ type FileSource struct{ Path string }
 // Inspect returns the current durable SQLite source manifest.
 func (s FileSource) Inspect(ctx context.Context) (relay.MigrationSourceManifest, error) {
 	return relay.InspectMigrationSource(ctx, s.Path)
+}
+
+// CheckEnrollmentCoverage proves the persisted runtime can reclaim every source endpoint.
+func (s FileSource) CheckEnrollmentCoverage(ctx context.Context, enrollment string) error {
+	return relay.CheckMigrationSourceEnrollmentCoverage(ctx, s.Path, enrollment)
 }
 
 // Prepare installs the exact SQLite write barrier.

--- a/internal/cutover/executor_test.go
+++ b/internal/cutover/executor_test.go
@@ -1,0 +1,279 @@
+package cutover
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/rock3r/punaro/internal/operator"
+	"github.com/rock3r/punaro/internal/postgres"
+	"github.com/rock3r/punaro/internal/relay"
+)
+
+func TestExecutorCrossesBoundariesInOrderAndPublishesLast(t *testing.T) {
+	t.Parallel()
+	manifest := testManifest(relay.MigrationSourceActive)
+	var events []string
+	source := &fakeSource{manifest: manifest, events: &events}
+	destination := &fakeDestination{identity: manifest.TargetIdentity, events: &events}
+	publisher := func(_ context.Context, publication operator.MailCutoverPublication) error {
+		events = append(events, "publish")
+		if publication.EpochID != manifest.EpochID || publication.SourceFingerprint == "" {
+			t.Fatalf("publication=%#v", publication)
+		}
+		return nil
+	}
+	executor := Executor{Source: source, Destination: destination, Publish: publisher, BatchSize: 1}
+	result, err := executor.Execute(context.Background(), Request{ActorPrincipalID: "11111111-1111-4111-8111-111111111111", EpochID: manifest.EpochID, ExpectedSourceFingerprint: manifest.Fingerprint, Cutoff: time.Now().UTC()})
+	if err != nil || result.Phase != postgres.MailCutoverActive || result.SourcePhase != relay.MigrationSourceRetired {
+		t.Fatalf("result=%#v err=%v", result, err)
+	}
+	want := []string{"identity", "inspect", "prepare", "begin", "checkpoint:mail_endpoints", "read:mail_endpoints", "stage:mail_endpoints", "checkpoint:mail_conversations"}
+	if len(events) < len(want) || !reflect.DeepEqual(events[:len(want)], want) {
+		t.Fatalf("events=%v want prefix=%v", events, want)
+	}
+	retireIndex, activateIndex, publishIndex := indexOf(events, "retire"), indexOf(events, "activate"), indexOf(events, "publish")
+	if retireIndex < 0 || activateIndex <= retireIndex || publishIndex <= activateIndex || events[len(events)-1] != "publish" {
+		t.Fatalf("irreversible ordering=%v", events)
+	}
+}
+
+func TestExecutorDoesNotSealAfterImportFailureAndRecoversActivePublication(t *testing.T) {
+	t.Parallel()
+	manifest := testManifest(relay.MigrationSourceActive)
+	var failedEvents []string
+	failing := &fakeDestination{identity: manifest.TargetIdentity, events: &failedEvents, stageErr: errors.New("injected stage failure")}
+	if _, err := (Executor{Source: &fakeSource{manifest: manifest, events: &failedEvents}, Destination: failing, Publish: func(context.Context, operator.MailCutoverPublication) error {
+		failedEvents = append(failedEvents, "publish")
+		return nil
+	}, BatchSize: 1}).Execute(context.Background(), Request{ActorPrincipalID: "11111111-1111-4111-8111-111111111111", EpochID: manifest.EpochID, ExpectedSourceFingerprint: manifest.Fingerprint, Cutoff: time.Now().UTC()}); err == nil {
+		t.Fatal("injected import failure succeeded")
+	}
+	if indexOf(failedEvents, "retire") >= 0 || indexOf(failedEvents, "activate") >= 0 || indexOf(failedEvents, "publish") >= 0 {
+		t.Fatalf("failure crossed irreversible boundary: %v", failedEvents)
+	}
+
+	retired := testManifest(relay.MigrationSourceRetired)
+	var recoveryEvents []string
+	recoveryDestination := &fakeDestination{identity: retired.TargetIdentity, phase: postgres.MailCutoverActive, events: &recoveryEvents}
+	result, err := (Executor{Source: &fakeSource{manifest: retired, events: &recoveryEvents}, Destination: recoveryDestination, Publish: func(context.Context, operator.MailCutoverPublication) error {
+		recoveryEvents = append(recoveryEvents, "publish")
+		return nil
+	}, BatchSize: 1}).Execute(context.Background(), Request{ActorPrincipalID: "11111111-1111-4111-8111-111111111111", EpochID: retired.EpochID, ExpectedSourceFingerprint: retired.ExpectedFingerprint, Cutoff: time.Now().UTC()})
+	if err != nil || result.Phase != postgres.MailCutoverActive || !reflect.DeepEqual(recoveryEvents, []string{"identity", "inspect", "begin", "publish"}) {
+		t.Fatalf("recovery result=%#v events=%v err=%v", result, recoveryEvents, err)
+	}
+	changedEvents := []string{}
+	if _, err := (Executor{Source: &fakeSource{manifest: retired, events: &changedEvents}, Destination: &fakeDestination{identity: retired.TargetIdentity, phase: postgres.MailCutoverActive, events: &changedEvents}, Publish: func(context.Context, operator.MailCutoverPublication) error { return nil }, BatchSize: 1}).Execute(context.Background(), Request{ActorPrincipalID: "11111111-1111-4111-8111-111111111111", EpochID: retired.EpochID, ExpectedSourceFingerprint: strings.Repeat("f", 64), Cutoff: time.Now().UTC()}); err == nil || indexOf(changedEvents, "begin") >= 0 {
+		t.Fatalf("changed recovery binding events=%v err=%v", changedEvents, err)
+	}
+}
+
+func TestDryRunDoesNotMutateEitherAuthority(t *testing.T) {
+	t.Parallel()
+	manifest := testManifest(relay.MigrationSourceActive)
+	var events []string
+	plan, err := (Executor{Source: &fakeSource{manifest: manifest, events: &events}, Destination: &fakeDestination{identity: manifest.TargetIdentity, events: &events}}).DryRun(context.Background())
+	if err != nil || plan.SourceFingerprint != manifest.Fingerprint || plan.TargetIdentity != manifest.TargetIdentity || !reflect.DeepEqual(events, []string{"identity", "inspect"}) {
+		t.Fatalf("plan=%#v events=%v err=%v", plan, events, err)
+	}
+}
+
+func TestAbortReopensSourceBeforeDestinationAndRefusesActiveBarrier(t *testing.T) {
+	t.Parallel()
+	prepared := testManifest(relay.MigrationSourcePrepared)
+	var events []string
+	result, err := (Executor{Source: &fakeSource{manifest: prepared, events: &events}, Destination: &fakeDestination{identity: prepared.TargetIdentity, phase: postgres.MailCutoverVerified, events: &events}}).Abort(context.Background(), "11111111-1111-4111-8111-111111111111", prepared.EpochID)
+	if err != nil || result.SourcePhase != relay.MigrationSourceActive || result.Phase != postgres.MailCutoverAborted || indexOf(events, "source-abort") >= indexOf(events, "destination-abort") {
+		t.Fatalf("abort result=%#v events=%v err=%v", result, events, err)
+	}
+	events = nil
+	if _, err := (Executor{Source: &fakeSource{manifest: prepared, events: &events}, Destination: &fakeDestination{identity: prepared.TargetIdentity, phase: postgres.MailCutoverActive, events: &events}}).Abort(context.Background(), "11111111-1111-4111-8111-111111111111", prepared.EpochID); err == nil || indexOf(events, "source-abort") >= 0 {
+		t.Fatalf("active abort events=%v err=%v", events, err)
+	}
+}
+
+func TestAbortRetryCompletesDestinationAfterSourceReopensAndChanges(t *testing.T) {
+	t.Parallel()
+	prepared := testManifest(relay.MigrationSourcePrepared)
+	var events []string
+	source := &fakeSource{manifest: prepared, events: &events}
+	destination := &fakeDestination{identity: prepared.TargetIdentity, phase: postgres.MailCutoverVerified, events: &events, abortErr: errors.New("injected destination abort failure")}
+	executor := Executor{Source: source, Destination: destination}
+	if _, err := executor.Abort(context.Background(), "11111111-1111-4111-8111-111111111111", prepared.EpochID); err == nil || source.manifest.Phase != relay.MigrationSourceActive {
+		t.Fatalf("first abort source=%#v events=%v err=%v", source.manifest, events, err)
+	}
+	// Simulate an old daemon writing after SQLite reopened but before the
+	// uncertain PostgreSQL abort was recovered.
+	source.manifest.Fingerprint = strings.Repeat("c", 64)
+	destination.abortErr = nil
+	result, err := executor.Abort(context.Background(), "11111111-1111-4111-8111-111111111111", prepared.EpochID)
+	if err != nil || result.Phase != postgres.MailCutoverAborted || result.SourcePhase != relay.MigrationSourceActive || events[len(events)-1] != "destination-abort" {
+		t.Fatalf("retry result=%#v source=%#v events=%v err=%v", result, source.manifest, events, err)
+	}
+}
+
+func TestAbortRecoversPreparedSourceWhenDestinationRejectedBeforeEpochInsert(t *testing.T) {
+	t.Parallel()
+	prepared := testManifest(relay.MigrationSourcePrepared)
+	var events []string
+	source := &fakeSource{manifest: prepared, events: &events}
+	destination := &fakeDestination{identity: prepared.TargetIdentity, events: &events, statusErr: postgres.ErrNotFound}
+	executor := Executor{Source: source, Destination: destination}
+	result, err := executor.Abort(context.Background(), "11111111-1111-4111-8111-111111111111", prepared.EpochID)
+	if err != nil || result.SourcePhase != relay.MigrationSourceActive || result.Phase != postgres.MailCutoverAborted || indexOf(events, "reserve-abort") >= indexOf(events, "source-abort") || indexOf(events, "source-abort") >= indexOf(events, "destination-abort") {
+		t.Fatalf("missing epoch abort result=%#v events=%v err=%v", result, events, err)
+	}
+	// A delayed begin observes the durable aborted tombstone instead of
+	// resurrecting an importing fence, even after a fresh source journal exists.
+	source.manifest = testManifest(relay.MigrationSourcePrepared)
+	source.manifest.EpochID = "019f7f07-7b88-7c12-a394-b663274a6555"
+	request, requestErr := destinationRequest(prepared, prepared.EpochID, prepared.TargetIdentity)
+	if requestErr != nil {
+		t.Fatal(requestErr)
+	}
+	delayed, err := destination.BeginMailCutover(context.Background(), "11111111-1111-4111-8111-111111111111", request)
+	if err != nil || delayed.Phase != postgres.MailCutoverAborted {
+		t.Fatalf("delayed begin epoch=%#v err=%v", delayed, err)
+	}
+	source.manifest = prepared
+	source.manifest.Phase = relay.MigrationSourceActive
+	result, err = executor.Abort(context.Background(), "11111111-1111-4111-8111-111111111111", prepared.EpochID)
+	if err != nil || result.SourcePhase != relay.MigrationSourceActive || result.Phase != postgres.MailCutoverAborted {
+		t.Fatalf("missing epoch abort retry result=%#v events=%v err=%v", result, events, err)
+	}
+}
+
+type fakeSource struct {
+	manifest relay.MigrationSourceManifest
+	events   *[]string
+}
+
+func (s *fakeSource) Inspect(context.Context) (relay.MigrationSourceManifest, error) {
+	*s.events = append(*s.events, "inspect")
+	return s.manifest, nil
+}
+func (s *fakeSource) Prepare(_ context.Context, epoch, target, expected string, _ time.Time) (relay.MigrationSourceManifest, error) {
+	*s.events = append(*s.events, "prepare")
+	if s.manifest.Phase != relay.MigrationSourceActive || expected != s.manifest.Fingerprint {
+		return relay.MigrationSourceManifest{}, errors.New("unexpected prepare")
+	}
+	s.manifest.Phase, s.manifest.EpochID, s.manifest.TargetIdentity = relay.MigrationSourcePrepared, epoch, target
+	s.manifest.ExpectedFingerprint = expected
+	return s.manifest, nil
+}
+func (s *fakeSource) ReadBatch(_ context.Context, table, after string, _ int) (relay.MigrationSourceBatch, error) {
+	*s.events = append(*s.events, "read:"+table)
+	if table != "mail_endpoints" {
+		return relay.MigrationSourceBatch{Done: true}, nil
+	}
+	row := testEndpointRow()
+	if after == row.Key {
+		return relay.MigrationSourceBatch{Done: true}, nil
+	}
+	return relay.MigrationSourceBatch{Rows: []relay.MigrationSourceRow{row}, NextKey: row.Key, Done: true}, nil
+}
+func (s *fakeSource) Retire(context.Context, string, string, string) (relay.MigrationSourceManifest, error) {
+	*s.events = append(*s.events, "retire")
+	s.manifest.Phase = relay.MigrationSourceRetired
+	return s.manifest, nil
+}
+func (s *fakeSource) Abort(context.Context, string, string, string) (relay.MigrationSourceManifest, error) {
+	*s.events = append(*s.events, "source-abort")
+	s.manifest.Phase = relay.MigrationSourceActive
+	return s.manifest, nil
+}
+
+type fakeDestination struct {
+	identity  string
+	phase     postgres.MailCutoverPhase
+	events    *[]string
+	stageErr  error
+	abortErr  error
+	statusErr error
+}
+
+func (d *fakeDestination) Identity(context.Context) (string, error) {
+	*d.events = append(*d.events, "identity")
+	return d.identity, nil
+}
+func (d *fakeDestination) BeginMailCutover(_ context.Context, _ string, request postgres.MailCutoverRequest) (postgres.MailCutoverEpoch, error) {
+	*d.events = append(*d.events, "begin")
+	if d.phase == "" {
+		d.phase = postgres.MailCutoverImporting
+	}
+	return postgres.MailCutoverEpoch{MailCutoverRequest: request, Phase: d.phase}, nil
+}
+func (d *fakeDestination) MailCutoverStatus(_ context.Context, _ string, epoch string) (postgres.MailCutoverEpoch, error) {
+	*d.events = append(*d.events, "status")
+	if d.statusErr != nil {
+		return postgres.MailCutoverEpoch{}, d.statusErr
+	}
+	return postgres.MailCutoverEpoch{MailCutoverRequest: postgres.MailCutoverRequest{EpochID: epoch, TargetIdentity: d.identity, SourceFingerprint: strings.Repeat("b", 64)}, Phase: d.phase}, nil
+}
+func (d *fakeDestination) ReserveMailCutoverAbort(_ context.Context, _ string, request postgres.MailCutoverRequest) (postgres.MailCutoverEpoch, error) {
+	*d.events = append(*d.events, "reserve-abort")
+	d.phase = postgres.MailCutoverAborted
+	d.statusErr = nil
+	return postgres.MailCutoverEpoch{MailCutoverRequest: request, Phase: d.phase}, nil
+}
+func (d *fakeDestination) MailCutoverCheckpoint(_ context.Context, _ string, _ string, table string) (postgres.MailCutoverCheckpoint, error) {
+	*d.events = append(*d.events, "checkpoint:"+table)
+	return postgres.MailCutoverCheckpoint{Table: table, RollingSHA256: hex.EncodeToString(sha256.New().Sum(nil))}, nil
+}
+func (d *fakeDestination) StageMailCutoverBatch(_ context.Context, _ string, batch postgres.MailCutoverBatch) (postgres.MailCutoverCheckpoint, error) {
+	*d.events = append(*d.events, "stage:"+batch.Table)
+	if d.stageErr != nil {
+		return postgres.MailCutoverCheckpoint{}, d.stageErr
+	}
+	return postgres.MailCutoverCheckpoint{Table: batch.Table, RowCount: int64(len(batch.Rows))}, nil
+}
+func (d *fakeDestination) VerifyMailCutover(_ context.Context, _ string, _ string, _ string) (postgres.MailCutoverEpoch, error) {
+	*d.events = append(*d.events, "verify")
+	d.phase = postgres.MailCutoverVerified
+	return postgres.MailCutoverEpoch{Phase: d.phase}, nil
+}
+func (d *fakeDestination) ActivateMailCutover(_ context.Context, _ string, _ string, _ string, _ relay.MigrationSourceManifest) (postgres.MailCutoverEpoch, error) {
+	*d.events = append(*d.events, "activate")
+	d.phase = postgres.MailCutoverActive
+	return postgres.MailCutoverEpoch{Phase: d.phase}, nil
+}
+func (d *fakeDestination) AbortMailCutover(context.Context, string, string, string) error {
+	*d.events = append(*d.events, "destination-abort")
+	if d.abortErr != nil {
+		return d.abortErr
+	}
+	d.phase = postgres.MailCutoverAborted
+	return nil
+}
+
+func testManifest(phase relay.MigrationSourcePhase) relay.MigrationSourceManifest {
+	row := testEndpointRow()
+	hasher, _ := relay.NewMigrationTableHasher("mail_endpoints")
+	_ = hasher.Add(row)
+	count, digest := hasher.Evidence()
+	empty := sha256.Sum256(nil)
+	emptyDigest := hex.EncodeToString(empty[:])
+	return relay.MigrationSourceManifest{Version: 1, SourceID: "019f7f07-9b88-7c12-a394-b663274a6555", Phase: phase, EpochID: "019f7f07-8b88-7c12-a394-b663274a6555", TargetIdentity: strings.Repeat("a", 64), Fingerprint: strings.Repeat("b", 64), ExpectedFingerprint: strings.Repeat("b", 64), Counts: relay.MigrationSourceCounts{Endpoints: count}, TableSHA256: relay.MigrationSourceHashes{Endpoints: digest, Conversations: emptyDigest, Memberships: emptyDigest, Messages: emptyDigest, Deliveries: emptyDigest, RecipientCursors: emptyDigest, MessageIdempotency: emptyDigest, ConversationIdempotency: emptyDigest, RequestNonces: emptyDigest}}
+}
+
+func testEndpointRow() relay.MigrationSourceRow {
+	payload, _ := json.Marshal(map[string]any{"endpoint": "agent/a", "machine_id": "machine-a", "lease_until": int64(1), "ownership_generation": int64(1), "consumer_id": nil, "consumer_generation": int64(0), "consumer_lease_until": nil})
+	digest := sha256.Sum256(payload)
+	return relay.MigrationSourceRow{Table: "mail_endpoints", Key: hex.EncodeToString([]byte("agent/a")), Payload: payload, SHA256: hex.EncodeToString(digest[:])}
+}
+
+func indexOf(values []string, target string) int {
+	for i, value := range values {
+		if value == target {
+			return i
+		}
+	}
+	return -1
+}

--- a/internal/cutover/executor_test.go
+++ b/internal/cutover/executor_test.go
@@ -34,7 +34,7 @@ func TestExecutorCrossesBoundariesInOrderAndPublishesLast(t *testing.T) {
 	if err != nil || result.Phase != postgres.MailCutoverActive || result.SourcePhase != relay.MigrationSourceRetired {
 		t.Fatalf("result=%#v err=%v", result, err)
 	}
-	want := []string{"identity", "inspect", "prepare", "begin", "checkpoint:mail_endpoints", "read:mail_endpoints", "stage:mail_endpoints", "checkpoint:mail_conversations"}
+	want := []string{"schema-readiness", "identity", "inspect", "prepare", "begin", "checkpoint:mail_endpoints", "read:mail_endpoints", "stage:mail_endpoints"}
 	if len(events) < len(want) || !reflect.DeepEqual(events[:len(want)], want) {
 		t.Fatalf("events=%v want prefix=%v", events, want)
 	}
@@ -66,7 +66,7 @@ func TestExecutorDoesNotSealAfterImportFailureAndRecoversActivePublication(t *te
 		recoveryEvents = append(recoveryEvents, "publish")
 		return nil
 	}, BatchSize: 1}).Execute(context.Background(), Request{ActorPrincipalID: "11111111-1111-4111-8111-111111111111", EpochID: retired.EpochID, ExpectedSourceFingerprint: retired.ExpectedFingerprint, Cutoff: time.Now().UTC()})
-	if err != nil || result.Phase != postgres.MailCutoverActive || !reflect.DeepEqual(recoveryEvents, []string{"identity", "inspect", "begin", "publish"}) {
+	if err != nil || result.Phase != postgres.MailCutoverActive || !reflect.DeepEqual(recoveryEvents, []string{"schema-readiness", "identity", "inspect", "begin", "publish"}) {
 		t.Fatalf("recovery result=%#v events=%v err=%v", result, recoveryEvents, err)
 	}
 	changedEvents := []string{}
@@ -94,8 +94,24 @@ func TestDryRunDoesNotMutateEitherAuthority(t *testing.T) {
 	manifest := testManifest(relay.MigrationSourceActive)
 	var events []string
 	plan, err := (Executor{Source: &fakeSource{manifest: manifest, events: &events}, Destination: &fakeDestination{identity: manifest.TargetIdentity, events: &events}}).DryRun(context.Background())
-	if err != nil || plan.SourceFingerprint != manifest.Fingerprint || plan.TargetIdentity != manifest.TargetIdentity || !reflect.DeepEqual(events, []string{"identity", "inspect"}) {
+	if err != nil || plan.SourceFingerprint != manifest.Fingerprint || plan.TargetIdentity != manifest.TargetIdentity || !reflect.DeepEqual(events, []string{"schema-readiness", "identity", "inspect"}) {
 		t.Fatalf("plan=%#v events=%v err=%v", plan, events, err)
+	}
+}
+
+func TestExecutorRequiresCurrentDestinationSchemaBeforeInspectingSource(t *testing.T) {
+	t.Parallel()
+	manifest := testManifest(relay.MigrationSourceActive)
+	var events []string
+	readinessErr := errors.New("destination schema is not current")
+	executor := Executor{
+		Source:      &fakeSource{manifest: manifest, events: &events},
+		Destination: &fakeDestination{identity: manifest.TargetIdentity, events: &events, schemaReadinessErr: readinessErr},
+		Publish:     func(context.Context, operator.MailCutoverPublication) error { return nil },
+	}
+	_, err := executor.Execute(context.Background(), Request{ActorPrincipalID: "11111111-1111-4111-8111-111111111111", EpochID: manifest.EpochID, ExpectedSourceFingerprint: manifest.Fingerprint, Cutoff: time.Now().UTC()})
+	if !errors.Is(err, readinessErr) || !reflect.DeepEqual(events, []string{"schema-readiness"}) {
+		t.Fatalf("events=%v err=%v", events, err)
 	}
 }
 
@@ -205,15 +221,20 @@ func (s *fakeSource) Abort(context.Context, string, string, string) (relay.Migra
 }
 
 type fakeDestination struct {
-	identity     string
-	phase        postgres.MailCutoverPhase
-	events       *[]string
-	stageErr     error
-	abortErr     error
-	statusErr    error
-	readinessErr error
+	identity           string
+	phase              postgres.MailCutoverPhase
+	events             *[]string
+	stageErr           error
+	abortErr           error
+	statusErr          error
+	readinessErr       error
+	schemaReadinessErr error
 }
 
+func (d *fakeDestination) CheckMailCutoverSchemaReadiness(context.Context) error {
+	*d.events = append(*d.events, "schema-readiness")
+	return d.schemaReadinessErr
+}
 func (d *fakeDestination) Identity(context.Context) (string, error) {
 	*d.events = append(*d.events, "identity")
 	return d.identity, nil

--- a/internal/cutover/executor_test.go
+++ b/internal/cutover/executor_test.go
@@ -38,8 +38,8 @@ func TestExecutorCrossesBoundariesInOrderAndPublishesLast(t *testing.T) {
 	if len(events) < len(want) || !reflect.DeepEqual(events[:len(want)], want) {
 		t.Fatalf("events=%v want prefix=%v", events, want)
 	}
-	retireIndex, activateIndex, publishIndex := indexOf(events, "retire"), indexOf(events, "activate"), indexOf(events, "publish")
-	if retireIndex < 0 || activateIndex <= retireIndex || publishIndex <= activateIndex || events[len(events)-1] != "publish" {
+	readinessIndex, retireIndex, activateIndex, publishIndex := indexOf(events, "activation-readiness"), indexOf(events, "retire"), indexOf(events, "activate"), indexOf(events, "publish")
+	if readinessIndex < 0 || retireIndex <= readinessIndex || activateIndex <= retireIndex || publishIndex <= activateIndex || events[len(events)-1] != "publish" {
 		t.Fatalf("irreversible ordering=%v", events)
 	}
 }
@@ -72,6 +72,20 @@ func TestExecutorDoesNotSealAfterImportFailureAndRecoversActivePublication(t *te
 	changedEvents := []string{}
 	if _, err := (Executor{Source: &fakeSource{manifest: retired, events: &changedEvents}, Destination: &fakeDestination{identity: retired.TargetIdentity, phase: postgres.MailCutoverActive, events: &changedEvents}, Publish: func(context.Context, operator.MailCutoverPublication) error { return nil }, BatchSize: 1}).Execute(context.Background(), Request{ActorPrincipalID: "11111111-1111-4111-8111-111111111111", EpochID: retired.EpochID, ExpectedSourceFingerprint: strings.Repeat("f", 64), Cutoff: time.Now().UTC()}); err == nil || indexOf(changedEvents, "begin") >= 0 {
 		t.Fatalf("changed recovery binding events=%v err=%v", changedEvents, err)
+	}
+}
+
+func TestExecutorChecksActivationReadinessBeforeRetiringSource(t *testing.T) {
+	t.Parallel()
+	prepared := testManifest(relay.MigrationSourcePrepared)
+	var events []string
+	readinessErr := errors.New("pending legacy machine")
+	source := &fakeSource{manifest: prepared, events: &events}
+	destination := &fakeDestination{identity: prepared.TargetIdentity, phase: postgres.MailCutoverVerified, events: &events, readinessErr: readinessErr}
+	executor := Executor{Source: source, Destination: destination, Publish: func(context.Context, operator.MailCutoverPublication) error { return nil }}
+	_, err := executor.Execute(context.Background(), Request{ActorPrincipalID: "11111111-1111-4111-8111-111111111111", EpochID: prepared.EpochID, ExpectedSourceFingerprint: prepared.ExpectedFingerprint, Cutoff: time.Now().UTC()})
+	if !errors.Is(err, readinessErr) || source.manifest.Phase != relay.MigrationSourcePrepared || indexOf(events, "activation-readiness") < 0 || indexOf(events, "retire") >= 0 {
+		t.Fatalf("source=%#v events=%v err=%v", source.manifest, events, err)
 	}
 }
 
@@ -191,12 +205,13 @@ func (s *fakeSource) Abort(context.Context, string, string, string) (relay.Migra
 }
 
 type fakeDestination struct {
-	identity  string
-	phase     postgres.MailCutoverPhase
-	events    *[]string
-	stageErr  error
-	abortErr  error
-	statusErr error
+	identity     string
+	phase        postgres.MailCutoverPhase
+	events       *[]string
+	stageErr     error
+	abortErr     error
+	statusErr    error
+	readinessErr error
 }
 
 func (d *fakeDestination) Identity(context.Context) (string, error) {
@@ -238,6 +253,10 @@ func (d *fakeDestination) VerifyMailCutover(_ context.Context, _ string, _ strin
 	*d.events = append(*d.events, "verify")
 	d.phase = postgres.MailCutoverVerified
 	return postgres.MailCutoverEpoch{Phase: d.phase}, nil
+}
+func (d *fakeDestination) CheckMailCutoverActivationReadiness(context.Context, string, string, string) error {
+	*d.events = append(*d.events, "activation-readiness")
+	return d.readinessErr
 }
 func (d *fakeDestination) ActivateMailCutover(_ context.Context, _ string, _ string, _ string, _ relay.MigrationSourceManifest) (postgres.MailCutoverEpoch, error) {
 	*d.events = append(*d.events, "activate")

--- a/internal/cutover/executor_test.go
+++ b/internal/cutover/executor_test.go
@@ -29,12 +29,12 @@ func TestExecutorCrossesBoundariesInOrderAndPublishesLast(t *testing.T) {
 		}
 		return nil
 	}
-	executor := Executor{Source: source, Destination: destination, Publish: publisher, BatchSize: 1}
+	executor := Executor{Source: source, Destination: destination, Publish: publisher, BatchSize: 1, Enrollment: "test-enrollment"}
 	result, err := executor.Execute(context.Background(), Request{ActorPrincipalID: "11111111-1111-4111-8111-111111111111", EpochID: manifest.EpochID, ExpectedSourceFingerprint: manifest.Fingerprint, Cutoff: time.Now().UTC()})
 	if err != nil || result.Phase != postgres.MailCutoverActive || result.SourcePhase != relay.MigrationSourceRetired {
 		t.Fatalf("result=%#v err=%v", result, err)
 	}
-	want := []string{"schema-readiness", "identity", "inspect", "prepare", "begin", "checkpoint:mail_endpoints", "read:mail_endpoints", "stage:mail_endpoints"}
+	want := []string{"schema-readiness", "identity", "inspect", "coverage", "prepare", "coverage", "begin", "checkpoint:mail_endpoints", "read:mail_endpoints", "stage:mail_endpoints"}
 	if len(events) < len(want) || !reflect.DeepEqual(events[:len(want)], want) {
 		t.Fatalf("events=%v want prefix=%v", events, want)
 	}
@@ -52,7 +52,7 @@ func TestExecutorDoesNotSealAfterImportFailureAndRecoversActivePublication(t *te
 	if _, err := (Executor{Source: &fakeSource{manifest: manifest, events: &failedEvents}, Destination: failing, Publish: func(context.Context, operator.MailCutoverPublication) error {
 		failedEvents = append(failedEvents, "publish")
 		return nil
-	}, BatchSize: 1}).Execute(context.Background(), Request{ActorPrincipalID: "11111111-1111-4111-8111-111111111111", EpochID: manifest.EpochID, ExpectedSourceFingerprint: manifest.Fingerprint, Cutoff: time.Now().UTC()}); err == nil {
+	}, BatchSize: 1, Enrollment: "test-enrollment"}).Execute(context.Background(), Request{ActorPrincipalID: "11111111-1111-4111-8111-111111111111", EpochID: manifest.EpochID, ExpectedSourceFingerprint: manifest.Fingerprint, Cutoff: time.Now().UTC()}); err == nil {
 		t.Fatal("injected import failure succeeded")
 	}
 	if indexOf(failedEvents, "retire") >= 0 || indexOf(failedEvents, "activate") >= 0 || indexOf(failedEvents, "publish") >= 0 {
@@ -65,12 +65,12 @@ func TestExecutorDoesNotSealAfterImportFailureAndRecoversActivePublication(t *te
 	result, err := (Executor{Source: &fakeSource{manifest: retired, events: &recoveryEvents}, Destination: recoveryDestination, Publish: func(context.Context, operator.MailCutoverPublication) error {
 		recoveryEvents = append(recoveryEvents, "publish")
 		return nil
-	}, BatchSize: 1}).Execute(context.Background(), Request{ActorPrincipalID: "11111111-1111-4111-8111-111111111111", EpochID: retired.EpochID, ExpectedSourceFingerprint: retired.ExpectedFingerprint, Cutoff: time.Now().UTC()})
-	if err != nil || result.Phase != postgres.MailCutoverActive || !reflect.DeepEqual(recoveryEvents, []string{"schema-readiness", "identity", "inspect", "begin", "publish"}) {
+	}, BatchSize: 1, Enrollment: "test-enrollment"}).Execute(context.Background(), Request{ActorPrincipalID: "11111111-1111-4111-8111-111111111111", EpochID: retired.EpochID, ExpectedSourceFingerprint: retired.ExpectedFingerprint, Cutoff: time.Now().UTC()})
+	if err != nil || result.Phase != postgres.MailCutoverActive || !reflect.DeepEqual(recoveryEvents, []string{"schema-readiness", "identity", "inspect", "coverage", "begin", "publish"}) {
 		t.Fatalf("recovery result=%#v events=%v err=%v", result, recoveryEvents, err)
 	}
 	changedEvents := []string{}
-	if _, err := (Executor{Source: &fakeSource{manifest: retired, events: &changedEvents}, Destination: &fakeDestination{identity: retired.TargetIdentity, phase: postgres.MailCutoverActive, events: &changedEvents}, Publish: func(context.Context, operator.MailCutoverPublication) error { return nil }, BatchSize: 1}).Execute(context.Background(), Request{ActorPrincipalID: "11111111-1111-4111-8111-111111111111", EpochID: retired.EpochID, ExpectedSourceFingerprint: strings.Repeat("f", 64), Cutoff: time.Now().UTC()}); err == nil || indexOf(changedEvents, "begin") >= 0 {
+	if _, err := (Executor{Source: &fakeSource{manifest: retired, events: &changedEvents}, Destination: &fakeDestination{identity: retired.TargetIdentity, phase: postgres.MailCutoverActive, events: &changedEvents}, Publish: func(context.Context, operator.MailCutoverPublication) error { return nil }, BatchSize: 1, Enrollment: "test-enrollment"}).Execute(context.Background(), Request{ActorPrincipalID: "11111111-1111-4111-8111-111111111111", EpochID: retired.EpochID, ExpectedSourceFingerprint: strings.Repeat("f", 64), Cutoff: time.Now().UTC()}); err == nil || indexOf(changedEvents, "begin") >= 0 {
 		t.Fatalf("changed recovery binding events=%v err=%v", changedEvents, err)
 	}
 }
@@ -82,7 +82,7 @@ func TestExecutorChecksActivationReadinessBeforeRetiringSource(t *testing.T) {
 	readinessErr := errors.New("pending legacy machine")
 	source := &fakeSource{manifest: prepared, events: &events}
 	destination := &fakeDestination{identity: prepared.TargetIdentity, phase: postgres.MailCutoverVerified, events: &events, readinessErr: readinessErr}
-	executor := Executor{Source: source, Destination: destination, Publish: func(context.Context, operator.MailCutoverPublication) error { return nil }}
+	executor := Executor{Source: source, Destination: destination, Publish: func(context.Context, operator.MailCutoverPublication) error { return nil }, Enrollment: "test-enrollment"}
 	_, err := executor.Execute(context.Background(), Request{ActorPrincipalID: "11111111-1111-4111-8111-111111111111", EpochID: prepared.EpochID, ExpectedSourceFingerprint: prepared.ExpectedFingerprint, Cutoff: time.Now().UTC()})
 	if !errors.Is(err, readinessErr) || source.manifest.Phase != relay.MigrationSourcePrepared || indexOf(events, "activation-readiness") < 0 || indexOf(events, "retire") >= 0 {
 		t.Fatalf("source=%#v events=%v err=%v", source.manifest, events, err)
@@ -108,10 +108,29 @@ func TestExecutorRequiresCurrentDestinationSchemaBeforeInspectingSource(t *testi
 		Source:      &fakeSource{manifest: manifest, events: &events},
 		Destination: &fakeDestination{identity: manifest.TargetIdentity, events: &events, schemaReadinessErr: readinessErr},
 		Publish:     func(context.Context, operator.MailCutoverPublication) error { return nil },
+		Enrollment:  "test-enrollment",
 	}
 	_, err := executor.Execute(context.Background(), Request{ActorPrincipalID: "11111111-1111-4111-8111-111111111111", EpochID: manifest.EpochID, ExpectedSourceFingerprint: manifest.Fingerprint, Cutoff: time.Now().UTC()})
 	if !errors.Is(err, readinessErr) || !reflect.DeepEqual(events, []string{"schema-readiness"}) {
 		t.Fatalf("events=%v err=%v", events, err)
+	}
+}
+
+func TestExecutorRefusesUncoveredEnrollmentBeforePreparingSource(t *testing.T) {
+	t.Parallel()
+	manifest := testManifest(relay.MigrationSourceActive)
+	var events []string
+	coverageErr := errors.New("enrollment does not cover source")
+	source := &fakeSource{manifest: manifest, events: &events, coverageErr: coverageErr}
+	executor := Executor{
+		Source:      source,
+		Destination: &fakeDestination{identity: manifest.TargetIdentity, events: &events},
+		Publish:     func(context.Context, operator.MailCutoverPublication) error { return nil },
+		Enrollment:  "test-enrollment",
+	}
+	_, err := executor.Execute(context.Background(), Request{ActorPrincipalID: "11111111-1111-4111-8111-111111111111", EpochID: manifest.EpochID, ExpectedSourceFingerprint: manifest.Fingerprint, Cutoff: time.Now().UTC()})
+	if !errors.Is(err, coverageErr) || !reflect.DeepEqual(events, []string{"schema-readiness", "identity", "inspect", "coverage"}) || source.manifest.Phase != relay.MigrationSourceActive {
+		t.Fatalf("source=%#v events=%v err=%v", source.manifest, events, err)
 	}
 }
 
@@ -181,13 +200,18 @@ func TestAbortRecoversPreparedSourceWhenDestinationRejectedBeforeEpochInsert(t *
 }
 
 type fakeSource struct {
-	manifest relay.MigrationSourceManifest
-	events   *[]string
+	manifest    relay.MigrationSourceManifest
+	events      *[]string
+	coverageErr error
 }
 
 func (s *fakeSource) Inspect(context.Context) (relay.MigrationSourceManifest, error) {
 	*s.events = append(*s.events, "inspect")
 	return s.manifest, nil
+}
+func (s *fakeSource) CheckEnrollmentCoverage(context.Context, string) error {
+	*s.events = append(*s.events, "coverage")
+	return s.coverageErr
 }
 func (s *fakeSource) Prepare(_ context.Context, epoch, target, expected string, _ time.Time) (relay.MigrationSourceManifest, error) {
 	*s.events = append(*s.events, "prepare")
@@ -275,7 +299,7 @@ func (d *fakeDestination) VerifyMailCutover(_ context.Context, _ string, _ strin
 	d.phase = postgres.MailCutoverVerified
 	return postgres.MailCutoverEpoch{Phase: d.phase}, nil
 }
-func (d *fakeDestination) CheckMailCutoverActivationReadiness(context.Context, string, string, string) error {
+func (d *fakeDestination) CheckMailCutoverActivationReadiness(context.Context, string, string, string, string) error {
 	*d.events = append(*d.events, "activation-readiness")
 	return d.readinessErr
 }

--- a/internal/operator/installation.go
+++ b/internal/operator/installation.go
@@ -2,6 +2,7 @@
 package operator
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -19,6 +20,7 @@ import (
 	"github.com/rock3r/punaro/internal/ingress"
 	"github.com/rock3r/punaro/internal/listener"
 	punaropostgres "github.com/rock3r/punaro/internal/postgres"
+	"github.com/rock3r/punaro/internal/relay"
 )
 
 const (
@@ -27,6 +29,7 @@ const (
 	envName                 = "punarod.env"
 	overrideName            = "compose.operator.yaml"
 	defaultHealthListenAddr = "127.0.0.1:8081"
+	maxRelayMachinesBytes   = 32 << 10
 )
 
 // EnvFile returns the generated daemon dotenv path for one installation.
@@ -48,24 +51,48 @@ func ComposeProjectName(installation Installation) (string, error) {
 	return "punaro-" + strings.ReplaceAll(ownerID.String(), "-", ""), nil
 }
 
+func canonicalRelayMachinesJSON(raw string) (string, error) {
+	if len(raw) == 0 || len(raw) > maxRelayMachinesBytes || relay.ValidateMachineEnrollments(raw) != nil {
+		return "", errors.New("relay machine enrollment is invalid")
+	}
+	var compact bytes.Buffer
+	if json.Compact(&compact, []byte(raw)) != nil || compact.Len() == 0 || strings.ContainsAny(compact.String(), "\r\n") {
+		return "", errors.New("relay machine enrollment is invalid")
+	}
+	canonical := strings.ReplaceAll(compact.String(), "'", `\u0027`)
+	if len(canonical) > maxRelayMachinesBytes {
+		return "", errors.New("relay machine enrollment is invalid")
+	}
+	return canonical, nil
+}
+
+func validateRelayMachinesJSON(raw string) error {
+	canonical, err := canonicalRelayMachinesJSON(raw)
+	if err != nil || canonical != raw {
+		return errors.New("relay machine enrollment is invalid")
+	}
+	return nil
+}
+
 // Installation is the content-free operator configuration. DSN values remain
 // in separately protected files and are never copied here.
 type Installation struct {
-	Version          int                     `json:"version"`
-	Directory        string                  `json:"-"`
-	DataDir          string                  `json:"data_dir"`
-	BackupDir        string                  `json:"backup_dir"`
-	Image            string                  `json:"image"`
-	OwnerDSNFile     string                  `json:"owner_dsn_file"`
-	AppDSNFile       string                  `json:"app_dsn_file"`
-	OwnerPrincipalID string                  `json:"owner_principal_id"`
-	OwnerName        string                  `json:"owner_name"`
-	RuntimeUID       string                  `json:"runtime_uid"`
-	RuntimeGID       string                  `json:"runtime_gid"`
-	Ingress          ingress.Policy          `json:"ingress"`
-	HealthListenAddr string                  `json:"health_listen_addr"`
-	HealthURL        string                  `json:"health_url"`
-	MailCutover      *MailCutoverPublication `json:"mail_cutover,omitempty"`
+	Version           int                     `json:"version"`
+	Directory         string                  `json:"-"`
+	DataDir           string                  `json:"data_dir"`
+	BackupDir         string                  `json:"backup_dir"`
+	Image             string                  `json:"image"`
+	OwnerDSNFile      string                  `json:"owner_dsn_file"`
+	AppDSNFile        string                  `json:"app_dsn_file"`
+	OwnerPrincipalID  string                  `json:"owner_principal_id"`
+	OwnerName         string                  `json:"owner_name"`
+	RuntimeUID        string                  `json:"runtime_uid"`
+	RuntimeGID        string                  `json:"runtime_gid"`
+	Ingress           ingress.Policy          `json:"ingress"`
+	HealthListenAddr  string                  `json:"health_listen_addr"`
+	HealthURL         string                  `json:"health_url"`
+	RelayMachinesJSON string                  `json:"relay_machines_json,omitempty"`
+	MailCutover       *MailCutoverPublication `json:"mail_cutover,omitempty"`
 }
 
 // InitOptions is the complete explicit input to a first installation.
@@ -310,8 +337,13 @@ func Load(directory string) (Installation, error) {
 	if installation.Version != 1 || uuid.Validate(installation.OwnerPrincipalID) != nil || !numericIdentity(installation.RuntimeUID) || !numericIdentity(installation.RuntimeGID) || !runtimeIdentityMatches(installation) {
 		return Installation{}, errors.New("published installation configuration is corrupt")
 	}
-	if installation.MailCutover != nil && installation.MailCutover.Validate() != nil {
+	if installation.MailCutover != nil && (installation.MailCutover.Validate() != nil || installation.RelayMachinesJSON == "") {
 		return Installation{}, errors.New("published installation mail cutover is invalid")
+	}
+	if installation.RelayMachinesJSON != "" {
+		if err := validateRelayMachinesJSON(installation.RelayMachinesJSON); err != nil {
+			return Installation{}, errors.New("published installation relay enrollment is invalid")
+		}
 	}
 	validated, err := validateStatic(InitOptions{Directory: directory, DataDir: installation.DataDir, BackupDir: installation.BackupDir, Image: installation.Image, OwnerDSNFile: installation.OwnerDSNFile, AppDSNFile: installation.AppDSNFile, OwnerName: installation.OwnerName, Ingress: installation.Ingress, HealthListenAddr: installation.HealthListenAddr})
 	if err != nil {
@@ -423,22 +455,42 @@ func CheckPaths(installation Installation) []string {
 		failures = append(failures, "daemon-writable data directory overlaps database credentials or operator state")
 	}
 	envPath := EnvFile(installation.Directory)
+	envAvailable, envCurrent, envLegacy := false, false, false
 	if err := requireTrustedProtectedFile(envPath, 64<<10); err != nil {
 		failures = append(failures, "generated daemon environment unavailable or unsafe")
 	} else {
 		// #nosec G304 -- fixed generated file below the explicit validated installation directory.
 		body, err := os.ReadFile(envPath)
-		if err != nil || string(body) != daemonEnv(installation) {
+		envAvailable = err == nil
+		if envAvailable {
+			envCurrent = string(body) == daemonEnv(installation)
+			envLegacy = installation.MailCutover == nil && installation.RelayMachinesJSON == "" && string(body) == legacyDaemonEnv(installation)
+		}
+		if !envCurrent && !envLegacy {
 			failures = append(failures, "generated daemon environment does not match installation configuration")
 		}
 	}
 	overridePath := OverrideFile(installation.Directory)
+	overrideAvailable, overrideCurrent, overrideLegacy := false, false, false
 	if err := requireTrustedProtectedFile(overridePath, 64<<10); err != nil {
 		failures = append(failures, "generated Compose override unavailable or unsafe")
 	} else {
 		// #nosec G304 -- fixed generated file below the explicit validated installation directory.
 		body, err := os.ReadFile(overridePath)
-		if err != nil || string(body) != composeOverride() {
+		overrideAvailable = err == nil
+		if overrideAvailable {
+			overrideCurrent = string(body) == composeOverride()
+			overrideLegacy = installation.MailCutover == nil && installation.RelayMachinesJSON == "" && string(body) == legacyComposeOverride()
+		}
+		if !overrideCurrent && !overrideLegacy {
+			failures = append(failures, "generated Compose override does not match installation configuration")
+		}
+	}
+	if envAvailable && overrideAvailable && (envLegacy || overrideLegacy) {
+		if envLegacy && !overrideLegacy {
+			failures = append(failures, "generated daemon environment does not match installation configuration")
+		}
+		if overrideLegacy && !envLegacy {
 			failures = append(failures, "generated Compose override does not match installation configuration")
 		}
 	}
@@ -459,9 +511,9 @@ func localURL(listenAddr string) string {
 }
 
 func daemonEnv(installation Installation) string {
-	relayStore, credentialTransition := "sqlite", "false"
+	relayStore, relayEnabled, credentialTransition := "sqlite", "false", "false"
 	if installation.MailCutover != nil {
-		relayStore, credentialTransition = "postgres", "true"
+		relayStore, relayEnabled, credentialTransition = "postgres", "true", "true"
 	}
 	return strings.Join([]string{
 		"PUNARO_IMAGE=" + installation.Image,
@@ -472,6 +524,8 @@ func daemonEnv(installation Installation) string {
 		"PUNARO_POSTGRES_ENABLED=true",
 		"PUNARO_POSTGRES_DSN_FILE=" + installation.AppDSNFile,
 		"PUNARO_DEVICE_AUTH_ENABLED=true",
+		"PUNARO_RELAY_ENABLED=" + relayEnabled,
+		"PUNARO_RELAY_MACHINES_JSON='" + installation.RelayMachinesJSON + "'",
 		"PUNARO_RELAY_STORE=" + relayStore,
 		"PUNARO_CREDENTIAL_TRANSITION_ENABLED=" + credentialTransition,
 		"PUNARO_INGRESS_MODE=" + string(installation.Ingress.Mode),
@@ -481,6 +535,10 @@ func daemonEnv(installation Installation) string {
 		"PUNARO_RUNTIME_UID=" + installation.RuntimeUID,
 		"PUNARO_RUNTIME_GID=" + installation.RuntimeGID,
 	}, "\n") + "\n"
+}
+
+func legacyDaemonEnv(installation Installation) string {
+	return strings.ReplaceAll(daemonEnv(installation), "PUNARO_RELAY_ENABLED=false\nPUNARO_RELAY_MACHINES_JSON=''\n", "")
 }
 
 func composeOverride() string {
@@ -505,6 +563,8 @@ func composeOverride() string {
       PUNARO_POSTGRES_ENABLED: ${PUNARO_POSTGRES_ENABLED:?required}
       PUNARO_POSTGRES_DSN_FILE: ${PUNARO_POSTGRES_DSN_FILE:?required}
       PUNARO_DEVICE_AUTH_ENABLED: ${PUNARO_DEVICE_AUTH_ENABLED:?required}
+      PUNARO_RELAY_ENABLED: ${PUNARO_RELAY_ENABLED:?required}
+      PUNARO_RELAY_MACHINES_JSON: ${PUNARO_RELAY_MACHINES_JSON:-}
       PUNARO_RELAY_STORE: ${PUNARO_RELAY_STORE:?required}
       PUNARO_CREDENTIAL_TRANSITION_ENABLED: ${PUNARO_CREDENTIAL_TRANSITION_ENABLED:?required}
       PUNARO_INGRESS_MODE: ${PUNARO_INGRESS_MODE:?required}
@@ -520,6 +580,10 @@ func composeOverride() string {
         target: ${PUNARO_POSTGRES_DSN_FILE:?required}
         read_only: true
 `
+}
+
+func legacyComposeOverride() string {
+	return strings.ReplaceAll(composeOverride(), "      PUNARO_RELAY_ENABLED: ${PUNARO_RELAY_ENABLED:?required}\n      PUNARO_RELAY_MACHINES_JSON: ${PUNARO_RELAY_MACHINES_JSON:-}\n", "")
 }
 
 func numericIdentity(value string) bool {

--- a/internal/operator/installation.go
+++ b/internal/operator/installation.go
@@ -51,20 +51,21 @@ func ComposeProjectName(installation Installation) (string, error) {
 // Installation is the content-free operator configuration. DSN values remain
 // in separately protected files and are never copied here.
 type Installation struct {
-	Version          int            `json:"version"`
-	Directory        string         `json:"-"`
-	DataDir          string         `json:"data_dir"`
-	BackupDir        string         `json:"backup_dir"`
-	Image            string         `json:"image"`
-	OwnerDSNFile     string         `json:"owner_dsn_file"`
-	AppDSNFile       string         `json:"app_dsn_file"`
-	OwnerPrincipalID string         `json:"owner_principal_id"`
-	OwnerName        string         `json:"owner_name"`
-	RuntimeUID       string         `json:"runtime_uid"`
-	RuntimeGID       string         `json:"runtime_gid"`
-	Ingress          ingress.Policy `json:"ingress"`
-	HealthListenAddr string         `json:"health_listen_addr"`
-	HealthURL        string         `json:"health_url"`
+	Version          int                     `json:"version"`
+	Directory        string                  `json:"-"`
+	DataDir          string                  `json:"data_dir"`
+	BackupDir        string                  `json:"backup_dir"`
+	Image            string                  `json:"image"`
+	OwnerDSNFile     string                  `json:"owner_dsn_file"`
+	AppDSNFile       string                  `json:"app_dsn_file"`
+	OwnerPrincipalID string                  `json:"owner_principal_id"`
+	OwnerName        string                  `json:"owner_name"`
+	RuntimeUID       string                  `json:"runtime_uid"`
+	RuntimeGID       string                  `json:"runtime_gid"`
+	Ingress          ingress.Policy          `json:"ingress"`
+	HealthListenAddr string                  `json:"health_listen_addr"`
+	HealthURL        string                  `json:"health_url"`
+	MailCutover      *MailCutoverPublication `json:"mail_cutover,omitempty"`
 }
 
 // InitOptions is the complete explicit input to a first installation.
@@ -309,6 +310,9 @@ func Load(directory string) (Installation, error) {
 	if installation.Version != 1 || uuid.Validate(installation.OwnerPrincipalID) != nil || !numericIdentity(installation.RuntimeUID) || !numericIdentity(installation.RuntimeGID) || !runtimeIdentityMatches(installation) {
 		return Installation{}, errors.New("published installation configuration is corrupt")
 	}
+	if installation.MailCutover != nil && installation.MailCutover.Validate() != nil {
+		return Installation{}, errors.New("published installation mail cutover is invalid")
+	}
 	validated, err := validateStatic(InitOptions{Directory: directory, DataDir: installation.DataDir, BackupDir: installation.BackupDir, Image: installation.Image, OwnerDSNFile: installation.OwnerDSNFile, AppDSNFile: installation.AppDSNFile, OwnerName: installation.OwnerName, Ingress: installation.Ingress, HealthListenAddr: installation.HealthListenAddr})
 	if err != nil {
 		return Installation{}, errors.New("published installation configuration is invalid")
@@ -455,6 +459,10 @@ func localURL(listenAddr string) string {
 }
 
 func daemonEnv(installation Installation) string {
+	relayStore, credentialTransition := "sqlite", "false"
+	if installation.MailCutover != nil {
+		relayStore, credentialTransition = "postgres", "true"
+	}
 	return strings.Join([]string{
 		"PUNARO_IMAGE=" + installation.Image,
 		"PUNARO_HOST_DATA_DIR=" + installation.DataDir,
@@ -464,6 +472,8 @@ func daemonEnv(installation Installation) string {
 		"PUNARO_POSTGRES_ENABLED=true",
 		"PUNARO_POSTGRES_DSN_FILE=" + installation.AppDSNFile,
 		"PUNARO_DEVICE_AUTH_ENABLED=true",
+		"PUNARO_RELAY_STORE=" + relayStore,
+		"PUNARO_CREDENTIAL_TRANSITION_ENABLED=" + credentialTransition,
 		"PUNARO_INGRESS_MODE=" + string(installation.Ingress.Mode),
 		"PUNARO_PUBLIC_URL=" + installation.Ingress.PublicURL,
 		"PUNARO_TRUSTED_LAN_CIDR=" + installation.Ingress.TrustedLAN,
@@ -495,6 +505,8 @@ func composeOverride() string {
       PUNARO_POSTGRES_ENABLED: ${PUNARO_POSTGRES_ENABLED:?required}
       PUNARO_POSTGRES_DSN_FILE: ${PUNARO_POSTGRES_DSN_FILE:?required}
       PUNARO_DEVICE_AUTH_ENABLED: ${PUNARO_DEVICE_AUTH_ENABLED:?required}
+      PUNARO_RELAY_STORE: ${PUNARO_RELAY_STORE:?required}
+      PUNARO_CREDENTIAL_TRANSITION_ENABLED: ${PUNARO_CREDENTIAL_TRANSITION_ENABLED:?required}
       PUNARO_INGRESS_MODE: ${PUNARO_INGRESS_MODE:?required}
       PUNARO_PUBLIC_URL: ${PUNARO_PUBLIC_URL:-}
       PUNARO_TRUSTED_LAN_CIDR: ${PUNARO_TRUSTED_LAN_CIDR:-}

--- a/internal/operator/installation.go
+++ b/internal/operator/installation.go
@@ -538,7 +538,12 @@ func daemonEnv(installation Installation) string {
 }
 
 func legacyDaemonEnv(installation Installation) string {
-	return strings.ReplaceAll(daemonEnv(installation), "PUNARO_RELAY_ENABLED=false\nPUNARO_RELAY_MACHINES_JSON=''\n", "")
+	return strings.NewReplacer(
+		"PUNARO_RELAY_ENABLED=false\n", "",
+		"PUNARO_RELAY_MACHINES_JSON=''\n", "",
+		"PUNARO_RELAY_STORE=sqlite\n", "",
+		"PUNARO_CREDENTIAL_TRANSITION_ENABLED=false\n", "",
+	).Replace(daemonEnv(installation))
 }
 
 func composeOverride() string {
@@ -583,7 +588,12 @@ func composeOverride() string {
 }
 
 func legacyComposeOverride() string {
-	return strings.ReplaceAll(composeOverride(), "      PUNARO_RELAY_ENABLED: ${PUNARO_RELAY_ENABLED:?required}\n      PUNARO_RELAY_MACHINES_JSON: ${PUNARO_RELAY_MACHINES_JSON:-}\n", "")
+	return strings.NewReplacer(
+		"      PUNARO_RELAY_ENABLED: ${PUNARO_RELAY_ENABLED:?required}\n", "",
+		"      PUNARO_RELAY_MACHINES_JSON: ${PUNARO_RELAY_MACHINES_JSON:-}\n", "",
+		"      PUNARO_RELAY_STORE: ${PUNARO_RELAY_STORE:?required}\n", "",
+		"      PUNARO_CREDENTIAL_TRANSITION_ENABLED: ${PUNARO_CREDENTIAL_TRANSITION_ENABLED:?required}\n", "",
+	).Replace(composeOverride())
 }
 
 func numericIdentity(value string) bool {

--- a/internal/operator/installation_test.go
+++ b/internal/operator/installation_test.go
@@ -16,6 +16,21 @@ import (
 
 const testImage = "registry.example/punaro@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
 
+const testRelayMachinesJSON = `[{"id":"machine-a","public_key":"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA","endpoint_prefixes":["agent/a/"],"endpoints":[],"attachment_device_id":""}]`
+
+func configureTestRelayMachines(t *testing.T, installation Installation) Installation {
+	t.Helper()
+	path := filepath.Join(filepath.Dir(installation.Directory), "relay-machines.json")
+	if err := os.WriteFile(path, []byte(testRelayMachinesJSON), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	configured, err := ConfigureMailCutoverRelayMachines(installation.Directory, path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return configured
+}
+
 func protectedFile(t *testing.T, path string) {
 	t.Helper()
 	if err := os.WriteFile(path, []byte("postgres://example.invalid/punaro\n"), 0o600); err != nil {
@@ -468,6 +483,10 @@ func TestPublishMailCutoverSwitchesRuntimeMarkerLast(t *testing.T) {
 		Version: 1, EpochID: "019f7f07-8b88-7c12-a394-b663274a6555",
 		TargetIdentity: strings.Repeat("a", 64), SourceFingerprint: strings.Repeat("b", 64),
 	}
+	if _, err := PublishMailCutover(installation.Directory, publication); err == nil {
+		t.Fatal("mail cutover publication accepted missing relay authority")
+	}
+	installation = configureTestRelayMachines(t, installation)
 	published, err := PublishMailCutover(installation.Directory, publication)
 	if err != nil || published.MailCutover == nil || *published.MailCutover != publication {
 		t.Fatalf("published installation=%#v err=%v", published, err)
@@ -477,7 +496,7 @@ func TestPublishMailCutoverSwitchesRuntimeMarkerLast(t *testing.T) {
 		t.Fatalf("loaded installation=%#v err=%v", loaded, err)
 	}
 	environment, err := os.ReadFile(EnvFile(installation.Directory)) // #nosec G304 -- generated test installation path.
-	if err != nil || !strings.Contains(string(environment), "PUNARO_RELAY_STORE=postgres\n") || !strings.Contains(string(environment), "PUNARO_CREDENTIAL_TRANSITION_ENABLED=true\n") {
+	if err != nil || !strings.Contains(string(environment), "PUNARO_RELAY_ENABLED=true\n") || !strings.Contains(string(environment), "PUNARO_RELAY_STORE=postgres\n") || !strings.Contains(string(environment), "PUNARO_CREDENTIAL_TRANSITION_ENABLED=true\n") {
 		t.Fatalf("cutover environment=%q err=%v", environment, err)
 	}
 	if failures := CheckPaths(loaded); len(failures) != 0 {
@@ -485,6 +504,9 @@ func TestPublishMailCutoverSwitchesRuntimeMarkerLast(t *testing.T) {
 	}
 	if repeated, err := PublishMailCutover(installation.Directory, publication); err != nil || repeated.MailCutover == nil || *repeated.MailCutover != publication {
 		t.Fatalf("cutover publication retry=%#v err=%v", repeated, err)
+	}
+	if repeated := configureTestRelayMachines(t, published); repeated.MailCutover == nil || *repeated.MailCutover != publication {
+		t.Fatalf("exact enrollment retry lost active cutover: %#v", repeated)
 	}
 	changed := publication
 	changed.SourceFingerprint = strings.Repeat("c", 64)
@@ -503,6 +525,7 @@ func TestPublishMailCutoverRecoversEveryDurableBoundary(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
+			installation = configureTestRelayMachines(t, installation)
 			publication := MailCutoverPublication{Version: 1, EpochID: "019f7f07-8b88-7c12-a394-b663274a6555", TargetIdentity: strings.Repeat("a", 64), SourceFingerprint: strings.Repeat("b", 64)}
 			injected := errors.New("injected publication crash")
 			if _, err := publishMailCutover(installation.Directory, publication, func(completed string) error {
@@ -537,6 +560,7 @@ func TestPublishMailCutoverRecoveryNeverDropsDurableCandidate(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
+			installation = configureTestRelayMachines(t, installation)
 			publication := MailCutoverPublication{Version: 1, EpochID: "019f7f07-8b88-7c12-a394-b663274a6555", TargetIdentity: strings.Repeat("a", 64), SourceFingerprint: strings.Repeat("b", 64)}
 			injected := errors.New("injected publication crash")
 			if _, err := publishMailCutover(installation.Directory, publication, func(completed string) error {
@@ -563,6 +587,72 @@ func TestPublishMailCutoverRecoveryNeverDropsDurableCandidate(t *testing.T) {
 				t.Fatalf("step=%s recovered=%#v err=%v", step, recovered, err)
 			}
 		})
+	}
+}
+
+func TestMailCutoverRelayConfigurationRepairsExactLegacyTemplates(t *testing.T) {
+	options := validInitOptions(t)
+	installation, err := Init(context.Background(), options, func(context.Context, string, string) (punaropostgres.Principal, error) {
+		return punaropostgres.Principal{ID: "11111111-1111-4111-8111-111111111111"}, nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(EnvFile(installation.Directory), []byte("tampered\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if failures := CheckPaths(installation); !containsFailure(failures, "generated daemon environment does not match installation configuration") {
+		t.Fatalf("tampered current template accepted: %v", failures)
+	}
+	if err := os.WriteFile(EnvFile(installation.Directory), []byte(legacyDaemonEnv(installation)), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(OverrideFile(installation.Directory), []byte(legacyComposeOverride()), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if failures := CheckPaths(installation); len(failures) != 0 {
+		t.Fatalf("exact legacy templates rejected: %v", failures)
+	}
+	if err := os.WriteFile(EnvFile(installation.Directory), []byte(daemonEnv(installation)), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if failures := CheckPaths(installation); !containsFailure(failures, "generated Compose override does not match installation configuration") {
+		t.Fatalf("mixed legacy/current templates accepted: %v", failures)
+	}
+	if err := os.WriteFile(EnvFile(installation.Directory), []byte(legacyDaemonEnv(installation)), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	configured := configureTestRelayMachines(t, installation)
+	if configured.RelayMachinesJSON != testRelayMachinesJSON || len(CheckPaths(configured)) != 0 {
+		t.Fatalf("configured=%#v failures=%v", configured, CheckPaths(configured))
+	}
+	environment, err := os.ReadFile(EnvFile(installation.Directory))
+	if err != nil || !strings.Contains(string(environment), "PUNARO_RELAY_ENABLED=false\n") || !strings.Contains(string(environment), "PUNARO_RELAY_MACHINES_JSON='"+testRelayMachinesJSON+"'\n") {
+		t.Fatalf("environment=%q err=%v", environment, err)
+	}
+}
+
+func TestMailCutoverRelayConfigurationQuotesDotenvMetacharacters(t *testing.T) {
+	options := validInitOptions(t)
+	installation, err := Init(context.Background(), options, func(context.Context, string, string) (punaropostgres.Principal, error) {
+		return punaropostgres.Principal{ID: "11111111-1111-4111-8111-111111111111"}, nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(filepath.Dir(installation.Directory), "relay-machines-metacharacters.json")
+	input := `[{"id":"machine-$authority","public_key":"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA","endpoints":["agent/o'hare/#1"]}]`
+	if err := os.WriteFile(path, []byte(input), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	configured, err := ConfigureMailCutoverRelayMachines(installation.Directory, path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := strings.ReplaceAll(input, "'", `\u0027`)
+	environment, err := os.ReadFile(EnvFile(installation.Directory))
+	if err != nil || configured.RelayMachinesJSON != want || !strings.Contains(string(environment), "PUNARO_RELAY_MACHINES_JSON='"+want+"'\n") {
+		t.Fatalf("configured=%q environment=%q err=%v", configured.RelayMachinesJSON, environment, err)
 	}
 }
 

--- a/internal/operator/installation_test.go
+++ b/internal/operator/installation_test.go
@@ -604,10 +604,17 @@ func TestMailCutoverRelayConfigurationRepairsExactLegacyTemplates(t *testing.T) 
 	if failures := CheckPaths(installation); !containsFailure(failures, "generated daemon environment does not match installation configuration") {
 		t.Fatalf("tampered current template accepted: %v", failures)
 	}
-	if err := os.WriteFile(EnvFile(installation.Directory), []byte(legacyDaemonEnv(installation)), 0o600); err != nil {
+	legacyEnvironment := legacyDaemonEnv(installation)
+	legacyOverride := legacyComposeOverride()
+	for _, added := range []string{"PUNARO_RELAY_ENABLED", "PUNARO_RELAY_MACHINES_JSON", "PUNARO_RELAY_STORE", "PUNARO_CREDENTIAL_TRANSITION_ENABLED"} {
+		if strings.Contains(legacyEnvironment, added) || strings.Contains(legacyOverride, added) {
+			t.Fatalf("pre-cutover generated configuration unexpectedly contains %s", added)
+		}
+	}
+	if err := os.WriteFile(EnvFile(installation.Directory), []byte(legacyEnvironment), 0o600); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(OverrideFile(installation.Directory), []byte(legacyComposeOverride()), 0o600); err != nil {
+	if err := os.WriteFile(OverrideFile(installation.Directory), []byte(legacyOverride), 0o600); err != nil {
 		t.Fatal(err)
 	}
 	if failures := CheckPaths(installation); len(failures) != 0 {

--- a/internal/operator/installation_test.go
+++ b/internal/operator/installation_test.go
@@ -456,6 +456,116 @@ func TestGeneratedConfigurationUsesDedicatedLoopbackHealthListener(t *testing.T)
 	}
 }
 
+func TestPublishMailCutoverSwitchesRuntimeMarkerLast(t *testing.T) {
+	options := validInitOptions(t)
+	installation, err := Init(context.Background(), options, func(context.Context, string, string) (punaropostgres.Principal, error) {
+		return punaropostgres.Principal{ID: "11111111-1111-4111-8111-111111111111"}, nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	publication := MailCutoverPublication{
+		Version: 1, EpochID: "019f7f07-8b88-7c12-a394-b663274a6555",
+		TargetIdentity: strings.Repeat("a", 64), SourceFingerprint: strings.Repeat("b", 64),
+	}
+	published, err := PublishMailCutover(installation.Directory, publication)
+	if err != nil || published.MailCutover == nil || *published.MailCutover != publication {
+		t.Fatalf("published installation=%#v err=%v", published, err)
+	}
+	loaded, err := Load(installation.Directory)
+	if err != nil || loaded.MailCutover == nil || *loaded.MailCutover != publication {
+		t.Fatalf("loaded installation=%#v err=%v", loaded, err)
+	}
+	environment, err := os.ReadFile(EnvFile(installation.Directory)) // #nosec G304 -- generated test installation path.
+	if err != nil || !strings.Contains(string(environment), "PUNARO_RELAY_STORE=postgres\n") || !strings.Contains(string(environment), "PUNARO_CREDENTIAL_TRANSITION_ENABLED=true\n") {
+		t.Fatalf("cutover environment=%q err=%v", environment, err)
+	}
+	if failures := CheckPaths(loaded); len(failures) != 0 {
+		t.Fatalf("published cutover paths failed: %v", failures)
+	}
+	if repeated, err := PublishMailCutover(installation.Directory, publication); err != nil || repeated.MailCutover == nil || *repeated.MailCutover != publication {
+		t.Fatalf("cutover publication retry=%#v err=%v", repeated, err)
+	}
+	changed := publication
+	changed.SourceFingerprint = strings.Repeat("c", 64)
+	if _, err := PublishMailCutover(installation.Directory, changed); err == nil {
+		t.Fatal("changed cutover publication was accepted")
+	}
+}
+
+func TestPublishMailCutoverRecoversEveryDurableBoundary(t *testing.T) {
+	for _, step := range []string{"staged", "environment", "override", "marker"} {
+		t.Run(step, func(t *testing.T) {
+			options := validInitOptions(t)
+			installation, err := Init(context.Background(), options, func(context.Context, string, string) (punaropostgres.Principal, error) {
+				return punaropostgres.Principal{ID: "11111111-1111-4111-8111-111111111111"}, nil
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			publication := MailCutoverPublication{Version: 1, EpochID: "019f7f07-8b88-7c12-a394-b663274a6555", TargetIdentity: strings.Repeat("a", 64), SourceFingerprint: strings.Repeat("b", 64)}
+			injected := errors.New("injected publication crash")
+			if _, err := publishMailCutover(installation.Directory, publication, func(completed string) error {
+				if completed == step {
+					return injected
+				}
+				return nil
+			}); !errors.Is(err, injected) {
+				t.Fatalf("step=%s err=%v", step, err)
+			}
+			if _, err := LoadMailCutoverRecovery(installation.Directory); err != nil {
+				t.Fatalf("step=%s recovery preflight: %v", step, err)
+			}
+			recovered, err := PublishMailCutover(installation.Directory, publication)
+			if err != nil || recovered.MailCutover == nil || *recovered.MailCutover != publication {
+				t.Fatalf("step=%s recovered=%#v err=%v", step, recovered, err)
+			}
+			if failures := CheckPaths(recovered); len(failures) != 0 {
+				t.Fatalf("step=%s failures=%v", step, failures)
+			}
+		})
+	}
+}
+
+func TestPublishMailCutoverRecoveryNeverDropsDurableCandidate(t *testing.T) {
+	for _, step := range []string{"candidate", "stages-cleared", "environment-staged", "override-staged", "staging-synced"} {
+		t.Run(step, func(t *testing.T) {
+			options := validInitOptions(t)
+			installation, err := Init(context.Background(), options, func(context.Context, string, string) (punaropostgres.Principal, error) {
+				return punaropostgres.Principal{ID: "11111111-1111-4111-8111-111111111111"}, nil
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			publication := MailCutoverPublication{Version: 1, EpochID: "019f7f07-8b88-7c12-a394-b663274a6555", TargetIdentity: strings.Repeat("a", 64), SourceFingerprint: strings.Repeat("b", 64)}
+			injected := errors.New("injected publication crash")
+			if _, err := publishMailCutover(installation.Directory, publication, func(completed string) error {
+				if completed == "environment" {
+					return injected
+				}
+				return nil
+			}); !errors.Is(err, injected) {
+				t.Fatalf("initial interruption err=%v", err)
+			}
+			if _, err := publishMailCutover(installation.Directory, publication, func(completed string) error {
+				if completed == step {
+					return injected
+				}
+				return nil
+			}); !errors.Is(err, injected) {
+				t.Fatalf("recovery step=%s err=%v", step, err)
+			}
+			if _, err := LoadMailCutoverRecovery(installation.Directory); err != nil {
+				t.Fatalf("step=%s lost durable candidate: %v", step, err)
+			}
+			recovered, err := PublishMailCutover(installation.Directory, publication)
+			if err != nil || recovered.MailCutover == nil || *recovered.MailCutover != publication {
+				t.Fatalf("step=%s recovered=%#v err=%v", step, recovered, err)
+			}
+		})
+	}
+}
+
 func TestInitRejectsInvalidOrAliasingHealthListener(t *testing.T) {
 	for _, address := range []string{"127.0.0.1:0", "127.0.0.1:", "127.0.0.1:http", "127.0.0.1:65536", "127.0.0.1:08080"} {
 		t.Run(address, func(t *testing.T) {

--- a/internal/operator/mail_cutover.go
+++ b/internal/operator/mail_cutover.go
@@ -1,0 +1,203 @@
+package operator
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"regexp"
+	"slices"
+
+	"github.com/google/uuid"
+)
+
+var mailCutoverPublicationDigest = regexp.MustCompile(`^[0-9a-f]{64}$`)
+
+// MailCutoverPublication is the content-free, marker-last local authority
+// publication. Its presence selects PostgreSQL and the migrated-credential
+// transition runtime; absence selects the pre-cutover SQLite runtime.
+type MailCutoverPublication struct {
+	Version           int    `json:"version"`
+	EpochID           string `json:"epoch_id"`
+	TargetIdentity    string `json:"target_identity"`
+	SourceFingerprint string `json:"source_fingerprint"`
+}
+
+// Validate rejects incomplete or noncanonical publication bindings.
+func (p MailCutoverPublication) Validate() error {
+	if p.Version != 1 || uuid.Validate(p.EpochID) != nil || !mailCutoverPublicationDigest.MatchString(p.TargetIdentity) || !mailCutoverPublicationDigest.MatchString(p.SourceFingerprint) {
+		return errors.New("invalid mail cutover publication")
+	}
+	return nil
+}
+
+// PublishMailCutover atomically replaces the generated environment and
+// Compose inputs, then publishes installation.json last. Exact retries recover
+// crashes at any earlier publication boundary; changed retries fail closed.
+func PublishMailCutover(directory string, publication MailCutoverPublication) (Installation, error) {
+	return publishMailCutover(directory, publication, nil)
+}
+
+func publishMailCutover(directory string, publication MailCutoverPublication, afterStep func(string) error) (Installation, error) {
+	if publication.Validate() != nil {
+		return Installation{}, errors.New("mail cutover publication is invalid")
+	}
+	installation, err := Load(directory)
+	if err != nil {
+		return Installation{}, err
+	}
+	if installation.MailCutover != nil {
+		if *installation.MailCutover != publication {
+			return Installation{}, errors.New("mail cutover publication conflicts with the active marker")
+		}
+		if failures := CheckPaths(installation); len(failures) != 0 {
+			return Installation{}, errors.New("published mail cutover files are inconsistent")
+		}
+		return installation, nil
+	}
+	installation.MailCutover = &publication
+	envStage := filepath.Join(directory, ".punarod.env.mail-cutover")
+	overrideStage := filepath.Join(directory, ".compose.operator.mail-cutover.yaml")
+	markerStage := filepath.Join(directory, ".installation.mail-cutover.json")
+	// Preserve an exact durable candidate across recovery retries. Once either
+	// runtime file has switched, deleting this candidate would remove the only
+	// proof that a marker-last recovery is safe.
+	if _, statErr := os.Lstat(markerStage); errors.Is(statErr, os.ErrNotExist) {
+		if err := writeExclusiveJSON(markerStage, installation); err != nil {
+			return Installation{}, errors.New("mail cutover marker cannot be staged")
+		}
+	} else if statErr != nil {
+		return Installation{}, errors.New("mail cutover publication staging cannot be recovered")
+	} else {
+		candidate, readErr := readInstallation(markerStage)
+		if readErr != nil {
+			return Installation{}, errors.New("mail cutover publication staging cannot be recovered")
+		}
+		candidateJSON, candidateErr := json.Marshal(candidate)
+		installationJSON, installationErr := json.Marshal(installation)
+		if candidateErr != nil || installationErr != nil || !bytes.Equal(candidateJSON, installationJSON) {
+			return Installation{}, errors.New("mail cutover publication staging conflicts with the requested marker")
+		}
+	}
+	if afterStep != nil {
+		if err := afterStep("candidate"); err != nil {
+			return Installation{}, err
+		}
+	}
+	for _, path := range []string{envStage, overrideStage} {
+		if err := os.Remove(path); err != nil && !errors.Is(err, os.ErrNotExist) {
+			return Installation{}, errors.New("mail cutover publication staging cannot be recovered")
+		}
+	}
+	if afterStep != nil {
+		if err := afterStep("stages-cleared"); err != nil {
+			return Installation{}, err
+		}
+	}
+	if err := writeExclusive(envStage, []byte(daemonEnv(installation))); err != nil {
+		return Installation{}, errors.New("mail cutover environment cannot be staged")
+	}
+	if afterStep != nil {
+		if err := afterStep("environment-staged"); err != nil {
+			return Installation{}, err
+		}
+	}
+	if err := writeExclusive(overrideStage, []byte(composeOverride())); err != nil {
+		return Installation{}, errors.New("mail cutover Compose override cannot be staged")
+	}
+	if afterStep != nil {
+		if err := afterStep("override-staged"); err != nil {
+			return Installation{}, err
+		}
+	}
+	if err := syncDirectory(directory); err != nil {
+		return Installation{}, errors.New("mail cutover staging cannot be made durable")
+	}
+	if afterStep != nil {
+		if err := afterStep("staging-synced"); err != nil {
+			return Installation{}, err
+		}
+		if err := afterStep("staged"); err != nil {
+			return Installation{}, err
+		}
+	}
+	if err := os.Rename(envStage, EnvFile(directory)); err != nil {
+		return Installation{}, errors.New("mail cutover environment cannot be published")
+	}
+	if afterStep != nil {
+		if err := afterStep("environment"); err != nil {
+			return Installation{}, err
+		}
+	}
+	if err := os.Rename(overrideStage, OverrideFile(directory)); err != nil {
+		return Installation{}, errors.New("mail cutover Compose override cannot be published")
+	}
+	if afterStep != nil {
+		if err := afterStep("override"); err != nil {
+			return Installation{}, err
+		}
+	}
+	if err := syncDirectory(directory); err != nil {
+		return Installation{}, errors.New("mail cutover runtime publication durability failed")
+	}
+	if err := os.Rename(markerStage, ConfigFile(directory)); err != nil {
+		return Installation{}, errors.New("mail cutover database is active; rerun publication recovery")
+	}
+	if err := syncDirectory(directory); err != nil {
+		return Installation{}, errors.New("mail cutover marker durability failed")
+	}
+	if afterStep != nil {
+		if err := afterStep("marker"); err != nil {
+			return Installation{}, err
+		}
+	}
+	return installation, nil
+}
+
+// LoadMailCutoverRecovery accepts only an exact marker-last publication
+// interruption: trusted base installation, intact staged candidate marker, and
+// generated files equal to either the old or exact candidate state.
+func LoadMailCutoverRecovery(directory string) (Installation, error) {
+	base, err := Load(directory)
+	if err != nil {
+		return Installation{}, err
+	}
+	failures := CheckPaths(base)
+	if len(failures) == 0 {
+		return base, nil
+	}
+	allowed := []string{"generated Compose override does not match installation configuration", "generated daemon environment does not match installation configuration"}
+	for _, failure := range failures {
+		if !slices.Contains(allowed, failure) {
+			return Installation{}, errors.New("mail cutover recovery paths are not safe")
+		}
+	}
+	markerStage := filepath.Join(directory, ".installation.mail-cutover.json")
+	candidate, err := readInstallation(markerStage)
+	if err != nil || candidate.MailCutover == nil || candidate.MailCutover.Validate() != nil {
+		return Installation{}, errors.New("mail cutover recovery marker is unavailable")
+	}
+	candidate.Directory = directory
+	baseComparable, candidateComparable := base, candidate
+	baseComparable.MailCutover, candidateComparable.MailCutover = nil, nil
+	if baseComparable != candidateComparable {
+		return Installation{}, errors.New("mail cutover recovery marker does not match the installation")
+	}
+	for _, file := range []struct {
+		path          string
+		old, intended string
+	}{
+		{path: EnvFile(directory), old: daemonEnv(base), intended: daemonEnv(candidate)},
+		{path: OverrideFile(directory), old: composeOverride(), intended: composeOverride()},
+	} {
+		if err := requireTrustedProtectedFile(file.path, 64<<10); err != nil {
+			return Installation{}, errors.New("mail cutover recovery file is unavailable")
+		}
+		body, err := os.ReadFile(file.path) // #nosec G304 -- validated fixed generated path.
+		if err != nil || string(body) != file.old && string(body) != file.intended {
+			return Installation{}, errors.New("mail cutover recovery file does not match either durable state")
+		}
+	}
+	return base, nil
+}

--- a/internal/operator/mail_cutover.go
+++ b/internal/operator/mail_cutover.go
@@ -56,7 +56,45 @@ func publishMailCutover(directory string, publication MailCutoverPublication, af
 		}
 		return installation, nil
 	}
+	if installation.RelayMachinesJSON == "" {
+		return Installation{}, errors.New("mail cutover relay enrollment is unavailable")
+	}
 	installation.MailCutover = &publication
+	return publishMailCutoverInstallation(directory, installation, afterStep)
+}
+
+// ConfigureMailCutoverRelayMachines durably records the exact non-secret
+// static relay authority before any irreversible source transition begins.
+func ConfigureMailCutoverRelayMachines(directory, enrollmentFile string) (Installation, error) {
+	if !filepath.IsAbs(enrollmentFile) || filepath.Clean(enrollmentFile) != enrollmentFile || requireTrustedProtectedFile(enrollmentFile, maxRelayMachinesBytes) != nil {
+		return Installation{}, errors.New("mail cutover relay enrollment file is unavailable")
+	}
+	body, err := os.ReadFile(enrollmentFile) // #nosec G304 -- explicit protected operator input.
+	if err != nil {
+		return Installation{}, errors.New("mail cutover relay enrollment file is unavailable")
+	}
+	canonical, err := canonicalRelayMachinesJSON(string(body))
+	if err != nil {
+		return Installation{}, err
+	}
+	installation, err := LoadMailCutoverRecovery(directory)
+	if err != nil {
+		return Installation{}, err
+	}
+	if installation.RelayMachinesJSON != "" {
+		if installation.RelayMachinesJSON != canonical {
+			return Installation{}, errors.New("mail cutover relay enrollment conflicts with the installation")
+		}
+		return installation, nil
+	}
+	if installation.MailCutover != nil {
+		return Installation{}, errors.New("active mail cutover relay enrollment cannot change")
+	}
+	installation.RelayMachinesJSON = canonical
+	return publishMailCutoverInstallation(directory, installation, nil)
+}
+
+func publishMailCutoverInstallation(directory string, installation Installation, afterStep func(string) error) (Installation, error) {
 	envStage := filepath.Join(directory, ".punarod.env.mail-cutover")
 	overrideStage := filepath.Join(directory, ".compose.operator.mail-cutover.yaml")
 	markerStage := filepath.Join(directory, ".installation.mail-cutover.json")
@@ -175,14 +213,20 @@ func LoadMailCutoverRecovery(directory string) (Installation, error) {
 	}
 	markerStage := filepath.Join(directory, ".installation.mail-cutover.json")
 	candidate, err := readInstallation(markerStage)
-	if err != nil || candidate.MailCutover == nil || candidate.MailCutover.Validate() != nil {
+	if err != nil || candidate.MailCutover != nil && candidate.MailCutover.Validate() != nil || candidate.RelayMachinesJSON != "" && validateRelayMachinesJSON(candidate.RelayMachinesJSON) != nil {
 		return Installation{}, errors.New("mail cutover recovery marker is unavailable")
 	}
 	candidate.Directory = directory
 	baseComparable, candidateComparable := base, candidate
 	baseComparable.MailCutover, candidateComparable.MailCutover = nil, nil
+	baseComparable.RelayMachinesJSON, candidateComparable.RelayMachinesJSON = "", ""
 	if baseComparable != candidateComparable {
 		return Installation{}, errors.New("mail cutover recovery marker does not match the installation")
+	}
+	cutoverAdvance := base.MailCutover == nil && candidate.MailCutover != nil && base.RelayMachinesJSON == candidate.RelayMachinesJSON
+	enrollmentAdvance := base.MailCutover == nil && candidate.MailCutover == nil && base.RelayMachinesJSON == "" && candidate.RelayMachinesJSON != ""
+	if !cutoverAdvance && !enrollmentAdvance {
+		return Installation{}, errors.New("mail cutover recovery marker transition is invalid")
 	}
 	for _, file := range []struct {
 		path          string
@@ -195,7 +239,15 @@ func LoadMailCutoverRecovery(directory string) (Installation, error) {
 			return Installation{}, errors.New("mail cutover recovery file is unavailable")
 		}
 		body, err := os.ReadFile(file.path) // #nosec G304 -- validated fixed generated path.
-		if err != nil || string(body) != file.old && string(body) != file.intended {
+		legacyOld := ""
+		if base.MailCutover == nil && base.RelayMachinesJSON == "" {
+			if file.path == EnvFile(directory) {
+				legacyOld = legacyDaemonEnv(base)
+			} else {
+				legacyOld = legacyComposeOverride()
+			}
+		}
+		if err != nil || string(body) != file.old && string(body) != file.intended && string(body) != legacyOld {
 			return Installation{}, errors.New("mail cutover recovery file does not match either durable state")
 		}
 	}

--- a/internal/postgres/db.go
+++ b/internal/postgres/db.go
@@ -969,7 +969,7 @@ FROM objects, table_ownership, routine_safety, routine_acl, table_acl, schema_ac
 		snapshot.CurrentObjectsPresent = relayObjectsPresent
 	}
 	if snapshot.CurrentObjectsPresent && len(snapshot.Records) > 0 && snapshot.Records[len(snapshot.Records)-1].Version >= 8 {
-		cutoverObjectsPresent, err := mailCutoverControlsAvailable(ctx, q)
+		cutoverObjectsPresent, err := mailCutoverControlsAvailable(ctx, q, snapshot.Records[len(snapshot.Records)-1].Version)
 		if err != nil {
 			return Snapshot{}, errors.New("PostgreSQL mail-cutover schema cannot be inspected")
 		}

--- a/internal/postgres/legacy_auth_store.go
+++ b/internal/postgres/legacy_auth_store.go
@@ -43,6 +43,19 @@ func (a *Administration) RegisterLegacyMachine(ctx context.Context, actorPrincip
 	if ok, err := lockInstallationOwner(ctx, tx, actorPrincipalID); err != nil || !ok {
 		return LegacyMachine{}, ErrForbidden
 	}
+	// Lock in the same order as activation readiness. Once a mail cutover
+	// epoch exists, no new intended legacy identity may appear between the
+	// pre-retirement proof and PostgreSQL activation.
+	if _, err := tx.ExecContext(ctx, `SELECT pg_advisory_xact_lock($1)`, mailCutoverLockKey); err != nil {
+		return LegacyMachine{}, errors.New("legacy registration cannot be serialized with mail cutover")
+	}
+	var cutoverActive bool
+	if err := tx.QueryRowContext(ctx, `SELECT EXISTS (SELECT 1 FROM relay.mail_cutover_epochs WHERE phase IN ('importing','verified','active'))`).Scan(&cutoverActive); err != nil {
+		return LegacyMachine{}, errors.New("legacy registration cannot inspect mail cutover")
+	}
+	if cutoverActive {
+		return LegacyMachine{}, errors.New("legacy registration is unavailable during mail cutover")
+	}
 	if err := lockLegacyMutations(ctx, tx); err != nil {
 		return LegacyMachine{}, err
 	}

--- a/internal/postgres/legacy_auth_store.go
+++ b/internal/postgres/legacy_auth_store.go
@@ -179,8 +179,22 @@ func (a *Administration) RetireLegacyMachine(ctx context.Context, actorPrincipal
 	if ok, err := lockInstallationOwner(ctx, tx, actorPrincipalID); err != nil || !ok {
 		return ErrForbidden
 	}
+	if _, err := tx.ExecContext(ctx, `SELECT pg_advisory_xact_lock($1)`, mailCutoverLockKey); err != nil {
+		return errors.New("legacy retirement cannot be serialized with mail cutover")
+	}
+	var cutoverActive bool
+	if err := tx.QueryRowContext(ctx, `SELECT EXISTS (SELECT 1 FROM relay.mail_cutover_epochs WHERE phase IN ('importing','verified','active'))`).Scan(&cutoverActive); err != nil {
+		return errors.New("legacy retirement cannot inspect mail cutover")
+	}
 	if err := lockLegacyMutations(ctx, tx); err != nil {
 		return err
+	}
+	var state LegacyMachineState
+	if err := tx.QueryRowContext(ctx, `SELECT state FROM auth.legacy_machines WHERE principal_id=$1 FOR UPDATE`, legacyPrincipalID).Scan(&state); err != nil {
+		return ErrNotFound
+	}
+	if cutoverActive && state != LegacyPending {
+		return errors.New("migrated legacy retirement is unavailable during mail cutover")
 	}
 	result, err := tx.ExecContext(ctx, `UPDATE auth.legacy_machines SET state = 'retired', migrated_credential_lookup_id = NULL, changed_at = statement_timestamp() WHERE principal_id = $1 AND state <> 'retired'`, legacyPrincipalID)
 	if err != nil {

--- a/internal/postgres/mail_cutover.go
+++ b/internal/postgres/mail_cutover.go
@@ -299,7 +299,7 @@ func (a *Administration) AbortMailCutover(ctx context.Context, actorPrincipalID,
 	return nil
 }
 
-func mailCutoverControlsAvailable(ctx context.Context, q queryer) (bool, error) {
+func mailCutoverControlsAvailable(ctx context.Context, q queryer, schemaVersion int64) (bool, error) {
 	var available bool
 	err := q.QueryRowContext(ctx, `
 WITH objects AS (
@@ -392,7 +392,11 @@ WITH objects AS (
            WHEN 'mail_cutover_epochs_aborted_at_check' THEN pg_get_expr(con.conbin,con.conrelid)='((phase = ''aborted''::text) = (aborted_at IS NOT NULL))'
            WHEN 'mail_cutover_staging_table_name_check' THEN pg_get_expr(con.conbin,con.conrelid)='(table_name = ANY (ARRAY[''mail_endpoints''::text, ''mail_conversations''::text, ''mail_memberships''::text, ''mail_messages''::text, ''mail_deliveries''::text, ''mail_recipient_cursors''::text, ''mail_message_idempotency''::text, ''mail_conversation_idempotency''::text, ''mail_request_nonces''::text]))'
            WHEN 'mail_cutover_staging_row_key_check' THEN pg_get_expr(con.conbin,con.conrelid)='((octet_length(row_key) >= 1) AND (octet_length(row_key) <= 4096))'
-           WHEN 'mail_cutover_staging_payload_check' THEN pg_get_expr(con.conbin,con.conrelid)='((jsonb_typeof(payload) = ''object''::text) AND (octet_length((payload)::text) <= 65536))'
+		WHEN 'mail_cutover_staging_payload_check' THEN pg_get_expr(con.conbin,con.conrelid)=CASE
+			WHEN $1 >= 9
+			THEN '((jsonb_typeof(payload) = ''object''::text) AND (octet_length((payload)::text) <= 262144))'
+			ELSE '((jsonb_typeof(payload) = ''object''::text) AND (octet_length((payload)::text) <= 65536))'
+		END
            WHEN 'mail_cutover_staging_row_sha256_check' THEN pg_get_expr(con.conbin,con.conrelid)='(row_sha256 ~ ''^[0-9a-f]{64}$''::text)'
            WHEN 'mail_cutover_checkpoints_table_name_check' THEN pg_get_expr(con.conbin,con.conrelid)='(table_name = ANY (ARRAY[''mail_endpoints''::text, ''mail_conversations''::text, ''mail_memberships''::text, ''mail_messages''::text, ''mail_deliveries''::text, ''mail_recipient_cursors''::text, ''mail_message_idempotency''::text, ''mail_conversation_idempotency''::text, ''mail_request_nonces''::text]))'
            WHEN 'mail_cutover_checkpoints_last_key_check' THEN pg_get_expr(con.conbin,con.conrelid)='((last_key IS NULL) OR ((octet_length(last_key) >= 1) AND (octet_length(last_key) <= 4096)))'
@@ -458,6 +462,6 @@ SELECT objects.epochs_oid IS NOT NULL AND objects.staging_oid IS NOT NULL AND ob
    AND objects.active_index_oid IS NOT NULL AND objects.guard_oid IS NOT NULL
    AND ownership.exact AND columns.exact AND defaults.exact AND constraints.exact AND active_index.exact AND routine.exact AND guards.exact AND table_acl.exact
    AND NOT has_function_privilege('punaro_app',objects.guard_oid,'EXECUTE')
-FROM objects,ownership,columns,defaults,constraints,active_index,routine,guards,table_acl`).Scan(&available)
+FROM objects,ownership,columns,defaults,constraints,active_index,routine,guards,table_acl`, schemaVersion).Scan(&available)
 	return available, err
 }

--- a/internal/postgres/mail_cutover.go
+++ b/internal/postgres/mail_cutover.go
@@ -188,11 +188,60 @@ func (a *Administration) MailCutoverStatus(ctx context.Context, actorPrincipalID
 		return MailCutoverEpoch{}, errors.New("mail cutover status is not authorized")
 	}
 	var epoch MailCutoverEpoch
-	if err := scanMailCutover(tx.QueryRowContext(ctx, mailCutoverSelect+` WHERE epoch_id=$1`, epochID), &epoch); err != nil {
+	if err := scanMailCutover(tx.QueryRowContext(ctx, mailCutoverSelect+` WHERE epoch_id=$1`, epochID), &epoch); errors.Is(err, sql.ErrNoRows) {
+		return MailCutoverEpoch{}, ErrNotFound
+	} else if err != nil {
 		return MailCutoverEpoch{}, errors.New("mail cutover status is unavailable")
 	}
 	if err := tx.Commit(); err != nil {
 		return MailCutoverEpoch{}, errors.New("mail cutover status cannot commit")
+	}
+	return epoch, nil
+}
+
+// ReserveMailCutoverAbort durably tombstones an exact epoch that was rejected
+// before BeginMailCutover inserted it. The tombstone prevents a delayed begin
+// from resurrecting the importing fence after SQLite has been reopened.
+func (a *Administration) ReserveMailCutoverAbort(ctx context.Context, actorPrincipalID string, request MailCutoverRequest) (MailCutoverEpoch, error) {
+	if !validOpaqueID(actorPrincipalID) || request.Validate() != nil {
+		return MailCutoverEpoch{}, errors.New("invalid mail cutover abort reservation")
+	}
+	canonicalManifest, err := canonicalMailCutoverManifest(request)
+	if err != nil {
+		return MailCutoverEpoch{}, errors.New("invalid mail cutover abort reservation")
+	}
+	request.Manifest = canonicalManifest
+	tx, err := a.db.BeginTx(ctx, nil)
+	if err != nil {
+		return MailCutoverEpoch{}, errors.New("mail cutover abort reservation cannot start")
+	}
+	defer func() { _ = tx.Rollback() }()
+	if ok, err := lockInstallationOwner(ctx, tx, actorPrincipalID); err != nil || !ok {
+		return MailCutoverEpoch{}, errors.New("mail cutover abort reservation is not authorized")
+	}
+	if _, err := tx.ExecContext(ctx, `SELECT pg_advisory_xact_lock($1)`, mailCutoverLockKey); err != nil {
+		return MailCutoverEpoch{}, errors.New("mail cutover abort reservation cannot be serialized")
+	}
+	identity, err := databaseIdentity(ctx, tx)
+	if err != nil || identity != request.TargetIdentity {
+		return MailCutoverEpoch{}, errors.New("mail cutover target identity does not match")
+	}
+	var epoch MailCutoverEpoch
+	err = scanMailCutover(tx.QueryRowContext(ctx, mailCutoverSelect+` WHERE epoch_id=$1`, request.EpochID), &epoch)
+	if err == nil {
+		if !sameMailCutoverRequest(epoch.MailCutoverRequest, request) {
+			return MailCutoverEpoch{}, ErrIdempotencyConflict
+		}
+		if epoch.Phase != MailCutoverAborted {
+			return MailCutoverEpoch{}, errors.New("mail cutover epoch already exists")
+		}
+	} else if !errors.Is(err, sql.ErrNoRows) {
+		return MailCutoverEpoch{}, errors.New("mail cutover state is unavailable")
+	} else if err := scanMailCutover(tx.QueryRowContext(ctx, `INSERT INTO relay.mail_cutover_epochs(epoch_id,source_id,target_identity,source_fingerprint,source_manifest,manifest_sha256,phase,aborted_at) VALUES($1,$2,$3,$4,$5,$6,'aborted',statement_timestamp()) RETURNING epoch_id::text,source_id::text,target_identity,source_fingerprint,source_manifest,manifest_sha256,phase,created_at,updated_at,verified_at,activated_at,aborted_at`, request.EpochID, request.SourceID, request.TargetIdentity, request.SourceFingerprint, string(request.Manifest), request.ManifestSHA256), &epoch); err != nil {
+		return MailCutoverEpoch{}, errors.New("mail cutover abort reservation cannot be recorded")
+	}
+	if err := tx.Commit(); err != nil {
+		return MailCutoverEpoch{}, errors.New("mail cutover abort reservation cannot commit")
 	}
 	return epoch, nil
 }
@@ -228,6 +277,12 @@ func (a *Administration) AbortMailCutover(ctx context.Context, actorPrincipalID,
 		return errors.New("active mail cutover cannot be aborted")
 	}
 	if phase != MailCutoverAborted {
+		for _, table := range []string{"mail_request_nonces", "mail_conversation_idempotency", "mail_message_idempotency", "mail_recipient_cursors", "mail_deliveries", "mail_messages", "mail_memberships", "mail_conversations", "mail_endpoints"} {
+			// #nosec G202 -- table comes only from the fixed dependency-order allowlist.
+			if _, err := tx.ExecContext(ctx, `DELETE FROM relay.`+table); err != nil {
+				return errors.New("mail cutover cannot be aborted")
+			}
+		}
 		if _, err := tx.ExecContext(ctx, `DELETE FROM relay.mail_cutover_staging WHERE epoch_id=$1`, epochID); err != nil {
 			return errors.New("mail cutover cannot be aborted")
 		}

--- a/internal/postgres/mail_cutover.go
+++ b/internal/postgres/mail_cutover.go
@@ -102,6 +102,28 @@ type MailCutoverEpoch struct {
 	AbortedAt   sql.NullTime
 }
 
+// CheckMailCutoverSchemaReadiness requires the exact current schema before the
+// source can be inspected or prepared for an irreversible cutover.
+func (a *Administration) CheckMailCutoverSchemaReadiness(ctx context.Context) error {
+	tx, err := a.db.BeginTx(ctx, &sql.TxOptions{Isolation: sql.LevelRepeatableRead, ReadOnly: true})
+	if err != nil {
+		return errors.New("mail cutover schema readiness is unavailable")
+	}
+	defer func() { _ = tx.Rollback() }()
+	snapshot, err := inspect(ctx, tx)
+	if err != nil {
+		return err
+	}
+	state := Classify(snapshot, CurrentManifest())
+	if err := tx.Commit(); err != nil {
+		return errors.New("mail cutover schema readiness is unavailable")
+	}
+	if state.Classification != Compatible || state.Version != CurrentManifest().MaxSupported {
+		return errors.New("mail cutover requires the current PostgreSQL schema")
+	}
+	return nil
+}
+
 // BeginMailCutover drains application writers and creates one dark import epoch.
 func (a *Administration) BeginMailCutover(ctx context.Context, actorPrincipalID string, request MailCutoverRequest) (MailCutoverEpoch, error) {
 	if !validOpaqueID(actorPrincipalID) || request.Validate() != nil {

--- a/internal/postgres/mail_cutover_import.go
+++ b/internal/postgres/mail_cutover_import.go
@@ -1,0 +1,461 @@
+package postgres
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"database/sql"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/rock3r/punaro/internal/relay"
+)
+
+var mailCutoverTables = []string{
+	"mail_endpoints", "mail_conversations", "mail_memberships", "mail_messages", "mail_deliveries",
+	"mail_recipient_cursors", "mail_message_idempotency", "mail_conversation_idempotency", "mail_request_nonces",
+}
+
+var emptyMailCutoverDigest = func() string {
+	digest := sha256.Sum256(nil)
+	return hex.EncodeToString(digest[:])
+}()
+
+// MailCutoverBatch is one bounded, ordered source page and its exact resume
+// binding. Done marks that the page reached the source table boundary.
+type MailCutoverBatch struct {
+	EpochID  string
+	Table    string
+	AfterKey string
+	Rows     []relay.MigrationSourceRow
+	Done     bool
+}
+
+// Validate rejects malformed, oversized, reordered, or cross-table pages.
+func (b MailCutoverBatch) Validate() error {
+	if uuid.Validate(b.EpochID) != nil || len(b.AfterKey) > 4096 || len(b.Rows) > 256 || len(b.Rows) == 0 && (!b.Done || b.AfterKey != "") {
+		return errors.New("invalid mail cutover batch")
+	}
+	hasher, err := relay.NewMigrationTableHasher(b.Table)
+	if err != nil {
+		return errors.New("invalid mail cutover batch")
+	}
+	previous := b.AfterKey
+	for _, row := range b.Rows {
+		if previous != "" && row.Key <= previous {
+			return errors.New("invalid mail cutover batch")
+		}
+		if err := hasher.Add(row); err != nil {
+			return errors.New("invalid mail cutover batch")
+		}
+		previous = row.Key
+	}
+	return nil
+}
+
+// MailCutoverCheckpoint is the durable resume position for one source table.
+type MailCutoverCheckpoint struct {
+	EpochID       string
+	Table         string
+	LastKey       sql.NullString
+	RowCount      int64
+	RollingSHA256 string
+	UpdatedAt     time.Time
+}
+
+// MailCutoverCheckpoint returns the current owner-authorized resume position.
+// A missing table checkpoint is returned as the zero row with the empty digest.
+func (a *Administration) MailCutoverCheckpoint(ctx context.Context, actorPrincipalID, epochID, table string) (MailCutoverCheckpoint, error) {
+	if !validOpaqueID(actorPrincipalID) || uuid.Validate(epochID) != nil {
+		return MailCutoverCheckpoint{}, errors.New("invalid mail cutover checkpoint request")
+	}
+	if _, err := relay.NewMigrationTableHasher(table); err != nil {
+		return MailCutoverCheckpoint{}, errors.New("invalid mail cutover checkpoint request")
+	}
+	tx, err := a.db.BeginTx(ctx, nil)
+	if err != nil {
+		return MailCutoverCheckpoint{}, errors.New("mail cutover checkpoint is unavailable")
+	}
+	defer func() { _ = tx.Rollback() }()
+	if ok, err := lockInstallationOwner(ctx, tx, actorPrincipalID); err != nil || !ok {
+		return MailCutoverCheckpoint{}, errors.New("mail cutover checkpoint is not authorized")
+	}
+	var phase MailCutoverPhase
+	if err := tx.QueryRowContext(ctx, `SELECT phase FROM relay.mail_cutover_epochs WHERE epoch_id=$1`, epochID).Scan(&phase); err != nil || phase == MailCutoverAborted {
+		return MailCutoverCheckpoint{}, errors.New("mail cutover checkpoint is unavailable")
+	}
+	checkpoint := MailCutoverCheckpoint{EpochID: epochID, Table: table, RollingSHA256: emptyMailCutoverDigest}
+	err = tx.QueryRowContext(ctx, `SELECT last_key,row_count,rolling_sha256,updated_at FROM relay.mail_cutover_checkpoints WHERE epoch_id=$1 AND table_name=$2`, epochID, table).Scan(&checkpoint.LastKey, &checkpoint.RowCount, &checkpoint.RollingSHA256, &checkpoint.UpdatedAt)
+	if err != nil && !errors.Is(err, sql.ErrNoRows) {
+		return MailCutoverCheckpoint{}, errors.New("mail cutover checkpoint is unavailable")
+	}
+	if err := tx.Commit(); err != nil {
+		return MailCutoverCheckpoint{}, errors.New("mail cutover checkpoint cannot commit")
+	}
+	return checkpoint, nil
+}
+
+func nextMailCutoverDigest(previous string, rows []relay.MigrationSourceRow) string {
+	h := sha256.New()
+	previousBytes, err := hex.DecodeString(previous)
+	if err != nil {
+		return ""
+	}
+	_, _ = h.Write(previousBytes)
+	for _, row := range rows {
+		digest, err := hex.DecodeString(row.SHA256)
+		if err != nil {
+			return ""
+		}
+		_, _ = h.Write(digest)
+	}
+	return hex.EncodeToString(h.Sum(nil))
+}
+
+// StageMailCutoverBatch durably appends one exact source page and advances its
+// checkpoint. Retrying the immediately committed page is idempotent.
+func (a *Administration) StageMailCutoverBatch(ctx context.Context, actorPrincipalID string, batch MailCutoverBatch) (MailCutoverCheckpoint, error) {
+	if !validOpaqueID(actorPrincipalID) || batch.Validate() != nil {
+		return MailCutoverCheckpoint{}, errors.New("invalid mail cutover batch")
+	}
+	tx, err := a.db.BeginTx(ctx, nil)
+	if err != nil {
+		return MailCutoverCheckpoint{}, errors.New("mail cutover batch cannot start")
+	}
+	defer func() { _ = tx.Rollback() }()
+	if err := guardMutation(ctx, tx); err != nil {
+		return MailCutoverCheckpoint{}, err
+	}
+	if ok, err := lockInstallationOwner(ctx, tx, actorPrincipalID); err != nil || !ok {
+		return MailCutoverCheckpoint{}, errors.New("mail cutover batch is not authorized")
+	}
+	if _, err := tx.ExecContext(ctx, `SELECT pg_advisory_xact_lock($1)`, mailCutoverLockKey); err != nil {
+		return MailCutoverCheckpoint{}, errors.New("mail cutover batch cannot be serialized")
+	}
+	var phase MailCutoverPhase
+	if err := tx.QueryRowContext(ctx, `SELECT phase FROM relay.mail_cutover_epochs WHERE epoch_id=$1 FOR UPDATE`, batch.EpochID).Scan(&phase); err != nil || phase != MailCutoverImporting {
+		return MailCutoverCheckpoint{}, errors.New("mail cutover is not importing")
+	}
+	checkpoint := MailCutoverCheckpoint{EpochID: batch.EpochID, Table: batch.Table, RollingSHA256: emptyMailCutoverDigest}
+	err = tx.QueryRowContext(ctx, `SELECT last_key,row_count,rolling_sha256,updated_at FROM relay.mail_cutover_checkpoints WHERE epoch_id=$1 AND table_name=$2 FOR UPDATE`, batch.EpochID, batch.Table).Scan(&checkpoint.LastKey, &checkpoint.RowCount, &checkpoint.RollingSHA256, &checkpoint.UpdatedAt)
+	checkpointExists := err == nil
+	if err != nil && !errors.Is(err, sql.ErrNoRows) {
+		return MailCutoverCheckpoint{}, errors.New("mail cutover checkpoint is unavailable")
+	}
+	currentKey := ""
+	if checkpoint.LastKey.Valid {
+		currentKey = checkpoint.LastKey.String
+	}
+	lastKey := batch.AfterKey
+	if len(batch.Rows) != 0 {
+		lastKey = batch.Rows[len(batch.Rows)-1].Key
+	}
+	if currentKey != batch.AfterKey {
+		if currentKey != lastKey || len(batch.Rows) == 0 {
+			return MailCutoverCheckpoint{}, ErrIdempotencyConflict
+		}
+		if err := verifyStagedMailRows(ctx, tx, batch); err != nil {
+			return MailCutoverCheckpoint{}, err
+		}
+		if err := tx.Commit(); err != nil {
+			return MailCutoverCheckpoint{}, errors.New("mail cutover batch retry cannot commit")
+		}
+		return checkpoint, nil
+	}
+	if checkpointExists && len(batch.Rows) == 0 {
+		if err := tx.Commit(); err != nil {
+			return MailCutoverCheckpoint{}, errors.New("mail cutover batch retry cannot commit")
+		}
+		return checkpoint, nil
+	}
+	for _, row := range batch.Rows {
+		result, err := tx.ExecContext(ctx, `INSERT INTO relay.mail_cutover_staging(epoch_id,table_name,row_key,payload,row_sha256) VALUES($1,$2,$3,$4,$5) ON CONFLICT DO NOTHING`, batch.EpochID, batch.Table, row.Key, string(row.Payload), row.SHA256)
+		if err != nil {
+			return MailCutoverCheckpoint{}, errors.New("mail cutover row cannot be staged")
+		}
+		if count, err := result.RowsAffected(); err != nil || count != 1 {
+			return MailCutoverCheckpoint{}, ErrIdempotencyConflict
+		}
+	}
+	rolling := nextMailCutoverDigest(checkpoint.RollingSHA256, batch.Rows)
+	if rolling == "" {
+		return MailCutoverCheckpoint{}, errors.New("mail cutover checkpoint digest is invalid")
+	}
+	var nullableLast any
+	if lastKey != "" {
+		nullableLast = lastKey
+	}
+	if err := tx.QueryRowContext(ctx, `INSERT INTO relay.mail_cutover_checkpoints(epoch_id,table_name,last_key,row_count,rolling_sha256) VALUES($1,$2,$3,$4,$5)
+		ON CONFLICT(epoch_id,table_name) DO UPDATE SET last_key=excluded.last_key,row_count=excluded.row_count,rolling_sha256=excluded.rolling_sha256,updated_at=statement_timestamp()
+		RETURNING last_key,row_count,rolling_sha256,updated_at`, batch.EpochID, batch.Table, nullableLast, checkpoint.RowCount+int64(len(batch.Rows)), rolling).Scan(&checkpoint.LastKey, &checkpoint.RowCount, &checkpoint.RollingSHA256, &checkpoint.UpdatedAt); err != nil {
+		return MailCutoverCheckpoint{}, errors.New("mail cutover checkpoint cannot advance")
+	}
+	if err := tx.Commit(); err != nil {
+		return MailCutoverCheckpoint{}, errors.New("mail cutover batch cannot commit")
+	}
+	return checkpoint, nil
+}
+
+func verifyStagedMailRows(ctx context.Context, tx *sql.Tx, batch MailCutoverBatch) error {
+	for _, row := range batch.Rows {
+		var exact bool
+		if err := tx.QueryRowContext(ctx, `SELECT payload=$4::jsonb AND row_sha256=$5 FROM relay.mail_cutover_staging WHERE epoch_id=$1 AND table_name=$2 AND row_key=$3`, batch.EpochID, batch.Table, row.Key, string(row.Payload), row.SHA256).Scan(&exact); err != nil || !exact {
+			return ErrIdempotencyConflict
+		}
+	}
+	return nil
+}
+
+// VerifyMailCutover streams and verifies every staged row against the durable
+// source manifest, then materializes the PostgreSQL relay atomically while the
+// application-role write fence remains closed.
+func (a *Administration) VerifyMailCutover(ctx context.Context, actorPrincipalID, epochID, sourceFingerprint string) (MailCutoverEpoch, error) {
+	if !validOpaqueID(actorPrincipalID) || uuid.Validate(epochID) != nil || !mailCutoverDigestPattern.MatchString(sourceFingerprint) {
+		return MailCutoverEpoch{}, errors.New("invalid mail cutover verification")
+	}
+	tx, err := a.db.BeginTx(ctx, nil)
+	if err != nil {
+		return MailCutoverEpoch{}, errors.New("mail cutover verification cannot start")
+	}
+	defer func() { _ = tx.Rollback() }()
+	if err := guardMutation(ctx, tx); err != nil {
+		return MailCutoverEpoch{}, err
+	}
+	if ok, err := lockInstallationOwner(ctx, tx, actorPrincipalID); err != nil || !ok {
+		return MailCutoverEpoch{}, errors.New("mail cutover verification is not authorized")
+	}
+	if _, err := tx.ExecContext(ctx, `SELECT pg_advisory_xact_lock($1)`, mailCutoverLockKey); err != nil {
+		return MailCutoverEpoch{}, errors.New("mail cutover verification cannot be serialized")
+	}
+	var epoch MailCutoverEpoch
+	if err := scanMailCutover(tx.QueryRowContext(ctx, mailCutoverSelect+` WHERE epoch_id=$1 FOR UPDATE`, epochID), &epoch); err != nil || epoch.SourceFingerprint != sourceFingerprint {
+		return MailCutoverEpoch{}, errors.New("mail cutover epoch is unavailable")
+	}
+	if epoch.Phase == MailCutoverVerified {
+		if err := tx.Commit(); err != nil {
+			return MailCutoverEpoch{}, errors.New("mail cutover verification retry cannot commit")
+		}
+		return epoch, nil
+	}
+	if epoch.Phase != MailCutoverImporting {
+		return MailCutoverEpoch{}, errors.New("mail cutover is not importing")
+	}
+	var manifest relay.MigrationSourceManifest
+	if err := json.Unmarshal(epoch.Manifest, &manifest); err != nil {
+		return MailCutoverEpoch{}, errors.New("mail cutover manifest is unavailable")
+	}
+	for _, table := range mailCutoverTables {
+		expectedCount, expectedDigest := mailCutoverTableEvidence(manifest, table)
+		var checkpointCount int64
+		if err := tx.QueryRowContext(ctx, `SELECT row_count FROM relay.mail_cutover_checkpoints WHERE epoch_id=$1 AND table_name=$2`, epochID, table).Scan(&checkpointCount); err != nil || checkpointCount != expectedCount {
+			return MailCutoverEpoch{}, errors.New("mail cutover checkpoint does not match the source manifest")
+		}
+		hasher, err := relay.NewMigrationTableHasher(table)
+		if err != nil {
+			return MailCutoverEpoch{}, errors.New("mail cutover table is unavailable")
+		}
+		rows, err := tx.QueryContext(ctx, `SELECT row_key,payload::text,row_sha256 FROM relay.mail_cutover_staging WHERE epoch_id=$1 AND table_name=$2 ORDER BY row_key`, epochID, table)
+		if err != nil {
+			return MailCutoverEpoch{}, errors.New("mail cutover staging is unavailable")
+		}
+		for rows.Next() {
+			var row relay.MigrationSourceRow
+			var payload []byte
+			row.Table = table
+			if err := rows.Scan(&row.Key, &payload, &row.SHA256); err != nil {
+				_ = rows.Close()
+				return MailCutoverEpoch{}, errors.New("mail cutover staged row is malformed")
+			}
+			canonical, err := canonicalizeStagedPayload(payload)
+			if err != nil {
+				_ = rows.Close()
+				return MailCutoverEpoch{}, err
+			}
+			row.Payload = canonical
+			if err := hasher.Add(row); err != nil {
+				_ = rows.Close()
+				return MailCutoverEpoch{}, errors.New("mail cutover staged row is invalid")
+			}
+		}
+		if err := rows.Close(); err != nil || rows.Err() != nil {
+			return MailCutoverEpoch{}, errors.New("mail cutover staging cannot be read")
+		}
+		count, digest := hasher.Evidence()
+		if count != expectedCount || digest != expectedDigest {
+			return MailCutoverEpoch{}, errors.New("mail cutover staging does not match the source manifest")
+		}
+	}
+	for _, statement := range mailCutoverMaterializationStatements {
+		if _, err := tx.ExecContext(ctx, statement, epochID); err != nil {
+			return MailCutoverEpoch{}, errors.New("mail cutover rows cannot be materialized")
+		}
+	}
+	for _, table := range mailCutoverTables {
+		expected, _ := mailCutoverTableEvidence(manifest, table)
+		var actual int64
+		if err := tx.QueryRowContext(ctx, `SELECT count(*) FROM relay.`+table).Scan(&actual); err != nil || actual != expected { // #nosec G202 -- table comes only from mailCutoverTables.
+			return MailCutoverEpoch{}, errors.New("mail cutover materialized count does not match")
+		}
+	}
+	if err := scanMailCutover(tx.QueryRowContext(ctx, `UPDATE relay.mail_cutover_epochs SET phase='verified',updated_at=statement_timestamp(),verified_at=statement_timestamp() WHERE epoch_id=$1 AND phase='importing' RETURNING epoch_id::text,source_id::text,target_identity,source_fingerprint,source_manifest,manifest_sha256,phase,created_at,updated_at,verified_at,activated_at,aborted_at`, epochID), &epoch); err != nil {
+		return MailCutoverEpoch{}, errors.New("mail cutover cannot be verified")
+	}
+	if err := tx.Commit(); err != nil {
+		return MailCutoverEpoch{}, errors.New("mail cutover verification cannot commit")
+	}
+	return epoch, nil
+}
+
+func canonicalizeStagedPayload(payload []byte) ([]byte, error) {
+	decoder := json.NewDecoder(bytes.NewReader(payload))
+	decoder.UseNumber()
+	var value map[string]any
+	if err := decoder.Decode(&value); err != nil {
+		return nil, errors.New("mail cutover staged payload is invalid")
+	}
+	canonical, err := json.Marshal(value)
+	if err != nil {
+		return nil, errors.New("mail cutover staged payload is invalid")
+	}
+	return canonical, nil
+}
+
+func mailCutoverTableEvidence(manifest relay.MigrationSourceManifest, table string) (int64, string) {
+	switch table {
+	case "mail_endpoints":
+		return manifest.Counts.Endpoints, manifest.TableSHA256.Endpoints
+	case "mail_conversations":
+		return manifest.Counts.Conversations, manifest.TableSHA256.Conversations
+	case "mail_memberships":
+		return manifest.Counts.Memberships, manifest.TableSHA256.Memberships
+	case "mail_messages":
+		return manifest.Counts.Messages, manifest.TableSHA256.Messages
+	case "mail_deliveries":
+		return manifest.Counts.Deliveries, manifest.TableSHA256.Deliveries
+	case "mail_recipient_cursors":
+		return manifest.Counts.RecipientCursors, manifest.TableSHA256.RecipientCursors
+	case "mail_message_idempotency":
+		return manifest.Counts.MessageIdempotency, manifest.TableSHA256.MessageIdempotency
+	case "mail_conversation_idempotency":
+		return manifest.Counts.ConversationIdempotency, manifest.TableSHA256.ConversationIdempotency
+	case "mail_request_nonces":
+		return manifest.Counts.RequestNonces, manifest.TableSHA256.RequestNonces
+	default:
+		return -1, ""
+	}
+}
+
+var mailCutoverMaterializationStatements = []string{
+	`INSERT INTO relay.mail_endpoints(endpoint,machine_id,lease_until,ownership_generation,consumer_id,consumer_generation,consumer_lease_until)
+	 SELECT payload->>'endpoint',payload->>'machine_id',TIMESTAMPTZ 'epoch'+(payload->>'lease_until')::bigint*INTERVAL '1 millisecond',(payload->>'ownership_generation')::bigint,payload->>'consumer_id',(payload->>'consumer_generation')::bigint,
+	 CASE WHEN payload->>'consumer_lease_until' IS NULL THEN NULL ELSE TIMESTAMPTZ 'epoch'+(payload->>'consumer_lease_until')::bigint*INTERVAL '1 millisecond' END
+	 FROM relay.mail_cutover_staging WHERE epoch_id=$1 AND table_name='mail_endpoints' ORDER BY row_key`,
+	`INSERT INTO relay.mail_conversations(id,next_sequence,created_at)
+	 SELECT (payload->>'id')::uuid,(payload->>'next_sequence')::bigint,TIMESTAMPTZ 'epoch'+(payload->>'created_at')::bigint*INTERVAL '1 millisecond'
+	 FROM relay.mail_cutover_staging WHERE epoch_id=$1 AND table_name='mail_conversations' ORDER BY row_key`,
+	`INSERT INTO relay.mail_memberships(conversation_id,endpoint,capabilities)
+	 SELECT (payload->>'conversation_id')::uuid,payload->>'endpoint',(payload->>'capabilities')::smallint
+	 FROM relay.mail_cutover_staging WHERE epoch_id=$1 AND table_name='mail_memberships' ORDER BY row_key`,
+	`INSERT INTO relay.mail_messages(id,conversation_id,sequence,from_endpoint,body,created_at)
+	 SELECT (payload->>'id')::uuid,(payload->>'conversation_id')::uuid,(payload->>'sequence')::bigint,payload->>'from_endpoint',payload->>'body',TIMESTAMPTZ 'epoch'+(payload->>'created_at')::bigint*INTERVAL '1 millisecond'
+	 FROM relay.mail_cutover_staging WHERE epoch_id=$1 AND table_name='mail_messages' ORDER BY row_key`,
+	`INSERT INTO relay.mail_deliveries(id,message_id,recipient_endpoint,lease_machine_id,lease_token,lease_generation,ownership_generation,consumer_generation,lease_until,acked_at)
+	 SELECT (payload->>'id')::uuid,(payload->>'message_id')::uuid,payload->>'recipient_endpoint',payload->>'lease_machine_id',(payload->>'lease_token')::uuid,(payload->>'lease_generation')::bigint,(payload->>'ownership_generation')::bigint,(payload->>'consumer_generation')::bigint,
+	 CASE WHEN payload->>'lease_until' IS NULL THEN NULL ELSE TIMESTAMPTZ 'epoch'+(payload->>'lease_until')::bigint*INTERVAL '1 millisecond' END,
+	 CASE WHEN payload->>'acked_at' IS NULL THEN NULL ELSE TIMESTAMPTZ 'epoch'+(payload->>'acked_at')::bigint*INTERVAL '1 millisecond' END
+	 FROM relay.mail_cutover_staging WHERE epoch_id=$1 AND table_name='mail_deliveries' ORDER BY row_key`,
+	`INSERT INTO relay.mail_recipient_cursors(recipient_endpoint,conversation_id,sequence)
+	 SELECT payload->>'recipient_endpoint',(payload->>'conversation_id')::uuid,(payload->>'sequence')::bigint
+	 FROM relay.mail_cutover_staging WHERE epoch_id=$1 AND table_name='mail_recipient_cursors' ORDER BY row_key`,
+	`INSERT INTO relay.mail_message_idempotency(machine_id,key,request_hash,message_id,created_at)
+	 SELECT payload->>'machine_id',payload->>'key',payload->>'request_hash',(payload->>'message_id')::uuid,TIMESTAMPTZ 'epoch'+(payload->>'created_at')::bigint*INTERVAL '1 millisecond'
+	 FROM relay.mail_cutover_staging WHERE epoch_id=$1 AND table_name='mail_message_idempotency' ORDER BY row_key`,
+	`INSERT INTO relay.mail_conversation_idempotency(machine_id,key,request_hash,conversation_id,created_at)
+	 SELECT payload->>'machine_id',payload->>'key',payload->>'request_hash',(payload->>'conversation_id')::uuid,TIMESTAMPTZ 'epoch'+(payload->>'created_at')::bigint*INTERVAL '1 millisecond'
+	 FROM relay.mail_cutover_staging WHERE epoch_id=$1 AND table_name='mail_conversation_idempotency' ORDER BY row_key`,
+	`INSERT INTO relay.mail_request_nonces(machine_id,nonce,expires_at)
+	 SELECT payload->>'machine_id',payload->>'nonce',TIMESTAMPTZ 'epoch'+(payload->>'expires_at')::bigint*INTERVAL '1 millisecond'
+	 FROM relay.mail_cutover_staging WHERE epoch_id=$1 AND table_name='mail_request_nonces' ORDER BY row_key`,
+}
+
+// ActivateMailCutover crosses the PostgreSQL authority barrier only after the
+// host-local executor presents the exact source manifest in its durable retired
+// phase. Legacy authentication closure and PostgreSQL activation commit in the
+// same owner transaction.
+func (a *Administration) ActivateMailCutover(ctx context.Context, actorPrincipalID, epochID, sourceFingerprint string, retired relay.MigrationSourceManifest) (MailCutoverEpoch, error) {
+	if !validOpaqueID(actorPrincipalID) || uuid.Validate(epochID) != nil || !mailCutoverDigestPattern.MatchString(sourceFingerprint) || retired.Phase != relay.MigrationSourceRetired || retired.EpochID != epochID || retired.Fingerprint != sourceFingerprint {
+		return MailCutoverEpoch{}, errors.New("invalid mail cutover activation")
+	}
+	tx, err := a.db.BeginTx(ctx, nil)
+	if err != nil {
+		return MailCutoverEpoch{}, errors.New("mail cutover activation cannot start")
+	}
+	defer func() { _ = tx.Rollback() }()
+	if err := guardMutation(ctx, tx); err != nil {
+		return MailCutoverEpoch{}, err
+	}
+	if ok, err := lockInstallationOwner(ctx, tx, actorPrincipalID); err != nil || !ok {
+		return MailCutoverEpoch{}, errors.New("mail cutover activation is not authorized")
+	}
+	if _, err := tx.ExecContext(ctx, `SELECT pg_advisory_xact_lock($1)`, mailCutoverLockKey); err != nil {
+		return MailCutoverEpoch{}, errors.New("mail cutover activation cannot be serialized")
+	}
+	if err := lockLegacyMutations(ctx, tx); err != nil {
+		return MailCutoverEpoch{}, err
+	}
+	var epoch MailCutoverEpoch
+	if err := scanMailCutover(tx.QueryRowContext(ctx, mailCutoverSelect+` WHERE epoch_id=$1 FOR UPDATE`, epochID), &epoch); err != nil || epoch.SourceFingerprint != sourceFingerprint {
+		return MailCutoverEpoch{}, errors.New("mail cutover epoch is unavailable")
+	}
+	var prepared relay.MigrationSourceManifest
+	if err := json.Unmarshal(epoch.Manifest, &prepared); err != nil || !sameMailCutoverSource(prepared, retired) {
+		return MailCutoverEpoch{}, errors.New("retired mail source does not match the verified epoch")
+	}
+	if epoch.Phase == MailCutoverActive {
+		if err := tx.Commit(); err != nil {
+			return MailCutoverEpoch{}, errors.New("mail cutover activation retry cannot commit")
+		}
+		return epoch, nil
+	}
+	if epoch.Phase != MailCutoverVerified {
+		return MailCutoverEpoch{}, errors.New("mail cutover is not verified")
+	}
+	var pending bool
+	if err := tx.QueryRowContext(ctx, `SELECT EXISTS (SELECT 1 FROM auth.legacy_machines WHERE state='pending')`).Scan(&pending); err != nil {
+		return MailCutoverEpoch{}, errors.New("legacy inventory is unavailable")
+	}
+	if pending {
+		return MailCutoverEpoch{}, errors.New("legacy authentication still has pending machines")
+	}
+	var legacyEnabled bool
+	if err := tx.QueryRowContext(ctx, `SELECT enabled FROM auth.legacy_auth_state WHERE singleton FOR UPDATE`).Scan(&legacyEnabled); err != nil {
+		return MailCutoverEpoch{}, errors.New("legacy authentication state is unavailable")
+	}
+	if legacyEnabled {
+		if _, err := tx.ExecContext(ctx, `UPDATE auth.legacy_auth_state SET enabled=false,changed_at=statement_timestamp() WHERE singleton AND enabled`); err != nil {
+			return MailCutoverEpoch{}, errors.New("legacy authentication cannot be closed")
+		}
+		control := &ControlTx{tx: tx}
+		if err := control.AppendAudit(ctx, AuditEvent{PrincipalID: actorPrincipalID, Action: AuditLegacyDisable, Outcome: AuditSucceeded, TargetKind: AuditTargetLegacyMachine}); err != nil {
+			return MailCutoverEpoch{}, err
+		}
+		if _, err := control.AdvanceChange(ctx); err != nil {
+			return MailCutoverEpoch{}, err
+		}
+	}
+	if err := scanMailCutover(tx.QueryRowContext(ctx, `UPDATE relay.mail_cutover_epochs SET phase='active',updated_at=statement_timestamp(),activated_at=statement_timestamp() WHERE epoch_id=$1 AND phase='verified' RETURNING epoch_id::text,source_id::text,target_identity,source_fingerprint,source_manifest,manifest_sha256,phase,created_at,updated_at,verified_at,activated_at,aborted_at`, epochID), &epoch); err != nil {
+		return MailCutoverEpoch{}, errors.New("mail cutover cannot activate")
+	}
+	if err := tx.Commit(); err != nil {
+		return MailCutoverEpoch{}, errors.New("mail cutover activation cannot commit")
+	}
+	return epoch, nil
+}
+
+func sameMailCutoverSource(prepared, retired relay.MigrationSourceManifest) bool {
+	return prepared.Version == retired.Version && prepared.SourceID == retired.SourceID && prepared.EpochID == retired.EpochID && prepared.TargetIdentity == retired.TargetIdentity && prepared.Fingerprint == retired.Fingerprint &&
+		prepared.Counts == retired.Counts && prepared.TableSHA256 == retired.TableSHA256 && prepared.Phase == relay.MigrationSourcePrepared && retired.Phase == relay.MigrationSourceRetired
+}

--- a/internal/postgres/mail_cutover_import.go
+++ b/internal/postgres/mail_cutover_import.go
@@ -385,11 +385,17 @@ var mailCutoverMaterializationStatements = []string{
 }
 
 // CheckMailCutoverActivationReadiness proves that the verified destination has
-// no known pending legacy identity before the host irreversibly retires SQLite.
-// ActivateMailCutover repeats this proof while closing the legacy gate in the
-// same transaction as PostgreSQL activation.
-func (a *Administration) CheckMailCutoverActivationReadiness(ctx context.Context, actorPrincipalID, epochID, sourceFingerprint string) error {
-	if !validOpaqueID(actorPrincipalID) || uuid.Validate(epochID) != nil || !mailCutoverDigestPattern.MatchString(sourceFingerprint) {
+// no pending legacy identity, every migrated key remains enrolled, and any
+// additionally enrolled key is a known retired identity whose source mail is
+// being preserved before the host irreversibly retires SQLite.
+// ActivateMailCutover repeats the pending-inventory proof while closing the
+// legacy gate in the same transaction as PostgreSQL activation.
+func (a *Administration) CheckMailCutoverActivationReadiness(ctx context.Context, actorPrincipalID, epochID, sourceFingerprint, enrollment string) error {
+	if !validOpaqueID(actorPrincipalID) || uuid.Validate(epochID) != nil || !mailCutoverDigestPattern.MatchString(sourceFingerprint) || relay.ValidateMachineEnrollments(enrollment) != nil {
+		return errors.New("invalid mail cutover activation readiness check")
+	}
+	machines, err := relay.ParseMachineEnrollments(enrollment)
+	if err != nil {
 		return errors.New("invalid mail cutover activation readiness check")
 	}
 	tx, err := a.db.BeginTx(ctx, nil)
@@ -420,8 +426,56 @@ func (a *Administration) CheckMailCutoverActivationReadiness(ctx context.Context
 	if pending {
 		return errors.New("legacy authentication still has pending machines")
 	}
+	rows, err := tx.QueryContext(ctx, `SELECT public_key,state FROM auth.legacy_machines WHERE state<>'pending' ORDER BY public_key_digest`)
+	if err != nil {
+		return errors.New("legacy inventory is unavailable")
+	}
+	var legacyKeys []mailCutoverLegacyKey
+	for rows.Next() {
+		var publicKey []byte
+		var state LegacyMachineState
+		if err := rows.Scan(&publicKey, &state); err != nil {
+			_ = rows.Close()
+			return errors.New("legacy inventory is malformed")
+		}
+		legacyKeys = append(legacyKeys, mailCutoverLegacyKey{publicKey: publicKey, state: state})
+	}
+	if err := rows.Close(); err != nil || rows.Err() != nil {
+		return errors.New("legacy inventory is unavailable")
+	}
+	if err := validateMailCutoverEnrollmentKeys(machines, legacyKeys); err != nil {
+		return err
+	}
 	if err := tx.Commit(); err != nil {
 		return errors.New("mail cutover activation readiness cannot commit")
+	}
+	return nil
+}
+
+type mailCutoverLegacyKey struct {
+	publicKey []byte
+	state     LegacyMachineState
+}
+
+func validateMailCutoverEnrollmentKeys(machines []relay.Machine, legacyKeys []mailCutoverLegacyKey) error {
+	configured := make(map[string]struct{}, len(machines))
+	for _, machine := range machines {
+		configured[string(machine.PublicKey)] = struct{}{}
+	}
+	known := make(map[string]LegacyMachineState, len(legacyKeys))
+	for _, legacy := range legacyKeys {
+		key := string(legacy.publicKey)
+		known[key] = legacy.state
+		if legacy.state == LegacyMigrated {
+			if _, ok := configured[key]; !ok {
+				return errors.New("static relay enrollment omits migrated legacy inventory")
+			}
+		}
+	}
+	for publicKey := range configured {
+		if _, ok := known[publicKey]; !ok {
+			return errors.New("static relay enrollment contains an unknown legacy key")
+		}
 	}
 	return nil
 }

--- a/internal/postgres/mail_cutover_import.go
+++ b/internal/postgres/mail_cutover_import.go
@@ -260,7 +260,7 @@ func (a *Administration) VerifyMailCutover(ctx context.Context, actorPrincipalID
 		if err != nil {
 			return MailCutoverEpoch{}, errors.New("mail cutover table is unavailable")
 		}
-		rows, err := tx.QueryContext(ctx, `SELECT row_key,payload::text,row_sha256 FROM relay.mail_cutover_staging WHERE epoch_id=$1 AND table_name=$2 ORDER BY row_key`, epochID, table)
+		rows, err := tx.QueryContext(ctx, `SELECT row_key,payload::text,row_sha256 FROM relay.mail_cutover_staging WHERE epoch_id=$1 AND table_name=$2 ORDER BY row_key COLLATE "C"`, epochID, table)
 		if err != nil {
 			return MailCutoverEpoch{}, errors.New("mail cutover staging is unavailable")
 		}
@@ -355,33 +355,75 @@ var mailCutoverMaterializationStatements = []string{
 	`INSERT INTO relay.mail_endpoints(endpoint,machine_id,lease_until,ownership_generation,consumer_id,consumer_generation,consumer_lease_until)
 	 SELECT payload->>'endpoint',payload->>'machine_id',TIMESTAMPTZ 'epoch'+(payload->>'lease_until')::bigint*INTERVAL '1 millisecond',(payload->>'ownership_generation')::bigint,payload->>'consumer_id',(payload->>'consumer_generation')::bigint,
 	 CASE WHEN payload->>'consumer_lease_until' IS NULL THEN NULL ELSE TIMESTAMPTZ 'epoch'+(payload->>'consumer_lease_until')::bigint*INTERVAL '1 millisecond' END
-	 FROM relay.mail_cutover_staging WHERE epoch_id=$1 AND table_name='mail_endpoints' ORDER BY row_key`,
+	 FROM relay.mail_cutover_staging WHERE epoch_id=$1 AND table_name='mail_endpoints' ORDER BY row_key COLLATE "C"`,
 	`INSERT INTO relay.mail_conversations(id,next_sequence,created_at)
 	 SELECT (payload->>'id')::uuid,(payload->>'next_sequence')::bigint,TIMESTAMPTZ 'epoch'+(payload->>'created_at')::bigint*INTERVAL '1 millisecond'
-	 FROM relay.mail_cutover_staging WHERE epoch_id=$1 AND table_name='mail_conversations' ORDER BY row_key`,
+	 FROM relay.mail_cutover_staging WHERE epoch_id=$1 AND table_name='mail_conversations' ORDER BY row_key COLLATE "C"`,
 	`INSERT INTO relay.mail_memberships(conversation_id,endpoint,capabilities)
 	 SELECT (payload->>'conversation_id')::uuid,payload->>'endpoint',(payload->>'capabilities')::smallint
-	 FROM relay.mail_cutover_staging WHERE epoch_id=$1 AND table_name='mail_memberships' ORDER BY row_key`,
+	 FROM relay.mail_cutover_staging WHERE epoch_id=$1 AND table_name='mail_memberships' ORDER BY row_key COLLATE "C"`,
 	`INSERT INTO relay.mail_messages(id,conversation_id,sequence,from_endpoint,body,created_at)
 	 SELECT (payload->>'id')::uuid,(payload->>'conversation_id')::uuid,(payload->>'sequence')::bigint,payload->>'from_endpoint',payload->>'body',TIMESTAMPTZ 'epoch'+(payload->>'created_at')::bigint*INTERVAL '1 millisecond'
-	 FROM relay.mail_cutover_staging WHERE epoch_id=$1 AND table_name='mail_messages' ORDER BY row_key`,
+	 FROM relay.mail_cutover_staging WHERE epoch_id=$1 AND table_name='mail_messages' ORDER BY row_key COLLATE "C"`,
 	`INSERT INTO relay.mail_deliveries(id,message_id,recipient_endpoint,lease_machine_id,lease_token,lease_generation,ownership_generation,consumer_generation,lease_until,acked_at)
 	 SELECT (payload->>'id')::uuid,(payload->>'message_id')::uuid,payload->>'recipient_endpoint',payload->>'lease_machine_id',(payload->>'lease_token')::uuid,(payload->>'lease_generation')::bigint,(payload->>'ownership_generation')::bigint,(payload->>'consumer_generation')::bigint,
 	 CASE WHEN payload->>'lease_until' IS NULL THEN NULL ELSE TIMESTAMPTZ 'epoch'+(payload->>'lease_until')::bigint*INTERVAL '1 millisecond' END,
 	 CASE WHEN payload->>'acked_at' IS NULL THEN NULL ELSE TIMESTAMPTZ 'epoch'+(payload->>'acked_at')::bigint*INTERVAL '1 millisecond' END
-	 FROM relay.mail_cutover_staging WHERE epoch_id=$1 AND table_name='mail_deliveries' ORDER BY row_key`,
+	 FROM relay.mail_cutover_staging WHERE epoch_id=$1 AND table_name='mail_deliveries' ORDER BY row_key COLLATE "C"`,
 	`INSERT INTO relay.mail_recipient_cursors(recipient_endpoint,conversation_id,sequence)
 	 SELECT payload->>'recipient_endpoint',(payload->>'conversation_id')::uuid,(payload->>'sequence')::bigint
-	 FROM relay.mail_cutover_staging WHERE epoch_id=$1 AND table_name='mail_recipient_cursors' ORDER BY row_key`,
+	 FROM relay.mail_cutover_staging WHERE epoch_id=$1 AND table_name='mail_recipient_cursors' ORDER BY row_key COLLATE "C"`,
 	`INSERT INTO relay.mail_message_idempotency(machine_id,key,request_hash,message_id,created_at)
 	 SELECT payload->>'machine_id',payload->>'key',payload->>'request_hash',(payload->>'message_id')::uuid,TIMESTAMPTZ 'epoch'+(payload->>'created_at')::bigint*INTERVAL '1 millisecond'
-	 FROM relay.mail_cutover_staging WHERE epoch_id=$1 AND table_name='mail_message_idempotency' ORDER BY row_key`,
+	 FROM relay.mail_cutover_staging WHERE epoch_id=$1 AND table_name='mail_message_idempotency' ORDER BY row_key COLLATE "C"`,
 	`INSERT INTO relay.mail_conversation_idempotency(machine_id,key,request_hash,conversation_id,created_at)
 	 SELECT payload->>'machine_id',payload->>'key',payload->>'request_hash',(payload->>'conversation_id')::uuid,TIMESTAMPTZ 'epoch'+(payload->>'created_at')::bigint*INTERVAL '1 millisecond'
-	 FROM relay.mail_cutover_staging WHERE epoch_id=$1 AND table_name='mail_conversation_idempotency' ORDER BY row_key`,
+	 FROM relay.mail_cutover_staging WHERE epoch_id=$1 AND table_name='mail_conversation_idempotency' ORDER BY row_key COLLATE "C"`,
 	`INSERT INTO relay.mail_request_nonces(machine_id,nonce,expires_at)
 	 SELECT payload->>'machine_id',payload->>'nonce',TIMESTAMPTZ 'epoch'+(payload->>'expires_at')::bigint*INTERVAL '1 millisecond'
-	 FROM relay.mail_cutover_staging WHERE epoch_id=$1 AND table_name='mail_request_nonces' ORDER BY row_key`,
+	 FROM relay.mail_cutover_staging WHERE epoch_id=$1 AND table_name='mail_request_nonces' ORDER BY row_key COLLATE "C"`,
+}
+
+// CheckMailCutoverActivationReadiness proves that the verified destination has
+// no known pending legacy identity before the host irreversibly retires SQLite.
+// ActivateMailCutover repeats this proof while closing the legacy gate in the
+// same transaction as PostgreSQL activation.
+func (a *Administration) CheckMailCutoverActivationReadiness(ctx context.Context, actorPrincipalID, epochID, sourceFingerprint string) error {
+	if !validOpaqueID(actorPrincipalID) || uuid.Validate(epochID) != nil || !mailCutoverDigestPattern.MatchString(sourceFingerprint) {
+		return errors.New("invalid mail cutover activation readiness check")
+	}
+	tx, err := a.db.BeginTx(ctx, nil)
+	if err != nil {
+		return errors.New("mail cutover activation readiness cannot start")
+	}
+	defer func() { _ = tx.Rollback() }()
+	if err := guardMutation(ctx, tx); err != nil {
+		return err
+	}
+	if ok, err := lockInstallationOwner(ctx, tx, actorPrincipalID); err != nil || !ok {
+		return errors.New("mail cutover activation readiness is not authorized")
+	}
+	if _, err := tx.ExecContext(ctx, `SELECT pg_advisory_xact_lock($1)`, mailCutoverLockKey); err != nil {
+		return errors.New("mail cutover activation readiness cannot be serialized")
+	}
+	if err := lockLegacyMutations(ctx, tx); err != nil {
+		return err
+	}
+	var phase MailCutoverPhase
+	if err := tx.QueryRowContext(ctx, `SELECT phase FROM relay.mail_cutover_epochs WHERE epoch_id=$1 AND source_fingerprint=$2 FOR UPDATE`, epochID, sourceFingerprint).Scan(&phase); err != nil || phase != MailCutoverVerified {
+		return errors.New("mail cutover is not verified")
+	}
+	var pending, legacyStatePresent bool
+	if err := tx.QueryRowContext(ctx, `SELECT EXISTS (SELECT 1 FROM auth.legacy_machines WHERE state='pending'),EXISTS (SELECT 1 FROM auth.legacy_auth_state WHERE singleton)`).Scan(&pending, &legacyStatePresent); err != nil || !legacyStatePresent {
+		return errors.New("legacy inventory is unavailable")
+	}
+	if pending {
+		return errors.New("legacy authentication still has pending machines")
+	}
+	if err := tx.Commit(); err != nil {
+		return errors.New("mail cutover activation readiness cannot commit")
+	}
+	return nil
 }
 
 // ActivateMailCutover crosses the PostgreSQL authority barrier only after the

--- a/internal/postgres/mail_cutover_import.go
+++ b/internal/postgres/mail_cutover_import.go
@@ -101,8 +101,11 @@ func (a *Administration) MailCutoverCheckpoint(ctx context.Context, actorPrincip
 func nextMailCutoverDigest(previous string, rows []relay.MigrationSourceRow) string {
 	h := sha256.New()
 	previousBytes, err := hex.DecodeString(previous)
-	if err != nil {
+	if err != nil || len(previousBytes) != sha256.Size {
 		return ""
+	}
+	if len(rows) == 0 {
+		return previous
 	}
 	_, _ = h.Write(previousBytes)
 	for _, row := range rows {

--- a/internal/postgres/mail_cutover_test.go
+++ b/internal/postgres/mail_cutover_test.go
@@ -143,6 +143,19 @@ func TestMailCutoverEnrollmentKeysExactlyMatchMigratedInventory(t *testing.T) {
 	}
 }
 
+func TestPostgresAppendRejectsNonPortableBodyBeforeDatabaseAccess(t *testing.T) {
+	t.Parallel()
+	database := &Database{}
+	base := relay.AppendInput{ConversationID: "019f7f07-4b88-7c12-a394-b663274a6555", SenderMachineID: "machine-a", FromEndpoint: "agent/a", IdempotencyKey: "portable-key"}
+	for _, body := range []string{string([]byte{0xff}), "body\x00value"} {
+		input := base
+		input.Body = body
+		if _, _, err := database.AppendMessage(input); err == nil || !strings.Contains(err.Error(), "portable UTF-8") {
+			t.Fatalf("non-portable body %q err=%v", body, err)
+		}
+	}
+}
+
 func migrationEndpointRow(t *testing.T, endpoint, machine string, generation int64) relay.MigrationSourceRow {
 	t.Helper()
 	payload, err := json.Marshal(map[string]any{

--- a/internal/postgres/mail_cutover_test.go
+++ b/internal/postgres/mail_cutover_test.go
@@ -123,6 +123,26 @@ func TestMailCutoverMaterializationUsesBinaryResumeOrdering(t *testing.T) {
 	}
 }
 
+func TestMailCutoverEnrollmentKeysExactlyMatchMigratedInventory(t *testing.T) {
+	t.Parallel()
+	keyA := make([]byte, 32)
+	keyA[0] = 1
+	keyB := make([]byte, 32)
+	keyB[0] = 2
+	machines := []relay.Machine{{ID: "machine-a", PublicKey: keyA}, {ID: "machine-b", PublicKey: keyB}}
+	if err := validateMailCutoverEnrollmentKeys(machines, []mailCutoverLegacyKey{{publicKey: keyB, state: LegacyRetired}, {publicKey: keyA, state: LegacyMigrated}}); err != nil {
+		t.Fatalf("matching migrated keys rejected: %v", err)
+	}
+	mismatched := append([]byte(nil), keyB...)
+	mismatched[0] = 3
+	if err := validateMailCutoverEnrollmentKeys(machines, []mailCutoverLegacyKey{{publicKey: keyA, state: LegacyMigrated}, {publicKey: mismatched, state: LegacyRetired}}); err == nil {
+		t.Fatal("mismatched migrated key was accepted")
+	}
+	if err := validateMailCutoverEnrollmentKeys(machines[:1], []mailCutoverLegacyKey{{publicKey: keyA, state: LegacyMigrated}, {publicKey: keyB, state: LegacyMigrated}}); err == nil {
+		t.Fatal("omitted migrated key was accepted")
+	}
+}
+
 func migrationEndpointRow(t *testing.T, endpoint, machine string, generation int64) relay.MigrationSourceRow {
 	t.Helper()
 	payload, err := json.Marshal(map[string]any{

--- a/internal/postgres/mail_cutover_test.go
+++ b/internal/postgres/mail_cutover_test.go
@@ -114,6 +114,15 @@ func TestMailCutoverBatchValidationAndRollingDigest(t *testing.T) {
 	}
 }
 
+func TestMailCutoverMaterializationUsesBinaryResumeOrdering(t *testing.T) {
+	t.Parallel()
+	for index, statement := range mailCutoverMaterializationStatements {
+		if !strings.Contains(statement, `ORDER BY row_key COLLATE "C"`) {
+			t.Fatalf("materialization statement %d lacks binary ordering: %s", index, statement)
+		}
+	}
+}
+
 func migrationEndpointRow(t *testing.T, endpoint, machine string, generation int64) relay.MigrationSourceRow {
 	t.Helper()
 	payload, err := json.Marshal(map[string]any{

--- a/internal/postgres/mail_cutover_test.go
+++ b/internal/postgres/mail_cutover_test.go
@@ -96,8 +96,9 @@ func TestMailCutoverBatchValidationAndRollingDigest(t *testing.T) {
 	first := nextMailCutoverDigest(emptyMailCutoverDigest, rows[:1])
 	second := nextMailCutoverDigest(first, rows[1:])
 	combined := nextMailCutoverDigest(emptyMailCutoverDigest, rows)
-	if first == emptyMailCutoverDigest || second == first || combined == second {
-		t.Fatalf("rolling digests first=%s second=%s combined=%s", first, second, combined)
+	empty := nextMailCutoverDigest(emptyMailCutoverDigest, nil)
+	if empty != emptyMailCutoverDigest || first == emptyMailCutoverDigest || second == first || combined == second {
+		t.Fatalf("rolling digests empty=%s first=%s second=%s combined=%s", empty, first, second, combined)
 	}
 	invalid := []MailCutoverBatch{
 		{},

--- a/internal/postgres/mail_cutover_test.go
+++ b/internal/postgres/mail_cutover_test.go
@@ -82,3 +82,50 @@ func TestMailCutoverRequestValidation(t *testing.T) {
 		}
 	}
 }
+
+func TestMailCutoverBatchValidationAndRollingDigest(t *testing.T) {
+	t.Parallel()
+	rows := []relay.MigrationSourceRow{
+		migrationEndpointRow(t, "agent/a", "machine-a", 1),
+		migrationEndpointRow(t, "agent/b", "machine-b", 2),
+	}
+	batch := MailCutoverBatch{EpochID: "019f7f07-4b88-7c12-a394-b663274a6555", Table: "mail_endpoints", Rows: rows, Done: true}
+	if err := batch.Validate(); err != nil {
+		t.Fatal(err)
+	}
+	first := nextMailCutoverDigest(emptyMailCutoverDigest, rows[:1])
+	second := nextMailCutoverDigest(first, rows[1:])
+	combined := nextMailCutoverDigest(emptyMailCutoverDigest, rows)
+	if first == emptyMailCutoverDigest || second == first || combined == second {
+		t.Fatalf("rolling digests first=%s second=%s combined=%s", first, second, combined)
+	}
+	invalid := []MailCutoverBatch{
+		{},
+		{EpochID: batch.EpochID, Table: "unknown", Rows: rows},
+		{EpochID: batch.EpochID, Table: batch.Table},
+		{EpochID: batch.EpochID, Table: batch.Table, Rows: []relay.MigrationSourceRow{rows[1], rows[0]}},
+		{EpochID: batch.EpochID, Table: batch.Table, Rows: []relay.MigrationSourceRow{rows[0], rows[0]}},
+	}
+	for index, candidate := range invalid {
+		if err := candidate.Validate(); err == nil {
+			t.Fatalf("invalid batch %d accepted: %#v", index, candidate)
+		}
+	}
+}
+
+func migrationEndpointRow(t *testing.T, endpoint, machine string, generation int64) relay.MigrationSourceRow {
+	t.Helper()
+	payload, err := json.Marshal(map[string]any{
+		"endpoint": endpoint, "machine_id": machine, "lease_until": int64(1), "ownership_generation": generation,
+		"consumer_id": nil, "consumer_generation": int64(0), "consumer_lease_until": nil,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	digest := sha256.Sum256(payload)
+	key, err := json.Marshal([]any{endpoint})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return relay.MigrationSourceRow{Table: "mail_endpoints", Key: string(key), Payload: payload, SHA256: hex.EncodeToString(digest[:])}
+}

--- a/internal/postgres/migrate.go
+++ b/internal/postgres/migrate.go
@@ -151,7 +151,7 @@ WHERE update_id=$1::uuid AND phase='migration_started' AND backup_id=$2::uuid
 	if _, err := conn.ExecContext(ctx, `SELECT set_config('punaro.update_id',$1,false)`, authorization.UpdateID); err != nil {
 		return SchemaState{}, errors.New("PostgreSQL update migration session cannot be bound")
 	}
-	return migrateConnExpectedAppRole(ctx, conn, manifest, "punaro_app")
+	return migrateConnExpectedAppRole(ctx, conn, manifest, "punaro_app", true)
 }
 
 func refuseOrdinaryUpgrade(ctx context.Context, db *sql.DB, manifest Manifest) error {
@@ -164,7 +164,8 @@ func refuseOrdinaryUpgrade(ctx context.Context, db *sql.DB, manifest Manifest) e
 	if err != nil {
 		return err
 	}
-	if migrationAuthorizationRequired(Classify(snapshot, manifest)) {
+	state := Classify(snapshot, manifest)
+	if migrationAuthorizationRequired(state) || state.Classification == Compatible && migrationPending(state, manifest) {
 		return errors.New("PostgreSQL upgrade requires the supported update transaction")
 	}
 	return nil
@@ -180,10 +181,10 @@ func migrate(ctx context.Context, db *sql.DB, manifest Manifest) (SchemaState, e
 }
 
 func migrateConn(ctx context.Context, conn *sql.Conn, manifest Manifest) (SchemaState, error) {
-	return migrateConnExpectedAppRole(ctx, conn, manifest, "punaro_app")
+	return migrateConnExpectedAppRole(ctx, conn, manifest, "punaro_app", false)
 }
 
-func migrateConnExpectedAppRole(ctx context.Context, conn *sql.Conn, manifest Manifest, appRole string) (SchemaState, error) {
+func migrateConnExpectedAppRole(ctx context.Context, conn *sql.Conn, manifest Manifest, appRole string, allowExistingUpgrade bool) (SchemaState, error) {
 	if err := manifest.Validate(); err != nil {
 		return SchemaState{}, err
 	}
@@ -204,10 +205,13 @@ func migrateConnExpectedAppRole(ctx context.Context, conn *sql.Conn, manifest Ma
 		return SchemaState{}, err
 	}
 	state := Classify(snapshot, manifest)
-	if state.Classification == Compatible {
+	if (state.Classification == Compatible || state.Classification == UpgradeRequired) && migrationPending(state, manifest) && !allowExistingUpgrade {
+		return state, errors.New("PostgreSQL upgrade requires the supported update transaction")
+	}
+	if state.Classification == Compatible && !migrationPending(state, manifest) {
 		return state, nil
 	}
-	if state.Classification != Pristine && state.Classification != UpgradeRequired {
+	if state.Classification != Pristine && state.Classification != UpgradeRequired && state.Classification != Compatible {
 		return state, contentFreeMigrationError(state.Classification)
 	}
 	if state.Classification == Pristine {
@@ -235,6 +239,10 @@ func migrateConnExpectedAppRole(ctx context.Context, conn *sql.Conn, manifest Ma
 		return final, contentFreeMigrationError(final.Classification)
 	}
 	return final, nil
+}
+
+func migrationPending(state SchemaState, manifest Manifest) bool {
+	return state.Version < manifest.MaxSupported
 }
 
 func migrationAuthorizationRequired(state SchemaState) bool {

--- a/internal/postgres/migrate.go
+++ b/internal/postgres/migrate.go
@@ -41,6 +41,7 @@ var migrationCompatibilityFloors = map[int64]int64{
 	6: 6,
 	7: 7,
 	8: 8,
+	9: 8,
 }
 
 // CurrentManifest returns the immutable migrations embedded in this binary.

--- a/internal/postgres/migrations/009_mail_cutover_payload_capacity.sql
+++ b/internal/postgres/migrations/009_mail_cutover_payload_capacity.sql
@@ -1,0 +1,6 @@
+ALTER TABLE relay.mail_cutover_staging
+    DROP CONSTRAINT mail_cutover_staging_payload_check;
+
+ALTER TABLE relay.mail_cutover_staging
+    ADD CONSTRAINT mail_cutover_staging_payload_check
+    CHECK (jsonb_typeof(payload) = 'object' AND octet_length(payload::text) <= 262144);

--- a/internal/postgres/postgres_integration_test.go
+++ b/internal/postgres/postgres_integration_test.go
@@ -601,7 +601,7 @@ AS $function$ BEGIN RETURN NEW; END $function$`); err != nil {
 		_ = ownerConn.Close()
 		t.Fatalf("missing-role fixture collision=%t err=%v", missingRoleExists, err)
 	}
-	if _, err := migrateConnExpectedAppRole(ctx, ownerConn, CurrentManifest(), missingRole); err == nil {
+	if _, err := migrateConnExpectedAppRole(ctx, ownerConn, CurrentManifest(), missingRole, false); err == nil {
 		_ = ownerConn.Close()
 		t.Fatal("migrator accepted a missing application role")
 	}
@@ -1345,6 +1345,20 @@ func testV5UpdateBridgeIntegration(ctx context.Context, t *testing.T, ownerDB *s
 		t.Fatalf("inspect v8 schema with current manifest: %v", inspectErr)
 	} else if state := Classify(snapshot, current); state.Classification != Compatible || state.Version != 8 {
 		t.Fatalf("current manifest rejected exact v8 schema: %#v", state)
+	}
+	if _, err := Migrate(ctx, Config{DSNFile: ownerFile}); err == nil || !strings.Contains(err.Error(), "supported update transaction") {
+		t.Fatalf("ordinary migrator accepted compatible-but-pending v9 upgrade: %v", err)
+	}
+	ordinaryConn, err := ownerDB.Conn(ctx)
+	if err != nil {
+		t.Fatalf("open ordinary migration engine connection: %v", err)
+	}
+	if state, migrateErr := migrateConnExpectedAppRole(ctx, ordinaryConn, current, "punaro_app", false); migrateErr == nil || !strings.Contains(migrateErr.Error(), "supported update transaction") || state.Classification != Compatible || state.Version != 8 {
+		_ = ordinaryConn.Close()
+		t.Fatalf("ordinary locked migration engine accepted compatible-but-pending v9 upgrade: state=%#v err=%v", state, migrateErr)
+	}
+	if err := ordinaryConn.Close(); err != nil {
+		t.Fatalf("close ordinary migration engine connection: %v", err)
 	}
 
 	request = UpdateRequest{

--- a/internal/postgres/postgres_integration_test.go
+++ b/internal/postgres/postgres_integration_test.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -894,6 +895,28 @@ func testMailCutoverSubstrate(ctx context.Context, t *testing.T, app *Database, 
 	if _, err := admin.VerifyMailCutover(ctx, actor, activationRequest.EpochID, activationRequest.SourceFingerprint); err != nil {
 		t.Fatal(err)
 	}
+	type activationEnrollmentRecord struct {
+		ID        string   `json:"id"`
+		PublicKey string   `json:"public_key"`
+		Endpoints []string `json:"endpoints"`
+	}
+	var activationRecords []activationEnrollmentRecord
+	existingMigrated, err := ownerDB.QueryContext(ctx, `SELECT public_key FROM auth.legacy_machines WHERE state='migrated' ORDER BY public_key_digest`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for existingMigrated.Next() {
+		var publicKey []byte
+		if err := existingMigrated.Scan(&publicKey); err != nil {
+			_ = existingMigrated.Close()
+			t.Fatal(err)
+		}
+		index := strconv.Itoa(len(activationRecords))
+		activationRecords = append(activationRecords, activationEnrollmentRecord{ID: "cutover-existing-" + index, PublicKey: base64.RawURLEncoding.EncodeToString(publicKey), Endpoints: []string{"agent/cutover/existing-" + index}})
+	}
+	if err := existingMigrated.Close(); err != nil || existingMigrated.Err() != nil {
+		t.Fatalf("existing migrated inventory err=%v close=%v", existingMigrated.Err(), err)
+	}
 	migratedKey := make([]byte, 32)
 	migratedKey[0] = 73
 	migratedKeyDigest := sha256.Sum256(migratedKey)
@@ -918,10 +941,24 @@ func testMailCutoverSubstrate(ctx context.Context, t *testing.T, app *Database, 
 	if _, err := ownerDB.ExecContext(ctx, `INSERT INTO auth.legacy_machines(principal_id,public_key,public_key_digest,state) VALUES($1,$2,$3,'retired')`, retiredLegacyID, retiredKey, retiredKeyDigest[:]); err != nil {
 		t.Fatal(err)
 	}
-	activationEnrollment := `[{"id":"cutover-machine-a","public_key":"` + base64.RawURLEncoding.EncodeToString(migratedKey) + `","endpoints":["agent/cutover/source-a"]},{"id":"cutover-machine-b","public_key":"` + base64.RawURLEncoding.EncodeToString(retiredKey) + `","endpoints":["agent/cutover/source-b"]}]`
+	activationRecords = append(activationRecords,
+		activationEnrollmentRecord{ID: "cutover-machine-a", PublicKey: base64.RawURLEncoding.EncodeToString(migratedKey), Endpoints: []string{"agent/cutover/source-a"}},
+		activationEnrollmentRecord{ID: "cutover-machine-b", PublicKey: base64.RawURLEncoding.EncodeToString(retiredKey), Endpoints: []string{"agent/cutover/source-b"}},
+	)
+	activationEnrollmentJSON, err := json.Marshal(activationRecords)
+	if err != nil {
+		t.Fatal(err)
+	}
+	activationEnrollment := string(activationEnrollmentJSON)
 	mismatchedKey := append([]byte(nil), migratedKey...)
 	mismatchedKey[0]++
-	mismatchedEnrollment := `[{"id":"cutover-machine-a","public_key":"` + base64.RawURLEncoding.EncodeToString(mismatchedKey) + `","endpoints":["agent/cutover/source-a"]},{"id":"cutover-machine-b","public_key":"` + base64.RawURLEncoding.EncodeToString(retiredKey) + `","endpoints":["agent/cutover/source-b"]}]`
+	mismatchedRecords := append([]activationEnrollmentRecord(nil), activationRecords...)
+	mismatchedRecords[len(mismatchedRecords)-2].PublicKey = base64.RawURLEncoding.EncodeToString(mismatchedKey)
+	mismatchedEnrollmentJSON, err := json.Marshal(mismatchedRecords)
+	if err != nil {
+		t.Fatal(err)
+	}
+	mismatchedEnrollment := string(mismatchedEnrollmentJSON)
 	if err := admin.CheckMailCutoverActivationReadiness(ctx, actor, activationRequest.EpochID, activationRequest.SourceFingerprint, mismatchedEnrollment); err == nil {
 		t.Fatal("activation readiness accepted a static enrollment key that did not match migrated inventory")
 	}

--- a/internal/postgres/postgres_integration_test.go
+++ b/internal/postgres/postgres_integration_test.go
@@ -1354,6 +1354,9 @@ func testV5UpdateBridgeIntegration(ctx context.Context, t *testing.T, ownerDB *s
 	} else if state := Classify(snapshot, current); state.Classification != Compatible || state.Version != 8 {
 		t.Fatalf("current manifest rejected exact v8 schema: %#v", state)
 	}
+	if err := admin.CheckMailCutoverSchemaReadiness(ctx); err == nil {
+		t.Fatal("mail cutover accepted exact v8 schema before migration 009")
+	}
 	if _, err := Migrate(ctx, Config{DSNFile: ownerFile}); err == nil || !strings.Contains(err.Error(), "supported update transaction") {
 		t.Fatalf("ordinary migrator accepted compatible-but-pending v9 upgrade: %v", err)
 	}
@@ -1419,6 +1422,9 @@ func testV5UpdateBridgeIntegration(ctx context.Context, t *testing.T, ownerDB *s
 	}
 	if state, err := MigrateUpdate(ctx, Config{DSNFile: ownerFile}, authorization); err != nil || state.Classification != Compatible || state.Version != CurrentManifest().MaxSupported {
 		t.Fatalf("v9 migration state=%#v err=%v", state, err)
+	}
+	if err := admin.CheckMailCutoverSchemaReadiness(ctx); err != nil {
+		t.Fatalf("mail cutover rejected exact v9 schema: %v", err)
 	}
 	for _, phases := range [][2]UpdatePhase{{UpdateMigrationStarted, UpdateMigrated}, {UpdateMigrated, UpdateCandidateReady}, {UpdateCandidateReady, UpdateDoctorPassed}, {UpdateDoctorPassed, UpdateConfigPublished}, {UpdateConfigPublished, UpdateCommitted}} {
 		transaction, err = admin.AdvanceUpdate(ctx, request.UpdateID, phases[0], phases[1], nil)

--- a/internal/postgres/postgres_integration_test.go
+++ b/internal/postgres/postgres_integration_test.go
@@ -751,7 +751,7 @@ func testMailCutoverSubstrate(ctx context.Context, t *testing.T, app *Database, 
 		UpdateID: "019f7f07-6b88-7c12-a394-b663274a6555", SourceRelease: "cutover-source", TargetRelease: "cutover-target",
 		SourceImage:  "ghcr.io/rock3r/punaro@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
 		TargetImage:  "ghcr.io/rock3r/punaro@sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
-		SourceSchema: 8, TargetSchema: 8, SchemaMin: 8, SchemaMax: 8, RollbackFloor: 8, PostgresMajor: postgresMajor,
+		SourceSchema: CurrentManifest().MaxSupported, TargetSchema: CurrentManifest().MaxSupported, SchemaMin: 8, SchemaMax: CurrentManifest().MaxSupported, RollbackFloor: 8, PostgresMajor: postgresMajor,
 		ReleaseSHA256: strings.Repeat("1", 64), ComposeSHA256: strings.Repeat("2", 64), MigrationManifestSHA256: MigrationManifestSHA256(),
 	}
 	if _, err := admin.BeginUpdate(ctx, updateRequest); !errors.Is(err, ErrUpdateConflict) {
@@ -892,6 +892,54 @@ func testMailCutoverSubstrate(ctx context.Context, t *testing.T, app *Database, 
 	}
 	if _, err := admin.VerifyMailCutover(ctx, actor, activationRequest.EpochID, activationRequest.SourceFingerprint); err != nil {
 		t.Fatal(err)
+	}
+	if err := admin.CheckMailCutoverActivationReadiness(ctx, uuid.NewString(), activationRequest.EpochID, activationRequest.SourceFingerprint); err == nil {
+		t.Fatal("non-owner passed activation readiness")
+	}
+	pendingLegacyKey := make([]byte, 32)
+	pendingLegacyKey[0] = 42
+	pendingLegacyDigest := sha256.Sum256(pendingLegacyKey)
+	var pendingLegacyID string
+	if err := ownerDB.QueryRowContext(ctx, `INSERT INTO auth.principals(kind,display_name) VALUES('legacy_machine','cutover readiness fixture') RETURNING id::text`).Scan(&pendingLegacyID); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ownerDB.ExecContext(ctx, `INSERT INTO auth.legacy_machines(principal_id,public_key,public_key_digest) VALUES($1,$2,$3)`, pendingLegacyID, pendingLegacyKey, pendingLegacyDigest[:]); err != nil {
+		t.Fatal(err)
+	}
+	if err := admin.CheckMailCutoverActivationReadiness(ctx, actor, activationRequest.EpochID, activationRequest.SourceFingerprint); err == nil {
+		t.Fatal("activation readiness accepted a pending legacy machine")
+	}
+	if sourceState, err := relay.InspectMigrationSource(ctx, sourcePath); err != nil || sourceState.Phase != relay.MigrationSourcePrepared {
+		t.Fatalf("readiness failure retired source state=%#v err=%v", sourceState, err)
+	}
+	if err := admin.RetireLegacyMachine(ctx, actor, pendingLegacyID); err != nil {
+		t.Fatal(err)
+	}
+	if err := admin.CheckMailCutoverActivationReadiness(ctx, actor, activationRequest.EpochID, activationRequest.SourceFingerprint); err != nil {
+		t.Fatalf("resolved activation readiness: %v", err)
+	}
+	if _, err := ownerDB.ExecContext(ctx, `UPDATE auth.legacy_auth_state SET enabled=true,changed_at=statement_timestamp() WHERE singleton`); err != nil {
+		t.Fatal(err)
+	}
+	registrationResult := make(chan error, 1)
+	go func() {
+		key := make([]byte, 32)
+		key[0] = 84
+		_, registerErr := admin.RegisterLegacyMachine(ctx, actor, "cutover readiness race", key)
+		registrationResult <- registerErr
+	}()
+	if err := admin.CheckMailCutoverActivationReadiness(ctx, actor, activationRequest.EpochID, activationRequest.SourceFingerprint); err != nil {
+		t.Fatalf("concurrent activation readiness: %v", err)
+	}
+	if err := <-registrationResult; err == nil {
+		t.Fatal("legacy registration crossed a verified mail cutover")
+	}
+	var pendingAfterReadiness bool
+	if err := ownerDB.QueryRowContext(ctx, `SELECT EXISTS (SELECT 1 FROM auth.legacy_machines WHERE state='pending')`).Scan(&pendingAfterReadiness); err != nil || pendingAfterReadiness {
+		t.Fatalf("pending legacy inventory crossed readiness pending=%t err=%v", pendingAfterReadiness, err)
+	}
+	if sourceState, err := relay.InspectMigrationSource(ctx, sourcePath); err != nil || sourceState.Phase != relay.MigrationSourcePrepared {
+		t.Fatalf("registration race retired source state=%#v err=%v", sourceState, err)
 	}
 	retiredManifest, err := relay.RetirePreparedMigrationSource(ctx, sourcePath, activationRequest.EpochID, targetIdentity, activationRequest.SourceFingerprint)
 	if err != nil {
@@ -1178,6 +1226,7 @@ func testV5UpdateBridgeIntegration(ctx context.Context, t *testing.T, ownerDB *s
 		}
 	}
 	v7Manifest := Manifest{MinSupported: 7, MaxSupported: 7, Migrations: append([]Migration(nil), current.Migrations[:7]...)}
+	v8Manifest := Manifest{MinSupported: 8, MaxSupported: 8, Migrations: append([]Migration(nil), current.Migrations[:8]...)}
 	request = UpdateRequest{
 		UpdateID:                "019b4eb0-798c-7a52-8d29-8560fcbb2085",
 		SourceRelease:           "v0.7.0",
@@ -1238,7 +1287,7 @@ func testV5UpdateBridgeIntegration(ctx context.Context, t *testing.T, ownerDB *s
 	request = UpdateRequest{
 		UpdateID:                "019b4eb0-798c-7a52-8d29-8560fcbb2086",
 		SourceRelease:           "v0.8.0",
-		TargetRelease:           "v0.9.0",
+		TargetRelease:           "v0.8.0",
 		SourceImage:             "ghcr.io/rock3r/punaro@sha256:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
 		TargetImage:             "ghcr.io/rock3r/punaro@sha256:eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
 		SourceSchema:            7,
@@ -1249,7 +1298,7 @@ func testV5UpdateBridgeIntegration(ctx context.Context, t *testing.T, ownerDB *s
 		PostgresMajor:           postgresMajor,
 		ReleaseSHA256:           "1212121212121212121212121212121212121212121212121212121212121212",
 		ComposeSHA256:           "3434343434343434343434343434343434343434343434343434343434343434",
-		MigrationManifestSHA256: MigrationManifestSHA256(),
+		MigrationManifestSHA256: migrationManifestSHA256(v8Manifest),
 	}
 	transaction, err = admin.BeginUpdate(ctx, request)
 	if err != nil || transaction.Phase != UpdateFenced {
@@ -1283,13 +1332,76 @@ func testV5UpdateBridgeIntegration(ctx context.Context, t *testing.T, ownerDB *s
 		TargetImage: request.TargetImage, TargetSchema: request.TargetSchema,
 		ExportedSnapshotID: marker.ExportedSnapshotID, ManifestSHA256: marker.ManifestSHA256,
 	}
-	if state, err := MigrateUpdate(ctx, Config{DSNFile: ownerFile}, authorization); err != nil || state.Classification != Compatible || state.Version != 8 {
+	if state, err := migrateUpdateManifest(ctx, Config{DSNFile: ownerFile}, authorization, v8Manifest); err != nil || state.Classification != Compatible || state.Version != 8 {
 		t.Fatalf("v8 migration state=%#v err=%v", state, err)
 	}
 	for _, phases := range [][2]UpdatePhase{{UpdateMigrationStarted, UpdateMigrated}, {UpdateMigrated, UpdateCandidateReady}, {UpdateCandidateReady, UpdateDoctorPassed}, {UpdateDoctorPassed, UpdateConfigPublished}, {UpdateConfigPublished, UpdateCommitted}} {
 		transaction, err = admin.AdvanceUpdate(ctx, request.UpdateID, phases[0], phases[1], nil)
 		if err != nil || transaction.Phase != phases[1] {
 			t.Fatalf("v8 phase %s -> %s transaction=%#v err=%v", phases[0], phases[1], transaction, err)
+		}
+	}
+	if snapshot, inspectErr := inspect(ctx, ownerDB); inspectErr != nil {
+		t.Fatalf("inspect v8 schema with current manifest: %v", inspectErr)
+	} else if state := Classify(snapshot, current); state.Classification != Compatible || state.Version != 8 {
+		t.Fatalf("current manifest rejected exact v8 schema: %#v", state)
+	}
+
+	request = UpdateRequest{
+		UpdateID:                "019b4eb0-798c-7a52-8d29-8560fcbb2087",
+		SourceRelease:           "v0.8.0",
+		TargetRelease:           "v0.9.0",
+		SourceImage:             "ghcr.io/rock3r/punaro@sha256:eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+		TargetImage:             "ghcr.io/rock3r/punaro@sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+		SourceSchema:            8,
+		TargetSchema:            9,
+		SchemaMin:               8,
+		SchemaMax:               9,
+		RollbackFloor:           8,
+		PostgresMajor:           postgresMajor,
+		ReleaseSHA256:           "7878787878787878787878787878787878787878787878787878787878787878",
+		ComposeSHA256:           "8989898989898989898989898989898989898989898989898989898989898989",
+		MigrationManifestSHA256: MigrationManifestSHA256(),
+	}
+	transaction, err = admin.BeginUpdate(ctx, request)
+	if err != nil || transaction.Phase != UpdateFenced {
+		t.Fatalf("begin v9 update transaction=%#v err=%v", transaction, err)
+	}
+	transaction, err = admin.AdvanceUpdate(ctx, request.UpdateID, UpdateFenced, UpdateWritersStopped, nil)
+	if err != nil || transaction.Phase != UpdateWritersStopped {
+		t.Fatalf("stop v9 writers transaction=%#v err=%v", transaction, err)
+	}
+	if err := ownerDB.QueryRowContext(ctx, `SELECT installation_id::text,timeline_id::text,change_sequence FROM jobs.server_state WHERE singleton`).Scan(&state.InstallationID, &state.TimelineID, &state.ChangeSequence); err != nil {
+		t.Fatal(err)
+	}
+	marker = &UpdateBackupMarker{
+		UpdateID: request.UpdateID, BackupID: "019b4eb0-5317-79a6-a0de-fd97719910fe",
+		InstallationID: state.InstallationID, TimelineID: state.TimelineID, ChangeSequence: state.ChangeSequence,
+		SourceSchema: request.SourceSchema, TargetRelease: request.TargetRelease,
+		TargetImageDigest:  "sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+		ExportedSnapshotID: "00000003-0000001B-4",
+		ManifestSHA256:     "9090909090909090909090909090909090909090909090909090909090909090",
+	}
+	transaction, err = admin.AdvanceUpdate(ctx, request.UpdateID, UpdateWritersStopped, UpdateBackupVerified, marker)
+	if err != nil || transaction.Phase != UpdateBackupVerified {
+		t.Fatalf("bind v9 backup transaction=%#v err=%v", transaction, err)
+	}
+	transaction, err = admin.AdvanceUpdate(ctx, request.UpdateID, UpdateBackupVerified, UpdateMigrationStarted, nil)
+	if err != nil || transaction.Phase != UpdateMigrationStarted {
+		t.Fatalf("start v9 migration transaction=%#v err=%v", transaction, err)
+	}
+	authorization = UpdateMigrationAuthorization{
+		UpdateID: request.UpdateID, BackupID: marker.BackupID, TargetRelease: request.TargetRelease,
+		TargetImage: request.TargetImage, TargetSchema: request.TargetSchema,
+		ExportedSnapshotID: marker.ExportedSnapshotID, ManifestSHA256: marker.ManifestSHA256,
+	}
+	if state, err := MigrateUpdate(ctx, Config{DSNFile: ownerFile}, authorization); err != nil || state.Classification != Compatible || state.Version != CurrentManifest().MaxSupported {
+		t.Fatalf("v9 migration state=%#v err=%v", state, err)
+	}
+	for _, phases := range [][2]UpdatePhase{{UpdateMigrationStarted, UpdateMigrated}, {UpdateMigrated, UpdateCandidateReady}, {UpdateCandidateReady, UpdateDoctorPassed}, {UpdateDoctorPassed, UpdateConfigPublished}, {UpdateConfigPublished, UpdateCommitted}} {
+		transaction, err = admin.AdvanceUpdate(ctx, request.UpdateID, phases[0], phases[1], nil)
+		if err != nil || transaction.Phase != phases[1] {
+			t.Fatalf("v9 phase %s -> %s transaction=%#v err=%v", phases[0], phases[1], transaction, err)
 		}
 	}
 	if _, err := ownerDB.ExecContext(ctx, `DELETE FROM jobs.update_transactions`); err != nil {

--- a/internal/postgres/postgres_integration_test.go
+++ b/internal/postgres/postgres_integration_test.go
@@ -1117,8 +1117,16 @@ func testV5UpdateBridgeIntegration(ctx context.Context, t *testing.T, ownerDB *s
 	t.Helper()
 	current := CurrentManifest()
 	v5Manifest := Manifest{MinSupported: 5, MaxSupported: 5, Migrations: append([]Migration(nil), current.Migrations[:5]...)}
-	if state, err := migrate(ctx, ownerDB, v5Manifest); err != nil || state.Classification != Compatible || state.Version != 5 {
-		t.Fatalf("v5 staging state=%#v err=%v", state, err)
+	stagingConn, err := ownerDB.Conn(ctx)
+	if err != nil {
+		t.Fatalf("open v5 staging connection: %v", err)
+	}
+	stagingState, stagingErr := migrateConnExpectedAppRole(ctx, stagingConn, v5Manifest, "punaro_app", true)
+	if closeErr := stagingConn.Close(); closeErr != nil {
+		t.Fatalf("close v5 staging connection: %v", closeErr)
+	}
+	if stagingErr != nil || stagingState.Classification != Compatible || stagingState.Version != 5 {
+		t.Fatalf("v5 staging state=%#v err=%v", stagingState, stagingErr)
 	}
 	var bridgeOwnerID string
 	if err := ownerDB.QueryRowContext(ctx, `INSERT INTO auth.principals (kind,display_name) VALUES ('owner','v5 bridge owner') RETURNING id::text`).Scan(&bridgeOwnerID); err != nil {

--- a/internal/postgres/postgres_integration_test.go
+++ b/internal/postgres/postgres_integration_test.go
@@ -635,9 +635,9 @@ func testMailCutoverSubstrate(ctx context.Context, t *testing.T, app *Database, 
 		Version: 1, SourceID: request.SourceID, Phase: relay.MigrationSourcePrepared, EpochID: request.EpochID,
 		TargetIdentity: request.TargetIdentity, Fingerprint: request.SourceFingerprint,
 		TableSHA256: relay.MigrationSourceHashes{
-			Endpoints: strings.Repeat("e", 64), Conversations: strings.Repeat("e", 64), Memberships: strings.Repeat("e", 64),
-			Messages: strings.Repeat("e", 64), Deliveries: strings.Repeat("e", 64), RecipientCursors: strings.Repeat("e", 64),
-			MessageIdempotency: strings.Repeat("e", 64), ConversationIdempotency: strings.Repeat("e", 64), RequestNonces: strings.Repeat("e", 64),
+			Endpoints: emptyMailCutoverDigest, Conversations: emptyMailCutoverDigest, Memberships: emptyMailCutoverDigest,
+			Messages: emptyMailCutoverDigest, Deliveries: emptyMailCutoverDigest, RecipientCursors: emptyMailCutoverDigest,
+			MessageIdempotency: emptyMailCutoverDigest, ConversationIdempotency: emptyMailCutoverDigest, RequestNonces: emptyMailCutoverDigest,
 		},
 	}
 	canonicalManifest, _ := json.Marshal(manifest)
@@ -661,6 +661,27 @@ func testMailCutoverSubstrate(ctx context.Context, t *testing.T, app *Database, 
 	var rejectedEpochs int
 	if err := ownerDB.QueryRowContext(ctx, `SELECT count(*) FROM relay.mail_cutover_epochs`).Scan(&rejectedEpochs); err != nil || rejectedEpochs != 0 {
 		t.Fatalf("rejected cutover created epochs=%d err=%v", rejectedEpochs, err)
+	}
+	tombstoneRequest := request
+	tombstoneRequest.EpochID = "019f7f07-3b88-7c12-a394-b663274a6555"
+	tombstoneManifest := manifest
+	tombstoneManifest.EpochID = tombstoneRequest.EpochID
+	tombstoneCanonical, _ := json.Marshal(tombstoneManifest)
+	tombstoneRequest.Manifest = tombstoneCanonical
+	tombstoneDigest := sha256.Sum256(tombstoneCanonical)
+	tombstoneRequest.ManifestSHA256 = hex.EncodeToString(tombstoneDigest[:])
+	tombstone, err := admin.ReserveMailCutoverAbort(ctx, actor, tombstoneRequest)
+	if err != nil || tombstone.Phase != MailCutoverAborted || !tombstone.AbortedAt.Valid {
+		t.Fatalf("absent abort reservation=%#v err=%v", tombstone, err)
+	}
+	if repeated, err := admin.ReserveMailCutoverAbort(ctx, actor, tombstoneRequest); err != nil || !reflect.DeepEqual(repeated, tombstone) {
+		t.Fatalf("repeated absent abort reservation=%#v err=%v", repeated, err)
+	}
+	if delayed, err := admin.BeginMailCutover(ctx, actor, tombstoneRequest); err != nil || delayed.Phase != MailCutoverAborted {
+		t.Fatalf("delayed begin after abort reservation=%#v err=%v", delayed, err)
+	}
+	if err := admin.AbortMailCutover(ctx, actor, tombstoneRequest.EpochID, tombstoneRequest.SourceFingerprint); err != nil {
+		t.Fatalf("reserved absent abort completion err=%v", err)
 	}
 	writer, err := app.relayPool().BeginTx(ctx, nil)
 	if err != nil {
@@ -707,6 +728,9 @@ func testMailCutoverSubstrate(ctx context.Context, t *testing.T, app *Database, 
 	result := <-beginDone
 	if result.err == nil {
 		t.Fatalf("cutover accepted a target populated by a drained writer: %#v", result.epoch)
+	}
+	if _, err := admin.MailCutoverStatus(ctx, actor, request.EpochID); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("rejected pre-insert cutover status err=%v", err)
 	}
 	if _, err := ownerDB.ExecContext(ctx, `DELETE FROM relay.mail_endpoints WHERE endpoint='agent/cutover/draining'`); err != nil {
 		t.Fatal(err)
@@ -759,6 +783,19 @@ func testMailCutoverSubstrate(ctx context.Context, t *testing.T, app *Database, 
 	if err := app.ConsumeRequestNonce("cutover-fenced-machine", "cutover-fenced-nonce", time.Now().UTC(), time.Now().UTC().Add(time.Minute)); !errors.Is(err, relay.ErrMaintenance) {
 		t.Fatalf("application nonce write during cutover err=%v", err)
 	}
+	for _, table := range mailCutoverTables {
+		checkpoint, err := admin.StageMailCutoverBatch(ctx, actor, MailCutoverBatch{EpochID: request.EpochID, Table: table, Done: true})
+		if err != nil || checkpoint.RowCount != 0 || checkpoint.RollingSHA256 != emptyMailCutoverDigest {
+			t.Fatalf("empty cutover checkpoint table=%s checkpoint=%#v err=%v", table, checkpoint, err)
+		}
+	}
+	verified, err := admin.VerifyMailCutover(ctx, actor, request.EpochID, request.SourceFingerprint)
+	if err != nil || verified.Phase != MailCutoverVerified || !verified.VerifiedAt.Valid {
+		t.Fatalf("verified empty cutover=%#v err=%v", verified, err)
+	}
+	if _, err := admin.VerifyMailCutover(ctx, actor, request.EpochID, request.SourceFingerprint); err != nil {
+		t.Fatalf("idempotent cutover verification: %v", err)
+	}
 	if err := admin.AbortMailCutover(ctx, actor, request.EpochID, request.SourceFingerprint); err != nil {
 		t.Fatal(err)
 	}
@@ -794,6 +831,92 @@ func testMailCutoverSubstrate(ctx context.Context, t *testing.T, app *Database, 
 	}
 	if _, err := ownerDB.ExecContext(ctx, `DELETE FROM relay.mail_endpoints WHERE endpoint='agent/cutover/unfenced'`); err != nil {
 		t.Fatal(err)
+	}
+	sourcePath := filepath.Join(t.TempDir(), "relay.db")
+	source, err := relay.Open(sourcePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	migrationNow := time.Date(2026, time.July, 21, 2, 0, 0, 0, time.UTC)
+	if err := source.AdvertiseEndpoints("cutover-machine-a", []string{"agent/cutover/source-a"}, migrationNow, time.Hour); err != nil {
+		t.Fatal(err)
+	}
+	if err := source.AdvertiseEndpoints("cutover-machine-b", []string{"agent/cutover/source-b"}, migrationNow, time.Hour); err != nil {
+		t.Fatal(err)
+	}
+	conversation, err := source.CreateConversationIdempotent(relay.CreateConversationInput{MachineID: "cutover-machine-a", IdempotencyKey: "cutover-conversation", CreatorEndpoint: "agent/cutover/source-a", Now: migrationNow, Members: []relay.Member{{Endpoint: "agent/cutover/source-a", Capabilities: relay.CapSend | relay.CapReceive | relay.CapAdmin}, {Endpoint: "agent/cutover/source-b", Capabilities: relay.CapReceive}}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	message, duplicate, err := source.AppendMessage(relay.AppendInput{ConversationID: conversation.ID, SenderMachineID: "cutover-machine-a", FromEndpoint: "agent/cutover/source-a", Body: "preserved cutover body", IdempotencyKey: "cutover-message", Now: migrationNow})
+	if err != nil || duplicate {
+		t.Fatalf("source message=%#v duplicate=%t err=%v", message, duplicate, err)
+	}
+	if err := source.ConsumeRequestNonce("cutover-machine-a", "cutover-nonce", migrationNow, migrationNow.Add(time.Hour)); err != nil {
+		t.Fatal(err)
+	}
+	if err := source.Close(); err != nil {
+		t.Fatal(err)
+	}
+	activeSource, err := relay.InspectMigrationSource(ctx, sourcePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	activationEpoch := "019f7f07-8b88-7c12-a394-b663274a6555"
+	activationManifest, err := relay.PrepareMigrationSource(ctx, sourcePath, activationEpoch, targetIdentity, activeSource.Fingerprint, migrationNow.Add(2*time.Hour))
+	if err != nil {
+		t.Fatal(err)
+	}
+	activationRequest := MailCutoverRequest{EpochID: activationEpoch, SourceID: activationManifest.SourceID, TargetIdentity: targetIdentity, SourceFingerprint: activationManifest.Fingerprint}
+	activationRequest.Manifest, _ = json.Marshal(activationManifest)
+	activationDigest := sha256.Sum256(activationRequest.Manifest)
+	activationRequest.ManifestSHA256 = hex.EncodeToString(activationDigest[:])
+	if _, err := admin.BeginMailCutover(ctx, actor, activationRequest); err != nil {
+		t.Fatal(err)
+	}
+	for _, table := range mailCutoverTables {
+		after := ""
+		for {
+			batch, err := relay.ReadMigrationSourceBatch(ctx, sourcePath, table, after, 1)
+			if err != nil {
+				t.Fatalf("source batch table=%s after=%q err=%v", table, after, err)
+			}
+			if _, err := admin.StageMailCutoverBatch(ctx, actor, MailCutoverBatch{EpochID: activationRequest.EpochID, Table: table, AfterKey: after, Rows: batch.Rows, Done: batch.Done}); err != nil {
+				t.Fatalf("activation staging table=%s err=%v", table, err)
+			}
+			if batch.Done {
+				break
+			}
+			after = batch.NextKey
+		}
+	}
+	if _, err := admin.VerifyMailCutover(ctx, actor, activationRequest.EpochID, activationRequest.SourceFingerprint); err != nil {
+		t.Fatal(err)
+	}
+	retiredManifest, err := relay.RetirePreparedMigrationSource(ctx, sourcePath, activationRequest.EpochID, targetIdentity, activationRequest.SourceFingerprint)
+	if err != nil {
+		t.Fatal(err)
+	}
+	active, err := admin.ActivateMailCutover(ctx, actor, activationRequest.EpochID, activationRequest.SourceFingerprint, retiredManifest)
+	if err != nil || active.Phase != MailCutoverActive || !active.ActivatedAt.Valid {
+		t.Fatalf("active mail cutover=%#v err=%v", active, err)
+	}
+	if repeated, err := admin.ActivateMailCutover(ctx, actor, activationRequest.EpochID, activationRequest.SourceFingerprint, retiredManifest); err != nil || repeated.Phase != MailCutoverActive {
+		t.Fatalf("idempotent activation=%#v err=%v", repeated, err)
+	}
+	if err := admin.AbortMailCutover(ctx, actor, activationRequest.EpochID, activationRequest.SourceFingerprint); err == nil {
+		t.Fatal("active mail cutover was abortable")
+	}
+	if err := app.AdvertiseEndpoints("cutover-active-machine", []string{"agent/cutover/active"}, time.Now().UTC(), time.Minute); err != nil {
+		t.Fatalf("PostgreSQL writes did not reopen after activation: %v", err)
+	}
+	var migratedBody string
+	if err := ownerDB.QueryRowContext(ctx, `SELECT body FROM relay.mail_messages WHERE id=$1`, message.ID).Scan(&migratedBody); err != nil || migratedBody != "preserved cutover body" {
+		t.Fatalf("migrated message body=%q err=%v", migratedBody, err)
+	}
+	var migratedEndpoints, migratedMessages, migratedNonces int64
+	if err := ownerDB.QueryRowContext(ctx, `SELECT (SELECT count(*) FROM relay.mail_endpoints),(SELECT count(*) FROM relay.mail_messages),(SELECT count(*) FROM relay.mail_request_nonces)`).Scan(&migratedEndpoints, &migratedMessages, &migratedNonces); err != nil || migratedEndpoints != activationManifest.Counts.Endpoints+1 || migratedMessages != activationManifest.Counts.Messages || migratedNonces != activationManifest.Counts.RequestNonces {
+		t.Fatalf("migrated counts endpoints=%d messages=%d nonces=%d manifest=%#v err=%v", migratedEndpoints, migratedMessages, migratedNonces, activationManifest.Counts, err)
 	}
 }
 

--- a/internal/postgres/postgres_integration_test.go
+++ b/internal/postgres/postgres_integration_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"database/sql"
+	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
@@ -893,7 +894,38 @@ func testMailCutoverSubstrate(ctx context.Context, t *testing.T, app *Database, 
 	if _, err := admin.VerifyMailCutover(ctx, actor, activationRequest.EpochID, activationRequest.SourceFingerprint); err != nil {
 		t.Fatal(err)
 	}
-	if err := admin.CheckMailCutoverActivationReadiness(ctx, uuid.NewString(), activationRequest.EpochID, activationRequest.SourceFingerprint); err == nil {
+	migratedKey := make([]byte, 32)
+	migratedKey[0] = 73
+	migratedKeyDigest := sha256.Sum256(migratedKey)
+	migratedDeviceID, migratedLookupID, migratedLegacyID := uuid.NewString(), uuid.NewString(), uuid.NewString()
+	migratedSecretDigest := sha256.Sum256([]byte(migratedLookupID))
+	if _, err := ownerDB.ExecContext(ctx, `INSERT INTO auth.principals(id,kind,display_name) VALUES($1,'device','cutover migrated device'),($2,'legacy_machine','cutover migrated legacy')`, migratedDeviceID, migratedLegacyID); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ownerDB.ExecContext(ctx, `INSERT INTO auth.device_credentials(lookup_id,principal_id,label,secret_digest) VALUES($1,$2,'cutover migrated device',$3)`, migratedLookupID, migratedDeviceID, migratedSecretDigest[:]); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ownerDB.ExecContext(ctx, `INSERT INTO auth.legacy_machines(principal_id,public_key,public_key_digest,state,migrated_credential_lookup_id) VALUES($1,$2,$3,'migrated',$4)`, migratedLegacyID, migratedKey, migratedKeyDigest[:], migratedLookupID); err != nil {
+		t.Fatal(err)
+	}
+	retiredKey := make([]byte, 32)
+	retiredKey[0] = 74
+	retiredKeyDigest := sha256.Sum256(retiredKey)
+	retiredLegacyID := uuid.NewString()
+	if _, err := ownerDB.ExecContext(ctx, `INSERT INTO auth.principals(id,kind,display_name) VALUES($1,'legacy_machine','cutover retired legacy')`, retiredLegacyID); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ownerDB.ExecContext(ctx, `INSERT INTO auth.legacy_machines(principal_id,public_key,public_key_digest,state) VALUES($1,$2,$3,'retired')`, retiredLegacyID, retiredKey, retiredKeyDigest[:]); err != nil {
+		t.Fatal(err)
+	}
+	activationEnrollment := `[{"id":"cutover-machine-a","public_key":"` + base64.RawURLEncoding.EncodeToString(migratedKey) + `","endpoints":["agent/cutover/source-a"]},{"id":"cutover-machine-b","public_key":"` + base64.RawURLEncoding.EncodeToString(retiredKey) + `","endpoints":["agent/cutover/source-b"]}]`
+	mismatchedKey := append([]byte(nil), migratedKey...)
+	mismatchedKey[0]++
+	mismatchedEnrollment := `[{"id":"cutover-machine-a","public_key":"` + base64.RawURLEncoding.EncodeToString(mismatchedKey) + `","endpoints":["agent/cutover/source-a"]},{"id":"cutover-machine-b","public_key":"` + base64.RawURLEncoding.EncodeToString(retiredKey) + `","endpoints":["agent/cutover/source-b"]}]`
+	if err := admin.CheckMailCutoverActivationReadiness(ctx, actor, activationRequest.EpochID, activationRequest.SourceFingerprint, mismatchedEnrollment); err == nil {
+		t.Fatal("activation readiness accepted a static enrollment key that did not match migrated inventory")
+	}
+	if err := admin.CheckMailCutoverActivationReadiness(ctx, uuid.NewString(), activationRequest.EpochID, activationRequest.SourceFingerprint, activationEnrollment); err == nil {
 		t.Fatal("non-owner passed activation readiness")
 	}
 	pendingLegacyKey := make([]byte, 32)
@@ -906,7 +938,7 @@ func testMailCutoverSubstrate(ctx context.Context, t *testing.T, app *Database, 
 	if _, err := ownerDB.ExecContext(ctx, `INSERT INTO auth.legacy_machines(principal_id,public_key,public_key_digest) VALUES($1,$2,$3)`, pendingLegacyID, pendingLegacyKey, pendingLegacyDigest[:]); err != nil {
 		t.Fatal(err)
 	}
-	if err := admin.CheckMailCutoverActivationReadiness(ctx, actor, activationRequest.EpochID, activationRequest.SourceFingerprint); err == nil {
+	if err := admin.CheckMailCutoverActivationReadiness(ctx, actor, activationRequest.EpochID, activationRequest.SourceFingerprint, activationEnrollment); err == nil {
 		t.Fatal("activation readiness accepted a pending legacy machine")
 	}
 	if sourceState, err := relay.InspectMigrationSource(ctx, sourcePath); err != nil || sourceState.Phase != relay.MigrationSourcePrepared {
@@ -915,8 +947,11 @@ func testMailCutoverSubstrate(ctx context.Context, t *testing.T, app *Database, 
 	if err := admin.RetireLegacyMachine(ctx, actor, pendingLegacyID); err != nil {
 		t.Fatal(err)
 	}
-	if err := admin.CheckMailCutoverActivationReadiness(ctx, actor, activationRequest.EpochID, activationRequest.SourceFingerprint); err != nil {
+	if err := admin.CheckMailCutoverActivationReadiness(ctx, actor, activationRequest.EpochID, activationRequest.SourceFingerprint, activationEnrollment); err != nil {
 		t.Fatalf("resolved activation readiness: %v", err)
+	}
+	if err := admin.RetireLegacyMachine(ctx, actor, migratedLegacyID); err == nil {
+		t.Fatal("migrated legacy mapping was retired after cutover readiness")
 	}
 	if _, err := ownerDB.ExecContext(ctx, `UPDATE auth.legacy_auth_state SET enabled=true,changed_at=statement_timestamp() WHERE singleton`); err != nil {
 		t.Fatal(err)
@@ -928,7 +963,7 @@ func testMailCutoverSubstrate(ctx context.Context, t *testing.T, app *Database, 
 		_, registerErr := admin.RegisterLegacyMachine(ctx, actor, "cutover readiness race", key)
 		registrationResult <- registerErr
 	}()
-	if err := admin.CheckMailCutoverActivationReadiness(ctx, actor, activationRequest.EpochID, activationRequest.SourceFingerprint); err != nil {
+	if err := admin.CheckMailCutoverActivationReadiness(ctx, actor, activationRequest.EpochID, activationRequest.SourceFingerprint, activationEnrollment); err != nil {
 		t.Fatalf("concurrent activation readiness: %v", err)
 	}
 	if err := <-registrationResult; err == nil {

--- a/internal/postgres/postgres_integration_test.go
+++ b/internal/postgres/postgres_integration_test.go
@@ -1287,7 +1287,7 @@ func testV5UpdateBridgeIntegration(ctx context.Context, t *testing.T, ownerDB *s
 	request = UpdateRequest{
 		UpdateID:                "019b4eb0-798c-7a52-8d29-8560fcbb2086",
 		SourceRelease:           "v0.8.0",
-		TargetRelease:           "v0.8.0",
+		TargetRelease:           "v0.9.0",
 		SourceImage:             "ghcr.io/rock3r/punaro@sha256:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
 		TargetImage:             "ghcr.io/rock3r/punaro@sha256:eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
 		SourceSchema:            7,
@@ -1349,8 +1349,8 @@ func testV5UpdateBridgeIntegration(ctx context.Context, t *testing.T, ownerDB *s
 
 	request = UpdateRequest{
 		UpdateID:                "019b4eb0-798c-7a52-8d29-8560fcbb2087",
-		SourceRelease:           "v0.8.0",
-		TargetRelease:           "v0.9.0",
+		SourceRelease:           "v0.9.0",
+		TargetRelease:           "v0.10.0",
 		SourceImage:             "ghcr.io/rock3r/punaro@sha256:eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
 		TargetImage:             "ghcr.io/rock3r/punaro@sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
 		SourceSchema:            8,

--- a/internal/postgres/relay_store.go
+++ b/internal/postgres/relay_store.go
@@ -232,6 +232,9 @@ func (d *Database) AppendMessage(input relay.AppendInput) (relay.Message, bool, 
 	if len(input.Body) > postgresRelayMaxMessageBytes {
 		return relay.Message{}, false, errors.New("message body exceeds limit")
 	}
+	if !relay.ValidMessageBody(input.Body) {
+		return relay.Message{}, false, errors.New("message body is not portable UTF-8 text")
+	}
 	if _, err := uuid.Parse(input.ConversationID); err != nil {
 		return relay.Message{}, false, relay.ErrForbidden
 	}

--- a/internal/postgres/state_test.go
+++ b/internal/postgres/state_test.go
@@ -79,3 +79,13 @@ func TestCurrentManifestRequiresControlPlaneSchema(t *testing.T) {
 		}
 	}
 }
+
+func TestCompatibleSchemaCanStillHavePendingMigrations(t *testing.T) {
+	manifest := CurrentManifest()
+	if !migrationPending(SchemaState{Classification: Compatible, Version: 8}, manifest) {
+		t.Fatal("compatible v8 schema must still apply the pending v9 migration")
+	}
+	if migrationPending(SchemaState{Classification: Compatible, Version: 9}, manifest) {
+		t.Fatal("current v9 schema reported a pending migration")
+	}
+}

--- a/internal/postgres/state_test.go
+++ b/internal/postgres/state_test.go
@@ -66,12 +66,16 @@ func TestManifestValidationRejectsMutableOrNonContiguousHistory(t *testing.T) {
 
 func TestCurrentManifestRequiresControlPlaneSchema(t *testing.T) {
 	manifest := CurrentManifest()
-	if manifest.MinSupported != 8 || manifest.MaxSupported != 8 || len(manifest.Migrations) != 8 {
-		t.Fatalf("manifest=%#v, want exact v8 compatibility window", manifest)
+	if manifest.MinSupported != 8 || manifest.MaxSupported != 9 || len(manifest.Migrations) != 9 {
+		t.Fatalf("manifest=%#v, want exact v8-v9 compatibility window", manifest)
 	}
 	for index, migration := range manifest.Migrations {
-		if migration.CompatibilityFloor != int64(index+1) {
-			t.Fatalf("migration %d floor=%d, want %d", index+1, migration.CompatibilityFloor, index+1)
+		want := int64(index + 1)
+		if want == 9 {
+			want = 8
+		}
+		if migration.CompatibilityFloor != want {
+			t.Fatalf("migration %d floor=%d, want %d", index+1, migration.CompatibilityFloor, want)
 		}
 	}
 }

--- a/internal/relay/backend.go
+++ b/internal/relay/backend.go
@@ -8,7 +8,7 @@ import (
 )
 
 func validBoundedText(value string, maxCharacters, maxBytes int) bool {
-	if value == "" || strings.TrimSpace(value) != value || len(value) > maxBytes || utf8.RuneCountInString(value) > maxCharacters {
+	if value == "" || !utf8.ValidString(value) || strings.TrimSpace(value) != value || len(value) > maxBytes || utf8.RuneCountInString(value) > maxCharacters {
 		return false
 	}
 	for _, character := range value {
@@ -28,6 +28,12 @@ func ValidEndpoint(value string) bool { return validBoundedText(value, 512, 2048
 
 // ValidRequestToken bounds nonces, idempotency keys, and consumer identities.
 func ValidRequestToken(value string) bool { return validBoundedText(value, 128, 512) }
+
+// ValidMessageBody reports whether a message has a portable SQLite/PostgreSQL
+// text representation within the durable relay limit.
+func ValidMessageBody(value string) bool {
+	return len(value) <= maxMessageBodyBytes && utf8.ValidString(value) && !strings.ContainsRune(value, 0)
+}
 
 // AppendRequestHash binds a message idempotency key to its immutable request.
 func AppendRequestHash(input AppendInput) string { return appendHash(input) }

--- a/internal/relay/enrollment.go
+++ b/internal/relay/enrollment.go
@@ -26,12 +26,20 @@ func (enrollmentValidationTransition) AuthorizeTransition(context.Context, strin
 // ValidateMachineEnrollments proves that raw enrollment JSON is safe for the
 // transition runtime, including non-overlapping authority and unique keys.
 func ValidateMachineEnrollments(raw string) error {
+	_, _, err := machineEnrollmentAuthenticator(raw)
+	return err
+}
+
+func machineEnrollmentAuthenticator(raw string) (*Authenticator, []Machine, error) {
 	machines, err := ParseMachineEnrollments(raw)
 	if err != nil {
-		return err
+		return nil, nil, err
 	}
-	_, err = newAuthenticator(enrollmentValidationStore{}, machines, enrollmentValidationTransition{})
-	return err
+	authenticator, err := newAuthenticator(enrollmentValidationStore{}, machines, enrollmentValidationTransition{})
+	if err != nil {
+		return nil, nil, err
+	}
+	return authenticator, machines, nil
 }
 
 // ParseMachineEnrollments parses the non-secret daemon enrollment setting. It

--- a/internal/relay/enrollment.go
+++ b/internal/relay/enrollment.go
@@ -1,13 +1,38 @@
 package relay
 
 import (
+	"context"
 	"crypto/ed25519"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"io"
 	"strings"
+	"time"
 )
+
+type enrollmentValidationStore struct{}
+
+func (enrollmentValidationStore) ConsumeRequestNonce(string, string, time.Time, time.Time) error {
+	return nil
+}
+
+type enrollmentValidationTransition struct{}
+
+func (enrollmentValidationTransition) AuthorizeTransition(context.Context, string, ed25519.PublicKey) (TransitionAuthorization, error) {
+	return TransitionAuthorization{}, ErrForbidden
+}
+
+// ValidateMachineEnrollments proves that raw enrollment JSON is safe for the
+// transition runtime, including non-overlapping authority and unique keys.
+func ValidateMachineEnrollments(raw string) error {
+	machines, err := ParseMachineEnrollments(raw)
+	if err != nil {
+		return err
+	}
+	_, err = newAuthenticator(enrollmentValidationStore{}, machines, enrollmentValidationTransition{})
+	return err
+}
 
 // ParseMachineEnrollments parses the non-secret daemon enrollment setting. It
 // deliberately accepts public keys only; an adapter's private key must never

--- a/internal/relay/enrollment_test.go
+++ b/internal/relay/enrollment_test.go
@@ -54,6 +54,15 @@ func TestParseMachineEnrollmentsRejectsNonCanonicalAttachmentDeviceBinding(t *te
 	}
 }
 
+func TestValidateMachineEnrollmentsRejectsAmbiguousAuthority(t *testing.T) {
+	if err := ValidateMachineEnrollments(`[{"id":"machine-a","public_key":"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA","endpoint_prefixes":["agent/"]},{"id":"machine-b","public_key":"AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA","endpoint_prefixes":["agent/a/"]}]`); err == nil {
+		t.Fatal("overlapping endpoint authority was accepted")
+	}
+	if err := ValidateMachineEnrollments(`[{"id":"machine-a","public_key":"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA","endpoint_prefixes":["agent/a/"]},{"id":"machine-b","public_key":"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA","endpoint_prefixes":["agent/b/"]}]`); err == nil {
+		t.Fatal("ambiguous transition public key was accepted")
+	}
+}
+
 func TestAuthenticatorRejectsDuplicatedAttachmentDeviceBinding(t *testing.T) {
 	publicKey := make([]byte, 32)
 	publicKey[0] = 1

--- a/internal/relay/migration_batch.go
+++ b/internal/relay/migration_batch.go
@@ -1,0 +1,267 @@
+package relay
+
+import (
+	"context"
+	"crypto/sha256"
+	"database/sql"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"hash"
+	"io"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+const maxMigrationBatchRows = 256
+
+var migrationRowDigestPattern = regexp.MustCompile(`^[0-9a-f]{64}$`)
+
+// MigrationSourceRow is one canonical, content-addressed SQLite relay row.
+// Payload contains only the allowlisted logical columns from the source
+// manifest; Key is an opaque resume cursor derived from the table primary key.
+type MigrationSourceRow struct {
+	Table   string          `json:"table"`
+	Key     string          `json:"key"`
+	Payload json.RawMessage `json:"payload"`
+	SHA256  string          `json:"sha256"`
+}
+
+// MigrationSourceBatch is a bounded page from one prepared SQLite source.
+type MigrationSourceBatch struct {
+	Rows    []MigrationSourceRow `json:"rows"`
+	NextKey string               `json:"next_key,omitempty"`
+	Done    bool                 `json:"done"`
+}
+
+// MigrationTableHasher verifies exported rows and reproduces the exact
+// per-table count and digest committed by MigrationSourceManifest.
+type MigrationTableHasher struct {
+	table   string
+	columns []string
+	hash    hash.Hash
+	count   int64
+}
+
+// NewMigrationTableHasher creates a streaming verifier for one allowlisted
+// destination table.
+func NewMigrationTableHasher(table string) (*MigrationTableHasher, error) {
+	for _, spec := range migrationBatchSpecs {
+		if spec.target == table {
+			return &MigrationTableHasher{table: table, columns: strings.Split(spec.source.columns, ","), hash: sha256.New()}, nil
+		}
+	}
+	return nil, errors.New("invalid relay migration table")
+}
+
+// Add verifies one row envelope and adds its source values in manifest order.
+func (h *MigrationTableHasher) Add(row MigrationSourceRow) error {
+	if h == nil || h.hash == nil || row.Table != h.table || row.Key == "" || len(row.Key) > 4096 || len(row.Payload) == 0 || len(row.Payload) > 65536 || !migrationRowDigestPattern.MatchString(row.SHA256) {
+		return errors.New("invalid relay migration row")
+	}
+	digest := sha256.Sum256(row.Payload)
+	if hex.EncodeToString(digest[:]) != row.SHA256 {
+		return errors.New("relay migration row digest does not match")
+	}
+	decoder := json.NewDecoder(strings.NewReader(string(row.Payload)))
+	decoder.UseNumber()
+	var payload map[string]any
+	if err := decoder.Decode(&payload); err != nil {
+		return errors.New("relay migration row payload is invalid")
+	}
+	if err := decoder.Decode(&struct{}{}); !errors.Is(err, io.EOF) || len(payload) != len(h.columns) {
+		return errors.New("relay migration row payload is invalid")
+	}
+	for _, column := range h.columns {
+		value, ok := payload[column]
+		if !ok {
+			return errors.New("relay migration row payload is incomplete")
+		}
+		if number, ok := value.(json.Number); ok {
+			integer, err := strconv.ParseInt(string(number), 10, 64)
+			if err != nil {
+				return errors.New("relay migration row number is invalid")
+			}
+			value = integer
+		} else if value != nil {
+			if _, ok := value.(string); !ok {
+				return errors.New("relay migration row value is invalid")
+			}
+		}
+		if err := writeMigrationHashValue(h.hash, value); err != nil {
+			return err
+		}
+	}
+	h.count++
+	return nil
+}
+
+// Evidence returns the current exact row count and manifest-compatible digest.
+func (h *MigrationTableHasher) Evidence() (int64, string) {
+	if h == nil || h.hash == nil {
+		return 0, ""
+	}
+	return h.count, hex.EncodeToString(h.hash.Sum(nil))
+}
+
+type migrationBatchSpec struct {
+	target     string
+	source     migrationTableSpec
+	keyColumns []string
+}
+
+var migrationBatchSpecs = []migrationBatchSpec{
+	{target: "mail_endpoints", source: migrationTableSpecs[0], keyColumns: []string{"endpoint"}},
+	{target: "mail_conversations", source: migrationTableSpecs[1], keyColumns: []string{"id"}},
+	{target: "mail_memberships", source: migrationTableSpecs[2], keyColumns: []string{"conversation_id", "endpoint"}},
+	{target: "mail_messages", source: migrationTableSpecs[3], keyColumns: []string{"id"}},
+	{target: "mail_deliveries", source: migrationTableSpecs[4], keyColumns: []string{"id"}},
+	{target: "mail_recipient_cursors", source: migrationTableSpecs[5], keyColumns: []string{"recipient_endpoint", "conversation_id"}},
+	{target: "mail_message_idempotency", source: migrationTableSpecs[6], keyColumns: []string{"machine_id", "key"}},
+	{target: "mail_conversation_idempotency", source: migrationTableSpecs[7], keyColumns: []string{"machine_id", "key"}},
+	{target: "mail_request_nonces", source: migrationTableSpecs[8], keyColumns: []string{"machine_id", "nonce"}},
+}
+
+// ReadMigrationSourceBatch reads one bounded page from the exact prepared
+// snapshot. The caller must present the last returned key to resume; invented
+// or stale cursors fail closed instead of skipping source rows.
+func ReadMigrationSourceBatch(ctx context.Context, path, table, afterKey string, limit int) (MigrationSourceBatch, error) {
+	if limit < 1 || limit > maxMigrationBatchRows {
+		return MigrationSourceBatch{}, errors.New("invalid relay migration batch")
+	}
+	var spec *migrationBatchSpec
+	for index := range migrationBatchSpecs {
+		if migrationBatchSpecs[index].target == table {
+			spec = &migrationBatchSpecs[index]
+			break
+		}
+	}
+	if spec == nil {
+		return MigrationSourceBatch{}, errors.New("invalid relay migration batch")
+	}
+	db, err := openMigrationSourceDatabase(path, true)
+	if err != nil {
+		return MigrationSourceBatch{}, err
+	}
+	defer func() { _ = db.Close() }()
+	tx, err := db.BeginTx(ctx, &sql.TxOptions{ReadOnly: true})
+	if err != nil {
+		return MigrationSourceBatch{}, errors.New("relay migration batch snapshot cannot start")
+	}
+	defer func() { _ = tx.Rollback() }()
+	manifest, err := inspectMigrationSource(ctx, tx)
+	if err != nil {
+		return MigrationSourceBatch{}, err
+	}
+	if manifest.Phase != MigrationSourcePrepared {
+		return MigrationSourceBatch{}, errors.New("relay migration source is not prepared")
+	}
+	var keyValues []any
+	where := ""
+	if afterKey != "" {
+		parts := strings.Split(afterKey, "\x1f")
+		if len(parts) != len(spec.keyColumns) {
+			return MigrationSourceBatch{}, errors.New("relay migration resume key is invalid")
+		}
+		keyValues = make([]any, len(parts))
+		predicates := make([]string, len(parts))
+		placeholders := make([]string, len(parts))
+		for index, part := range parts {
+			if part == "" || strings.ContainsRune(part, 0) || strings.ContainsRune(part, '\x1f') {
+				return MigrationSourceBatch{}, errors.New("relay migration resume key is invalid")
+			}
+			keyValues[index] = part
+			predicates[index] = spec.keyColumns[index] + "=?"
+			placeholders[index] = "?"
+		}
+		var present int
+		// #nosec G201 -- identifiers come only from migrationBatchSpecs.
+		exactQuery := fmt.Sprintf("SELECT 1 FROM %s WHERE %s LIMIT 1", spec.source.name, strings.Join(predicates, " AND "))
+		if err := tx.QueryRowContext(ctx, exactQuery, keyValues...).Scan(&present); err != nil || present != 1 { // #nosec G202 -- fragments come only from migrationBatchSpecs.
+			return MigrationSourceBatch{}, errors.New("relay migration resume key is unavailable")
+		}
+		if len(parts) == 1 {
+			where = " WHERE " + spec.keyColumns[0] + ">?"
+		} else {
+			where = " WHERE (" + strings.Join(spec.keyColumns, ",") + ")>(" + strings.Join(placeholders, ",") + ")"
+		}
+	}
+	// #nosec G201 -- fragments come only from migrationBatchSpecs.
+	query := fmt.Sprintf("SELECT %s FROM %s%s ORDER BY %s LIMIT ?", spec.source.columns, spec.source.name, where, spec.source.order)
+	arguments := make([]any, 0, len(keyValues)+1)
+	arguments = append(arguments, keyValues...)
+	arguments = append(arguments, limit+1)
+	rows, err := tx.QueryContext(ctx, query, arguments...) // #nosec G202 -- fragments come only from migrationBatchSpecs.
+	if err != nil {
+		return MigrationSourceBatch{}, errors.New("relay migration batch rows are unavailable")
+	}
+	defer func() { _ = rows.Close() }()
+	columns := strings.Split(spec.source.columns, ",")
+	keyIndexes := make([]int, len(spec.keyColumns))
+	for keyIndex, keyColumn := range spec.keyColumns {
+		keyIndexes[keyIndex] = -1
+		for columnIndex, column := range columns {
+			if column == keyColumn {
+				keyIndexes[keyIndex] = columnIndex
+				break
+			}
+		}
+		if keyIndexes[keyIndex] < 0 {
+			return MigrationSourceBatch{}, errors.New("relay migration batch schema is invalid")
+		}
+	}
+	batch := MigrationSourceBatch{Rows: make([]MigrationSourceRow, 0, limit), Done: true}
+	for rows.Next() {
+		values := make([]any, len(columns))
+		destinations := make([]any, len(columns))
+		for index := range values {
+			destinations[index] = &values[index]
+		}
+		if err := rows.Scan(destinations...); err != nil {
+			return MigrationSourceBatch{}, errors.New("relay migration batch row is malformed")
+		}
+		keyValues := make([]string, len(keyIndexes))
+		for index, columnIndex := range keyIndexes {
+			value, ok := values[columnIndex].(string)
+			if !ok || value == "" || strings.ContainsRune(value, 0) || strings.ContainsRune(value, '\x1f') {
+				return MigrationSourceBatch{}, errors.New("relay migration batch key is invalid")
+			}
+			keyValues[index] = value
+		}
+		key := encodeMigrationRowKey(keyValues)
+		if len(key) == 0 || len(key) > 4096 {
+			return MigrationSourceBatch{}, errors.New("relay migration batch key is invalid")
+		}
+		if len(batch.Rows) == limit {
+			batch.Done = false
+			break
+		}
+		payloadValues := make(map[string]any, len(columns))
+		for index, column := range columns {
+			payloadValues[column] = values[index]
+		}
+		payload, err := json.Marshal(payloadValues)
+		if err != nil || len(payload) == 0 || len(payload) > 65536 {
+			return MigrationSourceBatch{}, errors.New("relay migration batch payload is invalid")
+		}
+		digest := sha256.Sum256(payload)
+		batch.Rows = append(batch.Rows, MigrationSourceRow{Table: table, Key: key, Payload: payload, SHA256: hex.EncodeToString(digest[:])})
+		batch.NextKey = key
+	}
+	if err := rows.Err(); err != nil {
+		return MigrationSourceBatch{}, errors.New("relay migration batch rows are unavailable")
+	}
+	if err := tx.Commit(); err != nil {
+		return MigrationSourceBatch{}, errors.New("relay migration batch snapshot cannot commit")
+	}
+	return batch, nil
+}
+
+// encodeMigrationRowKey preserves SQLite's binary string ordering. Source key
+// columns reject control characters, so unit separator is an unambiguous tuple
+// delimiter and the raw UTF-8 cursor remains within the 4096-byte bound.
+func encodeMigrationRowKey(values []string) string {
+	return strings.Join(values, "\x1f")
+}

--- a/internal/relay/migration_batch.go
+++ b/internal/relay/migration_batch.go
@@ -19,6 +19,10 @@ const maxMigrationBatchRows = 256
 
 var migrationRowDigestPattern = regexp.MustCompile(`^[0-9a-f]{64}$`)
 
+// MaxMigrationSourcePayloadBytes accounts for worst-case JSON escaping of a
+// valid 32 KiB message body plus its bounded canonical metadata.
+const MaxMigrationSourcePayloadBytes = 256 << 10
+
 // MigrationSourceRow is one canonical, content-addressed SQLite relay row.
 // Payload contains only the allowlisted logical columns from the source
 // manifest; Key is an opaque resume cursor derived from the table primary key.
@@ -58,7 +62,7 @@ func NewMigrationTableHasher(table string) (*MigrationTableHasher, error) {
 
 // Add verifies one row envelope and adds its source values in manifest order.
 func (h *MigrationTableHasher) Add(row MigrationSourceRow) error {
-	if h == nil || h.hash == nil || row.Table != h.table || row.Key == "" || len(row.Key) > 4096 || len(row.Payload) == 0 || len(row.Payload) > 65536 || !migrationRowDigestPattern.MatchString(row.SHA256) {
+	if h == nil || h.hash == nil || row.Table != h.table || row.Key == "" || len(row.Key) > 4096 || len(row.Payload) == 0 || len(row.Payload) > MaxMigrationSourcePayloadBytes || !migrationRowDigestPattern.MatchString(row.SHA256) {
 		return errors.New("invalid relay migration row")
 	}
 	digest := sha256.Sum256(row.Payload)
@@ -243,7 +247,7 @@ func ReadMigrationSourceBatch(ctx context.Context, path, table, afterKey string,
 			payloadValues[column] = values[index]
 		}
 		payload, err := json.Marshal(payloadValues)
-		if err != nil || len(payload) == 0 || len(payload) > 65536 {
+		if err != nil || len(payload) == 0 || len(payload) > MaxMigrationSourcePayloadBytes {
 			return MigrationSourceBatch{}, errors.New("relay migration batch payload is invalid")
 		}
 		digest := sha256.Sum256(payload)

--- a/internal/relay/migration_source.go
+++ b/internal/relay/migration_source.go
@@ -119,6 +119,46 @@ func InspectMigrationSource(ctx context.Context, path string) (MigrationSourceMa
 	return manifest, nil
 }
 
+// CheckMigrationSourceEnrollmentCoverage proves every existing SQLite endpoint
+// remains claimable by at least one machine in the static PostgreSQL runtime.
+func CheckMigrationSourceEnrollmentCoverage(ctx context.Context, path, enrollment string) error {
+	authenticator, _, err := machineEnrollmentAuthenticator(enrollment)
+	if err != nil {
+		return errors.New("relay migration enrollment is invalid")
+	}
+	db, err := openMigrationSourceDatabase(path, true)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = db.Close() }()
+	tx, err := db.BeginTx(ctx, &sql.TxOptions{ReadOnly: true})
+	if err != nil {
+		return errors.New("relay migration enrollment snapshot cannot start")
+	}
+	defer func() { _ = tx.Rollback() }()
+	if _, err := inspectMigrationSource(ctx, tx); err != nil {
+		return err
+	}
+	rows, err := tx.QueryContext(ctx, `SELECT endpoint, machine_id FROM endpoints ORDER BY endpoint COLLATE BINARY`)
+	if err != nil {
+		return errors.New("relay migration endpoints are unavailable")
+	}
+	for rows.Next() {
+		var endpoint, machineID string
+		if err := rows.Scan(&endpoint, &machineID); err != nil || !authenticator.AllowsEndpoint(machineID, endpoint) {
+			_ = rows.Close()
+			return errors.New("relay migration enrollment does not cover every endpoint")
+		}
+	}
+	if err := rows.Close(); err != nil || rows.Err() != nil {
+		return errors.New("relay migration endpoints are unavailable")
+	}
+	if err := tx.Commit(); err != nil {
+		return errors.New("relay migration enrollment snapshot cannot commit")
+	}
+	return nil
+}
+
 // PrepareMigrationSource fences every SQLite relay mutation, advances all
 // carried lease fences, and records the exact post-fence logical fingerprint.
 func PrepareMigrationSource(ctx context.Context, path, epochID, targetIdentity, expectedFingerprint string, now time.Time) (MigrationSourceManifest, error) {

--- a/internal/relay/migration_source.go
+++ b/internal/relay/migration_source.go
@@ -69,6 +69,7 @@ type MigrationSourceManifest struct {
 	Counts                  MigrationSourceCounts `json:"counts"`
 	TableSHA256             MigrationSourceHashes `json:"table_sha256"`
 	Fingerprint             string                `json:"fingerprint"`
+	ExpectedFingerprint     string                `json:"-"`
 	lastEpochID             string
 	lastTargetIdentity      string
 	lastExpectedFingerprint string
@@ -153,6 +154,7 @@ func PrepareMigrationSource(ctx context.Context, path, epochID, targetIdentity, 
 		prepared.lastEpochID = epochID
 		prepared.lastTargetIdentity = targetIdentity
 		prepared.lastExpectedFingerprint = expectedFingerprint
+		prepared.ExpectedFingerprint = expectedFingerprint
 		prepared.lastResultFingerprint = prepared.Fingerprint
 		prepared.lastCutoff = now.UTC().UnixMilli()
 		prepared.lastTransition = "prepared"
@@ -182,7 +184,7 @@ func transitionPreparedMigrationSource(ctx context.Context, path, epochID, targe
 			}
 			return MigrationSourceManifest{}, ErrMigrationSourceRetired
 		}
-		if current.Phase == MigrationSourceActive && target == MigrationSourceActive && current.Fingerprint == fingerprint && current.lastEpochID == epochID && current.lastTargetIdentity == targetIdentity && current.lastResultFingerprint == fingerprint && current.lastTransition == "aborted" {
+		if current.Phase == MigrationSourceActive && target == MigrationSourceActive && current.lastEpochID == epochID && current.lastTargetIdentity == targetIdentity && current.lastResultFingerprint == fingerprint && current.lastTransition == "aborted" {
 			return current, nil
 		}
 		if current.Phase != MigrationSourcePrepared || current.EpochID != epochID || current.TargetIdentity != targetIdentity || current.Fingerprint != fingerprint {
@@ -258,6 +260,7 @@ func inspectMigrationSource(ctx context.Context, q migrationQueryer) (MigrationS
 	if err := q.QueryRowContext(ctx, `SELECT source_id,phase,COALESCE(epoch_id,''),COALESCE(target_identity,''),fingerprint,COALESCE(last_epoch_id,''),COALESCE(last_target_identity,''),COALESCE(last_expected_fingerprint,''),COALESCE(last_result_fingerprint,''),COALESCE(last_cutoff,0),COALESCE(last_transition,'') FROM relay_migration_control WHERE singleton=1`).Scan(&manifest.SourceID, &manifest.Phase, &manifest.EpochID, &manifest.TargetIdentity, &storedFingerprint, &manifest.lastEpochID, &manifest.lastTargetIdentity, &manifest.lastExpectedFingerprint, &manifest.lastResultFingerprint, &manifest.lastCutoff, &manifest.lastTransition); err != nil || uuid.Validate(manifest.SourceID) != nil {
 		return MigrationSourceManifest{}, errors.New("relay migration source control is unavailable")
 	}
+	manifest.ExpectedFingerprint = manifest.lastExpectedFingerprint
 	if manifest.Phase != MigrationSourceActive && manifest.Phase != MigrationSourcePrepared && manifest.Phase != MigrationSourceRetired {
 		return MigrationSourceManifest{}, errors.New("relay migration source phase is invalid")
 	}

--- a/internal/relay/migration_source.go
+++ b/internal/relay/migration_source.go
@@ -15,6 +15,7 @@ import (
 	"sort"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"github.com/google/uuid"
 )
@@ -347,7 +348,11 @@ func inspectMigrationSource(ctx context.Context, q migrationQueryer) (MigrationS
 				_ = rows.Close()
 				return MigrationSourceManifest{}, errors.New("relay migration source row is malformed")
 			}
-			for _, value := range values {
+			for index, value := range values {
+				if err := validateMigrationSourceValue(spec.name, columns[index], value); err != nil {
+					_ = rows.Close()
+					return MigrationSourceManifest{}, err
+				}
 				if err := writeMigrationHashValue(tableHash, value); err != nil {
 					_ = rows.Close()
 					return MigrationSourceManifest{}, err
@@ -616,6 +621,32 @@ func verifyMigrationSourceSchema(ctx context.Context, q migrationQueryer) error 
 	return nil
 }
 
+func validateMigrationSourceValue(table, column string, value any) error {
+	text, ok := value.(string)
+	if !ok {
+		return nil
+	}
+	var valid bool
+	switch table + "." + column {
+	case "endpoints.endpoint", "memberships.endpoint", "messages.from_endpoint", "deliveries.recipient_endpoint", "recipient_cursors.recipient_endpoint":
+		valid = ValidEndpoint(text)
+	case "endpoints.machine_id", "deliveries.lease_machine_id", "idempotency.machine_id", "conversation_idempotency.machine_id", "request_nonces.machine_id":
+		valid = ValidMachineID(text)
+	case "endpoints.consumer_id", "idempotency.key", "conversation_idempotency.key", "request_nonces.nonce":
+		valid = ValidRequestToken(text)
+	case "messages.body":
+		valid = ValidMessageBody(text)
+	case "conversations.id", "memberships.conversation_id", "messages.id", "messages.conversation_id", "deliveries.id", "deliveries.message_id", "recipient_cursors.conversation_id", "idempotency.message_id", "conversation_idempotency.conversation_id":
+		valid = uuid.Validate(text) == nil
+	default:
+		return nil
+	}
+	if !valid {
+		return errors.New("relay migration source contains invalid portable text")
+	}
+	return nil
+}
+
 func writeMigrationHashValue(destination hash.Hash, value any) error {
 	var kind byte
 	var body []byte
@@ -627,6 +658,9 @@ func writeMigrationHashValue(destination hash.Hash, value any) error {
 		body = make([]byte, 8)
 		binary.BigEndian.PutUint64(body, uint64(typed)) // #nosec G115 -- two's-complement bits are the canonical signed-int encoding.
 	case string:
+		if !utf8.ValidString(typed) || strings.ContainsRune(typed, 0) {
+			return errors.New("relay migration source contains non-portable text")
+		}
 		kind, body = 2, []byte(typed)
 	case []byte:
 		kind, body = 3, typed

--- a/internal/relay/migration_source_test.go
+++ b/internal/relay/migration_source_test.go
@@ -2,6 +2,7 @@ package relay
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"os"
 	"path/filepath"
@@ -92,6 +93,49 @@ func TestMigrationSourceManifestAndBarrier(t *testing.T) {
 	if _, err := PrepareMigrationSource(ctx, path, epochID, targetID, first.Fingerprint, now.Add(2*time.Minute)); err == nil {
 		t.Fatal("changed prepare cutoff was accepted as an exact retry")
 	}
+	firstBatch, err := ReadMigrationSourceBatch(ctx, path, "mail_endpoints", "", 1)
+	if err != nil || len(firstBatch.Rows) != 1 || firstBatch.Done || firstBatch.NextKey == "" {
+		t.Fatalf("first migration batch=%#v err=%v", firstBatch, err)
+	}
+	secondBatch, err := ReadMigrationSourceBatch(ctx, path, "mail_endpoints", firstBatch.NextKey, 1)
+	if err != nil || len(secondBatch.Rows) != 1 || !secondBatch.Done || secondBatch.NextKey == firstBatch.NextKey {
+		t.Fatalf("second migration batch=%#v err=%v", secondBatch, err)
+	}
+	if firstBatch.Rows[0].Table != "mail_endpoints" || firstBatch.Rows[0].Key >= secondBatch.Rows[0].Key || firstBatch.Rows[0].SHA256 == "" {
+		t.Fatalf("noncanonical migration rows first=%#v second=%#v", firstBatch.Rows[0], secondBatch.Rows[0])
+	}
+	endpointHasher, err := NewMigrationTableHasher("mail_endpoints")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, row := range append(firstBatch.Rows, secondBatch.Rows...) {
+		if err := endpointHasher.Add(row); err != nil {
+			t.Fatal(err)
+		}
+	}
+	endpointCount, endpointSHA256 := endpointHasher.Evidence()
+	if endpointCount != prepared.Counts.Endpoints || endpointSHA256 != prepared.TableSHA256.Endpoints {
+		t.Fatalf("export evidence count=%d sha=%s manifest=%#v", endpointCount, endpointSHA256, prepared)
+	}
+	deliveryBatch, err := ReadMigrationSourceBatch(ctx, path, "mail_deliveries", "", 10)
+	if err != nil || len(deliveryBatch.Rows) != 1 || !deliveryBatch.Done {
+		t.Fatalf("delivery migration batch=%#v err=%v", deliveryBatch, err)
+	}
+	var delivery map[string]any
+	if err := json.Unmarshal(deliveryBatch.Rows[0].Payload, &delivery); err != nil {
+		t.Fatal(err)
+	}
+	for _, field := range []string{"lease_machine_id", "lease_token", "ownership_generation", "consumer_generation", "lease_until"} {
+		if delivery[field] != nil {
+			t.Fatalf("prepared delivery retained %s=%v", field, delivery[field])
+		}
+	}
+	if _, err := ReadMigrationSourceBatch(ctx, path, "mail_endpoints", "missing-key", 1); err == nil {
+		t.Fatal("migration batch accepted an unknown resume key")
+	}
+	if _, err := ReadMigrationSourceBatch(ctx, path, "unknown", "", 1); err == nil {
+		t.Fatal("migration batch accepted an unknown table")
+	}
 	if _, err := store.db.ExecContext(ctx, `INSERT INTO request_nonces(machine_id,nonce,expires_at) VALUES('old-daemon','blocked-direct-write',?)`, now.Add(time.Hour).UnixMilli()); err == nil || !strings.Contains(err.Error(), "relay migration source is not writable") {
 		t.Fatalf("persisted mutation trigger err=%v", err)
 	}
@@ -135,8 +179,8 @@ func TestMigrationSourceManifestAndBarrier(t *testing.T) {
 	if err := store.ConsumeRequestNonce("machine-a", "post-abort-write", now.Add(2*time.Minute), now.Add(3*time.Minute)); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := AbortPreparedMigrationSource(ctx, path, epochID, targetID, prepared.Fingerprint); err == nil {
-		t.Fatal("stale abort retry accepted a changed active source")
+	if recovered, err := AbortPreparedMigrationSource(ctx, path, epochID, targetID, prepared.Fingerprint); err != nil || recovered.Phase != MigrationSourceActive || recovered.Fingerprint == prepared.Fingerprint {
+		t.Fatalf("post-write abort recovery=%#v err=%v", recovered, err)
 	}
 	active, err = InspectMigrationSource(ctx, path)
 	if err != nil {

--- a/internal/relay/migration_source_test.go
+++ b/internal/relay/migration_source_test.go
@@ -365,6 +365,55 @@ func TestMigrationSourceRefusesUnexpectedIndex(t *testing.T) {
 	}
 }
 
+func TestMigrationSourceRefusesNonPortableLegacyRequestTokens(t *testing.T) {
+	t.Parallel()
+	for _, test := range []struct {
+		name  string
+		query string
+	}{
+		{name: "invalid UTF-8", query: `INSERT INTO request_nonces(machine_id,nonce,expires_at) VALUES('machine-a',CAST(X'ff' AS TEXT),1)`},
+		{name: "NUL", query: `INSERT INTO request_nonces(machine_id,nonce,expires_at) VALUES('machine-a',CAST(X'610062' AS TEXT),1)`},
+		{name: "resume delimiter", query: `INSERT INTO request_nonces(machine_id,nonce,expires_at) VALUES('machine-a',CAST(X'611f62' AS TEXT),1)`},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "relay.db")
+			store, err := Open(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if _, err := store.db.ExecContext(context.Background(), test.query); err != nil { // #nosec G202 -- query is a fixed test-only SQL expression.
+				_ = store.Close()
+				t.Fatal(err)
+			}
+			if err := store.Close(); err != nil {
+				t.Fatal(err)
+			}
+			if _, err := InspectMigrationSource(context.Background(), path); err == nil {
+				t.Fatal("non-portable legacy request token was accepted")
+			}
+		})
+	}
+}
+
+func TestMigrationSourceRefusesDelimiterInLegacyUUIDKey(t *testing.T) {
+	t.Parallel()
+	path := filepath.Join(t.TempDir(), "relay.db")
+	store, err := Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.db.ExecContext(context.Background(), `INSERT INTO conversations(id,next_sequence,created_at) VALUES(CAST(X'611f62' AS TEXT),0,1)`); err != nil {
+		_ = store.Close()
+		t.Fatal(err)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := InspectMigrationSource(context.Background(), path); err == nil {
+		t.Fatal("resume delimiter in legacy UUID key was accepted")
+	}
+}
+
 func TestMigrationSourceRefusesMalformedRuntimeType(t *testing.T) {
 	t.Parallel()
 	path := filepath.Join(t.TempDir(), "relay.db")

--- a/internal/relay/migration_source_test.go
+++ b/internal/relay/migration_source_test.go
@@ -215,6 +215,33 @@ func TestMigrationSourceManifestAndBarrier(t *testing.T) {
 	}
 }
 
+func TestCheckMigrationSourceEnrollmentCoverage(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	path := filepath.Join(t.TempDir(), "relay.db")
+	store, err := Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	now := time.Date(2026, time.July, 21, 9, 0, 0, 0, time.UTC)
+	if err := store.AdvertiseEndpoints("machine-a", []string{"agent/source/a", "claude/jbr-reviewer"}, now, time.Hour); err != nil {
+		t.Fatal(err)
+	}
+	covered := `[{"id":"machine-a","public_key":"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA","endpoint_prefixes":["agent/source/"],"endpoints":["claude/jbr-reviewer"]}]`
+	if err := CheckMigrationSourceEnrollmentCoverage(ctx, path, covered); err != nil {
+		t.Fatalf("covered enrollment rejected: %v", err)
+	}
+	uncovered := `[{"id":"machine-a","public_key":"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA","endpoint_prefixes":["agent/source/"]}]`
+	if err := CheckMigrationSourceEnrollmentCoverage(ctx, path, uncovered); err == nil {
+		t.Fatal("enrollment missing an exact endpoint was accepted")
+	}
+	reassigned := `[{"id":"machine-a","public_key":"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA","endpoint_prefixes":["agent/source/"]},{"id":"machine-b","public_key":"AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA","endpoint_prefixes":["claude/"]}]`
+	if err := CheckMigrationSourceEnrollmentCoverage(ctx, path, reassigned); err == nil {
+		t.Fatal("another machine's authority was accepted for the persisted endpoint owner")
+	}
+}
+
 func TestMigrationBatchCarriesWorstCaseValidMessageBody(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()

--- a/internal/relay/migration_source_test.go
+++ b/internal/relay/migration_source_test.go
@@ -215,6 +215,61 @@ func TestMigrationSourceManifestAndBarrier(t *testing.T) {
 	}
 }
 
+func TestMigrationBatchCarriesWorstCaseValidMessageBody(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	now := time.Date(2026, time.July, 21, 10, 0, 0, 0, time.UTC)
+	path := filepath.Join(t.TempDir(), "relay.db")
+	store, err := Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	if err := store.AdvertiseEndpoints("machine-a", []string{"agent/source/a"}, now, time.Hour); err != nil {
+		t.Fatal(err)
+	}
+	conversation, err := store.CreateConversationIdempotent(CreateConversationInput{
+		MachineID: "machine-a", IdempotencyKey: "large-create", CreatorEndpoint: "agent/source/a", Now: now,
+		Members: []Member{{Endpoint: "agent/source/a", Capabilities: CapSend | CapReceive | CapAdmin}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	body := strings.Repeat("\x01", maxMessageBodyBytes)
+	if _, duplicate, err := store.AppendMessage(AppendInput{
+		ConversationID: conversation.ID, SenderMachineID: "machine-a", FromEndpoint: "agent/source/a",
+		Body: body, IdempotencyKey: "large-message", Now: now,
+	}); err != nil || duplicate {
+		t.Fatalf("append large message duplicate=%t err=%v", duplicate, err)
+	}
+	active, err := InspectMigrationSource(ctx, path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	prepared, err := PrepareMigrationSource(ctx, path, uuid.NewString(), strings.Repeat("a", 64), active.Fingerprint, now.Add(time.Minute))
+	if err != nil {
+		t.Fatal(err)
+	}
+	batch, err := ReadMigrationSourceBatch(ctx, path, "mail_messages", "", 1)
+	if err != nil || len(batch.Rows) != 1 || !batch.Done {
+		t.Fatalf("large message batch=%#v err=%v", batch, err)
+	}
+	if len(batch.Rows[0].Payload) <= 65536 || len(batch.Rows[0].Payload) > MaxMigrationSourcePayloadBytes {
+		t.Fatalf("large message payload bytes=%d", len(batch.Rows[0].Payload))
+	}
+	hasher, err := NewMigrationTableHasher("mail_messages")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := hasher.Add(batch.Rows[0]); err != nil {
+		t.Fatal(err)
+	}
+	count, digest := hasher.Evidence()
+	if count != prepared.Counts.Messages || digest != prepared.TableSHA256.Messages {
+		t.Fatalf("large message evidence count=%d digest=%s manifest=%#v", count, digest, prepared)
+	}
+}
+
 func TestMigrationSourceRefusesMissingOrPermissiveGuard(t *testing.T) {
 	t.Parallel()
 	for _, test := range []struct {

--- a/internal/relay/store.go
+++ b/internal/relay/store.go
@@ -572,6 +572,9 @@ func (s *Store) AppendMessage(input AppendInput) (Message, bool, error) {
 	if len(input.Body) > maxMessageBodyBytes {
 		return Message{}, false, fmt.Errorf("message body exceeds %d bytes", maxMessageBodyBytes)
 	}
+	if !ValidMessageBody(input.Body) {
+		return Message{}, false, errors.New("message body is not portable UTF-8 text")
+	}
 	requestHash := appendHash(input)
 	tx, err := s.db.BeginTx(context.Background(), nil)
 	if err != nil {

--- a/internal/relay/store_test.go
+++ b/internal/relay/store_test.go
@@ -3,9 +3,27 @@ package relay
 import (
 	"fmt"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 )
+
+func TestStoreRejectsNonPortableRequestAndMessageText(t *testing.T) {
+	t.Parallel()
+	invalidUTF8 := string([]byte{0xff})
+	if ValidRequestToken(invalidUTF8) || ValidRequestToken("token\x00value") {
+		t.Fatal("non-portable request token was accepted")
+	}
+	store := &Store{}
+	base := AppendInput{ConversationID: "019f7f07-4b88-7c12-a394-b663274a6555", SenderMachineID: "machine-a", FromEndpoint: "agent/a", IdempotencyKey: "portable-key"}
+	for _, body := range []string{invalidUTF8, "body\x00value"} {
+		input := base
+		input.Body = body
+		if _, _, err := store.AppendMessage(input); err == nil || !strings.Contains(err.Error(), "portable UTF-8") {
+			t.Fatalf("non-portable body %q err=%v", body, err)
+		}
+	}
+}
 
 func TestStoreProvidesDurableAtLeastOnceDelivery(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
## Summary

- add bounded, resumable canonical SQLite export and PostgreSQL staging/verification for all nine mail tables
- add crash-safe pre-seal abort, irreversible SQLite retirement, PostgreSQL activation, and exact aborted tombstones for rejected pre-insert epochs
- add the explicit `punaro mail cutover` dry-run/execute/abort operator path and marker-last runtime publication

## Safety contract

- no dual writes and no arbitrary source path
- SQLite retires only after PostgreSQL verification
- PostgreSQL activates only after SQLite retirement and legacy inventory closure
- local runtime selection publishes `installation.json` last and resumes every durable crash boundary
- Compose Pi, attachments, Big Brain data, and live infrastructure are out of scope

## Validation

- `make test`
- `make test-race`
- `make staticcheck`
- `make lint`
- `make security`
- independent alignment review: PASS
- independent adversarial correctness/security review: PASS; no remaining P0/P1/P2

Local Docker is unavailable, so the nonempty PostgreSQL import/verify/retire/activate flow and abort-tombstone assertions must pass in the hosted PostgreSQL integration job.