### PR TITLE
M17C2: add native memory profiles

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -82,8 +82,19 @@ only canonical active project IDs, bind the authenticated principal, require a
 canonical UUID idempotency key, and require a strong revision ETag for every
 CAS operation. PostgreSQL remains authoritative for capability checks,
 idempotency, atomic proposal application, secret rejection, and permanent
-read-only project aliases. The native local client remains a later
-independently reviewed slice.
+read-only project aliases. The native local memory client now exists as an
+independently reviewed slice. `punaro-memory` binds each command to a fixed
+HTTPS origin and protected device credential file. Operators may create an
+explicit local profile, but it is only a non-secret convenience contract:
+versioned JSON containing origin, credential-file path, and optional project
+UUID. The profile never stores the bearer credential value. Profile files are
+atomically replaced, owner-only regular files under trusted non-writable,
+non-symlink parent directories. Loading revalidates the path, owner-only file
+state, strict schema, fixed-HTTPS origin, absolute credential path, and
+optional project UUID before any request can use the defaults. Explicit CLI
+flags override profile defaults for the current invocation. Profiles do not
+add retry, queue, cache, Git discovery, project registry, fallback local brain,
+enrollment recovery, MCP, semantic retrieval, or Compose Pi behavior.
 
 ## Goals
 

--- a/cmd/punaro-memory/main.go
+++ b/cmd/punaro-memory/main.go
@@ -2,16 +2,19 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
 	"flag"
 	"fmt"
 	"io"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
 
+	"github.com/google/uuid"
 	"github.com/rock3r/punaro/internal/memoryclient"
 )
 
@@ -33,6 +36,18 @@ type client interface {
 var newMemoryClient = func(origin, credential string) (client, error) { return memoryclient.New(origin, credential) }
 var loadCredential = memoryclient.LoadCredential
 
+const (
+	profileVersion = 1
+	maxProfileSize = int64(4096)
+)
+
+type profile struct {
+	Version        int    `json:"version"`
+	Origin         string `json:"origin"`
+	CredentialFile string `json:"credential_file"`
+	Project        string `json:"project,omitempty"`
+}
+
 func main() { os.Exit(run(os.Args[1:], os.Stdout, os.Stderr)) }
 
 func run(args []string, stdout, stderr io.Writer) int {
@@ -43,6 +58,7 @@ func run(args []string, stdout, stderr io.Writer) int {
 	command := args[0]
 	flags := flag.NewFlagSet(command, flag.ContinueOnError)
 	flags.SetOutput(stderr)
+	profilePath := flags.String("profile", "", "absolute protected non-secret profile file")
 	origin := flags.String("origin", "", "fixed Punaro HTTPS origin")
 	credentialFile := flags.String("credential-file", "", "absolute protected device credential file")
 	project := flags.String("project", "", "opaque project UUID")
@@ -56,7 +72,39 @@ func run(args []string, stdout, stderr io.Writer) int {
 	kind := flags.String("kind", "", "project identity kind")
 	locator := flags.String("locator", "", "project identity locator")
 	cursorFile := flags.String("cursor-file", "", "optional absolute JSON cursor file")
-	if flags.Parse(args[1:]) != nil || flags.NArg() != 0 || !validFlags(command, args[1:], flags) || *origin == "" || !filepath.IsAbs(*credentialFile) {
+	if flags.Parse(args[1:]) != nil || flags.NArg() != 0 || !validFlags(command, args[1:], flags) {
+		return 2
+	}
+	explicit := make(map[string]bool)
+	flags.Visit(func(parsed *flag.Flag) { explicit[parsed.Name] = true })
+	if command == "profile-write" {
+		candidate := profile{Origin: *origin, CredentialFile: *credentialFile, Project: *project}
+		if !safeProfilePath(*profilePath) || !validProfile(candidate) || sameCleanPath(*profilePath, candidate.CredentialFile) {
+			return 2
+		}
+		if err := saveProfile(*profilePath, candidate); err != nil {
+			_, _ = fmt.Fprintln(stderr, "punaro-memory: profile failed")
+			return 1
+		}
+		return 0
+	}
+	if *profilePath != "" {
+		loaded, err := loadProfile(*profilePath)
+		if err != nil {
+			_, _ = fmt.Fprintln(stderr, "punaro-memory: profile failed")
+			return 1
+		}
+		if !explicit["origin"] {
+			*origin = loaded.Origin
+		}
+		if !explicit["credential-file"] {
+			*credentialFile = loaded.CredentialFile
+		}
+		if !explicit["project"] {
+			*project = loaded.Project
+		}
+	}
+	if *origin == "" || !filepath.IsAbs(*credentialFile) {
 		return 2
 	}
 	if !validCommand(command, *project, *item, *proposal, *key, *etag, *input, *query, *kind, *locator, *cursorFile, *limit) {
@@ -140,7 +188,7 @@ func run(args []string, stdout, stderr io.Writer) int {
 }
 
 func validFlags(command string, args []string, flags *flag.FlagSet) bool {
-	allowed := map[string]bool{"origin": true, "credential-file": true}
+	allowed := map[string]bool{"profile": true, "origin": true, "credential-file": true}
 	for _, name := range commandFlags(command) {
 		allowed[name] = true
 	}
@@ -188,6 +236,8 @@ func flagName(argument string) (string, bool) {
 
 func commandFlags(command string) []string {
 	switch command {
+	case "profile-write":
+		return []string{"profile", "origin", "credential-file", "project"}
 	case "resolve":
 		return []string{"kind", "locator"}
 	case "get":
@@ -211,6 +261,185 @@ func commandFlags(command string) []string {
 	default:
 		return nil
 	}
+}
+
+func saveProfile(path string, value profile) error {
+	if !safeProfilePath(path) || !privateProfilePath(path) || !validProfile(value) || sameCleanPath(path, value.CredentialFile) {
+		return errors.New("profile is invalid")
+	}
+	if !noSymlinkPath(filepath.Dir(path)) || !noSymlinkPath(filepath.Dir(value.CredentialFile)) {
+		return errors.New("profile path is unsafe")
+	}
+	value.Version = profileVersion
+	raw, err := json.MarshalIndent(value, "", "  ")
+	if err != nil {
+		return err
+	}
+	raw = append(raw, '\n')
+	if int64(len(raw)) > maxProfileSize {
+		return errors.New("profile is too large")
+	}
+	directory := filepath.Dir(path)
+	temp, err := os.CreateTemp(directory, "."+filepath.Base(path)+".tmp-") // #nosec G304 -- directory is explicit, absolute, and checked for symlink components.
+	if err != nil {
+		return err
+	}
+	tempPath := temp.Name()
+	removeTemp := true
+	defer func() {
+		if removeTemp {
+			_ = os.Remove(tempPath) // #nosec G703 -- tempPath comes from os.CreateTemp in the already validated profile directory.
+		}
+	}()
+	if err := temp.Chmod(0o600); err != nil {
+		_ = temp.Close()
+		return err
+	}
+	if _, err := temp.Write(raw); err != nil {
+		_ = temp.Close()
+		return err
+	}
+	if err := temp.Sync(); err != nil {
+		_ = temp.Close()
+		return err
+	}
+	if err := temp.Close(); err != nil {
+		return err
+	}
+	if !noSymlinkPath(directory) {
+		return errors.New("profile directory changed while writing")
+	}
+	if err := os.Rename(tempPath, path); err != nil { // #nosec G703 -- source and target are validated absolute profile paths in the same checked directory.
+		return err
+	}
+	removeTemp = false
+	if err := syncDirectory(directory); err != nil {
+		return err
+	}
+	return nil
+}
+
+func loadProfile(path string) (profile, error) {
+	var value profile
+	if !safeProfilePath(path) || !privateProfilePath(path) || !noSymlinkPath(path) {
+		return value, errors.New("profile path is unsafe")
+	}
+	before, err := os.Lstat(path) // #nosec G703 -- explicit absolute CLI profile path checked component-by-component.
+	if err != nil || !before.Mode().IsRegular() || !privateProfileFile(before) {
+		return value, errors.New("profile is unavailable")
+	}
+	file, err := os.Open(path) // #nosec G304,G703 -- explicit absolute CLI profile path checked before and after opening.
+	if err != nil {
+		return value, errors.New("profile is unavailable")
+	}
+	defer func() { _ = file.Close() }()
+	after, err := file.Stat()
+	if err != nil || !after.Mode().IsRegular() || !privateProfileFile(after) || !os.SameFile(before, after) || !noSymlinkPath(path) {
+		return value, errors.New("profile changed while opening")
+	}
+	raw, err := io.ReadAll(io.LimitReader(file, maxProfileSize+1))
+	if err != nil || int64(len(raw)) > maxProfileSize || len(strings.TrimSpace(string(raw))) == 0 {
+		return value, errors.New("profile is invalid")
+	}
+	if err := rejectDuplicateTopLevelJSONFields(raw); err != nil {
+		return value, err
+	}
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&value); err != nil {
+		return value, err
+	}
+	if decoder.Decode(&struct{}{}) != io.EOF {
+		return value, errors.New("profile has trailing data")
+	}
+	if value.Version != profileVersion || !validProfile(value) {
+		return value, errors.New("profile is invalid")
+	}
+	return value, nil
+}
+
+func safeProfilePath(path string) bool {
+	return filepath.IsAbs(path) && filepath.Clean(path) == path
+}
+
+func sameCleanPath(left, right string) bool {
+	return filepath.Clean(left) == filepath.Clean(right)
+}
+
+func validProfile(value profile) bool {
+	return validProfileOrigin(value.Origin) &&
+		filepath.IsAbs(value.CredentialFile) &&
+		filepath.Clean(value.CredentialFile) == value.CredentialFile &&
+		(value.Project == "" || validProfileUUID(value.Project))
+}
+
+func validProfileOrigin(raw string) bool {
+	parsed, err := url.Parse(raw)
+	return err == nil &&
+		parsed.Scheme == "https" &&
+		parsed.Host != "" &&
+		parsed.User == nil &&
+		parsed.RawQuery == "" &&
+		parsed.Fragment == "" &&
+		(parsed.Path == "" || parsed.Path == "/") &&
+		parsed.Opaque == ""
+}
+
+func validProfileUUID(value string) bool {
+	parsed, err := uuid.Parse(value)
+	return err == nil && parsed != uuid.Nil && parsed.String() == value
+}
+
+func rejectDuplicateTopLevelJSONFields(raw []byte) error {
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	token, err := decoder.Token()
+	if err != nil {
+		return err
+	}
+	delimiter, ok := token.(json.Delim)
+	if !ok || delimiter != '{' {
+		return errors.New("profile must be a JSON object")
+	}
+	seen := make(map[string]bool)
+	for decoder.More() {
+		token, err := decoder.Token()
+		if err != nil {
+			return err
+		}
+		key, ok := token.(string)
+		if !ok {
+			return errors.New("profile key is invalid")
+		}
+		if seen[key] {
+			return errors.New("profile has duplicate fields")
+		}
+		seen[key] = true
+		var discard json.RawMessage
+		if err := decoder.Decode(&discard); err != nil {
+			return err
+		}
+	}
+	token, err = decoder.Token()
+	if err != nil {
+		return err
+	}
+	delimiter, ok = token.(json.Delim)
+	if !ok || delimiter != '}' {
+		return errors.New("profile object is invalid")
+	}
+	if decoder.Decode(&struct{}{}) != io.EOF {
+		return errors.New("profile has trailing data")
+	}
+	return nil
+}
+
+func syncDirectory(path string) error {
+	directory, err := os.Open(path) // #nosec G304,G703 -- directory path is explicit and checked before use.
+	if err != nil {
+		return err
+	}
+	defer func() { _ = directory.Close() }()
+	return directory.Sync()
 }
 
 func validCommand(command, project, item, proposal, key, etag, input, query, kind, locator, cursorFile string, limit int) bool {
@@ -277,5 +506,5 @@ func noSymlinkPath(path string) bool {
 }
 
 func usage(stderr io.Writer) {
-	_, _ = fmt.Fprintln(stderr, "usage: punaro-memory <resolve|get|search|brief|changes|create|update|archive|restore|purge|propose|proposal-get|proposal-approve|proposal-reject> [flags]")
+	_, _ = fmt.Fprintln(stderr, "usage: punaro-memory <profile-write|resolve|get|search|brief|changes|create|update|archive|restore|purge|propose|proposal-get|proposal-approve|proposal-reject> [flags]")
 }

--- a/cmd/punaro-memory/main_test.go
+++ b/cmd/punaro-memory/main_test.go
@@ -192,6 +192,243 @@ func TestRunBoundsCreateInputBelowProposalLimit(t *testing.T) {
 	}
 }
 
+func TestRunUsesProtectedProfileDefaultsWithoutStoringCredential(t *testing.T) {
+	directory := resolvedTempDir(t)
+	profilePath := filepath.Join(directory, "profile.json")
+	credential := filepath.Join(directory, "credential")
+	if err := saveProfile(profilePath, profile{Origin: "https://profile.test", CredentialFile: credential, Project: cliProject}); err != nil {
+		t.Fatal(err)
+	}
+	rawProfile, err := os.ReadFile(profilePath) // #nosec G304 -- test reads the profile path created under its resolved temp directory.
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(rawProfile), "device-secret") {
+		t.Fatal("profile stored credential secret")
+	}
+	previousLoader, previousFactory := loadCredential, newMemoryClient
+	t.Cleanup(func() { loadCredential, newMemoryClient = previousLoader, previousFactory })
+	loadCredential = func(path string) (string, error) {
+		if path != credential {
+			t.Fatalf("credential path=%q", path)
+		}
+		return "device-secret", nil
+	}
+	fake := &recordingClient{}
+	newMemoryClient = func(origin, value string) (client, error) {
+		if origin != "https://profile.test" || value != "device-secret" {
+			t.Fatalf("factory origin=%q credential=%q", origin, value)
+		}
+		return fake, nil
+	}
+
+	var stdout, stderr strings.Builder
+	args := []string{"get", "--profile", profilePath, "--item", cliItem}
+	if code := run(args, &stdout, &stderr); code != 0 {
+		t.Fatalf("code=%d stderr=%q", code, stderr.String())
+	}
+	if fake.op != "get" || len(fake.args) != 2 || fake.args[0] != cliProject {
+		t.Fatalf("op=%q args=%v", fake.op, fake.args)
+	}
+}
+
+func TestRunExplicitProjectOverridesProfile(t *testing.T) {
+	directory := resolvedTempDir(t)
+	profilePath := filepath.Join(directory, "profile.json")
+	credential := filepath.Join(directory, "credential")
+	if err := saveProfile(profilePath, profile{Origin: "https://profile.test", CredentialFile: credential, Project: cliProject}); err != nil {
+		t.Fatal(err)
+	}
+	previousLoader, previousFactory := loadCredential, newMemoryClient
+	t.Cleanup(func() { loadCredential, newMemoryClient = previousLoader, previousFactory })
+	loadCredential = func(string) (string, error) { return "device-secret", nil }
+	fake := &recordingClient{}
+	newMemoryClient = func(string, string) (client, error) { return fake, nil }
+
+	override := "55555555-5555-4555-8555-555555555555"
+	var stdout, stderr strings.Builder
+	args := []string{"get", "--profile", profilePath, "--project", override, "--item", cliItem}
+	if code := run(args, &stdout, &stderr); code != 0 {
+		t.Fatalf("code=%d stderr=%q", code, stderr.String())
+	}
+	if fake.op != "get" || fake.args[0] != override {
+		t.Fatalf("op=%q args=%v", fake.op, fake.args)
+	}
+}
+
+func TestRunExplicitOriginAndCredentialOverrideProfile(t *testing.T) {
+	directory := resolvedTempDir(t)
+	profilePath := filepath.Join(directory, "profile.json")
+	profileCredential := filepath.Join(directory, "profile-credential")
+	overrideCredential := filepath.Join(directory, "override-credential")
+	if err := saveProfile(profilePath, profile{Origin: "https://profile.test", CredentialFile: profileCredential, Project: cliProject}); err != nil {
+		t.Fatal(err)
+	}
+	previousLoader, previousFactory := loadCredential, newMemoryClient
+	t.Cleanup(func() { loadCredential, newMemoryClient = previousLoader, previousFactory })
+	loadCredential = func(path string) (string, error) {
+		if path != overrideCredential {
+			t.Fatalf("credential path=%q", path)
+		}
+		return "override-secret", nil
+	}
+	fake := &recordingClient{}
+	newMemoryClient = func(origin, value string) (client, error) {
+		if origin != "https://override.test" || value != "override-secret" {
+			t.Fatalf("factory origin=%q credential=%q", origin, value)
+		}
+		return fake, nil
+	}
+
+	var stdout, stderr strings.Builder
+	args := []string{"get", "--profile", profilePath, "--origin", "https://override.test", "--credential-file", overrideCredential, "--item", cliItem}
+	if code := run(args, &stdout, &stderr); code != 0 {
+		t.Fatalf("code=%d stderr=%q", code, stderr.String())
+	}
+	if fake.op != "get" || fake.args[0] != cliProject {
+		t.Fatalf("op=%q args=%v", fake.op, fake.args)
+	}
+}
+
+func TestRunProfileWritePersistsProtectedDefaults(t *testing.T) {
+	directory := resolvedTempDir(t)
+	profilePath := filepath.Join(directory, "profile.json")
+	credential := filepath.Join(directory, "credential")
+	var stdout, stderr strings.Builder
+	args := []string{"profile-write", "--profile", profilePath, "--origin", "https://profile.test", "--credential-file", credential, "--project", cliProject}
+	if code := run(args, &stdout, &stderr); code != 0 || stdout.Len() != 0 || stderr.Len() != 0 {
+		t.Fatalf("code=%d stdout=%q stderr=%q", code, stdout.String(), stderr.String())
+	}
+	info, err := os.Lstat(profilePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm() != 0o600 {
+		t.Fatalf("profile mode=%o", info.Mode().Perm())
+	}
+	loaded, err := loadProfile(profilePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if loaded.Origin != "https://profile.test" || loaded.CredentialFile != credential || loaded.Project != cliProject {
+		t.Fatalf("profile=%#v", loaded)
+	}
+}
+
+func TestRunProfileWriteRejectsCredentialClobber(t *testing.T) {
+	directory := resolvedTempDir(t)
+	credential := filepath.Join(directory, "credential")
+	if err := os.WriteFile(credential, []byte("device-secret"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	var stdout, stderr strings.Builder
+	args := []string{"profile-write", "--profile", credential, "--origin", "https://profile.test", "--credential-file", credential}
+	if code := run(args, &stdout, &stderr); code != 2 || stdout.Len() != 0 {
+		t.Fatalf("code=%d stdout=%q stderr=%q", code, stdout.String(), stderr.String())
+	}
+	raw, err := os.ReadFile(credential) // #nosec G304 -- test verifies the explicitly created credential fixture was not overwritten.
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(raw) != "device-secret" {
+		t.Fatalf("credential was clobbered: %q", string(raw))
+	}
+}
+
+func TestRunProfileWriteRejectsInvalidDefaultsAsUsage(t *testing.T) {
+	directory := resolvedTempDir(t)
+	credential := filepath.Join(directory, "credential")
+	tests := [][]string{
+		{"profile-write", "--profile", "relative.json", "--origin", "https://profile.test", "--credential-file", credential},
+		{"profile-write", "--profile", filepath.Join(directory, "profile.json"), "--origin", "http://profile.test", "--credential-file", credential},
+		{"profile-write", "--profile", filepath.Join(directory, "profile.json"), "--origin", "https://user@profile.test", "--credential-file", credential},
+		{"profile-write", "--profile", filepath.Join(directory, "profile.json"), "--origin", "https://profile.test/path", "--credential-file", credential},
+		{"profile-write", "--profile", filepath.Join(directory, "profile.json"), "--origin", "https://profile.test", "--credential-file", credential, "--project", "not-a-uuid"},
+	}
+	for _, args := range tests {
+		var stdout, stderr strings.Builder
+		if code := run(args, &stdout, &stderr); code != 2 || stdout.Len() != 0 {
+			t.Fatalf("args=%v code=%d stdout=%q stderr=%q", args, code, stdout.String(), stderr.String())
+		}
+	}
+}
+
+func TestLoadProfileRejectsUnsafeProfileFiles(t *testing.T) {
+	directory := resolvedTempDir(t)
+	credential := filepath.Join(directory, "credential")
+	tests := []struct {
+		name string
+		raw  string
+		mode os.FileMode
+	}{
+		{"group readable", `{"version":1,"origin":"https://profile.test","credential_file":"` + credential + `"}`, 0o640},
+		{"unknown field", `{"version":1,"origin":"https://profile.test","credential_file":"` + credential + `","secret":"device-secret"}`, 0o600},
+		{"duplicate field", `{"version":1,"origin":"https://first.test","origin":"https://second.test","credential_file":"` + credential + `"}`, 0o600},
+		{"relative credential", `{"version":1,"origin":"https://profile.test","credential_file":"relative"}`, 0o600},
+		{"unsafe origin", `{"version":1,"origin":"https://user@profile.test","credential_file":"` + credential + `"}`, 0o600},
+		{"invalid project", `{"version":1,"origin":"https://profile.test","credential_file":"` + credential + `","project":"not-a-uuid"}`, 0o600},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			profilePath := filepath.Join(directory, strings.ReplaceAll(test.name, " ", "-")+".json")
+			if err := os.WriteFile(profilePath, []byte(test.raw), test.mode); err != nil {
+				t.Fatal(err)
+			}
+			if _, err := loadProfile(profilePath); err == nil {
+				t.Fatal("unsafe profile accepted")
+			}
+		})
+	}
+}
+
+func TestRunProfileFailureIsSanitized(t *testing.T) {
+	directory := resolvedTempDir(t)
+	profilePath := filepath.Join(directory, "profile.json")
+	if err := os.WriteFile(profilePath, []byte(`{"version":1,"origin":"https://profile.test","credential_file":"/tmp/device-secret"}`), 0o644); err != nil { // #nosec G306 -- test deliberately creates an over-permissive profile fixture.
+		t.Fatal(err)
+	}
+	var stdout, stderr strings.Builder
+	args := []string{"get", "--profile", profilePath, "--item", cliItem}
+	if code := run(args, &stdout, &stderr); code != 1 || stdout.Len() != 0 || stderr.String() != "punaro-memory: profile failed\n" {
+		t.Fatalf("code=%d stdout=%q stderr=%q", code, stdout.String(), stderr.String())
+	}
+	if strings.Contains(stderr.String(), "device-secret") || strings.Contains(stderr.String(), profilePath) {
+		t.Fatalf("sensitive profile detail leaked: %q", stderr.String())
+	}
+
+	missingParentProfile := filepath.Join(directory, "missing", "profile.json")
+	stdout.Reset()
+	stderr.Reset()
+	args = []string{"get", "--profile", missingParentProfile, "--item", cliItem}
+	if code := run(args, &stdout, &stderr); code != 1 || stdout.Len() != 0 || stderr.String() != "punaro-memory: profile failed\n" {
+		t.Fatalf("code=%d stdout=%q stderr=%q", code, stdout.String(), stderr.String())
+	}
+	if strings.Contains(stderr.String(), missingParentProfile) {
+		t.Fatalf("sensitive profile detail leaked: %q", stderr.String())
+	}
+}
+
+func TestRunRejectsProfileBelowWritableParent(t *testing.T) {
+	directory := resolvedTempDir(t)
+	writableDirectory := filepath.Join(directory, "writable")
+	if err := os.Mkdir(writableDirectory, 0o777); err != nil { // #nosec G301 -- test deliberately creates an unsafe writable parent directory.
+		t.Fatal(err)
+	}
+	if err := os.Chmod(writableDirectory, 0o777); err != nil { // #nosec G302 -- test deliberately creates an unsafe writable parent directory.
+		t.Fatal(err)
+	}
+	profilePath := filepath.Join(writableDirectory, "profile.json")
+	raw := `{"version":1,"origin":"https://profile.test","credential_file":"` + filepath.Join(directory, "credential") + `","project":"` + cliProject + `"}`
+	if err := os.WriteFile(profilePath, []byte(raw), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	var stdout, stderr strings.Builder
+	args := []string{"get", "--profile", profilePath, "--item", cliItem}
+	if code := run(args, &stdout, &stderr); code != 1 || stdout.Len() != 0 || stderr.String() != "punaro-memory: profile failed\n" {
+		t.Fatalf("code=%d stdout=%q stderr=%q", code, stdout.String(), stderr.String())
+	}
+}
+
 func TestReadInputRejectsSymlinkAndOversize(t *testing.T) {
 	directory := resolvedTempDir(t)
 	target := filepath.Join(directory, "target.json")
@@ -226,6 +463,32 @@ func resolvedTempDir(t *testing.T) string {
 	directory, err := filepath.EvalSymlinks(t.TempDir())
 	if err != nil {
 		t.Fatal(err)
+	}
+	if err := os.Chmod(directory, 0o700); err != nil { // #nosec G302 -- profile tests require an owner-only temporary directory.
+		t.Fatal(err)
+	}
+	if privateProfilePath(filepath.Join(directory, "profile.json")) {
+		return directory
+	}
+	directory, err = os.MkdirTemp(".", ".punaro-memory-profile-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := os.RemoveAll(directory); err != nil { // #nosec G304 -- test removes the private temporary directory it created.
+			t.Errorf("remove temporary profile directory: %v", err)
+		}
+	})
+	directory, err = filepath.Abs(directory)
+	if err != nil {
+		t.Fatal(err)
+	}
+	directory, err = filepath.EvalSymlinks(directory)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !privateProfilePath(filepath.Join(directory, "profile.json")) {
+		t.Fatal("temporary profile directory has unsafe ancestry")
 	}
 	return directory
 }

--- a/cmd/punaro-memory/profile_private_unix.go
+++ b/cmd/punaro-memory/profile_private_unix.go
@@ -1,0 +1,39 @@
+//go:build !windows
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"syscall"
+)
+
+func privateProfilePath(path string) bool {
+	uid := os.Getuid()
+	for directory := filepath.Dir(path); ; directory = filepath.Dir(directory) {
+		info, err := os.Lstat(directory) // #nosec G703 -- deliberate component walk of an explicit absolute profile path.
+		if err != nil {
+			return false
+		}
+		stat, ok := info.Sys().(*syscall.Stat_t)
+		if !ok || !info.IsDir() || info.Mode()&os.ModeSymlink != 0 || info.Mode().Perm()&0o022 != 0 {
+			return false
+		}
+		if uid < 0 {
+			return false
+		}
+		currentUID := uint32(uid) // #nosec G115 -- nonnegative OS UID fits the platform field.
+		if stat.Uid != currentUID && stat.Uid != 0 {
+			return false
+		}
+		if directory == filepath.Dir(directory) {
+			return true
+		}
+	}
+}
+
+func privateProfileFile(info os.FileInfo) bool {
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	uid := os.Getuid()
+	return ok && uid >= 0 && stat.Uid == uint32(uid) && stat.Nlink == 1 && info.Mode().Perm()&0o077 == 0 // #nosec G115 -- nonnegative OS UID fits the platform field.
+}

--- a/cmd/punaro-memory/profile_private_windows.go
+++ b/cmd/punaro-memory/profile_private_windows.go
@@ -1,0 +1,8 @@
+//go:build windows
+
+package main
+
+import "os"
+
+func privateProfilePath(string) bool      { return false }
+func privateProfileFile(os.FileInfo) bool { return false }

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -188,15 +188,15 @@ an existing private download root. Follow the
 send, receive, and delete safety boundaries. No production installer accepts
 legacy v2/v3 authority, role, directory, wrapping-key, or permit options.
 
-On macOS and Linux the same installer also builds `punaro-memory`, the
-stateless native client for an already enabled M-17 memory API. It does not
-create a memory profile or credential. Supply the fixed HTTPS origin, an
-absolute owner-only device credential file, and explicit project/key/ETag
-coordinates on every invocation; see the
-[operator guide](operator-guide.md#stateless-native-memory-client). Windows
-memory credential loading remains fail-closed until the persisted-client slice
-adds strong ACL and reparse-point verification, so the Windows installer does
-not install this binary yet.
+On macOS and Linux the same installer also builds `punaro-memory`, the native
+client for an already enabled M-17 memory API. Supply the fixed HTTPS origin,
+an absolute owner-only device credential file, and explicit project/key/ETag
+coordinates, or write a protected non-secret profile containing only the
+origin, credential-file path, and optional default project; see the
+[operator guide](operator-guide.md#native-memory-client). Windows memory
+credential loading remains fail-closed until a later slice adds paired ACL and
+reparse-point provisioning and verification, so the Windows installer does not
+install this binary yet.
 
 ## Agent mailbox behavior
 

--- a/docs/operator-guide.md
+++ b/docs/operator-guide.md
@@ -665,7 +665,7 @@ capability and is irreversible. Secret-shaped documents are rejected without
 echoing the value or fingerprint. There is still no native client, MCP adapter,
 semantic retrieval, offline queue, or Compose Pi integration.
 
-### Stateless native memory client
+### Native memory client
 
 M-17C1 adds `punaro-memory` without changing the server activation flags. Build
 it with `make memory-client`; the macOS/Linux client installer also places it
@@ -673,7 +673,24 @@ in `~/.local/bin`. The operator must separately provision an absolute regular
 credential file below non-writable, non-symlink parent directories. The file
 must be owned by the current user, have no group/other permissions, and have
 exactly one hard link. The CLI accepts an explicit HTTPS `--origin` and
-`--credential-file` on every invocation and never stores either value.
+`--credential-file`, and the bearer credential value is never stored by the
+client.
+
+M-17C2 adds a protected local profile for convenience. Create it only with an
+absolute target path:
+
+```sh
+punaro-memory profile-write \
+  --profile /absolute/path/to/punaro-memory-profile.json \
+  --origin https://punaro.example \
+  --credential-file /absolute/path/to/punaro-device \
+  --project 11111111-1111-4111-8111-111111111111
+```
+
+The profile is an atomically replaced `0600` JSON file containing only
+non-secret defaults: origin, credential-file path, and optional project UUID.
+Normal commands may pass `--profile`; explicit `--origin`, `--credential-file`,
+and `--project` flags override the profile defaults for that invocation.
 
 Pass an explicit `--project` UUID to project-scoped commands. `resolve` accepts
 only an explicit `--kind` and `--locator`; it discovers existing authorized
@@ -685,12 +702,12 @@ bounded `--input` file. Every mutation requires a caller-generated stable
 and rejection are separate commands, so no destructive action is inferred.
 
 The client makes one request and exits. It has no implicit retry, writable
-cache, queue, profile, Git configuration lookup, project registry, stdin body,
-or fallback memory. A retry is an explicit caller decision using the same body,
+cache, queue, Git configuration lookup, project registry, stdin body, or
+fallback memory. A retry is an explicit caller decision using the same body,
 key, and ETag. Errors are deliberately generic; use server-side content-free
 audit metadata for diagnosis. Windows credential loading is intentionally
-unavailable in this slice and fails closed until the persisted-client work adds
-verified DACL and reparse-point handling. MCP, enrollment/profile recovery,
+unavailable until a later slice pairs protected credential/profile creation
+with verified DACL and reparse-point handling. MCP, enrollment recovery,
 semantic retrieval, and Compose Pi remain absent.
 
 ## Operations and incident response

--- a/docs/platform-contracts.md
+++ b/docs/platform-contracts.md
@@ -309,17 +309,20 @@ permanent aliases exist only for compatible reads. Local credential/project
 state, retry/cache behavior, MCP, semantic retrieval, and Compose Pi remain
 absent.
 
-The first native client is `punaro-memory`. It is stateless and accepts only an
-explicit fixed HTTPS origin, absolute owner-protected credential file, and
-explicit project UUID or resolver request. It sends each command exactly once:
-there is no retry, queue, cache, profile, project registry, Git inference, or
-fallback brain. Mutation input comes from a bounded regular file; callers must
-reuse the same input, idempotency UUID, and exact strong ETag when they
+The first native client is `punaro-memory`. It accepts an explicit fixed HTTPS
+origin, absolute owner-protected credential file, and explicit project UUID or
+resolver request. It may also read an explicit protected profile containing
+only non-secret defaults: origin, credential-file path, and optional default
+project UUID. Explicit flags always override profile defaults, and the bearer
+credential value is never persisted by the profile. It sends each command
+exactly once: there is no retry, queue, cache, project registry, Git inference,
+or fallback brain. Mutation input comes from a bounded regular file; callers
+must reuse the same input, idempotency UUID, and exact strong ETag when they
 explicitly retry. Success is the validated server JSON on stdout. Failures are
 content-free on stderr and never include credentials, request bodies, response
-bodies, URLs, or server diagnostics. Windows credential loading remains
-fail-closed until the later persisted-client slice supplies and verifies its
-ACL and reparse-point contract.
+bodies, URLs, file paths, or server diagnostics. Windows credential loading
+remains fail-closed until a later slice supplies paired protected-file
+provisioning plus ACL and reparse-point verification.
 
 ### Implemented dark control-plane primitives
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -34,12 +34,13 @@ origin, project UUID, and safe download root. The installer never reads or
 prints the credential.
 
 On macOS and Linux the installer also provides `punaro-memory` for an already
-enabled native memory API. It is deliberately stateless: every command names
-the fixed HTTPS origin, protected credential file, project or resolver input,
-and any required idempotency key and strong ETag. It never discovers Git state,
-stores a profile, retries, queues writes, falls back to local memory, or accepts
-memory content from stdin. See the
-[operator guide](operator-guide.md#stateless-native-memory-client).
+enabled native memory API. Every command either names the fixed HTTPS origin,
+protected credential file, project or resolver input, and any required
+idempotency key and strong ETag, or uses an explicit protected profile that
+stores only non-secret defaults: origin, credential-file path, and optional
+project UUID. It never discovers Git state, retries, queues writes, falls back
+to local memory, or accepts memory content from stdin. See the
+[operator guide](operator-guide.md#native-memory-client).
 
 ## What you can do today
 


### PR DESCRIPTION
## Summary

- add `punaro-memory profile-write` for an atomic protected non-secret profile
- allow `--profile` to provide origin, credential-file path, and optional project defaults while explicit CLI flags override those defaults
- harden profile loading with absolute clean paths, no symlink components, `0600` mode, bounded strict JSON, duplicate-field rejection, and sanitized profile errors
- update user/operator/platform docs to describe the M17C2 profile boundary while keeping retry/cache/queue/MCP/fallback brain out of scope

## Validation

- `GOCACHE=/tmp/punaro-m17c-go-cache go test ./cmd/punaro-memory`
- `GOCACHE=/tmp/punaro-m17c-go-cache make test`
- `GOCACHE=/tmp/punaro-m17c-go-cache make test-race`
- `GOCACHE=/tmp/punaro-m17c-go-cache make staticcheck`
- `GOCACHE=/tmp/punaro-m17c-go-cache make security`
- `GOCACHE=/tmp/punaro-m17c-go-cache make lint`

## Notes

Windows memory credential loading remains fail-closed in this slice. The docs now call out that Windows support needs a paired protected-file provisioning and DACL/reparse verification slice rather than a read-side-only check.