### PR TITLE
feat(postgres): add canonical brain CRUD

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -39,6 +39,9 @@ unmounted, and their binaries are absent from production packaging. Their
 code, tests, RFCs, and vectors remain historical experimental evidence. The current
 executable release conditions are in
 [`docs/security-release-gates.md`](docs/security-release-gates.md).
+PostgreSQL schema 14 also contains the dark canonical Big Brain store. It has
+no production route or client switch yet; the first native memory client is a
+later independently reviewed slice.
 
 ## Goals
 
@@ -228,6 +231,40 @@ WS failure: exponential backoff with full jitter; polling continues
 The opportunistic reconnect is rate-limited (for example, once per 30 seconds),
 single-flight per adapter, and allowed to bypass backoff only once while work
 remains. This prevents a large backlog from creating a reconnect storm.
+
+## Canonical memory model
+
+Canonical memory is project-scoped PostgreSQL authority. Each item has an
+optional logical key unique only inside its opaque project scope, a bounded
+kind and trust classification, reversible active/archive state, and one current
+append-only JSONB revision. Reads expose an opaque ETag derived from the item
+and revision. Update, archive, restore, and hard delete require an exact ETag;
+a stale attempt commits no revision, audit row, change, or idempotency result.
+
+Create and every mutation use the shared operation-bound idempotency contract.
+Durable retry outcomes contain only opaque IDs, closed state, revision, ETag,
+and change sequence—never memory content, a logical key, or a content hash.
+An effective archive or restore state transition appends a revision even when
+the document bytes are unchanged, so an older ETag cannot survive the
+transition. Archive and restore use distinct closed audit actions. Requesting
+the already-current state is a stable no-op that returns the item's current
+timeline sequence rather than the installation watermark; that coordinate is
+zero until the item changes on a newly restored timeline. Create denial for missing,
+retired, and unauthorized projects is likewise non-disclosing.
+Reads report only the current timeline's change sequence; abandoned-timeline
+rows cannot become a live item cursor after restore.
+
+Hard delete requires the separate `memory.purge` capability. One transaction
+records a content-free change, audit event, and durable tombstone, then removes
+the item and every canonical revision. The tombstone retains only opaque scope,
+item, actor, timeline, sequence, and time fields. The application role has no
+direct table privilege on tombstones; only the narrow owner routine writes
+them. Change fetch is bounded,
+timeline-aware, project-authorized before reading, and permits gaps in the
+global sequence without exposing other projects. Until collision-aware scope
+rehoming is implemented, a project with any canonical memory scope or retained
+history fails closed at project-merge preview/approval rather than stranding or
+widening access.
 WebSocket reconnect never alters delivery cursors.
 
 ## Minimal HTTP surface

--- a/docs/platform-contracts.md
+++ b/docs/platform-contracts.md
@@ -130,6 +130,40 @@ URLs, ranges, or public capabilities. The whole surface is absent unless the
 trusted-attachment release switch, PostgreSQL device authentication, and the
 private absolute blob root are configured together.
 
+Schema version 14 adds the dark canonical Big Brain CRUD boundary without
+mounting an HTTP route or changing any client authority. `brain.scopes` binds
+one canonical scope to an opaque active project. Memory items hold only
+identity, bounded metadata, reversible state, and the current revision number;
+append-only revisions hold the bounded JSONB document and its server-computed
+SHA-256. An optional logical key is unique inside one scope, never globally.
+
+`memory.write` authorizes create, update, archive, and restore;
+`memory.read` authorizes full get and change fetch; irreversible deletion
+requires `memory.purge`. Create and item-target denial, a guessed ID, a wrong
+or retired project, and a missing item are non-disclosing. Mutations lock current project and grant
+authority, use the shared principal/operation/request-bound idempotency record,
+and compare an exact opaque ETag. An effective update/archive/restore state
+transition appends a revision, advances project content generation and the
+installation change sequence, and records one content-free, transition-specific audit event and
+feed row in the same transaction. A request for the already-current archive
+state is a stable no-op and reports the item's current-timeline sequence rather
+than unrelated installation activity. The item coordinate is zero until that
+item changes on a newly restored timeline.
+
+Hard delete records a content-free tombstone, audit event, and delete change,
+then removes the item and all canonical revisions through a narrow
+authorization-checking owner routine. Tombstones and feeds have no document,
+logical key, title, summary, or content hash. The application role cannot
+read or insert tombstones directly and cannot update/delete revisions or
+mutate changes; only the owner routine writes tombstones. Item reads and the
+feed report only the current timeline's change sequence. The feed is bounded
+and timeline-aware; authorized project pages may contain global-sequence gaps and
+reject abandoned or future cursors. Live brain records or retained brain
+history fail closed at project
+merge until a later collision-aware rehome contract is implemented. Secret
+guarding, evidence/proposals, lexical search, clients, and embeddings remain
+separate later slices.
+
 ### Implemented dark control-plane primitives
 
 Schema version 3 is the minimum for the current PostgreSQL opt-in. Version 2 adds

--- a/internal/postgres/brain.go
+++ b/internal/postgres/brain.go
@@ -1,0 +1,276 @@
+package postgres
+
+import (
+	"crypto/sha256"
+	"crypto/subtle"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+	"time"
+	"unicode"
+	"unicode/utf8"
+)
+
+const (
+	maxMemoryDocumentBytes   = 256 << 10
+	maxMemoryDocumentDepth   = 32
+	maxMemoryLogicalKeyRunes = 128
+	maxMemoryLogicalKeyBytes = 512
+	maxMemoryTokenRunes      = 64
+	maxMemoryChangePage      = 100
+)
+
+var (
+	// ErrMemoryLogicalKeyConflict is content-free and reveals no existing item.
+	ErrMemoryLogicalKeyConflict = errors.New("memory logical key is already in use")
+	// ErrStaleMemoryETag reports a failed compare-and-swap without revealing content.
+	ErrStaleMemoryETag = errors.New("memory ETag is stale")
+)
+
+// MemoryState is the closed canonical lifecycle state.
+type MemoryState string
+
+const (
+	// MemoryActive marks a current canonical memory.
+	MemoryActive MemoryState = "active"
+	// MemoryArchived marks a reversibly hidden canonical memory.
+	MemoryArchived MemoryState = "archived"
+)
+
+// MemoryCreateRequest creates one project-scoped curated memory.
+type MemoryCreateRequest struct {
+	PrincipalID    string
+	ProjectID      string
+	IdempotencyKey string
+	LogicalKey     string
+	Kind           string
+	Trust          string
+	Document       json.RawMessage
+}
+
+// MemoryUpdateRequest replaces the canonical document and descriptive metadata.
+type MemoryUpdateRequest struct {
+	PrincipalID    string
+	ProjectID      string
+	ItemID         string
+	IdempotencyKey string
+	ExpectedETag   string
+	LogicalKey     string
+	Kind           string
+	Trust          string
+	Document       json.RawMessage
+}
+
+// MemoryArchiveRequest changes reversible archive state through exact CAS.
+type MemoryArchiveRequest struct {
+	PrincipalID    string
+	ProjectID      string
+	ItemID         string
+	IdempotencyKey string
+	ExpectedETag   string
+	Archived       bool
+}
+
+// MemoryDeleteRequest irreversibly purges canonical content through exact CAS.
+type MemoryDeleteRequest struct {
+	PrincipalID    string
+	ProjectID      string
+	ItemID         string
+	IdempotencyKey string
+	ExpectedETag   string
+}
+
+// MemoryItem is one authorized current canonical revision.
+type MemoryItem struct {
+	ItemID         string          `json:"item_id"`
+	ScopeID        string          `json:"scope_id"`
+	ProjectID      string          `json:"project_id"`
+	LogicalKey     string          `json:"logical_key,omitempty"`
+	Kind           string          `json:"kind"`
+	State          MemoryState     `json:"state"`
+	Trust          string          `json:"trust"`
+	Revision       int64           `json:"revision"`
+	ETag           string          `json:"etag"`
+	Document       json.RawMessage `json:"document"`
+	ContentSHA256  string          `json:"content_sha256"`
+	AuthorID       string          `json:"author_id"`
+	CreatedAt      time.Time       `json:"created_at"`
+	RevisionAt     time.Time       `json:"revision_at"`
+	ChangeSequence int64           `json:"change_sequence"`
+}
+
+// MemoryMutationResult is deliberately content-free for durable idempotency.
+type MemoryMutationResult struct {
+	ItemID         string      `json:"item_id"`
+	Revision       int64       `json:"revision"`
+	ETag           string      `json:"etag,omitempty"`
+	State          MemoryState `json:"state,omitempty"`
+	ChangeSequence int64       `json:"change_sequence"`
+}
+
+// MemoryChangeType is a closed content-free change classification.
+type MemoryChangeType string
+
+const (
+	// MemoryChangeCreate records creation.
+	MemoryChangeCreate MemoryChangeType = "create"
+	// MemoryChangeUpdate records canonical content or metadata replacement.
+	MemoryChangeUpdate MemoryChangeType = "update"
+	// MemoryChangeArchive records a transition to archived state.
+	MemoryChangeArchive MemoryChangeType = "archive"
+	// MemoryChangeRestore records a transition to active state.
+	MemoryChangeRestore MemoryChangeType = "restore"
+	// MemoryChangeDelete records irreversible canonical-content purge.
+	MemoryChangeDelete MemoryChangeType = "delete"
+)
+
+// MemoryChange contains no canonical content or logical key.
+type MemoryChange struct {
+	TimelineID     string           `json:"timeline_id"`
+	ChangeSequence int64            `json:"change_sequence"`
+	ScopeID        string           `json:"scope_id"`
+	ItemID         string           `json:"item_id"`
+	Type           MemoryChangeType `json:"type"`
+	Revision       int64            `json:"revision"`
+	OccurredAt     time.Time        `json:"occurred_at"`
+}
+
+// MemoryChangeRequest fetches one authorized project feed after a durable cursor.
+type MemoryChangeRequest struct {
+	PrincipalID string
+	ProjectID   string
+	Cursor      InstallationState
+	Limit       int
+}
+
+// MemoryChangePage carries legal global-sequence gaps without exposing other projects.
+type MemoryChangePage struct {
+	Changes []MemoryChange    `json:"changes"`
+	Cursor  InstallationState `json:"cursor"`
+	More    bool              `json:"more"`
+}
+
+func (r MemoryCreateRequest) normalized() (MemoryCreateRequest, error) {
+	if !validOpaqueID(r.PrincipalID) || !validOpaqueID(r.ProjectID) || !validOpaqueID(r.IdempotencyKey) ||
+		!validMemoryLogicalKey(r.LogicalKey) || !validMemoryToken(r.Kind) || !validMemoryToken(r.Trust) {
+		return MemoryCreateRequest{}, errors.New("invalid memory create request")
+	}
+	document, err := canonicalMemoryDocument(r.Document)
+	if err != nil {
+		return MemoryCreateRequest{}, err
+	}
+	r.Document = document
+	return r, nil
+}
+
+func validMemoryLogicalKey(value string) bool {
+	if value == "" {
+		return true
+	}
+	if !utf8.ValidString(value) || utf8.RuneCountInString(value) > maxMemoryLogicalKeyRunes || len(value) > maxMemoryLogicalKeyBytes {
+		return false
+	}
+	for _, r := range value {
+		if unicode.IsControl(r) {
+			return false
+		}
+	}
+	return true
+}
+
+func validMemoryToken(value string) bool {
+	return utf8.ValidString(value) && utf8.RuneCountInString(value) <= maxMemoryTokenRunes && boundedTokenPattern.MatchString(value)
+}
+
+func canonicalMemoryDocument(raw json.RawMessage) (json.RawMessage, error) {
+	if len(raw) == 0 || len(raw) > maxMemoryDocumentBytes {
+		return nil, errors.New("invalid memory document")
+	}
+	decoder := json.NewDecoder(strings.NewReader(string(raw)))
+	decoder.UseNumber()
+	value, err := decodeUniqueJSON(decoder, 1)
+	if err != nil {
+		return nil, errors.New("invalid memory document")
+	}
+	if _, ok := value.(map[string]any); !ok {
+		return nil, errors.New("memory document must be an object")
+	}
+	if token, err := decoder.Token(); !errors.Is(err, io.EOF) || token != nil {
+		return nil, errors.New("invalid memory document")
+	}
+	canonical, err := json.Marshal(value)
+	if err != nil || len(canonical) > maxMemoryDocumentBytes {
+		return nil, errors.New("invalid memory document")
+	}
+	return canonical, nil
+}
+
+func decodeUniqueJSON(decoder *json.Decoder, depth int) (any, error) {
+	if depth > maxMemoryDocumentDepth {
+		return nil, errors.New("JSON nesting is too deep")
+	}
+	token, err := decoder.Token()
+	if err != nil {
+		return nil, err
+	}
+	delimiter, composite := token.(json.Delim)
+	if !composite {
+		return token, nil
+	}
+	switch delimiter {
+	case '{':
+		object := make(map[string]any)
+		for decoder.More() {
+			keyToken, err := decoder.Token()
+			if err != nil {
+				return nil, err
+			}
+			key, ok := keyToken.(string)
+			if !ok {
+				return nil, errors.New("invalid object key")
+			}
+			if _, exists := object[key]; exists {
+				return nil, errors.New("duplicate object key")
+			}
+			value, err := decodeUniqueJSON(decoder, depth+1)
+			if err != nil {
+				return nil, err
+			}
+			object[key] = value
+		}
+		end, err := decoder.Token()
+		if err != nil || end != json.Delim('}') {
+			return nil, errors.New("unterminated object")
+		}
+		return object, nil
+	case '[':
+		array := make([]any, 0)
+		for decoder.More() {
+			value, err := decodeUniqueJSON(decoder, depth+1)
+			if err != nil {
+				return nil, err
+			}
+			array = append(array, value)
+		}
+		end, err := decoder.Token()
+		if err != nil || end != json.Delim(']') {
+			return nil, errors.New("unterminated array")
+		}
+		return array, nil
+	default:
+		return nil, errors.New("invalid JSON delimiter")
+	}
+}
+
+func memoryETag(itemID string, revision int64) string {
+	digest := sha256.Sum256([]byte(fmt.Sprintf("punaro-memory-etag-v1\x00%s\x00%d", itemID, revision)))
+	return `"m1-` + hex.EncodeToString(digest[:]) + `"`
+}
+
+func memoryETagMatches(candidate, itemID string, revision int64) bool {
+	expected := memoryETag(itemID, revision)
+	return len(candidate) == len(expected) && subtle.ConstantTimeCompare([]byte(candidate), []byte(expected)) == 1
+}

--- a/internal/postgres/brain_integration_test.go
+++ b/internal/postgres/brain_integration_test.go
@@ -1,0 +1,678 @@
+package postgres
+
+import (
+	"context"
+	"crypto/sha256"
+	"database/sql"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"testing"
+)
+
+func testCanonicalBrainSchemaDriftIntegration(ctx context.Context, t *testing.T, app *Database, ownerDB *sql.DB) {
+	t.Helper()
+	for _, drift := range []struct {
+		name    string
+		apply   string
+		restore string
+	}{
+		{
+			name:    "memory table ownership",
+			apply:   `ALTER TABLE brain.memory_tombstones OWNER TO punaro_app`,
+			restore: `ALTER TABLE brain.memory_tombstones OWNER TO punaro_owner; REVOKE ALL ON brain.memory_tombstones FROM punaro_app`,
+		},
+		{
+			name:    "memory change delete privilege",
+			apply:   `GRANT DELETE ON brain.memory_changes TO punaro_app`,
+			restore: `REVOKE DELETE ON brain.memory_changes FROM punaro_app`,
+		},
+		{
+			name:    "memory scope maintain privilege",
+			apply:   `GRANT MAINTAIN ON brain.scopes TO punaro_app`,
+			restore: `REVOKE MAINTAIN ON brain.scopes FROM punaro_app`,
+		},
+		{
+			name:    "memory scope missing insert privilege",
+			apply:   `REVOKE INSERT ON brain.scopes FROM punaro_app`,
+			restore: `GRANT INSERT ON brain.scopes TO punaro_app`,
+		},
+		{
+			name:    "memory revision column update privilege",
+			apply:   `GRANT UPDATE (document) ON brain.memory_revisions TO punaro_app`,
+			restore: `REVOKE UPDATE (document) ON brain.memory_revisions FROM punaro_app`,
+		},
+		{
+			name:    "memory change column references privilege",
+			apply:   `GRANT REFERENCES (scope_id) ON brain.memory_changes TO punaro_app`,
+			restore: `REVOKE REFERENCES (scope_id) ON brain.memory_changes FROM punaro_app`,
+		},
+		{
+			name:    "memory tombstone read privilege",
+			apply:   `GRANT SELECT ON brain.memory_tombstones TO punaro_app`,
+			restore: `REVOKE SELECT ON brain.memory_tombstones FROM punaro_app`,
+		},
+		{
+			name:    "memory tombstone public read privilege",
+			apply:   `GRANT SELECT ON brain.memory_tombstones TO PUBLIC`,
+			restore: `REVOKE SELECT ON brain.memory_tombstones FROM PUBLIC`,
+		},
+		{
+			name:    "memory tombstone insert privilege",
+			apply:   `GRANT INSERT ON brain.memory_tombstones TO punaro_app`,
+			restore: `REVOKE INSERT ON brain.memory_tombstones FROM punaro_app`,
+		},
+		{
+			name:    "memory scope select grant option",
+			apply:   `GRANT SELECT ON brain.scopes TO punaro_app WITH GRANT OPTION`,
+			restore: `REVOKE GRANT OPTION FOR SELECT ON brain.scopes FROM punaro_app`,
+		},
+		{
+			name:    "memory mutation fence",
+			apply:   `ALTER TABLE brain.memory_items DISABLE TRIGGER application_mutation_fence`,
+			restore: `ALTER TABLE brain.memory_items ENABLE TRIGGER application_mutation_fence`,
+		},
+		{
+			name:    "memory scope state index",
+			apply:   `DROP INDEX brain.memory_items_scope_state`,
+			restore: `CREATE INDEX memory_items_scope_state ON brain.memory_items (scope_id,state,id)`,
+		},
+		{
+			name:    "memory purge public execute",
+			apply:   `GRANT EXECUTE ON FUNCTION brain.purge_memory(uuid,uuid,uuid,bigint) TO PUBLIC`,
+			restore: `REVOKE EXECUTE ON FUNCTION brain.purge_memory(uuid,uuid,uuid,bigint) FROM PUBLIC`,
+		},
+		{
+			name:    "memory state constraint",
+			apply:   `ALTER TABLE brain.memory_items DROP CONSTRAINT memory_items_state_check; ALTER TABLE brain.memory_items ADD CONSTRAINT memory_items_state_check CHECK (state IS NOT NULL)`,
+			restore: `ALTER TABLE brain.memory_items DROP CONSTRAINT memory_items_state_check; ALTER TABLE brain.memory_items ADD CONSTRAINT memory_items_state_check CHECK (state IN ('active','archived'))`,
+		},
+		{
+			name:    "memory document constraint",
+			apply:   `ALTER TABLE brain.memory_revisions DROP CONSTRAINT memory_revisions_document_check; ALTER TABLE brain.memory_revisions ADD CONSTRAINT memory_revisions_document_check CHECK (jsonb_typeof(document) IS NOT NULL)`,
+			restore: `ALTER TABLE brain.memory_revisions DROP CONSTRAINT memory_revisions_document_check; ALTER TABLE brain.memory_revisions ADD CONSTRAINT memory_revisions_document_check CHECK (jsonb_typeof(document)='object' AND octet_length(document::text)<=262144)`,
+		},
+		{
+			name:    "memory hash constraint",
+			apply:   `ALTER TABLE brain.memory_revisions DROP CONSTRAINT memory_revisions_content_sha256_check; ALTER TABLE brain.memory_revisions ADD CONSTRAINT memory_revisions_content_sha256_check CHECK (octet_length(content_sha256)>=1)`,
+			restore: `ALTER TABLE brain.memory_revisions DROP CONSTRAINT memory_revisions_content_sha256_check; ALTER TABLE brain.memory_revisions ADD CONSTRAINT memory_revisions_content_sha256_check CHECK (octet_length(content_sha256)=32)`,
+		},
+		{
+			name:    "memory operation constraint",
+			apply:   `ALTER TABLE brain.memory_revisions DROP CONSTRAINT memory_revisions_operation_check; ALTER TABLE brain.memory_revisions ADD CONSTRAINT memory_revisions_operation_check CHECK (operation IN ('create','update','archive','restore','unexpected'))`,
+			restore: `ALTER TABLE brain.memory_revisions DROP CONSTRAINT memory_revisions_operation_check; ALTER TABLE brain.memory_revisions ADD CONSTRAINT memory_revisions_operation_check CHECK (operation IN ('create','update','archive','restore'))`,
+		},
+		{
+			name:    "memory scope foreign key",
+			apply:   `ALTER TABLE brain.memory_items DROP CONSTRAINT memory_items_scope_id_fkey; ALTER TABLE brain.memory_items ADD CONSTRAINT memory_items_scope_id_fkey FOREIGN KEY (scope_id) REFERENCES relay.projects(id)`,
+			restore: `ALTER TABLE brain.memory_items DROP CONSTRAINT memory_items_scope_id_fkey; ALTER TABLE brain.memory_items ADD CONSTRAINT memory_items_scope_id_fkey FOREIGN KEY (scope_id) REFERENCES brain.scopes(id)`,
+		},
+	} {
+		t.Run("readiness rejects "+drift.name+" drift", func(t *testing.T) {
+			if _, err := ownerDB.ExecContext(ctx, drift.apply); err != nil {
+				t.Fatal(err)
+			}
+			driftErr := app.Ready(ctx)
+			if _, err := ownerDB.ExecContext(ctx, drift.restore); err != nil {
+				t.Fatal(err)
+			}
+			if driftErr == nil {
+				t.Fatalf("readiness accepted %s drift", drift.name)
+			}
+			if err := app.Ready(ctx); err != nil {
+				t.Fatalf("readiness did not recover after %s drift: %v", drift.name, err)
+			}
+		})
+	}
+	if _, err := ownerDB.ExecContext(ctx, `ALTER TABLE brain.memory_items DROP CONSTRAINT memory_items_logical_key_check; ALTER TABLE brain.memory_items ADD CONSTRAINT memory_items_logical_key_check CHECK (logical_key IS NULL OR (char_length(logical_key) >= 1 AND char_length(logical_key) <= 128 AND octet_length(logical_key) <= 512 AND logical_key !~ '[[:cntrl:]]'))`); err != nil {
+		t.Fatal(err)
+	}
+	restoredConstraintErr := app.Ready(ctx)
+	if _, err := ownerDB.ExecContext(ctx, `ALTER TABLE brain.memory_items DROP CONSTRAINT memory_items_logical_key_check; ALTER TABLE brain.memory_items ADD CONSTRAINT memory_items_logical_key_check CHECK (logical_key IS NULL OR (char_length(logical_key) BETWEEN 1 AND 128 AND octet_length(logical_key) <= 512 AND logical_key !~ '[[:cntrl:]]'))`); err != nil {
+		t.Fatal(err)
+	}
+	if restoredConstraintErr != nil {
+		t.Fatalf("readiness rejected dump/restore-normalized logical-key constraint: %v", restoredConstraintErr)
+	}
+	if err := app.Ready(ctx); err != nil {
+		t.Fatalf("readiness did not recover after logical-key constraint restoration: %v", err)
+	}
+	var purgeDefinition string
+	if err := ownerDB.QueryRowContext(ctx, `SELECT pg_get_functiondef('brain.purge_memory(uuid,uuid,uuid,bigint)'::regprocedure)`).Scan(&purgeDefinition); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ownerDB.ExecContext(ctx, `CREATE OR REPLACE FUNCTION brain.purge_memory(
+requested_principal uuid, requested_project uuid, requested_item uuid, expected_revision bigint
+) RETURNS TABLE (scope_id uuid,revision bigint,timeline_id uuid,change_sequence bigint)
+LANGUAGE plpgsql SECURITY DEFINER SET search_path=pg_catalog
+AS $function$ BEGIN RETURN; END $function$`); err != nil {
+		t.Fatal(err)
+	}
+	if err := app.Ready(ctx); err == nil {
+		t.Fatal("readiness accepted replacement memory purge routine")
+	}
+	if _, err := ownerDB.ExecContext(ctx, purgeDefinition); err != nil {
+		t.Fatal(err)
+	}
+	if err := app.Ready(ctx); err != nil {
+		t.Fatalf("readiness did not recover after memory purge routine restoration: %v", err)
+	}
+}
+
+func testCanonicalBrainIntegration(ctx context.Context, t *testing.T, app *Database, ownerDB *sql.DB) {
+	t.Helper()
+	actor, err := app.CreatePrincipal(ctx, PrincipalKindDevice, "memory actor")
+	if err != nil {
+		t.Fatal(err)
+	}
+	reader, err := app.CreatePrincipal(ctx, PrincipalKindDevice, "memory reader")
+	if err != nil {
+		t.Fatal(err)
+	}
+	outsider, err := app.CreatePrincipal(ctx, PrincipalKindDevice, "memory outsider")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var projectID, otherProjectID, retiredProjectID string
+	if err := ownerDB.QueryRowContext(ctx, `INSERT INTO relay.projects (display_name,created_by) VALUES ('brain project',$1) RETURNING id::text`, actor.ID).Scan(&projectID); err != nil {
+		t.Fatal(err)
+	}
+	if err := ownerDB.QueryRowContext(ctx, `INSERT INTO relay.projects (display_name,created_by) VALUES ('other brain project',$1) RETURNING id::text`, actor.ID).Scan(&otherProjectID); err != nil {
+		t.Fatal(err)
+	}
+	if err := ownerDB.QueryRowContext(ctx, `INSERT INTO relay.projects (display_name,created_by,merged_into,merged_at) VALUES ('retired brain project',$1,$2,statement_timestamp()) RETURNING id::text`, actor.ID, projectID).Scan(&retiredProjectID); err != nil {
+		t.Fatal(err)
+	}
+	for _, grant := range []struct {
+		principal  string
+		project    string
+		capability Capability
+	}{
+		{actor.ID, projectID, CapabilityMemoryRead},
+		{actor.ID, projectID, CapabilityMemoryWrite},
+		{actor.ID, projectID, CapabilityMemoryPurge},
+		{reader.ID, projectID, CapabilityMemoryRead},
+		{reader.ID, projectID, CapabilityMemoryWrite},
+		{actor.ID, otherProjectID, CapabilityMemoryRead},
+		{actor.ID, otherProjectID, CapabilityMemoryWrite},
+	} {
+		if _, err := ownerDB.ExecContext(ctx, `INSERT INTO auth.capability_grants (principal_id,scope,project_id,capability) VALUES ($1,'project',$2,$3)`, grant.principal, grant.project, grant.capability); err != nil {
+			t.Fatal(err)
+		}
+	}
+	allProjectsReader, err := app.CreatePrincipal(ctx, PrincipalKindDevice, "all-project memory reader")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ownerDB.ExecContext(ctx, `INSERT INTO auth.capability_grants (principal_id,scope,capability) VALUES ($1,'all_projects','memory.read')`, allProjectsReader.ID); err != nil {
+		t.Fatal(err)
+	}
+	start, err := app.InstallationState(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	create := MemoryCreateRequest{
+		PrincipalID: actor.ID, ProjectID: projectID,
+		IdempotencyKey: "14141414-1414-4414-8414-141414141401",
+		LogicalKey:     "agent.preference", Kind: "preference", Trust: "curated",
+		Document: json.RawMessage(`{"title":"Use focused tests","enabled":true,"numeric":1e0}`),
+	}
+	type createResult struct {
+		result MemoryMutationResult
+		err    error
+	}
+	started := make(chan struct{})
+	results := make(chan createResult, 2)
+	for range 2 {
+		go func() {
+			<-started
+			result, createErr := app.CreateMemory(ctx, create)
+			results <- createResult{result: result, err: createErr}
+		}()
+	}
+	close(started)
+	first, second := <-results, <-results
+	if first.err != nil || second.err != nil || first.result != second.result {
+		t.Fatalf("concurrent memory create=%#v/%#v", first, second)
+	}
+	created := first.result
+	if created.Revision != 1 || created.State != MemoryActive || created.ETag == "" {
+		t.Fatalf("created memory=%#v", created)
+	}
+	if retry, err := app.CreateMemory(ctx, create); err != nil || retry != created {
+		t.Fatalf("exact create retry=%#v err=%v", retry, err)
+	}
+	changedCreate := create
+	changedCreate.Document = json.RawMessage(`{"title":"changed retry"}`)
+	if _, err := app.CreateMemory(ctx, changedCreate); !errors.Is(err, ErrIdempotencyConflict) {
+		t.Fatalf("changed create retry error=%v", err)
+	}
+	logicalConflict := create
+	logicalConflict.IdempotencyKey = "14141414-1414-4414-8414-141414141402"
+	if _, err := app.CreateMemory(ctx, logicalConflict); !errors.Is(err, ErrMemoryLogicalKeyConflict) {
+		t.Fatalf("logical-key conflict error=%v", err)
+	}
+	otherScope := create
+	otherScope.ProjectID = otherProjectID
+	otherScope.IdempotencyKey = "14141414-1414-4414-8414-141414141403"
+	if _, err := app.CreateMemory(ctx, otherScope); err != nil {
+		t.Fatalf("same logical key in another project failed: %v", err)
+	}
+
+	item, err := app.GetMemory(ctx, reader.ID, projectID, created.ItemID)
+	documentHash := sha256.Sum256(item.Document)
+	if err != nil || item.ETag != created.ETag || item.Revision != 1 || item.ContentSHA256 != hex.EncodeToString(documentHash[:]) {
+		t.Fatalf("memory get=%#v err=%v", item, err)
+	}
+	var decodedDocument map[string]any
+	if json.Unmarshal(item.Document, &decodedDocument) != nil || decodedDocument["title"] != "Use focused tests" || decodedDocument["numeric"] != float64(1) {
+		t.Fatalf("memory document changed semantics: %s", item.Document)
+	}
+	if _, err := app.GetMemory(ctx, outsider.ID, projectID, created.ItemID); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("unauthorized get error=%v", err)
+	}
+	if _, err := app.GetMemory(ctx, reader.ID, otherProjectID, created.ItemID); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("cross-project get error=%v", err)
+	}
+	for name, deniedCreate := range map[string]MemoryCreateRequest{
+		"unauthorized": {
+			PrincipalID: outsider.ID, ProjectID: projectID, IdempotencyKey: "14141414-1414-4414-8414-141414141421",
+			Kind: "preference", Trust: "curated", Document: json.RawMessage(`{"title":"denied"}`),
+		},
+		"missing project": {
+			PrincipalID: actor.ID, ProjectID: "14141414-1414-4414-8414-141414141499", IdempotencyKey: "14141414-1414-4414-8414-141414141422",
+			Kind: "preference", Trust: "curated", Document: json.RawMessage(`{"title":"missing"}`),
+		},
+		"retired project": {
+			PrincipalID: actor.ID, ProjectID: retiredProjectID, IdempotencyKey: "14141414-1414-4414-8414-141414141423",
+			Kind: "preference", Trust: "curated", Document: json.RawMessage(`{"title":"retired"}`),
+		},
+	} {
+		if _, err := app.CreateMemory(ctx, deniedCreate); !errors.Is(err, ErrNotFound) {
+			t.Fatalf("%s create disclosed project state: %v", name, err)
+		}
+	}
+
+	update := MemoryUpdateRequest{
+		PrincipalID: actor.ID, ProjectID: projectID, ItemID: created.ItemID,
+		IdempotencyKey: "14141414-1414-4414-8414-141414141404", ExpectedETag: created.ETag,
+		LogicalKey: "agent.preference", Kind: "preference", Trust: "reviewed",
+		Document: json.RawMessage(`{"title":"Second canonical revision"}`),
+	}
+	updated, err := app.UpdateMemory(ctx, update)
+	if err != nil || updated.Revision != 2 || updated.ETag == created.ETag {
+		t.Fatalf("memory update=%#v err=%v", updated, err)
+	}
+	if retry, err := app.UpdateMemory(ctx, update); err != nil || retry != updated {
+		t.Fatalf("exact update retry=%#v err=%v", retry, err)
+	}
+	changedUpdate := update
+	changedUpdate.Document = json.RawMessage(`{"title":"changed update retry"}`)
+	if _, err := app.UpdateMemory(ctx, changedUpdate); !errors.Is(err, ErrIdempotencyConflict) {
+		t.Fatalf("changed update retry error=%v", err)
+	}
+	stale := update
+	stale.IdempotencyKey = "14141414-1414-4414-8414-141414141405"
+	stale.Document = json.RawMessage(`{"title":"must not persist"}`)
+	beforeStale := readBrainEffects(ctx, t, ownerDB, created.ItemID, stale.IdempotencyKey, projectID)
+	if _, err := app.UpdateMemory(ctx, stale); !errors.Is(err, ErrStaleMemoryETag) {
+		t.Fatalf("stale update error=%v", err)
+	}
+	assertBrainEffects(ctx, t, ownerDB, created.ItemID, stale.IdempotencyKey, projectID, beforeStale)
+	var revisionCount int
+	if err := ownerDB.QueryRowContext(ctx, `SELECT count(*) FROM brain.memory_revisions WHERE item_id=$1`, created.ItemID).Scan(&revisionCount); err != nil || revisionCount != 2 {
+		t.Fatalf("stale update revision count=%d err=%v", revisionCount, err)
+	}
+
+	archiveRequest := MemoryArchiveRequest{
+		PrincipalID: actor.ID, ProjectID: projectID, ItemID: created.ItemID,
+		IdempotencyKey: "14141414-1414-4414-8414-141414141406", ExpectedETag: updated.ETag, Archived: true,
+	}
+	archived, err := app.ArchiveMemory(ctx, archiveRequest)
+	if err != nil || archived.Revision != 3 || archived.State != MemoryArchived {
+		t.Fatalf("archive=%#v err=%v", archived, err)
+	}
+	if retry, err := app.ArchiveMemory(ctx, archiveRequest); err != nil || retry != archived {
+		t.Fatalf("exact archive retry=%#v err=%v", retry, err)
+	}
+	changedArchive := archiveRequest
+	changedArchive.Archived = false
+	if _, err := app.ArchiveMemory(ctx, changedArchive); !errors.Is(err, ErrIdempotencyConflict) {
+		t.Fatalf("changed archive retry error=%v", err)
+	}
+	staleArchive := archiveRequest
+	staleArchive.IdempotencyKey = "14141414-1414-4414-8414-141414141412"
+	staleArchive.Archived = false
+	beforeStale = readBrainEffects(ctx, t, ownerDB, created.ItemID, staleArchive.IdempotencyKey, projectID)
+	if _, err := app.ArchiveMemory(ctx, staleArchive); !errors.Is(err, ErrStaleMemoryETag) {
+		t.Fatalf("stale archive error=%v", err)
+	}
+	assertBrainEffects(ctx, t, ownerDB, created.ItemID, staleArchive.IdempotencyKey, projectID, beforeStale)
+	if _, err := app.DeleteMemory(ctx, MemoryDeleteRequest{
+		PrincipalID: reader.ID, ProjectID: projectID, ItemID: created.ItemID,
+		IdempotencyKey: "14141414-1414-4414-8414-141414141407", ExpectedETag: archived.ETag,
+	}); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("writer without purge delete error=%v", err)
+	}
+	restored, err := app.ArchiveMemory(ctx, MemoryArchiveRequest{
+		PrincipalID: actor.ID, ProjectID: projectID, ItemID: created.ItemID,
+		IdempotencyKey: "14141414-1414-4414-8414-141414141408", ExpectedETag: archived.ETag, Archived: false,
+	})
+	if err != nil || restored.Revision != 4 || restored.State != MemoryActive {
+		t.Fatalf("restore=%#v err=%v", restored, err)
+	}
+	abandonedTimeline := "dddddddd-dddd-4ddd-8ddd-dddddddddddd"
+	abandonedSequence := restored.ChangeSequence + 1000
+	abandonedTx, err := beginMutation(ctx, app.db)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := abandonedTx.ExecContext(ctx, `INSERT INTO brain.memory_changes
+(timeline_id,change_sequence,scope_id,item_id,operation,revision)
+SELECT $1,$2,scope_id,id,'restore',current_revision FROM brain.memory_items WHERE id=$3`, abandonedTimeline, abandonedSequence, created.ItemID); err != nil {
+		_ = abandonedTx.Rollback()
+		t.Fatal(err)
+	}
+	if err := abandonedTx.Commit(); err != nil {
+		t.Fatal(err)
+	}
+	timelineItem, err := app.GetMemory(ctx, reader.ID, projectID, created.ItemID)
+	if err != nil || timelineItem.ChangeSequence != restored.ChangeSequence {
+		t.Fatalf("current-timeline memory get=%#v want sequence=%d err=%v", timelineItem, restored.ChangeSequence, err)
+	}
+	cleanupAbandonedTx, err := beginMutation(ctx, ownerDB)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := cleanupAbandonedTx.ExecContext(ctx, `DELETE FROM brain.memory_changes WHERE timeline_id=$1 AND change_sequence=$2`, abandonedTimeline, abandonedSequence); err != nil {
+		_ = cleanupAbandonedTx.Rollback()
+		t.Fatal(err)
+	}
+	if err := cleanupAbandonedTx.Commit(); err != nil {
+		t.Fatal(err)
+	}
+	var restoreAuditAction string
+	if err := ownerDB.QueryRowContext(ctx, `SELECT action FROM audit.events WHERE target_id=$1 ORDER BY event_id DESC LIMIT 1`, created.ItemID).Scan(&restoreAuditAction); err != nil || restoreAuditAction != string(AuditMemoryRestore) {
+		t.Fatalf("restore audit action=%q err=%v", restoreAuditAction, err)
+	}
+	noOpRestore := MemoryArchiveRequest{
+		PrincipalID: actor.ID, ProjectID: projectID, ItemID: created.ItemID,
+		IdempotencyKey: "14141414-1414-4414-8414-141414141413", ExpectedETag: restored.ETag, Archived: false,
+	}
+	unrelatedBeforeNoOp := otherScope
+	unrelatedBeforeNoOp.IdempotencyKey = "14141414-1414-4414-8414-141414141416"
+	unrelatedBeforeNoOp.LogicalKey = "unrelated.noop.sequence"
+	unrelatedBeforeNoOp.Document = json.RawMessage(`{"title":"unrelated global sequence"}`)
+	if _, err := app.CreateMemory(ctx, unrelatedBeforeNoOp); err != nil {
+		t.Fatalf("unrelated activity before no-op: %v", err)
+	}
+	beforeNoOp := readBrainEffects(ctx, t, ownerDB, created.ItemID, noOpRestore.IdempotencyKey, projectID)
+	if result, err := app.ArchiveMemory(ctx, noOpRestore); err != nil || result.Revision != restored.Revision || result.ETag != restored.ETag || result.ChangeSequence != restored.ChangeSequence {
+		t.Fatalf("same-state restore=%#v err=%v", result, err)
+	}
+	afterNoOp := readBrainEffects(ctx, t, ownerDB, created.ItemID, noOpRestore.IdempotencyKey, projectID)
+	expectedNoOp := beforeNoOp
+	expectedNoOp.idempotency++
+	if afterNoOp != expectedNoOp {
+		t.Fatalf("same-state restore effects before=%#v after=%#v", beforeNoOp, afterNoOp)
+	}
+	func() {
+		beforeRotation, err := app.InstallationState(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+		rotatedTimeline := "eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee"
+		if _, err := ownerDB.ExecContext(ctx, `UPDATE jobs.server_state SET timeline_id=$1 WHERE singleton`, rotatedTimeline); err != nil {
+			t.Fatal(err)
+		}
+		defer func() {
+			if _, restoreErr := ownerDB.ExecContext(ctx, `UPDATE jobs.server_state SET timeline_id=$1 WHERE singleton`, beforeRotation.TimelineID); restoreErr != nil {
+				t.Fatalf("restore brain test timeline: %v", restoreErr)
+			}
+		}()
+		originNoOp := noOpRestore
+		originNoOp.IdempotencyKey = "14141414-1414-4414-8414-141414141417"
+		origin, err := app.ArchiveMemory(ctx, originNoOp)
+		if err != nil || origin.Revision != restored.Revision || origin.ETag != restored.ETag || origin.ChangeSequence != 0 {
+			t.Fatalf("timeline-origin no-op=%#v err=%v", origin, err)
+		}
+		if replay, err := app.ArchiveMemory(ctx, originNoOp); err != nil || replay != origin {
+			t.Fatalf("timeline-origin no-op replay=%#v want=%#v err=%v", replay, origin, err)
+		}
+	}()
+	if _, err := app.UpdateMemory(ctx, MemoryUpdateRequest{
+		PrincipalID: actor.ID, ProjectID: projectID, ItemID: created.ItemID,
+		IdempotencyKey: "14141414-1414-4414-8414-141414141409", ExpectedETag: archived.ETag,
+		Kind: "preference", Trust: "curated", Document: json.RawMessage(`{"title":"stale after restore"}`),
+	}); !errors.Is(err, ErrStaleMemoryETag) {
+		t.Fatalf("pre-restore ETag update error=%v", err)
+	}
+	staleDelete := MemoryDeleteRequest{
+		PrincipalID: actor.ID, ProjectID: projectID, ItemID: created.ItemID,
+		IdempotencyKey: "14141414-1414-4414-8414-141414141414", ExpectedETag: archived.ETag,
+	}
+	beforeStale = readBrainEffects(ctx, t, ownerDB, created.ItemID, staleDelete.IdempotencyKey, projectID)
+	if _, err := app.DeleteMemory(ctx, staleDelete); !errors.Is(err, ErrStaleMemoryETag) {
+		t.Fatalf("stale delete error=%v", err)
+	}
+	assertBrainEffects(ctx, t, ownerDB, created.ItemID, staleDelete.IdempotencyKey, projectID, beforeStale)
+	stateForACL, err := app.InstallationState(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	directTombstoneTx, err := beginMutation(ctx, app.db)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, directTombstoneErr := directTombstoneTx.ExecContext(ctx, `INSERT INTO brain.memory_tombstones
+(item_id,scope_id,deleted_by,timeline_id,change_sequence)
+SELECT id,scope_id,$2,$3,$4 FROM brain.memory_items WHERE id=$1`, created.ItemID, actor.ID, stateForACL.TimelineID, restored.ChangeSequence)
+	_ = directTombstoneTx.Rollback()
+	if directTombstoneErr == nil {
+		t.Fatal("application role inserted a memory tombstone directly")
+	}
+	var appTombstoneCount int
+	if err := app.db.QueryRowContext(ctx, `SELECT count(*) FROM brain.memory_tombstones`).Scan(&appTombstoneCount); err == nil {
+		t.Fatalf("application role read memory tombstones directly: count=%d", appTombstoneCount)
+	}
+
+	page, err := app.FetchMemoryChanges(ctx, MemoryChangeRequest{PrincipalID: reader.ID, ProjectID: projectID, Cursor: start, Limit: 2})
+	if err != nil || len(page.Changes) != 2 || !page.More || page.Changes[0].Type != MemoryChangeCreate || page.Changes[1].Type != MemoryChangeUpdate {
+		t.Fatalf("first memory change page=%#v err=%v", page, err)
+	}
+	if _, err := app.FetchMemoryChanges(ctx, MemoryChangeRequest{PrincipalID: outsider.ID, ProjectID: projectID, Cursor: start, Limit: 2}); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("unauthorized feed error=%v", err)
+	}
+	badOutsiderCursor := start
+	badOutsiderCursor.TimelineID = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"
+	if _, err := app.FetchMemoryChanges(ctx, MemoryChangeRequest{PrincipalID: outsider.ID, ProjectID: projectID, Cursor: badOutsiderCursor, Limit: 2}); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("unauthorized malformed cursor leaked state: %v", err)
+	}
+	allProjectPage, err := app.FetchMemoryChanges(ctx, MemoryChangeRequest{PrincipalID: allProjectsReader.ID, ProjectID: projectID, Cursor: start, Limit: 2})
+	if err != nil || len(allProjectPage.Changes) != 2 {
+		t.Fatalf("all-project feed=%#v err=%v", allProjectPage, err)
+	}
+	allChanges := append([]MemoryChange(nil), page.Changes...)
+	cursor := page.Cursor
+	for page.More {
+		page, err = app.FetchMemoryChanges(ctx, MemoryChangeRequest{PrincipalID: reader.ID, ProjectID: projectID, Cursor: cursor, Limit: 2})
+		if err != nil {
+			t.Fatal(err)
+		}
+		allChanges = append(allChanges, page.Changes...)
+		cursor = page.Cursor
+	}
+	if len(allChanges) != 4 || allChanges[0].Type != MemoryChangeCreate || allChanges[1].Type != MemoryChangeUpdate || allChanges[2].Type != MemoryChangeArchive || allChanges[3].Type != MemoryChangeRestore {
+		t.Fatalf("complete memory changes=%#v", allChanges)
+	}
+	gapSeen := false
+	for index := 1; index < len(allChanges); index++ {
+		if allChanges[index].ChangeSequence <= allChanges[index-1].ChangeSequence {
+			t.Fatalf("non-monotonic memory changes=%#v", allChanges)
+		}
+		gapSeen = gapSeen || allChanges[index].ChangeSequence > allChanges[index-1].ChangeSequence+1
+	}
+	if !gapSeen {
+		t.Fatal("project feed did not preserve the expected unrelated-project global sequence gap")
+	}
+	current, err := app.InstallationState(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	future := current
+	future.ChangeSequence++
+	if _, err := app.FetchMemoryChanges(ctx, MemoryChangeRequest{PrincipalID: reader.ID, ProjectID: projectID, Cursor: future, Limit: 2}); !errors.Is(err, ErrCursorFromFuture) {
+		t.Fatalf("future feed cursor error=%v", err)
+	}
+	wrongTimeline := current
+	wrongTimeline.TimelineID = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb"
+	if _, err := app.FetchMemoryChanges(ctx, MemoryChangeRequest{PrincipalID: reader.ID, ProjectID: projectID, Cursor: wrongTimeline, Limit: 2}); !errors.Is(err, ErrCursorTimelineChanged) {
+		t.Fatalf("wrong timeline feed error=%v", err)
+	}
+	wrongInstallation := current
+	wrongInstallation.InstallationID = "cccccccc-cccc-4ccc-8ccc-cccccccccccc"
+	if _, err := app.FetchMemoryChanges(ctx, MemoryChangeRequest{PrincipalID: reader.ID, ProjectID: projectID, Cursor: wrongInstallation, Limit: 2}); !errors.Is(err, ErrCursorTimelineChanged) {
+		t.Fatalf("wrong installation feed error=%v", err)
+	}
+	for _, limit := range []int{0, maxMemoryChangePage + 1} {
+		if _, err := app.FetchMemoryChanges(ctx, MemoryChangeRequest{PrincipalID: reader.ID, ProjectID: projectID, Cursor: current, Limit: limit}); err == nil {
+			t.Fatalf("invalid feed limit %d accepted", limit)
+		}
+	}
+	mergeTx, err := beginMutation(ctx, app.db)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, _, _, _, _, _, err := projectMergeCounts(ctx, mergeTx, actor.ID, projectID, otherProjectID); !errors.Is(err, ErrProjectMergeBrainState) {
+		_ = mergeTx.Rollback()
+		t.Fatalf("live memory merge fence error=%v", err)
+	}
+	_ = mergeTx.Rollback()
+
+	deleted, err := app.DeleteMemory(ctx, MemoryDeleteRequest{
+		PrincipalID: actor.ID, ProjectID: projectID, ItemID: created.ItemID,
+		IdempotencyKey: "14141414-1414-4414-8414-141414141410", ExpectedETag: restored.ETag,
+	})
+	if err != nil || deleted.ETag != "" || deleted.State != "" || deleted.Revision != restored.Revision {
+		t.Fatalf("delete=%#v err=%v", deleted, err)
+	}
+	changedDelete := MemoryDeleteRequest{
+		PrincipalID: actor.ID, ProjectID: projectID, ItemID: created.ItemID,
+		IdempotencyKey: "14141414-1414-4414-8414-141414141410", ExpectedETag: archived.ETag,
+	}
+	if _, err := app.DeleteMemory(ctx, changedDelete); !errors.Is(err, ErrIdempotencyConflict) {
+		t.Fatalf("changed delete retry error=%v", err)
+	}
+	if _, err := app.GetMemory(ctx, reader.ID, projectID, created.ItemID); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("deleted get error=%v", err)
+	}
+	if err := ownerDB.QueryRowContext(ctx, `SELECT count(*) FROM brain.memory_revisions WHERE item_id=$1`, created.ItemID).Scan(&revisionCount); err != nil || revisionCount != 0 {
+		t.Fatalf("purged revision count=%d err=%v", revisionCount, err)
+	}
+	var tombstoneCount int
+	if err := ownerDB.QueryRowContext(ctx, `SELECT count(*) FROM brain.memory_tombstones WHERE item_id=$1`, created.ItemID).Scan(&tombstoneCount); err != nil || tombstoneCount != 1 {
+		t.Fatalf("memory tombstone count=%d err=%v", tombstoneCount, err)
+	}
+	mergeTx, err = beginMutation(ctx, app.db)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, _, _, _, _, _, err := projectMergeCounts(ctx, mergeTx, actor.ID, projectID, otherProjectID); !errors.Is(err, ErrProjectMergeBrainState) {
+		_ = mergeTx.Rollback()
+		t.Fatalf("retained history merge fence error=%v", err)
+	}
+	_ = mergeTx.Rollback()
+	var leaked bool
+	if err := ownerDB.QueryRowContext(ctx, `SELECT
+EXISTS (SELECT 1 FROM brain.memory_changes WHERE item_id=$1 AND (operation LIKE '%Second canonical revision%' OR scope_id::text LIKE '%Second canonical revision%'))
+OR EXISTS (SELECT 1 FROM audit.events WHERE target_id=$1 AND (action LIKE '%Second canonical revision%' OR target_kind LIKE '%Second canonical revision%'))
+OR EXISTS (SELECT 1 FROM relay.idempotency_records WHERE resource_id=$1 AND (result::text LIKE '%Second canonical revision%' OR result::text LIKE '%agent.preference%'))`, created.ItemID).Scan(&leaked); err != nil || leaked {
+		t.Fatalf("hard-delete metadata leaked content=%v err=%v", leaked, err)
+	}
+	directCreate := create
+	directCreate.IdempotencyKey = "14141414-1414-4414-8414-141414141415"
+	directCreate.LogicalKey = "direct.purge"
+	directCreate.Document = json.RawMessage(`{"title":"direct routine evidence"}`)
+	directItem, err := app.CreateMemory(ctx, directCreate)
+	if err != nil {
+		t.Fatal(err)
+	}
+	directBefore, err := app.InstallationState(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	directTx, err := beginMutation(ctx, app.db)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var directScope, directTimeline string
+	var directRevision, directSequence int64
+	if err := directTx.QueryRowContext(ctx, `SELECT scope_id::text,revision,timeline_id::text,change_sequence
+FROM brain.purge_memory($1::uuid,$2::uuid,$3::uuid,$4)`, actor.ID, projectID, directItem.ItemID, directItem.Revision).Scan(&directScope, &directRevision, &directTimeline, &directSequence); err != nil {
+		_ = directTx.Rollback()
+		t.Fatalf("direct purge routine failed: %v", err)
+	}
+	if err := directTx.Commit(); err != nil {
+		t.Fatal(err)
+	}
+	if directRevision != directItem.Revision || directTimeline != directBefore.TimelineID || directSequence != directBefore.ChangeSequence+1 || !validOpaqueID(directScope) {
+		t.Fatalf("direct purge evidence scope=%q revision=%d timeline=%q sequence=%d before=%#v", directScope, directRevision, directTimeline, directSequence, directBefore)
+	}
+	var directEvidence int
+	if err := ownerDB.QueryRowContext(ctx, `SELECT
+  (SELECT count(*) FROM brain.memory_tombstones WHERE item_id=$1)
+ +(SELECT count(*) FROM brain.memory_changes WHERE item_id=$1 AND operation='delete')
+ +(SELECT count(*) FROM audit.events WHERE target_id=$1 AND action='memory.delete')`, directItem.ItemID).Scan(&directEvidence); err != nil || directEvidence != 3 {
+		t.Fatalf("direct purge evidence count=%d err=%v", directEvidence, err)
+	}
+	var purgeGrantID string
+	if err := ownerDB.QueryRowContext(ctx, `UPDATE auth.capability_grants SET revoked_at=statement_timestamp()
+WHERE principal_id=$1 AND project_id=$2 AND capability='memory.purge' AND revoked_at IS NULL RETURNING id::text`, actor.ID, projectID).Scan(&purgeGrantID); err != nil {
+		t.Fatal(err)
+	}
+	if retry, err := app.DeleteMemory(ctx, MemoryDeleteRequest{
+		PrincipalID: actor.ID, ProjectID: projectID, ItemID: created.ItemID,
+		IdempotencyKey: "14141414-1414-4414-8414-141414141410", ExpectedETag: restored.ETag,
+	}); err != nil || retry != deleted {
+		t.Fatalf("delete retry after revocation=%#v err=%v", retry, err)
+	}
+	reuse := create
+	reuse.IdempotencyKey = "14141414-1414-4414-8414-141414141411"
+	if _, err := app.CreateMemory(ctx, reuse); err != nil {
+		t.Fatalf("hard delete did not release logical key: %v", err)
+	}
+	if _, err := app.db.ExecContext(ctx, `UPDATE brain.memory_revisions SET document='{}'::jsonb WHERE item_id=$1`, created.ItemID); err == nil {
+		t.Fatal("application role mutated an immutable memory revision")
+	}
+}
+
+type brainEffects struct {
+	revisions         int
+	changes           int
+	audits            int
+	idempotency       int
+	changeSequence    int64
+	contentGeneration int64
+}
+
+func readBrainEffects(ctx context.Context, t *testing.T, ownerDB *sql.DB, itemID, idempotencyKey, projectID string) brainEffects {
+	t.Helper()
+	var effects brainEffects
+	if err := ownerDB.QueryRowContext(ctx, `SELECT
+  (SELECT count(*) FROM brain.memory_revisions WHERE item_id=$1),
+  (SELECT count(*) FROM brain.memory_changes WHERE item_id=$1),
+  (SELECT count(*) FROM audit.events WHERE target_id=$1 AND action LIKE 'memory.%'),
+	  (SELECT count(*) FROM relay.idempotency_records WHERE key=$2),
+	  (SELECT change_sequence FROM jobs.server_state WHERE singleton),
+	  (SELECT content_generation FROM relay.projects WHERE id=$3)`, itemID, idempotencyKey, projectID).Scan(&effects.revisions, &effects.changes, &effects.audits, &effects.idempotency, &effects.changeSequence, &effects.contentGeneration); err != nil {
+		t.Fatal(err)
+	}
+	return effects
+}
+
+func assertBrainEffects(ctx context.Context, t *testing.T, ownerDB *sql.DB, itemID, idempotencyKey, projectID string, want brainEffects) {
+	t.Helper()
+	if got := readBrainEffects(ctx, t, ownerDB, itemID, idempotencyKey, projectID); got != want {
+		t.Fatalf("memory failure changed state: got=%#v want=%#v", got, want)
+	}
+}

--- a/internal/postgres/brain_schema.go
+++ b/internal/postgres/brain_schema.go
@@ -1,0 +1,218 @@
+package postgres
+
+import "context"
+
+// canonicalBrainControlsAvailable verifies the exact schema-v14 canonical
+// memory authority. Migration checksums prove provenance; these catalog checks
+// detect later drift in storage, ownership, mutation fencing, routines, and
+// least-privilege application access.
+func canonicalBrainControlsAvailable(ctx context.Context, q queryer) (bool, error) {
+	var available bool
+	err := q.QueryRowContext(ctx, `
+WITH objects AS (
+    SELECT to_regclass('brain.scopes') AS scopes_oid,
+           to_regclass('brain.memory_items') AS items_oid,
+		   to_regclass('brain.memory_revisions') AS revisions_oid,
+		   to_regclass('brain.memory_changes') AS changes_oid,
+		   to_regclass('brain.memory_tombstones') AS tombstones_oid,
+           to_regclass('brain.memory_items_scope_logical_key') AS logical_key_index_oid,
+           to_regclass('brain.memory_items_scope_state') AS state_index_oid,
+           to_regclass('brain.memory_changes_scope_cursor') AS cursor_index_oid,
+           to_regprocedure('brain.purge_memory(uuid,uuid,uuid,bigint)') AS purge_oid,
+           to_regprocedure('jobs.guard_application_mutation()') AS fence_oid
+), expected_columns(relation_name,column_name,type_name,required,default_expression) AS (
+    VALUES
+      ('brain.scopes','id','uuid',true,'gen_random_uuid()'),
+      ('brain.scopes','project_id','uuid',true,''),
+      ('brain.scopes','created_by','uuid',true,''),
+      ('brain.scopes','created_at','timestamp with time zone',true,'statement_timestamp()'),
+      ('brain.memory_items','id','uuid',true,'gen_random_uuid()'),
+      ('brain.memory_items','scope_id','uuid',true,''),
+      ('brain.memory_items','kind','text',true,''),
+      ('brain.memory_items','state','text',true,'''active''::text'),
+      ('brain.memory_items','trust','text',true,''),
+      ('brain.memory_items','logical_key','text',false,''),
+      ('brain.memory_items','current_revision','bigint',true,''),
+      ('brain.memory_items','created_by','uuid',true,''),
+      ('brain.memory_items','created_at','timestamp with time zone',true,'statement_timestamp()'),
+      ('brain.memory_items','updated_at','timestamp with time zone',true,'statement_timestamp()'),
+      ('brain.memory_revisions','item_id','uuid',true,''),
+      ('brain.memory_revisions','revision','bigint',true,''),
+      ('brain.memory_revisions','document','jsonb',true,''),
+      ('brain.memory_revisions','content_sha256','bytea',true,''),
+      ('brain.memory_revisions','author_principal_id','uuid',true,''),
+      ('brain.memory_revisions','operation','text',true,''),
+      ('brain.memory_revisions','created_at','timestamp with time zone',true,'statement_timestamp()'),
+      ('brain.memory_changes','timeline_id','uuid',true,''),
+      ('brain.memory_changes','change_sequence','bigint',true,''),
+      ('brain.memory_changes','scope_id','uuid',true,''),
+      ('brain.memory_changes','item_id','uuid',true,''),
+      ('brain.memory_changes','operation','text',true,''),
+	  ('brain.memory_changes','revision','bigint',true,''),
+	  ('brain.memory_changes','occurred_at','timestamp with time zone',true,'statement_timestamp()'),
+	  ('brain.memory_tombstones','item_id','uuid',true,''),
+	  ('brain.memory_tombstones','scope_id','uuid',true,''),
+	  ('brain.memory_tombstones','deleted_by','uuid',true,''),
+	  ('brain.memory_tombstones','timeline_id','uuid',true,''),
+	  ('brain.memory_tombstones','change_sequence','bigint',true,''),
+	  ('brain.memory_tombstones','deleted_at','timestamp with time zone',true,'statement_timestamp()')
+), actual_columns AS (
+    SELECT attribute.attrelid::regclass::text, attribute.attname,
+           attribute.atttypid::regtype::text, attribute.attnotnull,
+           COALESCE(pg_get_expr(default_value.adbin,default_value.adrelid),'')
+    FROM pg_attribute AS attribute
+    LEFT JOIN pg_attrdef AS default_value
+      ON default_value.adrelid=attribute.attrelid AND default_value.adnum=attribute.attnum,
+         objects
+	WHERE attribute.attrelid = ANY(ARRAY[scopes_oid,items_oid,revisions_oid,changes_oid,tombstones_oid])
+      AND attribute.attnum > 0 AND NOT attribute.attisdropped
+), table_safety AS (
+	SELECT count(*) = 5
+       AND bool_and(pg_get_userbyid(relation.relowner) = 'punaro_owner')
+       AND bool_and(relation.relkind = 'r' AND NOT relation.relrowsecurity AND NOT relation.relforcerowsecurity) AS exact
+	FROM pg_class AS relation, objects
+	WHERE relation.oid = ANY(ARRAY[scopes_oid,items_oid,revisions_oid,changes_oid,tombstones_oid])
+), expected_constraints(relation_name,constraint_name,constraint_type,column_keys,referenced_relation,referenced_keys,delete_action,is_deferrable,is_deferred,expression) AS (
+	VALUES
+	  ('brain.scopes','scopes_pkey','p','{1}','','','',false,false,''),
+	  ('brain.scopes','scopes_project_id_key','u','{2}','','','',false,false,''),
+	  ('brain.scopes','scopes_project_id_fkey','f','{2}','relay.projects','{1}','a',false,false,''),
+	  ('brain.scopes','scopes_created_by_fkey','f','{3}','auth.principals','{1}','a',false,false,''),
+	  ('brain.memory_items','memory_items_pkey','p','{1}','','','',false,false,''),
+	  ('brain.memory_items','memory_items_scope_id_fkey','f','{2}','brain.scopes','{1}','a',false,false,''),
+	  ('brain.memory_items','memory_items_kind_check','c','{3}','','','',false,false,'(kind ~ ''^[a-z][a-z0-9_.:-]{0,63}$''::text)'),
+	  ('brain.memory_items','memory_items_state_check','c','{4}','','','',false,false,'(state = ANY (ARRAY[''active''::text, ''archived''::text]))'),
+	  ('brain.memory_items','memory_items_trust_check','c','{5}','','','',false,false,'(trust ~ ''^[a-z][a-z0-9_.:-]{0,63}$''::text)'),
+	  ('brain.memory_items','memory_items_logical_key_check','c','{6}','','','',false,false,'((logical_key IS NULL) OR (((char_length(logical_key) >= 1) AND (char_length(logical_key) <= 128)) AND (octet_length(logical_key) <= 512) AND (logical_key !~ ''[[:cntrl:]]''::text)))'),
+	  ('brain.memory_items','memory_items_current_revision_check','c','{7}','','','',false,false,'(current_revision >= 1)'),
+	  ('brain.memory_items','memory_items_created_by_fkey','f','{8}','auth.principals','{1}','a',false,false,''),
+	  ('brain.memory_items','memory_items_timestamp_check','c','{10,9}','','','',false,false,'(updated_at >= created_at)'),
+	  ('brain.memory_items','memory_items_current_revision_fkey','f','{1,7}','brain.memory_revisions','{1,2}','a',true,true,''),
+	  ('brain.memory_revisions','memory_revisions_pkey','p','{1,2}','','','',false,false,''),
+	  ('brain.memory_revisions','memory_revisions_item_id_fkey','f','{1}','brain.memory_items','{1}','c',false,false,''),
+	  ('brain.memory_revisions','memory_revisions_revision_check','c','{2}','','','',false,false,'(revision >= 1)'),
+	  ('brain.memory_revisions','memory_revisions_document_check','c','{3}','','','',false,false,'((jsonb_typeof(document) = ''object''::text) AND (octet_length((document)::text) <= 262144))'),
+	  ('brain.memory_revisions','memory_revisions_content_sha256_check','c','{4}','','','',false,false,'(octet_length(content_sha256) = 32)'),
+	  ('brain.memory_revisions','memory_revisions_author_principal_id_fkey','f','{5}','auth.principals','{1}','a',false,false,''),
+	  ('brain.memory_revisions','memory_revisions_operation_check','c','{6}','','','',false,false,'(operation = ANY (ARRAY[''create''::text, ''update''::text, ''archive''::text, ''restore''::text]))'),
+	  ('brain.memory_changes','memory_changes_pkey','p','{1,2}','','','',false,false,''),
+	  ('brain.memory_changes','memory_changes_sequence_check','c','{2}','','','',false,false,'(change_sequence >= 1)'),
+	  ('brain.memory_changes','memory_changes_scope_id_fkey','f','{3}','brain.scopes','{1}','a',false,false,''),
+	  ('brain.memory_changes','memory_changes_operation_check','c','{5}','','','',false,false,'(operation = ANY (ARRAY[''create''::text, ''update''::text, ''archive''::text, ''restore''::text, ''delete''::text]))'),
+	  ('brain.memory_changes','memory_changes_revision_check','c','{6}','','','',false,false,'(revision >= 1)'),
+	  ('brain.memory_tombstones','memory_tombstones_pkey','p','{1}','','','',false,false,''),
+	  ('brain.memory_tombstones','memory_tombstones_scope_id_fkey','f','{2}','brain.scopes','{1}','a',false,false,''),
+	  ('brain.memory_tombstones','memory_tombstones_deleted_by_fkey','f','{3}','auth.principals','{1}','a',false,false,''),
+	  ('brain.memory_tombstones','memory_tombstones_sequence_check','c','{5}','','','',false,false,'(change_sequence >= 1)')
+), actual_constraints AS (
+	SELECT constraint_row.conrelid::regclass::text, constraint_row.conname,
+	       constraint_row.contype::text, constraint_row.conkey::text,
+	       CASE WHEN constraint_row.contype='f' THEN constraint_row.confrelid::regclass::text ELSE '' END,
+	       CASE WHEN constraint_row.contype='f' THEN constraint_row.confkey::text ELSE '' END,
+	       CASE WHEN constraint_row.contype='f' THEN constraint_row.confdeltype::text ELSE '' END,
+	       constraint_row.condeferrable, constraint_row.condeferred,
+	       CASE WHEN constraint_row.contype='c' THEN
+	         CASE
+	           WHEN constraint_row.conname='memory_items_logical_key_check'
+	             AND pg_get_expr(constraint_row.conbin,constraint_row.conrelid)='((logical_key IS NULL) OR ((char_length(logical_key) >= 1) AND (char_length(logical_key) <= 128) AND (octet_length(logical_key) <= 512) AND (logical_key !~ ''[[:cntrl:]]''::text)))'
+	           THEN '((logical_key IS NULL) OR (((char_length(logical_key) >= 1) AND (char_length(logical_key) <= 128)) AND (octet_length(logical_key) <= 512) AND (logical_key !~ ''[[:cntrl:]]''::text)))'
+	           ELSE pg_get_expr(constraint_row.conbin,constraint_row.conrelid)
+	         END
+	       ELSE '' END
+	FROM pg_constraint AS constraint_row, objects
+	WHERE constraint_row.conrelid = ANY(ARRAY[scopes_oid,items_oid,revisions_oid,changes_oid,tombstones_oid])
+	  AND constraint_row.contype <> 'n' AND constraint_row.convalidated
+), constraint_safety AS (
+	SELECT count(*) = 30 AND bool_and(constraint_row.convalidated)
+	   AND bool_and(NOT constraint_row.condeferred OR constraint_row.conname = 'memory_items_current_revision_fkey')
+	   AND bool_and(NOT constraint_row.condeferrable OR constraint_row.conname = 'memory_items_current_revision_fkey')
+	   AND count(*) FILTER (WHERE constraint_row.contype='f' AND constraint_row.confupdtype='a' AND constraint_row.confmatchtype='s') = 10 AS exact
+    FROM pg_constraint AS constraint_row, objects
+	WHERE constraint_row.conrelid = ANY(ARRAY[scopes_oid,items_oid,revisions_oid,changes_oid,tombstones_oid])
+      AND constraint_row.contype <> 'n'
+), index_safety AS (
+	SELECT count(*) = 9 AND bool_and(index_row.indisvalid AND index_row.indisready) AS exact
+    FROM pg_index AS index_row, objects
+	WHERE index_row.indrelid = ANY(ARRAY[scopes_oid,items_oid,revisions_oid,changes_oid,tombstones_oid])
+), fence_safety AS (
+	SELECT count(*) = 5 AND bool_and(trigger_row.tgenabled = 'O' AND trigger_row.tgfoid = fence_oid AND trigger_row.tgtype = 62) AS exact
+    FROM pg_trigger AS trigger_row, objects
+	WHERE trigger_row.tgrelid = ANY(ARRAY[scopes_oid,items_oid,revisions_oid,changes_oid,tombstones_oid])
+      AND trigger_row.tgname = 'application_mutation_fence' AND NOT trigger_row.tgisinternal
+), routine_safety AS (
+    SELECT count(*) = 1
+       AND bool_and(pg_get_userbyid(routine.proowner) = 'punaro_owner')
+	   AND bool_and(language.lanname = 'plpgsql' AND routine.prokind = 'f' AND routine.prosecdef AND routine.provolatile = 'v')
+	   AND bool_and(routine.proretset AND routine.prorettype = 'record'::regtype AND routine.pronargs = 4)
+	   AND bool_and(pg_get_function_result(routine.oid) = 'TABLE(scope_id uuid, revision bigint, timeline_id uuid, change_sequence bigint)')
+	   AND bool_and(routine.proconfig = ARRAY['search_path=pg_catalog']::text[])
+	   AND bool_and(md5(btrim(routine.prosrc, E' \n\r\t')) = 'd86c3c70ca43f0e160fae9f3aaf5a9fd') AS exact
+    FROM pg_proc AS routine JOIN pg_language AS language ON language.oid=routine.prolang, objects
+    WHERE routine.oid = purge_oid
+), routine_acl AS (
+    SELECT count(*) = 2 AND bool_and(entry.privilege_type = 'EXECUTE' AND NOT entry.is_grantable)
+       AND bool_and(grantee.rolname IN ('punaro_owner','punaro_app')) AS exact
+    FROM pg_proc AS routine
+    CROSS JOIN LATERAL aclexplode(COALESCE(routine.proacl,acldefault('f',routine.proowner))) AS entry
+    LEFT JOIN pg_roles AS grantee ON grantee.oid=entry.grantee, objects
+    WHERE routine.oid=purge_oid
+), expected_table_acl(relation_name,grantee,privilege_type,is_grantable) AS (
+    SELECT relation_name,'punaro_owner',privilege_type,false
+    FROM (VALUES ('brain.scopes'),('brain.memory_items'),('brain.memory_revisions'),('brain.memory_changes'),('brain.memory_tombstones')) AS relations(relation_name)
+    CROSS JOIN (VALUES ('SELECT'),('INSERT'),('UPDATE'),('DELETE'),('TRUNCATE'),('REFERENCES'),('TRIGGER'),('MAINTAIN')) AS privileges(privilege_type)
+    UNION ALL
+    SELECT relation_name,'punaro_app',privilege_type,false
+    FROM (VALUES ('brain.scopes'),('brain.memory_items'),('brain.memory_revisions'),('brain.memory_changes')) AS relations(relation_name)
+    CROSS JOIN (VALUES ('SELECT'),('INSERT')) AS privileges(privilege_type)
+), actual_table_acl AS (
+    SELECT relation.oid::regclass::text,COALESCE(grantee.rolname,'PUBLIC'),entry.privilege_type,entry.is_grantable
+    FROM pg_class AS relation
+    CROSS JOIN LATERAL aclexplode(COALESCE(relation.relacl,acldefault('r',relation.relowner))) AS entry
+    LEFT JOIN pg_roles AS grantee ON grantee.oid=entry.grantee, objects
+    WHERE relation.oid = ANY(ARRAY[scopes_oid,items_oid,revisions_oid,changes_oid,tombstones_oid])
+), expected_column_acl(relation_name,column_name,grantee,privilege_type,is_grantable) AS (
+    SELECT 'brain.memory_items',column_name,'punaro_app','UPDATE',false
+    FROM (VALUES ('kind'),('state'),('trust'),('logical_key'),('current_revision'),('updated_at')) AS columns(column_name)
+), actual_column_acl AS (
+    SELECT attribute.attrelid::regclass::text,attribute.attname,COALESCE(grantee.rolname,'PUBLIC'),entry.privilege_type,entry.is_grantable
+    FROM pg_attribute AS attribute
+    CROSS JOIN LATERAL aclexplode(attribute.attacl) AS entry
+    LEFT JOIN pg_roles AS grantee ON grantee.oid=entry.grantee, objects
+    WHERE attribute.attrelid = ANY(ARRAY[scopes_oid,items_oid,revisions_oid,changes_oid,tombstones_oid])
+      AND attribute.attnum > 0 AND NOT attribute.attisdropped AND attribute.attacl IS NOT NULL
+)
+SELECT scopes_oid IS NOT NULL AND items_oid IS NOT NULL AND revisions_oid IS NOT NULL AND changes_oid IS NOT NULL AND tombstones_oid IS NOT NULL
+   AND logical_key_index_oid IS NOT NULL AND state_index_oid IS NOT NULL AND cursor_index_oid IS NOT NULL
+   AND purge_oid IS NOT NULL AND fence_oid IS NOT NULL
+   AND table_safety.exact AND constraint_safety.exact AND index_safety.exact AND fence_safety.exact
+	   AND routine_safety.exact AND routine_acl.exact
+	   AND NOT EXISTS (SELECT * FROM expected_columns EXCEPT SELECT * FROM actual_columns)
+	   AND NOT EXISTS (SELECT * FROM actual_columns EXCEPT SELECT * FROM expected_columns)
+	   AND NOT EXISTS (SELECT * FROM expected_constraints EXCEPT SELECT * FROM actual_constraints)
+	   AND NOT EXISTS (SELECT * FROM actual_constraints EXCEPT SELECT * FROM expected_constraints)
+	   AND NOT EXISTS (SELECT * FROM expected_table_acl EXCEPT SELECT * FROM actual_table_acl)
+	   AND NOT EXISTS (SELECT * FROM actual_table_acl EXCEPT SELECT * FROM expected_table_acl)
+	   AND NOT EXISTS (SELECT * FROM expected_column_acl EXCEPT SELECT * FROM actual_column_acl)
+	   AND NOT EXISTS (SELECT * FROM actual_column_acl EXCEPT SELECT * FROM expected_column_acl)
+   AND EXISTS (
+       SELECT 1 FROM pg_index
+       WHERE indexrelid=logical_key_index_oid AND indrelid=items_oid
+         AND indisunique AND indisvalid AND indisready AND indkey='2 6'::int2vector
+         AND indexprs IS NULL AND pg_get_expr(indpred,indrelid)='(logical_key IS NOT NULL)'
+   )
+   AND EXISTS (
+       SELECT 1 FROM pg_index
+       WHERE indexrelid=state_index_oid AND indrelid=items_oid
+         AND NOT indisunique AND indisvalid AND indisready AND indkey='2 4 1'::int2vector
+         AND indexprs IS NULL AND indpred IS NULL
+   )
+   AND EXISTS (
+       SELECT 1 FROM pg_index
+       WHERE indexrelid=cursor_index_oid AND indrelid=changes_oid
+         AND NOT indisunique AND indisvalid AND indisready AND indkey='3 1 2 4'::int2vector
+         AND indexprs IS NULL AND indpred IS NULL
+   )
+   AND has_function_privilege('punaro_app',purge_oid,'EXECUTE')
+FROM objects, table_safety, constraint_safety, index_safety, fence_safety, routine_safety, routine_acl`).Scan(&available)
+	return available, err
+}

--- a/internal/postgres/brain_store.go
+++ b/internal/postgres/brain_store.go
@@ -1,0 +1,476 @@
+package postgres
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"database/sql"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"strings"
+)
+
+func (r MemoryUpdateRequest) normalized() (MemoryUpdateRequest, error) {
+	if !validOpaqueID(r.PrincipalID) || !validOpaqueID(r.ProjectID) || !validOpaqueID(r.ItemID) || !validOpaqueID(r.IdempotencyKey) ||
+		!validMemoryETagShape(r.ExpectedETag) || !validMemoryLogicalKey(r.LogicalKey) || !validMemoryToken(r.Kind) || !validMemoryToken(r.Trust) {
+		return MemoryUpdateRequest{}, errors.New("invalid memory update request")
+	}
+	document, err := canonicalMemoryDocument(r.Document)
+	if err != nil {
+		return MemoryUpdateRequest{}, err
+	}
+	r.Document = document
+	return r, nil
+}
+
+func (r MemoryArchiveRequest) validate() error {
+	if !validOpaqueID(r.PrincipalID) || !validOpaqueID(r.ProjectID) || !validOpaqueID(r.ItemID) || !validOpaqueID(r.IdempotencyKey) || !validMemoryETagShape(r.ExpectedETag) {
+		return errors.New("invalid memory archive request")
+	}
+	return nil
+}
+
+func (r MemoryDeleteRequest) validate() error {
+	if !validOpaqueID(r.PrincipalID) || !validOpaqueID(r.ProjectID) || !validOpaqueID(r.ItemID) || !validOpaqueID(r.IdempotencyKey) || !validMemoryETagShape(r.ExpectedETag) {
+		return errors.New("invalid memory delete request")
+	}
+	return nil
+}
+
+func validMemoryETagShape(value string) bool {
+	if len(value) != len(`"m1-`)+sha256.Size*2+1 || !strings.HasPrefix(value, `"m1-`) || !strings.HasSuffix(value, `"`) {
+		return false
+	}
+	decoded, err := hex.DecodeString(value[len(`"m1-`) : len(value)-1])
+	return err == nil && len(decoded) == sha256.Size
+}
+
+// CreateMemory creates the canonical scope lazily and commits revision one.
+func (d *Database) CreateMemory(ctx context.Context, raw MemoryCreateRequest) (MemoryMutationResult, error) {
+	request, err := raw.normalized()
+	if err != nil {
+		return MemoryMutationResult{}, err
+	}
+	body, _ := json.Marshal(struct {
+		ProjectID  string          `json:"project_id"`
+		LogicalKey string          `json:"logical_key,omitempty"`
+		Kind       string          `json:"kind"`
+		Trust      string          `json:"trust"`
+		Document   json.RawMessage `json:"document"`
+	}{request.ProjectID, request.LogicalKey, request.Kind, request.Trust, request.Document})
+	tx, err := beginMutation(ctx, d.db)
+	if err != nil {
+		return MemoryMutationResult{}, mutationStartError(err, "memory create transaction cannot start")
+	}
+	defer func() { _ = tx.Rollback() }()
+	outcome, err := executeIdempotentTx(ctx, tx, IdempotencyRequest{PrincipalID: request.PrincipalID, Operation: "memory.create", Key: request.IdempotencyKey, Body: body}, func(control *ControlTx) (IdempotencyOutcome, error) {
+		project, err := lockDirectActiveProject(ctx, tx, request.ProjectID)
+		if err != nil {
+			return IdempotencyOutcome{}, ErrNotFound
+		}
+		allowed, err := lockCapability(ctx, tx, request.PrincipalID, project.ID, CapabilityMemoryWrite)
+		if err != nil {
+			return IdempotencyOutcome{}, err
+		}
+		if !allowed {
+			return IdempotencyOutcome{}, ErrNotFound
+		}
+		scopeID, err := ensureMemoryScope(ctx, tx, project.ID, request.PrincipalID)
+		if err != nil {
+			return IdempotencyOutcome{}, err
+		}
+		var itemID string
+		err = tx.QueryRowContext(ctx, `INSERT INTO brain.memory_items (scope_id,kind,state,trust,logical_key,current_revision,created_by)
+VALUES ($1,$2,'active',$3,$4,1,$5) RETURNING id::text`, scopeID, request.Kind, request.Trust, nullableMemoryKey(request.LogicalKey), request.PrincipalID).Scan(&itemID)
+		if isSQLState(err, "23505") {
+			return IdempotencyOutcome{}, ErrMemoryLogicalKeyConflict
+		}
+		if err != nil {
+			return IdempotencyOutcome{}, errors.New("memory item could not be created")
+		}
+		if err := insertMemoryRevision(ctx, tx, itemID, 1, request.Document, request.PrincipalID, MemoryChangeCreate); err != nil {
+			return IdempotencyOutcome{}, err
+		}
+		state, err := commitMemoryChange(ctx, tx, control, request.PrincipalID, project.ID, scopeID, itemID, 1, MemoryChangeCreate, AuditMemoryCreate)
+		if err != nil {
+			return IdempotencyOutcome{}, err
+		}
+		result := MemoryMutationResult{ItemID: itemID, Revision: 1, ETag: memoryETag(itemID, 1), State: MemoryActive, ChangeSequence: state.ChangeSequence}
+		return memoryOutcome(result)
+	})
+	if err != nil {
+		return MemoryMutationResult{}, err
+	}
+	if err := tx.Commit(); err != nil {
+		return MemoryMutationResult{}, errors.New("memory create transaction could not commit")
+	}
+	return decodeMemoryOutcome(outcome)
+}
+
+// GetMemory returns only an authorized current revision. Missing and denied are indistinguishable.
+func (d *Database) GetMemory(ctx context.Context, principalID, projectID, itemID string) (MemoryItem, error) {
+	if !validOpaqueID(principalID) || !validOpaqueID(projectID) || !validOpaqueID(itemID) {
+		return MemoryItem{}, errors.New("invalid memory lookup")
+	}
+	canonicalProjectID, err := resolveCanonicalActiveProject(ctx, d.db, projectID)
+	if err != nil {
+		return MemoryItem{}, ErrNotFound
+	}
+	allowed, err := hasCapability(ctx, d.db, principalID, canonicalProjectID, CapabilityMemoryRead)
+	if err != nil {
+		return MemoryItem{}, err
+	}
+	if !allowed {
+		return MemoryItem{}, ErrNotFound
+	}
+	var item MemoryItem
+	var logicalKey sql.NullString
+	var document, contentHash []byte
+	err = d.db.QueryRowContext(ctx, `SELECT item.id::text,scope.id::text,scope.project_id::text,item.logical_key,item.kind,item.state,item.trust,
+	       item.current_revision,revision.document::text,revision.content_sha256,revision.author_principal_id::text,
+       item.created_at,revision.created_at,
+       COALESCE((SELECT max(change.change_sequence) FROM brain.memory_changes AS change
+                 WHERE change.scope_id=scope.id AND change.item_id=item.id AND change.revision=item.current_revision
+                   AND change.timeline_id=(SELECT timeline_id FROM jobs.server_state WHERE singleton)),0)
+FROM brain.memory_items AS item
+JOIN brain.scopes AS scope ON scope.id=item.scope_id
+JOIN brain.memory_revisions AS revision ON revision.item_id=item.id AND revision.revision=item.current_revision
+WHERE item.id=$1 AND scope.project_id=$2`, itemID, canonicalProjectID).Scan(
+		&item.ItemID, &item.ScopeID, &item.ProjectID, &logicalKey, &item.Kind, &item.State, &item.Trust,
+		&item.Revision, &document, &contentHash, &item.AuthorID, &item.CreatedAt, &item.RevisionAt, &item.ChangeSequence)
+	if errors.Is(err, sql.ErrNoRows) {
+		return MemoryItem{}, ErrNotFound
+	}
+	documentDigest := sha256.Sum256(document)
+	if err != nil || len(contentHash) != sha256.Size || !bytes.Equal(documentDigest[:], contentHash) {
+		return MemoryItem{}, errors.New("memory item is unavailable")
+	}
+	item.LogicalKey = logicalKey.String
+	item.Document = append(json.RawMessage(nil), document...)
+	item.ContentSHA256 = hex.EncodeToString(contentHash)
+	item.ETag = memoryETag(item.ItemID, item.Revision)
+	return item, nil
+}
+
+// UpdateMemory appends one immutable canonical revision through exact CAS.
+func (d *Database) UpdateMemory(ctx context.Context, raw MemoryUpdateRequest) (MemoryMutationResult, error) {
+	request, err := raw.normalized()
+	if err != nil {
+		return MemoryMutationResult{}, err
+	}
+	body, _ := json.Marshal(struct {
+		ProjectID    string          `json:"project_id"`
+		ItemID       string          `json:"item_id"`
+		ExpectedETag string          `json:"expected_etag"`
+		LogicalKey   string          `json:"logical_key,omitempty"`
+		Kind         string          `json:"kind"`
+		Trust        string          `json:"trust"`
+		Document     json.RawMessage `json:"document"`
+	}{request.ProjectID, request.ItemID, request.ExpectedETag, request.LogicalKey, request.Kind, request.Trust, request.Document})
+	return d.mutateMemory(ctx, request.PrincipalID, request.IdempotencyKey, "memory.update", body, request.ProjectID, request.ItemID, CapabilityMemoryWrite, func(tx *sql.Tx, control *ControlTx, locked lockedMemory) (MemoryMutationResult, error) {
+		if !memoryETagMatches(request.ExpectedETag, request.ItemID, locked.Revision) {
+			return MemoryMutationResult{}, ErrStaleMemoryETag
+		}
+		next := locked.Revision + 1
+		if err := insertMemoryRevision(ctx, tx, request.ItemID, next, request.Document, request.PrincipalID, MemoryChangeUpdate); err != nil {
+			return MemoryMutationResult{}, err
+		}
+		_, err := tx.ExecContext(ctx, `UPDATE brain.memory_items SET logical_key=$2,kind=$3,trust=$4,current_revision=$5,updated_at=statement_timestamp() WHERE id=$1`, request.ItemID, nullableMemoryKey(request.LogicalKey), request.Kind, request.Trust, next)
+		if isSQLState(err, "23505") {
+			return MemoryMutationResult{}, ErrMemoryLogicalKeyConflict
+		}
+		if err != nil {
+			return MemoryMutationResult{}, errors.New("memory item could not be updated")
+		}
+		state, err := commitMemoryChange(ctx, tx, control, request.PrincipalID, locked.ProjectID, locked.ScopeID, request.ItemID, next, MemoryChangeUpdate, AuditMemoryUpdate)
+		if err != nil {
+			return MemoryMutationResult{}, err
+		}
+		return MemoryMutationResult{ItemID: request.ItemID, Revision: next, ETag: memoryETag(request.ItemID, next), State: locked.State, ChangeSequence: state.ChangeSequence}, nil
+	})
+}
+
+// ArchiveMemory reversibly archives or restores one memory and advances its ETag.
+func (d *Database) ArchiveMemory(ctx context.Context, request MemoryArchiveRequest) (MemoryMutationResult, error) {
+	if err := request.validate(); err != nil {
+		return MemoryMutationResult{}, err
+	}
+	body, _ := json.Marshal(struct {
+		ProjectID    string `json:"project_id"`
+		ItemID       string `json:"item_id"`
+		ExpectedETag string `json:"expected_etag"`
+		Archived     bool   `json:"archived"`
+	}{request.ProjectID, request.ItemID, request.ExpectedETag, request.Archived})
+	return d.mutateMemory(ctx, request.PrincipalID, request.IdempotencyKey, "memory.archive", body, request.ProjectID, request.ItemID, CapabilityMemoryWrite, func(tx *sql.Tx, control *ControlTx, locked lockedMemory) (MemoryMutationResult, error) {
+		if !memoryETagMatches(request.ExpectedETag, request.ItemID, locked.Revision) {
+			return MemoryMutationResult{}, ErrStaleMemoryETag
+		}
+		target := MemoryActive
+		change := MemoryChangeRestore
+		action := AuditMemoryRestore
+		if request.Archived {
+			target = MemoryArchived
+			change = MemoryChangeArchive
+			action = AuditMemoryArchive
+		}
+		if locked.State == target {
+			var changeSequence int64
+			if err := tx.QueryRowContext(ctx, `SELECT COALESCE((
+    SELECT max(change.change_sequence) FROM brain.memory_changes AS change
+    WHERE change.timeline_id=state.timeline_id AND change.scope_id=$1 AND change.item_id=$2 AND change.revision=$3
+),0)
+FROM jobs.server_state AS state WHERE state.singleton`, locked.ScopeID, request.ItemID, locked.Revision).Scan(&changeSequence); err != nil {
+				return MemoryMutationResult{}, errors.New("memory state is unavailable")
+			}
+			return MemoryMutationResult{ItemID: request.ItemID, Revision: locked.Revision, ETag: memoryETag(request.ItemID, locked.Revision), State: target, ChangeSequence: changeSequence}, nil
+		}
+		next := locked.Revision + 1
+		if err := insertMemoryRevision(ctx, tx, request.ItemID, next, locked.Document, request.PrincipalID, change); err != nil {
+			return MemoryMutationResult{}, err
+		}
+		if _, err := tx.ExecContext(ctx, `UPDATE brain.memory_items SET state=$2,current_revision=$3,updated_at=statement_timestamp() WHERE id=$1`, request.ItemID, target, next); err != nil {
+			return MemoryMutationResult{}, errors.New("memory archive state could not be updated")
+		}
+		state, err := commitMemoryChange(ctx, tx, control, request.PrincipalID, locked.ProjectID, locked.ScopeID, request.ItemID, next, change, action)
+		if err != nil {
+			return MemoryMutationResult{}, err
+		}
+		return MemoryMutationResult{ItemID: request.ItemID, Revision: next, ETag: memoryETag(request.ItemID, next), State: target, ChangeSequence: state.ChangeSequence}, nil
+	})
+}
+
+// DeleteMemory irreversibly removes the item and every canonical revision.
+func (d *Database) DeleteMemory(ctx context.Context, request MemoryDeleteRequest) (MemoryMutationResult, error) {
+	if err := request.validate(); err != nil {
+		return MemoryMutationResult{}, err
+	}
+	body, _ := json.Marshal(struct {
+		ProjectID    string `json:"project_id"`
+		ItemID       string `json:"item_id"`
+		ExpectedETag string `json:"expected_etag"`
+	}{request.ProjectID, request.ItemID, request.ExpectedETag})
+	return d.mutateMemory(ctx, request.PrincipalID, request.IdempotencyKey, "memory.delete", body, request.ProjectID, request.ItemID, CapabilityMemoryPurge, func(tx *sql.Tx, _ *ControlTx, locked lockedMemory) (MemoryMutationResult, error) {
+		if !memoryETagMatches(request.ExpectedETag, request.ItemID, locked.Revision) {
+			return MemoryMutationResult{}, ErrStaleMemoryETag
+		}
+		var scopeID, timelineID string
+		var revision, changeSequence int64
+		if err := tx.QueryRowContext(ctx, `SELECT scope_id::text,revision,timeline_id::text,change_sequence
+FROM brain.purge_memory($1::uuid,$2::uuid,$3::uuid,$4)`, request.PrincipalID, locked.ProjectID, request.ItemID, locked.Revision).Scan(&scopeID, &revision, &timelineID, &changeSequence); err != nil {
+			return MemoryMutationResult{}, errors.New("memory item could not be purged")
+		}
+		if scopeID != locked.ScopeID || revision != locked.Revision || !validOpaqueID(timelineID) || changeSequence < 1 {
+			return MemoryMutationResult{}, errors.New("memory purge result is unavailable")
+		}
+		return MemoryMutationResult{ItemID: request.ItemID, Revision: revision, ChangeSequence: changeSequence}, nil
+	})
+}
+
+type lockedMemory struct {
+	ScopeID     string
+	ProjectID   string
+	Revision    int64
+	State       MemoryState
+	Document    []byte
+	ContentHash []byte
+}
+
+func (d *Database) mutateMemory(ctx context.Context, principalID, idempotencyKey, operation string, body []byte, projectID, itemID string, capability Capability, mutation func(*sql.Tx, *ControlTx, lockedMemory) (MemoryMutationResult, error)) (MemoryMutationResult, error) {
+	tx, err := beginMutation(ctx, d.db)
+	if err != nil {
+		return MemoryMutationResult{}, mutationStartError(err, "memory transaction cannot start")
+	}
+	defer func() { _ = tx.Rollback() }()
+	outcome, err := executeIdempotentTx(ctx, tx, IdempotencyRequest{PrincipalID: principalID, Operation: operation, Key: idempotencyKey, Body: body}, func(control *ControlTx) (IdempotencyOutcome, error) {
+		project, err := lockDirectActiveProject(ctx, tx, projectID)
+		if err != nil {
+			return IdempotencyOutcome{}, ErrNotFound
+		}
+		allowed, err := lockCapability(ctx, tx, principalID, project.ID, capability)
+		if err != nil {
+			return IdempotencyOutcome{}, err
+		}
+		if !allowed {
+			return IdempotencyOutcome{}, ErrNotFound
+		}
+		locked, err := lockMemory(ctx, tx, project.ID, itemID)
+		if err != nil {
+			return IdempotencyOutcome{}, err
+		}
+		result, err := mutation(tx, control, locked)
+		if err != nil {
+			return IdempotencyOutcome{}, err
+		}
+		return memoryOutcome(result)
+	})
+	if err != nil {
+		return MemoryMutationResult{}, err
+	}
+	if err := tx.Commit(); err != nil {
+		return MemoryMutationResult{}, errors.New("memory transaction could not commit")
+	}
+	return decodeMemoryOutcome(outcome)
+}
+
+func lockMemory(ctx context.Context, tx *sql.Tx, projectID, itemID string) (lockedMemory, error) {
+	var locked lockedMemory
+	locked.ProjectID = projectID
+	err := tx.QueryRowContext(ctx, `SELECT scope.id::text,item.current_revision,item.state,revision.document::text,revision.content_sha256
+FROM brain.memory_items AS item
+JOIN brain.scopes AS scope ON scope.id=item.scope_id
+JOIN brain.memory_revisions AS revision ON revision.item_id=item.id AND revision.revision=item.current_revision
+WHERE item.id=$1 AND scope.project_id=$2
+FOR UPDATE OF item`, itemID, projectID).Scan(&locked.ScopeID, &locked.Revision, &locked.State, &locked.Document, &locked.ContentHash)
+	if errors.Is(err, sql.ErrNoRows) {
+		return lockedMemory{}, ErrNotFound
+	}
+	if err != nil || len(locked.ContentHash) != sha256.Size {
+		return lockedMemory{}, errors.New("memory item could not be locked")
+	}
+	return locked, nil
+}
+
+func ensureMemoryScope(ctx context.Context, tx *sql.Tx, projectID, principalID string) (string, error) {
+	var scopeID string
+	err := tx.QueryRowContext(ctx, `INSERT INTO brain.scopes (project_id,created_by) VALUES ($1,$2)
+ON CONFLICT (project_id) DO NOTHING RETURNING id::text`, projectID, principalID).Scan(&scopeID)
+	if errors.Is(err, sql.ErrNoRows) {
+		err = tx.QueryRowContext(ctx, `SELECT id::text FROM brain.scopes WHERE project_id=$1`, projectID).Scan(&scopeID)
+	}
+	if err != nil {
+		return "", errors.New("memory scope is unavailable")
+	}
+	return scopeID, nil
+}
+
+func insertMemoryRevision(ctx context.Context, tx *sql.Tx, itemID string, revision int64, document []byte, principalID string, operation MemoryChangeType) error {
+	var storedDocument string
+	if err := tx.QueryRowContext(ctx, `SELECT $1::jsonb::text`, string(document)).Scan(&storedDocument); err != nil || len(storedDocument) > maxMemoryDocumentBytes {
+		return errors.New("memory document could not be normalized")
+	}
+	contentHash := sha256.Sum256([]byte(storedDocument))
+	_, err := tx.ExecContext(ctx, `INSERT INTO brain.memory_revisions (item_id,revision,document,content_sha256,author_principal_id,operation)
+	VALUES ($1,$2,$3,$4,$5,$6)`, itemID, revision, storedDocument, contentHash[:], principalID, operation)
+	if err != nil {
+		return errors.New("memory revision could not be appended")
+	}
+	return nil
+}
+
+func commitMemoryChange(ctx context.Context, tx *sql.Tx, control *ControlTx, principalID, projectID, scopeID, itemID string, revision int64, change MemoryChangeType, action AuditAction) (InstallationState, error) {
+	advanced, err := tx.ExecContext(ctx, `UPDATE relay.projects SET content_generation=content_generation+1 WHERE id=$1 AND merged_into IS NULL`, projectID)
+	if err != nil {
+		return InstallationState{}, errors.New("project content generation could not advance")
+	}
+	if count, err := advanced.RowsAffected(); err != nil || count != 1 {
+		return InstallationState{}, ErrNotFound
+	}
+	state, err := control.AdvanceChange(ctx)
+	if err != nil {
+		return InstallationState{}, err
+	}
+	if _, err := tx.ExecContext(ctx, `INSERT INTO brain.memory_changes (timeline_id,change_sequence,scope_id,item_id,operation,revision)
+VALUES ($1,$2,$3,$4,$5,$6)`, state.TimelineID, state.ChangeSequence, scopeID, itemID, change, revision); err != nil {
+		return InstallationState{}, errors.New("memory change could not be recorded")
+	}
+	if err := control.AppendAudit(ctx, AuditEvent{PrincipalID: principalID, ProjectID: projectID, Action: action, Outcome: AuditSucceeded, TargetKind: AuditTargetMemoryItem, TargetID: itemID}); err != nil {
+		return InstallationState{}, err
+	}
+	return state, nil
+}
+
+func memoryOutcome(result MemoryMutationResult) (IdempotencyOutcome, error) {
+	encoded, err := json.Marshal(result)
+	if err != nil {
+		return IdempotencyOutcome{}, errors.New("memory result cannot be encoded")
+	}
+	return IdempotencyOutcome{Status: OutcomeSucceeded, ResourceID: result.ItemID, Result: encoded}, nil
+}
+
+func decodeMemoryOutcome(outcome IdempotencyOutcome) (MemoryMutationResult, error) {
+	var result MemoryMutationResult
+	if outcome.Status != OutcomeSucceeded || json.Unmarshal(outcome.Result, &result) != nil || !validOpaqueID(result.ItemID) || result.Revision < 1 || result.ChangeSequence < 0 || (result.ETag != "" && !validMemoryETagShape(result.ETag)) {
+		return MemoryMutationResult{}, errors.New("memory result is unavailable")
+	}
+	return result, nil
+}
+
+func nullableMemoryKey(value string) any {
+	if value == "" {
+		return nil
+	}
+	return value
+}
+
+// FetchMemoryChanges returns a bounded timeline-aware feed for one authorized project.
+func (d *Database) FetchMemoryChanges(ctx context.Context, request MemoryChangeRequest) (MemoryChangePage, error) {
+	if !validOpaqueID(request.PrincipalID) || !validOpaqueID(request.ProjectID) || request.Limit < 1 || request.Limit > maxMemoryChangePage {
+		return MemoryChangePage{}, errors.New("invalid memory change request")
+	}
+	tx, err := d.db.BeginTx(ctx, &sql.TxOptions{Isolation: sql.LevelRepeatableRead, ReadOnly: true})
+	if err != nil {
+		return MemoryChangePage{}, errors.New("memory change snapshot cannot start")
+	}
+	defer func() { _ = tx.Rollback() }()
+	projectID, err := resolveCanonicalActiveProject(ctx, tx, request.ProjectID)
+	if err != nil {
+		return MemoryChangePage{}, ErrNotFound
+	}
+	allowed, err := hasCapability(ctx, tx, request.PrincipalID, projectID, CapabilityMemoryRead)
+	if err != nil {
+		return MemoryChangePage{}, err
+	}
+	if !allowed {
+		return MemoryChangePage{}, ErrNotFound
+	}
+	var current InstallationState
+	if err := tx.QueryRowContext(ctx, `SELECT installation_id::text,timeline_id::text,change_sequence FROM jobs.server_state WHERE singleton`).Scan(&current.InstallationID, &current.TimelineID, &current.ChangeSequence); err != nil {
+		return MemoryChangePage{}, errors.New("memory change cursor is unavailable")
+	}
+	if err := ValidateCursor(current, request.Cursor); err != nil {
+		return MemoryChangePage{}, err
+	}
+	var scopeID string
+	err = tx.QueryRowContext(ctx, `SELECT id::text FROM brain.scopes WHERE project_id=$1`, projectID).Scan(&scopeID)
+	if errors.Is(err, sql.ErrNoRows) {
+		if err := tx.Commit(); err != nil {
+			return MemoryChangePage{}, errors.New("memory change snapshot cannot commit")
+		}
+		return MemoryChangePage{Changes: []MemoryChange{}, Cursor: current}, nil
+	}
+	if err != nil {
+		return MemoryChangePage{}, errors.New("memory scope is unavailable")
+	}
+	rows, err := tx.QueryContext(ctx, `SELECT timeline_id::text,change_sequence,scope_id::text,item_id::text,operation,revision,occurred_at
+FROM brain.memory_changes
+WHERE scope_id=$1 AND timeline_id=$2 AND change_sequence>$3
+ORDER BY change_sequence,item_id LIMIT $4`, scopeID, current.TimelineID, request.Cursor.ChangeSequence, request.Limit+1)
+	if err != nil {
+		return MemoryChangePage{}, errors.New("memory changes are unavailable")
+	}
+	defer func() { _ = rows.Close() }()
+	changes := make([]MemoryChange, 0, request.Limit+1)
+	for rows.Next() {
+		var change MemoryChange
+		if err := rows.Scan(&change.TimelineID, &change.ChangeSequence, &change.ScopeID, &change.ItemID, &change.Type, &change.Revision, &change.OccurredAt); err != nil {
+			return MemoryChangePage{}, errors.New("memory change is malformed")
+		}
+		changes = append(changes, change)
+	}
+	if err := rows.Err(); err != nil {
+		return MemoryChangePage{}, errors.New("memory changes are unavailable")
+	}
+	more := len(changes) > request.Limit
+	if more {
+		changes = changes[:request.Limit]
+	}
+	cursor := current
+	if more && len(changes) > 0 {
+		cursor.ChangeSequence = changes[len(changes)-1].ChangeSequence
+	}
+	if err := tx.Commit(); err != nil {
+		return MemoryChangePage{}, errors.New("memory change snapshot cannot commit")
+	}
+	return MemoryChangePage{Changes: changes, Cursor: cursor, More: more}, nil
+}

--- a/internal/postgres/brain_store_test.go
+++ b/internal/postgres/brain_store_test.go
@@ -1,0 +1,109 @@
+package postgres
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestCanonicalMemoryDocument(t *testing.T) {
+	canonical, err := canonicalMemoryDocument(json.RawMessage(` { "z": 1, "a": { "b": true } } `))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(canonical) != `{"a":{"b":true},"z":1}` {
+		t.Fatalf("canonical document=%s", canonical)
+	}
+	second, err := canonicalMemoryDocument(json.RawMessage(`{"a":{"b":true},"z":1}`))
+	if err != nil || !bytes.Equal(second, canonical) {
+		t.Fatalf("equivalent JSON was not canonical: document=%s err=%v", second, err)
+	}
+
+	for _, test := range []struct {
+		name string
+		doc  json.RawMessage
+	}{
+		{name: "empty", doc: nil},
+		{name: "array", doc: json.RawMessage(`[]`)},
+		{name: "trailing", doc: json.RawMessage(`{} {}`)},
+		{name: "duplicate key", doc: json.RawMessage(`{"a":1,"a":2}`)},
+		{name: "too deep", doc: json.RawMessage(strings.Repeat(`{"a":`, maxMemoryDocumentDepth+1) + `0` + strings.Repeat(`}`, maxMemoryDocumentDepth+1))},
+		{name: "too large", doc: json.RawMessage(`{"a":"` + strings.Repeat("x", maxMemoryDocumentBytes) + `"}`)},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if _, err := canonicalMemoryDocument(test.doc); err == nil {
+				t.Fatal("invalid memory document accepted")
+			}
+		})
+	}
+}
+
+func TestMemoryRequestValidation(t *testing.T) {
+	base := MemoryCreateRequest{
+		PrincipalID:    "11111111-1111-4111-8111-111111111111",
+		ProjectID:      "22222222-2222-4222-8222-222222222222",
+		IdempotencyKey: "33333333-3333-4333-8333-333333333333",
+		LogicalKey:     "agent.preference",
+		Kind:           "preference",
+		Trust:          "curated",
+		Document:       json.RawMessage(`{"title":"Use focused tests"}`),
+	}
+	if _, err := base.normalized(); err != nil {
+		t.Fatalf("valid create rejected: %v", err)
+	}
+	for _, mutate := range []func(*MemoryCreateRequest){
+		func(request *MemoryCreateRequest) { request.PrincipalID = "friendly" },
+		func(request *MemoryCreateRequest) { request.ProjectID = "friendly" },
+		func(request *MemoryCreateRequest) { request.IdempotencyKey = "friendly" },
+		func(request *MemoryCreateRequest) {
+			request.LogicalKey = strings.Repeat("k", maxMemoryLogicalKeyRunes+1)
+		},
+		func(request *MemoryCreateRequest) { request.LogicalKey = "has\ncontrol" },
+		func(request *MemoryCreateRequest) { request.Kind = "UPPER" },
+		func(request *MemoryCreateRequest) { request.Trust = "" },
+	} {
+		request := base
+		mutate(&request)
+		if _, err := request.normalized(); err == nil {
+			t.Fatalf("invalid create accepted: %#v", request)
+		}
+	}
+}
+
+func TestMemoryETagIsStrictAndOpaque(t *testing.T) {
+	itemID := "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"
+	etag := memoryETag(itemID, 42)
+	if etag == "" || strings.Contains(etag, itemID) || strings.Contains(etag, "42") {
+		t.Fatalf("etag exposes internal coordinates: %q", etag)
+	}
+	if !memoryETagMatches(etag, itemID, 42) || memoryETagMatches(etag, itemID, 41) || memoryETagMatches(etag+" ", itemID, 42) {
+		t.Fatalf("etag comparison is not exact: %q", etag)
+	}
+}
+
+func TestMemoryOutcomeAllowsCurrentTimelineOrigin(t *testing.T) {
+	itemID := "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"
+	result := MemoryMutationResult{
+		ItemID: itemID, Revision: 4, ETag: memoryETag(itemID, 4),
+		State: MemoryActive, ChangeSequence: 0,
+	}
+	outcome, err := memoryOutcome(result)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for attempt := 0; attempt < 2; attempt++ {
+		decoded, err := decodeMemoryOutcome(outcome)
+		if err != nil || decoded != result {
+			t.Fatalf("timeline-origin replay attempt=%d result=%#v err=%v", attempt, decoded, err)
+		}
+	}
+	result.ChangeSequence = -1
+	outcome, err = memoryOutcome(result)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := decodeMemoryOutcome(outcome); err == nil {
+		t.Fatal("negative memory change sequence accepted")
+	}
+}

--- a/internal/postgres/control.go
+++ b/internal/postgres/control.go
@@ -198,6 +198,11 @@ const (
 	AuditProjectIdentityAttach AuditAction = "project.identity.attach"
 	AuditProjectMergePreview   AuditAction = "project.merge.preview"
 	AuditProjectMerge          AuditAction = "project.merge"
+	AuditMemoryCreate          AuditAction = "memory.create"
+	AuditMemoryUpdate          AuditAction = "memory.update"
+	AuditMemoryArchive         AuditAction = "memory.archive"
+	AuditMemoryRestore         AuditAction = "memory.restore"
+	AuditMemoryDelete          AuditAction = "memory.delete"
 )
 
 // AuditOutcome is a closed content-free result class.
@@ -223,10 +228,11 @@ const (
 	AuditTargetLegacyMachine   AuditTargetKind = "legacy_machine"
 	AuditTargetProjectIdentity AuditTargetKind = "project_identity"
 	AuditTargetProjectMerge    AuditTargetKind = "project_merge"
+	AuditTargetMemoryItem      AuditTargetKind = "memory_item"
 )
 
 var validAuditActions = map[AuditAction]struct{}{
-	AuditPrincipalCreate: {}, AuditProjectCreate: {}, AuditGrantCreate: {}, AuditGrantDelete: {}, AuditJobEnqueue: {}, AuditJobComplete: {}, AuditJobRetry: {}, AuditJobFail: {}, AuditOwnerBootstrap: {}, AuditEnrollmentCreate: {}, AuditEnrollmentRedeem: {}, AuditCredentialRotate: {}, AuditCredentialRevoke: {}, AuditLegacyRegister: {}, AuditLegacyExchange: {}, AuditLegacyRetire: {}, AuditLegacyDisable: {}, AuditProjectIdentityAttach: {}, AuditProjectMergePreview: {}, AuditProjectMerge: {},
+	AuditPrincipalCreate: {}, AuditProjectCreate: {}, AuditGrantCreate: {}, AuditGrantDelete: {}, AuditJobEnqueue: {}, AuditJobComplete: {}, AuditJobRetry: {}, AuditJobFail: {}, AuditOwnerBootstrap: {}, AuditEnrollmentCreate: {}, AuditEnrollmentRedeem: {}, AuditCredentialRotate: {}, AuditCredentialRevoke: {}, AuditLegacyRegister: {}, AuditLegacyExchange: {}, AuditLegacyRetire: {}, AuditLegacyDisable: {}, AuditProjectIdentityAttach: {}, AuditProjectMergePreview: {}, AuditProjectMerge: {}, AuditMemoryCreate: {}, AuditMemoryUpdate: {}, AuditMemoryArchive: {}, AuditMemoryRestore: {}, AuditMemoryDelete: {},
 }
 
 // AuditEvent contains identifiers and closed classification values only.
@@ -254,7 +260,7 @@ func (e AuditEvent) Validate() error {
 	if _, ok := validAuditActions[e.Action]; !ok {
 		return errors.New("invalid audit classification")
 	}
-	if (e.Outcome != AuditSucceeded && e.Outcome != AuditRejected) || (e.TargetKind != AuditTargetPrincipal && e.TargetKind != AuditTargetProject && e.TargetKind != AuditTargetGrant && e.TargetKind != AuditTargetJob && e.TargetKind != AuditTargetEnrollment && e.TargetKind != AuditTargetCredential && e.TargetKind != AuditTargetLegacyMachine && e.TargetKind != AuditTargetProjectIdentity && e.TargetKind != AuditTargetProjectMerge) {
+	if (e.Outcome != AuditSucceeded && e.Outcome != AuditRejected) || (e.TargetKind != AuditTargetPrincipal && e.TargetKind != AuditTargetProject && e.TargetKind != AuditTargetGrant && e.TargetKind != AuditTargetJob && e.TargetKind != AuditTargetEnrollment && e.TargetKind != AuditTargetCredential && e.TargetKind != AuditTargetLegacyMachine && e.TargetKind != AuditTargetProjectIdentity && e.TargetKind != AuditTargetProjectMerge && e.TargetKind != AuditTargetMemoryItem) {
 		return errors.New("invalid audit classification")
 	}
 	return nil

--- a/internal/postgres/db.go
+++ b/internal/postgres/db.go
@@ -139,6 +139,19 @@ func (d *Database) TrustedAttachmentRuntimeReady(ctx context.Context) error {
 	return nil
 }
 
+// CanonicalBrainRuntimeReady requires the exact current schema because the
+// additive brain tables remain dark on compatible historical mail schemas.
+func (d *Database) CanonicalBrainRuntimeReady(ctx context.Context) error {
+	state, err := d.SchemaState(ctx)
+	if err != nil {
+		return err
+	}
+	if state.Classification != Compatible || state.Version != d.manifest.MaxSupported || state.Version < 14 {
+		return errors.New("PostgreSQL canonical brain schema is unavailable")
+	}
+	return nil
+}
+
 // InstallationState reads stable installation, timeline, and change metadata.
 func (d *Database) InstallationState(ctx context.Context) (InstallationState, error) {
 	var state InstallationState
@@ -575,14 +588,16 @@ SELECT
         WHERE conrelid = 'audit.events'::regclass AND conname = 'events_action_check'
           AND contype = 'c' AND conkey = ARRAY[5]::smallint[] AND convalidated
           AND (($1 = 3 AND pg_get_expr(conbin, conrelid) = '(action = ANY (ARRAY[''principal.create''::text, ''project.create''::text, ''grant.create''::text, ''grant.delete''::text, ''job.enqueue''::text, ''job.complete''::text, ''job.retry''::text, ''job.fail''::text, ''owner.bootstrap''::text, ''enrollment.create''::text, ''enrollment.redeem''::text, ''credential.rotate''::text, ''credential.revoke''::text, ''legacy.register''::text, ''legacy.exchange''::text, ''legacy.retire''::text, ''legacy.disable''::text]))')
-            OR ($1 >= 4 AND pg_get_expr(conbin, conrelid) = '(action = ANY (ARRAY[''principal.create''::text, ''project.create''::text, ''grant.create''::text, ''grant.delete''::text, ''job.enqueue''::text, ''job.complete''::text, ''job.retry''::text, ''job.fail''::text, ''owner.bootstrap''::text, ''enrollment.create''::text, ''enrollment.redeem''::text, ''credential.rotate''::text, ''credential.revoke''::text, ''legacy.register''::text, ''legacy.exchange''::text, ''legacy.retire''::text, ''legacy.disable''::text, ''project.identity.attach''::text, ''project.merge.preview''::text, ''project.merge''::text]))'))
+            OR ($1 BETWEEN 4 AND 13 AND pg_get_expr(conbin, conrelid) = '(action = ANY (ARRAY[''principal.create''::text, ''project.create''::text, ''grant.create''::text, ''grant.delete''::text, ''job.enqueue''::text, ''job.complete''::text, ''job.retry''::text, ''job.fail''::text, ''owner.bootstrap''::text, ''enrollment.create''::text, ''enrollment.redeem''::text, ''credential.rotate''::text, ''credential.revoke''::text, ''legacy.register''::text, ''legacy.exchange''::text, ''legacy.retire''::text, ''legacy.disable''::text, ''project.identity.attach''::text, ''project.merge.preview''::text, ''project.merge''::text]))')
+            OR ($1 >= 14 AND pg_get_expr(conbin, conrelid) = '(action = ANY (ARRAY[''principal.create''::text, ''project.create''::text, ''grant.create''::text, ''grant.delete''::text, ''job.enqueue''::text, ''job.complete''::text, ''job.retry''::text, ''job.fail''::text, ''owner.bootstrap''::text, ''enrollment.create''::text, ''enrollment.redeem''::text, ''credential.rotate''::text, ''credential.revoke''::text, ''legacy.register''::text, ''legacy.exchange''::text, ''legacy.retire''::text, ''legacy.disable''::text, ''project.identity.attach''::text, ''project.merge.preview''::text, ''project.merge''::text, ''memory.create''::text, ''memory.update''::text, ''memory.archive''::text, ''memory.restore''::text, ''memory.delete''::text]))'))
     )
     AND EXISTS (
         SELECT 1 FROM pg_constraint
         WHERE conrelid = 'audit.events'::regclass AND conname = 'events_target_kind_check'
           AND contype = 'c' AND conkey = ARRAY[7]::smallint[] AND convalidated
           AND (($1 = 3 AND pg_get_expr(conbin, conrelid) = '(target_kind = ANY (ARRAY[''principal''::text, ''project''::text, ''grant''::text, ''job''::text, ''enrollment''::text, ''credential''::text, ''legacy_machine''::text]))')
-            OR ($1 >= 4 AND pg_get_expr(conbin, conrelid) = '(target_kind = ANY (ARRAY[''principal''::text, ''project''::text, ''grant''::text, ''job''::text, ''enrollment''::text, ''credential''::text, ''legacy_machine''::text, ''project_identity''::text, ''project_merge''::text]))'))
+            OR ($1 BETWEEN 4 AND 13 AND pg_get_expr(conbin, conrelid) = '(target_kind = ANY (ARRAY[''principal''::text, ''project''::text, ''grant''::text, ''job''::text, ''enrollment''::text, ''credential''::text, ''legacy_machine''::text, ''project_identity''::text, ''project_merge''::text]))')
+            OR ($1 >= 14 AND pg_get_expr(conbin, conrelid) = '(target_kind = ANY (ARRAY[''principal''::text, ''project''::text, ''grant''::text, ''job''::text, ''enrollment''::text, ''credential''::text, ''legacy_machine''::text, ''project_identity''::text, ''project_merge''::text, ''memory_item''::text]))'))
     )
     AND has_table_privilege('punaro_app', owner_oid, 'SELECT')
     AND NOT has_table_privilege('punaro_app', owner_oid, 'INSERT,UPDATE,DELETE,TRUNCATE,REFERENCES,TRIGGER')
@@ -1013,6 +1028,13 @@ FROM objects, table_ownership, routine_safety, routine_acl, table_acl, schema_ac
 			return Snapshot{}, errors.New("PostgreSQL attachment-deletion schema cannot be inspected")
 		}
 		snapshot.CurrentObjectsPresent = deletionObjectsPresent
+	}
+	if snapshot.CurrentObjectsPresent && len(snapshot.Records) > 0 && snapshot.Records[len(snapshot.Records)-1].Version >= 14 {
+		brainObjectsPresent, err := canonicalBrainControlsAvailable(ctx, q)
+		if err != nil {
+			return Snapshot{}, errors.New("PostgreSQL canonical brain schema cannot be inspected")
+		}
+		snapshot.CurrentObjectsPresent = brainObjectsPresent
 	}
 	return snapshot, nil
 }

--- a/internal/postgres/migrate.go
+++ b/internal/postgres/migrate.go
@@ -46,6 +46,7 @@ var migrationCompatibilityFloors = map[int64]int64{
 	11: 10,
 	12: 10,
 	13: 10,
+	14: 10,
 }
 
 // CurrentManifest returns the immutable migrations embedded in this binary.

--- a/internal/postgres/migrations/014_canonical_brain.sql
+++ b/internal/postgres/migrations/014_canonical_brain.sql
@@ -1,0 +1,222 @@
+CREATE TABLE brain.scopes (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    project_id uuid NOT NULL UNIQUE REFERENCES relay.projects(id),
+    created_by uuid NOT NULL REFERENCES auth.principals(id),
+    created_at timestamptz NOT NULL DEFAULT statement_timestamp()
+);
+
+CREATE TABLE brain.memory_items (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    scope_id uuid NOT NULL REFERENCES brain.scopes(id),
+    kind text NOT NULL CONSTRAINT memory_items_kind_check CHECK (
+        kind ~ '^[a-z][a-z0-9_.:-]{0,63}$'
+    ),
+    state text NOT NULL DEFAULT 'active'
+        CONSTRAINT memory_items_state_check CHECK (state IN ('active', 'archived')),
+    trust text NOT NULL CONSTRAINT memory_items_trust_check CHECK (
+        trust ~ '^[a-z][a-z0-9_.:-]{0,63}$'
+    ),
+    logical_key text CONSTRAINT memory_items_logical_key_check CHECK (
+        logical_key IS NULL OR (
+            char_length(logical_key) BETWEEN 1 AND 128
+            AND octet_length(logical_key) <= 512
+            AND logical_key !~ '[[:cntrl:]]'
+        )
+    ),
+    current_revision bigint NOT NULL
+        CONSTRAINT memory_items_current_revision_check CHECK (current_revision >= 1),
+    created_by uuid NOT NULL REFERENCES auth.principals(id),
+    created_at timestamptz NOT NULL DEFAULT statement_timestamp(),
+    updated_at timestamptz NOT NULL DEFAULT statement_timestamp(),
+    CONSTRAINT memory_items_timestamp_check CHECK (updated_at >= created_at)
+);
+
+CREATE UNIQUE INDEX memory_items_scope_logical_key
+ON brain.memory_items (scope_id, logical_key)
+WHERE logical_key IS NOT NULL;
+
+CREATE INDEX memory_items_scope_state
+ON brain.memory_items (scope_id, state, id);
+
+CREATE TABLE brain.memory_revisions (
+    item_id uuid NOT NULL REFERENCES brain.memory_items(id) ON DELETE CASCADE,
+    revision bigint NOT NULL CONSTRAINT memory_revisions_revision_check CHECK (revision >= 1),
+    document jsonb NOT NULL CONSTRAINT memory_revisions_document_check CHECK (
+        jsonb_typeof(document) = 'object'
+        AND octet_length(document::text) <= 262144
+    ),
+    content_sha256 bytea NOT NULL
+        CONSTRAINT memory_revisions_content_sha256_check CHECK (octet_length(content_sha256) = 32),
+    author_principal_id uuid NOT NULL REFERENCES auth.principals(id),
+    operation text NOT NULL
+        CONSTRAINT memory_revisions_operation_check CHECK (operation IN ('create', 'update', 'archive', 'restore')),
+    created_at timestamptz NOT NULL DEFAULT statement_timestamp(),
+    PRIMARY KEY (item_id, revision)
+);
+
+ALTER TABLE brain.memory_items
+ADD CONSTRAINT memory_items_current_revision_fkey
+FOREIGN KEY (id, current_revision)
+REFERENCES brain.memory_revisions(item_id, revision)
+DEFERRABLE INITIALLY DEFERRED;
+
+CREATE TABLE brain.memory_changes (
+    timeline_id uuid NOT NULL,
+    change_sequence bigint NOT NULL
+        CONSTRAINT memory_changes_sequence_check CHECK (change_sequence >= 1),
+    scope_id uuid NOT NULL REFERENCES brain.scopes(id),
+    item_id uuid NOT NULL,
+    operation text NOT NULL
+        CONSTRAINT memory_changes_operation_check CHECK (operation IN ('create', 'update', 'archive', 'restore', 'delete')),
+    revision bigint NOT NULL CONSTRAINT memory_changes_revision_check CHECK (revision >= 1),
+    occurred_at timestamptz NOT NULL DEFAULT statement_timestamp(),
+    PRIMARY KEY (timeline_id, change_sequence)
+);
+
+CREATE INDEX memory_changes_scope_cursor
+ON brain.memory_changes (scope_id, timeline_id, change_sequence, item_id);
+
+CREATE TABLE brain.memory_tombstones (
+    item_id uuid PRIMARY KEY,
+    scope_id uuid NOT NULL REFERENCES brain.scopes(id),
+    deleted_by uuid NOT NULL REFERENCES auth.principals(id),
+    timeline_id uuid NOT NULL,
+    change_sequence bigint NOT NULL
+        CONSTRAINT memory_tombstones_sequence_check CHECK (change_sequence >= 1),
+    deleted_at timestamptz NOT NULL DEFAULT statement_timestamp()
+);
+
+CREATE FUNCTION brain.purge_memory(
+    requested_principal uuid,
+    requested_project uuid,
+    requested_item uuid,
+    expected_revision bigint
+)
+RETURNS TABLE (scope_id uuid, revision bigint, timeline_id uuid, change_sequence bigint)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog
+AS $function$
+DECLARE
+    active_project uuid;
+    authority_id uuid;
+    deleted_scope uuid;
+    deleted_revision bigint;
+    next_timeline uuid;
+    next_sequence bigint;
+BEGIN
+    PERFORM jobs.assert_application_mutation();
+    SELECT project.id INTO active_project
+    FROM relay.projects AS project
+    WHERE project.id = requested_project AND project.merged_into IS NULL
+    FOR UPDATE;
+    IF active_project IS NULL THEN
+        RETURN;
+    END IF;
+    SELECT capability_grant.id INTO authority_id
+    FROM auth.principals AS principal
+    JOIN auth.capability_grants AS capability_grant
+      ON capability_grant.principal_id = principal.id
+    WHERE principal.id = requested_principal
+      AND principal.disabled_at IS NULL
+      AND capability_grant.revoked_at IS NULL
+      AND capability_grant.capability = 'memory.purge'
+      AND ((capability_grant.scope = 'project' AND capability_grant.project_id = requested_project)
+           OR (capability_grant.scope = 'all_projects' AND capability_grant.project_id IS NULL))
+    ORDER BY capability_grant.id
+    LIMIT 1
+    FOR SHARE OF principal, capability_grant;
+    IF authority_id IS NULL THEN
+        RETURN;
+    END IF;
+    SELECT item.scope_id, item.current_revision
+    INTO deleted_scope, deleted_revision
+    FROM brain.memory_items AS item
+    JOIN brain.scopes AS scope ON scope.id = item.scope_id
+    WHERE item.id = requested_item
+      AND item.current_revision = expected_revision
+      AND scope.project_id = requested_project
+    FOR UPDATE OF item;
+    IF deleted_scope IS NULL THEN
+        RETURN;
+    END IF;
+    SELECT advanced.timeline_id, advanced.change_sequence
+    INTO next_timeline, next_sequence
+    FROM jobs.advance_change_sequence() AS advanced;
+    INSERT INTO brain.memory_changes (
+        timeline_id, change_sequence, scope_id, item_id, operation, revision
+    ) VALUES (
+        next_timeline, next_sequence, deleted_scope, requested_item, 'delete', deleted_revision
+    );
+    INSERT INTO brain.memory_tombstones (
+        item_id, scope_id, deleted_by, timeline_id, change_sequence
+    ) VALUES (
+        requested_item, deleted_scope, requested_principal, next_timeline, next_sequence
+    );
+    INSERT INTO audit.events (
+        principal_id, project_id, action, outcome, target_kind, target_id
+    ) VALUES (
+        requested_principal, requested_project, 'memory.delete', 'succeeded', 'memory_item', requested_item
+    );
+    UPDATE relay.projects
+    SET content_generation = content_generation + 1
+    WHERE id = active_project;
+    DELETE FROM brain.memory_items AS item
+    WHERE item.id = requested_item AND item.current_revision = deleted_revision;
+    IF NOT FOUND THEN
+        RAISE EXCEPTION USING ERRCODE = '40001', MESSAGE = 'memory purge target changed';
+    END IF;
+    scope_id := deleted_scope;
+    revision := deleted_revision;
+    timeline_id := next_timeline;
+    change_sequence := next_sequence;
+    RETURN NEXT;
+END
+$function$;
+
+ALTER TABLE audit.events DROP CONSTRAINT events_action_check;
+ALTER TABLE audit.events ADD CONSTRAINT events_action_check CHECK (action IN (
+    'principal.create', 'project.create', 'grant.create', 'grant.delete',
+    'job.enqueue', 'job.complete', 'job.retry', 'job.fail',
+    'owner.bootstrap', 'enrollment.create', 'enrollment.redeem',
+    'credential.rotate', 'credential.revoke',
+    'legacy.register', 'legacy.exchange', 'legacy.retire', 'legacy.disable',
+    'project.identity.attach', 'project.merge.preview', 'project.merge',
+    'memory.create', 'memory.update', 'memory.archive', 'memory.restore', 'memory.delete'
+));
+
+ALTER TABLE audit.events DROP CONSTRAINT events_target_kind_check;
+ALTER TABLE audit.events ADD CONSTRAINT events_target_kind_check CHECK (target_kind IN (
+    'principal', 'project', 'grant', 'job', 'enrollment', 'credential',
+    'legacy_machine', 'project_identity', 'project_merge', 'memory_item'
+));
+
+DO $block$
+DECLARE
+    target regclass;
+BEGIN
+    FOREACH target IN ARRAY ARRAY[
+        'brain.scopes'::regclass,
+        'brain.memory_items'::regclass,
+        'brain.memory_revisions'::regclass,
+        'brain.memory_changes'::regclass,
+        'brain.memory_tombstones'::regclass
+    ]
+    LOOP
+        EXECUTE format(
+            'CREATE TRIGGER application_mutation_fence BEFORE INSERT OR UPDATE OR DELETE OR TRUNCATE ON %s FOR EACH STATEMENT EXECUTE FUNCTION jobs.guard_application_mutation()',
+            target
+        );
+    END LOOP;
+END
+$block$;
+
+REVOKE ALL ON brain.scopes, brain.memory_items, brain.memory_revisions, brain.memory_changes, brain.memory_tombstones FROM PUBLIC, punaro_app;
+REVOKE ALL ON FUNCTION brain.purge_memory(uuid,uuid,uuid,bigint) FROM PUBLIC;
+
+GRANT USAGE ON SCHEMA brain TO punaro_app;
+GRANT SELECT ON brain.scopes, brain.memory_items, brain.memory_revisions, brain.memory_changes TO punaro_app;
+GRANT INSERT ON brain.scopes, brain.memory_items, brain.memory_revisions, brain.memory_changes TO punaro_app;
+GRANT UPDATE (kind, state, trust, logical_key, current_revision, updated_at) ON brain.memory_items TO punaro_app;
+GRANT EXECUTE ON FUNCTION brain.purge_memory(uuid,uuid,uuid,bigint) TO punaro_app;
+REVOKE CREATE ON SCHEMA brain FROM punaro_app;

--- a/internal/postgres/postgres_integration_test.go
+++ b/internal/postgres/postgres_integration_test.go
@@ -441,6 +441,8 @@ RETURNS boolean LANGUAGE plpgsql SECURITY DEFINER SET search_path=pg_catalog AS 
 	testDeviceAuthIntegration(ctx, t, app, ownerDB)
 	testTrustedAttachmentIntegration(ctx, t, app, ownerDB)
 	testProjectIdentityIntegration(ctx, t, app, ownerDB)
+	testCanonicalBrainSchemaDriftIntegration(ctx, t, app, ownerDB)
+	testCanonicalBrainIntegration(ctx, t, app, ownerDB)
 	testBackupRestoreIntegration(ctx, t, app, ownerDB, ownerFile, appFile)
 	testTransactionalUpdateFenceIntegration(ctx, t, app, ownerDB)
 	testMailCutoverSubstrate(ctx, t, app, ownerDB)
@@ -545,10 +547,10 @@ AS $function$ BEGIN RETURN NEW; END $function$`); err != nil {
 		{name: "permissive credential expiry constraint", apply: `ALTER TABLE auth.device_credentials DROP CONSTRAINT device_credentials_check; ALTER TABLE auth.device_credentials ADD CONSTRAINT device_credentials_check CHECK (expires_at IS NULL OR expires_at > created_at OR true)`, restore: `ALTER TABLE auth.device_credentials DROP CONSTRAINT device_credentials_check; ALTER TABLE auth.device_credentials ADD CONSTRAINT device_credentials_check CHECK (expires_at IS NULL OR expires_at > created_at)`},
 		{name: "principal auth generation constraint", apply: `ALTER TABLE auth.principals DROP CONSTRAINT principals_auth_generation_check`, restore: `ALTER TABLE auth.principals ADD CONSTRAINT principals_auth_generation_check CHECK (auth_generation >= 0)`},
 		{name: "permissive principal auth generation constraint", apply: `ALTER TABLE auth.principals DROP CONSTRAINT principals_auth_generation_check; ALTER TABLE auth.principals ADD CONSTRAINT principals_auth_generation_check CHECK (auth_generation >= 0 OR true)`, restore: `ALTER TABLE auth.principals DROP CONSTRAINT principals_auth_generation_check; ALTER TABLE auth.principals ADD CONSTRAINT principals_auth_generation_check CHECK (auth_generation >= 0)`},
-		{name: "audit action value set", apply: `ALTER TABLE audit.events DROP CONSTRAINT events_action_check; ALTER TABLE audit.events ADD CONSTRAINT events_action_check CHECK (action IN ('principal.create', 'project.create', 'grant.create', 'grant.delete', 'job.enqueue', 'job.complete', 'job.retry', 'job.fail', 'owner.bootstrap', 'enrollment.create', 'enrollment.redeem', 'credential.rotate', 'credential.revoke', 'legacy.register', 'legacy.exchange', 'legacy.retire', 'legacy.disable', 'project.identity.attach', 'project.merge.preview', 'project.merge', 'unexpected'))`, restore: `ALTER TABLE audit.events DROP CONSTRAINT events_action_check; ALTER TABLE audit.events ADD CONSTRAINT events_action_check CHECK (action IN ('principal.create', 'project.create', 'grant.create', 'grant.delete', 'job.enqueue', 'job.complete', 'job.retry', 'job.fail', 'owner.bootstrap', 'enrollment.create', 'enrollment.redeem', 'credential.rotate', 'credential.revoke', 'legacy.register', 'legacy.exchange', 'legacy.retire', 'legacy.disable', 'project.identity.attach', 'project.merge.preview', 'project.merge'))`},
-		{name: "permissive audit action constraint", apply: `ALTER TABLE audit.events DROP CONSTRAINT events_action_check; ALTER TABLE audit.events ADD CONSTRAINT events_action_check CHECK (action IN ('principal.create', 'project.create', 'grant.create', 'grant.delete', 'job.enqueue', 'job.complete', 'job.retry', 'job.fail', 'owner.bootstrap', 'enrollment.create', 'enrollment.redeem', 'credential.rotate', 'credential.revoke', 'legacy.register', 'legacy.exchange', 'legacy.retire', 'legacy.disable', 'project.identity.attach', 'project.merge.preview', 'project.merge') OR true)`, restore: `ALTER TABLE audit.events DROP CONSTRAINT events_action_check; ALTER TABLE audit.events ADD CONSTRAINT events_action_check CHECK (action IN ('principal.create', 'project.create', 'grant.create', 'grant.delete', 'job.enqueue', 'job.complete', 'job.retry', 'job.fail', 'owner.bootstrap', 'enrollment.create', 'enrollment.redeem', 'credential.rotate', 'credential.revoke', 'legacy.register', 'legacy.exchange', 'legacy.retire', 'legacy.disable', 'project.identity.attach', 'project.merge.preview', 'project.merge'))`},
-		{name: "audit target value set", apply: `ALTER TABLE audit.events DROP CONSTRAINT events_target_kind_check; ALTER TABLE audit.events ADD CONSTRAINT events_target_kind_check CHECK (target_kind IN ('principal', 'project', 'grant', 'job', 'enrollment', 'credential', 'legacy_machine', 'project_identity', 'project_merge', 'unexpected'))`, restore: `ALTER TABLE audit.events DROP CONSTRAINT events_target_kind_check; ALTER TABLE audit.events ADD CONSTRAINT events_target_kind_check CHECK (target_kind IN ('principal', 'project', 'grant', 'job', 'enrollment', 'credential', 'legacy_machine', 'project_identity', 'project_merge'))`},
-		{name: "permissive audit target constraint", apply: `ALTER TABLE audit.events DROP CONSTRAINT events_target_kind_check; ALTER TABLE audit.events ADD CONSTRAINT events_target_kind_check CHECK (target_kind IN ('principal', 'project', 'grant', 'job', 'enrollment', 'credential', 'legacy_machine', 'project_identity', 'project_merge') OR true)`, restore: `ALTER TABLE audit.events DROP CONSTRAINT events_target_kind_check; ALTER TABLE audit.events ADD CONSTRAINT events_target_kind_check CHECK (target_kind IN ('principal', 'project', 'grant', 'job', 'enrollment', 'credential', 'legacy_machine', 'project_identity', 'project_merge'))`},
+		{name: "audit action value set", apply: `ALTER TABLE audit.events DROP CONSTRAINT events_action_check; ALTER TABLE audit.events ADD CONSTRAINT events_action_check CHECK (action IN ('principal.create', 'project.create', 'grant.create', 'grant.delete', 'job.enqueue', 'job.complete', 'job.retry', 'job.fail', 'owner.bootstrap', 'enrollment.create', 'enrollment.redeem', 'credential.rotate', 'credential.revoke', 'legacy.register', 'legacy.exchange', 'legacy.retire', 'legacy.disable', 'project.identity.attach', 'project.merge.preview', 'project.merge', 'memory.create', 'memory.update', 'memory.archive', 'memory.restore', 'memory.delete', 'unexpected'))`, restore: `ALTER TABLE audit.events DROP CONSTRAINT events_action_check; ALTER TABLE audit.events ADD CONSTRAINT events_action_check CHECK (action IN ('principal.create', 'project.create', 'grant.create', 'grant.delete', 'job.enqueue', 'job.complete', 'job.retry', 'job.fail', 'owner.bootstrap', 'enrollment.create', 'enrollment.redeem', 'credential.rotate', 'credential.revoke', 'legacy.register', 'legacy.exchange', 'legacy.retire', 'legacy.disable', 'project.identity.attach', 'project.merge.preview', 'project.merge', 'memory.create', 'memory.update', 'memory.archive', 'memory.restore', 'memory.delete'))`},
+		{name: "permissive audit action constraint", apply: `ALTER TABLE audit.events DROP CONSTRAINT events_action_check; ALTER TABLE audit.events ADD CONSTRAINT events_action_check CHECK (action IN ('principal.create', 'project.create', 'grant.create', 'grant.delete', 'job.enqueue', 'job.complete', 'job.retry', 'job.fail', 'owner.bootstrap', 'enrollment.create', 'enrollment.redeem', 'credential.rotate', 'credential.revoke', 'legacy.register', 'legacy.exchange', 'legacy.retire', 'legacy.disable', 'project.identity.attach', 'project.merge.preview', 'project.merge', 'memory.create', 'memory.update', 'memory.archive', 'memory.restore', 'memory.delete') OR true)`, restore: `ALTER TABLE audit.events DROP CONSTRAINT events_action_check; ALTER TABLE audit.events ADD CONSTRAINT events_action_check CHECK (action IN ('principal.create', 'project.create', 'grant.create', 'grant.delete', 'job.enqueue', 'job.complete', 'job.retry', 'job.fail', 'owner.bootstrap', 'enrollment.create', 'enrollment.redeem', 'credential.rotate', 'credential.revoke', 'legacy.register', 'legacy.exchange', 'legacy.retire', 'legacy.disable', 'project.identity.attach', 'project.merge.preview', 'project.merge', 'memory.create', 'memory.update', 'memory.archive', 'memory.restore', 'memory.delete'))`},
+		{name: "audit target value set", apply: `ALTER TABLE audit.events DROP CONSTRAINT events_target_kind_check; ALTER TABLE audit.events ADD CONSTRAINT events_target_kind_check CHECK (target_kind IN ('principal', 'project', 'grant', 'job', 'enrollment', 'credential', 'legacy_machine', 'project_identity', 'project_merge', 'memory_item', 'unexpected'))`, restore: `ALTER TABLE audit.events DROP CONSTRAINT events_target_kind_check; ALTER TABLE audit.events ADD CONSTRAINT events_target_kind_check CHECK (target_kind IN ('principal', 'project', 'grant', 'job', 'enrollment', 'credential', 'legacy_machine', 'project_identity', 'project_merge', 'memory_item'))`},
+		{name: "permissive audit target constraint", apply: `ALTER TABLE audit.events DROP CONSTRAINT events_target_kind_check; ALTER TABLE audit.events ADD CONSTRAINT events_target_kind_check CHECK (target_kind IN ('principal', 'project', 'grant', 'job', 'enrollment', 'credential', 'legacy_machine', 'project_identity', 'project_merge', 'memory_item') OR true)`, restore: `ALTER TABLE audit.events DROP CONSTRAINT events_target_kind_check; ALTER TABLE audit.events ADD CONSTRAINT events_target_kind_check CHECK (target_kind IN ('principal', 'project', 'grant', 'job', 'enrollment', 'credential', 'legacy_machine', 'project_identity', 'project_merge', 'memory_item'))`},
 		{name: "legacy machine state value set", apply: `ALTER TABLE auth.legacy_machines DROP CONSTRAINT legacy_machines_state_check; ALTER TABLE auth.legacy_machines ADD CONSTRAINT legacy_machines_state_check CHECK (state IN ('pending', 'migrated', 'retired', 'unexpected'))`, restore: `ALTER TABLE auth.legacy_machines DROP CONSTRAINT legacy_machines_state_check; ALTER TABLE auth.legacy_machines ADD CONSTRAINT legacy_machines_state_check CHECK (state IN ('pending', 'migrated', 'retired'))`},
 		{name: "project identity lookup index", apply: `DROP INDEX relay.project_identities_project`, restore: `CREATE INDEX project_identities_project ON relay.project_identities (project_id, id)`},
 		{name: "preview prune index expression", apply: `DROP INDEX relay.project_merge_previews_prune; CREATE INDEX project_merge_previews_prune ON relay.project_merge_previews (COALESCE(created_at, expires_at), id)`, restore: `DROP INDEX relay.project_merge_previews_prune; CREATE INDEX project_merge_previews_prune ON relay.project_merge_previews (COALESCE(consumed_at, expires_at), id)`},
@@ -570,11 +572,12 @@ AS $function$ BEGIN RETURN NEW; END $function$`); err != nil {
 			if _, err := ownerDB.ExecContext(ctx, drift.apply); err != nil {
 				t.Fatal(err)
 			}
-			if err := app.Ready(ctx); err == nil {
-				t.Fatalf("readiness accepted %s drift", drift.name)
-			}
+			driftErr := app.Ready(ctx)
 			if _, err := ownerDB.ExecContext(ctx, drift.restore); err != nil {
 				t.Fatal(err)
+			}
+			if driftErr == nil {
+				t.Fatalf("readiness accepted %s drift", drift.name)
 			}
 			if err := app.Ready(ctx); err != nil {
 				t.Fatalf("readiness did not recover after %s drift: %v", drift.name, err)
@@ -1727,13 +1730,13 @@ FROM jobs.server_state WHERE singleton`, bridgeCorruptArtifactID, bridgeCorruptP
 	request = UpdateRequest{
 		UpdateID:                "019b4eb0-798c-7a52-8d29-8560fcbb2089",
 		SourceRelease:           "v0.10.0",
-		TargetRelease:           "v0.13.0",
+		TargetRelease:           "v0.14.0",
 		SourceImage:             "ghcr.io/rock3r/punaro@sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
 		TargetImage:             "ghcr.io/rock3r/punaro@sha256:abababababababababababababababababababababababababababababababab",
 		SourceSchema:            10,
-		TargetSchema:            13,
+		TargetSchema:            14,
 		SchemaMin:               10,
-		SchemaMax:               13,
+		SchemaMax:               14,
 		RollbackFloor:           10,
 		PostgresMajor:           postgresMajor,
 		ReleaseSHA256:           "9494949494949494949494949494949494949494949494949494949494949494",
@@ -1742,11 +1745,11 @@ FROM jobs.server_state WHERE singleton`, bridgeCorruptArtifactID, bridgeCorruptP
 	}
 	transaction, err = admin.BeginUpdate(ctx, request)
 	if err != nil || transaction.Phase != UpdateFenced {
-		t.Fatalf("begin v13 update transaction=%#v err=%v", transaction, err)
+		t.Fatalf("begin v14 update transaction=%#v err=%v", transaction, err)
 	}
 	transaction, err = admin.AdvanceUpdate(ctx, request.UpdateID, UpdateFenced, UpdateWritersStopped, nil)
 	if err != nil || transaction.Phase != UpdateWritersStopped {
-		t.Fatalf("stop v13 writers transaction=%#v err=%v", transaction, err)
+		t.Fatalf("stop v14 writers transaction=%#v err=%v", transaction, err)
 	}
 	if err := ownerDB.QueryRowContext(ctx, `SELECT installation_id::text,timeline_id::text,change_sequence FROM jobs.server_state WHERE singleton`).Scan(&state.InstallationID, &state.TimelineID, &state.ChangeSequence); err != nil {
 		t.Fatal(err)
@@ -1761,11 +1764,11 @@ FROM jobs.server_state WHERE singleton`, bridgeCorruptArtifactID, bridgeCorruptP
 	}
 	transaction, err = admin.AdvanceUpdate(ctx, request.UpdateID, UpdateWritersStopped, UpdateBackupVerified, marker)
 	if err != nil || transaction.Phase != UpdateBackupVerified {
-		t.Fatalf("bind v13 backup transaction=%#v err=%v", transaction, err)
+		t.Fatalf("bind v14 backup transaction=%#v err=%v", transaction, err)
 	}
 	transaction, err = admin.AdvanceUpdate(ctx, request.UpdateID, UpdateBackupVerified, UpdateMigrationStarted, nil)
 	if err != nil || transaction.Phase != UpdateMigrationStarted {
-		t.Fatalf("start v13 migration transaction=%#v err=%v", transaction, err)
+		t.Fatalf("start v14 migration transaction=%#v err=%v", transaction, err)
 	}
 	authorization = UpdateMigrationAuthorization{
 		UpdateID: request.UpdateID, BackupID: marker.BackupID, TargetRelease: request.TargetRelease,
@@ -1773,18 +1776,22 @@ FROM jobs.server_state WHERE singleton`, bridgeCorruptArtifactID, bridgeCorruptP
 		ExportedSnapshotID: marker.ExportedSnapshotID, ManifestSHA256: marker.ManifestSHA256,
 	}
 	if state, err := MigrateUpdate(ctx, Config{DSNFile: ownerFile}, authorization); err != nil || state.Classification != Compatible || state.Version != CurrentManifest().MaxSupported {
-		t.Fatalf("v13 migration state=%#v err=%v", state, err)
+		t.Fatalf("v14 migration state=%#v err=%v", state, err)
 	}
-	v13App, err := OpenApplication(ctx, Config{DSNFile: appFile})
+	v14App, err := OpenApplication(ctx, Config{DSNFile: appFile})
 	if err != nil {
-		t.Fatalf("open exact v13 application: %v", err)
+		t.Fatalf("open exact v14 application: %v", err)
 	}
-	if err := v13App.TrustedAttachmentRuntimeReady(ctx); err != nil {
-		_ = v13App.Close()
-		t.Fatalf("trusted attachment runtime rejected exact v13 schema: %v", err)
+	if err := v14App.TrustedAttachmentRuntimeReady(ctx); err != nil {
+		_ = v14App.Close()
+		t.Fatalf("trusted attachment runtime rejected exact v14 schema: %v", err)
 	}
-	if err := v13App.Close(); err != nil {
-		t.Fatalf("close exact v13 application: %v", err)
+	if err := v14App.CanonicalBrainRuntimeReady(ctx); err != nil {
+		_ = v14App.Close()
+		t.Fatalf("canonical brain runtime rejected exact v14 schema: %v", err)
+	}
+	if err := v14App.Close(); err != nil {
+		t.Fatalf("close exact v14 application: %v", err)
 	}
 	var (
 		corruptProjectID, corruptOwnerID, corruptPath, corruptSHA256, corruptState string
@@ -1809,12 +1816,12 @@ FROM attachment.deletions WHERE artifact_id=$1`, bridgeCorruptArtifactID).Scan(
 			corruptTombstonedAt, corruptGCAfter, corruptGeneration)
 	}
 	if err := admin.CheckMailCutoverSchemaReadiness(ctx); err != nil {
-		t.Fatalf("mail cutover rejected exact v13 schema: %v", err)
+		t.Fatalf("mail cutover rejected exact v14 schema: %v", err)
 	}
 	for _, phases := range [][2]UpdatePhase{{UpdateMigrationStarted, UpdateMigrated}, {UpdateMigrated, UpdateCandidateReady}, {UpdateCandidateReady, UpdateDoctorPassed}, {UpdateDoctorPassed, UpdateConfigPublished}, {UpdateConfigPublished, UpdateCommitted}} {
 		transaction, err = admin.AdvanceUpdate(ctx, request.UpdateID, phases[0], phases[1], nil)
 		if err != nil || transaction.Phase != phases[1] {
-			t.Fatalf("v13 phase %s -> %s transaction=%#v err=%v", phases[0], phases[1], transaction, err)
+			t.Fatalf("v14 phase %s -> %s transaction=%#v err=%v", phases[0], phases[1], transaction, err)
 		}
 	}
 	if _, err := ownerDB.ExecContext(ctx, `DELETE FROM attachment.deletions WHERE artifact_id=$1`, bridgeCorruptArtifactID); err != nil {

--- a/internal/postgres/project_identity_store.go
+++ b/internal/postgres/project_identity_store.go
@@ -23,6 +23,9 @@ var (
 	// ErrProjectMergeAttachmentState fences project identities until the later
 	// attachment lifecycle defines an explicit, transactional merge behavior.
 	ErrProjectMergeAttachmentState = errors.New("project attachment state blocks merge")
+	// ErrProjectMergeBrainState prevents retiring a project while canonical
+	// memory would remain bound to its now-inaccessible scope.
+	ErrProjectMergeBrainState = errors.New("project memory state blocks merge")
 )
 
 const (
@@ -603,6 +606,19 @@ WHERE consumed_at IS NULL AND expires_at > statement_timestamp()`, actorPrincipa
 
 func projectMergeCounts(ctx context.Context, tx *sql.Tx, actorPrincipalID, sourceID, canonicalID string) (int, int, int, int, int, []string, error) {
 	var identityCount, canonicalIdentityCount, grantCount, aliasCount, pendingEnrollmentCount, privateRecordCount int
+	var brainLifecyclePresent bool
+	if err := tx.QueryRowContext(ctx, `SELECT to_regclass('brain.memory_items') IS NOT NULL AND to_regclass('brain.scopes') IS NOT NULL`).Scan(&brainLifecyclePresent); err != nil {
+		return 0, 0, 0, 0, 0, nil, errors.New("project memory state is unavailable")
+	}
+	if brainLifecyclePresent {
+		var hasMemoryLifecycle bool
+		if err := tx.QueryRowContext(ctx, `SELECT EXISTS (SELECT 1 FROM brain.scopes WHERE project_id=$1)`, sourceID).Scan(&hasMemoryLifecycle); err != nil {
+			return 0, 0, 0, 0, 0, nil, errors.New("project memory state is unavailable")
+		}
+		if hasMemoryLifecycle {
+			return 0, 0, 0, 0, 0, nil, ErrProjectMergeBrainState
+		}
+	}
 	var attachmentLifecyclePresent bool
 	if err := tx.QueryRowContext(ctx, `SELECT to_regclass('attachment.uploads') IS NOT NULL`).Scan(&attachmentLifecyclePresent); err != nil {
 		return 0, 0, 0, 0, 0, nil, errors.New("project attachment state is unavailable")

--- a/internal/postgres/state_test.go
+++ b/internal/postgres/state_test.go
@@ -66,8 +66,8 @@ func TestManifestValidationRejectsMutableOrNonContiguousHistory(t *testing.T) {
 
 func TestCurrentManifestRequiresControlPlaneSchema(t *testing.T) {
 	manifest := CurrentManifest()
-	if manifest.MinSupported != 10 || manifest.MaxSupported != 13 || len(manifest.Migrations) != 13 {
-		t.Fatalf("manifest=%#v, want exact v10-v13 compatibility window", manifest)
+	if manifest.MinSupported != 10 || manifest.MaxSupported != 14 || len(manifest.Migrations) != 14 {
+		t.Fatalf("manifest=%#v, want exact v10-v14 compatibility window", manifest)
 	}
 	for index, migration := range manifest.Migrations {
 		want := int64(index + 1)
@@ -79,6 +79,8 @@ func TestCurrentManifestRequiresControlPlaneSchema(t *testing.T) {
 		case 11:
 			want = 10
 		case 12, 13:
+			want = 10
+		case 14:
 			want = 10
 		}
 		if migration.CompatibilityFloor != want {
@@ -101,7 +103,10 @@ func TestCompatibleSchemaCanStillHavePendingMigrations(t *testing.T) {
 	if !migrationPending(SchemaState{Classification: Compatible, Version: 12}, manifest) {
 		t.Fatal("compatible v12 schema must still apply the pending v13 migration")
 	}
-	if migrationPending(SchemaState{Classification: Compatible, Version: 13}, manifest) {
-		t.Fatal("current v13 schema reported a pending migration")
+	if !migrationPending(SchemaState{Classification: Compatible, Version: 13}, manifest) {
+		t.Fatal("compatible v13 schema must still apply the pending v14 migration")
+	}
+	if migrationPending(SchemaState{Classification: Compatible, Version: 14}, manifest) {
+		t.Fatal("current v14 schema reported a pending migration")
 	}
 }


### PR DESCRIPTION
## Summary
- add the dark PostgreSQL brain schema for project-scoped canonical memory, append-only revisions, content-free tombstones, and a monotonic change feed
- implement capability-gated CRUD with durable idempotency, exact ETag CAS, JSONB normalization, hard-delete evidence, and fail-closed project merge handling
- add exact schema/readiness validation, adversarial integration coverage, and platform contract documentation

## Validation
- make test
- make test-race
- make staticcheck
- make security
- make lint
- independent alignment review: PASS
- independent adversarial review: PASS
- independent simplification review: PASS

Local Docker/Compose is unavailable, so the hosted PostgreSQL check is the mandatory integration gate before merge.

Compose Pi integration is intentionally excluded.