### PR TITLE
Add memory consistency verifier

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -144,6 +144,19 @@ evidence/result coordinates intentionally remain durable provenance and are
 never reconciliation targets. The operation does not discover or merge
 projects, rewrite memory, or repair derived indexes.
 
+The schema-neutral canonical consistency verifier completes deterministic
+memory maintenance. A direct active canonical project's `memory.administer`
+caller scans at most 64 current revisions per stable item-ID page across the
+canonical project and authoritative retired projects merged into it. One
+read-only repeatable-read snapshot compares the canonical document with its
+stored SHA-256 digest and synchronous generated lexical title/vector, and
+reports whether the exact lexical columns and access paths still satisfy
+readiness. Results contain only opaque item/revision coordinates and closed
+issue classes; they never return content, hashes, titles, vectors, snippets, or
+cross-project counts. The verifier does not repair, reindex, write audit, or
+advance generations. Embedding/chunk cleanup and side-by-side generation
+rebuilds remain later derived-index work.
+
 ## Goals
 
 - Durable, ordered delivery to an enrolled machine, even when it sleeps.

--- a/docs/platform-contracts.md
+++ b/docs/platform-contracts.md
@@ -295,6 +295,24 @@ coordinates are durable provenance and readers already redact unavailable
 live sources. Schema-22 rollback requires the normal verified pre-update backup
 restore because a schema-21 image rejects the newer manifest.
 
+The schema-neutral `memory.administer` consistency verifier is read-only and
+accepts only a direct active canonical project ID. In one repeatable-read,
+two-second isolated-pool transaction it checks at most 64 current revisions in
+stable item-ID order across the canonical project plus authoritative retired
+projects whose `merged_into` names it. Each row's canonical JSON text is
+compared with its stored SHA-256 digest and with the synchronous generated
+lexical title/vector expressions. The same report records whether the exact
+generated columns and title/GIN access paths still satisfy lexical readiness.
+
+Pages return a checked-row count, stable continuation cursor, `more`, the
+lexical-control boolean, and only opaque item/revision coordinates with closed
+`content_hash`, `lexical_title`, or `lexical_vector` issue classes. They never
+return documents, hashes, titles, vectors, snippets, or foreign-project counts.
+Lookup aliases do not grant verifier authority or define project membership.
+The operation performs no repair, reindex, generation/audit advancement, or
+schema mutation; rollback therefore removes only application code. Physical
+derived-generation cleanup and rebuild remain the M-19/M-20 boundary.
+
 The dark prompt-brief read adds no schema and exposes no route or client. It
 accepts the same bounded normalized query as lexical search, resolves the
 active canonical project, and requires only `memory.search` because it returns

--- a/internal/postgres/brain_consistency.go
+++ b/internal/postgres/brain_consistency.go
@@ -1,0 +1,194 @@
+package postgres
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"database/sql"
+	"errors"
+	"strings"
+)
+
+const maxMemoryConsistencyRows = 64
+
+// MemoryConsistencyRequest asks for one bounded canonical consistency page.
+type MemoryConsistencyRequest struct {
+	PrincipalID string
+	ProjectID   string
+	AfterItemID string
+	Limit       int
+}
+
+// MemoryConsistencyIssueClass is a closed content-free inconsistency class.
+type MemoryConsistencyIssueClass string
+
+const (
+	// MemoryConsistencyContentHash reports a canonical document/digest mismatch.
+	MemoryConsistencyContentHash MemoryConsistencyIssueClass = "content_hash"
+	// MemoryConsistencyLexicalTitle reports a generated lexical-title mismatch.
+	MemoryConsistencyLexicalTitle MemoryConsistencyIssueClass = "lexical_title"
+	// MemoryConsistencyLexicalVector reports a generated lexical-vector mismatch.
+	MemoryConsistencyLexicalVector MemoryConsistencyIssueClass = "lexical_vector"
+)
+
+// MemoryConsistencyIssue identifies one inconsistent current revision without
+// returning its content or derived values.
+type MemoryConsistencyIssue struct {
+	ItemID   string                      `json:"item_id"`
+	Revision int64                       `json:"revision"`
+	Class    MemoryConsistencyIssueClass `json:"class"`
+}
+
+// MemoryConsistencyPage is one stable scan page. NextAfterItemID is populated
+// only when More is true.
+type MemoryConsistencyPage struct {
+	Checked                   int                      `json:"checked"`
+	LexicalControlsConsistent bool                     `json:"lexical_controls_consistent"`
+	Issues                    []MemoryConsistencyIssue `json:"issues"`
+	NextAfterItemID           string                   `json:"next_after_item_id,omitempty"`
+	More                      bool                     `json:"more"`
+}
+
+func (request MemoryConsistencyRequest) normalized() (MemoryConsistencyRequest, error) {
+	if !validOpaqueID(request.PrincipalID) || !validOpaqueID(request.ProjectID) ||
+		(request.AfterItemID != "" && !validOpaqueID(request.AfterItemID)) ||
+		request.Limit < 1 || request.Limit > maxMemoryConsistencyRows {
+		return MemoryConsistencyRequest{}, errors.New("invalid memory consistency request")
+	}
+	return request, nil
+}
+
+// VerifyMemoryConsistency returns a bounded, snapshot-consistent and
+// content-free canonical/lexical consistency report. It never repairs data.
+func (d *Database) VerifyMemoryConsistency(ctx context.Context, raw MemoryConsistencyRequest) (MemoryConsistencyPage, error) {
+	request, err := raw.normalized()
+	if err != nil {
+		return MemoryConsistencyPage{}, err
+	}
+	verificationCtx, cancel := context.WithTimeout(ctx, memoryMaintenanceReadTimeout)
+	defer cancel()
+	tx, err := d.brainPool().BeginTx(verificationCtx, &sql.TxOptions{Isolation: sql.LevelRepeatableRead, ReadOnly: true})
+	if err != nil {
+		return MemoryConsistencyPage{}, errors.New("memory consistency transaction cannot start")
+	}
+	defer func() { _ = tx.Rollback() }()
+	projectID, err := resolveCanonicalActiveProject(verificationCtx, tx, request.ProjectID)
+	if err != nil || !strings.EqualFold(projectID, request.ProjectID) {
+		return MemoryConsistencyPage{}, ErrNotFound
+	}
+	allowed, err := hasCapability(verificationCtx, tx, request.PrincipalID, projectID, CapabilityMemoryAdminister)
+	if err != nil {
+		return MemoryConsistencyPage{}, err
+	}
+	if !allowed {
+		return MemoryConsistencyPage{}, ErrNotFound
+	}
+	if _, err := tx.ExecContext(verificationCtx, `SET LOCAL statement_timeout = '2s'`); err != nil {
+		return MemoryConsistencyPage{}, errors.New("memory consistency timeout cannot be installed")
+	}
+	lexicalControls, err := memoryLexicalControlsAvailable(verificationCtx, tx)
+	if err != nil {
+		return MemoryConsistencyPage{}, errors.New("memory lexical controls cannot be inspected")
+	}
+	page := MemoryConsistencyPage{
+		LexicalControlsConsistent: lexicalControls,
+		Issues:                    make([]MemoryConsistencyIssue, 0),
+	}
+	if lexicalControls {
+		page, err = verifyMemoryConsistencyInTx(verificationCtx, tx, projectID, request.AfterItemID, request.Limit)
+		if err != nil {
+			return MemoryConsistencyPage{}, err
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		return MemoryConsistencyPage{}, errors.New("memory consistency transaction could not finish")
+	}
+	return page, nil
+}
+
+func verifyMemoryConsistencyInTx(ctx context.Context, tx *sql.Tx, projectID, afterItemID string, limit int) (MemoryConsistencyPage, error) {
+	var cursor any
+	if afterItemID != "" {
+		cursor = afterItemID
+	}
+	rows, err := tx.QueryContext(ctx, `SELECT item.id::text,item.current_revision,revision.document::text,
+       revision.content_sha256,
+       revision.search_title = CASE
+         WHEN jsonb_typeof(revision.document -> 'title')='string' THEN revision.document ->> 'title'
+         ELSE ''
+       END AS title_consistent,
+       revision.search_vector = (
+         setweight(to_tsvector('simple'::regconfig,
+           CASE WHEN jsonb_typeof(revision.document -> 'title')='string' THEN revision.document ->> 'title' ELSE '' END),'A')
+         || setweight(to_tsvector('simple'::regconfig,
+           CASE WHEN jsonb_typeof(revision.document -> 'summary')='string' THEN revision.document ->> 'summary' ELSE '' END),'B')
+         || setweight(to_tsvector('simple'::regconfig,
+           CASE WHEN jsonb_typeof(revision.document -> 'keywords') IN ('string','array') THEN revision.document ->> 'keywords' ELSE '' END),'C')
+         || setweight(to_tsvector('simple'::regconfig,
+           CASE WHEN jsonb_typeof(revision.document -> 'body')='string' THEN revision.document ->> 'body' ELSE '' END),'D')
+       ) AS vector_consistent
+FROM brain.memory_items AS item
+JOIN brain.scopes AS scope ON scope.id=item.scope_id
+JOIN relay.projects AS source_project ON source_project.id=scope.project_id
+JOIN brain.memory_revisions AS revision
+  ON revision.item_id=item.id AND revision.revision=item.current_revision
+WHERE ((source_project.id=$1 AND source_project.merged_into IS NULL)
+       OR source_project.merged_into=$1)
+  AND ($2::uuid IS NULL OR item.id>$2::uuid)
+ORDER BY item.id
+LIMIT $3`, projectID, cursor, limit+1)
+	if err != nil {
+		return MemoryConsistencyPage{}, errors.New("memory consistency report is unavailable")
+	}
+	defer func() { _ = rows.Close() }()
+	type checkedRevision struct {
+		itemID           string
+		revision         int64
+		document         []byte
+		contentHash      []byte
+		titleConsistent  bool
+		vectorConsistent bool
+	}
+	checked := make([]checkedRevision, 0, limit+1)
+	for rows.Next() {
+		var revision checkedRevision
+		if err := rows.Scan(&revision.itemID, &revision.revision, &revision.document, &revision.contentHash,
+			&revision.titleConsistent, &revision.vectorConsistent); err != nil ||
+			!validOpaqueID(revision.itemID) || revision.revision < 1 || len(revision.contentHash) != sha256.Size {
+			return MemoryConsistencyPage{}, errors.New("memory consistency report is unavailable")
+		}
+		checked = append(checked, revision)
+	}
+	if err := rows.Err(); err != nil {
+		return MemoryConsistencyPage{}, errors.New("memory consistency report is unavailable")
+	}
+	page := MemoryConsistencyPage{
+		Checked:                   min(len(checked), limit),
+		LexicalControlsConsistent: true,
+		Issues:                    make([]MemoryConsistencyIssue, 0),
+	}
+	if len(checked) > limit {
+		checked = checked[:limit]
+		page.More = true
+		page.NextAfterItemID = checked[len(checked)-1].itemID
+	}
+	for _, revision := range checked {
+		documentHash := sha256.Sum256(revision.document)
+		if !bytes.Equal(documentHash[:], revision.contentHash) {
+			page.Issues = append(page.Issues, MemoryConsistencyIssue{
+				ItemID: revision.itemID, Revision: revision.revision, Class: MemoryConsistencyContentHash,
+			})
+		}
+		if !revision.titleConsistent {
+			page.Issues = append(page.Issues, MemoryConsistencyIssue{
+				ItemID: revision.itemID, Revision: revision.revision, Class: MemoryConsistencyLexicalTitle,
+			})
+		}
+		if !revision.vectorConsistent {
+			page.Issues = append(page.Issues, MemoryConsistencyIssue{
+				ItemID: revision.itemID, Revision: revision.revision, Class: MemoryConsistencyLexicalVector,
+			})
+		}
+	}
+	return page, nil
+}

--- a/internal/postgres/brain_consistency_integration_test.go
+++ b/internal/postgres/brain_consistency_integration_test.go
@@ -1,0 +1,276 @@
+package postgres
+
+import (
+	"context"
+	"crypto/sha256"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+)
+
+func testMemoryConsistencyIntegration(ctx context.Context, t *testing.T, app *Database, ownerDB *sql.DB) {
+	t.Helper()
+	actor, err := app.CreatePrincipal(ctx, PrincipalKindDevice, "memory consistency actor")
+	if err != nil {
+		t.Fatal(err)
+	}
+	outsider, err := app.CreatePrincipal(ctx, PrincipalKindDevice, "memory consistency outsider")
+	if err != nil {
+		t.Fatal(err)
+	}
+	disabled, err := app.CreatePrincipal(ctx, PrincipalKindDevice, "memory consistency disabled")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var canonical, retired, other, foreign string
+	for name, target := range map[string]*string{
+		"consistency canonical": &canonical,
+		"consistency retired":   &retired,
+		"consistency other":     &other,
+		"consistency foreign":   &foreign,
+	} {
+		if err := ownerDB.QueryRowContext(ctx, `INSERT INTO relay.projects(display_name,created_by) VALUES ($1,$2) RETURNING id::text`, name, actor.ID).Scan(target); err != nil {
+			t.Fatal(err)
+		}
+	}
+	for _, projectID := range []string{canonical, retired, other, foreign} {
+		for _, capability := range []Capability{CapabilityMemoryAdminister, CapabilityMemoryWrite} {
+			if _, err := ownerDB.ExecContext(ctx, `INSERT INTO auth.capability_grants(principal_id,scope,project_id,capability)
+VALUES ($1,'project',$2,$3)`, actor.ID, projectID, capability); err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+	if _, err := ownerDB.ExecContext(ctx, `INSERT INTO auth.capability_grants(principal_id,scope,project_id,capability)
+VALUES ($1,'project',$2,$3)`, disabled.ID, canonical, CapabilityMemoryAdminister); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ownerDB.ExecContext(ctx, `UPDATE auth.principals SET disabled_at=statement_timestamp() WHERE id=$1`, disabled.ID); err != nil {
+		t.Fatal(err)
+	}
+	create := func(projectID, key, logicalKey, title string) MemoryMutationResult {
+		t.Helper()
+		result, createErr := app.CreateMemory(ctx, MemoryCreateRequest{
+			PrincipalID: actor.ID, ProjectID: projectID, IdempotencyKey: key,
+			LogicalKey: logicalKey, Kind: "preference", Trust: "curated",
+			Document: json.RawMessage(`{"title":` + strconvQuote(title) + `,"body":"stable body"}`),
+		})
+		if createErr != nil {
+			t.Fatal(createErr)
+		}
+		return result
+	}
+	first := create(canonical, "23232323-2323-4232-8232-232323232311", "consistency.first", "healthy first")
+	second := create(canonical, "23232323-2323-4232-8232-232323232312", "consistency.second", "corrupt second")
+	retiredItem := create(retired, "23232323-2323-4232-8232-232323232313", "consistency.retired", "retired item")
+	otherItem := create(other, "23232323-2323-4232-8232-232323232314", "consistency.other", "other item")
+	foreignItem := create(foreign, "23232323-2323-4232-8232-232323232315", "consistency.foreign", "foreign item")
+	if _, err := ownerDB.ExecContext(ctx, `UPDATE relay.projects
+SET merged_into=$2,merged_at=statement_timestamp() WHERE id=$1`, retired, canonical); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ownerDB.ExecContext(ctx, `INSERT INTO relay.project_lookup_aliases(alias_project_id,canonical_project_id)
+VALUES ($1,$2),($3,$2)`, retired, canonical, foreign); err != nil {
+		t.Fatal(err)
+	}
+	for _, itemID := range []string{second.ItemID, retiredItem.ItemID, otherItem.ItemID, foreignItem.ItemID} {
+		if _, err := ownerDB.ExecContext(ctx, `UPDATE brain.memory_revisions
+SET content_sha256=decode(repeat('00',32),'hex') WHERE item_id=$1 AND revision=1`, itemID); err != nil {
+			t.Fatal(err)
+		}
+	}
+	for _, projectID := range []string{other, foreign} {
+		if _, err := ownerDB.ExecContext(ctx, `UPDATE auth.capability_grants
+SET revoked_at=statement_timestamp()
+WHERE principal_id=$1 AND project_id=$2 AND capability=$3 AND revoked_at IS NULL`,
+			actor.ID, projectID, CapabilityMemoryAdminister); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if _, err := app.VerifyMemoryConsistency(ctx, MemoryConsistencyRequest{
+		PrincipalID: outsider.ID, ProjectID: canonical, Limit: 1,
+	}); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("unauthorized consistency error=%v", err)
+	}
+	if _, err := app.VerifyMemoryConsistency(ctx, MemoryConsistencyRequest{
+		PrincipalID: disabled.ID, ProjectID: canonical, Limit: 1,
+	}); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("disabled consistency error=%v", err)
+	}
+	if _, err := app.VerifyMemoryConsistency(ctx, MemoryConsistencyRequest{
+		PrincipalID: actor.ID, ProjectID: retired, Limit: 1,
+	}); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("alias consistency authority error=%v", err)
+	}
+	if _, err := app.VerifyMemoryConsistency(ctx, MemoryConsistencyRequest{
+		PrincipalID: actor.ID, ProjectID: foreign, Limit: 1,
+	}); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("corrupt active alias consistency authority error=%v", err)
+	}
+	if _, err := app.VerifyMemoryConsistency(ctx, MemoryConsistencyRequest{
+		PrincipalID: actor.ID, ProjectID: other, Limit: 1,
+	}); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("cross-project consistency error=%v", err)
+	}
+	var checked int
+	var issues []MemoryConsistencyIssue
+	cursor := ""
+	for {
+		page, verifyErr := app.VerifyMemoryConsistency(ctx, MemoryConsistencyRequest{
+			PrincipalID: actor.ID, ProjectID: canonical, AfterItemID: cursor, Limit: 1,
+		})
+		if verifyErr != nil || !page.LexicalControlsConsistent || page.Checked != 1 {
+			t.Fatalf("consistency page=%#v err=%v", page, verifyErr)
+		}
+		checked += page.Checked
+		issues = append(issues, page.Issues...)
+		if !page.More {
+			if page.NextAfterItemID != "" {
+				t.Fatalf("terminal consistency cursor=%q", page.NextAfterItemID)
+			}
+			break
+		}
+		if !validOpaqueID(page.NextAfterItemID) || page.NextAfterItemID == cursor {
+			t.Fatalf("invalid consistency cursor=%q after=%q", page.NextAfterItemID, cursor)
+		}
+		cursor = page.NextAfterItemID
+	}
+	if checked != 3 {
+		t.Fatalf("checked=%d, want canonical plus retired rows only", checked)
+	}
+	if len(issues) != 2 {
+		t.Fatalf("issues=%#v, want canonical and retired hash corruption", issues)
+	}
+	issueItems := map[string]bool{}
+	for _, issue := range issues {
+		if issue.Class != MemoryConsistencyContentHash || issue.Revision != 1 {
+			t.Fatalf("unexpected consistency issue=%#v", issue)
+		}
+		issueItems[issue.ItemID] = true
+	}
+	if !issueItems[second.ItemID] || !issueItems[retiredItem.ItemID] ||
+		issueItems[first.ItemID] || issueItems[otherItem.ItemID] || issueItems[foreignItem.ItemID] {
+		t.Fatalf("consistency issue isolation=%#v", issueItems)
+	}
+	encoded, err := json.Marshal(issues)
+	if err != nil || strings.Contains(string(encoded), "healthy first") || strings.Contains(string(encoded), "stable body") ||
+		strings.Contains(string(encoded), "content_sha256") {
+		t.Fatalf("consistency result leaked content/hash: %s err=%v", encoded, err)
+	}
+	if _, err := ownerDB.ExecContext(ctx, `ALTER INDEX brain.memory_revisions_search_vector
+RENAME TO memory_revisions_search_vector_drift`); err != nil {
+		t.Fatal(err)
+	}
+	drifted, driftErr := app.VerifyMemoryConsistency(ctx, MemoryConsistencyRequest{
+		PrincipalID: actor.ID, ProjectID: canonical, Limit: 2,
+	})
+	if _, err := ownerDB.ExecContext(ctx, `ALTER INDEX brain.memory_revisions_search_vector_drift
+RENAME TO memory_revisions_search_vector`); err != nil {
+		t.Fatal(err)
+	}
+	if driftErr != nil || drifted.LexicalControlsConsistent || drifted.Checked != 0 || len(drifted.Issues) != 0 || drifted.More {
+		t.Fatalf("lexical drift report=%#v err=%v", drifted, driftErr)
+	}
+	lockTx, err := ownerDB.BeginTx(ctx, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := lockTx.ExecContext(ctx, `LOCK TABLE brain.memory_items IN ACCESS EXCLUSIVE MODE`); err != nil {
+		_ = lockTx.Rollback()
+		t.Fatal(err)
+	}
+	started := time.Now()
+	_, timeoutErr := app.VerifyMemoryConsistency(ctx, MemoryConsistencyRequest{
+		PrincipalID: actor.ID, ProjectID: canonical, Limit: 2,
+	})
+	elapsed := time.Since(started)
+	if err := lockTx.Rollback(); err != nil {
+		t.Fatal(err)
+	}
+	if timeoutErr == nil || elapsed < time.Second || elapsed > 3*time.Second {
+		t.Fatalf("consistency timeout err=%v elapsed=%s", timeoutErr, elapsed)
+	}
+	if recovered, err := app.VerifyMemoryConsistency(ctx, MemoryConsistencyRequest{
+		PrincipalID: actor.ID, ProjectID: canonical, Limit: 2,
+	}); err != nil || recovered.Checked != 2 {
+		t.Fatalf("consistency recovery=%#v err=%v", recovered, err)
+	}
+	for _, itemID := range []string{second.ItemID, retiredItem.ItemID, otherItem.ItemID, foreignItem.ItemID} {
+		var document string
+		if err := ownerDB.QueryRowContext(ctx, `SELECT document::text FROM brain.memory_revisions
+WHERE item_id=$1 AND revision=1`, itemID).Scan(&document); err != nil {
+			t.Fatal(err)
+		}
+		documentHash := sha256.Sum256([]byte(document))
+		if _, err := ownerDB.ExecContext(ctx, `UPDATE brain.memory_revisions SET content_sha256=$2
+WHERE item_id=$1 AND revision=1`, itemID, documentHash[:]); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if finalPage, err := app.VerifyMemoryConsistency(ctx, MemoryConsistencyRequest{
+		PrincipalID: actor.ID, ProjectID: canonical, Limit: maxMemoryConsistencyRows,
+	}); err != nil || finalPage.More || finalPage.Checked != 3 || len(finalPage.Issues) != 0 {
+		t.Fatalf("restored consistency page=%#v err=%v", finalPage, err)
+	}
+	snapshotTx, err := app.brainPool().BeginTx(ctx, &sql.TxOptions{
+		Isolation: sql.LevelRepeatableRead,
+		ReadOnly:  true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	snapshotBefore, err := verifyMemoryConsistencyInTx(ctx, snapshotTx, canonical, "", maxMemoryConsistencyRows)
+	if err != nil {
+		_ = snapshotTx.Rollback()
+		t.Fatal(err)
+	}
+	if _, err := ownerDB.ExecContext(ctx, `UPDATE brain.memory_revisions
+SET content_sha256=decode(repeat('00',32),'hex') WHERE item_id=$1 AND revision=1`, first.ItemID); err != nil {
+		_ = snapshotTx.Rollback()
+		t.Fatal(err)
+	}
+	snapshotAfter, err := verifyMemoryConsistencyInTx(ctx, snapshotTx, canonical, "", maxMemoryConsistencyRows)
+	if err != nil {
+		_ = snapshotTx.Rollback()
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(snapshotAfter, snapshotBefore) || len(snapshotAfter.Issues) != 0 {
+		_ = snapshotTx.Rollback()
+		t.Fatalf("repeatable-read report changed before=%#v after=%#v", snapshotBefore, snapshotAfter)
+	}
+	if err := snapshotTx.Commit(); err != nil {
+		t.Fatal(err)
+	}
+	freshAfterMutation, err := app.VerifyMemoryConsistency(ctx, MemoryConsistencyRequest{
+		PrincipalID: actor.ID, ProjectID: canonical, Limit: maxMemoryConsistencyRows,
+	})
+	if err != nil || len(freshAfterMutation.Issues) != 1 ||
+		freshAfterMutation.Issues[0].ItemID != first.ItemID ||
+		freshAfterMutation.Issues[0].Class != MemoryConsistencyContentHash {
+		t.Fatalf("fresh consistency report=%#v err=%v", freshAfterMutation, err)
+	}
+	var firstDocument string
+	if err := ownerDB.QueryRowContext(ctx, `SELECT document::text FROM brain.memory_revisions
+WHERE item_id=$1 AND revision=1`, first.ItemID).Scan(&firstDocument); err != nil {
+		t.Fatal(err)
+	}
+	firstHash := sha256.Sum256([]byte(firstDocument))
+	if _, err := ownerDB.ExecContext(ctx, `UPDATE brain.memory_revisions SET content_sha256=$2
+WHERE item_id=$1 AND revision=1`, first.ItemID, firstHash[:]); err != nil {
+		t.Fatal(err)
+	}
+	if converged, err := app.VerifyMemoryConsistency(ctx, MemoryConsistencyRequest{
+		PrincipalID: actor.ID, ProjectID: canonical, Limit: maxMemoryConsistencyRows,
+	}); err != nil || len(converged.Issues) != 0 {
+		t.Fatalf("converged consistency report=%#v err=%v", converged, err)
+	}
+}
+
+func strconvQuote(value string) string {
+	encoded, _ := json.Marshal(value)
+	return string(encoded)
+}

--- a/internal/postgres/brain_consistency_test.go
+++ b/internal/postgres/brain_consistency_test.go
@@ -1,0 +1,68 @@
+package postgres
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestMemoryConsistencyRequestRequiresDirectBoundedCursor(t *testing.T) {
+	valid := MemoryConsistencyRequest{
+		PrincipalID: "23232323-2323-4232-8232-232323232301",
+		ProjectID:   "23232323-2323-4232-8232-232323232302",
+		AfterItemID: "23232323-2323-4232-8232-232323232303",
+		Limit:       maxMemoryConsistencyRows,
+	}
+	if _, err := valid.normalized(); err != nil {
+		t.Fatalf("valid request rejected: %v", err)
+	}
+	withoutCursor := valid
+	withoutCursor.AfterItemID = ""
+	if _, err := withoutCursor.normalized(); err != nil {
+		t.Fatalf("initial request rejected: %v", err)
+	}
+	for name, mutate := range map[string]func(*MemoryConsistencyRequest){
+		"principal": func(request *MemoryConsistencyRequest) { request.PrincipalID = "friendly" },
+		"project":   func(request *MemoryConsistencyRequest) { request.ProjectID = "friendly" },
+		"cursor":    func(request *MemoryConsistencyRequest) { request.AfterItemID = "friendly" },
+		"zero":      func(request *MemoryConsistencyRequest) { request.Limit = 0 },
+		"over":      func(request *MemoryConsistencyRequest) { request.Limit = maxMemoryConsistencyRows + 1 },
+	} {
+		t.Run(name, func(t *testing.T) {
+			request := valid
+			mutate(&request)
+			if _, err := request.normalized(); err == nil {
+				t.Fatal("invalid consistency request accepted")
+			}
+		})
+	}
+}
+
+func TestMemoryConsistencyPageIsContentFree(t *testing.T) {
+	page := MemoryConsistencyPage{
+		Checked:                   2,
+		LexicalControlsConsistent: true,
+		Issues: []MemoryConsistencyIssue{{
+			ItemID:   "23232323-2323-4232-8232-232323232304",
+			Revision: 7,
+			Class:    MemoryConsistencyContentHash,
+		}},
+		NextAfterItemID: "23232323-2323-4232-8232-232323232305",
+		More:            true,
+	}
+	encoded, err := json.Marshal(page)
+	if err != nil {
+		t.Fatal(err)
+	}
+	text := string(encoded)
+	for _, forbidden := range []string{"document", "content_sha256", "search_title", "search_vector", "secret-value"} {
+		if strings.Contains(text, forbidden) {
+			t.Fatalf("consistency page leaked %q: %s", forbidden, text)
+		}
+	}
+	for _, required := range []string{`"checked":2`, `"lexical_controls_consistent":true`, `"class":"content_hash"`, `"more":true`} {
+		if !strings.Contains(text, required) {
+			t.Fatalf("consistency page missing %q: %s", required, text)
+		}
+	}
+}

--- a/internal/postgres/postgres_integration_test.go
+++ b/internal/postgres/postgres_integration_test.go
@@ -456,6 +456,7 @@ RETURNS boolean LANGUAGE plpgsql SECURITY DEFINER SET search_path=pg_catalog AS 
 	testMemoryUsageAndArchiveCandidatesIntegration(ctx, t, app, ownerDB)
 	testMemoryReferenceReconciliationIntegration(ctx, t, app, ownerDB)
 	testMemoryReferenceReconciliationRaces(ctx, t, app, ownerDB)
+	testMemoryConsistencyIntegration(ctx, t, app, ownerDB)
 	testMemoryEvidenceIntegration(ctx, t, app, ownerDB)
 	testMemoryProposalIntegration(ctx, t, app, ownerDB)
 	testBackupRestoreIntegration(ctx, t, app, ownerDB, ownerFile, appFile)


### PR DESCRIPTION
## Summary

Adds the internal M18E PostgreSQL memory-consistency verifier for direct active canonical projects.

- validates stored document SHA-256 and generated lexical title/vector state in one bounded, read-only repeatable-read snapshot;
- authorizes only `memory.administer` on the direct canonical project and traverses authoritative merged retired projects;
- provides stable UUID pagination, content-free issue coordinates, a two-second isolated-pool timeout, and no repair or public surface;
- documents the canonical/lexical consistency contract and adds integration coverage, including concurrent-mutation snapshot proof.

## Validation

- `make test`
- `make test-race`
- `make staticcheck`
- `make security`
- `make lint`
- `git diff --check`

The commit is SSH-signed with the configured 1Password signer. Direct Grok CLI review calls were inconclusive: the CLI repeatedly ended after its inspection preamble without emitting findings or a verdict.