### PR TITLE
Add fenced embedding vector publication

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -439,6 +439,15 @@ application role cannot activate a generation, and replay fails after the
 generation has ceased to be building. There is still no provider, vector
 storage, semantic ranking, or client-facing semantic surface.
 
+Schema version 29 records finite pgvector output for every bounded chunk only
+when the worker's exact leased-generation, revision, digest, and lease fence
+still holds. Each vector must exactly match the generation's pinned dimension.
+Coordinate-only successes from older schemas are derived data, so upgrade
+requeues them and clears their chunks; terminal failures remain diagnostics
+rather than being erased. There is no provider credential or fragment text in
+the database, no vector index, and still no semantic query, hybrid ranking, or
+client-facing surface.
+
 Schema version 15 places one deterministic secret guard inside the authorized
 create/update transaction before any scope, revision, change, audit,
 idempotency result, or derived job can be written. Findings contain only the

--- a/cmd/punaro/main.go
+++ b/cmd/punaro/main.go
@@ -906,7 +906,7 @@ func restoreBackup(ctx context.Context, request restoreRequest) (punarobackup.St
 				return &punarobackup.OperationError{Phase: punarobackup.PhasePreflight, Err: err}
 			}
 			if manifest.SchemaVersion >= 29 {
-				if err := punaropostgres.RequirePGVector(preflightCtx, punaropostgres.Config{DSNFile: request.OwnerDSNFile}); err != nil {
+				if err := punaropostgres.RequireInstalledPGVector(preflightCtx, punaropostgres.Config{DSNFile: request.OwnerDSNFile}); err != nil {
 					return &punarobackup.OperationError{Phase: punarobackup.PhasePreflight, Err: err}
 				}
 			}

--- a/cmd/punaro/main.go
+++ b/cmd/punaro/main.go
@@ -905,6 +905,11 @@ func restoreBackup(ctx context.Context, request restoreRequest) (punarobackup.St
 			if err := verifyPristinePair(preflightCtx, request.AppDSNFile, request.OwnerDSNFile); err != nil {
 				return &punarobackup.OperationError{Phase: punarobackup.PhasePreflight, Err: err}
 			}
+			if manifest.SchemaVersion >= 29 {
+				if err := punaropostgres.RequirePGVector(preflightCtx, punaropostgres.Config{DSNFile: request.OwnerDSNFile}); err != nil {
+					return &punarobackup.OperationError{Phase: punarobackup.PhasePreflight, Err: err}
+				}
+			}
 			return nil
 		},
 		RestoreDump: func(restoreCtx context.Context, dump io.Reader) error {

--- a/cmd/punaro/update_command.go
+++ b/cmd/punaro/update_command.go
@@ -282,6 +282,9 @@ func (executor *commandUpdateExecutor) PreflightAndPull(ctx context.Context) err
 	if appErr != nil || ownerErr != nil || appIdentity != ownerIdentity || inspectErr != nil || owner.ID != executor.installation.OwnerPrincipalID {
 		return errors.New("installation database identity changed")
 	}
+	if err := punaropostgres.RequirePGVector(ctx, punaropostgres.Config{DSNFile: executor.installation.OwnerDSNFile}); err != nil {
+		return err
+	}
 	for _, path := range []string{executor.installation.DataDir, executor.installation.BackupDir} {
 		available, err := operator.UpdateAvailableBytes(path)
 		if err != nil || available < minimumUpdateFreeBytes {

--- a/docs/platform-contracts.md
+++ b/docs/platform-contracts.md
@@ -383,6 +383,19 @@ the completed promotion fails because the requested generation is no longer
 building. Rollback remains the verified pre-update restore boundary for
 derived-only state.
 
+Schema 29 stores the first derived vector payload without enabling semantic
+retrieval. The pinned pgvector extension receives one finite vector for every
+ordered chunk, exactly matching the immutable leased generation's declared
+dimension. The existing publication routine keeps its generation, current
+revision, canonical-digest, unexpired-lease-token, and lease-generation fence;
+invalid dimensionality or numeric values leave both chunks and the job
+unchanged. Upgrade drops only prior coordinate-only chunk output and requeues
+previously succeeded or interrupted derived jobs, while preserving terminal
+failures as explicit degradation evidence. The application role remains unable
+to mutate vector rows, no provider configuration or text is stored, and no
+vector index, semantic query, route, client surface, hybrid ranking, or RRF is
+introduced.
+
 The dark prompt-brief read adds no schema and exposes no route or client. It
 accepts the same bounded normalized query as lexical search, resolves the
 active canonical project, and requires only `memory.search` because it returns

--- a/internal/postgres/brain_embedding.go
+++ b/internal/postgres/brain_embedding.go
@@ -5,6 +5,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"errors"
+	"math"
 	"regexp"
 	"time"
 )
@@ -63,19 +64,27 @@ type MemoryEmbeddingWork struct {
 	ContentSHA256 string
 }
 
-// MemoryEmbeddingChunk is content-free, revision-bound output metadata for
-// one derived fragment. The actual fragment and vector are deliberately not
-// stored in this M19C control-plane slice.
+// MemoryEmbeddingChunk is revision-bound derived output for one fragment. Its
+// vector is bounded worker output, never canonical content or provider state.
 type MemoryEmbeddingChunk struct {
-	Ordinal       int    `json:"ordinal"`
-	ContentSHA256 string `json:"content_sha256"`
-	StartOffset   int    `json:"start_offset"`
-	EndOffset     int    `json:"end_offset"`
+	Ordinal       int       `json:"ordinal"`
+	ContentSHA256 string    `json:"content_sha256"`
+	StartOffset   int       `json:"start_offset"`
+	EndOffset     int       `json:"end_offset"`
+	Vector        []float64 `json:"embedding"`
 }
 
 func (chunk MemoryEmbeddingChunk) valid() bool {
 	if chunk.Ordinal < 0 || chunk.StartOffset < 0 || chunk.EndOffset <= chunk.StartOffset || chunk.EndOffset > 262144 || len(chunk.ContentSHA256) != 64 {
 		return false
+	}
+	if len(chunk.Vector) < 1 || len(chunk.Vector) > maxMemoryEmbeddingDimensions {
+		return false
+	}
+	for _, value := range chunk.Vector {
+		if math.IsNaN(value) || math.IsInf(value, 0) {
+			return false
+		}
 	}
 	digest, err := hex.DecodeString(chunk.ContentSHA256)
 	return err == nil && len(digest) == 32 && hex.EncodeToString(digest) == chunk.ContentSHA256

--- a/internal/postgres/brain_embedding.go
+++ b/internal/postgres/brain_embedding.go
@@ -82,7 +82,7 @@ func (chunk MemoryEmbeddingChunk) valid() bool {
 		return false
 	}
 	for _, value := range chunk.Vector {
-		if math.IsNaN(value) || math.IsInf(value, 0) || math.Abs(value) > math.MaxFloat32 {
+		if math.IsNaN(value) || math.IsInf(value, 0) || math.Abs(value) > math.MaxFloat32 || (value != 0 && float64(float32(value)) == 0) {
 			return false
 		}
 	}

--- a/internal/postgres/brain_embedding.go
+++ b/internal/postgres/brain_embedding.go
@@ -82,7 +82,7 @@ func (chunk MemoryEmbeddingChunk) valid() bool {
 		return false
 	}
 	for _, value := range chunk.Vector {
-		if math.IsNaN(value) || math.IsInf(value, 0) {
+		if math.IsNaN(value) || math.IsInf(value, 0) || math.Abs(value) > math.MaxFloat32 {
 			return false
 		}
 	}

--- a/internal/postgres/brain_embedding.go
+++ b/internal/postgres/brain_embedding.go
@@ -136,6 +136,21 @@ func (d *Database) PublishMemoryEmbeddingWork(ctx context.Context, publication M
 		return errors.New("embedding work could not be published")
 	}
 	if !changed {
+		var dimensions int
+		err = tx.QueryRowContext(ctx, `SELECT generation.dimensions
+FROM brain.embedding_jobs AS job
+JOIN brain.embedding_generations AS generation ON generation.id=job.generation_id
+JOIN brain.memory_items AS item ON item.id=job.item_id AND item.current_revision=job.revision
+WHERE job.generation_id=$1 AND job.item_id=$2 AND job.revision=$3
+  AND job.content_sha256=$4 AND job.state='running' AND job.lease_token=$5
+  AND job.lease_generation=$6 AND job.lease_until > statement_timestamp()`, publication.Lease.GenerationID, publication.Lease.ItemID, publication.Lease.Revision, digest, publication.Lease.Token, publication.Lease.LeaseGeneration).Scan(&dimensions)
+		if err == nil {
+			for _, chunk := range publication.Chunks {
+				if len(chunk.Vector) != dimensions {
+					return errors.New("invalid embedding publication")
+				}
+			}
+		}
 		return ErrStaleEmbeddingLease
 	}
 	if err := tx.Commit(); err != nil {

--- a/internal/postgres/brain_embedding_integration_test.go
+++ b/internal/postgres/brain_embedding_integration_test.go
@@ -281,8 +281,8 @@ func testMemoryEmbeddingQueueIntegration(ctx context.Context, t *testing.T, app 
 	}
 	dimensionMismatchChunks := `[{"ordinal":0,"content_sha256":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","start_offset":0,"end_offset":12,"embedding":[0.25,0.5]}]`
 	err = app.db.QueryRowContext(ctx, `SELECT brain.publish_embedding_job($1,$2,$3,decode($4,'hex'),$5,$6,$7::jsonb)`, rollbackLease.GenerationID, rollbackLease.ItemID, rollbackLease.Revision, rollbackLease.ContentSHA256, rollbackLease.Token, rollbackLease.LeaseGeneration, dimensionMismatchChunks).Scan(&published)
-	if err == nil {
-		t.Fatalf("wrong-dimension publication succeeded: published=%t", published)
+	if err != nil || published {
+		t.Fatalf("wrong-dimension publication=%t err=%v, want unchanged false result", published, err)
 	}
 	var rollbackState, rollbackToken, rollbackDigest string
 	var rollbackLeaseGeneration int64

--- a/internal/postgres/brain_embedding_integration_test.go
+++ b/internal/postgres/brain_embedding_integration_test.go
@@ -279,6 +279,11 @@ func testMemoryEmbeddingQueueIntegration(ctx context.Context, t *testing.T, app 
 	if err == nil {
 		t.Fatalf("duplicate-ordinal publication succeeded: published=%t", published)
 	}
+	dimensionMismatchChunks := `[{"ordinal":0,"content_sha256":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","start_offset":0,"end_offset":12,"embedding":[0.25,0.5]}]`
+	err = app.db.QueryRowContext(ctx, `SELECT brain.publish_embedding_job($1,$2,$3,decode($4,'hex'),$5,$6,$7::jsonb)`, rollbackLease.GenerationID, rollbackLease.ItemID, rollbackLease.Revision, rollbackLease.ContentSHA256, rollbackLease.Token, rollbackLease.LeaseGeneration, dimensionMismatchChunks).Scan(&published)
+	if err == nil {
+		t.Fatalf("wrong-dimension publication succeeded: published=%t", published)
+	}
 	var rollbackState, rollbackToken, rollbackDigest string
 	var rollbackLeaseGeneration int64
 	if err := ownerDB.QueryRowContext(ctx, `SELECT state,lease_token::text,encode(content_sha256,'hex'),lease_generation FROM brain.embedding_jobs WHERE generation_id=$1 AND item_id=$2`, rollbackLease.GenerationID, rollbackLease.ItemID).Scan(&rollbackState, &rollbackToken, &rollbackDigest, &rollbackLeaseGeneration); err != nil || rollbackState != "running" || rollbackToken != rollbackLease.Token || rollbackDigest != rollbackLease.ContentSHA256 || rollbackLeaseGeneration != rollbackLease.LeaseGeneration {

--- a/internal/postgres/brain_embedding_integration_test.go
+++ b/internal/postgres/brain_embedding_integration_test.go
@@ -173,7 +173,7 @@ func testMemoryEmbeddingQueueIntegration(ctx context.Context, t *testing.T, app 
 	}
 
 	var generationID string
-	if err := ownerDB.QueryRowContext(ctx, `INSERT INTO brain.embedding_generations(model,model_revision,dimensions) VALUES ('local.e5-base','2026-07-01',768) RETURNING id::text`).Scan(&generationID); err != nil {
+	if err := ownerDB.QueryRowContext(ctx, `INSERT INTO brain.embedding_generations(model,model_revision,dimensions) VALUES ('local.e5-base','2026-07-01',3) RETURNING id::text`).Scan(&generationID); err != nil {
 		t.Fatal(err)
 	}
 	if _, err := ownerDB.ExecContext(ctx, `UPDATE brain.embedding_generations SET dimensions=1024 WHERE id=$1`, generationID); err == nil {
@@ -249,13 +249,13 @@ func testMemoryEmbeddingQueueIntegration(ctx context.Context, t *testing.T, app 
 		t.Fatalf("terminal embedding state=%q code=%q err=%v", state, errorCode, err)
 	}
 	publishable := create("19191919-1919-4191-8191-191919191917", "publish chunks")
-	claimed, err = app.ClaimMemoryEmbeddingWork(ctx, MemoryEmbeddingClaimRequest{WorkerID: "19191919-1919-4191-8191-191919191918", Limit: 1, LeaseDuration: memoryEmbeddingMinLease})
+	claimed, err = app.ClaimMemoryEmbeddingWork(ctx, MemoryEmbeddingClaimRequest{WorkerID: "19191919-1919-4191-8191-191919191918", Limit: 1, LeaseDuration: memoryEmbeddingMaxLease})
 	if err != nil || len(claimed) != 1 || claimed[0].ItemID != publishable.ItemID {
 		t.Fatalf("publishable embedding claim=%#v err=%v", claimed, err)
 	}
 	publication := MemoryEmbeddingPublication{Lease: claimed[0], Chunks: []MemoryEmbeddingChunk{
-		{Ordinal: 0, ContentSHA256: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", StartOffset: 0, EndOffset: 12},
-		{Ordinal: 1, ContentSHA256: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", StartOffset: 12, EndOffset: 28},
+		{Ordinal: 0, ContentSHA256: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", StartOffset: 0, EndOffset: 12, Vector: []float64{0.25, 0.5, 0.75}},
+		{Ordinal: 1, ContentSHA256: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", StartOffset: 12, EndOffset: 28, Vector: []float64{0.75, 0.5, 0.25}},
 	}}
 	rollback := create("19191919-1919-4191-8191-191919191925", "rollback publication")
 	claimed, err = app.ClaimMemoryEmbeddingWork(ctx, MemoryEmbeddingClaimRequest{WorkerID: "19191919-1919-4191-8191-191919191926", Limit: 1, LeaseDuration: memoryEmbeddingMinLease})
@@ -263,14 +263,14 @@ func testMemoryEmbeddingQueueIntegration(ctx context.Context, t *testing.T, app 
 		t.Fatalf("rollback publication claim=%#v err=%v", claimed, err)
 	}
 	rollbackLease := claimed[0]
-	if _, err := ownerDB.ExecContext(ctx, `INSERT INTO brain.embedding_chunks(generation_id,item_id,revision,ordinal,content_sha256,start_offset,end_offset) VALUES ($1,$2,$3,0,decode($4,'hex'),0,12)`, rollbackLease.GenerationID, rollbackLease.ItemID, rollbackLease.Revision, "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"); err != nil {
+	if _, err := ownerDB.ExecContext(ctx, `INSERT INTO brain.embedding_chunks(generation_id,item_id,revision,ordinal,content_sha256,start_offset,end_offset,embedding) VALUES ($1,$2,$3,0,decode($4,'hex'),0,12,'[0.25,0.5,0.75]'::vector)`, rollbackLease.GenerationID, rollbackLease.ItemID, rollbackLease.Revision, "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"); err != nil {
 		t.Fatal(err)
 	}
 	rollbackConn, err := app.db.Conn(ctx)
 	if err != nil {
 		t.Fatal(err)
 	}
-	invalidChunks := `[{"ordinal":0,"content_sha256":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","start_offset":0,"end_offset":12},{"ordinal":0,"content_sha256":"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb","start_offset":12,"end_offset":28}]`
+	invalidChunks := `[{"ordinal":0,"content_sha256":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","start_offset":0,"end_offset":12,"embedding":[0.25,0.5,0.75]},{"ordinal":0,"content_sha256":"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb","start_offset":12,"end_offset":28,"embedding":[0.75,0.5,0.25]}]`
 	var published bool
 	err = rollbackConn.QueryRowContext(ctx, `SELECT brain.publish_embedding_job($1,$2,$3,decode($4,'hex'),$5,$6,$7::jsonb)`, rollbackLease.GenerationID, rollbackLease.ItemID, rollbackLease.Revision, rollbackLease.ContentSHA256, rollbackLease.Token, rollbackLease.LeaseGeneration, invalidChunks).Scan(&published)
 	if closeErr := rollbackConn.Close(); closeErr != nil {
@@ -303,7 +303,7 @@ func testMemoryEmbeddingQueueIntegration(ctx context.Context, t *testing.T, app 
 	if err != nil {
 		t.Fatal(err)
 	}
-	validChunks := `[{"ordinal":0,"content_sha256":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","start_offset":0,"end_offset":12}]`
+	validChunks := `[{"ordinal":0,"content_sha256":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","start_offset":0,"end_offset":12,"embedding":[0.25,0.5,0.75]}]`
 	if err := disconnectTx.QueryRowContext(ctx, `SELECT brain.publish_embedding_job($1,$2,$3,decode($4,'hex'),$5,$6,$7::jsonb)`, disconnectLease.GenerationID, disconnectLease.ItemID, disconnectLease.Revision, disconnectLease.ContentSHA256, disconnectLease.Token, disconnectLease.LeaseGeneration, validChunks).Scan(&published); err != nil || !published {
 		t.Fatalf("uncommitted publication=%t err=%v", published, err)
 	}
@@ -358,6 +358,10 @@ func testMemoryEmbeddingQueueIntegration(ctx context.Context, t *testing.T, app 
 	}
 	if err := ownerDB.QueryRowContext(ctx, `SELECT count(*) FROM brain.embedding_chunks WHERE generation_id=$1 AND item_id=$2 AND revision=$3`, generationID, publishable.ItemID, publication.Lease.Revision).Scan(&count); err != nil || count != len(publication.Chunks) {
 		t.Fatalf("published embedding chunks=%d err=%v", count, err)
+	}
+	var storedVector string
+	if err := ownerDB.QueryRowContext(ctx, `SELECT embedding::text FROM brain.embedding_chunks WHERE generation_id=$1 AND item_id=$2 AND revision=$3 AND ordinal=0`, generationID, publishable.ItemID, publication.Lease.Revision).Scan(&storedVector); err != nil || storedVector != "[0.25,0.5,0.75]" {
+		t.Fatalf("published embedding vector=%q err=%v", storedVector, err)
 	}
 	if err := app.PublishMemoryEmbeddingWork(ctx, publication); !errors.Is(err, ErrStaleEmbeddingLease) {
 		t.Fatalf("replayed embedding publication error=%v", err)

--- a/internal/postgres/brain_embedding_publication_schema.go
+++ b/internal/postgres/brain_embedding_publication_schema.go
@@ -13,7 +13,7 @@ func memoryEmbeddingPublicationControlsAvailable(ctx context.Context, q queryer,
            to_regprocedure('jobs.guard_application_mutation()') AS fence_oid,
            to_regprocedure('brain.guard_embedding_chunk_delete()') AS delete_fence_oid
 ), expected_columns(relation_name,column_name,type_name,not_null,default_expression) AS (
-    VALUES
+    SELECT * FROM (VALUES
       ('brain.embedding_chunks','generation_id','uuid',true,''),
       ('brain.embedding_chunks','item_id','uuid',true,''),
       ('brain.embedding_chunks','revision','bigint',true,''),
@@ -22,6 +22,8 @@ func memoryEmbeddingPublicationControlsAvailable(ctx context.Context, q queryer,
       ('brain.embedding_chunks','start_offset','integer',true,''),
       ('brain.embedding_chunks','end_offset','integer',true,''),
       ('brain.embedding_chunks','created_at','timestamp with time zone',true,'statement_timestamp()')
+    ) AS base(relation_name,column_name,type_name,not_null,default_expression)
+    UNION ALL SELECT 'brain.embedding_chunks','embedding','vector',true,'' WHERE $1 >= 29
 ), actual_columns AS (
     SELECT attribute.attrelid::regclass::text,attribute.attname,format_type(attribute.atttypid,attribute.atttypmod),attribute.attnotnull,
            COALESCE(pg_get_expr(default_value.adbin,default_value.adrelid),'')
@@ -79,7 +81,7 @@ func memoryEmbeddingPublicationControlsAvailable(ctx context.Context, q queryer,
         AND proc.prorettype='boolean'::regtype AND NOT proc.proretset AND proc.prosecdef
         AND proc.provolatile='v' AND proc.prolang=(SELECT oid FROM pg_language WHERE lanname='plpgsql')
         AND proc.proconfig=ARRAY['search_path=pg_catalog']::text[]
-        AND md5(btrim(proc.prosrc,E' \n\r\t'))='2a5bb540102e4944f41c63c31a5aed49') AS exact
+        AND md5(btrim(proc.prosrc,E' \n\r\t'))=CASE WHEN $1 < 29 THEN '2a5bb540102e4944f41c63c31a5aed49' ELSE $2 END) AS exact
     FROM pg_proc AS proc,objects WHERE proc.oid=publish_oid
 ), expected_routine_acl(grantee,privilege_type,is_grantable) AS (
     VALUES ('punaro_owner','EXECUTE',false),('punaro_app','EXECUTE',false)
@@ -118,6 +120,6 @@ SELECT chunks_oid IS NOT NULL AND publish_oid IS NOT NULL AND fence_oid IS NOT N
    AND NOT EXISTS (SELECT * FROM actual_checks EXCEPT SELECT * FROM expected_checks)
    AND has_table_privilege('punaro_app',chunks_oid,'SELECT')
    AND NOT has_table_privilege('punaro_app',chunks_oid,'INSERT,UPDATE,DELETE,TRUNCATE,REFERENCES,TRIGGER')
-FROM objects,table_safety,constraint_safety,index_safety,fence_safety,routine_safety,routine_acl,column_acl,table_acl`, schemaVersion).Scan(&available)
+FROM objects,table_safety,constraint_safety,index_safety,fence_safety,routine_safety,routine_acl,column_acl,table_acl`, schemaVersion, memoryEmbeddingVectorPublicationRoutineMD5).Scan(&available)
 	return available, err
 }

--- a/internal/postgres/brain_embedding_publication_schema.go
+++ b/internal/postgres/brain_embedding_publication_schema.go
@@ -25,7 +25,8 @@ func memoryEmbeddingPublicationControlsAvailable(ctx context.Context, q queryer,
     ) AS base(relation_name,column_name,type_name,not_null,default_expression)
     UNION ALL SELECT 'brain.embedding_chunks','embedding','vector',true,'' WHERE $1 >= 29
 ), actual_columns AS (
-    SELECT attribute.attrelid::regclass::text,attribute.attname,format_type(attribute.atttypid,attribute.atttypmod),attribute.attnotnull,
+    SELECT attribute.attrelid::regclass::text,attribute.attname,
+           CASE WHEN attribute.atttypid='public.vector'::regtype THEN 'vector' ELSE format_type(attribute.atttypid,attribute.atttypmod) END,attribute.attnotnull,
            COALESCE(pg_get_expr(default_value.adbin,default_value.adrelid),'')
     FROM pg_attribute AS attribute
     LEFT JOIN pg_attrdef AS default_value ON default_value.adrelid=attribute.attrelid AND default_value.adnum=attribute.attnum,objects

--- a/internal/postgres/brain_embedding_publication_schema.go
+++ b/internal/postgres/brain_embedding_publication_schema.go
@@ -26,7 +26,7 @@ func memoryEmbeddingPublicationControlsAvailable(ctx context.Context, q queryer,
     UNION ALL SELECT 'brain.embedding_chunks','embedding','vector',true,'' WHERE $1 >= 29
 ), actual_columns AS (
     SELECT attribute.attrelid::regclass::text,attribute.attname,
-           CASE WHEN attribute.atttypid='public.vector'::regtype THEN 'vector' ELSE format_type(attribute.atttypid,attribute.atttypmod) END,attribute.attnotnull,
+           CASE WHEN $1 >= 29 AND attribute.atttypid=to_regtype('public.vector') THEN 'vector' ELSE format_type(attribute.atttypid,attribute.atttypmod) END,attribute.attnotnull,
            COALESCE(pg_get_expr(default_value.adbin,default_value.adrelid),'')
     FROM pg_attribute AS attribute
     LEFT JOIN pg_attrdef AS default_value ON default_value.adrelid=attribute.attrelid AND default_value.adnum=attribute.attnum,objects

--- a/internal/postgres/brain_embedding_test.go
+++ b/internal/postgres/brain_embedding_test.go
@@ -108,6 +108,7 @@ func TestMemoryEmbeddingPublicationValidation(t *testing.T) {
 		"empty vector":           {Lease: lease, Chunks: []MemoryEmbeddingChunk{{ContentSHA256: lease.ContentSHA256, EndOffset: 32}}},
 		"infinite vector":        {Lease: lease, Chunks: []MemoryEmbeddingChunk{{ContentSHA256: lease.ContentSHA256, EndOffset: 32, Vector: []float64{math.Inf(1)}}}},
 		"unrepresentable vector": {Lease: lease, Chunks: []MemoryEmbeddingChunk{{ContentSHA256: lease.ContentSHA256, EndOffset: 32, Vector: []float64{math.MaxFloat64}}}},
+		"underflow vector":       {Lease: lease, Chunks: []MemoryEmbeddingChunk{{ContentSHA256: lease.ContentSHA256, EndOffset: 32, Vector: []float64{math.SmallestNonzeroFloat64}}}},
 		"overlapping range":      {Lease: lease, Chunks: []MemoryEmbeddingChunk{{ContentSHA256: lease.ContentSHA256, EndOffset: 32, Vector: []float64{0.25}}, {Ordinal: 1, ContentSHA256: lease.ContentSHA256, StartOffset: 31, EndOffset: 64, Vector: []float64{0.5}}}},
 	} {
 		t.Run(name, func(t *testing.T) {

--- a/internal/postgres/brain_embedding_test.go
+++ b/internal/postgres/brain_embedding_test.go
@@ -1,6 +1,7 @@
 package postgres
 
 import (
+	"math"
 	"testing"
 	"time"
 )
@@ -95,16 +96,18 @@ func TestMemoryEmbeddingPublicationValidation(t *testing.T) {
 		Revision:      1,
 		ContentSHA256: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
 	}, Attempts: 1, Holder: "33333333-3333-4333-8333-333333333333", Token: "44444444-4444-4444-8444-444444444444", LeaseGeneration: 1, LeaseUntil: time.Now()}
-	valid := MemoryEmbeddingPublication{Lease: lease, Chunks: []MemoryEmbeddingChunk{{Ordinal: 0, ContentSHA256: lease.ContentSHA256, StartOffset: 0, EndOffset: 32}}}
+	valid := MemoryEmbeddingPublication{Lease: lease, Chunks: []MemoryEmbeddingChunk{{Ordinal: 0, ContentSHA256: lease.ContentSHA256, StartOffset: 0, EndOffset: 32, Vector: []float64{0.25, 0.5, 0.75}}}}
 	if err := valid.Validate(); err != nil {
 		t.Fatalf("valid embedding publication rejected: %v", err)
 	}
 	for name, publication := range map[string]MemoryEmbeddingPublication{
 		"no chunks":         {Lease: lease},
-		"nonzero first":     {Lease: lease, Chunks: []MemoryEmbeddingChunk{{Ordinal: 1, ContentSHA256: lease.ContentSHA256, EndOffset: 32}}},
-		"invalid digest":    {Lease: lease, Chunks: []MemoryEmbeddingChunk{{ContentSHA256: "bad", EndOffset: 32}}},
-		"empty range":       {Lease: lease, Chunks: []MemoryEmbeddingChunk{{ContentSHA256: lease.ContentSHA256, EndOffset: 0}}},
-		"overlapping range": {Lease: lease, Chunks: []MemoryEmbeddingChunk{{ContentSHA256: lease.ContentSHA256, EndOffset: 32}, {Ordinal: 1, ContentSHA256: lease.ContentSHA256, StartOffset: 31, EndOffset: 64}}},
+		"nonzero first":     {Lease: lease, Chunks: []MemoryEmbeddingChunk{{Ordinal: 1, ContentSHA256: lease.ContentSHA256, EndOffset: 32, Vector: []float64{0.25}}}},
+		"invalid digest":    {Lease: lease, Chunks: []MemoryEmbeddingChunk{{ContentSHA256: "bad", EndOffset: 32, Vector: []float64{0.25}}}},
+		"empty range":       {Lease: lease, Chunks: []MemoryEmbeddingChunk{{ContentSHA256: lease.ContentSHA256, EndOffset: 0, Vector: []float64{0.25}}}},
+		"empty vector":      {Lease: lease, Chunks: []MemoryEmbeddingChunk{{ContentSHA256: lease.ContentSHA256, EndOffset: 32}}},
+		"infinite vector":   {Lease: lease, Chunks: []MemoryEmbeddingChunk{{ContentSHA256: lease.ContentSHA256, EndOffset: 32, Vector: []float64{math.Inf(1)}}}},
+		"overlapping range": {Lease: lease, Chunks: []MemoryEmbeddingChunk{{ContentSHA256: lease.ContentSHA256, EndOffset: 32, Vector: []float64{0.25}}, {Ordinal: 1, ContentSHA256: lease.ContentSHA256, StartOffset: 31, EndOffset: 64, Vector: []float64{0.5}}}},
 	} {
 		t.Run(name, func(t *testing.T) {
 			if err := publication.Validate(); err == nil {

--- a/internal/postgres/brain_embedding_test.go
+++ b/internal/postgres/brain_embedding_test.go
@@ -101,13 +101,14 @@ func TestMemoryEmbeddingPublicationValidation(t *testing.T) {
 		t.Fatalf("valid embedding publication rejected: %v", err)
 	}
 	for name, publication := range map[string]MemoryEmbeddingPublication{
-		"no chunks":         {Lease: lease},
-		"nonzero first":     {Lease: lease, Chunks: []MemoryEmbeddingChunk{{Ordinal: 1, ContentSHA256: lease.ContentSHA256, EndOffset: 32, Vector: []float64{0.25}}}},
-		"invalid digest":    {Lease: lease, Chunks: []MemoryEmbeddingChunk{{ContentSHA256: "bad", EndOffset: 32, Vector: []float64{0.25}}}},
-		"empty range":       {Lease: lease, Chunks: []MemoryEmbeddingChunk{{ContentSHA256: lease.ContentSHA256, EndOffset: 0, Vector: []float64{0.25}}}},
-		"empty vector":      {Lease: lease, Chunks: []MemoryEmbeddingChunk{{ContentSHA256: lease.ContentSHA256, EndOffset: 32}}},
-		"infinite vector":   {Lease: lease, Chunks: []MemoryEmbeddingChunk{{ContentSHA256: lease.ContentSHA256, EndOffset: 32, Vector: []float64{math.Inf(1)}}}},
-		"overlapping range": {Lease: lease, Chunks: []MemoryEmbeddingChunk{{ContentSHA256: lease.ContentSHA256, EndOffset: 32, Vector: []float64{0.25}}, {Ordinal: 1, ContentSHA256: lease.ContentSHA256, StartOffset: 31, EndOffset: 64, Vector: []float64{0.5}}}},
+		"no chunks":              {Lease: lease},
+		"nonzero first":          {Lease: lease, Chunks: []MemoryEmbeddingChunk{{Ordinal: 1, ContentSHA256: lease.ContentSHA256, EndOffset: 32, Vector: []float64{0.25}}}},
+		"invalid digest":         {Lease: lease, Chunks: []MemoryEmbeddingChunk{{ContentSHA256: "bad", EndOffset: 32, Vector: []float64{0.25}}}},
+		"empty range":            {Lease: lease, Chunks: []MemoryEmbeddingChunk{{ContentSHA256: lease.ContentSHA256, EndOffset: 0, Vector: []float64{0.25}}}},
+		"empty vector":           {Lease: lease, Chunks: []MemoryEmbeddingChunk{{ContentSHA256: lease.ContentSHA256, EndOffset: 32}}},
+		"infinite vector":        {Lease: lease, Chunks: []MemoryEmbeddingChunk{{ContentSHA256: lease.ContentSHA256, EndOffset: 32, Vector: []float64{math.Inf(1)}}}},
+		"unrepresentable vector": {Lease: lease, Chunks: []MemoryEmbeddingChunk{{ContentSHA256: lease.ContentSHA256, EndOffset: 32, Vector: []float64{math.MaxFloat64}}}},
+		"overlapping range":      {Lease: lease, Chunks: []MemoryEmbeddingChunk{{ContentSHA256: lease.ContentSHA256, EndOffset: 32, Vector: []float64{0.25}}, {Ordinal: 1, ContentSHA256: lease.ContentSHA256, StartOffset: 31, EndOffset: 64, Vector: []float64{0.5}}}},
 	} {
 		t.Run(name, func(t *testing.T) {
 			if err := publication.Validate(); err == nil {

--- a/internal/postgres/brain_embedding_vector_schema.go
+++ b/internal/postgres/brain_embedding_vector_schema.go
@@ -10,7 +10,7 @@ func memoryEmbeddingVectorControlsAvailable(ctx context.Context, q queryer) (boo
 	if err := q.QueryRowContext(ctx, `SELECT EXISTS (
     SELECT 1 FROM pg_extension AS ext
     WHERE ext.extname='vector' AND ext.extnamespace='public'::regnamespace
-      AND pg_get_userbyid(ext.extowner)='punaro_owner' AND ext.extversion='0.8.2'
+      AND pg_get_userbyid(ext.extowner)='punaro_owner' AND ext.extversion=$1
 ) AND (SELECT array_agg(attribute.attname::text ORDER BY attribute.attnum)=ARRAY['generation_id','item_id','revision','ordinal','content_sha256','start_offset','end_offset','created_at','embedding']::text[]
          FROM pg_attribute AS attribute
          WHERE attribute.attrelid='brain.embedding_chunks'::regclass AND attribute.attnum>0 AND NOT attribute.attisdropped)
@@ -18,7 +18,7 @@ func memoryEmbeddingVectorControlsAvailable(ctx context.Context, q queryer) (boo
     SELECT 1 FROM pg_attribute AS attribute
     WHERE attribute.attrelid='brain.embedding_chunks'::regclass AND attribute.attname='embedding'
       AND attribute.attnotnull AND format_type(attribute.atttypid,attribute.atttypmod)='vector' AND attribute.attacl IS NULL
-)`).Scan(&exact); err != nil || !exact {
+)`, requiredPGVectorVersion).Scan(&exact); err != nil || !exact {
 		return exact, err
 	}
 	if err := q.QueryRowContext(ctx, `SELECT pg_get_userbyid(relation.relowner)='punaro_owner'

--- a/internal/postgres/brain_embedding_vector_schema.go
+++ b/internal/postgres/brain_embedding_vector_schema.go
@@ -52,4 +52,4 @@ FROM pg_trigger AS trigger_row WHERE trigger_row.tgrelid='brain.embedding_chunks
 	return exact, nil
 }
 
-const memoryEmbeddingVectorPublicationRoutineMD5 = "5ada115b541ba0b7f9d9d70d968e28df"
+const memoryEmbeddingVectorPublicationRoutineMD5 = "7c5f2698ecd2998cafcaf13e1d54992a"

--- a/internal/postgres/brain_embedding_vector_schema.go
+++ b/internal/postgres/brain_embedding_vector_schema.go
@@ -17,7 +17,7 @@ func memoryEmbeddingVectorControlsAvailable(ctx context.Context, q queryer) (boo
   AND EXISTS (
     SELECT 1 FROM pg_attribute AS attribute
     WHERE attribute.attrelid='brain.embedding_chunks'::regclass AND attribute.attname='embedding'
-      AND attribute.attnotnull AND format_type(attribute.atttypid,attribute.atttypmod)='vector' AND attribute.attacl IS NULL
+      AND attribute.attnotnull AND attribute.atttypid='public.vector'::regtype AND attribute.attacl IS NULL
 )`, requiredPGVectorVersion).Scan(&exact); err != nil || !exact {
 		return exact, err
 	}

--- a/internal/postgres/brain_embedding_vector_schema.go
+++ b/internal/postgres/brain_embedding_vector_schema.go
@@ -43,9 +43,13 @@ FROM pg_trigger AS trigger_row WHERE trigger_row.tgrelid='brain.embedding_chunks
 	}
 	if err := q.QueryRowContext(ctx, `SELECT NOT EXISTS (
     SELECT 1 FROM pg_index AS index_row
-    JOIN pg_attribute AS attribute ON attribute.attrelid=index_row.indrelid
-      AND attribute.attname='embedding' AND attribute.attnum=ANY(index_row.indkey::smallint[])
     WHERE index_row.indrelid='brain.embedding_chunks'::regclass
+      AND ((0=ANY(index_row.indkey::smallint[])
+            AND index_row.indexprs IS NOT NULL
+            AND pg_get_expr(index_row.indexprs,index_row.indrelid) ~ '(^|[^a-z_])embedding([^a-z_]|$)')
+           OR EXISTS (SELECT 1 FROM pg_attribute AS attribute
+                      WHERE attribute.attrelid=index_row.indrelid AND attribute.attname='embedding'
+                        AND attribute.attnum=ANY(index_row.indkey::smallint[])))
 )`).Scan(&exact); err != nil {
 		return false, err
 	}

--- a/internal/postgres/brain_embedding_vector_schema.go
+++ b/internal/postgres/brain_embedding_vector_schema.go
@@ -1,0 +1,55 @@
+package postgres
+
+import "context"
+
+// memoryEmbeddingVectorControlsAvailable verifies v29's derived vector
+// payload. It intentionally forbids vector indexes: approximate indexing is a
+// separately benchmark-gated decision, not an incidental schema side effect.
+func memoryEmbeddingVectorControlsAvailable(ctx context.Context, q queryer) (bool, error) {
+	var exact bool
+	if err := q.QueryRowContext(ctx, `SELECT EXISTS (
+    SELECT 1 FROM pg_extension AS ext
+    WHERE ext.extname='vector' AND ext.extnamespace='public'::regnamespace
+      AND pg_get_userbyid(ext.extowner)='punaro_owner'
+) AND (SELECT array_agg(attribute.attname::text ORDER BY attribute.attnum)=ARRAY['generation_id','item_id','revision','ordinal','content_sha256','start_offset','end_offset','created_at','embedding']::text[]
+         FROM pg_attribute AS attribute
+         WHERE attribute.attrelid='brain.embedding_chunks'::regclass AND attribute.attnum>0 AND NOT attribute.attisdropped)
+  AND EXISTS (
+    SELECT 1 FROM pg_attribute AS attribute
+    WHERE attribute.attrelid='brain.embedding_chunks'::regclass AND attribute.attname='embedding'
+      AND attribute.attnotnull AND format_type(attribute.atttypid,attribute.atttypmod)='vector' AND attribute.attacl IS NULL
+)`).Scan(&exact); err != nil || !exact {
+		return exact, err
+	}
+	if err := q.QueryRowContext(ctx, `SELECT pg_get_userbyid(relation.relowner)='punaro_owner'
+    AND relation.relkind='r' AND NOT relation.relrowsecurity
+    AND has_table_privilege('punaro_app',relation.oid,'SELECT')
+    AND NOT has_table_privilege('punaro_app',relation.oid,'INSERT,UPDATE,DELETE,TRUNCATE,REFERENCES,TRIGGER')
+FROM pg_class AS relation WHERE relation.oid='brain.embedding_chunks'::regclass`).Scan(&exact); err != nil || !exact {
+		return exact, err
+	}
+	if err := q.QueryRowContext(ctx, `SELECT count(*)=1 AND bool_and(pg_get_userbyid(proc.proowner)='punaro_owner' AND proc.prokind='f'
+    AND proc.prorettype='boolean'::regtype AND NOT proc.proretset AND proc.prosecdef AND proc.provolatile='v'
+    AND proc.prolang=(SELECT oid FROM pg_language WHERE lanname='plpgsql') AND proc.proconfig=ARRAY['search_path=pg_catalog']::text[]
+    AND md5(btrim(proc.prosrc,E' \n\r\t'))=$1)
+FROM pg_proc AS proc WHERE proc.oid=to_regprocedure('brain.publish_embedding_job(uuid,uuid,bigint,bytea,uuid,bigint,jsonb)')`, memoryEmbeddingVectorPublicationRoutineMD5).Scan(&exact); err != nil || !exact {
+		return exact, err
+	}
+	if err := q.QueryRowContext(ctx, `SELECT count(*)=2 AND bool_and(trigger_row.tgenabled='O')
+    AND bool_and((trigger_row.tgname='application_mutation_fence' AND trigger_row.tgfoid=to_regprocedure('jobs.guard_application_mutation()') AND trigger_row.tgtype=54)
+                 OR (trigger_row.tgname='embedding_chunks_delete_fence' AND trigger_row.tgfoid=to_regprocedure('brain.guard_embedding_chunk_delete()') AND trigger_row.tgtype=11))
+FROM pg_trigger AS trigger_row WHERE trigger_row.tgrelid='brain.embedding_chunks'::regclass AND NOT trigger_row.tgisinternal`).Scan(&exact); err != nil || !exact {
+		return exact, err
+	}
+	if err := q.QueryRowContext(ctx, `SELECT NOT EXISTS (
+    SELECT 1 FROM pg_index AS index_row
+    JOIN pg_attribute AS attribute ON attribute.attrelid=index_row.indrelid
+      AND attribute.attname='embedding' AND attribute.attnum=ANY(index_row.indkey::smallint[])
+    WHERE index_row.indrelid='brain.embedding_chunks'::regclass
+)`).Scan(&exact); err != nil {
+		return false, err
+	}
+	return exact, nil
+}
+
+const memoryEmbeddingVectorPublicationRoutineMD5 = "5ada115b541ba0b7f9d9d70d968e28df"

--- a/internal/postgres/brain_embedding_vector_schema.go
+++ b/internal/postgres/brain_embedding_vector_schema.go
@@ -52,4 +52,4 @@ FROM pg_trigger AS trigger_row WHERE trigger_row.tgrelid='brain.embedding_chunks
 	return exact, nil
 }
 
-const memoryEmbeddingVectorPublicationRoutineMD5 = "ee4e52dca2448dc87a17032745a869df"
+const memoryEmbeddingVectorPublicationRoutineMD5 = "b92b7ce20b55dff93b657461cee58de0"

--- a/internal/postgres/brain_embedding_vector_schema.go
+++ b/internal/postgres/brain_embedding_vector_schema.go
@@ -52,4 +52,4 @@ FROM pg_trigger AS trigger_row WHERE trigger_row.tgrelid='brain.embedding_chunks
 	return exact, nil
 }
 
-const memoryEmbeddingVectorPublicationRoutineMD5 = "7c5f2698ecd2998cafcaf13e1d54992a"
+const memoryEmbeddingVectorPublicationRoutineMD5 = "ee4e52dca2448dc87a17032745a869df"

--- a/internal/postgres/brain_embedding_vector_schema.go
+++ b/internal/postgres/brain_embedding_vector_schema.go
@@ -56,4 +56,4 @@ FROM pg_trigger AS trigger_row WHERE trigger_row.tgrelid='brain.embedding_chunks
 	return exact, nil
 }
 
-const memoryEmbeddingVectorPublicationRoutineMD5 = "b92b7ce20b55dff93b657461cee58de0"
+const memoryEmbeddingVectorPublicationRoutineMD5 = "88e9c93c7a9b27b8dcb35d04e538185c"

--- a/internal/postgres/brain_embedding_vector_schema.go
+++ b/internal/postgres/brain_embedding_vector_schema.go
@@ -56,4 +56,4 @@ FROM pg_trigger AS trigger_row WHERE trigger_row.tgrelid='brain.embedding_chunks
 	return exact, nil
 }
 
-const memoryEmbeddingVectorPublicationRoutineMD5 = "88e9c93c7a9b27b8dcb35d04e538185c"
+const memoryEmbeddingVectorPublicationRoutineMD5 = "b92b7ce20b55dff93b657461cee58de0"

--- a/internal/postgres/brain_embedding_vector_schema.go
+++ b/internal/postgres/brain_embedding_vector_schema.go
@@ -10,7 +10,7 @@ func memoryEmbeddingVectorControlsAvailable(ctx context.Context, q queryer) (boo
 	if err := q.QueryRowContext(ctx, `SELECT EXISTS (
     SELECT 1 FROM pg_extension AS ext
     WHERE ext.extname='vector' AND ext.extnamespace='public'::regnamespace
-      AND pg_get_userbyid(ext.extowner)='punaro_owner'
+      AND pg_get_userbyid(ext.extowner)='punaro_owner' AND ext.extversion='0.8.2'
 ) AND (SELECT array_agg(attribute.attname::text ORDER BY attribute.attnum)=ARRAY['generation_id','item_id','revision','ordinal','content_sha256','start_offset','end_offset','created_at','embedding']::text[]
          FROM pg_attribute AS attribute
          WHERE attribute.attrelid='brain.embedding_chunks'::regclass AND attribute.attnum>0 AND NOT attribute.attisdropped)

--- a/internal/postgres/db.go
+++ b/internal/postgres/db.go
@@ -1174,6 +1174,13 @@ FROM objects, table_ownership, routine_safety, routine_acl, table_acl, schema_ac
 		}
 		snapshot.CurrentObjectsPresent = embeddingActivationObjectsPresent
 	}
+	if snapshot.CurrentObjectsPresent && len(snapshot.Records) > 0 && snapshot.Records[len(snapshot.Records)-1].Version >= 29 {
+		embeddingVectorObjectsPresent, err := memoryEmbeddingVectorControlsAvailable(ctx, q)
+		if err != nil {
+			return Snapshot{}, errors.New("PostgreSQL memory embedding vector schema cannot be inspected")
+		}
+		snapshot.CurrentObjectsPresent = embeddingVectorObjectsPresent
+	}
 	return snapshot, nil
 }
 

--- a/internal/postgres/migrate.go
+++ b/internal/postgres/migrate.go
@@ -61,6 +61,7 @@ var migrationCompatibilityFloors = map[int64]int64{
 	26: 10,
 	27: 10,
 	28: 10,
+	29: 10,
 }
 
 // CurrentManifest returns the immutable migrations embedded in this binary.

--- a/internal/postgres/migrations/029_memory_embedding_vectors.sql
+++ b/internal/postgres/migrations/029_memory_embedding_vectors.sql
@@ -1,0 +1,90 @@
+CREATE EXTENSION IF NOT EXISTS vector;
+
+-- v25-v28 output intentionally carried only chunk coordinates. They are
+-- derived state, so requeue completed or interrupted work rather than ever
+-- treating a coordinate-only success as a semantic result.
+DELETE FROM brain.embedding_chunks;
+
+UPDATE brain.embedding_jobs
+SET state='queued', attempts=0, lease_holder=NULL, lease_token=NULL,
+    lease_generation=lease_generation+1, lease_until=NULL,
+    available_at=statement_timestamp(), last_error_code=NULL,
+    completed_at=NULL, updated_at=statement_timestamp()
+WHERE state IN ('running','succeeded');
+
+ALTER TABLE brain.embedding_chunks
+ADD COLUMN embedding vector NOT NULL;
+
+CREATE OR REPLACE FUNCTION brain.publish_embedding_job(requested_generation uuid, requested_item uuid, requested_revision bigint, requested_sha256 bytea, requested_token uuid, requested_lease_generation bigint, requested_chunks jsonb)
+RETURNS boolean
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog
+AS $function$
+DECLARE
+    chunk_count integer;
+BEGIN
+    PERFORM jobs.assert_application_mutation();
+    IF requested_generation IS NULL OR requested_item IS NULL OR requested_revision IS NULL OR requested_sha256 IS NULL
+       OR requested_token IS NULL OR requested_lease_generation IS NULL OR requested_chunks IS NULL
+       OR requested_revision < 1 OR octet_length(requested_sha256) <> 32 OR requested_lease_generation < 1
+       OR jsonb_typeof(requested_chunks) <> 'array' THEN
+        RAISE EXCEPTION USING ERRCODE = '22023', MESSAGE = 'invalid embedding publication';
+    END IF;
+    chunk_count := jsonb_array_length(requested_chunks);
+    IF chunk_count < 1 OR chunk_count > 64 OR EXISTS (
+        SELECT 1
+        FROM jsonb_to_recordset(requested_chunks) AS chunk(ordinal integer, content_sha256 text, start_offset integer, end_offset integer, embedding jsonb)
+        WHERE ordinal IS NULL OR content_sha256 IS NULL OR start_offset IS NULL OR end_offset IS NULL OR embedding IS NULL
+           OR ordinal < 0 OR ordinal >= chunk_count OR content_sha256 !~ '^[0-9a-f]{64}$'
+           OR start_offset < 0 OR end_offset <= start_offset OR end_offset > 262144
+           OR jsonb_typeof(embedding) <> 'array'
+           OR EXISTS (SELECT 1 FROM jsonb_array_elements(embedding) AS value WHERE jsonb_typeof(value) <> 'number')
+    ) OR EXISTS (
+        SELECT 1 FROM jsonb_to_recordset(requested_chunks) AS chunk(ordinal integer, content_sha256 text, start_offset integer, end_offset integer, embedding jsonb)
+        GROUP BY ordinal HAVING count(*) <> 1
+    ) OR EXISTS (
+        SELECT 1 FROM generate_series(0, chunk_count - 1) AS expected(ordinal)
+        LEFT JOIN jsonb_to_recordset(requested_chunks) AS chunk(ordinal integer, content_sha256 text, start_offset integer, end_offset integer, embedding jsonb) USING (ordinal)
+        WHERE chunk.ordinal IS NULL
+    ) OR EXISTS (
+        SELECT 1 FROM (
+            SELECT start_offset,lag(end_offset) OVER (ORDER BY ordinal) AS previous_end
+            FROM jsonb_to_recordset(requested_chunks) AS chunk(ordinal integer, content_sha256 text, start_offset integer, end_offset integer, embedding jsonb)
+        ) AS ordered WHERE start_offset < previous_end
+    ) THEN
+        RAISE EXCEPTION USING ERRCODE = '22023', MESSAGE = 'invalid embedding publication';
+    END IF;
+    WITH locked AS MATERIALIZED (
+        SELECT job.generation_id,job.item_id,job.revision,generation.dimensions
+        FROM brain.embedding_jobs AS job
+        JOIN brain.embedding_generations AS generation ON generation.id=job.generation_id
+        JOIN brain.memory_items AS item ON item.id=job.item_id AND item.current_revision=job.revision
+        WHERE job.generation_id=requested_generation AND job.item_id=requested_item AND job.revision=requested_revision
+          AND job.content_sha256=requested_sha256 AND job.state='running' AND job.lease_token=requested_token
+          AND job.lease_generation=requested_lease_generation AND job.lease_until > statement_timestamp()
+        FOR UPDATE OF job
+    ), input AS MATERIALIZED (
+        SELECT chunk.ordinal,chunk.content_sha256,chunk.start_offset,chunk.end_offset,chunk.embedding
+        FROM jsonb_to_recordset(requested_chunks) AS chunk(ordinal smallint, content_sha256 text, start_offset integer, end_offset integer, embedding jsonb)
+    ), checked AS MATERIALIZED (
+        SELECT input.* FROM input CROSS JOIN locked
+        WHERE jsonb_array_length(input.embedding)=locked.dimensions
+    ), cleared AS (
+        DELETE FROM brain.embedding_chunks AS chunk USING locked
+        WHERE chunk.generation_id=locked.generation_id AND chunk.item_id=locked.item_id AND chunk.revision=locked.revision
+    ), inserted AS (
+        INSERT INTO brain.embedding_chunks(generation_id,item_id,revision,ordinal,content_sha256,start_offset,end_offset,embedding)
+        SELECT locked.generation_id,locked.item_id,locked.revision,checked.ordinal,decode(checked.content_sha256,'hex'),checked.start_offset,checked.end_offset,checked.embedding::text::public.vector
+        FROM locked CROSS JOIN checked
+        RETURNING 1
+    )
+    UPDATE brain.embedding_jobs AS job
+    SET state='succeeded', lease_holder=NULL, lease_token=NULL, lease_until=NULL,
+        last_error_code=NULL, completed_at=statement_timestamp(), updated_at=statement_timestamp()
+    FROM locked
+    WHERE job.generation_id=locked.generation_id AND job.item_id=locked.item_id
+      AND (SELECT count(*) FROM inserted)=chunk_count;
+    RETURN FOUND;
+END
+$function$;

--- a/internal/postgres/migrations/029_memory_embedding_vectors.sql
+++ b/internal/postgres/migrations/029_memory_embedding_vectors.sql
@@ -39,6 +39,7 @@ BEGIN
            OR ordinal < 0 OR ordinal >= chunk_count OR content_sha256 !~ '^[0-9a-f]{64}$'
            OR start_offset < 0 OR end_offset <= start_offset OR end_offset > 262144
            OR jsonb_typeof(embedding) <> 'array'
+           OR jsonb_array_length(embedding) < 1 OR jsonb_array_length(embedding) > 4096
            OR EXISTS (SELECT 1 FROM jsonb_array_elements(embedding) AS value WHERE jsonb_typeof(value) <> 'number')
     ) OR EXISTS (
         SELECT 1 FROM jsonb_to_recordset(requested_chunks) AS chunk(ordinal integer, content_sha256 text, start_offset integer, end_offset integer, embedding jsonb)

--- a/internal/postgres/migrations/029_memory_embedding_vectors.sql
+++ b/internal/postgres/migrations/029_memory_embedding_vectors.sql
@@ -11,6 +11,24 @@ ALTER EXTENSION vector UPDATE TO '0.8.2';
 -- v25-v28 output intentionally carried only chunk coordinates. They are
 -- derived state, so requeue completed or interrupted work rather than ever
 -- treating a coordinate-only success as a semantic result.
+DO $migration$
+DECLARE
+    existing_chunks bigint;
+    existing_chunk_bytes bigint;
+    reset_jobs bigint;
+BEGIN
+    SELECT count(*), COALESCE(sum(pg_column_size(chunk)), 0)
+    INTO existing_chunks, existing_chunk_bytes
+    FROM brain.embedding_chunks AS chunk;
+    SELECT count(*) INTO reset_jobs
+    FROM brain.embedding_jobs
+    WHERE state IN ('running','succeeded');
+    IF existing_chunks > 100000 OR existing_chunk_bytes > 268435456 OR reset_jobs > 100000 THEN
+        RAISE EXCEPTION USING ERRCODE = '54000', MESSAGE = 'memory embedding vector migration exceeds the inline migration ceiling';
+    END IF;
+END
+$migration$;
+
 DELETE FROM brain.embedding_chunks;
 
 UPDATE brain.embedding_jobs

--- a/internal/postgres/migrations/029_memory_embedding_vectors.sql
+++ b/internal/postgres/migrations/029_memory_embedding_vectors.sql
@@ -1,4 +1,4 @@
-CREATE EXTENSION IF NOT EXISTS vector WITH SCHEMA public;
+CREATE EXTENSION IF NOT EXISTS vector WITH SCHEMA public VERSION '0.8.2';
 DO $migration$
 BEGIN
     IF EXISTS (SELECT 1 FROM pg_extension WHERE extname='vector' AND extnamespace <> 'public'::regnamespace) THEN

--- a/internal/postgres/migrations/029_memory_embedding_vectors.sql
+++ b/internal/postgres/migrations/029_memory_embedding_vectors.sql
@@ -31,6 +31,7 @@ SET search_path = pg_catalog
 AS $function$
 DECLARE
     chunk_count integer;
+    expected_dimensions integer;
 BEGIN
     PERFORM jobs.assert_application_mutation();
     IF requested_generation IS NULL OR requested_item IS NULL OR requested_revision IS NULL OR requested_sha256 IS NULL
@@ -61,6 +62,24 @@ BEGIN
             SELECT start_offset,lag(end_offset) OVER (ORDER BY ordinal) AS previous_end
             FROM jsonb_to_recordset(requested_chunks) AS chunk(ordinal integer, content_sha256 text, start_offset integer, end_offset integer, embedding jsonb)
         ) AS ordered WHERE start_offset < previous_end
+    ) THEN
+        RAISE EXCEPTION USING ERRCODE = '22023', MESSAGE = 'invalid embedding publication';
+    END IF;
+    SELECT generation.dimensions INTO expected_dimensions
+    FROM brain.embedding_jobs AS job
+    JOIN brain.embedding_generations AS generation ON generation.id=job.generation_id
+    JOIN brain.memory_items AS item ON item.id=job.item_id AND item.current_revision=job.revision
+    WHERE job.generation_id=requested_generation AND job.item_id=requested_item AND job.revision=requested_revision
+      AND job.content_sha256=requested_sha256 AND job.state='running' AND job.lease_token=requested_token
+      AND job.lease_generation=requested_lease_generation AND job.lease_until > statement_timestamp()
+    FOR UPDATE OF job;
+    IF NOT FOUND THEN
+        RETURN false;
+    END IF;
+    IF EXISTS (
+        SELECT 1
+        FROM jsonb_to_recordset(requested_chunks) AS chunk(embedding jsonb)
+        WHERE jsonb_array_length(chunk.embedding) <> expected_dimensions
     ) THEN
         RAISE EXCEPTION USING ERRCODE = '22023', MESSAGE = 'invalid embedding publication';
     END IF;

--- a/internal/postgres/migrations/029_memory_embedding_vectors.sql
+++ b/internal/postgres/migrations/029_memory_embedding_vectors.sql
@@ -70,19 +70,23 @@ BEGIN
     ), checked AS MATERIALIZED (
         SELECT input.* FROM input CROSS JOIN locked
         WHERE jsonb_array_length(input.embedding)=locked.dimensions
+    ), validated AS MATERIALIZED (
+        SELECT 1
+        FROM locked
+        WHERE (SELECT count(*) FROM checked)=chunk_count
     ), cleared AS (
-        DELETE FROM brain.embedding_chunks AS chunk USING locked
+        DELETE FROM brain.embedding_chunks AS chunk USING locked,validated
         WHERE chunk.generation_id=locked.generation_id AND chunk.item_id=locked.item_id AND chunk.revision=locked.revision
     ), inserted AS (
         INSERT INTO brain.embedding_chunks(generation_id,item_id,revision,ordinal,content_sha256,start_offset,end_offset,embedding)
         SELECT locked.generation_id,locked.item_id,locked.revision,checked.ordinal,decode(checked.content_sha256,'hex'),checked.start_offset,checked.end_offset,checked.embedding::text::public.vector
-        FROM locked CROSS JOIN checked
+        FROM locked CROSS JOIN checked CROSS JOIN validated
         RETURNING 1
     )
     UPDATE brain.embedding_jobs AS job
     SET state='succeeded', lease_holder=NULL, lease_token=NULL, lease_until=NULL,
         last_error_code=NULL, completed_at=statement_timestamp(), updated_at=statement_timestamp()
-    FROM locked
+    FROM locked CROSS JOIN validated
     WHERE job.generation_id=locked.generation_id AND job.item_id=locked.item_id
       AND (SELECT count(*) FROM inserted)=chunk_count;
     RETURN FOUND;

--- a/internal/postgres/migrations/029_memory_embedding_vectors.sql
+++ b/internal/postgres/migrations/029_memory_embedding_vectors.sql
@@ -1,5 +1,11 @@
 CREATE EXTENSION IF NOT EXISTS vector WITH SCHEMA public;
-ALTER EXTENSION vector SET SCHEMA public;
+DO $migration$
+BEGIN
+    IF EXISTS (SELECT 1 FROM pg_extension WHERE extname='vector' AND extnamespace <> 'public'::regnamespace) THEN
+        ALTER EXTENSION vector SET SCHEMA public;
+    END IF;
+END
+$migration$;
 ALTER EXTENSION vector UPDATE TO '0.8.2';
 
 -- v25-v28 output intentionally carried only chunk coordinates. They are

--- a/internal/postgres/migrations/029_memory_embedding_vectors.sql
+++ b/internal/postgres/migrations/029_memory_embedding_vectors.sql
@@ -1,5 +1,6 @@
 CREATE EXTENSION IF NOT EXISTS vector WITH SCHEMA public;
 ALTER EXTENSION vector SET SCHEMA public;
+ALTER EXTENSION vector UPDATE TO '0.8.2';
 
 -- v25-v28 output intentionally carried only chunk coordinates. They are
 -- derived state, so requeue completed or interrupted work rather than ever

--- a/internal/postgres/migrations/029_memory_embedding_vectors.sql
+++ b/internal/postgres/migrations/029_memory_embedding_vectors.sql
@@ -28,7 +28,7 @@ BEGIN
     IF requested_generation IS NULL OR requested_item IS NULL OR requested_revision IS NULL OR requested_sha256 IS NULL
        OR requested_token IS NULL OR requested_lease_generation IS NULL OR requested_chunks IS NULL
        OR requested_revision < 1 OR octet_length(requested_sha256) <> 32 OR requested_lease_generation < 1
-       OR jsonb_typeof(requested_chunks) <> 'array' THEN
+       OR jsonb_typeof(requested_chunks) <> 'array' OR pg_column_size(requested_chunks) > 8388608 THEN
         RAISE EXCEPTION USING ERRCODE = '22023', MESSAGE = 'invalid embedding publication';
     END IF;
     chunk_count := jsonb_array_length(requested_chunks);

--- a/internal/postgres/migrations/029_memory_embedding_vectors.sql
+++ b/internal/postgres/migrations/029_memory_embedding_vectors.sql
@@ -14,7 +14,7 @@ SET state='queued', attempts=0, lease_holder=NULL, lease_token=NULL,
 WHERE state IN ('running','succeeded');
 
 ALTER TABLE brain.embedding_chunks
-ADD COLUMN embedding vector NOT NULL;
+ADD COLUMN embedding public.vector NOT NULL;
 
 CREATE OR REPLACE FUNCTION brain.publish_embedding_job(requested_generation uuid, requested_item uuid, requested_revision bigint, requested_sha256 bytea, requested_token uuid, requested_lease_generation bigint, requested_chunks jsonb)
 RETURNS boolean

--- a/internal/postgres/migrations/029_memory_embedding_vectors.sql
+++ b/internal/postgres/migrations/029_memory_embedding_vectors.sql
@@ -31,7 +31,6 @@ SET search_path = pg_catalog
 AS $function$
 DECLARE
     chunk_count integer;
-    expected_dimensions integer;
 BEGIN
     PERFORM jobs.assert_application_mutation();
     IF requested_generation IS NULL OR requested_item IS NULL OR requested_revision IS NULL OR requested_sha256 IS NULL
@@ -62,24 +61,6 @@ BEGIN
             SELECT start_offset,lag(end_offset) OVER (ORDER BY ordinal) AS previous_end
             FROM jsonb_to_recordset(requested_chunks) AS chunk(ordinal integer, content_sha256 text, start_offset integer, end_offset integer, embedding jsonb)
         ) AS ordered WHERE start_offset < previous_end
-    ) THEN
-        RAISE EXCEPTION USING ERRCODE = '22023', MESSAGE = 'invalid embedding publication';
-    END IF;
-    SELECT generation.dimensions INTO expected_dimensions
-    FROM brain.embedding_jobs AS job
-    JOIN brain.embedding_generations AS generation ON generation.id=job.generation_id
-    JOIN brain.memory_items AS item ON item.id=job.item_id AND item.current_revision=job.revision
-    WHERE job.generation_id=requested_generation AND job.item_id=requested_item AND job.revision=requested_revision
-      AND job.content_sha256=requested_sha256 AND job.state='running' AND job.lease_token=requested_token
-      AND job.lease_generation=requested_lease_generation AND job.lease_until > statement_timestamp()
-    FOR UPDATE OF job;
-    IF NOT FOUND THEN
-        RETURN false;
-    END IF;
-    IF EXISTS (
-        SELECT 1
-        FROM jsonb_to_recordset(requested_chunks) AS chunk(embedding jsonb)
-        WHERE jsonb_array_length(chunk.embedding) <> expected_dimensions
     ) THEN
         RAISE EXCEPTION USING ERRCODE = '22023', MESSAGE = 'invalid embedding publication';
     END IF;

--- a/internal/postgres/migrations/029_memory_embedding_vectors.sql
+++ b/internal/postgres/migrations/029_memory_embedding_vectors.sql
@@ -1,4 +1,5 @@
-CREATE EXTENSION IF NOT EXISTS vector;
+CREATE EXTENSION IF NOT EXISTS vector WITH SCHEMA public;
+ALTER EXTENSION vector SET SCHEMA public;
 
 -- v25-v28 output intentionally carried only chunk coordinates. They are
 -- derived state, so requeue completed or interrupted work rather than ever

--- a/internal/postgres/pair.go
+++ b/internal/postgres/pair.go
@@ -19,6 +19,9 @@ var ErrMigrationNotAttempted = errors.New("PostgreSQL migration was not attempte
 // by PostgreSQL to one database, so a second session can observe it only when
 // both connections share that target.
 func MigratePristinePair(ctx context.Context, appConfig, ownerConfig Config) (SchemaState, error) {
+	if err := RequirePGVector(ctx, ownerConfig); err != nil {
+		return SchemaState{}, preMigrationError(err)
+	}
 	return withPristinePair(ctx, appConfig, ownerConfig, func(ownerConn *sql.Conn) (SchemaState, error) {
 		return migrateConn(ctx, ownerConn, CurrentManifest())
 	})

--- a/internal/postgres/pgvector_preflight.go
+++ b/internal/postgres/pgvector_preflight.go
@@ -20,12 +20,17 @@ func RequirePGVector(ctx context.Context, cfg Config) error {
 	}
 	defer func() { _ = db.Close() }()
 	var available bool
-	err = db.QueryRowContext(ctx, `SELECT EXISTS (
-    SELECT 1 FROM pg_available_extension_versions
-    WHERE name='vector' AND version=$1
+	err = db.QueryRowContext(ctx, `SELECT (
+    EXISTS (SELECT 1 FROM pg_extension WHERE extname='vector' AND extversion=$1)
+    OR NOT EXISTS (SELECT 1 FROM pg_extension WHERE extname='vector')
+       AND EXISTS (
+           SELECT 1 FROM pg_available_extensions
+           WHERE name='vector' AND default_version=$1
+       )
 ) AND NOT EXISTS (
     SELECT 1 FROM pg_extension AS ext
-    WHERE ext.extname='vector' AND pg_get_userbyid(ext.extowner) <> current_user
+    WHERE ext.extname='vector'
+      AND (ext.extversion <> $1 OR pg_get_userbyid(ext.extowner) <> current_user)
 )`, requiredPGVectorVersion).Scan(&available)
 	if err != nil || !available {
 		return errors.New("PostgreSQL pgvector 0.8.2 prerequisite is unavailable")

--- a/internal/postgres/pgvector_preflight.go
+++ b/internal/postgres/pgvector_preflight.go
@@ -20,18 +20,26 @@ func RequirePGVector(ctx context.Context, cfg Config) error {
 	}
 	defer func() { _ = db.Close() }()
 	var available bool
-	err = db.QueryRowContext(ctx, `SELECT (
-    EXISTS (SELECT 1 FROM pg_extension WHERE extname='vector' AND extversion=$1)
-    OR NOT EXISTS (SELECT 1 FROM pg_extension WHERE extname='vector')
-       AND EXISTS (
-           SELECT 1 FROM pg_available_extensions
-           WHERE name='vector' AND default_version=$1
-       )
-) AND NOT EXISTS (
-    SELECT 1 FROM pg_extension AS ext
-    WHERE ext.extname='vector'
-      AND (ext.extversion <> $1 OR pg_get_userbyid(ext.extowner) <> current_user)
-)`, requiredPGVectorVersion).Scan(&available)
+	err = db.QueryRowContext(ctx, `SELECT
+    (NOT EXISTS (SELECT 1 FROM pg_extension WHERE extname='vector')
+     AND EXISTS (
+         SELECT 1 FROM pg_available_extension_versions
+         WHERE name='vector' AND version=$1
+     ))
+    OR EXISTS (
+        SELECT 1
+        FROM pg_extension AS ext
+        WHERE ext.extname='vector'
+          AND pg_get_userbyid(ext.extowner)=current_user
+          AND (
+              ext.extversion=$1
+              OR EXISTS (
+                  SELECT 1
+                  FROM pg_extension_update_paths('vector') AS path
+                  WHERE path.source=ext.extversion AND path.target=$1
+              )
+          )
+    )`, requiredPGVectorVersion).Scan(&available)
 	if err != nil || !available {
 		return errors.New("PostgreSQL pgvector 0.8.2 prerequisite is unavailable")
 	}

--- a/internal/postgres/pgvector_preflight.go
+++ b/internal/postgres/pgvector_preflight.go
@@ -23,6 +23,30 @@ func RequirePGVector(ctx context.Context, cfg Config) error {
 	return nil
 }
 
+// RequireInstalledPGVector verifies that restore will use the pinned pgvector
+// implementation rather than pg_restore selecting a package-default version.
+func RequireInstalledPGVector(ctx context.Context, cfg Config) error {
+	dsn, err := ReadDSNFile(cfg.DSNFile)
+	if err != nil {
+		return err
+	}
+	db, err := open(ctx, dsn)
+	if err != nil {
+		return errors.New("PostgreSQL pgvector 0.8.2 prerequisite is unavailable")
+	}
+	defer func() { _ = db.Close() }()
+	var available bool
+	err = db.QueryRowContext(ctx, `SELECT EXISTS (
+    SELECT 1 FROM pg_extension AS ext
+    WHERE ext.extname='vector' AND ext.extnamespace='public'::regnamespace
+      AND ext.extversion=$1 AND pg_get_userbyid(ext.extowner)=current_user
+)`, requiredPGVectorVersion).Scan(&available)
+	if err != nil || !available {
+		return errors.New("PostgreSQL pgvector 0.8.2 prerequisite is unavailable")
+	}
+	return nil
+}
+
 func pgVectorAvailable(ctx context.Context, dsn string) (bool, error) {
 	db, err := open(ctx, dsn)
 	if err != nil {

--- a/internal/postgres/pgvector_preflight.go
+++ b/internal/postgres/pgvector_preflight.go
@@ -37,6 +37,7 @@ func RequirePGVector(ctx context.Context, cfg Config) error {
                   SELECT 1
                   FROM pg_extension_update_paths('vector') AS path
                   WHERE path.source=ext.extversion AND path.target=$1
+                    AND path.path IS NOT NULL
               )
           )
     )`, requiredPGVectorVersion).Scan(&available)

--- a/internal/postgres/pgvector_preflight.go
+++ b/internal/postgres/pgvector_preflight.go
@@ -40,7 +40,7 @@ func RequireInstalledPGVector(ctx context.Context, cfg Config) error {
     SELECT 1 FROM pg_extension AS ext
     WHERE ext.extname='vector' AND ext.extnamespace='public'::regnamespace
       AND ext.extversion=$1 AND pg_get_userbyid(ext.extowner)=current_user
-)`, requiredPGVectorVersion).Scan(&available)
+) AND '[0]'::public.vector IS NOT NULL`, requiredPGVectorVersion).Scan(&available)
 	if err != nil || !available {
 		return errors.New("PostgreSQL pgvector 0.8.2 prerequisite is unavailable")
 	}

--- a/internal/postgres/pgvector_preflight.go
+++ b/internal/postgres/pgvector_preflight.go
@@ -7,6 +7,8 @@ import (
 
 const requiredPGVectorVersion = "0.8.2"
 
+var pgVectorAvailableFn = pgVectorAvailable
+
 // RequirePGVector verifies the exact extension package is available before an
 // update crosses its irreversible migration boundary.
 func RequirePGVector(ctx context.Context, cfg Config) error {
@@ -14,9 +16,17 @@ func RequirePGVector(ctx context.Context, cfg Config) error {
 	if err != nil {
 		return err
 	}
+	available, err := pgVectorAvailableFn(ctx, dsn)
+	if err != nil || !available {
+		return errors.New("PostgreSQL pgvector 0.8.2 prerequisite is unavailable")
+	}
+	return nil
+}
+
+func pgVectorAvailable(ctx context.Context, dsn string) (bool, error) {
 	db, err := open(ctx, dsn)
 	if err != nil {
-		return errors.New("PostgreSQL pgvector prerequisite is unavailable")
+		return false, err
 	}
 	defer func() { _ = db.Close() }()
 	var available bool
@@ -25,6 +35,9 @@ func RequirePGVector(ctx context.Context, cfg Config) error {
      AND EXISTS (
          SELECT 1 FROM pg_available_extension_versions
          WHERE name='vector' AND version=$1
+     )
+     AND EXISTS (
+         SELECT 1 FROM pg_roles WHERE rolname=current_user AND rolsuper
      ))
     OR EXISTS (
         SELECT 1
@@ -41,8 +54,5 @@ func RequirePGVector(ctx context.Context, cfg Config) error {
               )
           )
     )`, requiredPGVectorVersion).Scan(&available)
-	if err != nil || !available {
-		return errors.New("PostgreSQL pgvector 0.8.2 prerequisite is unavailable")
-	}
-	return nil
+	return available, err
 }

--- a/internal/postgres/pgvector_preflight.go
+++ b/internal/postgres/pgvector_preflight.go
@@ -44,6 +44,8 @@ func pgVectorAvailable(ctx context.Context, dsn string) (bool, error) {
         FROM pg_extension AS ext
         WHERE ext.extname='vector'
           AND pg_get_userbyid(ext.extowner)=current_user
+          AND (ext.extnamespace='public'::regnamespace
+               OR has_schema_privilege(current_user, 'public', 'CREATE'))
           AND (
               ext.extversion=$1
               OR EXISTS (

--- a/internal/postgres/pgvector_preflight.go
+++ b/internal/postgres/pgvector_preflight.go
@@ -21,8 +21,11 @@ func RequirePGVector(ctx context.Context, cfg Config) error {
 	defer func() { _ = db.Close() }()
 	var available bool
 	err = db.QueryRowContext(ctx, `SELECT EXISTS (
-    SELECT 1 FROM pg_available_extensions
-    WHERE name='vector' AND default_version=$1
+    SELECT 1 FROM pg_available_extension_versions
+    WHERE name='vector' AND version=$1
+) AND NOT EXISTS (
+    SELECT 1 FROM pg_extension AS ext
+    WHERE ext.extname='vector' AND pg_get_userbyid(ext.extowner) <> current_user
 )`, requiredPGVectorVersion).Scan(&available)
 	if err != nil || !available {
 		return errors.New("PostgreSQL pgvector 0.8.2 prerequisite is unavailable")

--- a/internal/postgres/pgvector_preflight.go
+++ b/internal/postgres/pgvector_preflight.go
@@ -1,0 +1,31 @@
+package postgres
+
+import (
+	"context"
+	"errors"
+)
+
+const requiredPGVectorVersion = "0.8.2"
+
+// RequirePGVector verifies the exact extension package is available before an
+// update crosses its irreversible migration boundary.
+func RequirePGVector(ctx context.Context, cfg Config) error {
+	dsn, err := ReadDSNFile(cfg.DSNFile)
+	if err != nil {
+		return err
+	}
+	db, err := open(ctx, dsn)
+	if err != nil {
+		return errors.New("PostgreSQL pgvector prerequisite is unavailable")
+	}
+	defer func() { _ = db.Close() }()
+	var available bool
+	err = db.QueryRowContext(ctx, `SELECT EXISTS (
+    SELECT 1 FROM pg_available_extensions
+    WHERE name='vector' AND default_version=$1
+)`, requiredPGVectorVersion).Scan(&available)
+	if err != nil || !available {
+		return errors.New("PostgreSQL pgvector 0.8.2 prerequisite is unavailable")
+	}
+	return nil
+}

--- a/internal/postgres/pgvector_preflight_test.go
+++ b/internal/postgres/pgvector_preflight_test.go
@@ -1,0 +1,44 @@
+package postgres
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestRequirePGVectorRejectsUnavailablePrerequisite(t *testing.T) {
+	path := writeTestDSN(t, "pgvector-owner.dsn", "postgres://ignored")
+	original := pgVectorAvailableFn
+	t.Cleanup(func() { pgVectorAvailableFn = original })
+	pgVectorAvailableFn = func(context.Context, string) (bool, error) { return false, nil }
+	if err := RequirePGVector(context.Background(), Config{DSNFile: path}); err == nil {
+		t.Fatal("RequirePGVector() accepted an unavailable prerequisite")
+	}
+}
+
+func TestRequirePGVectorRejectsProbeFailureWithoutLeakingDSN(t *testing.T) {
+	const dsn = "postgres://secret@example.invalid/punaro"
+	path := filepath.Join(t.TempDir(), "pgvector-owner.dsn")
+	if err := os.WriteFile(path, []byte(dsn), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	original := pgVectorAvailableFn
+	t.Cleanup(func() { pgVectorAvailableFn = original })
+	pgVectorAvailableFn = func(context.Context, string) (bool, error) { return false, errors.New("probe failed") }
+	err := RequirePGVector(context.Background(), Config{DSNFile: path})
+	if err == nil || err.Error() == dsn {
+		t.Fatalf("RequirePGVector() error=%v, want generic prerequisite refusal", err)
+	}
+}
+
+func TestRequirePGVectorAcceptsAvailablePrerequisite(t *testing.T) {
+	path := writeTestDSN(t, "pgvector-owner.dsn", "postgres://ignored")
+	original := pgVectorAvailableFn
+	t.Cleanup(func() { pgVectorAvailableFn = original })
+	pgVectorAvailableFn = func(context.Context, string) (bool, error) { return true, nil }
+	if err := RequirePGVector(context.Background(), Config{DSNFile: path}); err != nil {
+		t.Fatalf("RequirePGVector() error=%v, want success", err)
+	}
+}

--- a/internal/postgres/postgres_integration_test.go
+++ b/internal/postgres/postgres_integration_test.go
@@ -795,8 +795,12 @@ func testV26EmbeddingRebuildUpgradeIntegration(ctx context.Context, t *testing.T
 		FROM brain.embedding_generations AS generation
 		LEFT JOIN brain.embedding_jobs AS job ON job.generation_id=generation.id
 		LEFT JOIN brain.embedding_chunks AS chunk ON chunk.generation_id=generation.id
-	`).Scan(&active, &building, &activeJobs, &buildingJobs, &activeChunks, &buildingChunks); err != nil || active != 1 || building != 0 || activeJobs != 1 || buildingJobs != 0 || activeChunks != 1 || buildingChunks != 0 {
+	`).Scan(&active, &building, &activeJobs, &buildingJobs, &activeChunks, &buildingChunks); err != nil || active != 1 || building != 0 || activeJobs != 1 || buildingJobs != 0 || activeChunks != 0 || buildingChunks != 0 {
 		t.Fatalf("current generation cleanup active=%d building=%d active_jobs=%d building_jobs=%d active_chunks=%d building_chunks=%d err=%v", active, building, activeJobs, buildingJobs, activeChunks, buildingChunks, err)
+	}
+	var activeJobState string
+	if err := ownerDB.QueryRowContext(ctx, `SELECT state FROM brain.embedding_jobs`).Scan(&activeJobState); err != nil || activeJobState != "queued" {
+		t.Fatalf("coordinate-only bridge job state=%q err=%v, want requeued", activeJobState, err)
 	}
 }
 
@@ -846,6 +850,9 @@ func seedV26EmbeddingRebuildDerivedWork(ctx context.Context, t *testing.T, owner
 		if _, err := tx.ExecContext(ctx, `INSERT INTO brain.embedding_chunks(generation_id,item_id,revision,ordinal,content_sha256,start_offset,end_offset) VALUES ($1,$2,1,0,$3,0,1)`, generationID, itemID, contentSHA256); err != nil {
 			t.Fatal(err)
 		}
+	}
+	if _, err := tx.ExecContext(ctx, `UPDATE brain.embedding_jobs SET state='succeeded',completed_at=statement_timestamp(),updated_at=statement_timestamp() WHERE generation_id=$1`, activeGenerationID); err != nil {
+		t.Fatal(err)
 	}
 	if err := tx.Commit(); err != nil {
 		t.Fatal(err)

--- a/internal/postgres/state_test.go
+++ b/internal/postgres/state_test.go
@@ -69,8 +69,8 @@ func TestManifestValidationRejectsMutableOrNonContiguousHistory(t *testing.T) {
 
 func TestCurrentManifestRequiresControlPlaneSchema(t *testing.T) {
 	manifest := CurrentManifest()
-	if manifest.MinSupported != 10 || manifest.MaxSupported != 28 || len(manifest.Migrations) != 28 {
-		t.Fatalf("manifest=%#v, want exact v10-v28 compatibility window", manifest)
+	if manifest.MinSupported != 10 || manifest.MaxSupported != 29 || len(manifest.Migrations) != 29 {
+		t.Fatalf("manifest=%#v, want exact v10-v29 compatibility window", manifest)
 	}
 	embedding := manifest.Migrations[23]
 	if embedding.Version != 24 || embedding.Name != "024_memory_embedding_worker_control" ||
@@ -88,7 +88,7 @@ func TestCurrentManifestRequiresControlPlaneSchema(t *testing.T) {
 			want = 10
 		case 12, 13:
 			want = 10
-		case 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28:
+		case 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29:
 			want = 10
 		}
 		if migration.CompatibilityFloor != want {
@@ -171,7 +171,10 @@ func TestCompatibleSchemaCanStillHavePendingMigrations(t *testing.T) {
 	if !migrationPending(SchemaState{Classification: Compatible, Version: 27}, manifest) {
 		t.Fatal("compatible v27 schema must still apply the pending v28 migration")
 	}
-	if migrationPending(SchemaState{Classification: Compatible, Version: 28}, manifest) {
-		t.Fatal("current v28 schema reported a pending migration")
+	if !migrationPending(SchemaState{Classification: Compatible, Version: 28}, manifest) {
+		t.Fatal("compatible v28 schema must still apply the pending v29 migration")
+	}
+	if migrationPending(SchemaState{Classification: Compatible, Version: 29}, manifest) {
+		t.Fatal("current v29 schema reported a pending migration")
 	}
 }


### PR DESCRIPTION
## Summary
- add migration 29 with pgvector-backed, fenced embedding publication
- reset coordinate-only derived results and preserve failed-job degradation evidence
- verify vector schema and publication routine integrity at readiness

## Validation
- make test
- make test-race
- make staticcheck
- make security
- make lint
- isolated PostgreSQL integration: ok  	github.com/rock3r/punaro/internal/postgres	0.346s