### PR TITLE
Add authenticated native memory read API

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,6 +21,9 @@ PUNARO_LOG_LEVEL=info
 # schema. Put the application DSN in an absolute 0600 file; never put it here.
 # PUNARO_POSTGRES_ENABLED=false
 # PUNARO_POSTGRES_DSN_FILE=/run/secrets/punaro-postgres-app-dsn
+# Dark native memory read API. Requires PostgreSQL device authentication and
+# the validated ingress policy; mutation and client surfaces remain separate.
+# PUNARO_MEMORY_API_ENABLED=false
 # Explicit test/qualification selector. `postgres` requires the compatible
 # schema above and does not import or dual-write the existing SQLite relay.
 # PUNARO_RELAY_STORE=sqlite

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -66,8 +66,16 @@ authority or truth. The response is fixed to versioned section budgets and a
 16,384-rune/64-KiB rendered ceiling, reports lexical-only semantic status, and
 binds future client caches to the same-snapshot installation, timeline, change,
 project-content, and project-ACL generations. It never returns bodies, source
-coordinates, or control-plane arguments. The first native memory client remains
-a later independently reviewed slice.
+coordinates, or control-plane arguments. The dark native read API is separately
+gated by `PUNARO_MEMORY_API_ENABLED`. It authenticates one device bearer under
+the existing ingress policy and exposes project resolution, full authorized
+get, proposal get, bounded search/brief, and timeline-aware change fetch on
+project-scoped v1 routes. The server binds the principal, uses strict bounded
+inputs and content-free failures, and keeps unauthorized resources
+indistinguishable from missing. An explicit null change cursor starts at the
+current installation/timeline origin; subsequent cursors fail on restore or
+future coordinates. Mutations and the native local client remain later
+independently reviewed slices.
 
 ## Goals
 

--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ precedence over dotenv values.
 | `PUNARO_POSTGRES_ENABLED` | `false` | Opts into the PostgreSQL platform substrate. Ordinary startup only checks compatibility and never migrates. |
 | `PUNARO_POSTGRES_DSN_FILE` | unset | Required with PostgreSQL enabled: absolute path to a private application-role DSN file. The application role has no DDL authority. |
 | `PUNARO_DEVICE_AUTH_ENABLED` | `false` | Mounts bounded enrollment redemption and device-session authentication; requires PostgreSQL and a complete ingress policy. |
+| `PUNARO_MEMORY_API_ENABLED` | `false` | Separately mounts the dark authenticated native memory read API; requires PostgreSQL device authentication. It does not enable mutations, a local client, MCP, semantic retrieval, or Compose Pi integration. |
 | `PUNARO_CREDENTIAL_TRANSITION_ENABLED` | `false` | Dormant M-9 bridge. Requires device auth and the PostgreSQL relay. Legacy Ed25519 requests must pass the durable global gate; a migrated device bearer resolves through its proof-bound exchange to the exact static machine enrollment and inherits no additional endpoint authority. |
 | `PUNARO_INGRESS_MODE` | unset | Required with device auth: `lan`, `proxy`, or `internet`. Proxy and Internet origins bind loopback and require `PUNARO_PUBLIC_URL=https://...`. |
 | `PUNARO_PUBLIC_URL` | unset | Canonical HTTPS public URL for proxy/Internet mode. It does not make forwarded headers trustworthy. |

--- a/cmd/punaro/main.go
+++ b/cmd/punaro/main.go
@@ -365,6 +365,7 @@ func runInit(args []string, stdout, stderr io.Writer) int {
 	publicURL := flags.String("public-url", "", "canonical HTTPS public URL")
 	trustedLAN := flags.String("trusted-lan-cidr", "", "private or link-local trusted LAN")
 	allowLANHTTP := flags.Bool("allow-lan-http", false, "explicitly allow plaintext credentials from the trusted LAN")
+	memoryAPI := flags.Bool("memory-api", false, "enable the authenticated native memory API")
 	healthListen := flags.String("health-listen-addr", "127.0.0.1:8081", "distinct loopback-only health listener")
 	resume := flags.Bool("resume", false, "resume a durably staged initialization")
 	if flags.Parse(args) != nil || flags.NArg() != 0 || *directory == "" {
@@ -401,7 +402,7 @@ func runInit(args []string, stdout, stderr io.Writer) int {
 		}
 		return createOwner(ctx, ownerFile, name)
 	}
-	installation, err := operator.Init(context.Background(), operator.InitOptions{Directory: *directory, DataDir: *dataDir, BackupDir: *backupDir, Image: *image, OwnerDSNFile: *ownerDSN, AppDSNFile: *appDSN, OwnerName: *ownerName, Ingress: ingress.Policy{Mode: ingress.Mode(*mode), ListenAddr: *listen, PublicURL: *publicURL, TrustedLAN: *trustedLAN, AllowPlaintext: *allowLANHTTP}, HealthListenAddr: *healthListen}, bootstrap)
+	installation, err := operator.Init(context.Background(), operator.InitOptions{Directory: *directory, DataDir: *dataDir, BackupDir: *backupDir, Image: *image, OwnerDSNFile: *ownerDSN, AppDSNFile: *appDSN, OwnerName: *ownerName, Ingress: ingress.Policy{Mode: ingress.Mode(*mode), ListenAddr: *listen, PublicURL: *publicURL, TrustedLAN: *trustedLAN, AllowPlaintext: *allowLANHTTP}, HealthListenAddr: *healthListen, MemoryAPIEnabled: *memoryAPI}, bootstrap)
 	if err != nil {
 		_, _ = fmt.Fprintf(stderr, "punaro init failed: %v\n", err)
 		return 1

--- a/cmd/punarod/main.go
+++ b/cmd/punarod/main.go
@@ -57,6 +57,7 @@ type trustedAttachmentDatabase interface {
 
 type memoryDatabase interface {
 	deviceDatabase
+	CanonicalBrainRuntimeReady(context.Context) error
 	ResolveProjectIdentity(context.Context, string, punaropostgres.ProjectIdentityKind, string) (punaropostgres.ProjectIdentityResolution, error)
 	GetMemory(context.Context, string, string, string) (punaropostgres.MemoryItem, error)
 	GetMemoryProposal(context.Context, string, string, string) (punaropostgres.MemoryProposal, error)
@@ -289,6 +290,11 @@ func buildMemoryHandler(cfg config.Config, platformDB platformDatabase) (http.Ha
 	database, ok := platformDB.(memoryDatabase)
 	if !ok {
 		return nil, errors.New("PostgreSQL memory database authority is unavailable")
+	}
+	readinessCtx, readinessCancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer readinessCancel()
+	if err := database.CanonicalBrainRuntimeReady(readinessCtx); err != nil {
+		return nil, errors.New("PostgreSQL canonical brain schema is unavailable")
 	}
 	policy := &ingress.Policy{Mode: ingress.Mode(cfg.IngressMode), ListenAddr: cfg.ListenAddr, PublicURL: cfg.PublicURL, TrustedLAN: cfg.TrustedLANCIDR, AllowPlaintext: cfg.TrustedLANHTTP}
 	if err := policy.Validate(); err != nil {

--- a/cmd/punarod/main.go
+++ b/cmd/punarod/main.go
@@ -23,6 +23,7 @@ import (
 	"github.com/rock3r/punaro/internal/config"
 	"github.com/rock3r/punaro/internal/devicehttp"
 	"github.com/rock3r/punaro/internal/ingress"
+	"github.com/rock3r/punaro/internal/memoryhttp"
 	punaropostgres "github.com/rock3r/punaro/internal/postgres"
 	"github.com/rock3r/punaro/internal/relay"
 	"github.com/rock3r/punaro/internal/trustedattachment"
@@ -52,6 +53,16 @@ type trustedAttachmentDatabase interface {
 	trustedattachment.Repository
 	TrustedAttachmentRuntimeReady(context.Context) error
 	ReserveAttachment(context.Context, punaropostgres.AttachmentReservationRequest) (punaropostgres.AttachmentReservation, error)
+}
+
+type memoryDatabase interface {
+	deviceDatabase
+	ResolveProjectIdentity(context.Context, string, punaropostgres.ProjectIdentityKind, string) (punaropostgres.ProjectIdentityResolution, error)
+	GetMemory(context.Context, string, string, string) (punaropostgres.MemoryItem, error)
+	GetMemoryProposal(context.Context, string, string, string) (punaropostgres.MemoryProposal, error)
+	SearchMemory(context.Context, punaropostgres.MemorySearchRequest) (punaropostgres.MemorySearchPage, error)
+	BuildMemoryPromptBrief(context.Context, punaropostgres.MemoryPromptBriefRequest) (punaropostgres.MemoryPromptBrief, error)
+	FetchMemoryChanges(context.Context, punaropostgres.MemoryChangeRequest) (punaropostgres.MemoryChangePage, error)
 }
 
 type credentialTransitionDatabase interface {
@@ -180,6 +191,11 @@ func run(args []string, stderr io.Writer) int {
 	if trustedAttachmentHandler != nil {
 		defer trustedAttachmentHandler.Close()
 	}
+	memoryHandler, err := buildMemoryHandler(cfg, platformDB)
+	if err != nil {
+		_, _ = fmt.Fprintf(stderr, "punarod memory API configuration error: %v\n", err)
+		return 2
+	}
 	logger := log.New(os.Stderr, "punarod ", log.LstdFlags|log.LUTC)
 	healthMux := http.NewServeMux()
 	healthMux.HandleFunc("GET /healthz", func(w http.ResponseWriter, _ *http.Request) { _, _ = w.Write([]byte(`{"status":"ok"}\n`)) })
@@ -206,7 +222,7 @@ func run(args []string, stderr io.Writer) int {
 		mux.Handle("/v1/enrollments/redeem", deviceHandler)
 		mux.Handle("/v1/device/session", deviceHandler)
 	}
-	registerProductionRoutes(mux, trustedAttachmentHandler, relayHandler)
+	registerProductionRoutes(mux, memoryHandler, trustedAttachmentHandler, relayHandler)
 	server := configuredServer(cfg.ListenAddr, securityHeaders(mux))
 	healthServer := configuredServer(cfg.HealthListenAddr, securityHeaders(healthMux))
 	publicListener, err := listenTCP("tcp", cfg.ListenAddr)
@@ -252,7 +268,11 @@ func run(args []string, stderr io.Writer) int {
 	}
 }
 
-func registerProductionRoutes(mux *http.ServeMux, trustedAttachmentHandler *trustedAttachmentRuntime, relayHandler http.Handler) {
+func registerProductionRoutes(mux *http.ServeMux, memoryHandler http.Handler, trustedAttachmentHandler *trustedAttachmentRuntime, relayHandler http.Handler) {
+	if memoryHandler != nil {
+		mux.Handle("/v1/projects/resolve", memoryHandler)
+		mux.Handle("/v1/projects/", memoryHandler)
+	}
 	if trustedAttachmentHandler != nil {
 		mux.Handle("/v1/trusted-attachments", trustedAttachmentHandler)
 		mux.Handle("/v1/trusted-attachments/", trustedAttachmentHandler)
@@ -260,6 +280,21 @@ func registerProductionRoutes(mux *http.ServeMux, trustedAttachmentHandler *trus
 	if relayHandler != nil {
 		mux.Handle("/v1/", relayHandler)
 	}
+}
+
+func buildMemoryHandler(cfg config.Config, platformDB platformDatabase) (http.Handler, error) {
+	if !cfg.MemoryAPIEnabled {
+		return nil, nil
+	}
+	database, ok := platformDB.(memoryDatabase)
+	if !ok {
+		return nil, errors.New("PostgreSQL memory database authority is unavailable")
+	}
+	policy := &ingress.Policy{Mode: ingress.Mode(cfg.IngressMode), ListenAddr: cfg.ListenAddr, PublicURL: cfg.PublicURL, TrustedLAN: cfg.TrustedLANCIDR, AllowPlaintext: cfg.TrustedLANHTTP}
+	if err := policy.Validate(); err != nil {
+		return nil, errors.New("memory credential transport policy is invalid")
+	}
+	return memoryhttp.New(database, policy), nil
 }
 
 func buildTrustedAttachmentHandler(cfg config.Config, platformDB platformDatabase) (*trustedAttachmentRuntime, error) {

--- a/cmd/punarod/main_test.go
+++ b/cmd/punarod/main_test.go
@@ -72,6 +72,44 @@ func TestBuildMemoryHandlerIsDarkByDefaultAndRequiresCompleteAuthority(t *testin
 	}
 }
 
+type unavailableMemoryDatabase struct {
+	deviceDatabase
+	readyCalled bool
+}
+
+func (*unavailableMemoryDatabase) Ready(context.Context) error { return nil }
+func (*unavailableMemoryDatabase) Close() error                { return nil }
+func (database *unavailableMemoryDatabase) CanonicalBrainRuntimeReady(context.Context) error {
+	database.readyCalled = true
+	return errors.New("schema 14 is unavailable")
+}
+func (*unavailableMemoryDatabase) ResolveProjectIdentity(context.Context, string, punaropostgres.ProjectIdentityKind, string) (punaropostgres.ProjectIdentityResolution, error) {
+	return punaropostgres.ProjectIdentityResolution{}, errors.New("unused")
+}
+func (*unavailableMemoryDatabase) GetMemory(context.Context, string, string, string) (punaropostgres.MemoryItem, error) {
+	return punaropostgres.MemoryItem{}, errors.New("unused")
+}
+func (*unavailableMemoryDatabase) GetMemoryProposal(context.Context, string, string, string) (punaropostgres.MemoryProposal, error) {
+	return punaropostgres.MemoryProposal{}, errors.New("unused")
+}
+func (*unavailableMemoryDatabase) SearchMemory(context.Context, punaropostgres.MemorySearchRequest) (punaropostgres.MemorySearchPage, error) {
+	return punaropostgres.MemorySearchPage{}, errors.New("unused")
+}
+func (*unavailableMemoryDatabase) BuildMemoryPromptBrief(context.Context, punaropostgres.MemoryPromptBriefRequest) (punaropostgres.MemoryPromptBrief, error) {
+	return punaropostgres.MemoryPromptBrief{}, errors.New("unused")
+}
+func (*unavailableMemoryDatabase) FetchMemoryChanges(context.Context, punaropostgres.MemoryChangeRequest) (punaropostgres.MemoryChangePage, error) {
+	return punaropostgres.MemoryChangePage{}, errors.New("unused")
+}
+
+func TestBuildMemoryHandlerRejectsCompatibleHistoricalSchema(t *testing.T) {
+	database := &unavailableMemoryDatabase{}
+	_, err := buildMemoryHandler(config.Config{MemoryAPIEnabled: true, IngressMode: "internet", ListenAddr: "127.0.0.1:8080", PublicURL: "https://punaro.example"}, database)
+	if err == nil || !database.readyCalled || !strings.Contains(err.Error(), "schema is unavailable") {
+		t.Fatalf("ready=%t error=%v", database.readyCalled, err)
+	}
+}
+
 func TestProductionRoutesKeepMemoryAPIDarkWhenHandlerIsAbsent(t *testing.T) {
 	mux := http.NewServeMux()
 	registerProductionRoutes(mux, nil, nil, nil)

--- a/cmd/punarod/main_test.go
+++ b/cmd/punarod/main_test.go
@@ -32,10 +32,13 @@ func TestRunFailsClosedBeforeStartingAttachmentRuntime(t *testing.T) {
 
 func TestProductionRoutesOmitRetiredAttachments(t *testing.T) {
 	mux := http.NewServeMux()
+	memory := http.HandlerFunc(func(response http.ResponseWriter, _ *http.Request) {
+		response.WriteHeader(http.StatusAccepted)
+	})
 	trusted := &trustedAttachmentRuntime{handler: http.HandlerFunc(func(response http.ResponseWriter, _ *http.Request) {
 		response.WriteHeader(http.StatusNoContent)
 	})}
-	registerProductionRoutes(mux, trusted, nil)
+	registerProductionRoutes(mux, memory, trusted, nil)
 	for _, path := range []string{"/v2/directory", "/v2/permits", "/v3/permits", "/v3/attachments/example"} {
 		request := httptest.NewRequestWithContext(t.Context(), http.MethodGet, path, nil)
 		response := httptest.NewRecorder()
@@ -49,6 +52,34 @@ func TestProductionRoutesOmitRetiredAttachments(t *testing.T) {
 	mux.ServeHTTP(response, request)
 	if response.Code != http.StatusNoContent {
 		t.Fatalf("trusted attachment route status=%d", response.Code)
+	}
+	request = httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/v1/projects/resolve", nil)
+	response = httptest.NewRecorder()
+	mux.ServeHTTP(response, request)
+	if response.Code != http.StatusAccepted {
+		t.Fatalf("memory route status=%d", response.Code)
+	}
+}
+
+func TestBuildMemoryHandlerIsDarkByDefaultAndRequiresCompleteAuthority(t *testing.T) {
+	handler, err := buildMemoryHandler(config.Config{}, &refusingPlatformDatabase{})
+	if err != nil || handler != nil {
+		t.Fatalf("disabled handler=%v err=%v", handler, err)
+	}
+	_, err = buildMemoryHandler(config.Config{MemoryAPIEnabled: true, IngressMode: "internet", ListenAddr: "127.0.0.1:8080", PublicURL: "https://punaro.example"}, &refusingPlatformDatabase{})
+	if err == nil || !strings.Contains(err.Error(), "memory database authority") {
+		t.Fatalf("enabled incomplete authority error=%v", err)
+	}
+}
+
+func TestProductionRoutesKeepMemoryAPIDarkWhenHandlerIsAbsent(t *testing.T) {
+	mux := http.NewServeMux()
+	registerProductionRoutes(mux, nil, nil, nil)
+	request := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/v1/projects/resolve", nil)
+	response := httptest.NewRecorder()
+	mux.ServeHTTP(response, request)
+	if response.Code != http.StatusNotFound {
+		t.Fatalf("dark memory route status=%d", response.Code)
 	}
 }
 

--- a/docs/operator-guide.md
+++ b/docs/operator-guide.md
@@ -623,6 +623,28 @@ writes reopen. Keep the abandoned stack stopped. Raw `docker compose up`, raw
 `punarod`, and direct `punaro-migrate` invocation never clear or bypass a live
 fence.
 
+### Dark native memory read API
+
+M-17A adds an opt-in server read surface without enabling a native client or
+memory mutations. New installations persist the supported choice with
+`punaro init --memory-api`; without that flag the generated environment records
+`PUNARO_MEMORY_API_ENABLED=false`. The generated Compose override passes the
+persisted setting, so later `up`, update, resume, and restore operations do not
+depend on ambient shell state. Startup fails before binding if the enabled
+platform database does not provide the complete memory read authority. Existing
+installations remain dark until a later supported configuration command is
+delivered; do not hand-edit their generated environment or installation marker.
+
+The mounted v1 surface provides strict authenticated project resolution,
+authorized memory/proposal get, bounded lexical search and prompt brief, and a
+timeline-aware content-free change feed. Every response is `Cache-Control:
+no-store`; the server never accepts a principal ID from the caller. A first
+change request uses `"cursor": null`; clients must retain the returned
+installation/timeline/sequence cursor and discard it on the typed restore or
+future-cursor conflict. There is intentionally no offline writable brain,
+mutation route, CLI/MCP binary, semantic retrieval, or Compose Pi integration
+in this slice.
+
 ## Operations and incident response
 
 If a credential or machine is suspected compromised, stop the local service,

--- a/docs/platform-contracts.md
+++ b/docs/platform-contracts.md
@@ -259,6 +259,32 @@ client cache must additionally bind principal, normalized query, budget
 version, project, installation, timeline, change sequence, and project
 generations. Compose Pi cache/send behavior is outside this implementation.
 
+The first native memory network slice is dark by default behind
+`PUNARO_MEMORY_API_ENABLED` and requires the already validated PostgreSQL device
+authentication ingress. It adds no schema. The server accepts exactly one
+bearer credential, binds its principal internally, and exposes only project
+identity resolution plus project-scoped get, proposal-get, lexical search,
+prompt-brief, and change-fetch routes. Callers cannot select a principal,
+origin, route, credential, destination, source path, URL fetch, secret
+resolution, or other control-plane argument through memory input.
+
+All JSON is strict, duplicate-free, unknown-field rejecting, and limited to
+4 KiB. Handler concurrency is capped at 32 and each complete authentication and
+store operation has a five-second deadline; the lexical/brief store retains its
+stricter two-second SQL deadline. Responses are `no-store`. Full documents
+remain exclusive to authorized get. Search and brief keep their existing
+bounded projections, proposals keep their existing bounded staged payload, and
+changes remain content-free. Missing, unauthorized, and cross-project
+resources all return the same not-found boundary. Stale merged project IDs
+resolve only through their permanent canonical lookup aliases and confer no
+authority beyond the caller's grant on the canonical project. Cursor
+timeline/future conflicts are typed but content-free. A null cursor means the
+current installation and timeline at sequence zero, enabling a first bounded
+enumeration; every returned cursor then pins installation, timeline, and
+sequence so restore cannot create silent divergence. Mutation routes, local
+credential/project state, retry/cache behavior, MCP, semantic retrieval, and
+Compose Pi remain absent.
+
 ### Implemented dark control-plane primitives
 
 Schema version 3 is the minimum for the current PostgreSQL opt-in. Version 2 adds

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -30,6 +30,7 @@ type Config struct {
 	PostgresEnabled             bool
 	PostgresDSNFile             string
 	DeviceAuthEnabled           bool
+	MemoryAPIEnabled            bool
 	TrustedAttachmentsEnabled   bool
 	TrustedAttachmentBlobDir    string
 	CredentialTransitionEnabled bool
@@ -84,6 +85,10 @@ func Load(explicitEnvFile string) (Config, error) {
 	if err != nil {
 		return Config{}, fmt.Errorf("parse PUNARO_DEVICE_AUTH_ENABLED: %w", err)
 	}
+	memoryAPIEnabled, err := strconv.ParseBool(value("PUNARO_MEMORY_API_ENABLED", "false"))
+	if err != nil {
+		return Config{}, fmt.Errorf("parse PUNARO_MEMORY_API_ENABLED: %w", err)
+	}
 	trustedAttachmentsEnabled, err := strconv.ParseBool(value("PUNARO_TRUSTED_ATTACHMENTS_ENABLED", "false"))
 	if err != nil {
 		return Config{}, fmt.Errorf("parse PUNARO_TRUSTED_ATTACHMENTS_ENABLED: %w", err)
@@ -132,6 +137,9 @@ func Load(explicitEnvFile string) (Config, error) {
 	} else if trustedAttachmentBlobDir != "" {
 		return Config{}, fmt.Errorf("PUNARO_TRUSTED_ATTACHMENT_BLOB_DIR requires PUNARO_TRUSTED_ATTACHMENTS_ENABLED")
 	}
+	if memoryAPIEnabled && (!postgresEnabled || !deviceAuthEnabled) {
+		return Config{}, fmt.Errorf("memory API requires PostgreSQL device authentication")
+	}
 	if relayEnabled && relayMachines == "" {
 		return Config{}, fmt.Errorf("enabled relay requires PUNARO_RELAY_MACHINES_JSON")
 	}
@@ -156,7 +164,7 @@ func Load(explicitEnvFile string) (Config, error) {
 	if !postgresEnabled && postgresDSNFile != "" {
 		return Config{}, fmt.Errorf("PUNARO_POSTGRES_DSN_FILE requires PUNARO_POSTGRES_ENABLED")
 	}
-	return Config{ListenAddr: listenAddr, HealthListenAddr: healthListenAddr, DataDir: dataDir, LogLevel: level, RelayEnabled: relayEnabled, RelayMachinesJSON: relayMachines, RelayStore: relayStore, AccessIssuer: accessIssuer, AccessAudience: accessAudience, AccessJWKSURL: accessJWKSURL, AccessJWKSFile: accessJWKSFile, PostgresEnabled: postgresEnabled, PostgresDSNFile: postgresDSNFile, DeviceAuthEnabled: deviceAuthEnabled, TrustedAttachmentsEnabled: trustedAttachmentsEnabled, TrustedAttachmentBlobDir: trustedAttachmentBlobDir, CredentialTransitionEnabled: credentialTransitionEnabled, IngressMode: ingressMode, PublicURL: publicURL, TrustedLANCIDR: trustedLANCIDR, TrustedLANHTTP: trustedLANHTTP}, nil
+	return Config{ListenAddr: listenAddr, HealthListenAddr: healthListenAddr, DataDir: dataDir, LogLevel: level, RelayEnabled: relayEnabled, RelayMachinesJSON: relayMachines, RelayStore: relayStore, AccessIssuer: accessIssuer, AccessAudience: accessAudience, AccessJWKSURL: accessJWKSURL, AccessJWKSFile: accessJWKSFile, PostgresEnabled: postgresEnabled, PostgresDSNFile: postgresDSNFile, DeviceAuthEnabled: deviceAuthEnabled, MemoryAPIEnabled: memoryAPIEnabled, TrustedAttachmentsEnabled: trustedAttachmentsEnabled, TrustedAttachmentBlobDir: trustedAttachmentBlobDir, CredentialTransitionEnabled: credentialTransitionEnabled, IngressMode: ingressMode, PublicURL: publicURL, TrustedLANCIDR: trustedLANCIDR, TrustedLANHTTP: trustedLANHTTP}, nil
 }
 
 func rejectRetiredAttachmentConfiguration() error {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -281,6 +281,26 @@ func TestLoadRequiresCompleteTrustedAttachmentReleaseSurface(t *testing.T) {
 	}
 }
 
+func TestLoadMemoryAPIIsDarkByDefaultAndRequiresPostgresDeviceAuthority(t *testing.T) {
+	cfg, err := Load("")
+	if err != nil || cfg.MemoryAPIEnabled {
+		t.Fatalf("default config=%#v err=%v", cfg, err)
+	}
+	t.Setenv("PUNARO_MEMORY_API_ENABLED", "true")
+	if _, err := Load(""); err == nil {
+		t.Fatal("memory API was enabled without PostgreSQL device authority")
+	}
+	t.Setenv("PUNARO_POSTGRES_ENABLED", "true")
+	t.Setenv("PUNARO_POSTGRES_DSN_FILE", "/run/secrets/punaro-app-dsn")
+	t.Setenv("PUNARO_DEVICE_AUTH_ENABLED", "true")
+	t.Setenv("PUNARO_INGRESS_MODE", "internet")
+	t.Setenv("PUNARO_PUBLIC_URL", "https://punaro.example")
+	cfg, err = Load("")
+	if err != nil || !cfg.MemoryAPIEnabled {
+		t.Fatalf("memory API config=%#v err=%v", cfg, err)
+	}
+}
+
 func TestLoadAcceptsExplicitRelayMachineEnrollment(t *testing.T) {
 	t.Setenv("PUNARO_RELAY_ENABLED", "true")
 	t.Setenv("PUNARO_RELAY_MACHINES_JSON", `[{"id":"machine-a","public_key":"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA","endpoint_prefixes":["agent/a/"]}]`)

--- a/internal/memoryhttp/handler.go
+++ b/internal/memoryhttp/handler.go
@@ -1,0 +1,426 @@
+// Package memoryhttp exposes Punaro's bounded, device-authenticated native
+// memory read surface. Canonical authorization remains in the PostgreSQL store.
+package memoryhttp
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"mime"
+	"net/http"
+	"strings"
+	"time"
+	"unicode"
+	"unicode/utf8"
+
+	"github.com/google/uuid"
+	"github.com/rock3r/punaro/internal/ingress"
+	"github.com/rock3r/punaro/internal/postgres"
+)
+
+const (
+	maxRequestBytes      = 4096
+	maxConcurrentReads   = 32
+	readOperationTimeout = 5 * time.Second
+)
+
+type store interface {
+	AuthenticateDevice(context.Context, string) (postgres.AuthenticatedDevice, error)
+	ResolveProjectIdentity(context.Context, string, postgres.ProjectIdentityKind, string) (postgres.ProjectIdentityResolution, error)
+	GetMemory(context.Context, string, string, string) (postgres.MemoryItem, error)
+	GetMemoryProposal(context.Context, string, string, string) (postgres.MemoryProposal, error)
+	SearchMemory(context.Context, postgres.MemorySearchRequest) (postgres.MemorySearchPage, error)
+	BuildMemoryPromptBrief(context.Context, postgres.MemoryPromptBriefRequest) (postgres.MemoryPromptBrief, error)
+	FetchMemoryChanges(context.Context, postgres.MemoryChangeRequest) (postgres.MemoryChangePage, error)
+}
+
+type handler struct {
+	store   store
+	policy  *ingress.Policy
+	mux     *http.ServeMux
+	slots   chan struct{}
+	timeout time.Duration
+}
+
+// New constructs the native memory read handler. The caller decides whether
+// the dark surface is mounted in the production mux.
+func New(database store, policy *ingress.Policy) http.Handler {
+	return newHandler(database, policy, maxConcurrentReads, readOperationTimeout)
+}
+
+func newHandler(database store, policy *ingress.Policy, concurrency int, timeout time.Duration) http.Handler {
+	if concurrency < 1 {
+		concurrency = 1
+	}
+	h := &handler{store: database, policy: policy, mux: http.NewServeMux(), slots: make(chan struct{}, concurrency), timeout: timeout}
+	h.mux.HandleFunc("POST /v1/projects/resolve", h.resolveProject)
+	h.mux.HandleFunc("GET /v1/projects/{project}/memories/{item}", h.getMemory)
+	h.mux.HandleFunc("POST /v1/projects/{project}/memories/search", h.searchMemory)
+	h.mux.HandleFunc("POST /v1/projects/{project}/memories/brief", h.promptBrief)
+	h.mux.HandleFunc("POST /v1/projects/{project}/memories/changes", h.memoryChanges)
+	h.mux.HandleFunc("GET /v1/projects/{project}/memory-proposals/{proposal}", h.getProposal)
+	return h
+}
+
+func (h *handler) ServeHTTP(response http.ResponseWriter, request *http.Request) {
+	response.Header().Set("Cache-Control", "no-store")
+	if h.store == nil || h.policy == nil || !h.policy.AllowsCredential(request) {
+		writeError(response, http.StatusForbidden, "credential transport is forbidden")
+		return
+	}
+	select {
+	case h.slots <- struct{}{}:
+		defer func() { <-h.slots }()
+	default:
+		response.Header().Set("Retry-After", "1")
+		writeError(response, http.StatusTooManyRequests, "memory service is busy")
+		return
+	}
+	credential, ok := bearerCredential(request)
+	if !ok {
+		unauthenticated(response)
+		return
+	}
+	operationCtx, cancel := context.WithTimeout(request.Context(), h.timeout)
+	defer cancel()
+	device, err := h.store.AuthenticateDevice(operationCtx, credential)
+	if err != nil || !validID(device.PrincipalID) || !validID(device.LookupID) || device.Generation < 1 {
+		unauthenticated(response)
+		return
+	}
+	h.mux.ServeHTTP(response, request.WithContext(context.WithValue(operationCtx, authenticatedDeviceKey{}, device)))
+}
+
+type authenticatedDeviceKey struct{}
+
+func authenticatedDevice(ctx context.Context) (postgres.AuthenticatedDevice, bool) {
+	device, ok := ctx.Value(authenticatedDeviceKey{}).(postgres.AuthenticatedDevice)
+	return device, ok
+}
+
+func bearerCredential(request *http.Request) (string, bool) {
+	if len(request.Header.Values("Authorization")) != 1 {
+		return "", false
+	}
+	value := request.Header.Get("Authorization")
+	scheme, credential, ok := strings.Cut(value, " ")
+	if !ok || !strings.EqualFold(scheme, "Bearer") {
+		return "", false
+	}
+	return credential, credential != "" && !strings.ContainsAny(credential, " \t\r\n")
+}
+
+func (h *handler) resolveProject(response http.ResponseWriter, request *http.Request) {
+	device, ok := authenticatedDevice(request.Context())
+	if !ok {
+		unauthenticated(response)
+		return
+	}
+	fields, ok := readObject(response, request, "kind", "locator")
+	if !ok {
+		return
+	}
+	var kind postgres.ProjectIdentityKind
+	var locator string
+	if !decodeString(fields["kind"], (*string)(&kind)) || !decodeString(fields["locator"], &locator) ||
+		len(locator) > maxRequestBytes || strings.TrimSpace(locator) == "" {
+		writeError(response, http.StatusBadRequest, "request is malformed")
+		return
+	}
+	if _, err := postgres.NormalizeProjectIdentityLocator(kind, locator); err != nil {
+		writeError(response, http.StatusBadRequest, "request is invalid")
+		return
+	}
+	result, err := h.store.ResolveProjectIdentity(request.Context(), device.PrincipalID, kind, locator)
+	if err != nil {
+		writeStoreError(response, err)
+		return
+	}
+	writeJSON(response, http.StatusOK, result)
+}
+
+func (h *handler) getMemory(response http.ResponseWriter, request *http.Request) {
+	device, projectID, ok := deviceProject(response, request)
+	itemID := request.PathValue("item")
+	if !ok || !validID(itemID) || !emptyRequest(request) {
+		if ok {
+			writeError(response, http.StatusBadRequest, "request is invalid")
+		}
+		return
+	}
+	item, err := h.store.GetMemory(request.Context(), device.PrincipalID, projectID, itemID)
+	if err != nil {
+		writeStoreError(response, err)
+		return
+	}
+	response.Header().Set("ETag", item.ETag)
+	writeJSON(response, http.StatusOK, item)
+}
+
+func (h *handler) getProposal(response http.ResponseWriter, request *http.Request) {
+	device, projectID, ok := deviceProject(response, request)
+	proposalID := request.PathValue("proposal")
+	if !ok || !validID(proposalID) || !emptyRequest(request) {
+		if ok {
+			writeError(response, http.StatusBadRequest, "request is invalid")
+		}
+		return
+	}
+	proposal, err := h.store.GetMemoryProposal(request.Context(), device.PrincipalID, projectID, proposalID)
+	if err != nil {
+		writeStoreError(response, err)
+		return
+	}
+	response.Header().Set("ETag", proposal.ETag)
+	writeJSON(response, http.StatusOK, proposal)
+}
+
+func (h *handler) searchMemory(response http.ResponseWriter, request *http.Request) {
+	device, projectID, ok := deviceProject(response, request)
+	if !ok {
+		return
+	}
+	fields, ok := readObject(response, request, "query", "limit")
+	if !ok {
+		return
+	}
+	var query string
+	var limit int
+	if !decodeString(fields["query"], &query) || !decodeInt(fields["limit"], &limit) || !validQuery(query) || limit < 1 || limit > 50 {
+		writeError(response, http.StatusBadRequest, "request is invalid")
+		return
+	}
+	page, err := h.store.SearchMemory(request.Context(), postgres.MemorySearchRequest{PrincipalID: device.PrincipalID, ProjectID: projectID, Query: query, Limit: limit})
+	if err != nil {
+		writeStoreError(response, err)
+		return
+	}
+	writeJSON(response, http.StatusOK, page)
+}
+
+func (h *handler) promptBrief(response http.ResponseWriter, request *http.Request) {
+	device, projectID, ok := deviceProject(response, request)
+	if !ok {
+		return
+	}
+	fields, ok := readObject(response, request, "query")
+	if !ok {
+		return
+	}
+	var query string
+	if !decodeString(fields["query"], &query) || !validQuery(query) {
+		writeError(response, http.StatusBadRequest, "request is invalid")
+		return
+	}
+	brief, err := h.store.BuildMemoryPromptBrief(request.Context(), postgres.MemoryPromptBriefRequest{PrincipalID: device.PrincipalID, ProjectID: projectID, Query: query})
+	if err != nil {
+		writeStoreError(response, err)
+		return
+	}
+	writeJSON(response, http.StatusOK, brief)
+}
+
+type changeCursor struct {
+	InstallationID string
+	TimelineID     string
+	ChangeSequence int64
+}
+
+type changePage struct {
+	Changes []postgres.MemoryChange `json:"changes"`
+	Cursor  cursorOutput            `json:"cursor"`
+	More    bool                    `json:"more"`
+}
+
+type cursorOutput struct {
+	InstallationID string `json:"installation_id"`
+	TimelineID     string `json:"timeline_id"`
+	ChangeSequence int64  `json:"change_sequence"`
+}
+
+func (h *handler) memoryChanges(response http.ResponseWriter, request *http.Request) {
+	device, projectID, ok := deviceProject(response, request)
+	if !ok {
+		return
+	}
+	fields, ok := readObject(response, request, "cursor", "limit")
+	if !ok {
+		return
+	}
+	cursor, ok := decodeCursor(fields["cursor"])
+	var limit int
+	if !ok || !decodeInt(fields["limit"], &limit) || limit < 1 || limit > 100 {
+		writeError(response, http.StatusBadRequest, "request is invalid")
+		return
+	}
+	page, err := h.store.FetchMemoryChanges(request.Context(), postgres.MemoryChangeRequest{PrincipalID: device.PrincipalID, ProjectID: projectID, Cursor: postgres.InstallationState{InstallationID: cursor.InstallationID, TimelineID: cursor.TimelineID, ChangeSequence: cursor.ChangeSequence}, Limit: limit})
+	if err != nil {
+		writeStoreError(response, err)
+		return
+	}
+	writeJSON(response, http.StatusOK, changePage{Changes: page.Changes, Cursor: cursorOutput{InstallationID: page.Cursor.InstallationID, TimelineID: page.Cursor.TimelineID, ChangeSequence: page.Cursor.ChangeSequence}, More: page.More})
+}
+
+func deviceProject(response http.ResponseWriter, request *http.Request) (postgres.AuthenticatedDevice, string, bool) {
+	device, ok := authenticatedDevice(request.Context())
+	if !ok {
+		unauthenticated(response)
+		return postgres.AuthenticatedDevice{}, "", false
+	}
+	projectID := request.PathValue("project")
+	if !validID(projectID) {
+		writeError(response, http.StatusBadRequest, "request is invalid")
+		return postgres.AuthenticatedDevice{}, "", false
+	}
+	return device, projectID, true
+}
+
+func emptyRequest(request *http.Request) bool {
+	return request.URL.RawQuery == "" && (request.Body == nil || request.Body == http.NoBody || request.ContentLength == 0)
+}
+
+func validID(value string) bool {
+	parsed, err := uuid.Parse(value)
+	return err == nil && parsed.String() == value
+}
+
+func validQuery(value string) bool {
+	return value != "" && strings.TrimSpace(value) != "" && utf8.ValidString(value) && len(value) <= 1024 && utf8.RuneCountInString(value) <= 256 && strings.IndexFunc(value, unicode.IsControl) < 0
+}
+
+func readObject(response http.ResponseWriter, request *http.Request, names ...string) (map[string]json.RawMessage, bool) {
+	if request.URL.RawQuery != "" || !exactJSON(request) {
+		writeError(response, http.StatusUnsupportedMediaType, "application/json is required")
+		return nil, false
+	}
+	if request.ContentLength > maxRequestBytes {
+		writeError(response, http.StatusRequestEntityTooLarge, "request is too large")
+		return nil, false
+	}
+	body, err := io.ReadAll(io.LimitReader(request.Body, maxRequestBytes+1))
+	if err != nil || len(body) > maxRequestBytes {
+		writeError(response, http.StatusRequestEntityTooLarge, "request is too large")
+		return nil, false
+	}
+	fields, err := decodeObject(body, names...)
+	if err != nil {
+		writeError(response, http.StatusBadRequest, "request is malformed")
+		return nil, false
+	}
+	return fields, true
+}
+
+func decodeObject(body []byte, names ...string) (map[string]json.RawMessage, error) {
+	allowed := make(map[string]struct{}, len(names))
+	for _, name := range names {
+		allowed[name] = struct{}{}
+	}
+	decoder := json.NewDecoder(bytes.NewReader(body))
+	start, err := decoder.Token()
+	if err != nil || start != json.Delim('{') {
+		return nil, errors.New("not an object")
+	}
+	fields := make(map[string]json.RawMessage, len(names))
+	for decoder.More() {
+		token, err := decoder.Token()
+		name, ok := token.(string)
+		if err != nil || !ok {
+			return nil, errors.New("invalid field")
+		}
+		if _, ok := allowed[name]; !ok {
+			return nil, errors.New("unknown field")
+		}
+		if _, duplicate := fields[name]; duplicate {
+			return nil, errors.New("duplicate field")
+		}
+		var raw json.RawMessage
+		if err := decoder.Decode(&raw); err != nil {
+			return nil, errors.New("invalid value")
+		}
+		fields[name] = raw
+	}
+	end, err := decoder.Token()
+	if err != nil || end != json.Delim('}') || len(fields) != len(names) {
+		return nil, errors.New("incomplete object")
+	}
+	if _, err := decoder.Token(); !errors.Is(err, io.EOF) {
+		return nil, errors.New("trailing input")
+	}
+	return fields, nil
+}
+
+func decodeCursor(raw json.RawMessage) (changeCursor, bool) {
+	if bytes.Equal(bytes.TrimSpace(raw), []byte("null")) {
+		return changeCursor{}, true
+	}
+	fields, err := decodeObject(raw, "installation_id", "timeline_id", "change_sequence")
+	if err != nil {
+		return changeCursor{}, false
+	}
+	var cursor changeCursor
+	return cursor, decodeString(fields["installation_id"], &cursor.InstallationID) && validID(cursor.InstallationID) &&
+		decodeString(fields["timeline_id"], &cursor.TimelineID) && validID(cursor.TimelineID) &&
+		decodeInt64(fields["change_sequence"], &cursor.ChangeSequence) && cursor.ChangeSequence >= 0
+}
+
+func decodeString(raw json.RawMessage, destination *string) bool {
+	return json.Unmarshal(raw, destination) == nil
+}
+
+func decodeInt(raw json.RawMessage, destination *int) bool {
+	return json.Unmarshal(raw, destination) == nil
+}
+
+func decodeInt64(raw json.RawMessage, destination *int64) bool {
+	return json.Unmarshal(raw, destination) == nil
+}
+
+func exactJSON(request *http.Request) bool {
+	if len(request.Header.Values("Content-Type")) != 1 {
+		return false
+	}
+	mediaType, parameters, err := mime.ParseMediaType(request.Header.Get("Content-Type"))
+	if err != nil || mediaType != "application/json" {
+		return false
+	}
+	if len(parameters) == 0 {
+		return true
+	}
+	charset, ok := parameters["charset"]
+	return len(parameters) == 1 && ok && strings.EqualFold(charset, "utf-8")
+}
+
+func unauthenticated(response http.ResponseWriter) {
+	response.Header().Set("WWW-Authenticate", "Bearer")
+	writeError(response, http.StatusUnauthorized, "unauthenticated")
+}
+
+func writeStoreError(response http.ResponseWriter, err error) {
+	switch {
+	case errors.Is(err, postgres.ErrNotFound), errors.Is(err, postgres.ErrForbidden):
+		writeError(response, http.StatusNotFound, "memory resource was not found")
+	case errors.Is(err, postgres.ErrCursorTimelineChanged):
+		writeCursorError(response, "timeline_changed")
+	case errors.Is(err, postgres.ErrCursorFromFuture):
+		writeCursorError(response, "from_future")
+	default:
+		writeError(response, http.StatusServiceUnavailable, "memory service is unavailable")
+	}
+}
+
+func writeCursorError(response http.ResponseWriter, code string) {
+	writeJSON(response, http.StatusConflict, map[string]string{"error": "memory cursor is invalid", "code": code})
+}
+
+func writeError(response http.ResponseWriter, status int, message string) {
+	writeJSON(response, status, map[string]string{"error": message})
+}
+
+func writeJSON(response http.ResponseWriter, status int, value any) {
+	response.Header().Set("Content-Type", "application/json")
+	response.Header().Set("Cache-Control", "no-store")
+	response.WriteHeader(status)
+	_ = json.NewEncoder(response).Encode(value)
+}

--- a/internal/memoryhttp/handler_test.go
+++ b/internal/memoryhttp/handler_test.go
@@ -1,0 +1,348 @@
+package memoryhttp
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/rock3r/punaro/internal/ingress"
+	"github.com/rock3r/punaro/internal/postgres"
+)
+
+const (
+	testPrincipalID = "11111111-1111-4111-8111-111111111111"
+	testLookupID    = "22222222-2222-4222-8222-222222222222"
+	testProjectID   = "33333333-3333-4333-8333-333333333333"
+	testItemID      = "44444444-4444-4444-8444-444444444444"
+	testProposalID  = "55555555-5555-4555-8555-555555555555"
+	testIdentityID  = "66666666-6666-4666-8666-666666666666"
+	testInstallID   = "77777777-7777-4777-8777-777777777777"
+	testTimelineID  = "88888888-8888-4888-8888-888888888888"
+)
+
+type fakeStore struct {
+	mu sync.Mutex
+
+	device  postgres.AuthenticatedDevice
+	authErr error
+	err     error
+
+	credential string
+	principal  string
+	project    string
+	item       string
+	proposal   string
+	query      string
+	limit      int
+	cursor     postgres.InstallationState
+	kind       postgres.ProjectIdentityKind
+	locator    string
+
+	block   chan struct{}
+	entered chan struct{}
+}
+
+func newFakeStore() *fakeStore {
+	return &fakeStore{device: postgres.AuthenticatedDevice{PrincipalID: testPrincipalID, LookupID: testLookupID, Generation: 3}}
+}
+
+func (s *fakeStore) AuthenticateDevice(_ context.Context, credential string) (postgres.AuthenticatedDevice, error) {
+	s.mu.Lock()
+	s.credential = credential
+	s.mu.Unlock()
+	return s.device, s.authErr
+}
+
+func (s *fakeStore) wait(ctx context.Context) error {
+	if s.entered != nil {
+		s.entered <- struct{}{}
+	}
+	if s.block == nil {
+		return s.err
+	}
+	select {
+	case <-s.block:
+		return s.err
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func (s *fakeStore) ResolveProjectIdentity(ctx context.Context, principal string, kind postgres.ProjectIdentityKind, locator string) (postgres.ProjectIdentityResolution, error) {
+	s.mu.Lock()
+	s.principal, s.kind, s.locator = principal, kind, locator
+	s.mu.Unlock()
+	if err := s.wait(ctx); err != nil {
+		return postgres.ProjectIdentityResolution{}, err
+	}
+	return postgres.ProjectIdentityResolution{IdentityID: testIdentityID, ProjectID: testProjectID, Kind: kind}, nil
+}
+
+func (s *fakeStore) GetMemory(ctx context.Context, principal, project, item string) (postgres.MemoryItem, error) {
+	s.mu.Lock()
+	s.principal, s.project, s.item = principal, project, item
+	s.mu.Unlock()
+	if err := s.wait(ctx); err != nil {
+		return postgres.MemoryItem{}, err
+	}
+	return postgres.MemoryItem{ItemID: item, ProjectID: project, ScopeID: testIdentityID, Kind: "decision", State: postgres.MemoryActive, Trust: "curated", Layer: postgres.MemoryLayerCurated, Revision: 2, ETag: `"memory:2"`, Document: json.RawMessage(`{"title":"Decision"}`), ContentSHA256: strings.Repeat("a", 64), AuthorID: principal, ChangeSequence: 9}, nil
+}
+
+func (s *fakeStore) GetMemoryProposal(ctx context.Context, principal, project, proposal string) (postgres.MemoryProposal, error) {
+	s.mu.Lock()
+	s.principal, s.project, s.proposal = principal, project, proposal
+	s.mu.Unlock()
+	if err := s.wait(ctx); err != nil {
+		return postgres.MemoryProposal{}, err
+	}
+	return postgres.MemoryProposal{ProposalID: proposal, ProjectID: project, ScopeID: testIdentityID, Action: postgres.MemoryProposalCreate, State: postgres.MemoryProposalPending, ETag: `"proposal:1"`, ProposedBy: principal, Steps: []postgres.MemoryProposalStep{}, Evidence: []postgres.MemoryProposalEvidence{}}, nil
+}
+
+func (s *fakeStore) SearchMemory(ctx context.Context, request postgres.MemorySearchRequest) (postgres.MemorySearchPage, error) {
+	s.mu.Lock()
+	s.principal, s.project, s.query, s.limit = request.PrincipalID, request.ProjectID, request.Query, request.Limit
+	s.mu.Unlock()
+	if err := s.wait(ctx); err != nil {
+		return postgres.MemorySearchPage{}, err
+	}
+	return postgres.MemorySearchPage{Results: []postgres.MemorySearchResult{{ItemID: testItemID, Revision: 2, ETag: `"memory:2"`, Kind: "decision", Trust: "curated", Layer: postgres.MemoryLayerCurated, Title: "Decision", Summary: "Bounded summary", Match: postgres.MemorySearchMatchLexical}}}, nil
+}
+
+func (s *fakeStore) BuildMemoryPromptBrief(ctx context.Context, request postgres.MemoryPromptBriefRequest) (postgres.MemoryPromptBrief, error) {
+	s.mu.Lock()
+	s.principal, s.project, s.query = request.PrincipalID, request.ProjectID, request.Query
+	s.mu.Unlock()
+	if err := s.wait(ctx); err != nil {
+		return postgres.MemoryPromptBrief{}, err
+	}
+	return postgres.MemoryPromptBrief{Cursor: postgres.MemoryPromptBriefCursor{InstallationID: testInstallID, TimelineID: testTimelineID, ChangeSequence: 9}, ProjectID: testProjectID, RetrievalMode: postgres.MemoryPromptBriefRetrievalLexical, SemanticStatus: postgres.MemoryPromptBriefSemanticNotConfigured, BudgetVersion: "prompt-brief-v1", Entries: []postgres.MemoryPromptBriefEntry{}, Context: `{"entries":[]}`}, nil
+}
+
+func (s *fakeStore) FetchMemoryChanges(ctx context.Context, request postgres.MemoryChangeRequest) (postgres.MemoryChangePage, error) {
+	s.mu.Lock()
+	s.principal, s.project, s.limit, s.cursor = request.PrincipalID, request.ProjectID, request.Limit, request.Cursor
+	s.mu.Unlock()
+	if err := s.wait(ctx); err != nil {
+		return postgres.MemoryChangePage{}, err
+	}
+	return postgres.MemoryChangePage{Changes: []postgres.MemoryChange{{TimelineID: testTimelineID, ChangeSequence: 9, ScopeID: testIdentityID, ItemID: testItemID, Type: postgres.MemoryChangeUpdate, Revision: 2}}, Cursor: postgres.InstallationState{InstallationID: testInstallID, TimelineID: testTimelineID, ChangeSequence: 9}}, nil
+}
+
+func newTestHandler(store *fakeStore) http.Handler {
+	policy := &ingress.Policy{Mode: ingress.LAN, ListenAddr: "127.0.0.1:8443", PublicURL: "https://punaro.test"}
+	return New(store, policy)
+}
+
+func request(method, path, body string) *http.Request {
+	r := httptest.NewRequestWithContext(context.Background(), method, "https://punaro.test"+path, strings.NewReader(body))
+	r.Header.Set("Authorization", "Bearer device-credential")
+	r.Header.Set("X-Forwarded-Proto", "https")
+	if body != "" {
+		r.Header.Set("Content-Type", "application/json")
+	}
+	return r
+}
+
+func serve(t *testing.T, handler http.Handler, r *http.Request, wantStatus int) *httptest.ResponseRecorder {
+	t.Helper()
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, r)
+	if w.Code != wantStatus {
+		t.Fatalf("status=%d want=%d body=%s", w.Code, wantStatus, w.Body.String())
+	}
+	if w.Header().Get("Cache-Control") != "no-store" {
+		t.Fatalf("Cache-Control=%q", w.Header().Get("Cache-Control"))
+	}
+	return w
+}
+
+func TestHandlerBindsAuthenticatedPrincipalAcrossBoundedReadRoutes(t *testing.T) {
+	store := newFakeStore()
+	handler := newTestHandler(store)
+
+	w := serve(t, handler, request(http.MethodPost, "/v1/projects/resolve", `{"kind":"git_remote","locator":"git@github.com:Owner/Repo.git"}`), http.StatusOK)
+	if store.principal != testPrincipalID || store.kind != postgres.ProjectIdentityGitRemote || store.locator != "git@github.com:Owner/Repo.git" {
+		t.Fatalf("resolve principal=%q kind=%q locator=%q", store.principal, store.kind, store.locator)
+	}
+	if !strings.Contains(w.Body.String(), `"project_id":"`+testProjectID+`"`) || strings.Contains(w.Body.String(), "ProjectID") || strings.Contains(w.Body.String(), "locator") {
+		t.Fatalf("resolve response=%s", w.Body.String())
+	}
+
+	w = serve(t, handler, request(http.MethodGet, "/v1/projects/"+testProjectID+"/memories/"+testItemID, ""), http.StatusOK)
+	if store.principal != testPrincipalID || store.project != testProjectID || store.item != testItemID || w.Header().Get("ETag") != `"memory:2"` || !strings.Contains(w.Body.String(), `"document":{"title":"Decision"}`) {
+		t.Fatalf("get binding=%q/%q/%q headers=%v body=%s", store.principal, store.project, store.item, w.Header(), w.Body.String())
+	}
+
+	w = serve(t, handler, request(http.MethodPost, "/v1/projects/"+testProjectID+"/memories/search", `{"query":"needle","limit":3}`), http.StatusOK)
+	if store.principal != testPrincipalID || store.query != "needle" || store.limit != 3 {
+		t.Fatalf("search binding principal=%q query=%q limit=%d", store.principal, store.query, store.limit)
+	}
+	var search postgres.MemorySearchPage
+	if err := json.Unmarshal(w.Body.Bytes(), &search); err != nil || len(search.Results) != 1 || search.Results[0].ItemID != testItemID || search.Results[0].Title != "Decision" || search.Results[0].Summary != "Bounded summary" || strings.Contains(w.Body.String(), "document") || search.More {
+		t.Fatalf("search projection=%#v err=%v body=%s", search, err, w.Body.String())
+	}
+
+	w = serve(t, handler, request(http.MethodPost, "/v1/projects/"+testProjectID+"/memories/brief", `{"query":"needle"}`), http.StatusOK)
+	if store.principal != testPrincipalID || store.query != "needle" {
+		t.Fatalf("brief binding principal=%q query=%q", store.principal, store.query)
+	}
+	var brief postgres.MemoryPromptBrief
+	if err := json.Unmarshal(w.Body.Bytes(), &brief); err != nil || brief.ProjectID != testProjectID || brief.Cursor.InstallationID != testInstallID || brief.Context != `{"entries":[]}` || len(brief.Entries) != 0 {
+		t.Fatalf("brief projection=%#v err=%v body=%s", brief, err, w.Body.String())
+	}
+
+	changes := `{"cursor":{"installation_id":"` + testInstallID + `","timeline_id":"` + testTimelineID + `","change_sequence":8},"limit":10}`
+	w = serve(t, handler, request(http.MethodPost, "/v1/projects/"+testProjectID+"/memories/changes", changes), http.StatusOK)
+	if store.principal != testPrincipalID || store.cursor.InstallationID != testInstallID || store.cursor.TimelineID != testTimelineID || store.cursor.ChangeSequence != 8 || store.limit != 10 || strings.Contains(w.Body.String(), "InstallationID") || !strings.Contains(w.Body.String(), `"installation_id"`) {
+		t.Fatalf("changes binding=%#v limit=%d body=%s", store.cursor, store.limit, w.Body.String())
+	}
+	serve(t, handler, request(http.MethodPost, "/v1/projects/"+testProjectID+"/memories/changes", `{"cursor":null,"limit":10}`), http.StatusOK)
+	if store.cursor != (postgres.InstallationState{}) {
+		t.Fatalf("initial changes cursor=%#v", store.cursor)
+	}
+
+	w = serve(t, handler, request(http.MethodGet, "/v1/projects/"+testProjectID+"/memory-proposals/"+testProposalID, ""), http.StatusOK)
+	if store.principal != testPrincipalID || store.proposal != testProposalID || w.Header().Get("ETag") != `"proposal:1"` {
+		t.Fatalf("proposal binding=%q/%q etag=%q", store.principal, store.proposal, w.Header().Get("ETag"))
+	}
+	var proposal map[string]json.RawMessage
+	if err := json.Unmarshal(w.Body.Bytes(), &proposal); err != nil {
+		t.Fatalf("proposal response err=%v body=%s", err, w.Body.String())
+	}
+	wantProposalFields := []string{"proposal_id", "scope_id", "project_id", "action", "state", "etag", "proposed_by", "created_at", "expires_at", "steps", "evidence"}
+	if len(proposal) != len(wantProposalFields) {
+		t.Fatalf("proposal fields=%v body=%s", proposal, w.Body.String())
+	}
+	for _, field := range wantProposalFields {
+		if _, ok := proposal[field]; !ok {
+			t.Fatalf("proposal missing %s: %s", field, w.Body.String())
+		}
+	}
+}
+
+func TestHandlerRejectsAuthenticationTransportAndStrictInputBeforeStore(t *testing.T) {
+	store := newFakeStore()
+	handler := newTestHandler(store)
+	validPath := "/v1/projects/" + testProjectID + "/memories/search"
+
+	missing := request(http.MethodPost, validPath, `{"query":"needle","limit":3}`)
+	missing.Header.Del("Authorization")
+	serve(t, handler, missing, http.StatusUnauthorized)
+	duplicate := request(http.MethodPost, validPath, `{"query":"needle","limit":3}`)
+	duplicate.Header["Authorization"] = []string{"Bearer one", "Bearer two"}
+	serve(t, handler, duplicate, http.StatusUnauthorized)
+	for _, authorization := range []string{"Basic token", "Bearer", "Bearer ", "Bearer two words", "Bearer\ttoken", "Bearertoken"} {
+		malformed := request(http.MethodPost, validPath, `{"query":"needle","limit":3}`)
+		malformed.Header.Set("Authorization", authorization)
+		serve(t, handler, malformed, http.StatusUnauthorized)
+	}
+	plaintext := request(http.MethodPost, validPath, `{"query":"needle","limit":3}`)
+	plaintext.URL.Scheme = "http"
+	plaintext.TLS = nil
+	plaintext.RemoteAddr = "203.0.113.1:12345"
+	plaintext.Header.Del("X-Forwarded-Proto")
+	serve(t, handler, plaintext, http.StatusForbidden)
+
+	for _, body := range []string{
+		`{"query":"needle","query":"other","limit":3}`,
+		`{"query":"needle","limit":3,"unknown":true}`,
+		`{"query":"needle","limit":3} trailing`,
+		`{"query":"","limit":3}`,
+	} {
+		serve(t, handler, request(http.MethodPost, validPath, body), http.StatusBadRequest)
+	}
+	wrongType := request(http.MethodPost, validPath, `{"query":"needle","limit":3}`)
+	wrongType.Header.Set("Content-Type", "text/plain")
+	serve(t, handler, wrongType, http.StatusUnsupportedMediaType)
+	withQuery := request(http.MethodGet, "/v1/projects/"+testProjectID+"/memories/"+testItemID+"?unexpected=1", "")
+	serve(t, handler, withQuery, http.StatusBadRequest)
+	serve(t, handler, request(http.MethodPut, "/v1/projects/resolve", ""), http.StatusMethodNotAllowed)
+	serve(t, handler, request(http.MethodGet, "/v1/projects/not-a-project/memories/"+testItemID, ""), http.StatusBadRequest)
+	oversized := request(http.MethodPost, validPath, `{"query":"`+strings.Repeat("a", maxRequestBytes)+`","limit":3}`)
+	serve(t, handler, oversized, http.StatusRequestEntityTooLarge)
+	badCursor := `{"cursor":{"installation_id":"` + testInstallID + `","timeline_id":"` + testTimelineID + `","timeline_id":"` + testTimelineID + `","change_sequence":0},"limit":10}`
+	serve(t, handler, request(http.MethodPost, "/v1/projects/"+testProjectID+"/memories/changes", badCursor), http.StatusBadRequest)
+	if store.principal != "" || store.query != "" || store.item != "" {
+		t.Fatalf("rejected request reached store: %#v", store)
+	}
+
+	store.authErr = postgres.ErrUnauthenticated
+	w := serve(t, handler, request(http.MethodGet, "/v1/projects/"+testProjectID+"/memories/"+testItemID, ""), http.StatusUnauthorized)
+	if w.Header().Get("WWW-Authenticate") != "Bearer" || store.principal != "" {
+		t.Fatalf("revoked credential reached store or lacked challenge: principal=%q headers=%v", store.principal, w.Header())
+	}
+}
+
+func TestHandlerAcceptsCaseInsensitiveBearerAndUTF8JSONButRejectsControlQueries(t *testing.T) {
+	store := newFakeStore()
+	handler := newTestHandler(store)
+	path := "/v1/projects/" + testProjectID + "/memories/search"
+	interoperable := request(http.MethodPost, path, `{"query":"needle","limit":3}`)
+	interoperable.Header.Set("Authorization", "bEaReR device-credential")
+	interoperable.Header.Set("Content-Type", "application/json; charset=UTF-8")
+	serve(t, handler, interoperable, http.StatusOK)
+
+	for _, route := range []string{"search", "brief"} {
+		store.query = ""
+		body := `{"query":"line\nbreak"`
+		if route == "search" {
+			body += `,"limit":3`
+		}
+		body += `}`
+		serve(t, handler, request(http.MethodPost, "/v1/projects/"+testProjectID+"/memories/"+route, body), http.StatusBadRequest)
+		if store.query != "" {
+			t.Fatalf("control query reached %s store: %q", route, store.query)
+		}
+	}
+}
+
+func TestHandlerMasksAuthorityAndMapsCursorConflictsWithoutLeakingStoreErrors(t *testing.T) {
+	store := newFakeStore()
+	handler := newTestHandler(store)
+	path := "/v1/projects/" + testProjectID + "/memories/" + testItemID
+	for _, test := range []struct {
+		err  error
+		want int
+	}{
+		{postgres.ErrNotFound, http.StatusNotFound},
+		{postgres.ErrForbidden, http.StatusNotFound},
+		{postgres.ErrCursorTimelineChanged, http.StatusConflict},
+		{postgres.ErrCursorFromFuture, http.StatusConflict},
+		{errors.New("sql failed with secret document"), http.StatusServiceUnavailable},
+	} {
+		store.err = test.err
+		w := serve(t, handler, request(http.MethodGet, path, ""), test.want)
+		if strings.Contains(w.Body.String(), test.err.Error()) || strings.Contains(w.Body.String(), "secret document") {
+			t.Fatalf("error leaked for %v: %s", test.err, w.Body.String())
+		}
+	}
+}
+
+func TestHandlerBoundsConcurrencyAndCancelsBlockedStoreWork(t *testing.T) {
+	store := newFakeStore()
+	store.block = make(chan struct{})
+	store.entered = make(chan struct{}, 1)
+	policy := &ingress.Policy{Mode: ingress.LAN, ListenAddr: "127.0.0.1:8443", PublicURL: "https://punaro.test"}
+	handler := newHandler(store, policy, 1, 20*time.Millisecond)
+	done := make(chan *httptest.ResponseRecorder, 1)
+	go func() {
+		w := httptest.NewRecorder()
+		handler.ServeHTTP(w, request(http.MethodGet, "/v1/projects/"+testProjectID+"/memories/"+testItemID, ""))
+		done <- w
+	}()
+	<-store.entered
+	w := serve(t, handler, request(http.MethodGet, "/v1/projects/"+testProjectID+"/memories/"+testItemID, ""), http.StatusTooManyRequests)
+	if w.Header().Get("Retry-After") != "1" {
+		t.Fatalf("Retry-After=%q", w.Header().Get("Retry-After"))
+	}
+	first := <-done
+	if first.Code != http.StatusServiceUnavailable {
+		t.Fatalf("blocked request status=%d body=%s", first.Code, first.Body.String())
+	}
+}

--- a/internal/operator/installation.go
+++ b/internal/operator/installation.go
@@ -91,6 +91,7 @@ type Installation struct {
 	Ingress           ingress.Policy          `json:"ingress"`
 	HealthListenAddr  string                  `json:"health_listen_addr"`
 	HealthURL         string                  `json:"health_url"`
+	MemoryAPIEnabled  bool                    `json:"memory_api_enabled"`
 	RelayMachinesJSON string                  `json:"relay_machines_json,omitempty"`
 	MailCutover       *MailCutoverPublication `json:"mail_cutover,omitempty"`
 }
@@ -106,6 +107,7 @@ type InitOptions struct {
 	OwnerName        string
 	Ingress          ingress.Policy
 	HealthListenAddr string
+	MemoryAPIEnabled bool
 }
 
 // BootstrapOwner is the only database mutation performed by Init.
@@ -209,7 +211,7 @@ func Resume(ctx context.Context, directory string, recoverOwner RecoverOwner) (I
 		return Installation{}, errors.New("initialization staging configuration is corrupt")
 	}
 	installation.Directory = directory
-	if _, err := validateStatic(InitOptions{Directory: directory, DataDir: installation.DataDir, BackupDir: installation.BackupDir, Image: installation.Image, OwnerDSNFile: installation.OwnerDSNFile, AppDSNFile: installation.AppDSNFile, OwnerName: installation.OwnerName, Ingress: installation.Ingress, HealthListenAddr: installation.HealthListenAddr}); err != nil {
+	if _, err := validateStatic(InitOptions{Directory: directory, DataDir: installation.DataDir, BackupDir: installation.BackupDir, Image: installation.Image, OwnerDSNFile: installation.OwnerDSNFile, AppDSNFile: installation.AppDSNFile, OwnerName: installation.OwnerName, Ingress: installation.Ingress, HealthListenAddr: installation.HealthListenAddr, MemoryAPIEnabled: installation.MemoryAPIEnabled}); err != nil {
 		return Installation{}, errors.New("initialization staging configuration is invalid")
 	}
 	if failures := CheckPaths(installation); len(failures) != 0 {
@@ -315,7 +317,7 @@ func validateStatic(options InitOptions) (Installation, error) {
 	if !listener.IsLoopback(healthListenAddr) || listener.Same(policy.ListenAddr, healthListenAddr) {
 		return Installation{}, errors.New("health listener must be a distinct concrete loopback address")
 	}
-	return Installation{Version: 1, Directory: options.Directory, DataDir: options.DataDir, BackupDir: options.BackupDir, Image: options.Image, OwnerDSNFile: options.OwnerDSNFile, AppDSNFile: options.AppDSNFile, OwnerName: options.OwnerName, Ingress: policy, HealthListenAddr: healthListenAddr, HealthURL: localURL(healthListenAddr)}, nil
+	return Installation{Version: 1, Directory: options.Directory, DataDir: options.DataDir, BackupDir: options.BackupDir, Image: options.Image, OwnerDSNFile: options.OwnerDSNFile, AppDSNFile: options.AppDSNFile, OwnerName: options.OwnerName, Ingress: policy, HealthListenAddr: healthListenAddr, HealthURL: localURL(healthListenAddr), MemoryAPIEnabled: options.MemoryAPIEnabled}, nil
 }
 
 // Load reads only a completely published installation marker.
@@ -345,7 +347,7 @@ func Load(directory string) (Installation, error) {
 			return Installation{}, errors.New("published installation relay enrollment is invalid")
 		}
 	}
-	validated, err := validateStatic(InitOptions{Directory: directory, DataDir: installation.DataDir, BackupDir: installation.BackupDir, Image: installation.Image, OwnerDSNFile: installation.OwnerDSNFile, AppDSNFile: installation.AppDSNFile, OwnerName: installation.OwnerName, Ingress: installation.Ingress, HealthListenAddr: installation.HealthListenAddr})
+	validated, err := validateStatic(InitOptions{Directory: directory, DataDir: installation.DataDir, BackupDir: installation.BackupDir, Image: installation.Image, OwnerDSNFile: installation.OwnerDSNFile, AppDSNFile: installation.AppDSNFile, OwnerName: installation.OwnerName, Ingress: installation.Ingress, HealthListenAddr: installation.HealthListenAddr, MemoryAPIEnabled: installation.MemoryAPIEnabled})
 	if err != nil {
 		return Installation{}, errors.New("published installation configuration is invalid")
 	}
@@ -524,6 +526,7 @@ func daemonEnv(installation Installation) string {
 		"PUNARO_POSTGRES_ENABLED=true",
 		"PUNARO_POSTGRES_DSN_FILE=" + installation.AppDSNFile,
 		"PUNARO_DEVICE_AUTH_ENABLED=true",
+		fmt.Sprintf("PUNARO_MEMORY_API_ENABLED=%t", installation.MemoryAPIEnabled),
 		"PUNARO_RELAY_ENABLED=" + relayEnabled,
 		"PUNARO_RELAY_MACHINES_JSON='" + installation.RelayMachinesJSON + "'",
 		"PUNARO_RELAY_STORE=" + relayStore,
@@ -568,6 +571,7 @@ func composeOverride() string {
       PUNARO_POSTGRES_ENABLED: ${PUNARO_POSTGRES_ENABLED:?required}
       PUNARO_POSTGRES_DSN_FILE: ${PUNARO_POSTGRES_DSN_FILE:?required}
       PUNARO_DEVICE_AUTH_ENABLED: ${PUNARO_DEVICE_AUTH_ENABLED:?required}
+      PUNARO_MEMORY_API_ENABLED: ${PUNARO_MEMORY_API_ENABLED:-false}
       PUNARO_RELAY_ENABLED: ${PUNARO_RELAY_ENABLED:?required}
       PUNARO_RELAY_MACHINES_JSON: ${PUNARO_RELAY_MACHINES_JSON:-}
       PUNARO_RELAY_STORE: ${PUNARO_RELAY_STORE:?required}

--- a/internal/operator/installation.go
+++ b/internal/operator/installation.go
@@ -457,7 +457,7 @@ func CheckPaths(installation Installation) []string {
 		failures = append(failures, "daemon-writable data directory overlaps database credentials or operator state")
 	}
 	envPath := EnvFile(installation.Directory)
-	envAvailable, envCurrent, envLegacy := false, false, false
+	envAvailable, envCurrent, envPreMemoryAPI, envLegacy := false, false, false, false
 	if err := requireTrustedProtectedFile(envPath, 64<<10); err != nil {
 		failures = append(failures, "generated daemon environment unavailable or unsafe")
 	} else {
@@ -466,14 +466,15 @@ func CheckPaths(installation Installation) []string {
 		envAvailable = err == nil
 		if envAvailable {
 			envCurrent = string(body) == daemonEnv(installation)
-			envLegacy = installation.MailCutover == nil && installation.RelayMachinesJSON == "" && string(body) == legacyDaemonEnv(installation)
+			envPreMemoryAPI = !installation.MemoryAPIEnabled && string(body) == preMemoryAPIDaemonEnv(installation)
+			envLegacy = !installation.MemoryAPIEnabled && installation.MailCutover == nil && installation.RelayMachinesJSON == "" && string(body) == legacyDaemonEnv(installation)
 		}
-		if !envCurrent && !envLegacy {
+		if !envCurrent && !envPreMemoryAPI && !envLegacy {
 			failures = append(failures, "generated daemon environment does not match installation configuration")
 		}
 	}
 	overridePath := OverrideFile(installation.Directory)
-	overrideAvailable, overrideCurrent, overrideLegacy := false, false, false
+	overrideAvailable, overrideCurrent, overridePreMemoryAPI, overrideLegacy := false, false, false, false
 	if err := requireTrustedProtectedFile(overridePath, 64<<10); err != nil {
 		failures = append(failures, "generated Compose override unavailable or unsafe")
 	} else {
@@ -482,17 +483,17 @@ func CheckPaths(installation Installation) []string {
 		overrideAvailable = err == nil
 		if overrideAvailable {
 			overrideCurrent = string(body) == composeOverride()
-			overrideLegacy = installation.MailCutover == nil && installation.RelayMachinesJSON == "" && string(body) == legacyComposeOverride()
+			overridePreMemoryAPI = !installation.MemoryAPIEnabled && string(body) == preMemoryAPIComposeOverride()
+			overrideLegacy = !installation.MemoryAPIEnabled && installation.MailCutover == nil && installation.RelayMachinesJSON == "" && string(body) == legacyComposeOverride()
 		}
-		if !overrideCurrent && !overrideLegacy {
+		if !overrideCurrent && !overridePreMemoryAPI && !overrideLegacy {
 			failures = append(failures, "generated Compose override does not match installation configuration")
 		}
 	}
-	if envAvailable && overrideAvailable && (envLegacy || overrideLegacy) {
-		if envLegacy && !overrideLegacy {
+	if envAvailable && overrideAvailable {
+		sameGeneration := envCurrent && overrideCurrent || envPreMemoryAPI && overridePreMemoryAPI || envLegacy && overrideLegacy
+		if !sameGeneration && (envCurrent || envPreMemoryAPI || envLegacy) && (overrideCurrent || overridePreMemoryAPI || overrideLegacy) {
 			failures = append(failures, "generated daemon environment does not match installation configuration")
-		}
-		if overrideLegacy && !envLegacy {
 			failures = append(failures, "generated Compose override does not match installation configuration")
 		}
 	}
@@ -546,7 +547,11 @@ func legacyDaemonEnv(installation Installation) string {
 		"PUNARO_RELAY_MACHINES_JSON=''\n", "",
 		"PUNARO_RELAY_STORE=sqlite\n", "",
 		"PUNARO_CREDENTIAL_TRANSITION_ENABLED=false\n", "",
-	).Replace(daemonEnv(installation))
+	).Replace(preMemoryAPIDaemonEnv(installation))
+}
+
+func preMemoryAPIDaemonEnv(installation Installation) string {
+	return strings.Replace(daemonEnv(installation), fmt.Sprintf("PUNARO_MEMORY_API_ENABLED=%t\n", installation.MemoryAPIEnabled), "", 1)
 }
 
 func composeOverride() string {
@@ -597,7 +602,11 @@ func legacyComposeOverride() string {
 		"      PUNARO_RELAY_MACHINES_JSON: ${PUNARO_RELAY_MACHINES_JSON:-}\n", "",
 		"      PUNARO_RELAY_STORE: ${PUNARO_RELAY_STORE:?required}\n", "",
 		"      PUNARO_CREDENTIAL_TRANSITION_ENABLED: ${PUNARO_CREDENTIAL_TRANSITION_ENABLED:?required}\n", "",
-	).Replace(composeOverride())
+	).Replace(preMemoryAPIComposeOverride())
+}
+
+func preMemoryAPIComposeOverride() string {
+	return strings.Replace(composeOverride(), "      PUNARO_MEMORY_API_ENABLED: ${PUNARO_MEMORY_API_ENABLED:-false}\n", "", 1)
 }
 
 func numericIdentity(value string) bool {

--- a/internal/operator/installation_test.go
+++ b/internal/operator/installation_test.go
@@ -67,6 +67,7 @@ func validInitOptions(t *testing.T) InitOptions {
 
 func TestInitPublishesConfigurationOnlyAfterOwnerBootstrap(t *testing.T) {
 	options := validInitOptions(t)
+	options.MemoryAPIEnabled = true
 	called := false
 	installation, err := Init(context.Background(), options, func(_ context.Context, dsnFile, name string) (punaropostgres.Principal, error) {
 		called = true
@@ -82,8 +83,12 @@ func TestInitPublishesConfigurationOnlyAfterOwnerBootstrap(t *testing.T) {
 		t.Fatalf("installation=%#v called=%t err=%v", installation, called, err)
 	}
 	loaded, err := Load(options.Directory)
-	if err != nil || loaded.OwnerPrincipalID != "11111111-1111-4111-8111-111111111111" {
+	if err != nil || loaded.OwnerPrincipalID != "11111111-1111-4111-8111-111111111111" || !loaded.MemoryAPIEnabled {
 		t.Fatalf("loaded=%#v err=%v", loaded, err)
+	}
+	environment, err := os.ReadFile(EnvFile(options.Directory))
+	if err != nil || !strings.Contains(string(environment), "PUNARO_MEMORY_API_ENABLED=true\n") {
+		t.Fatalf("memory API environment=%q err=%v", environment, err)
 	}
 	info, err := os.Stat(filepath.Join(options.Directory, configName))
 	if err != nil || info.Mode().Perm() != 0o600 {
@@ -512,6 +517,16 @@ func TestPublishMailCutoverSwitchesRuntimeMarkerLast(t *testing.T) {
 	changed.SourceFingerprint = strings.Repeat("c", 64)
 	if _, err := PublishMailCutover(installation.Directory, changed); err == nil {
 		t.Fatal("changed cutover publication was accepted")
+	}
+}
+
+func TestComposeOverrideKeepsMemoryAPIDarkButOperatorEnableable(t *testing.T) {
+	override := composeOverride()
+	if !strings.Contains(override, "PUNARO_MEMORY_API_ENABLED: ${PUNARO_MEMORY_API_ENABLED:-false}") {
+		t.Fatalf("compose override does not pass the dark memory API switch: %s", override)
+	}
+	if environment := daemonEnv(Installation{}); !strings.Contains(environment, "PUNARO_MEMORY_API_ENABLED=false\n") {
+		t.Fatalf("default generated environment is not dark: %s", environment)
 	}
 }
 

--- a/internal/operator/installation_test.go
+++ b/internal/operator/installation_test.go
@@ -530,6 +530,35 @@ func TestComposeOverrideKeepsMemoryAPIDarkButOperatorEnableable(t *testing.T) {
 	}
 }
 
+func TestCheckPathsAcceptsExactPreMemoryAPITemplatesAsDark(t *testing.T) {
+	options := validInitOptions(t)
+	installation, err := Init(context.Background(), options, func(context.Context, string, string) (punaropostgres.Principal, error) {
+		return punaropostgres.Principal{ID: "11111111-1111-4111-8111-111111111111"}, nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(EnvFile(installation.Directory), []byte(preMemoryAPIDaemonEnv(installation)), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(OverrideFile(installation.Directory), []byte(preMemoryAPIComposeOverride()), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if failures := CheckPaths(installation); len(failures) != 0 {
+		t.Fatalf("exact pre-memory-API templates rejected: %v", failures)
+	}
+	if err := os.WriteFile(EnvFile(installation.Directory), []byte(daemonEnv(installation)), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if failures := CheckPaths(installation); !containsFailure(failures, "generated Compose override does not match installation configuration") {
+		t.Fatalf("mixed current/pre-memory-API templates accepted: %v", failures)
+	}
+	installation.MemoryAPIEnabled = true
+	if failures := CheckPaths(installation); len(failures) == 0 {
+		t.Fatal("pre-memory-API templates accepted for an enabled installation")
+	}
+}
+
 func TestPublishMailCutoverRecoversEveryDurableBoundary(t *testing.T) {
 	for _, step := range []string{"staged", "environment", "override", "marker"} {
 		t.Run(step, func(t *testing.T) {
@@ -560,6 +589,87 @@ func TestPublishMailCutoverRecoversEveryDurableBoundary(t *testing.T) {
 			}
 			if failures := CheckPaths(recovered); len(failures) != 0 {
 				t.Fatalf("step=%s failures=%v", step, failures)
+			}
+		})
+	}
+}
+
+func TestPublishMailCutoverRecoversFromPreMemoryAPIConfiguration(t *testing.T) {
+	for _, step := range []string{"staged", "environment", "override", "marker"} {
+		t.Run(step, func(t *testing.T) {
+			options := validInitOptions(t)
+			installation, err := Init(context.Background(), options, func(context.Context, string, string) (punaropostgres.Principal, error) {
+				return punaropostgres.Principal{ID: "11111111-1111-4111-8111-111111111111"}, nil
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			installation = configureTestRelayMachines(t, installation)
+			if err := os.WriteFile(EnvFile(installation.Directory), []byte(preMemoryAPIDaemonEnv(installation)), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(OverrideFile(installation.Directory), []byte(preMemoryAPIComposeOverride()), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			publication := MailCutoverPublication{Version: 1, EpochID: "019f7f07-8b88-7c12-a394-b663274a6555", TargetIdentity: strings.Repeat("a", 64), SourceFingerprint: strings.Repeat("b", 64)}
+			injected := errors.New("injected publication crash")
+			if _, err := publishMailCutover(installation.Directory, publication, func(completed string) error {
+				if completed == step {
+					return injected
+				}
+				return nil
+			}); !errors.Is(err, injected) {
+				t.Fatalf("step=%s err=%v", step, err)
+			}
+			if _, err := LoadMailCutoverRecovery(installation.Directory); err != nil {
+				t.Fatalf("step=%s recovery preflight: %v", step, err)
+			}
+			recovered, err := PublishMailCutover(installation.Directory, publication)
+			if err != nil || recovered.MailCutover == nil || recovered.MemoryAPIEnabled || len(CheckPaths(recovered)) != 0 {
+				t.Fatalf("step=%s recovered=%#v failures=%v err=%v", step, recovered, CheckPaths(recovered), err)
+			}
+		})
+	}
+}
+
+func TestMailCutoverRecoveryRejectsPreMemoryTemplatesForEnabledInstallation(t *testing.T) {
+	for name, render := range map[string]func(Installation) (string, string){
+		"pre-memory API": func(installation Installation) (string, string) {
+			return preMemoryAPIDaemonEnv(installation), preMemoryAPIComposeOverride()
+		},
+		"legacy": func(installation Installation) (string, string) {
+			return legacyDaemonEnv(installation), legacyComposeOverride()
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			options := validInitOptions(t)
+			options.MemoryAPIEnabled = true
+			installation, err := Init(context.Background(), options, func(context.Context, string, string) (punaropostgres.Principal, error) {
+				return punaropostgres.Principal{ID: "11111111-1111-4111-8111-111111111111"}, nil
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			installation = configureTestRelayMachines(t, installation)
+			publication := MailCutoverPublication{Version: 1, EpochID: "019f7f07-8b88-7c12-a394-b663274a6555", TargetIdentity: strings.Repeat("a", 64), SourceFingerprint: strings.Repeat("b", 64)}
+			injected := errors.New("injected publication crash")
+			if _, err := publishMailCutover(installation.Directory, publication, func(completed string) error {
+				if completed == "staged" {
+					return injected
+				}
+				return nil
+			}); !errors.Is(err, injected) {
+				t.Fatalf("stage error=%v", err)
+			}
+			environment, override := render(installation)
+			if err := os.WriteFile(EnvFile(installation.Directory), []byte(environment), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(OverrideFile(installation.Directory), []byte(override), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			if _, err := LoadMailCutoverRecovery(installation.Directory); err == nil {
+				t.Fatal("enabled installation recovery accepted templates without its memory API setting")
 			}
 		})
 	}

--- a/internal/operator/mail_cutover.go
+++ b/internal/operator/mail_cutover.go
@@ -239,15 +239,22 @@ func LoadMailCutoverRecovery(directory string) (Installation, error) {
 			return Installation{}, errors.New("mail cutover recovery file is unavailable")
 		}
 		body, err := os.ReadFile(file.path) // #nosec G304 -- validated fixed generated path.
-		legacyOld := ""
-		if base.MailCutover == nil && base.RelayMachinesJSON == "" {
+		legacyOld, preMemoryAPIOld := "", ""
+		if !base.MemoryAPIEnabled {
+			if file.path == EnvFile(directory) {
+				preMemoryAPIOld = preMemoryAPIDaemonEnv(base)
+			} else {
+				preMemoryAPIOld = preMemoryAPIComposeOverride()
+			}
+		}
+		if !base.MemoryAPIEnabled && base.MailCutover == nil && base.RelayMachinesJSON == "" {
 			if file.path == EnvFile(directory) {
 				legacyOld = legacyDaemonEnv(base)
 			} else {
 				legacyOld = legacyComposeOverride()
 			}
 		}
-		if err != nil || string(body) != file.old && string(body) != file.intended && string(body) != legacyOld {
+		if err != nil || string(body) != file.old && string(body) != file.intended && string(body) != preMemoryAPIOld && string(body) != legacyOld {
 			return Installation{}, errors.New("mail cutover recovery file does not match either durable state")
 		}
 	}

--- a/internal/operator/restore.go
+++ b/internal/operator/restore.go
@@ -55,7 +55,7 @@ func ParseInstallationArtifact(body []byte) (Installation, error) {
 		return Installation{}, errors.New("backup installation configuration is invalid")
 	}
 	validationDirectory := filepath.Join(filepath.VolumeName(os.TempDir())+string(filepath.Separator), ".punaro-backup-source")
-	validated, err := validateStatic(InitOptions{Directory: validationDirectory, DataDir: installation.DataDir, BackupDir: installation.BackupDir, Image: installation.Image, OwnerDSNFile: installation.OwnerDSNFile, AppDSNFile: installation.AppDSNFile, OwnerName: installation.OwnerName, Ingress: installation.Ingress, HealthListenAddr: installation.HealthListenAddr})
+	validated, err := validateStatic(InitOptions{Directory: validationDirectory, DataDir: installation.DataDir, BackupDir: installation.BackupDir, Image: installation.Image, OwnerDSNFile: installation.OwnerDSNFile, AppDSNFile: installation.AppDSNFile, OwnerName: installation.OwnerName, Ingress: installation.Ingress, HealthListenAddr: installation.HealthListenAddr, MemoryAPIEnabled: installation.MemoryAPIEnabled})
 	if err != nil || validated.HealthURL != installation.HealthURL {
 		return Installation{}, errors.New("backup installation configuration is invalid")
 	}
@@ -116,7 +116,7 @@ func PrepareRestore(options RestoreOptions) (Installation, error) {
 	if err != nil {
 		return Installation{}, err
 	}
-	installation, err := validateStatic(InitOptions{Directory: options.Directory, DataDir: options.DataDir, BackupDir: options.BackupDir, Image: options.Source.Image, OwnerDSNFile: options.OwnerDSNFile, AppDSNFile: options.AppDSNFile, OwnerName: options.Source.OwnerName, Ingress: options.Source.Ingress, HealthListenAddr: options.Source.HealthListenAddr})
+	installation, err := validateStatic(InitOptions{Directory: options.Directory, DataDir: options.DataDir, BackupDir: options.BackupDir, Image: options.Source.Image, OwnerDSNFile: options.OwnerDSNFile, AppDSNFile: options.AppDSNFile, OwnerName: options.Source.OwnerName, Ingress: options.Source.Ingress, HealthListenAddr: options.Source.HealthListenAddr, MemoryAPIEnabled: options.Source.MemoryAPIEnabled})
 	if err != nil {
 		return Installation{}, err
 	}

--- a/internal/operator/restore_test.go
+++ b/internal/operator/restore_test.go
@@ -39,7 +39,7 @@ func TestPrepareAndPublishRestoreCreatesOnlyNewInstallation(t *testing.T) {
 	protectedFile(t, ownerDSN)
 	protectedFile(t, appDSN)
 	options := RestoreOptions{
-		Source:       Installation{Version: 1, Image: testImage, OwnerPrincipalID: "11111111-1111-4111-8111-111111111111", OwnerName: "Primary operator", Ingress: ingress.Policy{Mode: ingress.Internet, ListenAddr: "127.0.0.1:8080", PublicURL: "https://punaro.example"}, HealthListenAddr: "127.0.0.1:8081", HealthURL: "http://127.0.0.1:8081"},
+		Source:       Installation{Version: 1, Image: testImage, OwnerPrincipalID: "11111111-1111-4111-8111-111111111111", OwnerName: "Primary operator", Ingress: ingress.Policy{Mode: ingress.Internet, ListenAddr: "127.0.0.1:8080", PublicURL: "https://punaro.example"}, HealthListenAddr: "127.0.0.1:8081", HealthURL: "http://127.0.0.1:8081", MemoryAPIEnabled: true},
 		Directory:    filepath.Join(root, "restored-installation"),
 		DataDir:      filepath.Join(root, "restored-data"),
 		BackupDir:    backupDir,
@@ -63,7 +63,7 @@ func TestPrepareAndPublishRestoreCreatesOnlyNewInstallation(t *testing.T) {
 	if err != nil {
 		t.Fatalf("load: %v", err)
 	}
-	if loaded.OwnerPrincipalID != options.Source.OwnerPrincipalID || loaded.DataDir != options.DataDir || loaded.RuntimeUID == "" || loaded.RuntimeGID == "" {
+	if loaded.OwnerPrincipalID != options.Source.OwnerPrincipalID || loaded.DataDir != options.DataDir || loaded.RuntimeUID == "" || loaded.RuntimeGID == "" || !loaded.MemoryAPIEnabled {
 		t.Fatalf("unexpected restored installation: %#v", loaded)
 	}
 }

--- a/internal/operator/update_test.go
+++ b/internal/operator/update_test.go
@@ -94,6 +94,35 @@ func TestStageUpdateIsPrivateDurableAndDoesNotPublish(t *testing.T) {
 	}
 }
 
+func TestStageUpdateAcceptsAndModernizesExactPreMemoryAPIConfiguration(t *testing.T) {
+	request := installedUpdateRequest(t)
+	installation, err := Load(request.Directory)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(EnvFile(request.Directory), []byte(preMemoryAPIDaemonEnv(installation)), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(OverrideFile(request.Directory), []byte(preMemoryAPIComposeOverride()), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if failures := CheckPaths(installation); len(failures) != 0 {
+		t.Fatalf("pre-memory-API update source rejected: %v", failures)
+	}
+	published, err := PublishUpdate(request)
+	if err != nil || published.MemoryAPIEnabled || published.Image != request.TargetImage {
+		t.Fatalf("published=%#v err=%v", published, err)
+	}
+	environment, err := os.ReadFile(EnvFile(request.Directory))
+	if err != nil || !strings.Contains(string(environment), "PUNARO_MEMORY_API_ENABLED=false\n") {
+		t.Fatalf("modernized environment=%q err=%v", environment, err)
+	}
+	override, err := os.ReadFile(OverrideFile(request.Directory))
+	if err != nil || string(override) != composeOverride() || len(CheckPaths(published)) != 0 {
+		t.Fatalf("modernized override=%q failures=%v err=%v", override, CheckPaths(published), err)
+	}
+}
+
 func TestResumeUpdateStageNeverCreatesMissingAuthority(t *testing.T) {
 	request := installedUpdateRequest(t)
 	if _, err := ResumeUpdateStage(request); !errors.Is(err, ErrUpdateStageNotFound) {

--- a/internal/postgres/brain_integration_test.go
+++ b/internal/postgres/brain_integration_test.go
@@ -1753,6 +1753,9 @@ func testCanonicalBrainIntegration(ctx context.Context, t *testing.T, app *Datab
 	if err := ownerDB.QueryRowContext(ctx, `INSERT INTO relay.projects (display_name,created_by,merged_into,merged_at) VALUES ('retired brain project',$1,$2,statement_timestamp()) RETURNING id::text`, actor.ID, projectID).Scan(&retiredProjectID); err != nil {
 		t.Fatal(err)
 	}
+	if _, err := ownerDB.ExecContext(ctx, `INSERT INTO relay.project_lookup_aliases(alias_project_id,canonical_project_id) VALUES ($1,$2)`, retiredProjectID, projectID); err != nil {
+		t.Fatal(err)
+	}
 	for _, grant := range []struct {
 		principal  string
 		project    string
@@ -2065,6 +2068,13 @@ WHERE usename='punaro_app' AND wait_event_type='Lock'
 	if _, err := app.GetMemory(ctx, reader.ID, otherProjectID, created.ItemID); !errors.Is(err, ErrNotFound) {
 		t.Fatalf("cross-project get error=%v", err)
 	}
+	aliasedItem, err := app.GetMemory(ctx, reader.ID, retiredProjectID, created.ItemID)
+	if err != nil || aliasedItem.ProjectID != projectID || aliasedItem.ItemID != created.ItemID {
+		t.Fatalf("permanent project alias get=%#v err=%v", aliasedItem, err)
+	}
+	if _, err := app.GetMemory(ctx, outsider.ID, retiredProjectID, created.ItemID); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("project alias conferred authority: %v", err)
+	}
 	testMemorySecretQuarantine(ctx, t, app, ownerDB, actor.ID, reader.ID, outsider.ID)
 	for name, deniedCreate := range map[string]MemoryCreateRequest{
 		"unauthorized": {
@@ -2268,6 +2278,10 @@ SELECT id,scope_id,$2,$3,$4 FROM brain.memory_items WHERE id=$1`, created.ItemID
 		t.Fatalf("application role read memory tombstones directly: count=%d", appTombstoneCount)
 	}
 
+	initialPage, err := app.FetchMemoryChanges(ctx, MemoryChangeRequest{PrincipalID: reader.ID, ProjectID: projectID, Limit: 2})
+	if err != nil || len(initialPage.Changes) != 2 || initialPage.Cursor.InstallationID != start.InstallationID || initialPage.Cursor.TimelineID != start.TimelineID {
+		t.Fatalf("initial memory change page=%#v err=%v", initialPage, err)
+	}
 	page, err := app.FetchMemoryChanges(ctx, MemoryChangeRequest{PrincipalID: reader.ID, ProjectID: projectID, Cursor: start, Limit: 2})
 	if err != nil || len(page.Changes) != 2 || !page.More || page.Changes[0].Type != MemoryChangeCreate || page.Changes[1].Type != MemoryChangeUpdate {
 		t.Fatalf("first memory change page=%#v err=%v", page, err)

--- a/internal/postgres/brain_store.go
+++ b/internal/postgres/brain_store.go
@@ -459,6 +459,9 @@ func (d *Database) FetchMemoryChanges(ctx context.Context, request MemoryChangeR
 	if err := tx.QueryRowContext(ctx, `SELECT installation_id::text,timeline_id::text,change_sequence FROM jobs.server_state WHERE singleton`).Scan(&current.InstallationID, &current.TimelineID, &current.ChangeSequence); err != nil {
 		return MemoryChangePage{}, errors.New("memory change cursor is unavailable")
 	}
+	if request.Cursor == (InstallationState{}) {
+		request.Cursor = InstallationState{InstallationID: current.InstallationID, TimelineID: current.TimelineID}
+	}
 	if err := ValidateCursor(current, request.Cursor); err != nil {
 		return MemoryChangePage{}, err
 	}

--- a/internal/postgres/project_identity_store.go
+++ b/internal/postgres/project_identity_store.go
@@ -62,9 +62,9 @@ type ProjectIdentityAttachment struct {
 
 // ProjectIdentityResolution returns only an identity visible to the caller.
 type ProjectIdentityResolution struct {
-	IdentityID string
-	ProjectID  string
-	Kind       ProjectIdentityKind
+	IdentityID string              `json:"identity_id"`
+	ProjectID  string              `json:"project_id"`
+	Kind       ProjectIdentityKind `json:"kind"`
 }
 
 // ProjectMergePreviewRequest identifies the local project and claimed locator.


### PR DESCRIPTION
## Summary
- add a dark, device-authenticated native memory read API for project resolution, get, search, brief, proposal get, and change fetch
- persist the opt-in operator setting across init, resume, update, backup, restore, and generated Compose configuration
- preserve canonical project-alias authorization and add bounded strict HTTP contracts

## Validation
- make test
- make test-race
- make staticcheck
- make security
- make lint
- local PostgreSQL 18 integration: internal/postgres and cmd/punaro
- independent alignment review: PASS
- independent adversarial review: PASS

Compose Pi integration remains explicitly out of scope.