### PR TITLE
M18A: expire ephemeral memory evidence

### DIFF
--- a/docs/platform-contracts.md
+++ b/docs/platform-contracts.md
@@ -229,6 +229,16 @@ documents; a larger corpus requires the separately backed-up, bounded backfill
 slice. Large version-18 corpora remain deliberately upgrade-blocked until that
 slice exists; the ordinary migration will not proceed.
 
+Schema version 20 adds explicitly ephemeral evidence. Evidence creation may
+attach one expiry timestamp, stored separately from canonical memory items so
+only evidence can be marked ephemeral. Expiry does not delete source history;
+an authorized `memory.administer` maintenance pass archives at most 64 due
+evidence records in one mutation transaction, copies revision-bound provenance
+forward, emits ordinary content-free archive audit events, and covers scopes
+behind permanent project lookup aliases under the same bounded pass. Ordinary
+evidence reads require the item to remain active, so expired evidence leaves
+prompt/search paths without destructive cleanup.
+
 The dark prompt-brief read adds no schema and exposes no route or client. It
 accepts the same bounded normalized query as lexical search, resolves the
 active canonical project, and requires only `memory.search` because it returns

--- a/internal/postgres/brain_evidence.go
+++ b/internal/postgres/brain_evidence.go
@@ -20,6 +20,7 @@ const (
 	maxMemoryEvidenceDocumentBytes = 64 << 10
 	maxMemoryEvidenceSources       = 8
 	maxMemoryEvidenceClaims        = 16
+	memoryEvidenceMaintenanceBatch = 64
 )
 
 // MemoryLayer distinguishes curated knowledge from explicit evidence.
@@ -102,6 +103,7 @@ type MemoryEvidenceCreateRequest struct {
 	Document       json.RawMessage             `json:"document"`
 	Sources        []MemoryEvidenceSourceInput `json:"sources"`
 	Claims         []MemoryEvidenceClaimInput  `json:"claims,omitempty"`
+	ExpiresAt      *time.Time                  `json:"expires_at,omitempty"`
 }
 
 // MemoryEvidenceGetRequest fetches one target-authorized evidence revision.
@@ -152,6 +154,13 @@ func (request MemoryEvidenceCreateRequest) normalized() (MemoryEvidenceCreateReq
 		return MemoryEvidenceCreateRequest{}, errors.New("invalid memory evidence document")
 	}
 	request.Document = document
+	if request.ExpiresAt != nil {
+		expiresAt := request.ExpiresAt.UTC()
+		if !expiresAt.After(time.Now()) {
+			return MemoryEvidenceCreateRequest{}, errors.New("invalid memory evidence expiry")
+		}
+		request.ExpiresAt = &expiresAt
+	}
 	sources := make([]MemoryEvidenceSourceInput, len(request.Sources))
 	seenSources := make(map[string]struct{}, len(request.Sources))
 	for index, source := range request.Sources {
@@ -345,6 +354,11 @@ VALUES ($1,$2,'active',$3,$4,1,$5,'evidence') RETURNING id::text`, scopeID, requ
 		if err != nil {
 			return IdempotencyOutcome{}, errors.New("memory evidence item could not be created")
 		}
+		if request.ExpiresAt != nil {
+			if _, err := tx.ExecContext(ctx, `INSERT INTO brain.memory_evidence_expirations(item_id,expires_at,created_by) VALUES ($1,$2,$3)`, itemID, *request.ExpiresAt, request.PrincipalID); err != nil {
+				return IdempotencyOutcome{}, errors.New("memory evidence expiry could not be recorded")
+			}
+		}
 		if err := insertMemoryRevision(ctx, tx, itemID, 1, request.Document, request.PrincipalID, MemoryChangeEvidenceCreate); err != nil {
 			return IdempotencyOutcome{}, err
 		}
@@ -495,6 +509,7 @@ FROM brain.memory_items AS item
 JOIN brain.scopes AS scope ON scope.id=item.scope_id
 JOIN brain.memory_revisions AS revision ON revision.item_id=item.id AND revision.revision=item.current_revision
 WHERE item.id=$1 AND scope.project_id=$2 AND item.layer='evidence'
+AND item.state='active'
 AND NOT EXISTS (SELECT 1 FROM brain.memory_quarantines AS quarantine WHERE quarantine.item_id=item.id AND quarantine.released_at IS NULL)`, request.ItemID, projectID).Scan(
 		&result.Item.ItemID, &result.Item.ScopeID, &result.Item.ProjectID, &logicalKey, &result.Item.Kind, &result.Item.State, &result.Item.Trust, &result.Item.Layer,
 		&result.Item.Revision, &document, &contentHash, &result.Item.AuthorID, &result.Item.CreatedAt, &result.Item.RevisionAt, &result.Item.ChangeSequence)
@@ -592,6 +607,92 @@ FROM brain.memory_edges WHERE from_item_id=$1 AND from_revision=$2 ORDER BY ordi
 		return MemoryEvidence{}, errors.New("memory evidence snapshot cannot commit")
 	}
 	return result, nil
+}
+
+// MaintainMemoryEvidence archives an authorized bounded batch of explicitly expired evidence.
+func (d *Database) MaintainMemoryEvidence(ctx context.Context, principalID, projectID string, limit int) (int, error) {
+	if !validOpaqueID(principalID) || !validOpaqueID(projectID) || limit < 1 || limit > memoryEvidenceMaintenanceBatch {
+		return 0, errors.New("invalid memory evidence maintenance request")
+	}
+	tx, err := beginMutation(ctx, d.db)
+	if err != nil {
+		return 0, mutationStartError(err, "memory evidence maintenance cannot start")
+	}
+	defer func() { _ = tx.Rollback() }()
+	project, err := lockDirectActiveProject(ctx, tx, projectID)
+	if err != nil {
+		return 0, ErrNotFound
+	}
+	allowed, err := lockCapability(ctx, tx, principalID, project.ID, CapabilityMemoryAdminister)
+	if err != nil {
+		return 0, err
+	}
+	if !allowed {
+		return 0, ErrNotFound
+	}
+	type expiredEvidence struct {
+		itemID   string
+		scopeID  string
+		revision int64
+		document []byte
+	}
+	rows, err := tx.QueryContext(ctx, `SELECT item.id::text,scope.id::text,item.current_revision,revision.document::text
+FROM brain.memory_evidence_expirations AS expiry
+JOIN brain.memory_items AS item ON item.id=expiry.item_id
+JOIN brain.scopes AS scope ON scope.id=item.scope_id
+LEFT JOIN relay.project_lookup_aliases AS alias ON alias.alias_project_id=scope.project_id
+JOIN brain.memory_revisions AS revision ON revision.item_id=item.id AND revision.revision=item.current_revision
+WHERE COALESCE(alias.canonical_project_id,scope.project_id)=$1
+  AND item.layer='evidence' AND item.state='active'
+  AND expiry.expires_at <= statement_timestamp()
+ORDER BY expiry.expires_at,item.id
+LIMIT $2
+FOR UPDATE OF item SKIP LOCKED`, project.ID, limit)
+	if err != nil {
+		return 0, errors.New("expired memory evidence could not be claimed")
+	}
+	candidates := make([]expiredEvidence, 0, limit)
+	for rows.Next() {
+		var candidate expiredEvidence
+		if err := rows.Scan(&candidate.itemID, &candidate.scopeID, &candidate.revision, &candidate.document); err != nil {
+			_ = rows.Close()
+			return 0, errors.New("expired memory evidence is malformed")
+		}
+		candidates = append(candidates, candidate)
+	}
+	if err := rows.Err(); err != nil {
+		_ = rows.Close()
+		return 0, errors.New("expired memory evidence is unavailable")
+	}
+	if err := rows.Close(); err != nil {
+		return 0, errors.New("expired memory evidence cannot close")
+	}
+	control := &ControlTx{tx: tx}
+	for _, candidate := range candidates {
+		next := candidate.revision + 1
+		if err := insertMemoryRevision(ctx, tx, candidate.itemID, next, candidate.document, principalID, MemoryChangeArchive); err != nil {
+			return 0, err
+		}
+		if err := copyMemoryEvidenceProvenance(ctx, tx, candidate.itemID, candidate.revision, next, principalID); err != nil {
+			return 0, err
+		}
+		updated, err := tx.ExecContext(ctx, `UPDATE brain.memory_items
+SET state='archived',current_revision=$2,updated_at=statement_timestamp()
+WHERE id=$1 AND state='active' AND current_revision=$3 AND layer='evidence'`, candidate.itemID, next, candidate.revision)
+		if err != nil {
+			return 0, errors.New("expired memory evidence could not be archived")
+		}
+		if count, err := updated.RowsAffected(); err != nil || count != 1 {
+			return 0, errors.New("expired memory evidence archive was not stable")
+		}
+		if _, err := commitMemoryChange(ctx, tx, control, principalID, project.ID, candidate.scopeID, candidate.itemID, next, MemoryChangeArchive, AuditMemoryArchive); err != nil {
+			return 0, err
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		return 0, errors.New("memory evidence maintenance cannot commit")
+	}
+	return len(candidates), nil
 }
 
 func evidenceSourceAuthorized(ctx context.Context, q queryer, principalID string, kind MemorySourceKind, projectID, resourceID string, revision int64) (bool, error) {

--- a/internal/postgres/brain_evidence_expiry_schema.go
+++ b/internal/postgres/brain_evidence_expiry_schema.go
@@ -1,0 +1,88 @@
+package postgres
+
+import "context"
+
+// memoryEvidenceExpiryControlsAvailable verifies the exact schema-v20 evidence expiry authority.
+func memoryEvidenceExpiryControlsAvailable(ctx context.Context, q queryer) (bool, error) {
+	var available bool
+	err := q.QueryRowContext(ctx, `WITH objects AS (
+    SELECT to_regclass('brain.memory_evidence_expirations') AS expirations_oid,
+           to_regclass('brain.memory_evidence_expirations_due') AS due_index_oid,
+           to_regprocedure('jobs.guard_application_mutation()') AS fence_oid
+), expected_columns(relation_name,column_name,type_name,not_null,default_expression) AS (
+    VALUES
+      ('brain.memory_evidence_expirations','item_id','uuid',true,''),
+      ('brain.memory_evidence_expirations','expires_at','timestamp with time zone',true,''),
+      ('brain.memory_evidence_expirations','created_by','uuid',true,''),
+      ('brain.memory_evidence_expirations','created_at','timestamp with time zone',true,'statement_timestamp()')
+), actual_columns AS (
+    SELECT attribute.attrelid::regclass::text,attribute.attname,format_type(attribute.atttypid,attribute.atttypmod),attribute.attnotnull,
+           COALESCE(pg_get_expr(default_value.adbin,default_value.adrelid),'')
+    FROM pg_attribute AS attribute
+    LEFT JOIN pg_attrdef AS default_value ON default_value.adrelid=attribute.attrelid AND default_value.adnum=attribute.attnum,objects
+    WHERE attribute.attrelid=expirations_oid AND attribute.attnum>0 AND NOT attribute.attisdropped
+), expected_constraints(relation_name,constraint_name,constraint_type,column_keys,referenced_relation,referenced_keys,update_action,delete_action,match_type,expression) AS (
+    VALUES
+      ('brain.memory_evidence_expirations','memory_evidence_expirations_pkey','p','{1}','','','','','',''),
+      ('brain.memory_evidence_expirations','memory_evidence_expirations_item_id_fkey','f','{1}','brain.memory_items','{1}','a','c','s',''),
+      ('brain.memory_evidence_expirations','memory_evidence_expirations_created_by_fkey','f','{3}','auth.principals','{1}','a','a','s',''),
+      ('brain.memory_evidence_expirations','memory_evidence_expirations_future_check','c','{2,4}','','','','','','(expires_at > created_at)')
+), actual_constraints AS (
+    SELECT constraint_row.conrelid::regclass::text,constraint_row.conname,constraint_row.contype::text,constraint_row.conkey::text,
+           CASE WHEN constraint_row.contype='f' THEN constraint_row.confrelid::regclass::text ELSE '' END,
+           CASE WHEN constraint_row.contype='f' THEN constraint_row.confkey::text ELSE '' END,
+           CASE WHEN constraint_row.contype='f' THEN constraint_row.confupdtype::text ELSE '' END,
+           CASE WHEN constraint_row.contype='f' THEN constraint_row.confdeltype::text ELSE '' END,
+           CASE WHEN constraint_row.contype='f' THEN constraint_row.confmatchtype::text ELSE '' END,
+           CASE WHEN constraint_row.contype='c' THEN pg_get_expr(constraint_row.conbin,constraint_row.conrelid) ELSE '' END
+    FROM pg_constraint AS constraint_row,objects
+    WHERE constraint_row.conrelid=expirations_oid AND constraint_row.contype<>'n'
+      AND constraint_row.convalidated AND NOT constraint_row.condeferrable AND NOT constraint_row.condeferred
+), table_safety AS (
+    SELECT count(*)=1 AND bool_and(relation.relkind='r' AND relation.relpersistence='p' AND NOT relation.relrowsecurity
+        AND NOT relation.relforcerowsecurity AND pg_get_userbyid(relation.relowner)='punaro_owner') AS exact
+    FROM pg_class AS relation,objects WHERE relation.oid=expirations_oid
+), constraint_safety AS (
+    SELECT count(*)=4 AND bool_and(constraint_row.convalidated AND NOT constraint_row.condeferrable AND NOT constraint_row.condeferred) AS exact
+    FROM pg_constraint AS constraint_row,objects WHERE constraint_row.conrelid=expirations_oid AND constraint_row.contype<>'n'
+), index_safety AS (
+    SELECT count(*)=2 AND bool_and(index_row.indisvalid AND index_row.indisready) AS exact
+    FROM pg_index AS index_row,objects WHERE index_row.indrelid=expirations_oid
+), fence_safety AS (
+    SELECT count(*)=1 AND bool_and(trigger_row.tgenabled='O' AND trigger_row.tgfoid=fence_oid AND trigger_row.tgtype=62) AS exact
+    FROM pg_trigger AS trigger_row,objects
+    WHERE trigger_row.tgrelid=expirations_oid AND trigger_row.tgname='application_mutation_fence' AND NOT trigger_row.tgisinternal
+), expected_table_acl(relation_name,grantee,privilege_type,is_grantable) AS (
+    SELECT 'brain.memory_evidence_expirations','punaro_owner',privilege_type,false
+    FROM (VALUES ('SELECT'),('INSERT'),('UPDATE'),('DELETE'),('TRUNCATE'),('REFERENCES'),('TRIGGER'),('MAINTAIN')) AS privileges(privilege_type)
+    UNION ALL SELECT 'brain.memory_evidence_expirations','punaro_app','SELECT',false
+), actual_table_acl AS (
+    SELECT relation.oid::regclass::text,COALESCE(grantee.rolname,'PUBLIC'),entry.privilege_type,entry.is_grantable
+    FROM pg_class AS relation
+    CROSS JOIN LATERAL aclexplode(COALESCE(relation.relacl,acldefault('r',relation.relowner))) AS entry
+    LEFT JOIN pg_roles AS grantee ON grantee.oid=entry.grantee,objects
+    WHERE relation.oid=expirations_oid
+), expected_column_acl(relation_name,column_name,grantee,privilege_type,is_grantable) AS (
+    SELECT 'brain.memory_evidence_expirations',column_name,'punaro_app','INSERT',false
+    FROM (VALUES ('item_id'),('expires_at'),('created_by')) AS columns(column_name)
+), actual_column_acl AS (
+    SELECT attribute.attrelid::regclass::text,attribute.attname,COALESCE(grantee.rolname,'PUBLIC'),entry.privilege_type,entry.is_grantable
+    FROM pg_attribute AS attribute CROSS JOIN LATERAL aclexplode(attribute.attacl) AS entry
+    LEFT JOIN pg_roles AS grantee ON grantee.oid=entry.grantee,objects
+    WHERE attribute.attrelid=expirations_oid AND attribute.attnum>0 AND NOT attribute.attisdropped AND attribute.attacl IS NOT NULL
+)
+SELECT expirations_oid IS NOT NULL AND due_index_oid IS NOT NULL AND fence_oid IS NOT NULL
+   AND table_safety.exact AND constraint_safety.exact AND index_safety.exact AND fence_safety.exact
+   AND NOT EXISTS (SELECT * FROM expected_columns EXCEPT SELECT * FROM actual_columns)
+   AND NOT EXISTS (SELECT * FROM actual_columns EXCEPT SELECT * FROM expected_columns)
+   AND NOT EXISTS (SELECT * FROM expected_constraints EXCEPT SELECT * FROM actual_constraints)
+   AND NOT EXISTS (SELECT * FROM actual_constraints EXCEPT SELECT * FROM expected_constraints)
+   AND NOT EXISTS (SELECT * FROM expected_table_acl EXCEPT SELECT * FROM actual_table_acl)
+   AND NOT EXISTS (SELECT * FROM actual_table_acl EXCEPT SELECT * FROM expected_table_acl)
+   AND NOT EXISTS (SELECT * FROM expected_column_acl EXCEPT SELECT * FROM actual_column_acl)
+   AND NOT EXISTS (SELECT * FROM actual_column_acl EXCEPT SELECT * FROM expected_column_acl)
+   AND EXISTS (SELECT 1 FROM pg_index WHERE indexrelid=due_index_oid AND indrelid=expirations_oid AND NOT indisunique
+       AND indisvalid AND indisready AND indkey='2 1'::int2vector AND indexprs IS NULL AND indpred IS NULL)
+FROM objects,table_safety,constraint_safety,index_safety,fence_safety`).Scan(&available)
+	return available, err
+}

--- a/internal/postgres/brain_evidence_test.go
+++ b/internal/postgres/brain_evidence_test.go
@@ -3,6 +3,7 @@ package postgres
 import (
 	"encoding/json"
 	"testing"
+	"time"
 )
 
 func TestMemoryEvidenceCreateRequestValidation(t *testing.T) {
@@ -24,6 +25,11 @@ func TestMemoryEvidenceCreateRequestValidation(t *testing.T) {
 	}
 	if normalized, err := valid.normalized(); err != nil || string(normalized.Document) != `{"excerpt":"bounded source fact"}` {
 		t.Fatalf("valid evidence request normalized=%#v err=%v", normalized, err)
+	}
+	futureExpiry := time.Now().Add(time.Hour).UTC()
+	valid.ExpiresAt = &futureExpiry
+	if normalized, err := valid.normalized(); err != nil || normalized.ExpiresAt == nil || !normalized.ExpiresAt.Equal(futureExpiry) {
+		t.Fatalf("valid expiring evidence request normalized=%#v err=%v", normalized, err)
 	}
 
 	tests := []struct {
@@ -78,6 +84,10 @@ func TestMemoryEvidenceCreateRequestValidation(t *testing.T) {
 		{"invalid target", func(request *MemoryEvidenceCreateRequest) { request.Claims[0].TargetItemID = "nope" }},
 		{"invalid revision", func(request *MemoryEvidenceCreateRequest) { request.Claims[0].TargetRevision = 0 }},
 		{"duplicate claim", func(request *MemoryEvidenceCreateRequest) { request.Claims = append(request.Claims, request.Claims[0]) }},
+		{"expired evidence", func(request *MemoryEvidenceCreateRequest) {
+			expired := time.Now().Add(-time.Hour)
+			request.ExpiresAt = &expired
+		}},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {

--- a/internal/postgres/brain_integration_test.go
+++ b/internal/postgres/brain_integration_test.go
@@ -1468,6 +1468,32 @@ WHERE usename='punaro_app' AND wait_event_type='Lock'
 	if err != nil {
 		t.Fatal(err)
 	}
+	ephemeralExpiry := time.Now().Add(time.Hour).UTC()
+	ephemeral, err := app.CreateMemoryEvidence(ctx, MemoryEvidenceCreateRequest{
+		PrincipalID: actor.ID, ProjectID: targetProject, IdempotencyKey: "17171717-1717-4717-8717-171717171757",
+		LogicalKey: "evidence.ephemeral", Kind: "evidence.excerpt", Trust: "observed", Document: json.RawMessage(`{"excerpt":"expires"}`),
+		Sources:   []MemoryEvidenceSourceInput{{Mode: MemorySourceCopied, Kind: MemorySourceExternal, ReferenceSHA256: strings.Repeat("5f", 32)}},
+		ExpiresAt: &ephemeralExpiry,
+	})
+	if err != nil {
+		t.Fatalf("ephemeral evidence create: %v", err)
+	}
+	if _, err := ownerDB.ExecContext(ctx, `UPDATE brain.memory_evidence_expirations
+SET created_at=statement_timestamp()-interval '2 hours',expires_at=statement_timestamp()-interval '1 second'
+WHERE item_id=$1`, ephemeral.ItemID); err != nil {
+		t.Fatal(err)
+	}
+	expiredEvidence, err := app.MaintainMemoryEvidence(ctx, actor.ID, targetProject, memoryEvidenceMaintenanceBatch)
+	if err != nil || expiredEvidence != 1 {
+		t.Fatalf("ephemeral evidence maintenance count=%d err=%v", expiredEvidence, err)
+	}
+	if _, err := app.GetMemoryEvidence(ctx, MemoryEvidenceGetRequest{PrincipalID: actor.ID, ProjectID: targetProject, ItemID: ephemeral.ItemID}); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("expired evidence get error=%v", err)
+	}
+	var ephemeralState MemoryState
+	if err := ownerDB.QueryRowContext(ctx, `SELECT state FROM brain.memory_items WHERE id=$1`, ephemeral.ItemID).Scan(&ephemeralState); err != nil || ephemeralState != MemoryArchived {
+		t.Fatalf("expired evidence state=%q err=%v", ephemeralState, err)
+	}
 	directEdgeTx, err := beginMutation(ctx, app.db)
 	if err != nil {
 		t.Fatal(err)

--- a/internal/postgres/db.go
+++ b/internal/postgres/db.go
@@ -1092,6 +1092,13 @@ FROM objects, table_ownership, routine_safety, routine_acl, table_acl, schema_ac
 		}
 		snapshot.CurrentObjectsPresent = lexicalObjectsPresent
 	}
+	if snapshot.CurrentObjectsPresent && len(snapshot.Records) > 0 && snapshot.Records[len(snapshot.Records)-1].Version >= 20 {
+		evidenceExpiryObjectsPresent, err := memoryEvidenceExpiryControlsAvailable(ctx, q)
+		if err != nil {
+			return Snapshot{}, errors.New("PostgreSQL memory evidence expiry schema cannot be inspected")
+		}
+		snapshot.CurrentObjectsPresent = evidenceExpiryObjectsPresent
+	}
 	return snapshot, nil
 }
 

--- a/internal/postgres/migrate.go
+++ b/internal/postgres/migrate.go
@@ -52,6 +52,7 @@ var migrationCompatibilityFloors = map[int64]int64{
 	17: 10,
 	18: 10,
 	19: 10,
+	20: 10,
 }
 
 // CurrentManifest returns the immutable migrations embedded in this binary.

--- a/internal/postgres/migrations/020_memory_evidence_expiry.sql
+++ b/internal/postgres/migrations/020_memory_evidence_expiry.sql
@@ -1,0 +1,18 @@
+CREATE TABLE brain.memory_evidence_expirations (
+    item_id uuid PRIMARY KEY REFERENCES brain.memory_items(id) ON DELETE CASCADE,
+    expires_at timestamptz NOT NULL,
+    created_by uuid NOT NULL REFERENCES auth.principals(id),
+    created_at timestamptz NOT NULL DEFAULT statement_timestamp(),
+    CONSTRAINT memory_evidence_expirations_future_check CHECK (expires_at > created_at)
+);
+
+CREATE INDEX memory_evidence_expirations_due
+ON brain.memory_evidence_expirations (expires_at, item_id);
+
+CREATE TRIGGER application_mutation_fence
+BEFORE INSERT OR UPDATE OR DELETE OR TRUNCATE ON brain.memory_evidence_expirations
+FOR EACH STATEMENT EXECUTE FUNCTION jobs.guard_application_mutation();
+
+REVOKE ALL ON brain.memory_evidence_expirations FROM PUBLIC, punaro_app;
+GRANT SELECT ON brain.memory_evidence_expirations TO punaro_app;
+GRANT INSERT (item_id, expires_at, created_by) ON brain.memory_evidence_expirations TO punaro_app;

--- a/internal/postgres/state_test.go
+++ b/internal/postgres/state_test.go
@@ -69,8 +69,8 @@ func TestManifestValidationRejectsMutableOrNonContiguousHistory(t *testing.T) {
 
 func TestCurrentManifestRequiresControlPlaneSchema(t *testing.T) {
 	manifest := CurrentManifest()
-	if manifest.MinSupported != 10 || manifest.MaxSupported != 19 || len(manifest.Migrations) != 19 {
-		t.Fatalf("manifest=%#v, want exact v10-v19 compatibility window", manifest)
+	if manifest.MinSupported != 10 || manifest.MaxSupported != 20 || len(manifest.Migrations) != 20 {
+		t.Fatalf("manifest=%#v, want exact v10-v20 compatibility window", manifest)
 	}
 	for index, migration := range manifest.Migrations {
 		want := int64(index + 1)
@@ -83,7 +83,7 @@ func TestCurrentManifestRequiresControlPlaneSchema(t *testing.T) {
 			want = 10
 		case 12, 13:
 			want = 10
-		case 14, 15, 16, 17, 18, 19:
+		case 14, 15, 16, 17, 18, 19, 20:
 			want = 10
 		}
 		if migration.CompatibilityFloor != want {
@@ -139,7 +139,10 @@ func TestCompatibleSchemaCanStillHavePendingMigrations(t *testing.T) {
 	if !migrationPending(SchemaState{Classification: Compatible, Version: 18}, manifest) {
 		t.Fatal("compatible v18 schema must still apply the pending v19 migration")
 	}
-	if migrationPending(SchemaState{Classification: Compatible, Version: 19}, manifest) {
-		t.Fatal("current v19 schema reported a pending migration")
+	if !migrationPending(SchemaState{Classification: Compatible, Version: 19}, manifest) {
+		t.Fatal("compatible v19 schema must still apply the pending v20 migration")
+	}
+	if migrationPending(SchemaState{Classification: Compatible, Version: 20}, manifest) {
+		t.Fatal("current v20 schema reported a pending migration")
 	}
 }


### PR DESCRIPTION
## Summary

Adds the deterministic maintenance slice for explicitly ephemeral evidence:

- adds schema v20 with `brain.memory_evidence_expirations` as an evidence-only expiry side table
- lets evidence creation attach a future `expires_at` timestamp
- adds bounded `MaintainMemoryEvidence` maintenance that archives due active evidence, preserves revision-bound provenance, and covers canonical project alias scopes
- makes ordinary evidence reads require active evidence so expired evidence drops out of prompt/search paths without destructive deletion
- pins schema-readiness drift checks and updates the platform contract

## Validation

- `GOCACHE=/tmp/punaro-m18-go-cache go test ./internal/postgres -run TestMemoryEvidenceCreateRequestValidation -count=1`
- `GOCACHE=/tmp/punaro-m18-go-cache go test ./internal/postgres -run 'TestMemoryEvidenceCreateRequestValidation|TestPostgresPlatformSubstrateIntegration' -count=1`
- `GOCACHE=/tmp/punaro-m18-go-cache go test ./internal/postgres -count=1`
- `git diff --check`
- `GOCACHE=/tmp/punaro-m18-go-cache make test` (sandboxed run hit localhost bind restrictions; rerun outside sandbox passed)
- `GOCACHE=/tmp/punaro-m18-go-cache make lint`
- `GOCACHE=/tmp/punaro-m18-go-cache make staticcheck`
- `GOCACHE=/tmp/punaro-m18-go-cache make security`
- `GOCACHE=/tmp/punaro-m18-go-cache make test-race` (sandboxed run hit localhost bind restrictions; rerun outside sandbox passed)