### PR TITLE
M18B: detect exact memory duplicates

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -39,7 +39,7 @@ unmounted, and their binaries are absent from production packaging. Their
 code, tests, RFCs, and vectors remain historical experimental evidence. The current
 executable release conditions are in
 [`docs/security-release-gates.md`](docs/security-release-gates.md).
-PostgreSQL schema 19 also contains the dark canonical Big Brain store and its
+PostgreSQL schema 20 also contains the dark canonical Big Brain store and its
 operator-approved proposal authority. A writer can stage one immutable,
 bounded create, update, archive, merge, or split proposal; an administrator
 can approve or reject its exact pending ETag. Approval locks every referenced
@@ -100,6 +100,21 @@ path, profile path, or credential value. Profiles and MCP mode do not add
 retry, queue, cache, Git discovery, project registry, fallback local brain,
 enrollment recovery, semantic retrieval, remote MCP/OAuth, or Compose Pi
 behavior.
+
+Schema 20 adds optional expiry only for explicit evidence. A bounded
+`memory.administer` maintenance transaction archives due active evidence,
+copies its exact revision-bound provenance, and covers historical scopes behind
+permanent project lookup aliases. Ordinary evidence reads require active state;
+expiry is reversible archive, not content deletion. Exact duplicate detection
+adds no schema: it is a
+read-only, repeatable-read administrator report over active current revisions,
+excluding active quarantine and including permanent-alias scopes. It verifies
+JSONB equality in addition to the hash grouping, returns only hashes, opaque
+item IDs, revisions, and layers, and caps each report at 64 duplicate
+candidates. The deterministic oldest item is a reporting anchor only:
+detection never merges, archives, proposes, or rewrites content. A two-second
+SQL deadline and the isolated two-connection brain pool bound its effect on the
+rest of the service.
 
 ## Goals
 

--- a/docs/platform-contracts.md
+++ b/docs/platform-contracts.md
@@ -239,6 +239,18 @@ behind permanent project lookup aliases under the same bounded pass. Ordinary
 evidence reads require the item to remain active, so expired evidence leaves
 prompt/search paths without destructive cleanup.
 
+Deterministic exact-content duplicate detection adds no schema. A
+`memory.administer` caller receives at most 64 content-free candidate rows from
+one repeatable-read snapshot of active current, non-quarantined revisions. The
+report includes the SHA-256, opaque item IDs, revision numbers, and layers; it
+never returns documents and never mutates, proposes, archives, or merges. Equal
+hashes must also have equal JSONB documents. The oldest item by creation time
+and opaque ID is only a stable reporting anchor. Canonical project detection
+covers scopes retained behind permanent lookup aliases, while an alias remains
+neither authority nor a writable target. The isolated two-connection brain
+pool and a two-second SQL statement deadline bound report work so it cannot
+starve mail. Application rollback needs no database change.
+
 The dark prompt-brief read adds no schema and exposes no route or client. It
 accepts the same bounded normalized query as lexical search, resolves the
 active canonical project, and requires only `memory.search` because it returns

--- a/internal/postgres/brain_integration_test.go
+++ b/internal/postgres/brain_integration_test.go
@@ -201,6 +201,218 @@ func testMemoryEvidenceSchemaDriftIntegration(ctx context.Context, t *testing.T,
 	}
 }
 
+func testMemoryDuplicateDetectionIntegration(ctx context.Context, t *testing.T, app *Database, ownerDB *sql.DB) {
+	t.Helper()
+	actor, err := app.CreatePrincipal(ctx, PrincipalKindDevice, "duplicate actor")
+	if err != nil {
+		t.Fatal(err)
+	}
+	reader, err := app.CreatePrincipal(ctx, PrincipalKindDevice, "duplicate reader")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var projectID, aliasProjectID, otherProjectID string
+	for name, destination := range map[string]*string{
+		"duplicate canonical": &projectID,
+		"duplicate alias":     &aliasProjectID,
+		"duplicate other":     &otherProjectID,
+	} {
+		if err := ownerDB.QueryRowContext(ctx, `INSERT INTO relay.projects(display_name,created_by) VALUES ($1,$2) RETURNING id::text`, name, actor.ID).Scan(destination); err != nil {
+			t.Fatal(err)
+		}
+	}
+	for _, grant := range []struct {
+		principal, project string
+		capability         Capability
+	}{
+		{actor.ID, projectID, CapabilityMemoryWrite},
+		{actor.ID, projectID, CapabilityMemoryAdminister},
+		{actor.ID, aliasProjectID, CapabilityMemoryWrite},
+		{actor.ID, otherProjectID, CapabilityMemoryWrite},
+		{actor.ID, otherProjectID, CapabilityMemoryAdminister},
+		{reader.ID, projectID, CapabilityMemoryRead},
+	} {
+		if _, err := ownerDB.ExecContext(ctx, `INSERT INTO auth.capability_grants(principal_id,scope,project_id,capability) VALUES ($1,'project',$2,$3)`, grant.principal, grant.project, grant.capability); err != nil {
+			t.Fatal(err)
+		}
+	}
+	create := func(project, key, idempotency, document string) MemoryMutationResult {
+		t.Helper()
+		result, createErr := app.CreateMemory(ctx, MemoryCreateRequest{
+			PrincipalID: actor.ID, ProjectID: project, IdempotencyKey: idempotency,
+			LogicalKey: key, Kind: "fact", Trust: "curated", Document: json.RawMessage(document),
+		})
+		if createErr != nil {
+			t.Fatalf("create duplicate fixture %s: %v", key, createErr)
+		}
+		return result
+	}
+	duplicateDocument := `{"fact":"same","nested":{"order":1}}`
+	keeper := create(projectID, "duplicate.keeper", "21212121-2121-4121-8121-212121212111", duplicateDocument)
+	direct := create(projectID, "duplicate.direct", "21212121-2121-4121-8121-212121212112", duplicateDocument)
+	stale := create(projectID, "duplicate.stale", "21212121-2121-4121-8121-212121212113", duplicateDocument)
+	stale, err = app.UpdateMemory(ctx, MemoryUpdateRequest{
+		PrincipalID: actor.ID, ProjectID: projectID, ItemID: stale.ItemID,
+		IdempotencyKey: "21212121-2121-4121-8121-212121212114", ExpectedETag: stale.ETag,
+		LogicalKey: "duplicate.stale", Kind: "fact", Trust: "curated", Document: json.RawMessage(`{"fact":"changed"}`),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	current := create(projectID, "duplicate.current", "21212121-2121-4121-8121-212121212115", `{"fact":"old"}`)
+	current, err = app.UpdateMemory(ctx, MemoryUpdateRequest{
+		PrincipalID: actor.ID, ProjectID: projectID, ItemID: current.ItemID,
+		IdempotencyKey: "21212121-2121-4121-8121-212121212116", ExpectedETag: current.ETag,
+		LogicalKey: "duplicate.current", Kind: "fact", Trust: "curated", Document: json.RawMessage(duplicateDocument),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	archived := create(projectID, "duplicate.archived", "21212121-2121-4121-8121-212121212117", duplicateDocument)
+	if _, err := app.ArchiveMemory(ctx, MemoryArchiveRequest{
+		PrincipalID: actor.ID, ProjectID: projectID, ItemID: archived.ItemID,
+		IdempotencyKey: "21212121-2121-4121-8121-212121212118", ExpectedETag: archived.ETag, Archived: true,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	quarantined := create(projectID, "duplicate.quarantined", "21212121-2121-4121-8121-212121212123", duplicateDocument)
+	if _, err := ownerDB.ExecContext(ctx, `INSERT INTO brain.memory_quarantines
+(item_id,detected_revision,rule_version,rule_id,field_path,value_fingerprint,quarantined_by)
+VALUES ($1,1,1,'sensitive-field','/fact',decode(repeat('77',32),'hex'),$2)`, quarantined.ItemID, actor.ID); err != nil {
+		t.Fatal(err)
+	}
+	alias := create(aliasProjectID, "duplicate.alias", "21212121-2121-4121-8121-212121212119", duplicateDocument)
+	other := create(otherProjectID, "duplicate.other", "21212121-2121-4121-8121-212121212120", duplicateDocument)
+	collision := create(projectID, "duplicate.collision", "21212121-2121-4121-8121-212121212121", `{"fact":"different despite forged hash"}`)
+	var originalCollisionHash []byte
+	if err := ownerDB.QueryRowContext(ctx, `SELECT content_sha256 FROM brain.memory_revisions WHERE item_id=$1 AND revision=1`, collision.ItemID).Scan(&originalCollisionHash); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ownerDB.ExecContext(ctx, `UPDATE brain.memory_revisions AS collision
+SET content_sha256=keeper.content_sha256
+FROM brain.memory_revisions AS keeper
+WHERE collision.item_id=$1 AND collision.revision=1 AND keeper.item_id=$2 AND keeper.revision=1`, collision.ItemID, keeper.ItemID); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ownerDB.ExecContext(ctx, `UPDATE brain.memory_items SET created_at='2020-01-01T00:00:00Z' WHERE id=$1`, keeper.ItemID); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ownerDB.ExecContext(ctx, `INSERT INTO relay.project_lookup_aliases(alias_project_id,canonical_project_id) VALUES ($1,$2)`, aliasProjectID, projectID); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ownerDB.ExecContext(ctx, `UPDATE relay.projects SET merged_into=$2,merged_at=statement_timestamp() WHERE id=$1`, aliasProjectID, projectID); err != nil {
+		t.Fatal(err)
+	}
+
+	request := MemoryDuplicateRequest{PrincipalID: actor.ID, ProjectID: projectID, Limit: maxMemoryDuplicateCandidates}
+	page, err := app.DetectExactMemoryDuplicates(ctx, request)
+	if err != nil || page.More || len(page.Candidates) != 3 {
+		t.Fatalf("duplicate page=%#v err=%v", page, err)
+	}
+	wantDuplicates := map[string]int64{direct.ItemID: 1, current.ItemID: 2, alias.ItemID: 1}
+	for _, candidate := range page.Candidates {
+		wantRevision, ok := wantDuplicates[candidate.DuplicateItemID]
+		if !ok || candidate.KeeperItemID != keeper.ItemID || candidate.KeeperRevision != 1 || candidate.DuplicateRevision != wantRevision || candidate.ContentSHA256 == "" {
+			t.Fatalf("unexpected duplicate candidate=%#v", candidate)
+		}
+		delete(wantDuplicates, candidate.DuplicateItemID)
+	}
+	if len(wantDuplicates) != 0 {
+		t.Fatalf("missing duplicate candidates=%v", wantDuplicates)
+	}
+	bounded, err := app.DetectExactMemoryDuplicates(ctx, MemoryDuplicateRequest{PrincipalID: actor.ID, ProjectID: projectID, Limit: 2})
+	if err != nil || len(bounded.Candidates) != 2 || !bounded.More {
+		t.Fatalf("bounded duplicate page=%#v err=%v", bounded, err)
+	}
+	repeated, err := app.DetectExactMemoryDuplicates(ctx, MemoryDuplicateRequest{PrincipalID: actor.ID, ProjectID: aliasProjectID, Limit: 2})
+	if err != nil || len(repeated.Candidates) != len(bounded.Candidates) || repeated.More != bounded.More {
+		t.Fatalf("alias duplicate page=%#v err=%v", repeated, err)
+	}
+	for index := range bounded.Candidates {
+		if repeated.Candidates[index] != bounded.Candidates[index] {
+			t.Fatalf("duplicate order changed: first=%#v repeated=%#v", bounded, repeated)
+		}
+	}
+	if _, err := app.DetectExactMemoryDuplicates(ctx, MemoryDuplicateRequest{PrincipalID: reader.ID, ProjectID: projectID, Limit: 1}); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("non-admin duplicate detection error=%v", err)
+	}
+	otherPage, err := app.DetectExactMemoryDuplicates(ctx, MemoryDuplicateRequest{PrincipalID: actor.ID, ProjectID: otherProjectID, Limit: 5})
+	if err != nil || len(otherPage.Candidates) != 0 || otherPage.More {
+		t.Fatalf("cross-project duplicate leak page=%#v other=%s err=%v", otherPage, other.ItemID, err)
+	}
+	quarantined, err = app.UpdateMemory(ctx, MemoryUpdateRequest{
+		PrincipalID: actor.ID, ProjectID: projectID, ItemID: quarantined.ItemID,
+		IdempotencyKey: "21212121-2121-4121-8121-212121212124", ExpectedETag: quarantined.ETag,
+		LogicalKey: "duplicate.quarantined", Kind: "fact", Trust: "curated", Document: json.RawMessage(duplicateDocument),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	releasedPage, err := app.DetectExactMemoryDuplicates(ctx, request)
+	if err != nil || len(releasedPage.Candidates) != 4 {
+		t.Fatalf("duplicate page after quarantine release=%#v err=%v", releasedPage, err)
+	}
+	releasedCandidate := false
+	for _, candidate := range releasedPage.Candidates {
+		if candidate.DuplicateItemID == quarantined.ItemID && candidate.DuplicateRevision == 2 {
+			releasedCandidate = true
+		}
+	}
+	if !releasedCandidate {
+		t.Fatalf("released quarantined duplicate missing from page=%#v", releasedPage)
+	}
+	if _, err := app.UpdateMemory(ctx, MemoryUpdateRequest{
+		PrincipalID: actor.ID, ProjectID: projectID, ItemID: quarantined.ItemID,
+		IdempotencyKey: "21212121-2121-4121-8121-212121212125", ExpectedETag: quarantined.ETag,
+		LogicalKey: "duplicate.quarantined", Kind: "fact", Trust: "curated", Document: json.RawMessage(`{"fact":"released and changed"}`),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ownerDB.ExecContext(ctx, `UPDATE brain.memory_revisions SET content_sha256=$2 WHERE item_id=$1 AND revision=1`, collision.ItemID, originalCollisionHash); err != nil {
+		t.Fatal(err)
+	}
+	snapshotTx, err := app.brainPool().BeginTx(ctx, &sql.TxOptions{Isolation: sql.LevelRepeatableRead, ReadOnly: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	snapshotBefore, err := detectExactMemoryDuplicatesInTx(ctx, snapshotTx, projectID, maxMemoryDuplicateCandidates)
+	if err != nil || len(snapshotBefore.Candidates) != 3 {
+		_ = snapshotTx.Rollback()
+		t.Fatalf("duplicate snapshot before update=%#v err=%v", snapshotBefore, err)
+	}
+	if _, err := app.UpdateMemory(ctx, MemoryUpdateRequest{
+		PrincipalID: actor.ID, ProjectID: projectID, ItemID: direct.ItemID,
+		IdempotencyKey: "21212121-2121-4121-8121-212121212122", ExpectedETag: direct.ETag,
+		LogicalKey: "duplicate.direct", Kind: "fact", Trust: "curated", Document: json.RawMessage(`{"fact":"no longer duplicate"}`),
+	}); err != nil {
+		_ = snapshotTx.Rollback()
+		t.Fatal(err)
+	}
+	snapshotAfter, err := detectExactMemoryDuplicatesInTx(ctx, snapshotTx, projectID, maxMemoryDuplicateCandidates)
+	if err != nil || len(snapshotAfter.Candidates) != len(snapshotBefore.Candidates) {
+		_ = snapshotTx.Rollback()
+		t.Fatalf("duplicate snapshot after concurrent update=%#v err=%v", snapshotAfter, err)
+	}
+	for index := range snapshotBefore.Candidates {
+		if snapshotAfter.Candidates[index] != snapshotBefore.Candidates[index] {
+			_ = snapshotTx.Rollback()
+			t.Fatalf("repeatable-read duplicate snapshot changed: before=%#v after=%#v", snapshotBefore, snapshotAfter)
+		}
+	}
+	if err := snapshotTx.Commit(); err != nil {
+		t.Fatal(err)
+	}
+	fresh, err := app.DetectExactMemoryDuplicates(ctx, request)
+	if err != nil || len(fresh.Candidates) != 2 {
+		t.Fatalf("fresh duplicate page after concurrent update=%#v err=%v", fresh, err)
+	}
+	for _, candidate := range fresh.Candidates {
+		if candidate.DuplicateItemID == direct.ItemID {
+			t.Fatalf("fresh duplicate page retained updated item=%#v", candidate)
+		}
+	}
+}
+
 func testMemoryProposalSchemaDriftIntegration(ctx context.Context, t *testing.T, app *Database, ownerDB *sql.DB) {
 	t.Helper()
 	for _, drift := range []struct {

--- a/internal/postgres/brain_maintenance.go
+++ b/internal/postgres/brain_maintenance.go
@@ -1,0 +1,136 @@
+package postgres
+
+import (
+	"context"
+	"crypto/sha256"
+	"database/sql"
+	"encoding/hex"
+	"errors"
+	"time"
+)
+
+const (
+	maxMemoryDuplicateCandidates = 64
+	memoryMaintenanceReadTimeout = 2 * time.Second
+)
+
+// MemoryDuplicateRequest asks for one bounded exact-content duplicate report.
+type MemoryDuplicateRequest struct {
+	PrincipalID string
+	ProjectID   string
+	Limit       int
+}
+
+// MemoryDuplicateCandidate identifies one active current revision that exactly
+// matches the deterministic oldest item in its content group.
+type MemoryDuplicateCandidate struct {
+	ContentSHA256     string      `json:"content_sha256"`
+	KeeperItemID      string      `json:"keeper_item_id"`
+	KeeperRevision    int64       `json:"keeper_revision"`
+	KeeperLayer       MemoryLayer `json:"keeper_layer"`
+	DuplicateItemID   string      `json:"duplicate_item_id"`
+	DuplicateRevision int64       `json:"duplicate_revision"`
+	DuplicateLayer    MemoryLayer `json:"duplicate_layer"`
+}
+
+// MemoryDuplicatePage is bounded by candidate rows rather than groups.
+type MemoryDuplicatePage struct {
+	Candidates []MemoryDuplicateCandidate `json:"candidates"`
+	More       bool                       `json:"more"`
+}
+
+func (request MemoryDuplicateRequest) normalized() (MemoryDuplicateRequest, error) {
+	if !validOpaqueID(request.PrincipalID) || !validOpaqueID(request.ProjectID) ||
+		request.Limit < 1 || request.Limit > maxMemoryDuplicateCandidates {
+		return MemoryDuplicateRequest{}, errors.New("invalid memory duplicate request")
+	}
+	return request, nil
+}
+
+// DetectExactMemoryDuplicates returns a snapshot-consistent, content-free
+// report. It never mutates, archives, or merges canonical memory.
+func (d *Database) DetectExactMemoryDuplicates(ctx context.Context, raw MemoryDuplicateRequest) (MemoryDuplicatePage, error) {
+	request, err := raw.normalized()
+	if err != nil {
+		return MemoryDuplicatePage{}, err
+	}
+	maintenanceCtx, cancel := context.WithTimeout(ctx, memoryMaintenanceReadTimeout)
+	defer cancel()
+	tx, err := d.brainPool().BeginTx(maintenanceCtx, &sql.TxOptions{Isolation: sql.LevelRepeatableRead, ReadOnly: true})
+	if err != nil {
+		return MemoryDuplicatePage{}, errors.New("memory duplicate transaction cannot start")
+	}
+	defer func() { _ = tx.Rollback() }()
+	projectID, err := resolveCanonicalActiveProject(maintenanceCtx, tx, request.ProjectID)
+	if err != nil {
+		return MemoryDuplicatePage{}, ErrNotFound
+	}
+	allowed, err := hasCapability(maintenanceCtx, tx, request.PrincipalID, projectID, CapabilityMemoryAdminister)
+	if err != nil {
+		return MemoryDuplicatePage{}, err
+	}
+	if !allowed {
+		return MemoryDuplicatePage{}, ErrNotFound
+	}
+	if _, err := tx.ExecContext(maintenanceCtx, `SET LOCAL statement_timeout = '2s'`); err != nil {
+		return MemoryDuplicatePage{}, errors.New("memory duplicate timeout cannot be installed")
+	}
+	page, err := detectExactMemoryDuplicatesInTx(maintenanceCtx, tx, projectID, request.Limit)
+	if err != nil {
+		return MemoryDuplicatePage{}, err
+	}
+	if err := tx.Commit(); err != nil {
+		return MemoryDuplicatePage{}, errors.New("memory duplicate transaction could not finish")
+	}
+	return page, nil
+}
+
+func detectExactMemoryDuplicatesInTx(ctx context.Context, tx *sql.Tx, projectID string, limit int) (MemoryDuplicatePage, error) {
+	rows, err := tx.QueryContext(ctx, `WITH current_records AS (
+	SELECT item.id,item.current_revision,item.layer,revision.content_sha256,
+	       row_number() OVER content_group AS group_ordinal,
+	       first_value(item.id) OVER content_group AS keeper_item_id,
+	       first_value(item.current_revision) OVER content_group AS keeper_revision,
+           first_value(item.layer) OVER content_group AS keeper_layer
+    FROM brain.memory_items AS item
+    JOIN brain.scopes AS scope ON scope.id=item.scope_id
+	LEFT JOIN relay.project_lookup_aliases AS alias ON alias.alias_project_id=scope.project_id
+	JOIN brain.memory_revisions AS revision ON revision.item_id=item.id AND revision.revision=item.current_revision
+	WHERE item.state='active' AND COALESCE(alias.canonical_project_id,scope.project_id)=$1
+	  AND NOT EXISTS (SELECT 1 FROM brain.memory_quarantines AS quarantine WHERE quarantine.item_id=item.id AND quarantine.released_at IS NULL)
+	WINDOW content_group AS (
+	    PARTITION BY revision.content_sha256,revision.document
+	    ORDER BY item.created_at,item.id
+	)
+)
+SELECT content_sha256,keeper_item_id::text,keeper_revision,keeper_layer,
+	   id::text,current_revision,layer
+FROM current_records
+WHERE group_ordinal>1
+ORDER BY content_sha256,keeper_item_id,id
+LIMIT $2`, projectID, limit+1)
+	if err != nil {
+		return MemoryDuplicatePage{}, errors.New("memory duplicate report is unavailable")
+	}
+	defer func() { _ = rows.Close() }()
+	candidates := make([]MemoryDuplicateCandidate, 0, limit+1)
+	for rows.Next() {
+		var candidate MemoryDuplicateCandidate
+		var contentHash []byte
+		if err := rows.Scan(&contentHash, &candidate.KeeperItemID, &candidate.KeeperRevision, &candidate.KeeperLayer,
+			&candidate.DuplicateItemID, &candidate.DuplicateRevision, &candidate.DuplicateLayer); err != nil || len(contentHash) != sha256.Size {
+			return MemoryDuplicatePage{}, errors.New("memory duplicate report is unavailable")
+		}
+		candidate.ContentSHA256 = hex.EncodeToString(contentHash)
+		candidates = append(candidates, candidate)
+	}
+	if err := rows.Err(); err != nil {
+		return MemoryDuplicatePage{}, errors.New("memory duplicate report is unavailable")
+	}
+	page := MemoryDuplicatePage{Candidates: candidates}
+	if len(page.Candidates) > limit {
+		page.Candidates = page.Candidates[:limit]
+		page.More = true
+	}
+	return page, nil
+}

--- a/internal/postgres/brain_maintenance_test.go
+++ b/internal/postgres/brain_maintenance_test.go
@@ -1,0 +1,28 @@
+package postgres
+
+import "testing"
+
+func TestMemoryDuplicateRequestRequiresStrictBoundedAuthority(t *testing.T) {
+	valid := MemoryDuplicateRequest{
+		PrincipalID: "21212121-2121-4121-8121-212121212101",
+		ProjectID:   "21212121-2121-4121-8121-212121212102",
+		Limit:       maxMemoryDuplicateCandidates,
+	}
+	if _, err := valid.normalized(); err != nil {
+		t.Fatalf("valid request rejected: %v", err)
+	}
+	for name, mutate := range map[string]func(*MemoryDuplicateRequest){
+		"principal": func(request *MemoryDuplicateRequest) { request.PrincipalID = "friendly" },
+		"project":   func(request *MemoryDuplicateRequest) { request.ProjectID = "friendly" },
+		"zero":      func(request *MemoryDuplicateRequest) { request.Limit = 0 },
+		"over":      func(request *MemoryDuplicateRequest) { request.Limit = maxMemoryDuplicateCandidates + 1 },
+	} {
+		t.Run(name, func(t *testing.T) {
+			request := valid
+			mutate(&request)
+			if _, err := request.normalized(); err == nil {
+				t.Fatal("invalid duplicate request accepted")
+			}
+		})
+	}
+}

--- a/internal/postgres/postgres_integration_test.go
+++ b/internal/postgres/postgres_integration_test.go
@@ -450,6 +450,7 @@ RETURNS boolean LANGUAGE plpgsql SECURITY DEFINER SET search_path=pg_catalog AS 
 	testCanonicalBrainIntegration(ctx, t, app, ownerDB)
 	testMemoryLexicalSearchIntegration(ctx, t, app, ownerDB)
 	testMemoryPromptBriefIntegration(ctx, t, app, ownerDB)
+	testMemoryDuplicateDetectionIntegration(ctx, t, app, ownerDB)
 	testMemoryEvidenceIntegration(ctx, t, app, ownerDB)
 	testMemoryProposalIntegration(ctx, t, app, ownerDB)
 	testBackupRestoreIntegration(ctx, t, app, ownerDB, ownerFile, appFile)


### PR DESCRIPTION
## What changed

- add a schema-neutral, read-only exact-content duplicate report for canonical memory administrators
- include canonical scopes retained behind permanent project lookup aliases without treating aliases as authority
- exclude archived, stale-revision, cross-project, and actively quarantined records
- require both stored SHA-256 equality and JSONB equality, with deterministic keeper/candidate ordering
- bound reports to 64 content-free candidate rows with a stable `more` indicator
- run each report in a two-second, read-only repeatable-read transaction on the isolated brain pool
- document authority, compatibility, rollback, alias, quarantine, and non-mutation contracts

## Why

The approved Big Brain maintenance plan requires deterministic exact-content duplicate detection before later model-assisted consolidation. This independently mergeable slice provides the safe reporting primitive only; it does not merge, archive, propose, rewrite, embed, or expose a public API/CLI/MCP surface.

## Compatibility and rollback

No schema or migration changes are included. Application rollback requires no database action. Existing canonical memory reads and writes are unchanged.

## Validation

Red-first:
- focused compile initially failed because the request, bound, and detector did not exist

Final:
- `go test ./internal/postgres -run TestMemoryDuplicate... -count=1`
- `go test ./internal/postgres -count=1`
- PostgreSQL 18.4 `TestPostgresPlatformSubstrateIntegration` on a fresh isolated cluster, including authorization, isolation, aliases, archive/stale/current revisions, quarantine release, forged hash collision, deterministic bounds, and overlapping-update snapshot stability
- `make test`
- `make test-race`
- `make staticcheck`
- `make security` — zero called vulnerabilities, zero gosec issues, no gitleaks findings
- `make lint` — including Windows build and deployment verification
- `git diff --check`

## Independent reviews

- plan alignment: PASS
- adversarial correctness/security: no material findings
- simplification/Kondo: no actionable findings

## Explicit exclusions

No fuzzy or semantic matching, automatic merge/archive/proposal, embeddings, Compose Pi integration, or public route/client surface.