### PR TITLE
Add bounded embedding rebuild batches

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -416,12 +416,20 @@ installation change-sequence row and records that sequence on one immutable
 `building` generation. The revision enqueue trigger takes the shared form of
 that advisory fence,
 so every subsequent revision is atomically queued for both immutable active
-and building generations. The bounded, resumable scan of canonical revisions
-at or before that watermark remains the following rebuild-worker slice; start
-itself never scans an unbounded corpus. At most one building generation exists;
-the active generation remains the sole serving generation. There is still no
-provider, vector storage, caught-up watermark, activation, semantic ranking,
-or client-facing semantic surface.
+and building generations. Start itself never scans an unbounded corpus.
+
+Schema version 27 adds the owner-only, bounded rebuild scan. The start routine
+also records the installation timeline and creates a private progress row. Each
+batch advances that cursor through at most 128 current canonical revisions on
+the captured timeline at or before the start watermark; historical revisions
+that are no longer current do not create stale jobs. Conflict updates only move
+jobs forward, so a revision dual-enqueued after start cannot be overwritten by
+the historical scan. A v26 building generation lacks the durable timeline
+identity needed for restore-safe scanning and is discarded as derived work
+during upgrade. At most one building generation exists; the active generation
+remains the sole serving generation. There is still no provider, vector
+storage, caught-up watermark, activation, semantic ranking, or client-facing
+semantic surface.
 
 Schema version 15 places one deterministic secret guard inside the authorized
 create/update transaction before any scope, revision, change, audit,

--- a/docs/platform-contracts.md
+++ b/docs/platform-contracts.md
@@ -361,6 +361,17 @@ watermarking, validation, activation, vectors, semantic search, and RRF remain
 later slices; rollback again requires verified pre-update restore because the
 schema is additive derived control state.
 
+Schema 27 makes that rebuild scan bounded and resumable. Start captures the
+installation timeline as well as its change-sequence watermark and creates an
+owner-only progress row. Each owner batch scans at most 128 current revisions
+from `brain.memory_changes` on that captured timeline through the watermark,
+then atomically advances the cursor. It never replaces a newer job that the
+post-start dual enqueue already produced. A v26 building generation is derived
+state without a restore-safe timeline identity, so upgrade discards it before
+accepting a new timeline-bound rebuild. Application callers cannot read or
+advance rebuild progress. There is still no caught-up watermark, activation,
+provider, vectors, semantic search, or RRF.
+
 The dark prompt-brief read adds no schema and exposes no route or client. It
 accepts the same bounded normalized query as lexical search, resolves the
 active canonical project, and requires only `memory.search` because it returns

--- a/internal/postgres/brain_embedding_integration_test.go
+++ b/internal/postgres/brain_embedding_integration_test.go
@@ -25,6 +25,9 @@ func testMemoryEmbeddingSchemaDriftIntegration(ctx context.Context, t *testing.T
 		{"generation state fence", `ALTER TABLE brain.embedding_generations DROP CONSTRAINT embedding_generations_state_check; ALTER TABLE brain.embedding_generations ADD CONSTRAINT embedding_generations_state_check CHECK (state IS NOT NULL)`, `ALTER TABLE brain.embedding_generations DROP CONSTRAINT embedding_generations_state_check; ALTER TABLE brain.embedding_generations ADD CONSTRAINT embedding_generations_state_check CHECK ((state = 'active' AND start_change_sequence IS NULL) OR (state = 'building' AND start_change_sequence >= 0))`},
 		{"legacy generation tuple uniqueness", `ALTER TABLE brain.embedding_generations ADD CONSTRAINT embedding_generations_model_model_revision_dimensions_key UNIQUE (model,model_revision,dimensions)`, `ALTER TABLE brain.embedding_generations DROP CONSTRAINT embedding_generations_model_model_revision_dimensions_key`},
 		{"rebuild routine ACL", `GRANT EXECUTE ON FUNCTION brain.start_embedding_generation(text,text,integer) TO punaro_app`, `REVOKE EXECUTE ON FUNCTION brain.start_embedding_generation(text,text,integer) FROM punaro_app`},
+		{"rebuild progress read", `GRANT SELECT ON brain.embedding_rebuild_progress TO punaro_app`, `REVOKE SELECT ON brain.embedding_rebuild_progress FROM punaro_app`},
+		{"rebuild batch routine ACL", `GRANT EXECUTE ON FUNCTION brain.enqueue_embedding_rebuild_batch(uuid,integer) TO punaro_app`, `REVOKE EXECUTE ON FUNCTION brain.enqueue_embedding_rebuild_batch(uuid,integer) FROM punaro_app`},
+		{"rebuild progress extra check", `ALTER TABLE brain.embedding_rebuild_progress ADD CONSTRAINT embedding_rebuild_progress_extra_check CHECK (complete OR NOT complete)`, `ALTER TABLE brain.embedding_rebuild_progress DROP CONSTRAINT embedding_rebuild_progress_extra_check`},
 		{"worker routine ACL", `REVOKE EXECUTE ON FUNCTION brain.retry_embedding_job(uuid,uuid,bigint,bytea,uuid,bigint,bigint,text) FROM punaro_app`, `GRANT EXECUTE ON FUNCTION brain.retry_embedding_job(uuid,uuid,bigint,bytea,uuid,bigint,bigint,text) TO punaro_app`},
 		{"worker routine public ACL", `GRANT EXECUTE ON FUNCTION brain.claim_embedding_jobs(uuid,integer,bigint) TO PUBLIC`, `REVOKE EXECUTE ON FUNCTION brain.claim_embedding_jobs(uuid,integer,bigint) FROM PUBLIC`},
 		{"worker routine security", `ALTER FUNCTION brain.claim_embedding_jobs(uuid,integer,bigint) SECURITY INVOKER`, `ALTER FUNCTION brain.claim_embedding_jobs(uuid,integer,bigint) SECURITY DEFINER`},
@@ -443,6 +446,40 @@ func testMemoryEmbeddingGenerationRebuildIntegration(ctx context.Context, t *tes
 	if err := ownerDB.QueryRowContext(ctx, `SELECT count(*) FROM brain.embedding_jobs WHERE generation_id=$1 AND item_id=$2`, buildingID, before.ItemID).Scan(&beforeJobs); err != nil || beforeJobs != 0 {
 		t.Fatalf("unbounded rebuild snapshot jobs=%d err=%v", beforeJobs, err)
 	}
+	beforeAfterStart, err := app.UpdateMemory(ctx, MemoryUpdateRequest{PrincipalID: actor.ID, ProjectID: projectID, ItemID: before.ItemID, IdempotencyKey: "19191919-1919-4191-8191-191919191940", ExpectedETag: before.ETag, LogicalKey: "rebuild-19191919-1919-4191-8191-191919191941", Kind: "decision", Trust: "curated", Document: json.RawMessage(`{"title":"before rebuild revised after start"}`)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var enqueued, rebuildCursor int64
+	var rebuildComplete bool
+	if err := ownerDB.QueryRowContext(ctx, `SELECT enqueued,cursor_change_sequence,complete FROM brain.enqueue_embedding_rebuild_batch($1,$2)`, buildingID, 128).Scan(&enqueued, &rebuildCursor, &rebuildComplete); err != nil {
+		t.Fatalf("enqueue bounded rebuild batch: %v", err)
+	}
+	if enqueued < 1 || rebuildCursor > buildingSequence {
+		t.Fatalf("first rebuild batch enqueued=%d cursor=%d complete=%t watermark=%d", enqueued, rebuildCursor, rebuildComplete, buildingSequence)
+	}
+	for attempts := 0; !rebuildComplete && attempts < 64; attempts++ {
+		previousCursor := rebuildCursor
+		if err := ownerDB.QueryRowContext(ctx, `SELECT enqueued,cursor_change_sequence,complete FROM brain.enqueue_embedding_rebuild_batch($1,$2)`, buildingID, 128).Scan(&enqueued, &rebuildCursor, &rebuildComplete); err != nil {
+			t.Fatalf("resume bounded rebuild batch: %v", err)
+		}
+		if rebuildCursor <= previousCursor {
+			t.Fatalf("bounded rebuild cursor did not advance: previous=%d current=%d", previousCursor, rebuildCursor)
+		}
+	}
+	if !rebuildComplete {
+		t.Fatal("bounded rebuild did not finish within 64 batches")
+	}
+	completedCursor := rebuildCursor
+	if err := ownerDB.QueryRowContext(ctx, `SELECT enqueued,cursor_change_sequence,complete FROM brain.enqueue_embedding_rebuild_batch($1,$2)`, buildingID, 128).Scan(&enqueued, &rebuildCursor, &rebuildComplete); err != nil {
+		t.Fatalf("restart completed rebuild batch: %v", err)
+	}
+	if enqueued != 0 || !rebuildComplete || rebuildCursor != completedCursor {
+		t.Fatalf("completed rebuild restart enqueued=%d cursor=%d complete=%t want cursor=%d", enqueued, rebuildCursor, rebuildComplete, completedCursor)
+	}
+	if err := ownerDB.QueryRowContext(ctx, `SELECT revision FROM brain.embedding_jobs WHERE generation_id=$1 AND item_id=$2`, buildingID, before.ItemID).Scan(&revision); err != nil || revision != beforeAfterStart.Revision {
+		t.Fatalf("bounded rebuild job revision=%d want=%d err=%v", revision, beforeAfterStart.Revision, err)
+	}
 	after := create("19191919-1919-4191-8191-191919191942", "after rebuild")
 	for _, generationID := range []string{activeID, buildingID} {
 		if err := ownerDB.QueryRowContext(ctx, `SELECT revision FROM brain.embedding_jobs WHERE generation_id=$1 AND item_id=$2`, generationID, after.ItemID).Scan(&revision); err != nil || revision != after.Revision {
@@ -478,5 +515,8 @@ func testMemoryEmbeddingGenerationRebuildIntegration(ctx context.Context, t *tes
 	}
 	if _, err := app.db.ExecContext(ctx, `SELECT generation_id FROM brain.start_embedding_generation($1,$2,$3)`, "local.e5-xl", "2026-07-01", 1536); err == nil {
 		t.Fatal("application role started an embedding rebuild")
+	}
+	if _, err := app.db.ExecContext(ctx, `SELECT enqueued FROM brain.enqueue_embedding_rebuild_batch($1,$2)`, buildingID, 1); err == nil {
+		t.Fatal("application role scanned an embedding rebuild")
 	}
 }

--- a/internal/postgres/brain_embedding_integration_test.go
+++ b/internal/postgres/brain_embedding_integration_test.go
@@ -479,7 +479,7 @@ FROM advanced JOIN brain.memory_items AS item ON item.id=$1`, before.ItemID); er
 	if err := ownerDB.QueryRowContext(ctx, `SELECT enqueued,cursor_change_sequence,complete FROM brain.enqueue_embedding_rebuild_batch($1,$2)`, buildingID, 128).Scan(&enqueued, &rebuildCursor, &rebuildComplete); err != nil {
 		t.Fatalf("enqueue bounded rebuild batch: %v", err)
 	}
-	if enqueued < 1 || rebuildCursor > buildingSequence {
+	if rebuildCursor > buildingSequence {
 		t.Fatalf("first rebuild batch enqueued=%d cursor=%d complete=%t watermark=%d", enqueued, rebuildCursor, rebuildComplete, buildingSequence)
 	}
 	for attempts := 0; !rebuildComplete && attempts < 64; attempts++ {

--- a/internal/postgres/brain_embedding_integration_test.go
+++ b/internal/postgres/brain_embedding_integration_test.go
@@ -422,6 +422,27 @@ func testMemoryEmbeddingGenerationRebuildIntegration(ctx context.Context, t *tes
 		return result
 	}
 	before := create("19191919-1919-4191-8191-191919191941", "before rebuild")
+	var restoredTimeline string
+	if err := ownerDB.QueryRowContext(ctx, `WITH prior AS (
+    SELECT installation_id,timeline_id,change_sequence FROM jobs.server_state WHERE singleton FOR UPDATE
+), rotated AS (
+    UPDATE jobs.server_state SET timeline_id=gen_random_uuid(),timeline_started_at=statement_timestamp()
+    WHERE singleton RETURNING installation_id,timeline_id,change_sequence
+), event AS (
+    INSERT INTO jobs.restore_events(restore_id,backup_id,installation_id,previous_timeline_id,restored_timeline_id,restored_change_sequence)
+    SELECT gen_random_uuid(),gen_random_uuid(),prior.installation_id,prior.timeline_id,rotated.timeline_id,prior.change_sequence FROM prior,rotated
+)
+SELECT timeline_id::text FROM rotated`).Scan(&restoredTimeline); err != nil {
+		t.Fatalf("rotate test restore timeline: %v", err)
+	}
+	if _, err := ownerDB.ExecContext(ctx, `WITH advanced AS (
+    UPDATE jobs.server_state SET change_sequence=change_sequence+1 WHERE singleton RETURNING timeline_id,change_sequence
+)
+INSERT INTO brain.memory_changes(timeline_id,change_sequence,scope_id,item_id,operation,revision)
+SELECT advanced.timeline_id,advanced.change_sequence,item.scope_id,item.id,'update',item.current_revision
+FROM advanced JOIN brain.memory_items AS item ON item.id=$1`, before.ItemID); err != nil {
+		t.Fatalf("add same-revision change: %v", err)
+	}
 	var activeID string
 	if err := ownerDB.QueryRowContext(ctx, `SELECT id::text FROM brain.embedding_generations WHERE state='active'`).Scan(&activeID); err != nil {
 		t.Fatalf("active generation: %v", err)
@@ -436,6 +457,9 @@ func testMemoryEmbeddingGenerationRebuildIntegration(ctx context.Context, t *tes
 	}
 	if buildingSequence != beforeSequence {
 		t.Fatalf("building watermark=%d want start sequence %d", buildingSequence, beforeSequence)
+	}
+	if restoredTimeline == "" {
+		t.Fatal("test restore timeline missing")
 	}
 	var state string
 	if err := ownerDB.QueryRowContext(ctx, `SELECT state FROM brain.embedding_generations WHERE id=$1`, buildingID).Scan(&state); err != nil || state != "building" {

--- a/internal/postgres/brain_embedding_rebuild_batch_schema.go
+++ b/internal/postgres/brain_embedding_rebuild_batch_schema.go
@@ -101,4 +101,4 @@ FROM objects,table_safety,constraint_safety,routine_safety,routine_acl,column_ac
 	return available, err
 }
 
-const memoryEmbeddingRebuildBatchRoutineMD5 = "3ee4777558c46f798e81ffeb301ca3cb"
+const memoryEmbeddingRebuildBatchRoutineMD5 = "9a0a0e5e434af9968d779c2243419c54"

--- a/internal/postgres/brain_embedding_rebuild_batch_schema.go
+++ b/internal/postgres/brain_embedding_rebuild_batch_schema.go
@@ -96,4 +96,4 @@ FROM objects,table_safety,constraint_safety,routine_safety,routine_acl,column_ac
 	return available, err
 }
 
-const memoryEmbeddingRebuildBatchRoutineMD5 = "a46eb7c2b1190056f25f01947a5b520f"
+const memoryEmbeddingRebuildBatchRoutineMD5 = "136060c043012b6b733fb5a129a1f08f"

--- a/internal/postgres/brain_embedding_rebuild_batch_schema.go
+++ b/internal/postgres/brain_embedding_rebuild_batch_schema.go
@@ -16,6 +16,7 @@ func memoryEmbeddingRebuildBatchControlsAvailable(ctx context.Context, q queryer
       ('brain.embedding_rebuild_progress','timeline_id','uuid',true,''),
       ('brain.embedding_rebuild_progress','timeline_watermark','bigint',true,''),
       ('brain.embedding_rebuild_progress','cursor_change_sequence','bigint',true,'0'),
+      ('brain.embedding_rebuild_progress','reported_progress','bigint',true,'0'),
       ('brain.embedding_rebuild_progress','complete','boolean',true,'false')
 ), actual_columns AS (
     SELECT attribute.attrelid::regclass::text,attribute.attname,format_type(attribute.atttypid,attribute.atttypmod),attribute.attnotnull,
@@ -44,6 +45,7 @@ func memoryEmbeddingRebuildBatchControlsAvailable(ctx context.Context, q queryer
 ), expected_checks(relation_name,constraint_name,expression) AS (
     VALUES
       ('brain.embedding_rebuild_progress','embedding_rebuild_progress_cursor_change_sequence_check','(cursor_change_sequence >= 0)'),
+      ('brain.embedding_rebuild_progress','embedding_rebuild_progress_reported_progress_check','(reported_progress >= 0)'),
       ('brain.embedding_rebuild_progress','embedding_rebuild_progress_timeline_watermark_check','(timeline_watermark >= 0)')
 ), actual_checks AS (
     SELECT constraint_row.conrelid::regclass::text,constraint_row.conname,pg_get_expr(constraint_row.conbin,constraint_row.conrelid)
@@ -51,7 +53,7 @@ func memoryEmbeddingRebuildBatchControlsAvailable(ctx context.Context, q queryer
     WHERE constraint_row.conrelid=progress_oid AND constraint_row.contype='c'
       AND constraint_row.convalidated AND NOT constraint_row.condeferrable AND NOT constraint_row.condeferred
 ), constraint_safety AS (
-    SELECT count(*)=4 AND bool_and(constraint_row.convalidated AND NOT constraint_row.condeferrable AND NOT constraint_row.condeferred) AS exact
+    SELECT count(*)=5 AND bool_and(constraint_row.convalidated AND NOT constraint_row.condeferrable AND NOT constraint_row.condeferred) AS exact
     FROM pg_constraint AS constraint_row,objects
     WHERE constraint_row.conrelid=progress_oid AND constraint_row.contype<>'n'
 ), routine_safety AS (
@@ -99,4 +101,4 @@ FROM objects,table_safety,constraint_safety,routine_safety,routine_acl,column_ac
 	return available, err
 }
 
-const memoryEmbeddingRebuildBatchRoutineMD5 = "f82a1bb5d75761b3ebef154c85e293b8"
+const memoryEmbeddingRebuildBatchRoutineMD5 = "0504e96e3ef59a16cf3607517a444a5a"

--- a/internal/postgres/brain_embedding_rebuild_batch_schema.go
+++ b/internal/postgres/brain_embedding_rebuild_batch_schema.go
@@ -101,4 +101,4 @@ FROM objects,table_safety,constraint_safety,routine_safety,routine_acl,column_ac
 	return available, err
 }
 
-const memoryEmbeddingRebuildBatchRoutineMD5 = "0504e96e3ef59a16cf3607517a444a5a"
+const memoryEmbeddingRebuildBatchRoutineMD5 = "3ee4777558c46f798e81ffeb301ca3cb"

--- a/internal/postgres/brain_embedding_rebuild_batch_schema.go
+++ b/internal/postgres/brain_embedding_rebuild_batch_schema.go
@@ -14,6 +14,7 @@ func memoryEmbeddingRebuildBatchControlsAvailable(ctx context.Context, q queryer
     VALUES
       ('brain.embedding_rebuild_progress','generation_id','uuid',true,''),
       ('brain.embedding_rebuild_progress','timeline_id','uuid',true,''),
+      ('brain.embedding_rebuild_progress','timeline_watermark','bigint',true,''),
       ('brain.embedding_rebuild_progress','cursor_change_sequence','bigint',true,'0'),
       ('brain.embedding_rebuild_progress','complete','boolean',true,'false')
 ), actual_columns AS (
@@ -41,14 +42,16 @@ func memoryEmbeddingRebuildBatchControlsAvailable(ctx context.Context, q queryer
     WHERE constraint_row.conrelid=progress_oid AND constraint_row.contype IN ('p','f')
       AND constraint_row.convalidated AND NOT constraint_row.condeferrable AND NOT constraint_row.condeferred
 ), expected_checks(relation_name,constraint_name,expression) AS (
-    VALUES ('brain.embedding_rebuild_progress','embedding_rebuild_progress_cursor_change_sequence_check','(cursor_change_sequence >= 0)')
+    VALUES
+      ('brain.embedding_rebuild_progress','embedding_rebuild_progress_cursor_change_sequence_check','(cursor_change_sequence >= 0)'),
+      ('brain.embedding_rebuild_progress','embedding_rebuild_progress_timeline_watermark_check','(timeline_watermark >= 0)')
 ), actual_checks AS (
     SELECT constraint_row.conrelid::regclass::text,constraint_row.conname,pg_get_expr(constraint_row.conbin,constraint_row.conrelid)
     FROM pg_constraint AS constraint_row,objects
     WHERE constraint_row.conrelid=progress_oid AND constraint_row.contype='c'
       AND constraint_row.convalidated AND NOT constraint_row.condeferrable AND NOT constraint_row.condeferred
 ), constraint_safety AS (
-    SELECT count(*)=3 AND bool_and(constraint_row.convalidated AND NOT constraint_row.condeferrable AND NOT constraint_row.condeferred) AS exact
+    SELECT count(*)=4 AND bool_and(constraint_row.convalidated AND NOT constraint_row.condeferrable AND NOT constraint_row.condeferred) AS exact
     FROM pg_constraint AS constraint_row,objects
     WHERE constraint_row.conrelid=progress_oid AND constraint_row.contype<>'n'
 ), routine_safety AS (
@@ -96,4 +99,4 @@ FROM objects,table_safety,constraint_safety,routine_safety,routine_acl,column_ac
 	return available, err
 }
 
-const memoryEmbeddingRebuildBatchRoutineMD5 = "136060c043012b6b733fb5a129a1f08f"
+const memoryEmbeddingRebuildBatchRoutineMD5 = "1717ed86f6562ddee2b756c4de1d2fb5"

--- a/internal/postgres/brain_embedding_rebuild_batch_schema.go
+++ b/internal/postgres/brain_embedding_rebuild_batch_schema.go
@@ -99,4 +99,4 @@ FROM objects,table_safety,constraint_safety,routine_safety,routine_acl,column_ac
 	return available, err
 }
 
-const memoryEmbeddingRebuildBatchRoutineMD5 = "1717ed86f6562ddee2b756c4de1d2fb5"
+const memoryEmbeddingRebuildBatchRoutineMD5 = "f82a1bb5d75761b3ebef154c85e293b8"

--- a/internal/postgres/brain_embedding_rebuild_batch_schema.go
+++ b/internal/postgres/brain_embedding_rebuild_batch_schema.go
@@ -96,4 +96,4 @@ FROM objects,table_safety,constraint_safety,routine_safety,routine_acl,column_ac
 	return available, err
 }
 
-const memoryEmbeddingRebuildBatchRoutineMD5 = "1b4ad4e7b2919fa1461e73fa6c9f41f7"
+const memoryEmbeddingRebuildBatchRoutineMD5 = "a46eb7c2b1190056f25f01947a5b520f"

--- a/internal/postgres/brain_embedding_rebuild_batch_schema.go
+++ b/internal/postgres/brain_embedding_rebuild_batch_schema.go
@@ -1,0 +1,99 @@
+package postgres
+
+import "context"
+
+// memoryEmbeddingRebuildBatchControlsAvailable verifies the schema-v27 bounded
+// rebuild boundary. The progress cursor is owner-only and the batch routine is
+// the sole authority that may advance it or enqueue historical work.
+func memoryEmbeddingRebuildBatchControlsAvailable(ctx context.Context, q queryer) (bool, error) {
+	var available bool
+	err := q.QueryRowContext(ctx, `WITH objects AS (
+    SELECT to_regclass('brain.embedding_rebuild_progress') AS progress_oid,
+           to_regprocedure('brain.enqueue_embedding_rebuild_batch(uuid,integer)') AS batch_oid
+), expected_columns(relation_name,column_name,type_name,not_null,default_expression) AS (
+    VALUES
+      ('brain.embedding_rebuild_progress','generation_id','uuid',true,''),
+      ('brain.embedding_rebuild_progress','timeline_id','uuid',true,''),
+      ('brain.embedding_rebuild_progress','cursor_change_sequence','bigint',true,'0'),
+      ('brain.embedding_rebuild_progress','complete','boolean',true,'false')
+), actual_columns AS (
+    SELECT attribute.attrelid::regclass::text,attribute.attname,format_type(attribute.atttypid,attribute.atttypmod),attribute.attnotnull,
+           COALESCE(pg_get_expr(default_value.adbin,default_value.adrelid),'')
+    FROM pg_attribute AS attribute
+    LEFT JOIN pg_attrdef AS default_value ON default_value.adrelid=attribute.attrelid AND default_value.adnum=attribute.attnum,objects
+    WHERE attribute.attrelid=progress_oid AND attribute.attnum>0 AND NOT attribute.attisdropped
+), table_safety AS (
+    SELECT count(*)=1 AND bool_and(relation.relkind='r' AND relation.relpersistence='p' AND NOT relation.relrowsecurity
+        AND NOT relation.relforcerowsecurity AND pg_get_userbyid(relation.relowner)='punaro_owner') AS exact
+    FROM pg_class AS relation,objects WHERE relation.oid=progress_oid
+), expected_relational_constraints(relation_name,constraint_name,constraint_type,column_keys,referenced_relation,referenced_keys,update_action,delete_action,match_type) AS (
+    VALUES
+      ('brain.embedding_rebuild_progress','embedding_rebuild_progress_pkey','p','{1}','','','','',''),
+      ('brain.embedding_rebuild_progress','embedding_rebuild_progress_generation_id_fkey','f','{1}','brain.embedding_generations','{1}','a','c','s')
+), actual_relational_constraints AS (
+    SELECT constraint_row.conrelid::regclass::text,constraint_row.conname,constraint_row.contype::text,constraint_row.conkey::text,
+           CASE WHEN constraint_row.contype='f' THEN constraint_row.confrelid::regclass::text ELSE '' END,
+           CASE WHEN constraint_row.contype='f' THEN constraint_row.confkey::text ELSE '' END,
+           CASE WHEN constraint_row.contype='f' THEN constraint_row.confupdtype::text ELSE '' END,
+           CASE WHEN constraint_row.contype='f' THEN constraint_row.confdeltype::text ELSE '' END,
+           CASE WHEN constraint_row.contype='f' THEN constraint_row.confmatchtype::text ELSE '' END
+    FROM pg_constraint AS constraint_row,objects
+    WHERE constraint_row.conrelid=progress_oid AND constraint_row.contype IN ('p','f')
+      AND constraint_row.convalidated AND NOT constraint_row.condeferrable AND NOT constraint_row.condeferred
+), expected_checks(relation_name,constraint_name,expression) AS (
+    VALUES ('brain.embedding_rebuild_progress','embedding_rebuild_progress_cursor_change_sequence_check','(cursor_change_sequence >= 0)')
+), actual_checks AS (
+    SELECT constraint_row.conrelid::regclass::text,constraint_row.conname,pg_get_expr(constraint_row.conbin,constraint_row.conrelid)
+    FROM pg_constraint AS constraint_row,objects
+    WHERE constraint_row.conrelid=progress_oid AND constraint_row.contype='c'
+      AND constraint_row.convalidated AND NOT constraint_row.condeferrable AND NOT constraint_row.condeferred
+), constraint_safety AS (
+    SELECT count(*)=3 AND bool_and(constraint_row.convalidated AND NOT constraint_row.condeferrable AND NOT constraint_row.condeferred) AS exact
+    FROM pg_constraint AS constraint_row,objects
+    WHERE constraint_row.conrelid=progress_oid AND constraint_row.contype<>'n'
+), routine_safety AS (
+    SELECT count(*)=1 AND bool_and(pg_get_userbyid(proc.proowner)='punaro_owner' AND proc.prokind='f'
+        AND pg_get_function_result(proc.oid)='TABLE(enqueued integer, cursor_change_sequence bigint, complete boolean)'
+        AND proc.prosecdef AND proc.provolatile='v'
+        AND proc.prolang=(SELECT oid FROM pg_language WHERE lanname='plpgsql')
+        AND proc.proconfig=ARRAY['search_path=pg_catalog']::text[]
+        AND md5(btrim(proc.prosrc,E' \n\r\t'))=$1) AS exact
+    FROM pg_proc AS proc,objects WHERE proc.oid=batch_oid
+), expected_routine_acl(grantee,privilege_type,is_grantable) AS (
+    VALUES ('punaro_owner','EXECUTE',false)
+), actual_routine_acl AS (
+    SELECT COALESCE(role.rolname,'PUBLIC'),entry.privilege_type,entry.is_grantable
+    FROM pg_proc AS proc
+    CROSS JOIN LATERAL aclexplode(COALESCE(proc.proacl,acldefault('f',proc.proowner))) AS entry
+    LEFT JOIN pg_roles AS role ON role.oid=entry.grantee,objects
+    WHERE proc.oid=batch_oid
+), routine_acl AS (
+    SELECT NOT EXISTS (SELECT * FROM expected_routine_acl EXCEPT SELECT * FROM actual_routine_acl)
+       AND NOT EXISTS (SELECT * FROM actual_routine_acl EXCEPT SELECT * FROM expected_routine_acl) AS exact
+), column_acl AS (
+    SELECT NOT EXISTS (
+        SELECT 1 FROM pg_attribute AS attribute,objects
+        WHERE attribute.attrelid=progress_oid AND attribute.attnum>0 AND NOT attribute.attisdropped AND attribute.attacl IS NOT NULL
+    ) AS exact
+), table_acl AS (
+    SELECT count(*)=8 AND bool_and(role.rolname='punaro_owner' AND NOT entry.is_grantable) AS exact
+    FROM pg_class AS relation
+    CROSS JOIN LATERAL aclexplode(COALESCE(relation.relacl,acldefault('r',relation.relowner))) AS entry
+    LEFT JOIN pg_roles AS role ON role.oid=entry.grantee,objects
+    WHERE relation.oid=progress_oid
+)
+SELECT progress_oid IS NOT NULL AND batch_oid IS NOT NULL
+   AND table_safety.exact AND constraint_safety.exact AND routine_safety.exact AND routine_acl.exact
+   AND column_acl.exact AND table_acl.exact
+   AND NOT EXISTS (SELECT * FROM expected_columns EXCEPT SELECT * FROM actual_columns)
+   AND NOT EXISTS (SELECT * FROM actual_columns EXCEPT SELECT * FROM expected_columns)
+   AND NOT EXISTS (SELECT * FROM expected_relational_constraints EXCEPT SELECT * FROM actual_relational_constraints)
+   AND NOT EXISTS (SELECT * FROM actual_relational_constraints EXCEPT SELECT * FROM expected_relational_constraints)
+   AND NOT EXISTS (SELECT * FROM expected_checks EXCEPT SELECT * FROM actual_checks)
+   AND NOT EXISTS (SELECT * FROM actual_checks EXCEPT SELECT * FROM expected_checks)
+   AND NOT has_table_privilege('punaro_app',progress_oid,'SELECT,INSERT,UPDATE,DELETE,TRUNCATE,REFERENCES,TRIGGER')
+FROM objects,table_safety,constraint_safety,routine_safety,routine_acl,column_acl,table_acl`, memoryEmbeddingRebuildBatchRoutineMD5).Scan(&available)
+	return available, err
+}
+
+const memoryEmbeddingRebuildBatchRoutineMD5 = "1b4ad4e7b2919fa1461e73fa6c9f41f7"

--- a/internal/postgres/brain_embedding_rebuild_schema.go
+++ b/internal/postgres/brain_embedding_rebuild_schema.go
@@ -5,7 +5,11 @@ import "context"
 // memoryEmbeddingRebuildControlsAvailable verifies the schema-v26 boundary:
 // a schema-owner-only building generation may be created beside, but never
 // replaces, the immutable active generation in this slice.
-func memoryEmbeddingRebuildControlsAvailable(ctx context.Context, q queryer) (bool, error) {
+func memoryEmbeddingRebuildControlsAvailable(ctx context.Context, q queryer, schemaVersion int64) (bool, error) {
+	startRoutineMD5 := memoryEmbeddingRebuildStartRoutineV26MD5
+	if schemaVersion >= 27 {
+		startRoutineMD5 = memoryEmbeddingRebuildStartRoutineV27MD5
+	}
 	var available bool
 	err := q.QueryRowContext(ctx, `WITH objects AS (
     SELECT to_regclass('brain.embedding_generations') AS generations_oid,
@@ -50,11 +54,12 @@ func memoryEmbeddingRebuildControlsAvailable(ctx context.Context, q queryer) (bo
 )
 SELECT generations_oid IS NOT NULL AND start_oid IS NOT NULL AND queue_oid IS NOT NULL
    AND generation_state.exact AND generation_tuple.exact AND routines.exact AND start_signature.exact AND start_acl.exact
-FROM objects,generation_state,generation_tuple,routines,start_signature,start_acl`, memoryEmbeddingRebuildQueueRoutineMD5, memoryEmbeddingRebuildStartRoutineMD5).Scan(&available)
+FROM objects,generation_state,generation_tuple,routines,start_signature,start_acl`, memoryEmbeddingRebuildQueueRoutineMD5, startRoutineMD5).Scan(&available)
 	return available, err
 }
 
 const (
-	memoryEmbeddingRebuildQueueRoutineMD5 = "b09c65e6d07819ec41948de85675de5c"
-	memoryEmbeddingRebuildStartRoutineMD5 = "ef8ca889c0937b89d9ea3406aff994c4"
+	memoryEmbeddingRebuildQueueRoutineMD5    = "b09c65e6d07819ec41948de85675de5c"
+	memoryEmbeddingRebuildStartRoutineV26MD5 = "ef8ca889c0937b89d9ea3406aff994c4"
+	memoryEmbeddingRebuildStartRoutineV27MD5 = "2dda6cbfeb8a25361c542b47c1657961"
 )

--- a/internal/postgres/brain_embedding_rebuild_schema.go
+++ b/internal/postgres/brain_embedding_rebuild_schema.go
@@ -61,5 +61,5 @@ FROM objects,generation_state,generation_tuple,routines,start_signature,start_ac
 const (
 	memoryEmbeddingRebuildQueueRoutineMD5    = "b09c65e6d07819ec41948de85675de5c"
 	memoryEmbeddingRebuildStartRoutineV26MD5 = "ef8ca889c0937b89d9ea3406aff994c4"
-	memoryEmbeddingRebuildStartRoutineV27MD5 = "2dda6cbfeb8a25361c542b47c1657961"
+	memoryEmbeddingRebuildStartRoutineV27MD5 = "6f11b5d03617ee975cc59d50d4860282"
 )

--- a/internal/postgres/brain_embedding_schema.go
+++ b/internal/postgres/brain_embedding_schema.go
@@ -44,6 +44,8 @@ WITH objects AS (
     SELECT 'brain.embedding_jobs','available_at','timestamp with time zone',true WHERE $1 >= 24
 	UNION ALL
 	SELECT 'brain.embedding_generations','start_change_sequence','bigint',false WHERE $1 >= 26
+	UNION ALL
+	SELECT 'brain.embedding_generations','start_timeline_id','uuid',false WHERE $1 >= 27
 ), actual_columns AS (
     SELECT attribute.attrelid::regclass::text,attribute.attname,attribute.atttypid::regtype::text,attribute.attnotnull
     FROM pg_attribute AS attribute,objects

--- a/internal/postgres/db.go
+++ b/internal/postgres/db.go
@@ -1154,11 +1154,18 @@ FROM objects, table_ownership, routine_safety, routine_acl, table_acl, schema_ac
 		snapshot.CurrentObjectsPresent = embeddingPublicationObjectsPresent
 	}
 	if snapshot.CurrentObjectsPresent && len(snapshot.Records) > 0 && snapshot.Records[len(snapshot.Records)-1].Version >= 26 {
-		embeddingRebuildObjectsPresent, err := memoryEmbeddingRebuildControlsAvailable(ctx, q)
+		embeddingRebuildObjectsPresent, err := memoryEmbeddingRebuildControlsAvailable(ctx, q, snapshot.Records[len(snapshot.Records)-1].Version)
 		if err != nil {
 			return Snapshot{}, errors.New("PostgreSQL memory embedding rebuild schema cannot be inspected")
 		}
 		snapshot.CurrentObjectsPresent = embeddingRebuildObjectsPresent
+	}
+	if snapshot.CurrentObjectsPresent && len(snapshot.Records) > 0 && snapshot.Records[len(snapshot.Records)-1].Version >= 27 {
+		embeddingRebuildBatchObjectsPresent, err := memoryEmbeddingRebuildBatchControlsAvailable(ctx, q)
+		if err != nil {
+			return Snapshot{}, errors.New("PostgreSQL memory embedding rebuild batch schema cannot be inspected")
+		}
+		snapshot.CurrentObjectsPresent = embeddingRebuildBatchObjectsPresent
 	}
 	return snapshot, nil
 }

--- a/internal/postgres/migrate.go
+++ b/internal/postgres/migrate.go
@@ -59,6 +59,7 @@ var migrationCompatibilityFloors = map[int64]int64{
 	24: 10,
 	25: 10,
 	26: 10,
+	27: 10,
 }
 
 // CurrentManifest returns the immutable migrations embedded in this binary.

--- a/internal/postgres/migrations/027_memory_embedding_rebuild_batches.sql
+++ b/internal/postgres/migrations/027_memory_embedding_rebuild_batches.sql
@@ -110,9 +110,9 @@ BEGIN
         WHERE brain.embedding_jobs.revision<EXCLUDED.revision
         RETURNING 1
     ), advanced AS (
-        SELECT count(*)::integer AS scanned,COALESCE(max(changes.change_sequence),progress.timeline_watermark) AS next_cursor
-        FROM changes CROSS JOIN brain.embedding_rebuild_progress AS progress
-        WHERE progress.generation_id=requested_generation
+        SELECT count(*)::integer AS scanned,COALESCE(max(changes.change_sequence),
+            (SELECT progress.timeline_watermark FROM brain.embedding_rebuild_progress AS progress WHERE progress.generation_id=requested_generation)) AS next_cursor
+        FROM changes
     ), applied AS (
         SELECT count(*) AS changed FROM queued
     )

--- a/internal/postgres/migrations/027_memory_embedding_rebuild_batches.sql
+++ b/internal/postgres/migrations/027_memory_embedding_rebuild_batches.sql
@@ -1,0 +1,114 @@
+ALTER TABLE brain.embedding_generations
+ADD COLUMN start_timeline_id uuid;
+
+-- A v26 building generation has no durable timeline identity, so its sequence
+-- watermark cannot be interpreted after restore or promotion. It is derived
+-- work only: discard it atomically before accepting timeline-bound rebuilds.
+ALTER TABLE brain.embedding_generations DISABLE TRIGGER USER;
+DELETE FROM brain.embedding_generations WHERE state = 'building';
+ALTER TABLE brain.embedding_generations ENABLE TRIGGER USER;
+
+CREATE TABLE brain.embedding_rebuild_progress (
+    generation_id uuid PRIMARY KEY REFERENCES brain.embedding_generations(id) ON DELETE CASCADE,
+    timeline_id uuid NOT NULL,
+    cursor_change_sequence bigint NOT NULL DEFAULT 0 CHECK (cursor_change_sequence >= 0),
+    complete boolean NOT NULL DEFAULT false
+);
+
+CREATE OR REPLACE FUNCTION brain.start_embedding_generation(requested_model text, requested_model_revision text, requested_dimensions integer)
+RETURNS TABLE (generation_id uuid, start_change_sequence bigint)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog
+AS $function$
+DECLARE
+    captured_sequence bigint;
+    captured_timeline uuid;
+    new_generation_id uuid;
+BEGIN
+    PERFORM jobs.assert_application_mutation();
+    IF requested_model IS NULL OR requested_model_revision IS NULL OR requested_dimensions IS NULL
+       OR requested_model !~ '^[a-z][a-z0-9_.:-]{0,63}$'
+       OR requested_model_revision !~ '^[a-z0-9][a-z0-9_.:-]{0,63}$'
+       OR requested_dimensions < 1 OR requested_dimensions > 4096 THEN
+        RAISE EXCEPTION USING ERRCODE = '22023', MESSAGE = 'invalid embedding generation';
+    END IF;
+    PERFORM pg_advisory_xact_lock(5788618938515408205);
+    PERFORM 1 FROM jobs.server_state WHERE singleton FOR UPDATE;
+    IF NOT EXISTS (SELECT 1 FROM brain.embedding_generations WHERE state = 'active') THEN
+        RAISE EXCEPTION USING ERRCODE = '23514', MESSAGE = 'active embedding generation is required';
+    END IF;
+    IF EXISTS (SELECT 1 FROM brain.embedding_generations WHERE state = 'building') THEN
+        RAISE EXCEPTION USING ERRCODE = '23505', MESSAGE = 'embedding generation rebuild already exists';
+    END IF;
+    SELECT timeline_id,change_sequence INTO captured_timeline,captured_sequence FROM jobs.server_state WHERE singleton;
+    INSERT INTO brain.embedding_generations (model,model_revision,dimensions,state,start_change_sequence,start_timeline_id)
+    VALUES (requested_model,requested_model_revision,requested_dimensions,'building',captured_sequence,captured_timeline)
+    RETURNING id INTO new_generation_id;
+    INSERT INTO brain.embedding_rebuild_progress(generation_id,timeline_id) VALUES (new_generation_id,captured_timeline);
+    generation_id := new_generation_id;
+    start_change_sequence := captured_sequence;
+    RETURN NEXT;
+END
+$function$;
+
+CREATE FUNCTION brain.enqueue_embedding_rebuild_batch(requested_generation uuid, requested_limit integer)
+RETURNS TABLE (enqueued integer, cursor_change_sequence bigint, complete boolean)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog
+AS $function$
+DECLARE
+    watermark bigint;
+    scanned integer;
+    next_cursor bigint;
+    done boolean;
+BEGIN
+    PERFORM jobs.assert_application_mutation();
+    IF requested_generation IS NULL OR requested_limit IS NULL OR requested_limit < 1 OR requested_limit > 128 THEN
+        RAISE EXCEPTION USING ERRCODE = '22023', MESSAGE = 'invalid embedding rebuild batch';
+    END IF;
+    SELECT generation.start_change_sequence,progress.complete
+    INTO watermark,done
+    FROM brain.embedding_rebuild_progress AS progress
+    JOIN brain.embedding_generations AS generation ON generation.id=progress.generation_id
+    WHERE progress.generation_id=requested_generation AND generation.state='building'
+    FOR UPDATE OF progress;
+    IF watermark IS NULL THEN
+        RAISE EXCEPTION USING ERRCODE = '23514', MESSAGE = 'embedding rebuild generation is unavailable';
+    END IF;
+    IF done THEN
+        SELECT progress.cursor_change_sequence INTO cursor_change_sequence
+        FROM brain.embedding_rebuild_progress AS progress
+        WHERE progress.generation_id=requested_generation;
+        enqueued := 0; complete := true; RETURN NEXT; RETURN;
+    END IF;
+    WITH candidates AS MATERIALIZED (
+        SELECT change.change_sequence,item.id AS item_id,change.revision,revision.content_sha256
+        FROM brain.embedding_rebuild_progress AS progress
+        JOIN brain.memory_changes AS change ON change.timeline_id=progress.timeline_id
+          AND change.change_sequence>progress.cursor_change_sequence AND change.change_sequence<=watermark
+        JOIN brain.memory_items AS item ON item.id=change.item_id AND item.current_revision=change.revision
+        JOIN brain.memory_revisions AS revision ON revision.item_id=change.item_id AND revision.revision=change.revision
+        WHERE progress.generation_id=requested_generation
+        ORDER BY change.change_sequence
+        LIMIT requested_limit
+    ), queued AS (
+        INSERT INTO brain.embedding_jobs(generation_id,item_id,revision,content_sha256)
+        SELECT requested_generation,item_id,revision,content_sha256 FROM candidates
+        ON CONFLICT (generation_id,item_id) DO UPDATE SET revision=EXCLUDED.revision,content_sha256=EXCLUDED.content_sha256,state='queued',attempts=0,lease_holder=NULL,lease_token=NULL,lease_generation=brain.embedding_jobs.lease_generation+1,lease_until=NULL,available_at=statement_timestamp(),last_error_code=NULL,updated_at=statement_timestamp(),completed_at=NULL
+        WHERE brain.embedding_jobs.revision<EXCLUDED.revision
+        RETURNING 1
+    ), advanced AS (
+        SELECT count(*)::integer AS scanned,COALESCE(max(change_sequence),watermark) AS next_cursor FROM candidates
+    ), applied AS (
+        SELECT count(*) AS changed FROM queued
+    )
+    SELECT advanced.scanned,advanced.next_cursor,advanced.scanned<requested_limit INTO scanned,next_cursor,done FROM advanced CROSS JOIN applied;
+    UPDATE brain.embedding_rebuild_progress SET cursor_change_sequence=next_cursor,complete=done WHERE generation_id=requested_generation;
+    enqueued := scanned; cursor_change_sequence := next_cursor; complete := done; RETURN NEXT;
+END
+$function$;
+
+REVOKE ALL ON brain.embedding_rebuild_progress FROM PUBLIC, punaro_app;
+REVOKE ALL ON FUNCTION brain.enqueue_embedding_rebuild_batch(uuid,integer) FROM PUBLIC, punaro_app;

--- a/internal/postgres/migrations/027_memory_embedding_rebuild_batches.sql
+++ b/internal/postgres/migrations/027_memory_embedding_rebuild_batches.sql
@@ -65,6 +65,7 @@ AS $function$
 DECLARE
     watermark bigint;
     scanned integer;
+    changed integer;
     next_cursor bigint;
     done boolean;
 BEGIN
@@ -87,12 +88,20 @@ BEGIN
         WHERE progress.generation_id=requested_generation;
         enqueued := 0; complete := true; RETURN NEXT; RETURN;
     END IF;
-    WITH changes AS MATERIALIZED (
+    WITH RECURSIVE timeline_chain(timeline_id,max_change_sequence) AS (
+        SELECT progress.timeline_id,watermark
+        FROM brain.embedding_rebuild_progress AS progress
+        WHERE progress.generation_id=requested_generation
+        UNION ALL
+        SELECT event.previous_timeline_id,event.restored_change_sequence
+        FROM jobs.restore_events AS event
+        JOIN timeline_chain ON event.restored_timeline_id=timeline_chain.timeline_id
+    ), changes AS MATERIALIZED (
         SELECT change.change_sequence,change.item_id,change.revision
         FROM brain.embedding_rebuild_progress AS progress
-        JOIN brain.memory_changes AS change ON change.timeline_id=progress.timeline_id
-          AND change.change_sequence>progress.cursor_change_sequence AND change.change_sequence<=watermark
-        WHERE progress.generation_id=requested_generation
+        JOIN timeline_chain ON true
+        JOIN brain.memory_changes AS change ON change.timeline_id=timeline_chain.timeline_id
+          AND change.change_sequence>progress.cursor_change_sequence AND change.change_sequence<=timeline_chain.max_change_sequence
         ORDER BY change.change_sequence
         LIMIT requested_limit
     ), candidates AS MATERIALIZED (
@@ -111,9 +120,9 @@ BEGIN
     ), applied AS (
         SELECT count(*) AS changed FROM queued
     )
-    SELECT advanced.scanned,advanced.next_cursor,advanced.scanned<requested_limit INTO scanned,next_cursor,done FROM advanced CROSS JOIN applied;
+    SELECT advanced.scanned,applied.changed,advanced.next_cursor,advanced.scanned<requested_limit INTO scanned,changed,next_cursor,done FROM advanced CROSS JOIN applied;
     UPDATE brain.embedding_rebuild_progress SET cursor_change_sequence=next_cursor,complete=done WHERE generation_id=requested_generation;
-    enqueued := scanned; cursor_change_sequence := next_cursor; complete := done; RETURN NEXT;
+    enqueued := changed; cursor_change_sequence := next_cursor; complete := done; RETURN NEXT;
 END
 $function$;
 

--- a/internal/postgres/migrations/027_memory_embedding_rebuild_batches.sql
+++ b/internal/postgres/migrations/027_memory_embedding_rebuild_batches.sql
@@ -15,6 +15,7 @@ ALTER TABLE brain.embedding_generations ENABLE TRIGGER USER;
 CREATE TABLE brain.embedding_rebuild_progress (
     generation_id uuid PRIMARY KEY REFERENCES brain.embedding_generations(id) ON DELETE CASCADE,
     timeline_id uuid NOT NULL,
+    timeline_watermark bigint NOT NULL CHECK (timeline_watermark >= 0),
     cursor_change_sequence bigint NOT NULL DEFAULT 0 CHECK (cursor_change_sequence >= 0),
     complete boolean NOT NULL DEFAULT false
 );
@@ -49,7 +50,7 @@ BEGIN
     INSERT INTO brain.embedding_generations (model,model_revision,dimensions,state,start_change_sequence,start_timeline_id)
     VALUES (requested_model,requested_model_revision,requested_dimensions,'building',captured_sequence,captured_timeline)
     RETURNING id INTO new_generation_id;
-    INSERT INTO brain.embedding_rebuild_progress(generation_id,timeline_id) VALUES (new_generation_id,captured_timeline);
+    INSERT INTO brain.embedding_rebuild_progress(generation_id,timeline_id,timeline_watermark) VALUES (new_generation_id,captured_timeline,captured_sequence);
     generation_id := new_generation_id;
     start_change_sequence := captured_sequence;
     RETURN NEXT;
@@ -68,6 +69,8 @@ DECLARE
     changed integer;
     next_cursor bigint;
     done boolean;
+    next_timeline uuid;
+    next_timeline_watermark bigint;
 BEGIN
     PERFORM jobs.assert_application_mutation();
     IF requested_generation IS NULL OR requested_limit IS NULL OR requested_limit < 1 OR requested_limit > 128 THEN
@@ -88,20 +91,11 @@ BEGIN
         WHERE progress.generation_id=requested_generation;
         enqueued := 0; complete := true; RETURN NEXT; RETURN;
     END IF;
-    WITH RECURSIVE timeline_chain(timeline_id,max_change_sequence) AS (
-        SELECT progress.timeline_id,watermark
-        FROM brain.embedding_rebuild_progress AS progress
-        WHERE progress.generation_id=requested_generation
-        UNION ALL
-        SELECT event.previous_timeline_id,event.restored_change_sequence
-        FROM jobs.restore_events AS event
-        JOIN timeline_chain ON event.restored_timeline_id=timeline_chain.timeline_id
-    ), changes AS MATERIALIZED (
+    WITH changes AS MATERIALIZED (
         SELECT change.change_sequence,change.item_id,change.revision
         FROM brain.embedding_rebuild_progress AS progress
-        JOIN timeline_chain ON true
-        JOIN brain.memory_changes AS change ON change.timeline_id=timeline_chain.timeline_id
-          AND change.change_sequence>progress.cursor_change_sequence AND change.change_sequence<=timeline_chain.max_change_sequence
+        JOIN brain.memory_changes AS change ON change.timeline_id=progress.timeline_id
+          AND change.change_sequence>progress.cursor_change_sequence AND change.change_sequence<=progress.timeline_watermark
         ORDER BY change.change_sequence
         LIMIT requested_limit
     ), candidates AS MATERIALIZED (
@@ -116,12 +110,27 @@ BEGIN
         WHERE brain.embedding_jobs.revision<EXCLUDED.revision
         RETURNING 1
     ), advanced AS (
-        SELECT count(*)::integer AS scanned,COALESCE(max(change_sequence),watermark) AS next_cursor FROM changes
+        SELECT count(*)::integer AS scanned,COALESCE(max(changes.change_sequence),progress.timeline_watermark) AS next_cursor
+        FROM changes CROSS JOIN brain.embedding_rebuild_progress AS progress
+        WHERE progress.generation_id=requested_generation
     ), applied AS (
         SELECT count(*) AS changed FROM queued
     )
     SELECT advanced.scanned,applied.changed,advanced.next_cursor,advanced.scanned<requested_limit INTO scanned,changed,next_cursor,done FROM advanced CROSS JOIN applied;
-    UPDATE brain.embedding_rebuild_progress SET cursor_change_sequence=next_cursor,complete=done WHERE generation_id=requested_generation;
+    IF done THEN
+        SELECT event.previous_timeline_id,event.restored_change_sequence INTO next_timeline,next_timeline_watermark
+        FROM jobs.restore_events AS event
+        JOIN brain.embedding_rebuild_progress AS progress ON event.restored_timeline_id=progress.timeline_id
+        WHERE progress.generation_id=requested_generation;
+        IF next_timeline IS NOT NULL THEN
+            UPDATE brain.embedding_rebuild_progress SET timeline_id=next_timeline,timeline_watermark=next_timeline_watermark,cursor_change_sequence=0 WHERE generation_id=requested_generation;
+            done := false; next_cursor := 0;
+        ELSE
+            UPDATE brain.embedding_rebuild_progress SET cursor_change_sequence=next_cursor,complete=true WHERE generation_id=requested_generation;
+        END IF;
+    ELSE
+        UPDATE brain.embedding_rebuild_progress SET cursor_change_sequence=next_cursor WHERE generation_id=requested_generation;
+    END IF;
     enqueued := changed; cursor_change_sequence := next_cursor; complete := done; RETURN NEXT;
 END
 $function$;

--- a/internal/postgres/migrations/027_memory_embedding_rebuild_batches.sql
+++ b/internal/postgres/migrations/027_memory_embedding_rebuild_batches.sql
@@ -124,13 +124,13 @@ BEGIN
         JOIN brain.embedding_rebuild_progress AS progress ON event.restored_timeline_id=progress.timeline_id
         WHERE progress.generation_id=requested_generation;
         IF next_timeline IS NOT NULL THEN
-            UPDATE brain.embedding_rebuild_progress SET timeline_id=next_timeline,timeline_watermark=next_timeline_watermark,cursor_change_sequence=0,reported_progress=reported_progress+scanned WHERE generation_id=requested_generation;
+            UPDATE brain.embedding_rebuild_progress SET timeline_id=next_timeline,timeline_watermark=next_timeline_watermark,cursor_change_sequence=0,reported_progress=reported_progress+GREATEST(scanned,1) WHERE generation_id=requested_generation;
             done := false;
         ELSE
-            UPDATE brain.embedding_rebuild_progress SET cursor_change_sequence=next_cursor,reported_progress=reported_progress+scanned,complete=true WHERE generation_id=requested_generation;
+            UPDATE brain.embedding_rebuild_progress SET cursor_change_sequence=next_cursor,reported_progress=reported_progress+GREATEST(scanned,1),complete=true WHERE generation_id=requested_generation;
         END IF;
     ELSE
-        UPDATE brain.embedding_rebuild_progress SET cursor_change_sequence=next_cursor,reported_progress=reported_progress+scanned WHERE generation_id=requested_generation;
+        UPDATE brain.embedding_rebuild_progress SET cursor_change_sequence=next_cursor,reported_progress=reported_progress+GREATEST(scanned,1) WHERE generation_id=requested_generation;
     END IF;
     SELECT progress.reported_progress INTO cursor_change_sequence FROM brain.embedding_rebuild_progress AS progress WHERE progress.generation_id=requested_generation;
     enqueued := changed; complete := done; RETURN NEXT;

--- a/internal/postgres/migrations/027_memory_embedding_rebuild_batches.sql
+++ b/internal/postgres/migrations/027_memory_embedding_rebuild_batches.sql
@@ -17,6 +17,7 @@ CREATE TABLE brain.embedding_rebuild_progress (
     timeline_id uuid NOT NULL,
     timeline_watermark bigint NOT NULL CHECK (timeline_watermark >= 0),
     cursor_change_sequence bigint NOT NULL DEFAULT 0 CHECK (cursor_change_sequence >= 0),
+    reported_progress bigint NOT NULL DEFAULT 0 CHECK (reported_progress >= 0),
     complete boolean NOT NULL DEFAULT false
 );
 
@@ -86,7 +87,7 @@ BEGIN
         RAISE EXCEPTION USING ERRCODE = '23514', MESSAGE = 'embedding rebuild generation is unavailable';
     END IF;
     IF done THEN
-        SELECT progress.cursor_change_sequence INTO cursor_change_sequence
+        SELECT progress.reported_progress INTO cursor_change_sequence
         FROM brain.embedding_rebuild_progress AS progress
         WHERE progress.generation_id=requested_generation;
         enqueued := 0; complete := true; RETURN NEXT; RETURN;
@@ -123,15 +124,16 @@ BEGIN
         JOIN brain.embedding_rebuild_progress AS progress ON event.restored_timeline_id=progress.timeline_id
         WHERE progress.generation_id=requested_generation;
         IF next_timeline IS NOT NULL THEN
-            UPDATE brain.embedding_rebuild_progress SET timeline_id=next_timeline,timeline_watermark=next_timeline_watermark,cursor_change_sequence=0 WHERE generation_id=requested_generation;
-            done := false; next_cursor := 0;
+            UPDATE brain.embedding_rebuild_progress SET timeline_id=next_timeline,timeline_watermark=next_timeline_watermark,cursor_change_sequence=0,reported_progress=reported_progress+scanned WHERE generation_id=requested_generation;
+            done := false;
         ELSE
-            UPDATE brain.embedding_rebuild_progress SET cursor_change_sequence=next_cursor,complete=true WHERE generation_id=requested_generation;
+            UPDATE brain.embedding_rebuild_progress SET cursor_change_sequence=next_cursor,reported_progress=reported_progress+scanned,complete=true WHERE generation_id=requested_generation;
         END IF;
     ELSE
-        UPDATE brain.embedding_rebuild_progress SET cursor_change_sequence=next_cursor WHERE generation_id=requested_generation;
+        UPDATE brain.embedding_rebuild_progress SET cursor_change_sequence=next_cursor,reported_progress=reported_progress+scanned WHERE generation_id=requested_generation;
     END IF;
-    enqueued := changed; cursor_change_sequence := next_cursor; complete := done; RETURN NEXT;
+    SELECT progress.reported_progress INTO cursor_change_sequence FROM brain.embedding_rebuild_progress AS progress WHERE progress.generation_id=requested_generation;
+    enqueued := changed; complete := done; RETURN NEXT;
 END
 $function$;
 

--- a/internal/postgres/migrations/027_memory_embedding_rebuild_batches.sql
+++ b/internal/postgres/migrations/027_memory_embedding_rebuild_batches.sql
@@ -5,6 +5,10 @@ ADD COLUMN start_timeline_id uuid;
 -- watermark cannot be interpreted after restore or promotion. It is derived
 -- work only: discard it atomically before accepting timeline-bound rebuilds.
 ALTER TABLE brain.embedding_generations DISABLE TRIGGER USER;
+DELETE FROM brain.embedding_chunks
+WHERE generation_id IN (SELECT id FROM brain.embedding_generations WHERE state = 'building');
+DELETE FROM brain.embedding_jobs
+WHERE generation_id IN (SELECT id FROM brain.embedding_generations WHERE state = 'building');
 DELETE FROM brain.embedding_generations WHERE state = 'building';
 ALTER TABLE brain.embedding_generations ENABLE TRIGGER USER;
 
@@ -83,16 +87,19 @@ BEGIN
         WHERE progress.generation_id=requested_generation;
         enqueued := 0; complete := true; RETURN NEXT; RETURN;
     END IF;
-    WITH candidates AS MATERIALIZED (
-        SELECT change.change_sequence,item.id AS item_id,change.revision,revision.content_sha256
+    WITH changes AS MATERIALIZED (
+        SELECT change.change_sequence,change.item_id,change.revision
         FROM brain.embedding_rebuild_progress AS progress
         JOIN brain.memory_changes AS change ON change.timeline_id=progress.timeline_id
           AND change.change_sequence>progress.cursor_change_sequence AND change.change_sequence<=watermark
-        JOIN brain.memory_items AS item ON item.id=change.item_id AND item.current_revision=change.revision
-        JOIN brain.memory_revisions AS revision ON revision.item_id=change.item_id AND revision.revision=change.revision
         WHERE progress.generation_id=requested_generation
         ORDER BY change.change_sequence
         LIMIT requested_limit
+    ), candidates AS MATERIALIZED (
+        SELECT changes.change_sequence,item.id AS item_id,changes.revision,revision.content_sha256
+        FROM changes
+        JOIN brain.memory_items AS item ON item.id=changes.item_id AND item.current_revision=changes.revision
+        JOIN brain.memory_revisions AS revision ON revision.item_id=changes.item_id AND revision.revision=changes.revision
     ), queued AS (
         INSERT INTO brain.embedding_jobs(generation_id,item_id,revision,content_sha256)
         SELECT requested_generation,item_id,revision,content_sha256 FROM candidates
@@ -100,7 +107,7 @@ BEGIN
         WHERE brain.embedding_jobs.revision<EXCLUDED.revision
         RETURNING 1
     ), advanced AS (
-        SELECT count(*)::integer AS scanned,COALESCE(max(change_sequence),watermark) AS next_cursor FROM candidates
+        SELECT count(*)::integer AS scanned,COALESCE(max(change_sequence),watermark) AS next_cursor FROM changes
     ), applied AS (
         SELECT count(*) AS changed FROM queued
     )

--- a/internal/postgres/migrations/027_memory_embedding_rebuild_batches.sql
+++ b/internal/postgres/migrations/027_memory_embedding_rebuild_batches.sql
@@ -100,10 +100,11 @@ BEGIN
         ORDER BY change.change_sequence
         LIMIT requested_limit
     ), candidates AS MATERIALIZED (
-        SELECT changes.change_sequence,item.id AS item_id,changes.revision,revision.content_sha256
+        SELECT DISTINCT ON (changes.item_id) changes.change_sequence,item.id AS item_id,changes.revision,revision.content_sha256
         FROM changes
         JOIN brain.memory_items AS item ON item.id=changes.item_id AND item.current_revision=changes.revision
         JOIN brain.memory_revisions AS revision ON revision.item_id=changes.item_id AND revision.revision=changes.revision
+        ORDER BY changes.item_id,changes.change_sequence DESC
     ), queued AS (
         INSERT INTO brain.embedding_jobs(generation_id,item_id,revision,content_sha256)
         SELECT requested_generation,item_id,revision,content_sha256 FROM candidates

--- a/internal/postgres/postgres_integration_test.go
+++ b/internal/postgres/postgres_integration_test.go
@@ -64,6 +64,7 @@ func TestPostgresPlatformSubstrateIntegration(t *testing.T) {
 	if err := pairDB.Close(); err != nil {
 		t.Fatal(err)
 	}
+	testV26EmbeddingRebuildUpgradeIntegration(ctx, t, pairOwnerDSN)
 
 	app, err := OpenApplication(ctx, Config{DSNFile: appFile})
 	if err != nil {
@@ -751,6 +752,113 @@ AS $function$ BEGIN RETURN NEW; END $function$`); err != nil {
 	if err := ownerDB.QueryRowContext(ctx, `SELECT to_regclass('jobs.schema_migrations') IS NOT NULL`).Scan(&trackerExists); err != nil || trackerExists {
 		t.Fatalf("missing-role refusal mutated schema: tracker_exists=%t err=%v", trackerExists, err)
 	}
+}
+
+func testV26EmbeddingRebuildUpgradeIntegration(ctx context.Context, t *testing.T, ownerDSN string) {
+	t.Helper()
+	ownerDB, err := open(ctx, ownerDSN)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = ownerDB.Close() }()
+	current := CurrentManifest()
+	v26 := Manifest{MinSupported: 10, MaxSupported: 26, Migrations: append([]Migration(nil), current.Migrations[:26]...)}
+	if state, err := migrate(ctx, ownerDB, v26); err != nil || state.Classification != Compatible {
+		t.Fatalf("v26 bridge setup state=%#v err=%v", state, err)
+	}
+	var activeGenerationID, buildingGenerationID string
+	if err := ownerDB.QueryRowContext(ctx, `
+		WITH inserted AS (
+			INSERT INTO brain.embedding_generations(model,model_revision,dimensions,state)
+			VALUES ('bridge.active','2026-01',1,'active'),('bridge.building','2026-01',1,'building')
+			RETURNING id,state
+		)
+		SELECT max(id::text) FILTER (WHERE state='active'),max(id::text) FILTER (WHERE state='building')
+		FROM inserted`).Scan(&activeGenerationID, &buildingGenerationID); err != nil {
+		t.Fatal(err)
+	}
+	seedV26EmbeddingRebuildDerivedWork(ctx, t, ownerDB, activeGenerationID, buildingGenerationID)
+	conn := mustConn(t, ctx, ownerDB)
+	defer func() { _ = conn.Close() }()
+	if state, err := migrateConnExpectedAppRole(ctx, conn, current, "punaro_app", true); err != nil || state.Classification != Compatible || state.Version != 27 {
+		t.Fatalf("v27 bridge state=%#v err=%v", state, err)
+	}
+	var active, building, activeJobs, buildingJobs, activeChunks, buildingChunks int
+	if err := ownerDB.QueryRowContext(ctx, `
+		SELECT
+			count(*) FILTER (WHERE generation.state='active'),
+			count(*) FILTER (WHERE generation.state='building'),
+			count(job.item_id) FILTER (WHERE generation.state='active'),
+			count(job.item_id) FILTER (WHERE generation.state='building'),
+			count(chunk.item_id) FILTER (WHERE generation.state='active'),
+			count(chunk.item_id) FILTER (WHERE generation.state='building')
+		FROM brain.embedding_generations AS generation
+		LEFT JOIN brain.embedding_jobs AS job ON job.generation_id=generation.id
+		LEFT JOIN brain.embedding_chunks AS chunk ON chunk.generation_id=generation.id
+	`).Scan(&active, &building, &activeJobs, &buildingJobs, &activeChunks, &buildingChunks); err != nil || active != 1 || building != 0 || activeJobs != 1 || buildingJobs != 0 || activeChunks != 1 || buildingChunks != 0 {
+		t.Fatalf("v27 generation cleanup active=%d building=%d active_jobs=%d building_jobs=%d active_chunks=%d building_chunks=%d err=%v", active, building, activeJobs, buildingJobs, activeChunks, buildingChunks, err)
+	}
+}
+
+func seedV26EmbeddingRebuildDerivedWork(ctx context.Context, t *testing.T, ownerDB *sql.DB, activeGenerationID, buildingGenerationID string) {
+	t.Helper()
+	for _, table := range []string{"brain.scopes", "brain.memory_items", "brain.memory_revisions", "brain.embedding_chunks"} {
+		if _, err := ownerDB.ExecContext(ctx, "ALTER TABLE "+table+" DISABLE TRIGGER USER"); err != nil {
+			t.Fatal(err)
+		}
+	}
+	defer func() {
+		for _, table := range []string{"brain.embedding_chunks", "brain.memory_revisions", "brain.memory_items", "brain.scopes"} {
+			if _, err := ownerDB.ExecContext(ctx, "ALTER TABLE "+table+" ENABLE TRIGGER USER"); err != nil {
+				t.Errorf("re-enable %s triggers: %v", table, err)
+			}
+		}
+	}()
+	tx, err := ownerDB.BeginTx(ctx, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = tx.Rollback() }()
+	var itemID string
+	var contentSHA256 []byte
+	if err := tx.QueryRowContext(ctx, `
+		WITH principal AS (
+			INSERT INTO auth.principals(kind,display_name) VALUES ('device','v26 rebuild bridge') RETURNING id
+		), project AS (
+			INSERT INTO relay.projects(display_name,created_by) SELECT 'v26 rebuild bridge',id FROM principal RETURNING id,created_by
+		), scope AS (
+			INSERT INTO brain.scopes(project_id,created_by) SELECT id,created_by FROM project RETURNING id,created_by
+		), item AS (
+			INSERT INTO brain.memory_items(scope_id,kind,trust,current_revision,created_by)
+			SELECT id,'bridge','curated',1,created_by FROM scope RETURNING id,created_by
+		), revision AS (
+			INSERT INTO brain.memory_revisions(item_id,revision,document,content_sha256,author_principal_id,operation)
+			SELECT id,1,'{}'::jsonb,decode(repeat('ab',32),'hex'),created_by,'create' FROM item
+			RETURNING item_id,content_sha256
+		)
+		SELECT item_id::text,content_sha256 FROM revision`).Scan(&itemID, &contentSHA256); err != nil {
+		t.Fatal(err)
+	}
+	for _, generationID := range []string{activeGenerationID, buildingGenerationID} {
+		if _, err := tx.ExecContext(ctx, `INSERT INTO brain.embedding_jobs(generation_id,item_id,revision,content_sha256) VALUES ($1,$2,1,$3)`, generationID, itemID, contentSHA256); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := tx.ExecContext(ctx, `INSERT INTO brain.embedding_chunks(generation_id,item_id,revision,ordinal,content_sha256,start_offset,end_offset) VALUES ($1,$2,1,0,$3,0,1)`, generationID, itemID, contentSHA256); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func mustConn(t *testing.T, ctx context.Context, db *sql.DB) *sql.Conn {
+	t.Helper()
+	conn, err := db.Conn(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return conn
 }
 
 func testMailCutoverSubstrate(ctx context.Context, t *testing.T, app *Database, ownerDB *sql.DB) {

--- a/internal/postgres/postgres_integration_test.go
+++ b/internal/postgres/postgres_integration_test.go
@@ -778,7 +778,7 @@ func testV26EmbeddingRebuildUpgradeIntegration(ctx context.Context, t *testing.T
 		t.Fatal(err)
 	}
 	seedV26EmbeddingRebuildDerivedWork(ctx, t, ownerDB, activeGenerationID, buildingGenerationID)
-	conn := mustConn(t, ctx, ownerDB)
+	conn := mustConn(ctx, t, ownerDB)
 	defer func() { _ = conn.Close() }()
 	if state, err := migrateConnExpectedAppRole(ctx, conn, current, "punaro_app", true); err != nil || state.Classification != Compatible || state.Version != 27 {
 		t.Fatalf("v27 bridge state=%#v err=%v", state, err)
@@ -852,7 +852,7 @@ func seedV26EmbeddingRebuildDerivedWork(ctx context.Context, t *testing.T, owner
 	}
 }
 
-func mustConn(t *testing.T, ctx context.Context, db *sql.DB) *sql.Conn {
+func mustConn(ctx context.Context, t *testing.T, db *sql.DB) *sql.Conn {
 	t.Helper()
 	conn, err := db.Conn(ctx)
 	if err != nil {

--- a/internal/postgres/state_test.go
+++ b/internal/postgres/state_test.go
@@ -69,8 +69,8 @@ func TestManifestValidationRejectsMutableOrNonContiguousHistory(t *testing.T) {
 
 func TestCurrentManifestRequiresControlPlaneSchema(t *testing.T) {
 	manifest := CurrentManifest()
-	if manifest.MinSupported != 10 || manifest.MaxSupported != 26 || len(manifest.Migrations) != 26 {
-		t.Fatalf("manifest=%#v, want exact v10-v26 compatibility window", manifest)
+	if manifest.MinSupported != 10 || manifest.MaxSupported != 27 || len(manifest.Migrations) != 27 {
+		t.Fatalf("manifest=%#v, want exact v10-v27 compatibility window", manifest)
 	}
 	embedding := manifest.Migrations[23]
 	if embedding.Version != 24 || embedding.Name != "024_memory_embedding_worker_control" ||
@@ -88,7 +88,7 @@ func TestCurrentManifestRequiresControlPlaneSchema(t *testing.T) {
 			want = 10
 		case 12, 13:
 			want = 10
-		case 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26:
+		case 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27:
 			want = 10
 		}
 		if migration.CompatibilityFloor != want {
@@ -165,7 +165,10 @@ func TestCompatibleSchemaCanStillHavePendingMigrations(t *testing.T) {
 	if !migrationPending(SchemaState{Classification: Compatible, Version: 25}, manifest) {
 		t.Fatal("compatible v25 schema must still apply the pending v26 migration")
 	}
-	if migrationPending(SchemaState{Classification: Compatible, Version: 26}, manifest) {
-		t.Fatal("current v26 schema reported a pending migration")
+	if !migrationPending(SchemaState{Classification: Compatible, Version: 26}, manifest) {
+		t.Fatal("compatible v26 schema must still apply the pending v27 migration")
+	}
+	if migrationPending(SchemaState{Classification: Compatible, Version: 27}, manifest) {
+		t.Fatal("current v27 schema reported a pending migration")
 	}
 }


### PR DESCRIPTION
## Summary
- add schema v27 owner-only, timeline-bound progress and bounded rebuild batches
- preserve newer post-start jobs while scanning historical current revisions
- fail closed on progress/routine schema or privilege drift

## Validation
- make test
- make test-race
- make staticcheck
- make security
- make lint
- focused PostgreSQL integration: TestPostgresPlatformSubstrateIntegration