### PR TITLE
Add embedding worker control

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -392,6 +392,16 @@ canonical, lexical, prompt-brief, authorization, and mail paths remain
 available. A later worker must recheck the exact generation, revision, hash,
 and lease before it may publish derived chunks.
 
+Schema version 24 adds only the fenced worker control plane. Owner routines
+first honor the global update/backup mutation fence, then claim bounded ready
+or expired coordinates with database-time leases, fresh
+opaque tokens, and monotonic generations; retry persists a bounded next-attempt
+time and requires the exact revision/hash/token/generation fence. A new
+canonical revision invalidates an outstanding lease, and the final permitted
+attempt is terminal with a code-only diagnostic. No provider, chunk/vector
+storage, success publication, semantic ranking, or client-facing semantic
+surface is enabled yet.
+
 Schema version 15 places one deterministic secret guard inside the authorized
 create/update transaction before any scope, revision, change, audit,
 idempotency result, or derived job can be written. Findings contain only the

--- a/docs/platform-contracts.md
+++ b/docs/platform-contracts.md
@@ -326,10 +326,17 @@ canonical writes, lexical retrieval, prompt briefs, and mail are unchanged.
 
 The application role can inspect but cannot directly create, modify, or delete
 generation/work rows; the security-definer enqueue trigger is the only M19A
-writer. Provider calls, chunking, vector publication, retry diagnostics,
-semantic ranking, generation rebuild, and ANN remain disabled pending later
-M-19/M-20 slices. Schema-23 rollback requires the normal verified pre-update
-backup restore because a schema-22 image correctly refuses this newer schema.
+writer. Schema 24 adds the only worker mutation path: bounded
+security-definer claim and retry routines. They first honor the global
+update/backup mutation fence, issue a fresh holder/token and
+monotonic lease generation, use database time and `SKIP LOCKED`, persist a
+bounded retry schedule, and require the exact generation/item/revision/hash and
+lease fence to release work. A stale, replayed, or superseded worker cannot
+alter newer work; the twenty-fifth failed attempt becomes a code-only terminal
+diagnostic. This remains a provider-free control plane: no document text,
+chunks, vectors, successful publication, semantic ranking, generation rebuild,
+or ANN is enabled. Schema-24 rollback requires the normal verified pre-update
+backup restore because a schema-23 image correctly refuses this newer schema.
 
 The dark prompt-brief read adds no schema and exposes no route or client. It
 accepts the same bounded normalized query as lexical search, resolves the

--- a/internal/postgres/brain_embedding.go
+++ b/internal/postgres/brain_embedding.go
@@ -4,9 +4,15 @@ import (
 	"encoding/hex"
 	"errors"
 	"regexp"
+	"time"
 )
 
-const maxMemoryEmbeddingDimensions = 4096
+const (
+	maxMemoryEmbeddingDimensions = 4096
+	maxMemoryEmbeddingClaimBatch = 32
+	memoryEmbeddingMinLease      = 5 * time.Second
+	memoryEmbeddingMaxLease      = 5 * time.Minute
+)
 
 var memoryEmbeddingRevisionPattern = regexp.MustCompile(`^[a-z0-9][a-z0-9_.:-]{0,63}$`)
 
@@ -49,6 +55,23 @@ type MemoryEmbeddingWork struct {
 	ItemID        string
 	Revision      int64
 	ContentSHA256 string
+}
+
+// MemoryEmbeddingClaimRequest is the bounded, provider-free worker claim
+// input. Worker identity is an opaque lease holder, never an authorization
+// principal or a provider credential.
+type MemoryEmbeddingClaimRequest struct {
+	WorkerID      string
+	Limit         int
+	LeaseDuration time.Duration
+}
+
+func (r MemoryEmbeddingClaimRequest) normalized() (MemoryEmbeddingClaimRequest, error) {
+	if !validOpaqueID(r.WorkerID) || r.Limit < 1 || r.Limit > maxMemoryEmbeddingClaimBatch ||
+		r.LeaseDuration < memoryEmbeddingMinLease || r.LeaseDuration > memoryEmbeddingMaxLease {
+		return MemoryEmbeddingClaimRequest{}, errors.New("invalid memory embedding claim")
+	}
+	return r, nil
 }
 
 // Validate accepts only opaque IDs, a positive revision, and a canonical

--- a/internal/postgres/brain_embedding_integration_test.go
+++ b/internal/postgres/brain_embedding_integration_test.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"errors"
 	"testing"
+	"time"
 )
 
 func testMemoryEmbeddingSchemaDriftIntegration(ctx context.Context, t *testing.T, app *Database, ownerDB *sql.DB) {
@@ -15,7 +17,10 @@ func testMemoryEmbeddingSchemaDriftIntegration(ctx context.Context, t *testing.T
 		{"application write", `GRANT INSERT ON brain.embedding_jobs TO punaro_app`, `REVOKE INSERT ON brain.embedding_jobs FROM punaro_app`},
 		{"application read", `REVOKE SELECT ON brain.embedding_generations FROM punaro_app`, `GRANT SELECT ON brain.embedding_generations TO punaro_app`},
 		{"queue trigger", `ALTER TABLE brain.memory_revisions DISABLE TRIGGER memory_revision_embedding_queue`, `ALTER TABLE brain.memory_revisions ENABLE TRIGGER memory_revision_embedding_queue`},
-		{"claim index", `DROP INDEX brain.embedding_jobs_claim_order`, `CREATE INDEX embedding_jobs_claim_order ON brain.embedding_jobs (generation_id, created_at, item_id) WHERE state='queued'`},
+		{"claim index", `DROP INDEX brain.embedding_jobs_claim_order`, `CREATE INDEX embedding_jobs_claim_order ON brain.embedding_jobs (generation_id, available_at, created_at, item_id) WHERE state='queued'`},
+		{"worker routine ACL", `REVOKE EXECUTE ON FUNCTION brain.retry_embedding_job(uuid,uuid,bigint,bytea,uuid,bigint,bigint,text) FROM punaro_app`, `GRANT EXECUTE ON FUNCTION brain.retry_embedding_job(uuid,uuid,bigint,bytea,uuid,bigint,bigint,text) TO punaro_app`},
+		{"worker routine public ACL", `GRANT EXECUTE ON FUNCTION brain.claim_embedding_jobs(uuid,integer,bigint) TO PUBLIC`, `REVOKE EXECUTE ON FUNCTION brain.claim_embedding_jobs(uuid,integer,bigint) FROM PUBLIC`},
+		{"worker routine security", `ALTER FUNCTION brain.claim_embedding_jobs(uuid,integer,bigint) SECURITY INVOKER`, `ALTER FUNCTION brain.claim_embedding_jobs(uuid,integer,bigint) SECURITY DEFINER`},
 	} {
 		t.Run(drift.name, func(t *testing.T) {
 			if _, err := ownerDB.ExecContext(ctx, drift.apply); err != nil {
@@ -79,6 +84,33 @@ func testMemoryEmbeddingQueueIntegration(ctx context.Context, t *testing.T, app 
 	if err := job.Validate(); err != nil || job.Revision != 1 {
 		t.Fatalf("queued work=%#v err=%v", job, err)
 	}
+	var invalidClaimCount int
+	err = app.db.QueryRowContext(ctx, `SELECT count(*) FROM brain.claim_embedding_jobs($1,NULL,$2)`, "19191919-1919-4191-8191-191919191914", memoryEmbeddingMinLease.Microseconds()).Scan(&invalidClaimCount)
+	if err == nil {
+		t.Fatal("embedding claim accepted an unbounded NULL limit")
+	}
+	claimed, err := app.ClaimMemoryEmbeddingWork(ctx, MemoryEmbeddingClaimRequest{WorkerID: "19191919-1919-4191-8191-191919191914", Limit: 1, LeaseDuration: memoryEmbeddingMinLease})
+	if err != nil || len(claimed) != 1 || claimed[0].ItemID != created.ItemID {
+		t.Fatalf("claimed embedding work=%#v err=%v", claimed, err)
+	}
+	firstLease := claimed[0]
+	if err := app.RetryMemoryEmbeddingWork(ctx, MemoryEmbeddingRetry{Lease: firstLease, ErrorCode: "provider_unavailable", Delay: time.Second}); err != nil {
+		t.Fatalf("embedding retry: %v", err)
+	}
+	if delayed, claimErr := app.ClaimMemoryEmbeddingWork(ctx, MemoryEmbeddingClaimRequest{WorkerID: "19191919-1919-4191-8191-191919191915", Limit: 1, LeaseDuration: memoryEmbeddingMinLease}); claimErr != nil || len(delayed) != 0 {
+		t.Fatalf("delayed embedding retry claim=%#v err=%v", delayed, claimErr)
+	}
+	if _, err := ownerDB.ExecContext(ctx, `UPDATE brain.embedding_jobs SET available_at=statement_timestamp() WHERE generation_id=$1 AND item_id=$2`, generationID, created.ItemID); err != nil {
+		t.Fatal(err)
+	}
+	if err := app.RetryMemoryEmbeddingWork(ctx, MemoryEmbeddingRetry{Lease: firstLease, ErrorCode: "replayed", Delay: 0}); !errors.Is(err, ErrStaleEmbeddingLease) {
+		t.Fatalf("replayed embedding retry error=%v", err)
+	}
+	claimed, err = app.ClaimMemoryEmbeddingWork(ctx, MemoryEmbeddingClaimRequest{WorkerID: "19191919-1919-4191-8191-191919191915", Limit: 1, LeaseDuration: memoryEmbeddingMinLease})
+	if err != nil || len(claimed) != 1 || claimed[0].Token == firstLease.Token || claimed[0].LeaseGeneration <= firstLease.LeaseGeneration {
+		t.Fatalf("reclaimed embedding work=%#v first=%#v err=%v", claimed, firstLease, err)
+	}
+	reclaimed := claimed[0]
 	retry, err := app.CreateMemory(ctx, MemoryCreateRequest{PrincipalID: actor.ID, ProjectID: projectID, IdempotencyKey: "19191919-1919-4191-8191-191919191912", LogicalKey: "embedding-19191919-1919-4191-8191-191919191912", Kind: "decision", Trust: "curated", Document: json.RawMessage(`{"title":"queue first"}`)})
 	if err != nil || retry.ItemID != created.ItemID {
 		t.Fatalf("create retry=%#v err=%v", retry, err)
@@ -92,5 +124,22 @@ func testMemoryEmbeddingQueueIntegration(ctx context.Context, t *testing.T, app 
 	}
 	if err := ownerDB.QueryRowContext(ctx, `SELECT generation_id::text,item_id::text,revision,encode(content_sha256,'hex') FROM brain.embedding_jobs WHERE generation_id=$1 AND item_id=$2`, generationID, created.ItemID).Scan(&job.GenerationID, &job.ItemID, &job.Revision, &job.ContentSHA256); err != nil || job.Revision != updated.Revision || job.ContentSHA256 == "" {
 		t.Fatalf("coalesced work=%#v update=%#v err=%v", job, updated, err)
+	}
+	if err := app.RetryMemoryEmbeddingWork(ctx, MemoryEmbeddingRetry{Lease: reclaimed, ErrorCode: "stale_revision", Delay: 0}); !errors.Is(err, ErrStaleEmbeddingLease) {
+		t.Fatalf("superseded embedding retry error=%v", err)
+	}
+	if _, err := ownerDB.ExecContext(ctx, `UPDATE brain.embedding_jobs SET attempts=24,available_at=statement_timestamp() WHERE generation_id=$1 AND item_id=$2`, generationID, created.ItemID); err != nil {
+		t.Fatal(err)
+	}
+	claimed, err = app.ClaimMemoryEmbeddingWork(ctx, MemoryEmbeddingClaimRequest{WorkerID: "19191919-1919-4191-8191-191919191916", Limit: 1, LeaseDuration: memoryEmbeddingMinLease})
+	if err != nil || len(claimed) != 1 || claimed[0].Attempts != 25 {
+		t.Fatalf("final embedding attempt=%#v err=%v", claimed, err)
+	}
+	if err := app.RetryMemoryEmbeddingWork(ctx, MemoryEmbeddingRetry{Lease: claimed[0], ErrorCode: "provider_terminal", Delay: 0}); err != nil {
+		t.Fatalf("terminal embedding retry: %v", err)
+	}
+	var state, errorCode string
+	if err := ownerDB.QueryRowContext(ctx, `SELECT state,last_error_code FROM brain.embedding_jobs WHERE generation_id=$1 AND item_id=$2`, generationID, created.ItemID).Scan(&state, &errorCode); err != nil || state != "failed" || errorCode != "provider_terminal" {
+		t.Fatalf("terminal embedding state=%q code=%q err=%v", state, errorCode, err)
 	}
 }

--- a/internal/postgres/brain_embedding_schema.go
+++ b/internal/postgres/brain_embedding_schema.go
@@ -6,7 +6,7 @@ import "context"
 // frontier. Canonical memory remains usable when no generation exists, but a
 // migrated database must never silently accept a damaged queue or weakened
 // application-role boundary.
-func memoryEmbeddingControlsAvailable(ctx context.Context, q queryer) (bool, error) {
+func memoryEmbeddingControlsAvailable(ctx context.Context, q queryer, schemaVersion int64) (bool, error) {
 	var available bool
 	err := q.QueryRowContext(ctx, `
 WITH objects AS (
@@ -39,6 +39,8 @@ WITH objects AS (
       ('brain.embedding_jobs','created_at','timestamp with time zone',true),
       ('brain.embedding_jobs','updated_at','timestamp with time zone',true),
       ('brain.embedding_jobs','completed_at','timestamp with time zone',false)
+    UNION ALL
+    SELECT 'brain.embedding_jobs','available_at','timestamp with time zone',true WHERE $1 >= 24
 ), actual_columns AS (
     SELECT attribute.attrelid::regclass::text,attribute.attname,attribute.atttypid::regtype::text,attribute.attnotnull
     FROM pg_attribute AS attribute,objects
@@ -55,7 +57,9 @@ WITH objects AS (
 ), index_safety AS (
     SELECT active_index_oid IS NOT NULL AND claim_index_oid IS NOT NULL AND expired_index_oid IS NOT NULL
       AND EXISTS (SELECT 1 FROM pg_index WHERE indexrelid=active_index_oid AND indisunique AND indisvalid AND indisready)
-      AND EXISTS (SELECT 1 FROM pg_index WHERE indexrelid=claim_index_oid AND NOT indisunique AND indisvalid AND indisready AND pg_get_expr(indpred,indrelid)='(state = ''queued''::text)')
+      AND EXISTS (SELECT 1 FROM pg_index WHERE indexrelid=claim_index_oid AND NOT indisunique AND indisvalid AND indisready
+          AND pg_get_expr(indpred,indrelid)='(state = ''queued''::text)'
+          AND (($1 < 24 AND indkey='1 12 2'::int2vector) OR ($1 >= 24 AND indkey='1 15 12 2'::int2vector)))
       AND EXISTS (SELECT 1 FROM pg_index WHERE indexrelid=expired_index_oid AND NOT indisunique AND indisvalid AND indisready AND pg_get_expr(indpred,indrelid)='(state = ''running''::text)') AS exact
     FROM objects
 )
@@ -71,6 +75,6 @@ SELECT generations_oid IS NOT NULL AND jobs_oid IS NOT NULL AND queue_oid IS NOT
 	AND NOT has_table_privilege('punaro_app',jobs_oid,'INSERT')
 	AND NOT has_table_privilege('punaro_app',jobs_oid,'UPDATE')
 	AND NOT has_table_privilege('punaro_app',jobs_oid,'DELETE')
-FROM objects,table_safety,trigger_safety,index_safety`).Scan(&available)
+FROM objects,table_safety,trigger_safety,index_safety`, schemaVersion).Scan(&available)
 	return available, err
 }

--- a/internal/postgres/brain_embedding_test.go
+++ b/internal/postgres/brain_embedding_test.go
@@ -55,3 +55,27 @@ func TestMemoryEmbeddingWorkValidation(t *testing.T) {
 		})
 	}
 }
+
+func TestMemoryEmbeddingClaimValidation(t *testing.T) {
+	valid := MemoryEmbeddingClaimRequest{
+		WorkerID:      "33333333-3333-4333-8333-333333333333",
+		Limit:         8,
+		LeaseDuration: memoryEmbeddingMinLease,
+	}
+	if _, err := valid.normalized(); err != nil {
+		t.Fatalf("valid claim rejected: %v", err)
+	}
+	for name, request := range map[string]MemoryEmbeddingClaimRequest{
+		"friendly worker": {WorkerID: "worker", Limit: valid.Limit, LeaseDuration: valid.LeaseDuration},
+		"zero limit":      {WorkerID: valid.WorkerID, LeaseDuration: valid.LeaseDuration},
+		"oversize limit":  {WorkerID: valid.WorkerID, Limit: maxMemoryEmbeddingClaimBatch + 1, LeaseDuration: valid.LeaseDuration},
+		"short lease":     {WorkerID: valid.WorkerID, Limit: valid.Limit, LeaseDuration: memoryEmbeddingMinLease - 1},
+		"long lease":      {WorkerID: valid.WorkerID, Limit: valid.Limit, LeaseDuration: memoryEmbeddingMaxLease + 1},
+	} {
+		t.Run(name, func(t *testing.T) {
+			if _, err := request.normalized(); err == nil {
+				t.Fatalf("invalid claim accepted: %#v", request)
+			}
+		})
+	}
+}

--- a/internal/postgres/brain_embedding_worker.go
+++ b/internal/postgres/brain_embedding_worker.go
@@ -1,0 +1,100 @@
+package postgres
+
+import (
+	"context"
+	"encoding/hex"
+	"errors"
+	"time"
+)
+
+// ErrStaleEmbeddingLease reports that a worker attempted to mutate a lease
+// which has expired, been reclaimed, or been superseded by a newer revision.
+var ErrStaleEmbeddingLease = errors.New("embedding lease is stale")
+
+// MemoryEmbeddingLease is one exact, content-free worker lease coordinate.
+type MemoryEmbeddingLease struct {
+	MemoryEmbeddingWork
+	Attempts        int
+	Holder          string
+	Token           string
+	LeaseGeneration int64
+	LeaseUntil      time.Time
+}
+
+func (lease MemoryEmbeddingLease) valid() bool {
+	return lease.Validate() == nil && lease.Attempts > 0 && lease.Attempts <= 25 &&
+		validOpaqueID(lease.Holder) && validOpaqueID(lease.Token) && lease.LeaseGeneration > 0 && !lease.LeaseUntil.IsZero()
+}
+
+// MemoryEmbeddingRetry releases a leased coordinate after a bounded delay or
+// records a terminal diagnostic when its final attempt has been consumed.
+type MemoryEmbeddingRetry struct {
+	Lease     MemoryEmbeddingLease
+	ErrorCode string
+	Delay     time.Duration
+}
+
+func (retry MemoryEmbeddingRetry) valid() bool {
+	return retry.Lease.valid() && boundedTokenPattern.MatchString(retry.ErrorCode) && retry.Delay >= 0 && retry.Delay <= time.Hour
+}
+
+// ClaimMemoryEmbeddingWork leases content-free, revision-bound work. It has no
+// provider interaction and never participates in canonical writes or search.
+func (d *Database) ClaimMemoryEmbeddingWork(ctx context.Context, raw MemoryEmbeddingClaimRequest) ([]MemoryEmbeddingLease, error) {
+	request, err := raw.normalized()
+	if err != nil {
+		return nil, err
+	}
+	tx, err := beginMutation(ctx, d.db)
+	if err != nil {
+		return nil, mutationStartError(err, "embedding claim transaction cannot start")
+	}
+	defer func() { _ = tx.Rollback() }()
+	rows, err := tx.QueryContext(ctx, `SELECT generation_id::text,item_id::text,revision,encode(content_sha256,'hex'),attempts,lease_holder::text,lease_token::text,lease_generation,lease_until FROM brain.claim_embedding_jobs($1,$2,$3)`, request.WorkerID, request.Limit, request.LeaseDuration.Microseconds())
+	if err != nil {
+		return nil, errors.New("embedding work could not be claimed")
+	}
+	defer func() { _ = rows.Close() }()
+	leases := make([]MemoryEmbeddingLease, 0, request.Limit)
+	for rows.Next() {
+		var lease MemoryEmbeddingLease
+		if err := rows.Scan(&lease.GenerationID, &lease.ItemID, &lease.Revision, &lease.ContentSHA256, &lease.Attempts, &lease.Holder, &lease.Token, &lease.LeaseGeneration, &lease.LeaseUntil); err != nil || !lease.valid() {
+			return nil, errors.New("claimed embedding work is malformed")
+		}
+		leases = append(leases, lease)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, errors.New("embedding work could not be claimed")
+	}
+	if err := tx.Commit(); err != nil {
+		return nil, errors.New("embedding claim transaction could not commit")
+	}
+	return leases, nil
+}
+
+// RetryMemoryEmbeddingWork conditionally releases a lease for a later attempt.
+// The exact revision, hash, token, and generation prevent a stale worker from
+// mutating work superseded by a new canonical revision or another claimant.
+func (d *Database) RetryMemoryEmbeddingWork(ctx context.Context, retry MemoryEmbeddingRetry) error {
+	if !retry.valid() {
+		return errors.New("invalid embedding retry")
+	}
+	digest, _ := hex.DecodeString(retry.Lease.ContentSHA256)
+	tx, err := beginMutation(ctx, d.db)
+	if err != nil {
+		return mutationStartError(err, "embedding retry transaction cannot start")
+	}
+	defer func() { _ = tx.Rollback() }()
+	var changed bool
+	err = tx.QueryRowContext(ctx, `SELECT brain.retry_embedding_job($1,$2,$3,$4,$5,$6,$7,$8)`, retry.Lease.GenerationID, retry.Lease.ItemID, retry.Lease.Revision, digest, retry.Lease.Token, retry.Lease.LeaseGeneration, retry.Delay.Microseconds(), retry.ErrorCode).Scan(&changed)
+	if err != nil {
+		return errors.New("embedding work could not be retried")
+	}
+	if !changed {
+		return ErrStaleEmbeddingLease
+	}
+	if err := tx.Commit(); err != nil {
+		return errors.New("embedding retry transaction could not commit")
+	}
+	return nil
+}

--- a/internal/postgres/brain_embedding_worker_schema.go
+++ b/internal/postgres/brain_embedding_worker_schema.go
@@ -1,0 +1,57 @@
+package postgres
+
+import "context"
+
+// memoryEmbeddingWorkerControlsAvailable verifies that the only application
+// mutation path for embedding jobs remains the bounded owner routines.
+func memoryEmbeddingWorkerControlsAvailable(ctx context.Context, q queryer) (bool, error) {
+	var available bool
+	err := q.QueryRowContext(ctx, `WITH objects AS (
+    SELECT to_regprocedure('brain.claim_embedding_jobs(uuid,integer,bigint)') AS claim_oid,
+           to_regprocedure('brain.retry_embedding_job(uuid,uuid,bigint,bytea,uuid,bigint,bigint,text)') AS retry_oid
+), routine_safety AS (
+    SELECT count(*)=2 AND bool_and(pg_get_userbyid(proc.proowner)='punaro_owner'
+        AND proc.prokind='f' AND proc.prosecdef AND proc.provolatile='v'
+        AND proc.prolang=(SELECT oid FROM pg_language WHERE lanname='plpgsql')
+        AND proc.proconfig=ARRAY['search_path=pg_catalog']::text[]
+        AND ((proc.oid=claim_oid AND md5(btrim(proc.prosrc,E' \n\r\t'))=$1)
+          OR (proc.oid=retry_oid AND md5(btrim(proc.prosrc,E' \n\r\t'))=$2))) AS exact
+    FROM pg_proc AS proc,objects WHERE proc.oid=ANY(ARRAY[claim_oid,retry_oid])
+), routine_acl AS (
+    SELECT count(*)=2
+       AND NOT EXISTS (SELECT * FROM (VALUES
+           ('brain.claim_embedding_jobs(uuid,integer,bigint)','punaro_owner','EXECUTE',false),
+           ('brain.claim_embedding_jobs(uuid,integer,bigint)','punaro_app','EXECUTE',false),
+           ('brain.retry_embedding_job(uuid,uuid,bigint,bytea,uuid,bigint,bigint,text)','punaro_owner','EXECUTE',false),
+           ('brain.retry_embedding_job(uuid,uuid,bigint,bytea,uuid,bigint,bigint,text)','punaro_app','EXECUTE',false)
+       ) AS expected(signature,grantee,privilege_type,is_grantable)
+       EXCEPT
+       SELECT proc.oid::regprocedure::text,COALESCE(role.rolname,'PUBLIC'),entry.privilege_type,entry.is_grantable
+       FROM pg_proc AS proc
+       CROSS JOIN LATERAL aclexplode(COALESCE(proc.proacl,acldefault('f',proc.proowner))) AS entry
+       LEFT JOIN pg_roles AS role ON role.oid=entry.grantee,objects
+       WHERE proc.oid=ANY(ARRAY[claim_oid,retry_oid]))
+       AND NOT EXISTS (
+       SELECT proc.oid::regprocedure::text,COALESCE(role.rolname,'PUBLIC'),entry.privilege_type,entry.is_grantable
+       FROM pg_proc AS proc
+       CROSS JOIN LATERAL aclexplode(COALESCE(proc.proacl,acldefault('f',proc.proowner))) AS entry
+       LEFT JOIN pg_roles AS role ON role.oid=entry.grantee,objects
+       WHERE proc.oid=ANY(ARRAY[claim_oid,retry_oid])
+       EXCEPT
+       SELECT * FROM (VALUES
+           ('brain.claim_embedding_jobs(uuid,integer,bigint)','punaro_owner','EXECUTE',false),
+           ('brain.claim_embedding_jobs(uuid,integer,bigint)','punaro_app','EXECUTE',false),
+           ('brain.retry_embedding_job(uuid,uuid,bigint,bytea,uuid,bigint,bigint,text)','punaro_owner','EXECUTE',false),
+           ('brain.retry_embedding_job(uuid,uuid,bigint,bytea,uuid,bigint,bigint,text)','punaro_app','EXECUTE',false)
+       ) AS expected(signature,grantee,privilege_type,is_grantable)) AS exact
+    FROM pg_proc AS proc,objects WHERE proc.oid=ANY(ARRAY[claim_oid,retry_oid])
+)
+SELECT claim_oid IS NOT NULL AND retry_oid IS NOT NULL AND routine_safety.exact AND routine_acl.exact
+FROM objects,routine_safety,routine_acl`, memoryEmbeddingClaimRoutineMD5, memoryEmbeddingRetryRoutineMD5).Scan(&available)
+	return available, err
+}
+
+const (
+	memoryEmbeddingClaimRoutineMD5 = "d211877029240bc95f35abb2b00df576"
+	memoryEmbeddingRetryRoutineMD5 = "06f3d49f9ba794dd42ccdfe0ddfd9e0a"
+)

--- a/internal/postgres/db.go
+++ b/internal/postgres/db.go
@@ -1133,11 +1133,18 @@ FROM objects, table_ownership, routine_safety, routine_acl, table_acl, schema_ac
 		snapshot.CurrentObjectsPresent = reconciliationObjectsPresent
 	}
 	if snapshot.CurrentObjectsPresent && len(snapshot.Records) > 0 && snapshot.Records[len(snapshot.Records)-1].Version >= 23 {
-		embeddingObjectsPresent, err := memoryEmbeddingControlsAvailable(ctx, q)
+		embeddingObjectsPresent, err := memoryEmbeddingControlsAvailable(ctx, q, snapshot.Records[len(snapshot.Records)-1].Version)
 		if err != nil {
 			return Snapshot{}, errors.New("PostgreSQL memory embedding schema cannot be inspected")
 		}
 		snapshot.CurrentObjectsPresent = embeddingObjectsPresent
+	}
+	if snapshot.CurrentObjectsPresent && len(snapshot.Records) > 0 && snapshot.Records[len(snapshot.Records)-1].Version >= 24 {
+		embeddingWorkerObjectsPresent, err := memoryEmbeddingWorkerControlsAvailable(ctx, q)
+		if err != nil {
+			return Snapshot{}, errors.New("PostgreSQL memory embedding worker schema cannot be inspected")
+		}
+		snapshot.CurrentObjectsPresent = embeddingWorkerObjectsPresent
 	}
 	return snapshot, nil
 }

--- a/internal/postgres/migrate.go
+++ b/internal/postgres/migrate.go
@@ -56,6 +56,7 @@ var migrationCompatibilityFloors = map[int64]int64{
 	21: 10,
 	22: 10,
 	23: 10,
+	24: 10,
 }
 
 // CurrentManifest returns the immutable migrations embedded in this binary.

--- a/internal/postgres/migrations/024_memory_embedding_worker_control.sql
+++ b/internal/postgres/migrations/024_memory_embedding_worker_control.sql
@@ -1,0 +1,103 @@
+ALTER TABLE brain.embedding_jobs ADD COLUMN available_at timestamptz NOT NULL DEFAULT statement_timestamp();
+DROP INDEX brain.embedding_jobs_claim_order;
+CREATE INDEX embedding_jobs_claim_order
+ON brain.embedding_jobs (generation_id, available_at, created_at, item_id)
+WHERE state='queued';
+
+CREATE OR REPLACE FUNCTION brain.queue_embedding_revision()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog
+AS $function$
+BEGIN
+    INSERT INTO brain.embedding_jobs (generation_id, item_id, revision, content_sha256)
+    SELECT generation.id, NEW.item_id, NEW.revision, NEW.content_sha256
+    FROM brain.embedding_generations AS generation
+    WHERE generation.state = 'active'
+    ON CONFLICT (generation_id, item_id) DO UPDATE
+    SET revision = EXCLUDED.revision,
+        content_sha256 = EXCLUDED.content_sha256,
+        state = 'queued', attempts = 0,
+        lease_holder = NULL, lease_token = NULL,
+        lease_generation = brain.embedding_jobs.lease_generation + 1,
+        lease_until = NULL, available_at = statement_timestamp(),
+        last_error_code = NULL, updated_at = statement_timestamp(), completed_at = NULL;
+    RETURN NEW;
+END
+$function$;
+
+CREATE FUNCTION brain.claim_embedding_jobs(requested_holder uuid, requested_limit integer, requested_lease_micros bigint)
+RETURNS TABLE(generation_id uuid, item_id uuid, revision bigint, content_sha256 bytea, attempts integer, lease_holder uuid, lease_token uuid, lease_generation bigint, lease_until timestamptz)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog
+AS $function$
+BEGIN
+    PERFORM jobs.assert_application_mutation();
+    IF requested_holder IS NULL OR requested_limit IS NULL OR requested_lease_micros IS NULL
+       OR requested_limit < 1 OR requested_limit > 32 OR requested_lease_micros < 5000000 OR requested_lease_micros > 300000000 THEN
+        RAISE EXCEPTION USING ERRCODE = '22023', MESSAGE = 'invalid embedding claim request';
+    END IF;
+    RETURN QUERY WITH exhausted AS MATERIALIZED (
+        SELECT job.generation_id, job.item_id
+        FROM brain.embedding_jobs AS job
+        WHERE job.state='running' AND job.lease_until <= statement_timestamp() AND job.attempts >= 25
+        ORDER BY job.lease_until, job.created_at, job.item_id
+        FOR UPDATE SKIP LOCKED
+        LIMIT requested_limit
+    ), failed AS (
+        UPDATE brain.embedding_jobs AS job
+        SET state='failed', lease_holder=NULL, lease_token=NULL, lease_until=NULL,
+            last_error_code='attempts_exhausted', completed_at=statement_timestamp(), updated_at=statement_timestamp()
+        FROM exhausted
+        WHERE job.generation_id=exhausted.generation_id AND job.item_id=exhausted.item_id
+    ), candidates AS MATERIALIZED (
+        SELECT job.generation_id, job.item_id
+        FROM brain.embedding_jobs AS job
+        WHERE job.attempts < 25 AND ((job.state='queued' AND job.available_at <= statement_timestamp()) OR (job.state='running' AND job.lease_until <= statement_timestamp()))
+        ORDER BY COALESCE(job.lease_until, job.available_at), job.created_at, job.item_id
+        FOR UPDATE SKIP LOCKED
+        LIMIT requested_limit
+    )
+    UPDATE brain.embedding_jobs AS job
+    SET state='running', attempts=job.attempts+1, lease_holder=requested_holder, lease_token=gen_random_uuid(),
+        lease_generation=job.lease_generation+1, lease_until=statement_timestamp() + (requested_lease_micros * interval '1 microsecond'),
+        last_error_code=NULL, completed_at=NULL, updated_at=statement_timestamp()
+    FROM candidates
+    WHERE job.generation_id=candidates.generation_id AND job.item_id=candidates.item_id
+    RETURNING job.generation_id,job.item_id,job.revision,job.content_sha256,job.attempts,job.lease_holder,job.lease_token,job.lease_generation,job.lease_until;
+END
+$function$;
+
+CREATE FUNCTION brain.retry_embedding_job(requested_generation uuid, requested_item uuid, requested_revision bigint, requested_sha256 bytea, requested_token uuid, requested_lease_generation bigint, requested_delay_micros bigint, requested_error_code text)
+RETURNS boolean
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog
+AS $function$
+BEGIN
+    PERFORM jobs.assert_application_mutation();
+    IF requested_generation IS NULL OR requested_item IS NULL OR requested_revision IS NULL OR requested_sha256 IS NULL
+       OR requested_token IS NULL OR requested_lease_generation IS NULL OR requested_delay_micros IS NULL OR requested_error_code IS NULL
+       OR requested_revision < 1 OR octet_length(requested_sha256) <> 32 OR requested_lease_generation < 1
+       OR requested_delay_micros < 0 OR requested_delay_micros > 3600000000
+       OR requested_error_code !~ '^[a-z][a-z0-9_.:-]{0,127}$' THEN
+        RAISE EXCEPTION USING ERRCODE = '22023', MESSAGE = 'invalid embedding retry request';
+    END IF;
+    UPDATE brain.embedding_jobs
+    SET state=CASE WHEN attempts >= 25 THEN 'failed' ELSE 'queued' END,
+        available_at=CASE WHEN attempts >= 25 THEN available_at ELSE statement_timestamp() + (requested_delay_micros * interval '1 microsecond') END,
+        lease_holder=NULL, lease_token=NULL, lease_until=NULL,
+        last_error_code=requested_error_code,
+        completed_at=CASE WHEN attempts >= 25 THEN statement_timestamp() ELSE NULL END,
+        updated_at=statement_timestamp()
+    WHERE generation_id=requested_generation AND item_id=requested_item AND revision=requested_revision
+      AND content_sha256=requested_sha256 AND state='running' AND lease_token=requested_token
+      AND lease_generation=requested_lease_generation AND lease_until > statement_timestamp();
+    RETURN FOUND;
+END
+$function$;
+
+REVOKE ALL ON FUNCTION brain.claim_embedding_jobs(uuid,integer,bigint), brain.retry_embedding_job(uuid,uuid,bigint,bytea,uuid,bigint,bigint,text) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION brain.claim_embedding_jobs(uuid,integer,bigint), brain.retry_embedding_job(uuid,uuid,bigint,bytea,uuid,bigint,bigint,text) TO punaro_app;

--- a/internal/postgres/state_test.go
+++ b/internal/postgres/state_test.go
@@ -69,13 +69,13 @@ func TestManifestValidationRejectsMutableOrNonContiguousHistory(t *testing.T) {
 
 func TestCurrentManifestRequiresControlPlaneSchema(t *testing.T) {
 	manifest := CurrentManifest()
-	if manifest.MinSupported != 10 || manifest.MaxSupported != 23 || len(manifest.Migrations) != 23 {
-		t.Fatalf("manifest=%#v, want exact v10-v23 compatibility window", manifest)
+	if manifest.MinSupported != 10 || manifest.MaxSupported != 24 || len(manifest.Migrations) != 24 {
+		t.Fatalf("manifest=%#v, want exact v10-v24 compatibility window", manifest)
 	}
-	embedding := manifest.Migrations[22]
-	if embedding.Version != 23 || embedding.Name != "023_memory_embedding_frontier" ||
-		embedding.CompatibilityFloor != 10 || !strings.Contains(embedding.SQL, "CREATE FUNCTION brain.queue_embedding_revision") {
-		t.Fatalf("unexpected embedding-frontier migration: %#v", embedding)
+	embedding := manifest.Migrations[23]
+	if embedding.Version != 24 || embedding.Name != "024_memory_embedding_worker_control" ||
+		embedding.CompatibilityFloor != 10 || !strings.Contains(embedding.SQL, "CREATE FUNCTION brain.claim_embedding_jobs") {
+		t.Fatalf("unexpected embedding-worker migration: %#v", embedding)
 	}
 	for index, migration := range manifest.Migrations {
 		want := int64(index + 1)
@@ -88,7 +88,7 @@ func TestCurrentManifestRequiresControlPlaneSchema(t *testing.T) {
 			want = 10
 		case 12, 13:
 			want = 10
-		case 14, 15, 16, 17, 18, 19, 20, 21, 22, 23:
+		case 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24:
 			want = 10
 		}
 		if migration.CompatibilityFloor != want {
@@ -156,7 +156,10 @@ func TestCompatibleSchemaCanStillHavePendingMigrations(t *testing.T) {
 	if !migrationPending(SchemaState{Classification: Compatible, Version: 22}, manifest) {
 		t.Fatal("compatible v22 schema must still apply the pending v23 migration")
 	}
-	if migrationPending(SchemaState{Classification: Compatible, Version: 23}, manifest) {
-		t.Fatal("current v23 schema reported a pending migration")
+	if !migrationPending(SchemaState{Classification: Compatible, Version: 23}, manifest) {
+		t.Fatal("compatible v23 schema must still apply the pending v24 migration")
+	}
+	if migrationPending(SchemaState{Classification: Compatible, Version: 24}, manifest) {
+		t.Fatal("current v24 schema reported a pending migration")
 	}
 }


### PR DESCRIPTION
## What changed

Adds M19B's provider-free embedding worker control plane:

- schema v24 adds database-time scheduled retries for embedding work;
- owner-only claim/retry routines provide bounded `SKIP LOCKED` leases with fresh token and monotonic generation fencing;
- stale, replayed, or superseded revision/hash/lease coordinates cannot mutate current work;
- the final permitted attempt records only a constrained terminal diagnostic;
- readiness verifies worker-routine ownership, security-definer configuration, application execution access, and the v24 scheduled-claim index.

## Why

This supplies the durable worker lifecycle needed before later slices add a provider, chunk text, vector storage, or semantic retrieval. Canonical memory, lexical search, prompt briefs, and mail remain independent of worker availability.

## Validation

- `make test`
- `make test-race`
- `make staticcheck`
- `make security`
- `make lint`
- `go test -count=1 -timeout=8m ./internal/postgres` against an isolated PostgreSQL 18.4 cluster
- `git diff --check`

No provider, credentials, chunks, vectors, success publication, semantic ranking, generation rebuild, ANN, CLI/MCP surface, or Compose Pi behavior is included.