### PR TITLE
Add embedding generation rebuild foundation

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -409,6 +409,20 @@ and terminally completes the exact unexpired lease only while the revision is
 current. It still stores no fragment text, provider credential, vector, index,
 or semantic result.
 
+Schema version 26 establishes the rebuild starting boundary without activating
+semantic retrieval. A schema-owner-only routine takes the same
+transaction-scoped advisory fence as revision enqueueing, then locks the
+installation change-sequence row and records that sequence on one immutable
+`building` generation. The revision enqueue trigger takes the shared form of
+that advisory fence,
+so every subsequent revision is atomically queued for both immutable active
+and building generations. The bounded, resumable scan of canonical revisions
+at or before that watermark remains the following rebuild-worker slice; start
+itself never scans an unbounded corpus. At most one building generation exists;
+the active generation remains the sole serving generation. There is still no
+provider, vector storage, caught-up watermark, activation, semantic ranking,
+or client-facing semantic surface.
+
 Schema version 15 places one deterministic secret guard inside the authorized
 create/update transaction before any scope, revision, change, audit,
 idempotency result, or derived job can be written. Findings contain only the

--- a/docs/platform-contracts.md
+++ b/docs/platform-contracts.md
@@ -345,6 +345,22 @@ one transaction; stale or replayed publications alter neither rows nor job.
 Chunk text, vectors, indexes, provider configuration, and semantic retrieval
 remain out of scope.
 
+Schema 26 begins a fenced generation rebuild while keeping the active
+generation as the only serving generation. The owner-only start routine holds
+a transaction-scoped advisory fence before the installation change-sequence
+row lock, records the current sequence on a single immutable `building`
+generation, and returns without scanning canonical rows. The memory-revision
+enqueue trigger holds the same advisory fence before selecting active/building
+generations, so every later revision queues for both. Ordinary enqueues use
+the shared advisory lock while rebuild start retains its exclusive lock. The following
+rebuild-worker slice must scan revisions at or before the recorded watermark
+through a bounded, resumable cursor; start itself cannot block ordinary writes
+or allocate one derived job per corpus item. Application callers cannot start
+a rebuild or mutate generation rows directly. Worker execution, caught-up
+watermarking, validation, activation, vectors, semantic search, and RRF remain
+later slices; rollback again requires verified pre-update restore because the
+schema is additive derived control state.
+
 The dark prompt-brief read adds no schema and exposes no route or client. It
 accepts the same bounded normalized query as lexical search, resolves the
 active canonical project, and requires only `memory.search` because it returns

--- a/internal/postgres/brain_embedding.go
+++ b/internal/postgres/brain_embedding.go
@@ -19,14 +19,17 @@ const (
 
 var memoryEmbeddingRevisionPattern = regexp.MustCompile(`^[a-z0-9][a-z0-9_.:-]{0,63}$`)
 
-// MemoryEmbeddingGenerationState is the closed state for the one M19A
-// generation that may receive revision-bound work. M20 extends this with a
-// building state and atomic activation; M19A rows are otherwise immutable.
+// MemoryEmbeddingGenerationState is the closed state for an immutable derived
+// generation. M20A introduces a building generation beside the active one;
+// later M20 slices add caught-up validation and atomic activation.
 type MemoryEmbeddingGenerationState string
 
 const (
 	// MemoryEmbeddingGenerationActive accepts work for one pinned model.
 	MemoryEmbeddingGenerationActive MemoryEmbeddingGenerationState = "active"
+	// MemoryEmbeddingGenerationBuilding receives rebuild work but does not serve
+	// semantic retrieval until a later fenced activation slice validates it.
+	MemoryEmbeddingGenerationBuilding MemoryEmbeddingGenerationState = "building"
 )
 
 // MemoryEmbeddingGeneration pins the non-secret identity and dimensionality of
@@ -44,7 +47,7 @@ type MemoryEmbeddingGeneration struct {
 func (g MemoryEmbeddingGeneration) Validate() error {
 	if !validOpaqueID(g.ID) || !validMemoryToken(g.Model) || !memoryEmbeddingRevisionPattern.MatchString(g.Revision) ||
 		g.Dimensions < 1 || g.Dimensions > maxMemoryEmbeddingDimensions ||
-		g.State != MemoryEmbeddingGenerationActive {
+		g.State != MemoryEmbeddingGenerationActive && g.State != MemoryEmbeddingGenerationBuilding {
 		return errors.New("invalid memory embedding generation")
 	}
 	return nil

--- a/internal/postgres/brain_embedding_integration_test.go
+++ b/internal/postgres/brain_embedding_integration_test.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -19,6 +20,11 @@ func testMemoryEmbeddingSchemaDriftIntegration(ctx context.Context, t *testing.T
 		{"application read", `REVOKE SELECT ON brain.embedding_generations FROM punaro_app`, `GRANT SELECT ON brain.embedding_generations TO punaro_app`},
 		{"queue trigger", `ALTER TABLE brain.memory_revisions DISABLE TRIGGER memory_revision_embedding_queue`, `ALTER TABLE brain.memory_revisions ENABLE TRIGGER memory_revision_embedding_queue`},
 		{"claim index", `DROP INDEX brain.embedding_jobs_claim_order`, `CREATE INDEX embedding_jobs_claim_order ON brain.embedding_jobs (generation_id, available_at, created_at, item_id) WHERE state='queued'`},
+		{"building generation index", `DROP INDEX brain.embedding_generations_one_building`, `CREATE UNIQUE INDEX embedding_generations_one_building ON brain.embedding_generations ((true)) WHERE state='building'`},
+		{"building generation key expression", `DROP INDEX brain.embedding_generations_one_building; CREATE UNIQUE INDEX embedding_generations_one_building ON brain.embedding_generations (id) WHERE state='building'`, `DROP INDEX brain.embedding_generations_one_building; CREATE UNIQUE INDEX embedding_generations_one_building ON brain.embedding_generations ((true)) WHERE state='building'`},
+		{"generation state fence", `ALTER TABLE brain.embedding_generations DROP CONSTRAINT embedding_generations_state_check; ALTER TABLE brain.embedding_generations ADD CONSTRAINT embedding_generations_state_check CHECK (state IS NOT NULL)`, `ALTER TABLE brain.embedding_generations DROP CONSTRAINT embedding_generations_state_check; ALTER TABLE brain.embedding_generations ADD CONSTRAINT embedding_generations_state_check CHECK ((state = 'active' AND start_change_sequence IS NULL) OR (state = 'building' AND start_change_sequence >= 0))`},
+		{"legacy generation tuple uniqueness", `ALTER TABLE brain.embedding_generations ADD CONSTRAINT embedding_generations_model_model_revision_dimensions_key UNIQUE (model,model_revision,dimensions)`, `ALTER TABLE brain.embedding_generations DROP CONSTRAINT embedding_generations_model_model_revision_dimensions_key`},
+		{"rebuild routine ACL", `GRANT EXECUTE ON FUNCTION brain.start_embedding_generation(text,text,integer) TO punaro_app`, `REVOKE EXECUTE ON FUNCTION brain.start_embedding_generation(text,text,integer) FROM punaro_app`},
 		{"worker routine ACL", `REVOKE EXECUTE ON FUNCTION brain.retry_embedding_job(uuid,uuid,bigint,bytea,uuid,bigint,bigint,text) FROM punaro_app`, `GRANT EXECUTE ON FUNCTION brain.retry_embedding_job(uuid,uuid,bigint,bytea,uuid,bigint,bigint,text) TO punaro_app`},
 		{"worker routine public ACL", `GRANT EXECUTE ON FUNCTION brain.claim_embedding_jobs(uuid,integer,bigint) TO PUBLIC`, `REVOKE EXECUTE ON FUNCTION brain.claim_embedding_jobs(uuid,integer,bigint) FROM PUBLIC`},
 		{"worker routine security", `ALTER FUNCTION brain.claim_embedding_jobs(uuid,integer,bigint) SECURITY INVOKER`, `ALTER FUNCTION brain.claim_embedding_jobs(uuid,integer,bigint) SECURITY DEFINER`},
@@ -48,6 +54,40 @@ func testMemoryEmbeddingSchemaDriftIntegration(ctx context.Context, t *testing.T
 		})
 	}
 	testMemoryEmbeddingPublicationReturnTypeDrift(ctx, t, app, ownerDB)
+	testMemoryEmbeddingRebuildRoutineACLDrift(ctx, t, app, ownerDB)
+}
+
+func testMemoryEmbeddingRebuildRoutineACLDrift(ctx context.Context, t *testing.T, app *Database, ownerDB *sql.DB) {
+	t.Helper()
+	const role = "embedding_rebuild_unexpected"
+	if _, err := ownerDB.ExecContext(ctx, `CREATE ROLE `+role+` NOLOGIN`); err != nil { // #nosec G202 -- fixed role name.
+		t.Fatal(err)
+	}
+	defer func() { _, _ = ownerDB.ExecContext(context.Background(), `DROP ROLE `+role) }()                                                        // #nosec G202 -- fixed role name.
+	if _, err := ownerDB.ExecContext(ctx, `GRANT EXECUTE ON FUNCTION brain.start_embedding_generation(text,text,integer) TO `+role); err != nil { // #nosec G202 -- fixed role name.
+		t.Fatal(err)
+	}
+	if err := app.Ready(ctx); err == nil {
+		t.Fatal("readiness accepted unexpected rebuild routine grantee")
+	}
+	if _, err := ownerDB.ExecContext(ctx, `REVOKE EXECUTE ON FUNCTION brain.start_embedding_generation(text,text,integer) FROM `+role); err != nil { // #nosec G202 -- fixed role name.
+		t.Fatal(err)
+	}
+	if err := app.Ready(ctx); err != nil {
+		t.Fatalf("readiness did not recover after rebuild routine ACL restoration: %v", err)
+	}
+	if _, err := ownerDB.ExecContext(ctx, `GRANT EXECUTE ON FUNCTION brain.start_embedding_generation(text,text,integer) TO PUBLIC`); err != nil {
+		t.Fatal(err)
+	}
+	if err := app.Ready(ctx); err == nil {
+		t.Fatal("readiness accepted public rebuild routine grantee")
+	}
+	if _, err := ownerDB.ExecContext(ctx, `REVOKE EXECUTE ON FUNCTION brain.start_embedding_generation(text,text,integer) FROM PUBLIC`); err != nil {
+		t.Fatal(err)
+	}
+	if err := app.Ready(ctx); err != nil {
+		t.Fatalf("readiness did not recover after public rebuild routine ACL restoration: %v", err)
+	}
 }
 
 func testMemoryEmbeddingPublicationReturnTypeDrift(ctx context.Context, t *testing.T, app *Database, ownerDB *sql.DB) {
@@ -354,5 +394,89 @@ func testMemoryEmbeddingQueueIntegration(ctx context.Context, t *testing.T, app 
 	}
 	if err := ownerDB.QueryRowContext(ctx, `SELECT count(*) FROM brain.embedding_chunks WHERE generation_id=$1 AND item_id=$2`, generationID, superseded.ItemID).Scan(&count); err != nil || count != 0 {
 		t.Fatalf("superseded embedding chunks=%d err=%v", count, err)
+	}
+}
+
+func testMemoryEmbeddingGenerationRebuildIntegration(ctx context.Context, t *testing.T, app *Database, ownerDB *sql.DB) {
+	t.Helper()
+	actor, err := app.CreatePrincipal(ctx, PrincipalKindDevice, "embedding rebuild actor")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var projectID string
+	if err := ownerDB.QueryRowContext(ctx, `INSERT INTO relay.projects(display_name,created_by) VALUES ('embedding rebuild project',$1) RETURNING id::text`, actor.ID).Scan(&projectID); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ownerDB.ExecContext(ctx, `INSERT INTO auth.capability_grants(principal_id,scope,project_id,capability) VALUES ($1,'project',$2,$3)`, actor.ID, projectID, CapabilityMemoryWrite); err != nil {
+		t.Fatal(err)
+	}
+	create := func(key, title string) MemoryMutationResult {
+		t.Helper()
+		result, createErr := app.CreateMemory(ctx, MemoryCreateRequest{PrincipalID: actor.ID, ProjectID: projectID, IdempotencyKey: key, LogicalKey: "rebuild-" + key, Kind: "decision", Trust: "curated", Document: json.RawMessage(`{"title":` + strconvQuote(title) + `}`)})
+		if createErr != nil {
+			t.Fatal(createErr)
+		}
+		return result
+	}
+	before := create("19191919-1919-4191-8191-191919191941", "before rebuild")
+	var activeID string
+	if err := ownerDB.QueryRowContext(ctx, `SELECT id::text FROM brain.embedding_generations WHERE state='active'`).Scan(&activeID); err != nil {
+		t.Fatalf("active generation: %v", err)
+	}
+	var beforeSequence, buildingSequence int64
+	if err := ownerDB.QueryRowContext(ctx, `SELECT change_sequence FROM jobs.server_state WHERE singleton`).Scan(&beforeSequence); err != nil {
+		t.Fatal(err)
+	}
+	var buildingID string
+	if err := ownerDB.QueryRowContext(ctx, `SELECT generation_id::text,start_change_sequence FROM brain.start_embedding_generation($1,$2,$3)`, "local.e5-base", "2026-07-01", 768).Scan(&buildingID, &buildingSequence); err != nil {
+		t.Fatalf("start embedding rebuild: %v", err)
+	}
+	if buildingSequence != beforeSequence {
+		t.Fatalf("building watermark=%d want start sequence %d", buildingSequence, beforeSequence)
+	}
+	var state string
+	if err := ownerDB.QueryRowContext(ctx, `SELECT state FROM brain.embedding_generations WHERE id=$1`, buildingID).Scan(&state); err != nil || state != "building" {
+		t.Fatalf("building generation state=%q err=%v", state, err)
+	}
+	var revision int64
+	var beforeJobs int
+	if err := ownerDB.QueryRowContext(ctx, `SELECT count(*) FROM brain.embedding_jobs WHERE generation_id=$1 AND item_id=$2`, buildingID, before.ItemID).Scan(&beforeJobs); err != nil || beforeJobs != 0 {
+		t.Fatalf("unbounded rebuild snapshot jobs=%d err=%v", beforeJobs, err)
+	}
+	after := create("19191919-1919-4191-8191-191919191942", "after rebuild")
+	for _, generationID := range []string{activeID, buildingID} {
+		if err := ownerDB.QueryRowContext(ctx, `SELECT revision FROM brain.embedding_jobs WHERE generation_id=$1 AND item_id=$2`, generationID, after.ItemID).Scan(&revision); err != nil || revision != after.Revision {
+			t.Fatalf("generation %s post-start job revision=%d want=%d err=%v", generationID, revision, after.Revision, err)
+		}
+	}
+	updated, err := app.UpdateMemory(ctx, MemoryUpdateRequest{PrincipalID: actor.ID, ProjectID: projectID, ItemID: after.ItemID, IdempotencyKey: "19191919-1919-4191-8191-191919191943", ExpectedETag: after.ETag, LogicalKey: "rebuild-19191919-1919-4191-8191-191919191942", Kind: "decision", Trust: "curated", Document: json.RawMessage(`{"title":"after rebuild revised"}`)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, generationID := range []string{activeID, buildingID} {
+		if err := ownerDB.QueryRowContext(ctx, `SELECT revision FROM brain.embedding_jobs WHERE generation_id=$1 AND item_id=$2`, generationID, updated.ItemID).Scan(&revision); err != nil || revision != updated.Revision {
+			t.Fatalf("generation %s coalesced job revision=%d want=%d err=%v", generationID, revision, updated.Revision, err)
+		}
+	}
+	concurrentCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+	concurrentResults := make(chan error, 8)
+	for i := 0; i < cap(concurrentResults); i++ {
+		i := i
+		go func() {
+			_, createErr := app.CreateMemory(concurrentCtx, MemoryCreateRequest{PrincipalID: actor.ID, ProjectID: projectID, IdempotencyKey: fmt.Sprintf("19191919-1919-4191-8191-%012d", 1944+i), LogicalKey: fmt.Sprintf("rebuild-concurrent-%d", i), Kind: "decision", Trust: "curated", Document: json.RawMessage(`{"title":"concurrent rebuild write"}`)})
+			concurrentResults <- createErr
+		}()
+	}
+	for i := 0; i < cap(concurrentResults); i++ {
+		if createErr := <-concurrentResults; createErr != nil {
+			t.Fatalf("concurrent embedding enqueue write %d: %v", i, createErr)
+		}
+	}
+	if _, err := ownerDB.ExecContext(ctx, `SELECT generation_id FROM brain.start_embedding_generation($1,$2,$3)`, "local.e5-xl", "2026-07-01", 1536); err == nil {
+		t.Fatal("second building generation succeeded")
+	}
+	if _, err := app.db.ExecContext(ctx, `SELECT generation_id FROM brain.start_embedding_generation($1,$2,$3)`, "local.e5-xl", "2026-07-01", 1536); err == nil {
+		t.Fatal("application role started an embedding rebuild")
 	}
 }

--- a/internal/postgres/brain_embedding_rebuild_schema.go
+++ b/internal/postgres/brain_embedding_rebuild_schema.go
@@ -1,0 +1,60 @@
+package postgres
+
+import "context"
+
+// memoryEmbeddingRebuildControlsAvailable verifies the schema-v26 boundary:
+// a schema-owner-only building generation may be created beside, but never
+// replaces, the immutable active generation in this slice.
+func memoryEmbeddingRebuildControlsAvailable(ctx context.Context, q queryer) (bool, error) {
+	var available bool
+	err := q.QueryRowContext(ctx, `WITH objects AS (
+    SELECT to_regclass('brain.embedding_generations') AS generations_oid,
+           to_regprocedure('brain.start_embedding_generation(text,text,integer)') AS start_oid,
+           to_regprocedure('brain.queue_embedding_revision()') AS queue_oid
+), generation_state AS (
+    SELECT count(*) = 1 AND bool_and(constraint_row.convalidated AND NOT constraint_row.condeferrable
+        AND NOT constraint_row.condeferred AND pg_get_expr(constraint_row.conbin,constraint_row.conrelid)
+        = '(((state = ''active''::text) AND (start_change_sequence IS NULL)) OR ((state = ''building''::text) AND (start_change_sequence >= 0)))') AS exact
+    FROM pg_constraint AS constraint_row,objects
+    WHERE constraint_row.conrelid=generations_oid AND constraint_row.conname='embedding_generations_state_check'
+), generation_tuple AS (
+    SELECT NOT EXISTS (
+        SELECT 1
+        FROM pg_constraint AS constraint_row,objects
+        WHERE constraint_row.conrelid=generations_oid
+          AND constraint_row.conname='embedding_generations_model_model_revision_dimensions_key'
+    ) AS exact
+), routines AS (
+    SELECT count(*) = 2 AND bool_and(proc.prokind='f' AND proc.prosecdef AND proc.provolatile='v'
+        AND proc.prolang=(SELECT oid FROM pg_language WHERE lanname='plpgsql')
+        AND proc.proconfig=ARRAY['search_path=pg_catalog']::text[]
+        AND pg_get_userbyid(proc.proowner)='punaro_owner'
+        AND ((proc.oid=queue_oid AND md5(btrim(proc.prosrc,E' \n\r\t'))=$1)
+          OR (proc.oid=start_oid AND md5(btrim(proc.prosrc,E' \n\r\t'))=$2))) AS exact
+    FROM pg_proc AS proc,objects WHERE proc.oid=ANY(ARRAY[start_oid,queue_oid])
+), start_signature AS (
+    SELECT start_oid IS NOT NULL AND pg_get_function_result(start_oid)='TABLE(generation_id uuid, start_change_sequence bigint)'
+       AS exact
+    FROM objects
+), expected_start_acl(grantee,privilege_type,is_grantable) AS (
+    VALUES ('punaro_owner','EXECUTE',false)
+), actual_start_acl AS (
+    SELECT COALESCE(role.rolname,'PUBLIC'),entry.privilege_type,entry.is_grantable
+    FROM pg_proc AS proc
+    CROSS JOIN LATERAL aclexplode(COALESCE(proc.proacl,acldefault('f',proc.proowner))) AS entry
+    LEFT JOIN pg_roles AS role ON role.oid=entry.grantee,objects
+    WHERE proc.oid=start_oid
+), start_acl AS (
+    SELECT NOT EXISTS (SELECT * FROM expected_start_acl EXCEPT SELECT * FROM actual_start_acl)
+       AND NOT EXISTS (SELECT * FROM actual_start_acl EXCEPT SELECT * FROM expected_start_acl) AS exact
+)
+SELECT generations_oid IS NOT NULL AND start_oid IS NOT NULL AND queue_oid IS NOT NULL
+   AND generation_state.exact AND generation_tuple.exact AND routines.exact AND start_signature.exact AND start_acl.exact
+FROM objects,generation_state,generation_tuple,routines,start_signature,start_acl`, memoryEmbeddingRebuildQueueRoutineMD5, memoryEmbeddingRebuildStartRoutineMD5).Scan(&available)
+	return available, err
+}
+
+const (
+	memoryEmbeddingRebuildQueueRoutineMD5 = "b09c65e6d07819ec41948de85675de5c"
+	memoryEmbeddingRebuildStartRoutineMD5 = "ef8ca889c0937b89d9ea3406aff994c4"
+)

--- a/internal/postgres/brain_embedding_schema.go
+++ b/internal/postgres/brain_embedding_schema.go
@@ -13,6 +13,7 @@ WITH objects AS (
     SELECT to_regclass('brain.embedding_generations') AS generations_oid,
            to_regclass('brain.embedding_jobs') AS jobs_oid,
            to_regclass('brain.embedding_generations_one_active') AS active_index_oid,
+		   to_regclass('brain.embedding_generations_one_building') AS building_index_oid,
            to_regclass('brain.embedding_jobs_claim_order') AS claim_index_oid,
            to_regclass('brain.embedding_jobs_expired_lease') AS expired_index_oid,
            to_regprocedure('brain.queue_embedding_revision()') AS queue_oid,
@@ -41,6 +42,8 @@ WITH objects AS (
       ('brain.embedding_jobs','completed_at','timestamp with time zone',false)
     UNION ALL
     SELECT 'brain.embedding_jobs','available_at','timestamp with time zone',true WHERE $1 >= 24
+	UNION ALL
+	SELECT 'brain.embedding_generations','start_change_sequence','bigint',false WHERE $1 >= 26
 ), actual_columns AS (
     SELECT attribute.attrelid::regclass::text,attribute.attname,attribute.atttypid::regtype::text,attribute.attnotnull
     FROM pg_attribute AS attribute,objects
@@ -57,6 +60,13 @@ WITH objects AS (
 ), index_safety AS (
     SELECT active_index_oid IS NOT NULL AND claim_index_oid IS NOT NULL AND expired_index_oid IS NOT NULL
       AND EXISTS (SELECT 1 FROM pg_index WHERE indexrelid=active_index_oid AND indisunique AND indisvalid AND indisready)
+	  AND ($1 < 26 OR (building_index_oid IS NOT NULL
+	      AND EXISTS (SELECT 1 FROM pg_index WHERE indexrelid=active_index_oid AND indisunique AND indisvalid AND indisready
+	          AND indkey='0'::int2vector AND pg_get_expr(indexprs,indrelid)='true'
+	          AND pg_get_expr(indpred,indrelid)='(state = ''active''::text)')
+	      AND EXISTS (SELECT 1 FROM pg_index WHERE indexrelid=building_index_oid AND indisunique AND indisvalid AND indisready
+	          AND indkey='0'::int2vector AND pg_get_expr(indexprs,indrelid)='true'
+	          AND pg_get_expr(indpred,indrelid)='(state = ''building''::text)')))
       AND EXISTS (SELECT 1 FROM pg_index WHERE indexrelid=claim_index_oid AND NOT indisunique AND indisvalid AND indisready
           AND pg_get_expr(indpred,indrelid)='(state = ''queued''::text)'
           AND (($1 < 24 AND indkey='1 12 2'::int2vector) OR ($1 >= 24 AND indkey='1 15 12 2'::int2vector)))

--- a/internal/postgres/brain_embedding_test.go
+++ b/internal/postgres/brain_embedding_test.go
@@ -16,6 +16,11 @@ func TestMemoryEmbeddingGenerationValidation(t *testing.T) {
 	if err := valid.Validate(); err != nil {
 		t.Fatalf("valid generation rejected: %v", err)
 	}
+	building := valid
+	building.State = MemoryEmbeddingGenerationBuilding
+	if err := building.Validate(); err != nil {
+		t.Fatalf("valid building generation rejected: %v", err)
+	}
 
 	for name, generation := range map[string]MemoryEmbeddingGeneration{
 		"friendly ID":          {ID: "friendly", Model: valid.Model, Revision: valid.Revision, Dimensions: valid.Dimensions, State: valid.State},

--- a/internal/postgres/db.go
+++ b/internal/postgres/db.go
@@ -1153,6 +1153,13 @@ FROM objects, table_ownership, routine_safety, routine_acl, table_acl, schema_ac
 		}
 		snapshot.CurrentObjectsPresent = embeddingPublicationObjectsPresent
 	}
+	if snapshot.CurrentObjectsPresent && len(snapshot.Records) > 0 && snapshot.Records[len(snapshot.Records)-1].Version >= 26 {
+		embeddingRebuildObjectsPresent, err := memoryEmbeddingRebuildControlsAvailable(ctx, q)
+		if err != nil {
+			return Snapshot{}, errors.New("PostgreSQL memory embedding rebuild schema cannot be inspected")
+		}
+		snapshot.CurrentObjectsPresent = embeddingRebuildObjectsPresent
+	}
 	return snapshot, nil
 }
 

--- a/internal/postgres/migrate.go
+++ b/internal/postgres/migrate.go
@@ -58,6 +58,7 @@ var migrationCompatibilityFloors = map[int64]int64{
 	23: 10,
 	24: 10,
 	25: 10,
+	26: 10,
 }
 
 // CurrentManifest returns the immutable migrations embedded in this binary.

--- a/internal/postgres/migrations/026_memory_embedding_generation_rebuild.sql
+++ b/internal/postgres/migrations/026_memory_embedding_generation_rebuild.sql
@@ -1,0 +1,87 @@
+ALTER TABLE brain.embedding_generations
+ADD COLUMN start_change_sequence bigint;
+
+ALTER TABLE brain.embedding_generations
+DROP CONSTRAINT embedding_generations_model_model_revision_dimensions_key;
+
+ALTER TABLE brain.embedding_generations
+DROP CONSTRAINT embedding_generations_state_check;
+
+ALTER TABLE brain.embedding_generations
+ADD CONSTRAINT embedding_generations_state_check CHECK (
+    (state = 'active' AND start_change_sequence IS NULL)
+    OR (state = 'building' AND start_change_sequence >= 0)
+);
+
+DROP INDEX brain.embedding_generations_one_active;
+
+CREATE UNIQUE INDEX embedding_generations_one_active
+ON brain.embedding_generations ((true))
+WHERE state = 'active';
+
+CREATE UNIQUE INDEX embedding_generations_one_building
+ON brain.embedding_generations ((true))
+WHERE state = 'building';
+
+CREATE OR REPLACE FUNCTION brain.queue_embedding_revision()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog
+AS $function$
+BEGIN
+    PERFORM pg_advisory_xact_lock_shared(5788618938515408205);
+    INSERT INTO brain.embedding_jobs (generation_id, item_id, revision, content_sha256)
+    SELECT generation.id, NEW.item_id, NEW.revision, NEW.content_sha256
+    FROM brain.embedding_generations AS generation
+    WHERE generation.state IN ('active', 'building')
+    ON CONFLICT (generation_id, item_id) DO UPDATE
+    SET revision = EXCLUDED.revision,
+        content_sha256 = EXCLUDED.content_sha256,
+        state = 'queued', attempts = 0,
+        lease_holder = NULL, lease_token = NULL,
+        lease_generation = brain.embedding_jobs.lease_generation + 1,
+        lease_until = NULL, available_at = statement_timestamp(),
+        last_error_code = NULL, updated_at = statement_timestamp(), completed_at = NULL;
+    RETURN NEW;
+END
+$function$;
+
+CREATE FUNCTION brain.start_embedding_generation(requested_model text, requested_model_revision text, requested_dimensions integer)
+RETURNS TABLE (generation_id uuid, start_change_sequence bigint)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog
+AS $function$
+DECLARE
+    captured_sequence bigint;
+    new_generation_id uuid;
+BEGIN
+    PERFORM jobs.assert_application_mutation();
+    IF requested_model IS NULL OR requested_model_revision IS NULL OR requested_dimensions IS NULL
+       OR requested_model !~ '^[a-z][a-z0-9_.:-]{0,63}$'
+       OR requested_model_revision !~ '^[a-z0-9][a-z0-9_.:-]{0,63}$'
+       OR requested_dimensions < 1 OR requested_dimensions > 4096 THEN
+        RAISE EXCEPTION USING ERRCODE = '22023', MESSAGE = 'invalid embedding generation';
+    END IF;
+    PERFORM pg_advisory_xact_lock(5788618938515408205);
+    PERFORM 1 FROM jobs.server_state WHERE singleton FOR UPDATE;
+    IF NOT EXISTS (SELECT 1 FROM brain.embedding_generations WHERE state = 'active') THEN
+        RAISE EXCEPTION USING ERRCODE = '23514', MESSAGE = 'active embedding generation is required';
+    END IF;
+    IF EXISTS (SELECT 1 FROM brain.embedding_generations WHERE state = 'building') THEN
+        RAISE EXCEPTION USING ERRCODE = '23505', MESSAGE = 'embedding generation rebuild already exists';
+    END IF;
+    SELECT change_sequence INTO captured_sequence
+    FROM jobs.server_state
+    WHERE singleton;
+    INSERT INTO brain.embedding_generations (model, model_revision, dimensions, state, start_change_sequence)
+    VALUES (requested_model, requested_model_revision, requested_dimensions, 'building', captured_sequence)
+    RETURNING id INTO new_generation_id;
+    generation_id := new_generation_id;
+    start_change_sequence := captured_sequence;
+    RETURN NEXT;
+END
+$function$;
+
+REVOKE ALL ON FUNCTION brain.start_embedding_generation(text,text,integer) FROM PUBLIC, punaro_app;

--- a/internal/postgres/postgres_integration_test.go
+++ b/internal/postgres/postgres_integration_test.go
@@ -459,6 +459,7 @@ RETURNS boolean LANGUAGE plpgsql SECURITY DEFINER SET search_path=pg_catalog AS 
 	testMemoryReferenceReconciliationRaces(ctx, t, app, ownerDB)
 	testMemoryConsistencyIntegration(ctx, t, app, ownerDB)
 	testMemoryEmbeddingQueueIntegration(ctx, t, app, ownerDB)
+	testMemoryEmbeddingGenerationRebuildIntegration(ctx, t, app, ownerDB)
 	testMemoryEvidenceIntegration(ctx, t, app, ownerDB)
 	testMemoryProposalIntegration(ctx, t, app, ownerDB)
 	testBackupRestoreIntegration(ctx, t, app, ownerDB, ownerFile, appFile)

--- a/internal/postgres/state_test.go
+++ b/internal/postgres/state_test.go
@@ -69,8 +69,8 @@ func TestManifestValidationRejectsMutableOrNonContiguousHistory(t *testing.T) {
 
 func TestCurrentManifestRequiresControlPlaneSchema(t *testing.T) {
 	manifest := CurrentManifest()
-	if manifest.MinSupported != 10 || manifest.MaxSupported != 25 || len(manifest.Migrations) != 25 {
-		t.Fatalf("manifest=%#v, want exact v10-v25 compatibility window", manifest)
+	if manifest.MinSupported != 10 || manifest.MaxSupported != 26 || len(manifest.Migrations) != 26 {
+		t.Fatalf("manifest=%#v, want exact v10-v26 compatibility window", manifest)
 	}
 	embedding := manifest.Migrations[23]
 	if embedding.Version != 24 || embedding.Name != "024_memory_embedding_worker_control" ||
@@ -88,7 +88,7 @@ func TestCurrentManifestRequiresControlPlaneSchema(t *testing.T) {
 			want = 10
 		case 12, 13:
 			want = 10
-		case 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25:
+		case 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26:
 			want = 10
 		}
 		if migration.CompatibilityFloor != want {
@@ -162,7 +162,10 @@ func TestCompatibleSchemaCanStillHavePendingMigrations(t *testing.T) {
 	if !migrationPending(SchemaState{Classification: Compatible, Version: 24}, manifest) {
 		t.Fatal("compatible v24 schema must still apply the pending v25 migration")
 	}
-	if migrationPending(SchemaState{Classification: Compatible, Version: 25}, manifest) {
-		t.Fatal("current v25 schema reported a pending migration")
+	if !migrationPending(SchemaState{Classification: Compatible, Version: 25}, manifest) {
+		t.Fatal("compatible v25 schema must still apply the pending v26 migration")
+	}
+	if migrationPending(SchemaState{Classification: Compatible, Version: 26}, manifest) {
+		t.Fatal("current v26 schema reported a pending migration")
 	}
 }


### PR DESCRIPTION
## Summary

- add schema v26 for active/building embedding generations and exact partial uniqueness indexes
- add an owner-only, O(1) generation-start routine that records a cutover watermark and uses an advisory fence with ordinary revision enqueueing
- add readiness checks and PostgreSQL integration coverage for state, index, ACL, routine, watermark, and concurrency invariants

## Scope

This is M20A only: generation lifecycle and safe fencing. It intentionally does not add vector providers, embedding activation, retrieval changes, or a corpus-wide rebuild scan. The next bounded worker slice will scan canonical revisions up to the recorded watermark resumably; post-start revisions already dual-enqueue atomically.

## Validation

- `go test -p 1 -count=1 -timeout 8m ./internal/postgres ./cmd/punaro` against isolated PostgreSQL 18.4
- `make test`
- `make test-race`
- `make staticcheck`
- `make security`
- `make lint`
