### PR TITLE
M17B: expose authenticated memory mutations

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -74,8 +74,16 @@ project-scoped v1 routes. The server binds the principal, uses strict bounded
 inputs and content-free failures, and keeps unauthorized resources
 indistinguishable from missing. An explicit null change cursor starts at the
 current installation/timeline origin; subsequent cursors fail on restore or
-future coordinates. Mutations and the native local client remain later
-independently reviewed slices.
+future coordinates. The mutation slice is separately dark behind
+`PUNARO_MEMORY_MUTATIONS_ENABLED`, which requires the read API opt-in. It adds
+strict canonical create/update/archive/restore/purge and staged-proposal
+create/approve/reject routes without changing the schema. Mutations accept
+only canonical active project IDs, bind the authenticated principal, require a
+canonical UUID idempotency key, and require a strong revision ETag for every
+CAS operation. PostgreSQL remains authoritative for capability checks,
+idempotency, atomic proposal application, secret rejection, and permanent
+read-only project aliases. The native local client remains a later
+independently reviewed slice.
 
 ## Goals
 

--- a/cmd/punaro/main.go
+++ b/cmd/punaro/main.go
@@ -366,6 +366,7 @@ func runInit(args []string, stdout, stderr io.Writer) int {
 	trustedLAN := flags.String("trusted-lan-cidr", "", "private or link-local trusted LAN")
 	allowLANHTTP := flags.Bool("allow-lan-http", false, "explicitly allow plaintext credentials from the trusted LAN")
 	memoryAPI := flags.Bool("memory-api", false, "enable the authenticated native memory API")
+	memoryMutations := flags.Bool("memory-mutations", false, "enable authenticated canonical memory mutations (requires --memory-api)")
 	healthListen := flags.String("health-listen-addr", "127.0.0.1:8081", "distinct loopback-only health listener")
 	resume := flags.Bool("resume", false, "resume a durably staged initialization")
 	if flags.Parse(args) != nil || flags.NArg() != 0 || *directory == "" {
@@ -402,7 +403,7 @@ func runInit(args []string, stdout, stderr io.Writer) int {
 		}
 		return createOwner(ctx, ownerFile, name)
 	}
-	installation, err := operator.Init(context.Background(), operator.InitOptions{Directory: *directory, DataDir: *dataDir, BackupDir: *backupDir, Image: *image, OwnerDSNFile: *ownerDSN, AppDSNFile: *appDSN, OwnerName: *ownerName, Ingress: ingress.Policy{Mode: ingress.Mode(*mode), ListenAddr: *listen, PublicURL: *publicURL, TrustedLAN: *trustedLAN, AllowPlaintext: *allowLANHTTP}, HealthListenAddr: *healthListen, MemoryAPIEnabled: *memoryAPI}, bootstrap)
+	installation, err := operator.Init(context.Background(), operator.InitOptions{Directory: *directory, DataDir: *dataDir, BackupDir: *backupDir, Image: *image, OwnerDSNFile: *ownerDSN, AppDSNFile: *appDSN, OwnerName: *ownerName, Ingress: ingress.Policy{Mode: ingress.Mode(*mode), ListenAddr: *listen, PublicURL: *publicURL, TrustedLAN: *trustedLAN, AllowPlaintext: *allowLANHTTP}, HealthListenAddr: *healthListen, MemoryAPIEnabled: *memoryAPI, MemoryMutationsEnabled: *memoryMutations}, bootstrap)
 	if err != nil {
 		_, _ = fmt.Fprintf(stderr, "punaro init failed: %v\n", err)
 		return 1

--- a/cmd/punarod/main.go
+++ b/cmd/punarod/main.go
@@ -64,6 +64,13 @@ type memoryDatabase interface {
 	SearchMemory(context.Context, punaropostgres.MemorySearchRequest) (punaropostgres.MemorySearchPage, error)
 	BuildMemoryPromptBrief(context.Context, punaropostgres.MemoryPromptBriefRequest) (punaropostgres.MemoryPromptBrief, error)
 	FetchMemoryChanges(context.Context, punaropostgres.MemoryChangeRequest) (punaropostgres.MemoryChangePage, error)
+	CreateMemory(context.Context, punaropostgres.MemoryCreateRequest) (punaropostgres.MemoryMutationResult, error)
+	UpdateMemory(context.Context, punaropostgres.MemoryUpdateRequest) (punaropostgres.MemoryMutationResult, error)
+	ArchiveMemory(context.Context, punaropostgres.MemoryArchiveRequest) (punaropostgres.MemoryMutationResult, error)
+	DeleteMemory(context.Context, punaropostgres.MemoryDeleteRequest) (punaropostgres.MemoryMutationResult, error)
+	ProposeMemory(context.Context, punaropostgres.MemoryProposalCreateRequest) (punaropostgres.MemoryProposalResult, error)
+	ApproveMemoryProposal(context.Context, punaropostgres.MemoryProposalDecisionRequest) (punaropostgres.MemoryProposalResult, error)
+	RejectMemoryProposal(context.Context, punaropostgres.MemoryProposalDecisionRequest) (punaropostgres.MemoryProposalResult, error)
 }
 
 type credentialTransitionDatabase interface {
@@ -300,7 +307,7 @@ func buildMemoryHandler(cfg config.Config, platformDB platformDatabase) (http.Ha
 	if err := policy.Validate(); err != nil {
 		return nil, errors.New("memory credential transport policy is invalid")
 	}
-	return memoryhttp.New(database, policy), nil
+	return memoryhttp.New(database, policy, cfg.MemoryMutationsEnabled), nil
 }
 
 func buildTrustedAttachmentHandler(cfg config.Config, platformDB platformDatabase) (*trustedAttachmentRuntime, error) {

--- a/cmd/punarod/main_test.go
+++ b/cmd/punarod/main_test.go
@@ -101,6 +101,27 @@ func (*unavailableMemoryDatabase) BuildMemoryPromptBrief(context.Context, punaro
 func (*unavailableMemoryDatabase) FetchMemoryChanges(context.Context, punaropostgres.MemoryChangeRequest) (punaropostgres.MemoryChangePage, error) {
 	return punaropostgres.MemoryChangePage{}, errors.New("unused")
 }
+func (*unavailableMemoryDatabase) CreateMemory(context.Context, punaropostgres.MemoryCreateRequest) (punaropostgres.MemoryMutationResult, error) {
+	return punaropostgres.MemoryMutationResult{}, errors.New("unused")
+}
+func (*unavailableMemoryDatabase) UpdateMemory(context.Context, punaropostgres.MemoryUpdateRequest) (punaropostgres.MemoryMutationResult, error) {
+	return punaropostgres.MemoryMutationResult{}, errors.New("unused")
+}
+func (*unavailableMemoryDatabase) ArchiveMemory(context.Context, punaropostgres.MemoryArchiveRequest) (punaropostgres.MemoryMutationResult, error) {
+	return punaropostgres.MemoryMutationResult{}, errors.New("unused")
+}
+func (*unavailableMemoryDatabase) DeleteMemory(context.Context, punaropostgres.MemoryDeleteRequest) (punaropostgres.MemoryMutationResult, error) {
+	return punaropostgres.MemoryMutationResult{}, errors.New("unused")
+}
+func (*unavailableMemoryDatabase) ProposeMemory(context.Context, punaropostgres.MemoryProposalCreateRequest) (punaropostgres.MemoryProposalResult, error) {
+	return punaropostgres.MemoryProposalResult{}, errors.New("unused")
+}
+func (*unavailableMemoryDatabase) ApproveMemoryProposal(context.Context, punaropostgres.MemoryProposalDecisionRequest) (punaropostgres.MemoryProposalResult, error) {
+	return punaropostgres.MemoryProposalResult{}, errors.New("unused")
+}
+func (*unavailableMemoryDatabase) RejectMemoryProposal(context.Context, punaropostgres.MemoryProposalDecisionRequest) (punaropostgres.MemoryProposalResult, error) {
+	return punaropostgres.MemoryProposalResult{}, errors.New("unused")
+}
 
 func TestBuildMemoryHandlerRejectsCompatibleHistoricalSchema(t *testing.T) {
 	database := &unavailableMemoryDatabase{}

--- a/docs/operator-guide.md
+++ b/docs/operator-guide.md
@@ -645,6 +645,26 @@ future-cursor conflict. There is intentionally no offline writable brain,
 mutation route, CLI/MCP binary, semantic retrieval, or Compose Pi integration
 in this slice.
 
+### Dark native memory mutations
+
+M-17B keeps every existing read-API installation read-only on upgrade. A new
+installation must explicitly pass both `punaro init --memory-api` and
+`--memory-mutations`; the persisted environment then records
+`PUNARO_MEMORY_MUTATIONS_ENABLED=true`. The mutation flag cannot be enabled
+without the read flag. Resume, update, and restore preserve the choice, while
+historical installation files that predate the mutation setting are accepted
+only as mutation-disabled generations. Do not hand-edit generated files.
+
+The enabled surface adds canonical create/update/archive/restore/purge and
+proposal create/approve/reject. Every operation needs a fresh canonical UUID
+`Idempotency-Key`; updates, state changes, purge, and proposal decisions also
+need the exact strong ETag returned by the preceding read or mutation in
+`If-Match`. Retired project aliases are readable compatibility coordinates but
+are deliberately rejected for every mutation. Purge requires its distinct
+capability and is irreversible. Secret-shaped documents are rejected without
+echoing the value or fingerprint. There is still no native client, MCP adapter,
+semantic retrieval, offline queue, or Compose Pi integration.
+
 ## Operations and incident response
 
 If a credential or machine is suspected compromised, stop the local service,

--- a/docs/platform-contracts.md
+++ b/docs/platform-contracts.md
@@ -268,7 +268,7 @@ prompt-brief, and change-fetch routes. Callers cannot select a principal,
 origin, route, credential, destination, source path, URL fetch, secret
 resolution, or other control-plane argument through memory input.
 
-All JSON is strict, duplicate-free, unknown-field rejecting, and limited to
+Read JSON is strict, duplicate-free, unknown-field rejecting, and limited to
 4 KiB. Handler concurrency is capped at 32 and each complete authentication and
 store operation has a five-second deadline; the lexical/brief store retains its
 stricter two-second SQL deadline. Responses are `no-store`. Full documents
@@ -281,9 +281,33 @@ authority beyond the caller's grant on the canonical project. Cursor
 timeline/future conflicts are typed but content-free. A null cursor means the
 current installation and timeline at sequence zero, enabling a first bounded
 enumeration; every returned cursor then pins installation, timeline, and
-sequence so restore cannot create silent divergence. Mutation routes, local
-credential/project state, retry/cache behavior, MCP, semantic retrieval, and
-Compose Pi remain absent.
+sequence so restore cannot create silent divergence.
+
+The separately persisted `PUNARO_MEMORY_MUTATIONS_ENABLED` opt-in requires the
+read API and mounts the following no-schema routes:
+
+| Method | Route | Contract |
+| --- | --- | --- |
+| `POST` | `/v1/projects/{project}/memories` | Exact `Idempotency-Key`; strict create object; 201 content-free mutation result. |
+| `PUT` | `/v1/projects/{project}/memories/{item}` | Idempotency key plus strong memory `If-Match`; strict replacement object. |
+| `POST` | `/v1/projects/{project}/memories/{item}/state` | Idempotency key plus memory `If-Match`; exact `{archived:boolean}`. |
+| `DELETE` | `/v1/projects/{project}/memories/{item}` | Idempotency key plus memory `If-Match`; no body. Requires separate purge authority. |
+| `POST` | `/v1/projects/{project}/memory-proposals` | Idempotency key; strict bounded action, steps, and evidence; 201 content-free proposal result. |
+| `POST` | `/v1/projects/{project}/memory-proposals/{proposal}/approve` | Idempotency key plus strong proposal `If-Match`; no body. |
+| `POST` | `/v1/projects/{project}/memory-proposals/{proposal}/reject` | Idempotency key plus strong proposal `If-Match`; no body. |
+
+Create and update bodies are capped at 264 KiB, proposal creation at 1 MiB,
+and state at 4 KiB. Nested JSON is also duplicate- and unknown-field rejecting;
+canonical documents remain objects with the store's 256 KiB and depth bounds.
+Non-purge success responses carry the result ETag as both JSON and the HTTP
+`ETag` header; the purge tombstone result has neither ETag nor state.
+Missing/denied targets remain 404; stale CAS, idempotency, logical-key,
+and immutable-item conflicts are closed 409 categories; secret rejection is a
+content-free 422 category; proposal capacity is 429; transient failures are
+503. Mutation project IDs are never canonicalized through a retired alias:
+permanent aliases exist only for compatible reads. Local credential/project
+state, retry/cache behavior, MCP, semantic retrieval, and Compose Pi remain
+absent.
 
 ### Implemented dark control-plane primitives
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -31,6 +31,7 @@ type Config struct {
 	PostgresDSNFile             string
 	DeviceAuthEnabled           bool
 	MemoryAPIEnabled            bool
+	MemoryMutationsEnabled      bool
 	TrustedAttachmentsEnabled   bool
 	TrustedAttachmentBlobDir    string
 	CredentialTransitionEnabled bool
@@ -89,6 +90,10 @@ func Load(explicitEnvFile string) (Config, error) {
 	if err != nil {
 		return Config{}, fmt.Errorf("parse PUNARO_MEMORY_API_ENABLED: %w", err)
 	}
+	memoryMutationsEnabled, err := strconv.ParseBool(value("PUNARO_MEMORY_MUTATIONS_ENABLED", "false"))
+	if err != nil {
+		return Config{}, fmt.Errorf("parse PUNARO_MEMORY_MUTATIONS_ENABLED: %w", err)
+	}
 	trustedAttachmentsEnabled, err := strconv.ParseBool(value("PUNARO_TRUSTED_ATTACHMENTS_ENABLED", "false"))
 	if err != nil {
 		return Config{}, fmt.Errorf("parse PUNARO_TRUSTED_ATTACHMENTS_ENABLED: %w", err)
@@ -140,6 +145,9 @@ func Load(explicitEnvFile string) (Config, error) {
 	if memoryAPIEnabled && (!postgresEnabled || !deviceAuthEnabled) {
 		return Config{}, fmt.Errorf("memory API requires PostgreSQL device authentication")
 	}
+	if memoryMutationsEnabled && !memoryAPIEnabled {
+		return Config{}, fmt.Errorf("memory mutations require PUNARO_MEMORY_API_ENABLED")
+	}
 	if relayEnabled && relayMachines == "" {
 		return Config{}, fmt.Errorf("enabled relay requires PUNARO_RELAY_MACHINES_JSON")
 	}
@@ -164,7 +172,7 @@ func Load(explicitEnvFile string) (Config, error) {
 	if !postgresEnabled && postgresDSNFile != "" {
 		return Config{}, fmt.Errorf("PUNARO_POSTGRES_DSN_FILE requires PUNARO_POSTGRES_ENABLED")
 	}
-	return Config{ListenAddr: listenAddr, HealthListenAddr: healthListenAddr, DataDir: dataDir, LogLevel: level, RelayEnabled: relayEnabled, RelayMachinesJSON: relayMachines, RelayStore: relayStore, AccessIssuer: accessIssuer, AccessAudience: accessAudience, AccessJWKSURL: accessJWKSURL, AccessJWKSFile: accessJWKSFile, PostgresEnabled: postgresEnabled, PostgresDSNFile: postgresDSNFile, DeviceAuthEnabled: deviceAuthEnabled, MemoryAPIEnabled: memoryAPIEnabled, TrustedAttachmentsEnabled: trustedAttachmentsEnabled, TrustedAttachmentBlobDir: trustedAttachmentBlobDir, CredentialTransitionEnabled: credentialTransitionEnabled, IngressMode: ingressMode, PublicURL: publicURL, TrustedLANCIDR: trustedLANCIDR, TrustedLANHTTP: trustedLANHTTP}, nil
+	return Config{ListenAddr: listenAddr, HealthListenAddr: healthListenAddr, DataDir: dataDir, LogLevel: level, RelayEnabled: relayEnabled, RelayMachinesJSON: relayMachines, RelayStore: relayStore, AccessIssuer: accessIssuer, AccessAudience: accessAudience, AccessJWKSURL: accessJWKSURL, AccessJWKSFile: accessJWKSFile, PostgresEnabled: postgresEnabled, PostgresDSNFile: postgresDSNFile, DeviceAuthEnabled: deviceAuthEnabled, MemoryAPIEnabled: memoryAPIEnabled, MemoryMutationsEnabled: memoryMutationsEnabled, TrustedAttachmentsEnabled: trustedAttachmentsEnabled, TrustedAttachmentBlobDir: trustedAttachmentBlobDir, CredentialTransitionEnabled: credentialTransitionEnabled, IngressMode: ingressMode, PublicURL: publicURL, TrustedLANCIDR: trustedLANCIDR, TrustedLANHTTP: trustedLANHTTP}, nil
 }
 
 func rejectRetiredAttachmentConfiguration() error {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -283,7 +283,7 @@ func TestLoadRequiresCompleteTrustedAttachmentReleaseSurface(t *testing.T) {
 
 func TestLoadMemoryAPIIsDarkByDefaultAndRequiresPostgresDeviceAuthority(t *testing.T) {
 	cfg, err := Load("")
-	if err != nil || cfg.MemoryAPIEnabled {
+	if err != nil || cfg.MemoryAPIEnabled || cfg.MemoryMutationsEnabled {
 		t.Fatalf("default config=%#v err=%v", cfg, err)
 	}
 	t.Setenv("PUNARO_MEMORY_API_ENABLED", "true")
@@ -298,6 +298,16 @@ func TestLoadMemoryAPIIsDarkByDefaultAndRequiresPostgresDeviceAuthority(t *testi
 	cfg, err = Load("")
 	if err != nil || !cfg.MemoryAPIEnabled {
 		t.Fatalf("memory API config=%#v err=%v", cfg, err)
+	}
+	t.Setenv("PUNARO_MEMORY_API_ENABLED", "false")
+	t.Setenv("PUNARO_MEMORY_MUTATIONS_ENABLED", "true")
+	if _, err := Load(""); err == nil {
+		t.Fatal("memory mutations were enabled without the read API")
+	}
+	t.Setenv("PUNARO_MEMORY_API_ENABLED", "true")
+	cfg, err = Load("")
+	if err != nil || !cfg.MemoryMutationsEnabled {
+		t.Fatalf("memory mutation config=%#v err=%v", cfg, err)
 	}
 }
 

--- a/internal/memoryhttp/handler.go
+++ b/internal/memoryhttp/handler.go
@@ -514,7 +514,7 @@ func validStrongETag(value, prefix string) bool {
 }
 
 func emptyMutationRequest(response http.ResponseWriter, request *http.Request) bool {
-	if request.URL.RawQuery != "" || !(request.Body == nil || request.Body == http.NoBody || request.ContentLength == 0) {
+	if request.URL.RawQuery != "" || request.Body != nil && request.Body != http.NoBody && request.ContentLength != 0 {
 		writeError(response, http.StatusBadRequest, "request is invalid")
 		return false
 	}
@@ -534,11 +534,15 @@ func validToken(value string) bool {
 		return false
 	}
 	for _, r := range value[1:] {
-		if !(r >= 'a' && r <= 'z' || r >= '0' && r <= '9' || r == '.' || r == '_' || r == ':' || r == '-') {
+		if !validTokenRune(r) {
 			return false
 		}
 	}
 	return true
+}
+
+func validTokenRune(r rune) bool {
+	return r >= 'a' && r <= 'z' || r >= '0' && r <= '9' || r == '.' || r == '_' || r == ':' || r == '-'
 }
 
 func validDocument(raw json.RawMessage) bool {

--- a/internal/memoryhttp/handler.go
+++ b/internal/memoryhttp/handler.go
@@ -1,15 +1,17 @@
 // Package memoryhttp exposes Punaro's bounded, device-authenticated native
-// memory read surface. Canonical authorization remains in the PostgreSQL store.
+// memory surface. Canonical authorization remains in the PostgreSQL store.
 package memoryhttp
 
 import (
 	"bytes"
 	"context"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"io"
 	"mime"
 	"net/http"
+	"reflect"
 	"strings"
 	"time"
 	"unicode"
@@ -21,9 +23,11 @@ import (
 )
 
 const (
-	maxRequestBytes      = 4096
-	maxConcurrentReads   = 32
-	readOperationTimeout = 5 * time.Second
+	maxRequestBytes         = 4096
+	maxMutationBytes        = (256 << 10) + (8 << 10)
+	maxProposalBytes        = 1 << 20
+	maxConcurrentOperations = 32
+	operationTimeout        = 5 * time.Second
 )
 
 type store interface {
@@ -34,6 +38,13 @@ type store interface {
 	SearchMemory(context.Context, postgres.MemorySearchRequest) (postgres.MemorySearchPage, error)
 	BuildMemoryPromptBrief(context.Context, postgres.MemoryPromptBriefRequest) (postgres.MemoryPromptBrief, error)
 	FetchMemoryChanges(context.Context, postgres.MemoryChangeRequest) (postgres.MemoryChangePage, error)
+	CreateMemory(context.Context, postgres.MemoryCreateRequest) (postgres.MemoryMutationResult, error)
+	UpdateMemory(context.Context, postgres.MemoryUpdateRequest) (postgres.MemoryMutationResult, error)
+	ArchiveMemory(context.Context, postgres.MemoryArchiveRequest) (postgres.MemoryMutationResult, error)
+	DeleteMemory(context.Context, postgres.MemoryDeleteRequest) (postgres.MemoryMutationResult, error)
+	ProposeMemory(context.Context, postgres.MemoryProposalCreateRequest) (postgres.MemoryProposalResult, error)
+	ApproveMemoryProposal(context.Context, postgres.MemoryProposalDecisionRequest) (postgres.MemoryProposalResult, error)
+	RejectMemoryProposal(context.Context, postgres.MemoryProposalDecisionRequest) (postgres.MemoryProposalResult, error)
 }
 
 type handler struct {
@@ -44,13 +55,13 @@ type handler struct {
 	timeout time.Duration
 }
 
-// New constructs the native memory read handler. The caller decides whether
-// the dark surface is mounted in the production mux.
-func New(database store, policy *ingress.Policy) http.Handler {
-	return newHandler(database, policy, maxConcurrentReads, readOperationTimeout)
+// New constructs the native memory handler. The caller independently decides
+// whether the dark read surface and its mutation extension are mounted.
+func New(database store, policy *ingress.Policy, mutationsEnabled bool) http.Handler {
+	return newHandler(database, policy, maxConcurrentOperations, operationTimeout, mutationsEnabled)
 }
 
-func newHandler(database store, policy *ingress.Policy, concurrency int, timeout time.Duration) http.Handler {
+func newHandler(database store, policy *ingress.Policy, concurrency int, timeout time.Duration, mutationsEnabled bool) http.Handler {
 	if concurrency < 1 {
 		concurrency = 1
 	}
@@ -61,7 +72,189 @@ func newHandler(database store, policy *ingress.Policy, concurrency int, timeout
 	h.mux.HandleFunc("POST /v1/projects/{project}/memories/brief", h.promptBrief)
 	h.mux.HandleFunc("POST /v1/projects/{project}/memories/changes", h.memoryChanges)
 	h.mux.HandleFunc("GET /v1/projects/{project}/memory-proposals/{proposal}", h.getProposal)
+	if mutationsEnabled {
+		h.mux.HandleFunc("POST /v1/projects/{project}/memories", h.createMemory)
+		h.mux.HandleFunc("PUT /v1/projects/{project}/memories/{item}", h.updateMemory)
+		h.mux.HandleFunc("POST /v1/projects/{project}/memories/{item}/state", h.setMemoryState)
+		h.mux.HandleFunc("DELETE /v1/projects/{project}/memories/{item}", h.deleteMemory)
+		h.mux.HandleFunc("POST /v1/projects/{project}/memory-proposals", h.createProposal)
+		h.mux.HandleFunc("POST /v1/projects/{project}/memory-proposals/{proposal}/approve", h.approveProposal)
+		h.mux.HandleFunc("POST /v1/projects/{project}/memory-proposals/{proposal}/reject", h.rejectProposal)
+	}
 	return h
+}
+
+type memoryWriteBody struct {
+	LogicalKey string          `json:"logical_key"`
+	Kind       string          `json:"kind"`
+	Trust      string          `json:"trust"`
+	Document   json.RawMessage `json:"document"`
+}
+
+func (h *handler) createMemory(response http.ResponseWriter, request *http.Request) {
+	device, projectID, ok := deviceProject(response, request)
+	if !ok {
+		return
+	}
+	key, okHeader := mutationHeaders(response, request, "")
+	if !okHeader {
+		return
+	}
+	var body memoryWriteBody
+	if !readStrictJSON(response, request, maxMutationBytes, &body) {
+		return
+	}
+	if !validMemoryWriteBody(body) {
+		writeError(response, http.StatusBadRequest, "request is invalid")
+		return
+	}
+	result, err := h.store.CreateMemory(request.Context(), postgres.MemoryCreateRequest{PrincipalID: device.PrincipalID, ProjectID: projectID, IdempotencyKey: key, LogicalKey: body.LogicalKey, Kind: body.Kind, Trust: body.Trust, Document: body.Document})
+	writeMutationResult(response, http.StatusCreated, result, err)
+}
+
+func (h *handler) updateMemory(response http.ResponseWriter, request *http.Request) {
+	device, projectID, ok := deviceProject(response, request)
+	if !ok {
+		return
+	}
+	itemID := request.PathValue("item")
+	if !validID(itemID) {
+		writeError(response, http.StatusBadRequest, "request is invalid")
+		return
+	}
+	key, etag, okHeader := mutationCASHeaders(response, request, "m1-")
+	var body memoryWriteBody
+	if !okHeader {
+		return
+	}
+	if !readStrictJSON(response, request, maxMutationBytes, &body) {
+		return
+	}
+	if !validMemoryWriteBody(body) {
+		writeError(response, http.StatusBadRequest, "request is invalid")
+		return
+	}
+	result, err := h.store.UpdateMemory(request.Context(), postgres.MemoryUpdateRequest{PrincipalID: device.PrincipalID, ProjectID: projectID, ItemID: itemID, IdempotencyKey: key, ExpectedETag: etag, LogicalKey: body.LogicalKey, Kind: body.Kind, Trust: body.Trust, Document: body.Document})
+	writeMutationResult(response, http.StatusOK, result, err)
+}
+
+func (h *handler) setMemoryState(response http.ResponseWriter, request *http.Request) {
+	device, projectID, ok := deviceProject(response, request)
+	if !ok {
+		return
+	}
+	itemID := request.PathValue("item")
+	if !validID(itemID) {
+		writeError(response, http.StatusBadRequest, "request is invalid")
+		return
+	}
+	key, etag, okHeader := mutationCASHeaders(response, request, "m1-")
+	var body struct {
+		Archived *bool `json:"archived"`
+	}
+	if !okHeader {
+		return
+	}
+	if !readStrictJSON(response, request, maxRequestBytes, &body) {
+		return
+	}
+	if body.Archived == nil {
+		writeError(response, http.StatusBadRequest, "request is invalid")
+		return
+	}
+	result, err := h.store.ArchiveMemory(request.Context(), postgres.MemoryArchiveRequest{PrincipalID: device.PrincipalID, ProjectID: projectID, ItemID: itemID, IdempotencyKey: key, ExpectedETag: etag, Archived: *body.Archived})
+	writeMutationResult(response, http.StatusOK, result, err)
+}
+
+func (h *handler) deleteMemory(response http.ResponseWriter, request *http.Request) {
+	device, projectID, ok := deviceProject(response, request)
+	if !ok {
+		return
+	}
+	itemID := request.PathValue("item")
+	if !validID(itemID) {
+		writeError(response, http.StatusBadRequest, "request is invalid")
+		return
+	}
+	key, etag, okHeader := mutationCASHeaders(response, request, "m1-")
+	if !okHeader || !emptyMutationRequest(response, request) {
+		return
+	}
+	result, err := h.store.DeleteMemory(request.Context(), postgres.MemoryDeleteRequest{PrincipalID: device.PrincipalID, ProjectID: projectID, ItemID: itemID, IdempotencyKey: key, ExpectedETag: etag})
+	writeMutationResult(response, http.StatusOK, result, err)
+}
+
+type proposalBody struct {
+	Action   postgres.MemoryProposalAction          `json:"action"`
+	Steps    []postgres.MemoryProposalStepInput     `json:"steps"`
+	Evidence []postgres.MemoryProposalEvidenceInput `json:"evidence"`
+}
+
+func (h *handler) createProposal(response http.ResponseWriter, request *http.Request) {
+	device, projectID, ok := deviceProject(response, request)
+	if !ok {
+		return
+	}
+	key, okHeader := mutationHeaders(response, request, "")
+	if !okHeader {
+		return
+	}
+	var body proposalBody
+	if !readStrictJSON(response, request, maxProposalBytes, &body) {
+		return
+	}
+	if !validProposalBody(body) {
+		writeError(response, http.StatusBadRequest, "request is invalid")
+		return
+	}
+	for index := range body.Steps {
+		if len(body.Steps[index].Document) != 0 {
+			body.Steps[index].Document, _ = canonicalDocument(body.Steps[index].Document)
+		}
+	}
+	payload, _ := json.Marshal(struct {
+		ProjectID string                                 `json:"project_id"`
+		Action    postgres.MemoryProposalAction          `json:"action"`
+		Steps     []postgres.MemoryProposalStepInput     `json:"steps"`
+		Evidence  []postgres.MemoryProposalEvidenceInput `json:"evidence,omitempty"`
+	}{projectID, body.Action, body.Steps, body.Evidence})
+	if len(payload) > 1<<20 {
+		writeError(response, http.StatusRequestEntityTooLarge, "request is too large")
+		return
+	}
+	result, err := h.store.ProposeMemory(request.Context(), postgres.MemoryProposalCreateRequest{PrincipalID: device.PrincipalID, ProjectID: projectID, IdempotencyKey: key, Action: body.Action, Steps: body.Steps, Evidence: body.Evidence})
+	writeProposalResult(response, http.StatusCreated, result, err)
+}
+
+func (h *handler) approveProposal(response http.ResponseWriter, request *http.Request) {
+	h.decideProposal(response, request, true)
+}
+func (h *handler) rejectProposal(response http.ResponseWriter, request *http.Request) {
+	h.decideProposal(response, request, false)
+}
+func (h *handler) decideProposal(response http.ResponseWriter, request *http.Request, approve bool) {
+	device, projectID, ok := deviceProject(response, request)
+	if !ok {
+		return
+	}
+	proposalID := request.PathValue("proposal")
+	if !validID(proposalID) {
+		writeError(response, http.StatusBadRequest, "request is invalid")
+		return
+	}
+	key, etag, okHeader := mutationCASHeaders(response, request, "p1-")
+	if !okHeader || !emptyMutationRequest(response, request) {
+		return
+	}
+	r := postgres.MemoryProposalDecisionRequest{PrincipalID: device.PrincipalID, ProjectID: projectID, ProposalID: proposalID, IdempotencyKey: key, ExpectedETag: etag}
+	var result postgres.MemoryProposalResult
+	var err error
+	if approve {
+		result, err = h.store.ApproveMemoryProposal(request.Context(), r)
+	} else {
+		result, err = h.store.RejectMemoryProposal(request.Context(), r)
+	}
+	writeProposalResult(response, http.StatusOK, result, err)
 }
 
 func (h *handler) ServeHTTP(response http.ResponseWriter, request *http.Request) {
@@ -283,11 +476,344 @@ func emptyRequest(request *http.Request) bool {
 
 func validID(value string) bool {
 	parsed, err := uuid.Parse(value)
-	return err == nil && parsed.String() == value
+	return err == nil && parsed != uuid.Nil && parsed.String() == value
 }
 
 func validQuery(value string) bool {
 	return value != "" && strings.TrimSpace(value) != "" && utf8.ValidString(value) && len(value) <= 1024 && utf8.RuneCountInString(value) <= 256 && strings.IndexFunc(value, unicode.IsControl) < 0
+}
+
+func mutationHeaders(response http.ResponseWriter, request *http.Request, _ string) (string, bool) {
+	values := request.Header.Values("Idempotency-Key")
+	if len(values) != 1 || !validID(values[0]) {
+		writeError(response, http.StatusBadRequest, "Idempotency-Key is required")
+		return "", false
+	}
+	return values[0], true
+}
+
+func mutationCASHeaders(response http.ResponseWriter, request *http.Request, prefix string) (string, string, bool) {
+	key, ok := mutationHeaders(response, request, "")
+	if !ok {
+		return "", "", false
+	}
+	values := request.Header.Values("If-Match")
+	if len(values) != 1 || !validStrongETag(values[0], prefix) {
+		writeError(response, http.StatusBadRequest, "If-Match is required")
+		return "", "", false
+	}
+	return key, values[0], true
+}
+
+func validStrongETag(value, prefix string) bool {
+	if len(value) != 4+64+1 || value[0] != '"' || value[len(value)-1] != '"' || value[1:4] != prefix {
+		return false
+	}
+	_, err := hex.DecodeString(value[4 : len(value)-1])
+	return err == nil
+}
+
+func emptyMutationRequest(response http.ResponseWriter, request *http.Request) bool {
+	if request.URL.RawQuery != "" || !(request.Body == nil || request.Body == http.NoBody || request.ContentLength == 0) {
+		writeError(response, http.StatusBadRequest, "request is invalid")
+		return false
+	}
+	return true
+}
+
+func validMemoryWriteBody(body memoryWriteBody) bool {
+	return validLogicalKey(body.LogicalKey) && validToken(body.Kind) && validToken(body.Trust) && validDocument(body.Document)
+}
+
+func validLogicalKey(value string) bool {
+	return utf8.ValidString(value) && len(value) <= 512 && utf8.RuneCountInString(value) <= 128 && strings.IndexFunc(value, unicode.IsControl) < 0
+}
+
+func validToken(value string) bool {
+	if value == "" || !utf8.ValidString(value) || utf8.RuneCountInString(value) > 64 || value[0] < 'a' || value[0] > 'z' {
+		return false
+	}
+	for _, r := range value[1:] {
+		if !(r >= 'a' && r <= 'z' || r >= '0' && r <= '9' || r == '.' || r == '_' || r == ':' || r == '-') {
+			return false
+		}
+	}
+	return true
+}
+
+func validDocument(raw json.RawMessage) bool {
+	_, err := canonicalDocument(raw)
+	return err == nil
+}
+
+func canonicalDocument(raw json.RawMessage) (json.RawMessage, error) {
+	if len(raw) == 0 || len(raw) > 256<<10 || !utf8.Valid(raw) {
+		return nil, errors.New("invalid document")
+	}
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	decoder.UseNumber()
+	if err := validateUniqueJSON(decoder, 1, 32, true); err != nil {
+		return nil, err
+	}
+	if _, err := decoder.Token(); !errors.Is(err, io.EOF) {
+		return nil, errors.New("trailing document")
+	}
+	canonicalDecoder := json.NewDecoder(bytes.NewReader(raw))
+	canonicalDecoder.UseNumber()
+	var value map[string]any
+	if canonicalDecoder.Decode(&value) != nil {
+		return nil, errors.New("invalid document")
+	}
+	canonical, err := json.Marshal(value)
+	if err != nil || len(canonical) > 256<<10 {
+		return nil, errors.New("document is too large")
+	}
+	return canonical, nil
+}
+
+func validProposalBody(body proposalBody) bool {
+	if len(body.Steps) < 1 || len(body.Steps) > 8 || len(body.Evidence) > 16 {
+		return false
+	}
+	evidenceIDs := make(map[string]struct{}, len(body.Evidence))
+	for _, evidence := range body.Evidence {
+		if !validID(evidence.ItemID) || evidence.Revision < 1 {
+			return false
+		}
+		if _, duplicate := evidenceIDs[evidence.ItemID]; duplicate {
+			return false
+		}
+		evidenceIDs[evidence.ItemID] = struct{}{}
+	}
+	targetIDs, logicalKeys := map[string]struct{}{}, map[string]struct{}{}
+	for _, step := range body.Steps {
+		switch step.Operation {
+		case postgres.MemoryProposalStepCreate:
+			if step.ItemID != "" || step.ExpectedETag != "" || step.Archived || !validLogicalKey(step.LogicalKey) || !validToken(step.Kind) || !validToken(step.Trust) || !validDocument(step.Document) {
+				return false
+			}
+		case postgres.MemoryProposalStepUpdate:
+			if !validID(step.ItemID) || !validStrongETag(step.ExpectedETag, "m1-") || step.Archived || !validLogicalKey(step.LogicalKey) || !validToken(step.Kind) || !validToken(step.Trust) || !validDocument(step.Document) {
+				return false
+			}
+		case postgres.MemoryProposalStepArchive:
+			if !validID(step.ItemID) || !validStrongETag(step.ExpectedETag, "m1-") || step.LogicalKey != "" || step.Kind != "" || step.Trust != "" || len(step.Document) != 0 {
+				return false
+			}
+		default:
+			return false
+		}
+		if step.ItemID != "" {
+			if _, duplicate := targetIDs[step.ItemID]; duplicate {
+				return false
+			}
+			targetIDs[step.ItemID] = struct{}{}
+		}
+		if step.Operation == postgres.MemoryProposalStepCreate && step.LogicalKey != "" {
+			if _, duplicate := logicalKeys[step.LogicalKey]; duplicate {
+				return false
+			}
+			logicalKeys[step.LogicalKey] = struct{}{}
+		}
+	}
+	switch body.Action {
+	case postgres.MemoryProposalCreate:
+		return len(body.Steps) == 1 && body.Steps[0].Operation == postgres.MemoryProposalStepCreate
+	case postgres.MemoryProposalUpdate:
+		return len(body.Steps) == 1 && body.Steps[0].Operation == postgres.MemoryProposalStepUpdate
+	case postgres.MemoryProposalArchive:
+		return len(body.Steps) == 1 && body.Steps[0].Operation == postgres.MemoryProposalStepArchive && body.Steps[0].Archived
+	case postgres.MemoryProposalMerge:
+		if len(body.Steps) < 2 || body.Steps[0].Operation != postgres.MemoryProposalStepUpdate {
+			return false
+		}
+		for _, s := range body.Steps[1:] {
+			if s.Operation != postgres.MemoryProposalStepArchive || !s.Archived {
+				return false
+			}
+		}
+		return true
+	case postgres.MemoryProposalSplit:
+		if len(body.Steps) < 3 || body.Steps[0].Operation != postgres.MemoryProposalStepArchive || !body.Steps[0].Archived {
+			return false
+		}
+		for _, s := range body.Steps[1:] {
+			if s.Operation != postgres.MemoryProposalStepCreate {
+				return false
+			}
+		}
+		return true
+	default:
+		return false
+	}
+}
+
+func readStrictJSON(response http.ResponseWriter, request *http.Request, limit int64, destination any) bool {
+	if request.URL.RawQuery != "" {
+		writeError(response, http.StatusBadRequest, "request is invalid")
+		return false
+	}
+	if !exactJSON(request) {
+		writeError(response, http.StatusUnsupportedMediaType, "application/json is required")
+		return false
+	}
+	if request.ContentLength > limit {
+		writeError(response, http.StatusRequestEntityTooLarge, "request is too large")
+		return false
+	}
+	body, err := io.ReadAll(io.LimitReader(request.Body, limit+1))
+	if err != nil || int64(len(body)) > limit {
+		writeError(response, http.StatusRequestEntityTooLarge, "request is too large")
+		return false
+	}
+	if !utf8.Valid(body) {
+		writeError(response, http.StatusBadRequest, "request is malformed")
+		return false
+	}
+	unique := json.NewDecoder(bytes.NewReader(body))
+	unique.UseNumber()
+	if err := validateUniqueJSON(unique, 1, 40, true); err != nil {
+		writeError(response, http.StatusBadRequest, "request is malformed")
+		return false
+	}
+	if _, err := unique.Token(); !errors.Is(err, io.EOF) {
+		writeError(response, http.StatusBadRequest, "request is malformed")
+		return false
+	}
+	if err := validateExactObject(body, reflect.TypeOf(destination)); err != nil {
+		writeError(response, http.StatusBadRequest, "request is malformed")
+		return false
+	}
+	decoder := json.NewDecoder(bytes.NewReader(body))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(destination); err != nil {
+		writeError(response, http.StatusBadRequest, "request is malformed")
+		return false
+	}
+	if _, err := decoder.Token(); !errors.Is(err, io.EOF) {
+		writeError(response, http.StatusBadRequest, "request is malformed")
+		return false
+	}
+	return true
+}
+
+func validateExactObject(raw []byte, destination reflect.Type) error {
+	for destination.Kind() == reflect.Pointer {
+		destination = destination.Elem()
+	}
+	if destination.Kind() != reflect.Struct {
+		return errors.New("destination is not an object")
+	}
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &fields); err != nil {
+		return err
+	}
+	allowed := make(map[string]reflect.Type, destination.NumField())
+	for index := 0; index < destination.NumField(); index++ {
+		field := destination.Field(index)
+		name := strings.Split(field.Tag.Get("json"), ",")[0]
+		if name == "" {
+			name = field.Name
+		}
+		if name == "-" {
+			continue
+		}
+		allowed[name] = field.Type
+	}
+	for name, value := range fields {
+		if bytes.Equal(bytes.TrimSpace(value), []byte("null")) {
+			return errors.New("null field")
+		}
+		fieldType, ok := allowed[name]
+		if !ok {
+			return errors.New("unknown field")
+		}
+		base := fieldType
+		for base.Kind() == reflect.Pointer {
+			base = base.Elem()
+		}
+		if base == reflect.TypeOf(json.RawMessage{}) {
+			continue
+		}
+		if base.Kind() == reflect.Struct {
+			if err := validateExactObject(value, base); err != nil {
+				return err
+			}
+		}
+		if base.Kind() == reflect.Slice {
+			element := base.Elem()
+			for element.Kind() == reflect.Pointer {
+				element = element.Elem()
+			}
+			if element.Kind() == reflect.Struct {
+				var entries []json.RawMessage
+				if err := json.Unmarshal(value, &entries); err != nil {
+					return err
+				}
+				for _, entry := range entries {
+					if err := validateExactObject(entry, element); err != nil {
+						return err
+					}
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func validateUniqueJSON(decoder *json.Decoder, depth, maxDepth int, requireObject bool) error {
+	if depth > maxDepth {
+		return errors.New("too deep")
+	}
+	token, err := decoder.Token()
+	if err != nil {
+		return err
+	}
+	delim, composite := token.(json.Delim)
+	if requireObject && (!composite || delim != '{') {
+		return errors.New("not object")
+	}
+	if !composite {
+		return nil
+	}
+	switch delim {
+	case '{':
+		seen := map[string]struct{}{}
+		for decoder.More() {
+			raw, err := decoder.Token()
+			if err != nil {
+				return err
+			}
+			key, ok := raw.(string)
+			if !ok {
+				return errors.New("bad key")
+			}
+			if _, ok := seen[key]; ok {
+				return errors.New("duplicate")
+			}
+			seen[key] = struct{}{}
+			if err := validateUniqueJSON(decoder, depth+1, maxDepth, false); err != nil {
+				return err
+			}
+		}
+		end, err := decoder.Token()
+		if err != nil || end != json.Delim('}') {
+			return errors.New("bad object")
+		}
+	case '[':
+		for decoder.More() {
+			if err := validateUniqueJSON(decoder, depth+1, maxDepth, false); err != nil {
+				return err
+			}
+		}
+		end, err := decoder.Token()
+		if err != nil || end != json.Delim(']') {
+			return errors.New("bad array")
+		}
+	default:
+		return errors.New("bad delimiter")
+	}
+	return nil
 }
 
 func readObject(response http.ResponseWriter, request *http.Request, names ...string) (map[string]json.RawMessage, bool) {
@@ -398,9 +924,35 @@ func unauthenticated(response http.ResponseWriter) {
 }
 
 func writeStoreError(response http.ResponseWriter, err error) {
+	var rejection postgres.MemorySecretRejection
 	switch {
 	case errors.Is(err, postgres.ErrNotFound), errors.Is(err, postgres.ErrForbidden):
 		writeError(response, http.StatusNotFound, "memory resource was not found")
+	case errors.Is(err, postgres.ErrStaleMemoryETag):
+		writeCodedError(response, http.StatusConflict, "memory precondition failed", "stale_etag")
+	case errors.Is(err, postgres.ErrStaleMemoryProposal):
+		writeCodedError(response, http.StatusConflict, "memory proposal precondition failed", "stale_proposal")
+	case errors.Is(err, postgres.ErrIdempotencyConflict):
+		writeCodedError(response, http.StatusConflict, "memory mutation conflicts with an earlier request", "idempotency_conflict")
+	case errors.Is(err, postgres.ErrMemoryLogicalKeyConflict):
+		writeCodedError(response, http.StatusConflict, "memory logical key conflicts with an existing item", "logical_key_conflict")
+	case errors.Is(err, postgres.ErrImmutableMemoryEvidence):
+		writeCodedError(response, http.StatusConflict, "memory item is immutable", "immutable_memory")
+	case errors.Is(err, postgres.ErrMemoryProposalCapacity):
+		writeCodedError(response, http.StatusTooManyRequests, "memory proposal cannot be accepted", "proposal_capacity")
+	case errors.Is(err, postgres.ErrMemoryProposalAlreadySatisfied):
+		writeCodedError(response, http.StatusConflict, "memory proposal conflicts with current state", "proposal_already_satisfied")
+	case errors.As(err, &rejection):
+		writeJSON(response, http.StatusUnprocessableEntity, struct {
+			Error       string `json:"error"`
+			Code        string `json:"code"`
+			RuleID      string `json:"rule_id"`
+			FieldPath   string `json:"field_path"`
+			RuleVersion int64  `json:"rule_version"`
+		}{"memory content was rejected", "secret_rejected", rejection.Finding.RuleID, rejection.Finding.FieldPath, rejection.Finding.RuleVersion})
+	case errors.Is(err, postgres.ErrMaintenance):
+		response.Header().Set("Retry-After", "1")
+		writeCodedError(response, http.StatusServiceUnavailable, "memory service is temporarily unavailable", "maintenance")
 	case errors.Is(err, postgres.ErrCursorTimelineChanged):
 		writeCursorError(response, "timeline_changed")
 	case errors.Is(err, postgres.ErrCursorFromFuture):
@@ -408,6 +960,32 @@ func writeStoreError(response http.ResponseWriter, err error) {
 	default:
 		writeError(response, http.StatusServiceUnavailable, "memory service is unavailable")
 	}
+}
+
+func writeMutationResult(response http.ResponseWriter, status int, result postgres.MemoryMutationResult, err error) {
+	if err != nil {
+		writeStoreError(response, err)
+		return
+	}
+	if result.ETag != "" {
+		response.Header().Set("ETag", result.ETag)
+	}
+	writeJSON(response, status, result)
+}
+
+func writeProposalResult(response http.ResponseWriter, status int, result postgres.MemoryProposalResult, err error) {
+	if err != nil {
+		writeStoreError(response, err)
+		return
+	}
+	if result.ETag != "" {
+		response.Header().Set("ETag", result.ETag)
+	}
+	writeJSON(response, status, result)
+}
+
+func writeCodedError(response http.ResponseWriter, status int, message, code string) {
+	writeJSON(response, status, map[string]string{"error": message, "code": code})
 }
 
 func writeCursorError(response http.ResponseWriter, code string) {

--- a/internal/memoryhttp/handler_test.go
+++ b/internal/memoryhttp/handler_test.go
@@ -13,17 +13,21 @@ import (
 
 	"github.com/rock3r/punaro/internal/ingress"
 	"github.com/rock3r/punaro/internal/postgres"
+	"github.com/rock3r/punaro/internal/secretguard"
 )
 
 const (
-	testPrincipalID = "11111111-1111-4111-8111-111111111111"
-	testLookupID    = "22222222-2222-4222-8222-222222222222"
-	testProjectID   = "33333333-3333-4333-8333-333333333333"
-	testItemID      = "44444444-4444-4444-8444-444444444444"
-	testProposalID  = "55555555-5555-4555-8555-555555555555"
-	testIdentityID  = "66666666-6666-4666-8666-666666666666"
-	testInstallID   = "77777777-7777-4777-8777-777777777777"
-	testTimelineID  = "88888888-8888-4888-8888-888888888888"
+	testPrincipalID  = "11111111-1111-4111-8111-111111111111"
+	testLookupID     = "22222222-2222-4222-8222-222222222222"
+	testProjectID    = "33333333-3333-4333-8333-333333333333"
+	testItemID       = "44444444-4444-4444-8444-444444444444"
+	testProposalID   = "55555555-5555-4555-8555-555555555555"
+	testIdentityID   = "66666666-6666-4666-8666-666666666666"
+	testInstallID    = "77777777-7777-4777-8777-777777777777"
+	testTimelineID   = "88888888-8888-4888-8888-888888888888"
+	testIdempotency  = "99999999-9999-4999-8999-999999999999"
+	testMemoryETag   = `"m1-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"`
+	testProposalETag = `"p1-bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"`
 )
 
 type fakeStore struct {
@@ -33,19 +37,106 @@ type fakeStore struct {
 	authErr error
 	err     error
 
-	credential string
-	principal  string
-	project    string
-	item       string
-	proposal   string
-	query      string
-	limit      int
-	cursor     postgres.InstallationState
-	kind       postgres.ProjectIdentityKind
-	locator    string
+	credential   string
+	principal    string
+	project      string
+	item         string
+	proposal     string
+	query        string
+	limit        int
+	cursor       postgres.InstallationState
+	kind         postgres.ProjectIdentityKind
+	locator      string
+	idempotency  string
+	expectedETag string
+	logicalKey   string
+	kindToken    string
+	trust        string
+	document     json.RawMessage
+	archived     bool
+	action       postgres.MemoryProposalAction
+	steps        []postgres.MemoryProposalStepInput
+	evidence     []postgres.MemoryProposalEvidenceInput
 
 	block   chan struct{}
 	entered chan struct{}
+}
+
+func (s *fakeStore) mutationResult(item string, state postgres.MemoryState) postgres.MemoryMutationResult {
+	return postgres.MemoryMutationResult{ItemID: item, Revision: 3, ETag: testMemoryETag, State: state, ChangeSequence: 10}
+}
+
+func (s *fakeStore) CreateMemory(ctx context.Context, r postgres.MemoryCreateRequest) (postgres.MemoryMutationResult, error) {
+	s.mu.Lock()
+	s.principal, s.project, s.idempotency, s.logicalKey, s.kindToken, s.trust, s.document = r.PrincipalID, r.ProjectID, r.IdempotencyKey, r.LogicalKey, r.Kind, r.Trust, r.Document
+	s.mu.Unlock()
+	if err := s.wait(ctx); err != nil {
+		return postgres.MemoryMutationResult{}, err
+	}
+	return s.mutationResult(testItemID, postgres.MemoryActive), nil
+}
+
+func (s *fakeStore) UpdateMemory(ctx context.Context, r postgres.MemoryUpdateRequest) (postgres.MemoryMutationResult, error) {
+	s.mu.Lock()
+	s.principal, s.project, s.item, s.idempotency, s.expectedETag, s.logicalKey, s.kindToken, s.trust, s.document = r.PrincipalID, r.ProjectID, r.ItemID, r.IdempotencyKey, r.ExpectedETag, r.LogicalKey, r.Kind, r.Trust, r.Document
+	s.mu.Unlock()
+	if err := s.wait(ctx); err != nil {
+		return postgres.MemoryMutationResult{}, err
+	}
+	return s.mutationResult(r.ItemID, postgres.MemoryActive), nil
+}
+
+func (s *fakeStore) ArchiveMemory(ctx context.Context, r postgres.MemoryArchiveRequest) (postgres.MemoryMutationResult, error) {
+	s.mu.Lock()
+	s.principal, s.project, s.item, s.idempotency, s.expectedETag, s.archived = r.PrincipalID, r.ProjectID, r.ItemID, r.IdempotencyKey, r.ExpectedETag, r.Archived
+	s.mu.Unlock()
+	if err := s.wait(ctx); err != nil {
+		return postgres.MemoryMutationResult{}, err
+	}
+	state := postgres.MemoryActive
+	if r.Archived {
+		state = postgres.MemoryArchived
+	}
+	return s.mutationResult(r.ItemID, state), nil
+}
+
+func (s *fakeStore) DeleteMemory(ctx context.Context, r postgres.MemoryDeleteRequest) (postgres.MemoryMutationResult, error) {
+	s.mu.Lock()
+	s.principal, s.project, s.item, s.idempotency, s.expectedETag = r.PrincipalID, r.ProjectID, r.ItemID, r.IdempotencyKey, r.ExpectedETag
+	s.mu.Unlock()
+	if err := s.wait(ctx); err != nil {
+		return postgres.MemoryMutationResult{}, err
+	}
+	result := s.mutationResult(r.ItemID, "")
+	result.ETag = ""
+	result.State = ""
+	return result, nil
+}
+
+func (s *fakeStore) ProposeMemory(ctx context.Context, r postgres.MemoryProposalCreateRequest) (postgres.MemoryProposalResult, error) {
+	s.mu.Lock()
+	s.principal, s.project, s.idempotency, s.action, s.steps, s.evidence = r.PrincipalID, r.ProjectID, r.IdempotencyKey, r.Action, r.Steps, r.Evidence
+	s.mu.Unlock()
+	if err := s.wait(ctx); err != nil {
+		return postgres.MemoryProposalResult{}, err
+	}
+	return postgres.MemoryProposalResult{ProposalID: testProposalID, State: postgres.MemoryProposalPending, ETag: testProposalETag}, nil
+}
+
+func (s *fakeStore) ApproveMemoryProposal(ctx context.Context, r postgres.MemoryProposalDecisionRequest) (postgres.MemoryProposalResult, error) {
+	return s.decide(ctx, r, postgres.MemoryProposalApproved)
+}
+func (s *fakeStore) RejectMemoryProposal(ctx context.Context, r postgres.MemoryProposalDecisionRequest) (postgres.MemoryProposalResult, error) {
+	return s.decide(ctx, r, postgres.MemoryProposalRejected)
+}
+func (s *fakeStore) decide(ctx context.Context, r postgres.MemoryProposalDecisionRequest, state postgres.MemoryProposalState) (postgres.MemoryProposalResult, error) {
+	s.mu.Lock()
+	s.principal, s.project, s.proposal, s.idempotency, s.expectedETag = r.PrincipalID, r.ProjectID, r.ProposalID, r.IdempotencyKey, r.ExpectedETag
+	s.mu.Unlock()
+	if err := s.wait(ctx); err != nil {
+		return postgres.MemoryProposalResult{}, err
+	}
+	return postgres.MemoryProposalResult{ProposalID: r.ProposalID, State: state, ETag: testProposalETag}, nil
 }
 
 func newFakeStore() *fakeStore {
@@ -136,7 +227,7 @@ func (s *fakeStore) FetchMemoryChanges(ctx context.Context, request postgres.Mem
 
 func newTestHandler(store *fakeStore) http.Handler {
 	policy := &ingress.Policy{Mode: ingress.LAN, ListenAddr: "127.0.0.1:8443", PublicURL: "https://punaro.test"}
-	return New(store, policy)
+	return New(store, policy, true)
 }
 
 func request(method, path, body string) *http.Request {
@@ -147,6 +238,205 @@ func request(method, path, body string) *http.Request {
 		r.Header.Set("Content-Type", "application/json")
 	}
 	return r
+}
+
+func mutationRequest(method, path, body string, cas bool) *http.Request {
+	r := request(method, path, body)
+	r.Header.Set("Idempotency-Key", testIdempotency)
+	if cas {
+		r.Header.Set("If-Match", testMemoryETag)
+	}
+	return r
+}
+
+func TestHandlerBindsAuthenticatedPrincipalAcrossMutationRoutes(t *testing.T) {
+	store := newFakeStore()
+	handler := newTestHandler(store)
+	base := "/v1/projects/" + testProjectID
+	body := `{"logical_key":"decision:one","kind":"decision","trust":"curated","document":{"title":"Decision"}}`
+	w := serve(t, handler, mutationRequest(http.MethodPost, base+"/memories", body, false), http.StatusCreated)
+	if store.principal != testPrincipalID || store.project != testProjectID || store.idempotency != testIdempotency || store.logicalKey != "decision:one" || string(store.document) != `{"title":"Decision"}` || w.Header().Get("ETag") != testMemoryETag {
+		t.Fatalf("create binding=%#v headers=%v body=%s", store, w.Header(), w.Body.String())
+	}
+
+	w = serve(t, handler, mutationRequest(http.MethodPut, base+"/memories/"+testItemID, body, true), http.StatusOK)
+	if store.item != testItemID || store.expectedETag != testMemoryETag || w.Header().Get("ETag") != testMemoryETag {
+		t.Fatalf("update binding=%#v", store)
+	}
+
+	w = serve(t, handler, mutationRequest(http.MethodPost, base+"/memories/"+testItemID+"/state", `{"archived":true}`, true), http.StatusOK)
+	if !store.archived || store.expectedETag != testMemoryETag || !strings.Contains(w.Body.String(), `"state":"archived"`) {
+		t.Fatalf("state binding=%#v body=%s", store, w.Body.String())
+	}
+
+	w = serve(t, handler, mutationRequest(http.MethodDelete, base+"/memories/"+testItemID, "", true), http.StatusOK)
+	if strings.Contains(w.Body.String(), "etag") || strings.Contains(w.Body.String(), "state") {
+		t.Fatalf("purge response leaked absent fields: %s", w.Body.String())
+	}
+
+	proposal := `{"action":"create","steps":[{"operation":"create","logical_key":"decision:two","kind":"decision","trust":"curated","document":{"title":"Proposed"}}],"evidence":[]}`
+	w = serve(t, handler, mutationRequest(http.MethodPost, base+"/memory-proposals", proposal, false), http.StatusCreated)
+	if store.action != postgres.MemoryProposalCreate || len(store.steps) != 1 || store.steps[0].LogicalKey != "decision:two" || w.Header().Get("ETag") != testProposalETag {
+		t.Fatalf("proposal binding=%#v headers=%v", store, w.Header())
+	}
+
+	for _, decision := range []struct {
+		path  string
+		state postgres.MemoryProposalState
+	}{{"approve", postgres.MemoryProposalApproved}, {"reject", postgres.MemoryProposalRejected}} {
+		r := mutationRequest(http.MethodPost, base+"/memory-proposals/"+testProposalID+"/"+decision.path, "", false)
+		r.Header.Set("If-Match", testProposalETag)
+		w = serve(t, handler, r, http.StatusOK)
+		if store.proposal != testProposalID || store.expectedETag != testProposalETag || !strings.Contains(w.Body.String(), `"state":"`+string(decision.state)+`"`) {
+			t.Fatalf("decision %s binding=%#v body=%s", decision.path, store, w.Body.String())
+		}
+	}
+}
+
+func TestHandlerKeepsMutationRoutesDarkUnderReadOnlyOptIn(t *testing.T) {
+	store := newFakeStore()
+	policy := &ingress.Policy{Mode: ingress.LAN, ListenAddr: "127.0.0.1:8443", PublicURL: "https://punaro.test"}
+	handler := New(store, policy, false)
+	body := `{"logical_key":"","kind":"decision","trust":"curated","document":{}}`
+	serve(t, handler, mutationRequest(http.MethodPost, "/v1/projects/"+testProjectID+"/memories", body, false), http.StatusNotFound)
+	if store.idempotency != "" {
+		t.Fatalf("dark mutation route reached store: %#v", store)
+	}
+}
+
+func TestHandlerRejectsMutationHeadersAndNestedJSONBeforeStore(t *testing.T) {
+	store := newFakeStore()
+	handler := newTestHandler(store)
+	base := "/v1/projects/" + testProjectID
+	body := `{"logical_key":"","kind":"decision","trust":"curated","document":{"title":"Decision"}}`
+	for _, mutate := range []func(*http.Request){
+		func(r *http.Request) { r.Header.Del("Idempotency-Key") },
+		func(r *http.Request) { r.Header["Idempotency-Key"] = []string{testIdempotency, testIdempotency} },
+		func(r *http.Request) { r.Header.Set("Idempotency-Key", "not-a-uuid") },
+	} {
+		r := mutationRequest(http.MethodPost, base+"/memories", body, false)
+		mutate(r)
+		serve(t, handler, r, http.StatusBadRequest)
+	}
+	for _, value := range []string{"", "*", "W/" + testMemoryETag, testMemoryETag + ", " + testMemoryETag, `"m1-bad"`} {
+		r := mutationRequest(http.MethodPut, base+"/memories/"+testItemID, body, false)
+		if value != "" {
+			r.Header.Set("If-Match", value)
+		}
+		serve(t, handler, r, http.StatusBadRequest)
+	}
+	for _, body := range []string{
+		`{"logical_key":"","kind":"decision","trust":"curated","document":{"title":"one","title":"two"}}`,
+		`{"action":"create","steps":[{"operation":"create","logical_key":"","kind":"decision","trust":"curated","document":{},"unknown":true}],"evidence":[]}`,
+		`{"action":"create","steps":[{"operation":"create","operation":"update","logical_key":"","kind":"decision","trust":"curated","document":{}}],"evidence":[]}`,
+		`{"logical_key":"","Kind":"decision","trust":"curated","document":{}}`,
+		`{"action":"create","steps":[{"Operation":"create","logical_key":"","kind":"decision","trust":"curated","document":{}}],"evidence":[]}`,
+		`{"action":"create","steps":[{"operation":"create","logical_key":"","kind":"decision","trust":"curated","document":{}}],"Evidence":[]}`,
+		`{"logical_key":null,"kind":"decision","trust":"curated","document":{}}`,
+		`{"action":"create","steps":[{"operation":"create","item_id":null,"logical_key":"","kind":"decision","trust":"curated","document":{}}],"evidence":[]}`,
+		`{"action":"create","steps":[{"operation":"create","logical_key":"","kind":"decision","trust":"curated","document":{}}],"evidence":null}`,
+	} {
+		serve(t, handler, mutationRequest(http.MethodPost, base+map[bool]string{true: "/memory-proposals", false: "/memories"}[strings.Contains(body, `"action"`)], body, false), http.StatusBadRequest)
+	}
+	for _, kind := range []string{"1decision", ".decision", "Decision"} {
+		invalidToken := `{"logical_key":"","kind":"` + kind + `","trust":"curated","document":{}}`
+		serve(t, handler, mutationRequest(http.MethodPost, base+"/memories", invalidToken, false), http.StatusBadRequest)
+	}
+	validColon := `{"logical_key":"","kind":"decision:architecture","trust":"curated","document":{}}`
+	serve(t, handler, mutationRequest(http.MethodPost, base+"/memories", validColon, false), http.StatusCreated)
+	store.idempotency = ""
+	nilProject := mutationRequest(http.MethodPost, "/v1/projects/00000000-0000-0000-0000-000000000000/memories", body, false)
+	serve(t, handler, nilProject, http.StatusBadRequest)
+	invalidUTF8 := `{"logical_key":"` + string([]byte{0xff}) + `","kind":"decision","trust":"curated","document":{}}`
+	serve(t, handler, mutationRequest(http.MethodPost, base+"/memories", invalidUTF8, false), http.StatusBadRequest)
+	invalidProposalUTF8 := `{"action":"create","steps":[{"operation":"create","logical_key":"` + string([]byte{0xff}) + `","kind":"decision","trust":"curated","document":{}}],"evidence":[]}`
+	serve(t, handler, mutationRequest(http.MethodPost, base+"/memory-proposals", invalidProposalUTF8, false), http.StatusBadRequest)
+	if store.idempotency != "" {
+		t.Fatalf("rejected mutation reached store: %#v", store)
+	}
+}
+
+func TestHandlerRejectsProposalWhoseCanonicalPayloadExceedsStoreBound(t *testing.T) {
+	store := newFakeStore()
+	handler := newTestHandler(store)
+	makeBody := func(characters int) string {
+		steps := []postgres.MemoryProposalStepInput{{Operation: postgres.MemoryProposalStepArchive, ItemID: testItemID, ExpectedETag: testMemoryETag, Archived: true}}
+		for index := 0; index < 4; index++ {
+			count := characters / 4
+			if index < characters%4 {
+				count++
+			}
+			steps = append(steps, postgres.MemoryProposalStepInput{Operation: postgres.MemoryProposalStepCreate, Kind: "decision", Trust: "curated", Document: json.RawMessage(`{"x":"` + strings.Repeat("a", count) + `"}`)})
+		}
+		encoded, err := json.Marshal(proposalBody{Action: postgres.MemoryProposalSplit, Steps: steps, Evidence: []postgres.MemoryProposalEvidenceInput{}})
+		if err != nil {
+			t.Fatal(err)
+		}
+		return string(encoded)
+	}
+	low, high := 0, maxProposalBytes
+	for low < high {
+		middle := (low + high + 1) / 2
+		if len(makeBody(middle)) < maxProposalBytes {
+			low = middle
+		} else {
+			high = middle - 1
+		}
+	}
+	body := makeBody(low)
+	if len(body) >= maxProposalBytes {
+		t.Fatalf("test body=%d", len(body))
+	}
+	serve(t, handler, mutationRequest(http.MethodPost, "/v1/projects/"+testProjectID+"/memory-proposals", body, false), http.StatusRequestEntityTooLarge)
+	if store.idempotency != "" {
+		t.Fatalf("oversized canonical proposal reached store: %#v", store)
+	}
+}
+
+func TestHandlerMapsMutationErrorsWithoutContentLeak(t *testing.T) {
+	store := newFakeStore()
+	handler := newTestHandler(store)
+	path := "/v1/projects/" + testProjectID + "/memories"
+	var rejection postgres.MemorySecretRejection
+	_ = json.Unmarshal([]byte(`{"x":1}`), &rejection)
+	for _, tc := range []struct {
+		err    error
+		status int
+		code   string
+	}{
+		{postgres.ErrStaleMemoryETag, http.StatusConflict, "stale_etag"},
+		{postgres.ErrStaleMemoryProposal, http.StatusConflict, "stale_proposal"},
+		{postgres.ErrIdempotencyConflict, http.StatusConflict, "idempotency_conflict"},
+		{postgres.ErrMemoryLogicalKeyConflict, http.StatusConflict, "logical_key_conflict"},
+		{postgres.ErrMemoryProposalCapacity, http.StatusTooManyRequests, "proposal_capacity"},
+		{postgres.ErrMemoryProposalAlreadySatisfied, http.StatusConflict, "proposal_already_satisfied"},
+	} {
+		store.err = tc.err
+		w := serve(t, handler, mutationRequest(http.MethodPost, path, `{"logical_key":"","kind":"decision","trust":"curated","document":{}}`, false), tc.status)
+		if !strings.Contains(w.Body.String(), `"code":"`+tc.code+`"`) || strings.Contains(w.Body.String(), tc.err.Error()) {
+			t.Fatalf("mapping err=%v body=%s", tc.err, w.Body.String())
+		}
+	}
+	store.err = postgres.ErrMaintenance
+	w := serve(t, handler, mutationRequest(http.MethodPost, path, `{"logical_key":"","kind":"decision","trust":"curated","document":{}}`, false), http.StatusServiceUnavailable)
+	if w.Header().Get("Retry-After") != "1" || !strings.Contains(w.Body.String(), `"code":"maintenance"`) {
+		t.Fatalf("maintenance response headers=%v body=%s", w.Header(), w.Body.String())
+	}
+}
+
+func TestHandlerReturnsOnlySafeSecretRejectionCoordinates(t *testing.T) {
+	store := newFakeStore()
+	store.err = secretguard.RejectionError{Finding: secretguard.Finding{RuleID: secretguard.RuleSensitiveField, FieldPath: "/password", RuleVersion: secretguard.RuleVersion, Fingerprint: [32]byte{1, 2, 3}}}
+	handler := newTestHandler(store)
+	w := serve(t, handler, mutationRequest(http.MethodPost, "/v1/projects/"+testProjectID+"/memories", `{"logical_key":"","kind":"decision","trust":"curated","document":{}}`, false), http.StatusUnprocessableEntity)
+	for _, want := range []string{`"code":"secret_rejected"`, `"rule_id":"sensitive-field"`, `"field_path":"/password"`} {
+		if !strings.Contains(w.Body.String(), want) {
+			t.Fatalf("secret response missing %s: %s", want, w.Body.String())
+		}
+	}
+	if strings.Contains(w.Body.String(), "fingerprint") || strings.Contains(w.Body.String(), store.err.Error()) {
+		t.Fatalf("secret response leaked internals: %s", w.Body.String())
+	}
 }
 
 func serve(t *testing.T, handler http.Handler, r *http.Request, wantStatus int) *httptest.ResponseRecorder {
@@ -329,7 +619,7 @@ func TestHandlerBoundsConcurrencyAndCancelsBlockedStoreWork(t *testing.T) {
 	store.block = make(chan struct{})
 	store.entered = make(chan struct{}, 1)
 	policy := &ingress.Policy{Mode: ingress.LAN, ListenAddr: "127.0.0.1:8443", PublicURL: "https://punaro.test"}
-	handler := newHandler(store, policy, 1, 20*time.Millisecond)
+	handler := newHandler(store, policy, 1, 20*time.Millisecond, true)
 	done := make(chan *httptest.ResponseRecorder, 1)
 	go func() {
 		w := httptest.NewRecorder()

--- a/internal/operator/installation.go
+++ b/internal/operator/installation.go
@@ -77,37 +77,39 @@ func validateRelayMachinesJSON(raw string) error {
 // Installation is the content-free operator configuration. DSN values remain
 // in separately protected files and are never copied here.
 type Installation struct {
-	Version           int                     `json:"version"`
-	Directory         string                  `json:"-"`
-	DataDir           string                  `json:"data_dir"`
-	BackupDir         string                  `json:"backup_dir"`
-	Image             string                  `json:"image"`
-	OwnerDSNFile      string                  `json:"owner_dsn_file"`
-	AppDSNFile        string                  `json:"app_dsn_file"`
-	OwnerPrincipalID  string                  `json:"owner_principal_id"`
-	OwnerName         string                  `json:"owner_name"`
-	RuntimeUID        string                  `json:"runtime_uid"`
-	RuntimeGID        string                  `json:"runtime_gid"`
-	Ingress           ingress.Policy          `json:"ingress"`
-	HealthListenAddr  string                  `json:"health_listen_addr"`
-	HealthURL         string                  `json:"health_url"`
-	MemoryAPIEnabled  bool                    `json:"memory_api_enabled"`
-	RelayMachinesJSON string                  `json:"relay_machines_json,omitempty"`
-	MailCutover       *MailCutoverPublication `json:"mail_cutover,omitempty"`
+	Version                int                     `json:"version"`
+	Directory              string                  `json:"-"`
+	DataDir                string                  `json:"data_dir"`
+	BackupDir              string                  `json:"backup_dir"`
+	Image                  string                  `json:"image"`
+	OwnerDSNFile           string                  `json:"owner_dsn_file"`
+	AppDSNFile             string                  `json:"app_dsn_file"`
+	OwnerPrincipalID       string                  `json:"owner_principal_id"`
+	OwnerName              string                  `json:"owner_name"`
+	RuntimeUID             string                  `json:"runtime_uid"`
+	RuntimeGID             string                  `json:"runtime_gid"`
+	Ingress                ingress.Policy          `json:"ingress"`
+	HealthListenAddr       string                  `json:"health_listen_addr"`
+	HealthURL              string                  `json:"health_url"`
+	MemoryAPIEnabled       bool                    `json:"memory_api_enabled"`
+	MemoryMutationsEnabled bool                    `json:"memory_mutations_enabled"`
+	RelayMachinesJSON      string                  `json:"relay_machines_json,omitempty"`
+	MailCutover            *MailCutoverPublication `json:"mail_cutover,omitempty"`
 }
 
 // InitOptions is the complete explicit input to a first installation.
 type InitOptions struct {
-	Directory        string
-	DataDir          string
-	BackupDir        string
-	Image            string
-	OwnerDSNFile     string
-	AppDSNFile       string
-	OwnerName        string
-	Ingress          ingress.Policy
-	HealthListenAddr string
-	MemoryAPIEnabled bool
+	Directory              string
+	DataDir                string
+	BackupDir              string
+	Image                  string
+	OwnerDSNFile           string
+	AppDSNFile             string
+	OwnerName              string
+	Ingress                ingress.Policy
+	HealthListenAddr       string
+	MemoryAPIEnabled       bool
+	MemoryMutationsEnabled bool
 }
 
 // BootstrapOwner is the only database mutation performed by Init.
@@ -211,7 +213,7 @@ func Resume(ctx context.Context, directory string, recoverOwner RecoverOwner) (I
 		return Installation{}, errors.New("initialization staging configuration is corrupt")
 	}
 	installation.Directory = directory
-	if _, err := validateStatic(InitOptions{Directory: directory, DataDir: installation.DataDir, BackupDir: installation.BackupDir, Image: installation.Image, OwnerDSNFile: installation.OwnerDSNFile, AppDSNFile: installation.AppDSNFile, OwnerName: installation.OwnerName, Ingress: installation.Ingress, HealthListenAddr: installation.HealthListenAddr, MemoryAPIEnabled: installation.MemoryAPIEnabled}); err != nil {
+	if _, err := validateStatic(InitOptions{Directory: directory, DataDir: installation.DataDir, BackupDir: installation.BackupDir, Image: installation.Image, OwnerDSNFile: installation.OwnerDSNFile, AppDSNFile: installation.AppDSNFile, OwnerName: installation.OwnerName, Ingress: installation.Ingress, HealthListenAddr: installation.HealthListenAddr, MemoryAPIEnabled: installation.MemoryAPIEnabled, MemoryMutationsEnabled: installation.MemoryMutationsEnabled}); err != nil {
 		return Installation{}, errors.New("initialization staging configuration is invalid")
 	}
 	if failures := CheckPaths(installation); len(failures) != 0 {
@@ -317,7 +319,10 @@ func validateStatic(options InitOptions) (Installation, error) {
 	if !listener.IsLoopback(healthListenAddr) || listener.Same(policy.ListenAddr, healthListenAddr) {
 		return Installation{}, errors.New("health listener must be a distinct concrete loopback address")
 	}
-	return Installation{Version: 1, Directory: options.Directory, DataDir: options.DataDir, BackupDir: options.BackupDir, Image: options.Image, OwnerDSNFile: options.OwnerDSNFile, AppDSNFile: options.AppDSNFile, OwnerName: options.OwnerName, Ingress: policy, HealthListenAddr: healthListenAddr, HealthURL: localURL(healthListenAddr), MemoryAPIEnabled: options.MemoryAPIEnabled}, nil
+	if options.MemoryMutationsEnabled && !options.MemoryAPIEnabled {
+		return Installation{}, errors.New("memory mutations require the memory API")
+	}
+	return Installation{Version: 1, Directory: options.Directory, DataDir: options.DataDir, BackupDir: options.BackupDir, Image: options.Image, OwnerDSNFile: options.OwnerDSNFile, AppDSNFile: options.AppDSNFile, OwnerName: options.OwnerName, Ingress: policy, HealthListenAddr: healthListenAddr, HealthURL: localURL(healthListenAddr), MemoryAPIEnabled: options.MemoryAPIEnabled, MemoryMutationsEnabled: options.MemoryMutationsEnabled}, nil
 }
 
 // Load reads only a completely published installation marker.
@@ -347,7 +352,7 @@ func Load(directory string) (Installation, error) {
 			return Installation{}, errors.New("published installation relay enrollment is invalid")
 		}
 	}
-	validated, err := validateStatic(InitOptions{Directory: directory, DataDir: installation.DataDir, BackupDir: installation.BackupDir, Image: installation.Image, OwnerDSNFile: installation.OwnerDSNFile, AppDSNFile: installation.AppDSNFile, OwnerName: installation.OwnerName, Ingress: installation.Ingress, HealthListenAddr: installation.HealthListenAddr, MemoryAPIEnabled: installation.MemoryAPIEnabled})
+	validated, err := validateStatic(InitOptions{Directory: directory, DataDir: installation.DataDir, BackupDir: installation.BackupDir, Image: installation.Image, OwnerDSNFile: installation.OwnerDSNFile, AppDSNFile: installation.AppDSNFile, OwnerName: installation.OwnerName, Ingress: installation.Ingress, HealthListenAddr: installation.HealthListenAddr, MemoryAPIEnabled: installation.MemoryAPIEnabled, MemoryMutationsEnabled: installation.MemoryMutationsEnabled})
 	if err != nil {
 		return Installation{}, errors.New("published installation configuration is invalid")
 	}
@@ -457,7 +462,7 @@ func CheckPaths(installation Installation) []string {
 		failures = append(failures, "daemon-writable data directory overlaps database credentials or operator state")
 	}
 	envPath := EnvFile(installation.Directory)
-	envAvailable, envCurrent, envPreMemoryAPI, envLegacy := false, false, false, false
+	envAvailable, envCurrent, envPreMemoryMutations, envPreMemoryAPI, envLegacy := false, false, false, false, false
 	if err := requireTrustedProtectedFile(envPath, 64<<10); err != nil {
 		failures = append(failures, "generated daemon environment unavailable or unsafe")
 	} else {
@@ -466,15 +471,16 @@ func CheckPaths(installation Installation) []string {
 		envAvailable = err == nil
 		if envAvailable {
 			envCurrent = string(body) == daemonEnv(installation)
+			envPreMemoryMutations = !installation.MemoryMutationsEnabled && string(body) == preMemoryMutationsDaemonEnv(installation)
 			envPreMemoryAPI = !installation.MemoryAPIEnabled && string(body) == preMemoryAPIDaemonEnv(installation)
 			envLegacy = !installation.MemoryAPIEnabled && installation.MailCutover == nil && installation.RelayMachinesJSON == "" && string(body) == legacyDaemonEnv(installation)
 		}
-		if !envCurrent && !envPreMemoryAPI && !envLegacy {
+		if !envCurrent && !envPreMemoryMutations && !envPreMemoryAPI && !envLegacy {
 			failures = append(failures, "generated daemon environment does not match installation configuration")
 		}
 	}
 	overridePath := OverrideFile(installation.Directory)
-	overrideAvailable, overrideCurrent, overridePreMemoryAPI, overrideLegacy := false, false, false, false
+	overrideAvailable, overrideCurrent, overridePreMemoryMutations, overridePreMemoryAPI, overrideLegacy := false, false, false, false, false
 	if err := requireTrustedProtectedFile(overridePath, 64<<10); err != nil {
 		failures = append(failures, "generated Compose override unavailable or unsafe")
 	} else {
@@ -483,16 +489,17 @@ func CheckPaths(installation Installation) []string {
 		overrideAvailable = err == nil
 		if overrideAvailable {
 			overrideCurrent = string(body) == composeOverride()
+			overridePreMemoryMutations = !installation.MemoryMutationsEnabled && string(body) == preMemoryMutationsComposeOverride()
 			overridePreMemoryAPI = !installation.MemoryAPIEnabled && string(body) == preMemoryAPIComposeOverride()
 			overrideLegacy = !installation.MemoryAPIEnabled && installation.MailCutover == nil && installation.RelayMachinesJSON == "" && string(body) == legacyComposeOverride()
 		}
-		if !overrideCurrent && !overridePreMemoryAPI && !overrideLegacy {
+		if !overrideCurrent && !overridePreMemoryMutations && !overridePreMemoryAPI && !overrideLegacy {
 			failures = append(failures, "generated Compose override does not match installation configuration")
 		}
 	}
 	if envAvailable && overrideAvailable {
-		sameGeneration := envCurrent && overrideCurrent || envPreMemoryAPI && overridePreMemoryAPI || envLegacy && overrideLegacy
-		if !sameGeneration && (envCurrent || envPreMemoryAPI || envLegacy) && (overrideCurrent || overridePreMemoryAPI || overrideLegacy) {
+		sameGeneration := envCurrent && overrideCurrent || envPreMemoryMutations && overridePreMemoryMutations || envPreMemoryAPI && overridePreMemoryAPI || envLegacy && overrideLegacy
+		if !sameGeneration && (envCurrent || envPreMemoryMutations || envPreMemoryAPI || envLegacy) && (overrideCurrent || overridePreMemoryMutations || overridePreMemoryAPI || overrideLegacy) {
 			failures = append(failures, "generated daemon environment does not match installation configuration")
 			failures = append(failures, "generated Compose override does not match installation configuration")
 		}
@@ -528,6 +535,7 @@ func daemonEnv(installation Installation) string {
 		"PUNARO_POSTGRES_DSN_FILE=" + installation.AppDSNFile,
 		"PUNARO_DEVICE_AUTH_ENABLED=true",
 		fmt.Sprintf("PUNARO_MEMORY_API_ENABLED=%t", installation.MemoryAPIEnabled),
+		fmt.Sprintf("PUNARO_MEMORY_MUTATIONS_ENABLED=%t", installation.MemoryMutationsEnabled),
 		"PUNARO_RELAY_ENABLED=" + relayEnabled,
 		"PUNARO_RELAY_MACHINES_JSON='" + installation.RelayMachinesJSON + "'",
 		"PUNARO_RELAY_STORE=" + relayStore,
@@ -541,6 +549,10 @@ func daemonEnv(installation Installation) string {
 	}, "\n") + "\n"
 }
 
+func preMemoryMutationsDaemonEnv(installation Installation) string {
+	return strings.Replace(daemonEnv(installation), fmt.Sprintf("PUNARO_MEMORY_MUTATIONS_ENABLED=%t\n", installation.MemoryMutationsEnabled), "", 1)
+}
+
 func legacyDaemonEnv(installation Installation) string {
 	return strings.NewReplacer(
 		"PUNARO_RELAY_ENABLED=false\n", "",
@@ -551,7 +563,7 @@ func legacyDaemonEnv(installation Installation) string {
 }
 
 func preMemoryAPIDaemonEnv(installation Installation) string {
-	return strings.Replace(daemonEnv(installation), fmt.Sprintf("PUNARO_MEMORY_API_ENABLED=%t\n", installation.MemoryAPIEnabled), "", 1)
+	return strings.Replace(preMemoryMutationsDaemonEnv(installation), fmt.Sprintf("PUNARO_MEMORY_API_ENABLED=%t\n", installation.MemoryAPIEnabled), "", 1)
 }
 
 func composeOverride() string {
@@ -577,6 +589,7 @@ func composeOverride() string {
       PUNARO_POSTGRES_DSN_FILE: ${PUNARO_POSTGRES_DSN_FILE:?required}
       PUNARO_DEVICE_AUTH_ENABLED: ${PUNARO_DEVICE_AUTH_ENABLED:?required}
       PUNARO_MEMORY_API_ENABLED: ${PUNARO_MEMORY_API_ENABLED:-false}
+      PUNARO_MEMORY_MUTATIONS_ENABLED: ${PUNARO_MEMORY_MUTATIONS_ENABLED:-false}
       PUNARO_RELAY_ENABLED: ${PUNARO_RELAY_ENABLED:?required}
       PUNARO_RELAY_MACHINES_JSON: ${PUNARO_RELAY_MACHINES_JSON:-}
       PUNARO_RELAY_STORE: ${PUNARO_RELAY_STORE:?required}
@@ -596,6 +609,10 @@ func composeOverride() string {
 `
 }
 
+func preMemoryMutationsComposeOverride() string {
+	return strings.Replace(composeOverride(), "      PUNARO_MEMORY_MUTATIONS_ENABLED: ${PUNARO_MEMORY_MUTATIONS_ENABLED:-false}\n", "", 1)
+}
+
 func legacyComposeOverride() string {
 	return strings.NewReplacer(
 		"      PUNARO_RELAY_ENABLED: ${PUNARO_RELAY_ENABLED:?required}\n", "",
@@ -606,7 +623,7 @@ func legacyComposeOverride() string {
 }
 
 func preMemoryAPIComposeOverride() string {
-	return strings.Replace(composeOverride(), "      PUNARO_MEMORY_API_ENABLED: ${PUNARO_MEMORY_API_ENABLED:-false}\n", "", 1)
+	return strings.Replace(preMemoryMutationsComposeOverride(), "      PUNARO_MEMORY_API_ENABLED: ${PUNARO_MEMORY_API_ENABLED:-false}\n", "", 1)
 }
 
 func numericIdentity(value string) bool {

--- a/internal/operator/installation_test.go
+++ b/internal/operator/installation_test.go
@@ -68,6 +68,7 @@ func validInitOptions(t *testing.T) InitOptions {
 func TestInitPublishesConfigurationOnlyAfterOwnerBootstrap(t *testing.T) {
 	options := validInitOptions(t)
 	options.MemoryAPIEnabled = true
+	options.MemoryMutationsEnabled = true
 	called := false
 	installation, err := Init(context.Background(), options, func(_ context.Context, dsnFile, name string) (punaropostgres.Principal, error) {
 		called = true
@@ -83,16 +84,27 @@ func TestInitPublishesConfigurationOnlyAfterOwnerBootstrap(t *testing.T) {
 		t.Fatalf("installation=%#v called=%t err=%v", installation, called, err)
 	}
 	loaded, err := Load(options.Directory)
-	if err != nil || loaded.OwnerPrincipalID != "11111111-1111-4111-8111-111111111111" || !loaded.MemoryAPIEnabled {
+	if err != nil || loaded.OwnerPrincipalID != "11111111-1111-4111-8111-111111111111" || !loaded.MemoryAPIEnabled || !loaded.MemoryMutationsEnabled {
 		t.Fatalf("loaded=%#v err=%v", loaded, err)
 	}
 	environment, err := os.ReadFile(EnvFile(options.Directory))
 	if err != nil || !strings.Contains(string(environment), "PUNARO_MEMORY_API_ENABLED=true\n") {
 		t.Fatalf("memory API environment=%q err=%v", environment, err)
 	}
+	if !strings.Contains(string(environment), "PUNARO_MEMORY_MUTATIONS_ENABLED=true\n") {
+		t.Fatalf("memory mutation environment=%q", environment)
+	}
 	info, err := os.Stat(filepath.Join(options.Directory, configName))
 	if err != nil || info.Mode().Perm() != 0o600 {
 		t.Fatalf("config mode=%v err=%v", info.Mode(), err)
+	}
+}
+
+func TestInitRejectsMemoryMutationsWithoutReadAPI(t *testing.T) {
+	options := validInitOptions(t)
+	options.MemoryMutationsEnabled = true
+	if _, err := validateStatic(options); err == nil || !strings.Contains(err.Error(), "require the memory API") {
+		t.Fatalf("memory mutations without read API err=%v", err)
 	}
 }
 
@@ -525,6 +537,9 @@ func TestComposeOverrideKeepsMemoryAPIDarkButOperatorEnableable(t *testing.T) {
 	if !strings.Contains(override, "PUNARO_MEMORY_API_ENABLED: ${PUNARO_MEMORY_API_ENABLED:-false}") {
 		t.Fatalf("compose override does not pass the dark memory API switch: %s", override)
 	}
+	if !strings.Contains(override, "PUNARO_MEMORY_MUTATIONS_ENABLED: ${PUNARO_MEMORY_MUTATIONS_ENABLED:-false}") {
+		t.Fatal("compose override did not default memory mutations to dark")
+	}
 	if environment := daemonEnv(Installation{}); !strings.Contains(environment, "PUNARO_MEMORY_API_ENABLED=false\n") {
 		t.Fatalf("default generated environment is not dark: %s", environment)
 	}
@@ -556,6 +571,30 @@ func TestCheckPathsAcceptsExactPreMemoryAPITemplatesAsDark(t *testing.T) {
 	installation.MemoryAPIEnabled = true
 	if failures := CheckPaths(installation); len(failures) == 0 {
 		t.Fatal("pre-memory-API templates accepted for an enabled installation")
+	}
+}
+
+func TestCheckPathsAcceptsExactPreMemoryMutationTemplatesAsReadOnly(t *testing.T) {
+	options := validInitOptions(t)
+	options.MemoryAPIEnabled = true
+	installation, err := Init(context.Background(), options, func(context.Context, string, string) (punaropostgres.Principal, error) {
+		return punaropostgres.Principal{ID: "11111111-1111-4111-8111-111111111111"}, nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(EnvFile(installation.Directory), []byte(preMemoryMutationsDaemonEnv(installation)), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(OverrideFile(installation.Directory), []byte(preMemoryMutationsComposeOverride()), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if failures := CheckPaths(installation); len(failures) != 0 {
+		t.Fatalf("pre-mutation generation failures=%v", failures)
+	}
+	installation.MemoryMutationsEnabled = true
+	if failures := CheckPaths(installation); len(failures) == 0 {
+		t.Fatal("enabled mutation installation accepted historical read-only templates")
 	}
 }
 
@@ -629,6 +668,76 @@ func TestPublishMailCutoverRecoversFromPreMemoryAPIConfiguration(t *testing.T) {
 				t.Fatalf("step=%s recovered=%#v failures=%v err=%v", step, recovered, CheckPaths(recovered), err)
 			}
 		})
+	}
+}
+
+func TestPublishMailCutoverRecoversFromPreMemoryMutationConfiguration(t *testing.T) {
+	for _, step := range []string{"staged", "environment", "override", "marker"} {
+		t.Run(step, func(t *testing.T) {
+			options := validInitOptions(t)
+			options.MemoryAPIEnabled = true
+			installation, err := Init(context.Background(), options, func(context.Context, string, string) (punaropostgres.Principal, error) {
+				return punaropostgres.Principal{ID: "11111111-1111-4111-8111-111111111111"}, nil
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			installation = configureTestRelayMachines(t, installation)
+			if err := os.WriteFile(EnvFile(installation.Directory), []byte(preMemoryMutationsDaemonEnv(installation)), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(OverrideFile(installation.Directory), []byte(preMemoryMutationsComposeOverride()), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			publication := MailCutoverPublication{Version: 1, EpochID: "019f7f07-8b88-7c12-a394-b663274a6555", TargetIdentity: strings.Repeat("a", 64), SourceFingerprint: strings.Repeat("b", 64)}
+			injected := errors.New("injected publication crash")
+			if _, err := publishMailCutover(installation.Directory, publication, func(completed string) error {
+				if completed == step {
+					return injected
+				}
+				return nil
+			}); !errors.Is(err, injected) {
+				t.Fatalf("step=%s err=%v", step, err)
+			}
+			if _, err := LoadMailCutoverRecovery(installation.Directory); err != nil {
+				t.Fatalf("step=%s recovery preflight: %v", step, err)
+			}
+			recovered, err := PublishMailCutover(installation.Directory, publication)
+			if err != nil || recovered.MailCutover == nil || !recovered.MemoryAPIEnabled || recovered.MemoryMutationsEnabled || len(CheckPaths(recovered)) != 0 {
+				t.Fatalf("step=%s recovered=%#v failures=%v err=%v", step, recovered, CheckPaths(recovered), err)
+			}
+		})
+	}
+}
+
+func TestMailCutoverRecoveryRejectsPreMemoryMutationTemplatesWhenMutationsEnabled(t *testing.T) {
+	options := validInitOptions(t)
+	options.MemoryAPIEnabled, options.MemoryMutationsEnabled = true, true
+	installation, err := Init(context.Background(), options, func(context.Context, string, string) (punaropostgres.Principal, error) {
+		return punaropostgres.Principal{ID: "11111111-1111-4111-8111-111111111111"}, nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	installation = configureTestRelayMachines(t, installation)
+	if err := os.WriteFile(EnvFile(installation.Directory), []byte(preMemoryMutationsDaemonEnv(installation)), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(OverrideFile(installation.Directory), []byte(preMemoryMutationsComposeOverride()), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	publication := MailCutoverPublication{Version: 1, EpochID: "019f7f07-8b88-7c12-a394-b663274a6555", TargetIdentity: strings.Repeat("a", 64), SourceFingerprint: strings.Repeat("b", 64)}
+	injected := errors.New("injected publication crash")
+	if _, err := publishMailCutover(installation.Directory, publication, func(completed string) error {
+		if completed == "staged" {
+			return injected
+		}
+		return nil
+	}); !errors.Is(err, injected) {
+		t.Fatal(err)
+	}
+	if _, err := LoadMailCutoverRecovery(installation.Directory); err == nil {
+		t.Fatal("mutation-enabled recovery accepted pre-mutation templates")
 	}
 }
 

--- a/internal/operator/mail_cutover.go
+++ b/internal/operator/mail_cutover.go
@@ -239,7 +239,14 @@ func LoadMailCutoverRecovery(directory string) (Installation, error) {
 			return Installation{}, errors.New("mail cutover recovery file is unavailable")
 		}
 		body, err := os.ReadFile(file.path) // #nosec G304 -- validated fixed generated path.
-		legacyOld, preMemoryAPIOld := "", ""
+		legacyOld, preMemoryAPIOld, preMemoryMutationsOld := "", "", ""
+		if !base.MemoryMutationsEnabled {
+			if file.path == EnvFile(directory) {
+				preMemoryMutationsOld = preMemoryMutationsDaemonEnv(base)
+			} else {
+				preMemoryMutationsOld = preMemoryMutationsComposeOverride()
+			}
+		}
 		if !base.MemoryAPIEnabled {
 			if file.path == EnvFile(directory) {
 				preMemoryAPIOld = preMemoryAPIDaemonEnv(base)
@@ -254,7 +261,7 @@ func LoadMailCutoverRecovery(directory string) (Installation, error) {
 				legacyOld = legacyComposeOverride()
 			}
 		}
-		if err != nil || string(body) != file.old && string(body) != file.intended && string(body) != preMemoryAPIOld && string(body) != legacyOld {
+		if err != nil || string(body) != file.old && string(body) != file.intended && string(body) != preMemoryMutationsOld && string(body) != preMemoryAPIOld && string(body) != legacyOld {
 			return Installation{}, errors.New("mail cutover recovery file does not match either durable state")
 		}
 	}

--- a/internal/operator/restore.go
+++ b/internal/operator/restore.go
@@ -55,7 +55,7 @@ func ParseInstallationArtifact(body []byte) (Installation, error) {
 		return Installation{}, errors.New("backup installation configuration is invalid")
 	}
 	validationDirectory := filepath.Join(filepath.VolumeName(os.TempDir())+string(filepath.Separator), ".punaro-backup-source")
-	validated, err := validateStatic(InitOptions{Directory: validationDirectory, DataDir: installation.DataDir, BackupDir: installation.BackupDir, Image: installation.Image, OwnerDSNFile: installation.OwnerDSNFile, AppDSNFile: installation.AppDSNFile, OwnerName: installation.OwnerName, Ingress: installation.Ingress, HealthListenAddr: installation.HealthListenAddr, MemoryAPIEnabled: installation.MemoryAPIEnabled})
+	validated, err := validateStatic(InitOptions{Directory: validationDirectory, DataDir: installation.DataDir, BackupDir: installation.BackupDir, Image: installation.Image, OwnerDSNFile: installation.OwnerDSNFile, AppDSNFile: installation.AppDSNFile, OwnerName: installation.OwnerName, Ingress: installation.Ingress, HealthListenAddr: installation.HealthListenAddr, MemoryAPIEnabled: installation.MemoryAPIEnabled, MemoryMutationsEnabled: installation.MemoryMutationsEnabled})
 	if err != nil || validated.HealthURL != installation.HealthURL {
 		return Installation{}, errors.New("backup installation configuration is invalid")
 	}
@@ -116,7 +116,7 @@ func PrepareRestore(options RestoreOptions) (Installation, error) {
 	if err != nil {
 		return Installation{}, err
 	}
-	installation, err := validateStatic(InitOptions{Directory: options.Directory, DataDir: options.DataDir, BackupDir: options.BackupDir, Image: options.Source.Image, OwnerDSNFile: options.OwnerDSNFile, AppDSNFile: options.AppDSNFile, OwnerName: options.Source.OwnerName, Ingress: options.Source.Ingress, HealthListenAddr: options.Source.HealthListenAddr, MemoryAPIEnabled: options.Source.MemoryAPIEnabled})
+	installation, err := validateStatic(InitOptions{Directory: options.Directory, DataDir: options.DataDir, BackupDir: options.BackupDir, Image: options.Source.Image, OwnerDSNFile: options.OwnerDSNFile, AppDSNFile: options.AppDSNFile, OwnerName: options.Source.OwnerName, Ingress: options.Source.Ingress, HealthListenAddr: options.Source.HealthListenAddr, MemoryAPIEnabled: options.Source.MemoryAPIEnabled, MemoryMutationsEnabled: options.Source.MemoryMutationsEnabled})
 	if err != nil {
 		return Installation{}, err
 	}

--- a/internal/postgres/brain_proposal.go
+++ b/internal/postgres/brain_proposal.go
@@ -68,6 +68,8 @@ var (
 	ErrStaleMemoryProposal = errors.New("memory proposal is stale")
 	// ErrMemoryProposalCapacity reports a hard live or retained proposal quota.
 	ErrMemoryProposalCapacity = errors.New("memory proposal capacity is full")
+	// ErrMemoryProposalAlreadySatisfied rejects a staged state transition that is already true.
+	ErrMemoryProposalAlreadySatisfied = errors.New("memory proposal state transition is already satisfied")
 )
 
 // MemoryProposalStepInput is a typed create, update, or archive primitive.

--- a/internal/postgres/brain_proposal_store.go
+++ b/internal/postgres/brain_proposal_store.go
@@ -61,7 +61,7 @@ func (d *Database) ProposeMemory(ctx context.Context, raw MemoryProposalCreateRe
 			if step.Operation == MemoryProposalStepArchive {
 				locked := items[step.ItemID]
 				if (locked.State == MemoryArchived) == step.Archived {
-					return IdempotencyOutcome{}, errors.New("memory proposal archive is already satisfied")
+					return IdempotencyOutcome{}, ErrMemoryProposalAlreadySatisfied
 				}
 			}
 		}


### PR DESCRIPTION
## Summary
- add separately gated authenticated create/update/archive/restore/purge and proposal mutation routes
- enforce canonical idempotency/CAS headers, recursive strict JSON, canonical document/proposal bounds, and content-free typed errors
- persist the mutation opt-in across init/update/restore and historical mail-cutover recovery without upgrading read-only installs into writers

## Validation
- independent alignment review: PASS
- independent adversarial/security review: PASS
- make test: PASS
- make test-race: PASS
- make staticcheck: PASS
- make security: PASS
- make lint: PASS
- PostgreSQL 18 integration (internal/postgres and cmd/punaro): PASS
- GitHub commit signature: verified

## Scope
No schema, native client/CLI, MCP, semantic retrieval, offline queue, live infrastructure, credential, or Compose Pi change.