### PR TITLE
Add exact semantic retrieval candidates

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -445,8 +445,13 @@ still holds. Each vector must exactly match the generation's pinned dimension.
 Coordinate-only successes from older schemas are derived data, so upgrade
 requeues them and clears their chunks; terminal failures remain diagnostics
 rather than being erased. There is no provider credential or fragment text in
-the database, no vector index, and still no semantic query, hybrid ranking, or
-client-facing surface.
+the database, and no vector index. An internal exact cosine-candidate read may
+use only the active generation's succeeded chunks and the same project,
+`memory.search`, current-revision, active, and quarantine boundaries as
+lexical search. It accepts an already-derived, dimension-matched query vector;
+it never invokes a provider, exposes a route, changes core readiness, or fuses
+lexical and semantic ranks. With no active generation it reports semantic
+`not_configured`, so callers keep lexical retrieval available.
 
 Schema version 15 places one deterministic secret guard inside the authorized
 create/update transaction before any scope, revision, change, audit,

--- a/internal/postgres/brain_semantic.go
+++ b/internal/postgres/brain_semantic.go
@@ -1,0 +1,145 @@
+package postgres
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"math"
+	"strconv"
+	"strings"
+)
+
+// ErrMemorySemanticNotConfigured reports that no serving embedding generation
+// is available. Callers can continue with lexical retrieval.
+var ErrMemorySemanticNotConfigured = errors.New("memory semantic retrieval is not configured")
+
+// MemorySemanticSearchRequest is the bounded, provider-free input to exact
+// semantic candidate retrieval. A later hybrid layer supplies the query
+// embedding; this primitive never invokes a provider.
+type MemorySemanticSearchRequest struct {
+	PrincipalID string
+	ProjectID   string
+	Embedding   []float64
+	Limit       int
+}
+
+// MemorySemanticSearchResult identifies one current memory item and its exact
+// cosine distance from the supplied query embedding.
+type MemorySemanticSearchResult struct {
+	ItemID   string  `json:"item_id"`
+	Revision int64   `json:"revision"`
+	Distance float64 `json:"distance"`
+}
+
+// MemorySemanticSearchPage carries a bounded candidate set without a total.
+type MemorySemanticSearchPage struct {
+	Results []MemorySemanticSearchResult `json:"results"`
+	More    bool                         `json:"more"`
+}
+
+func (r MemorySemanticSearchRequest) normalized() (MemorySemanticSearchRequest, error) {
+	if !validOpaqueID(r.PrincipalID) || !validOpaqueID(r.ProjectID) || r.Limit < 1 || r.Limit > maxMemorySearchResults ||
+		len(r.Embedding) < 1 || len(r.Embedding) > maxMemoryEmbeddingDimensions {
+		return MemorySemanticSearchRequest{}, errors.New("invalid memory semantic search request")
+	}
+	nonzero := false
+	for _, value := range r.Embedding {
+		if math.IsNaN(value) || math.IsInf(value, 0) || math.Abs(value) > math.MaxFloat32 || (value != 0 && float64(float32(value)) == 0) {
+			return MemorySemanticSearchRequest{}, errors.New("invalid memory semantic search request")
+		}
+		nonzero = nonzero || value != 0
+	}
+	if !nonzero {
+		return MemorySemanticSearchRequest{}, errors.New("invalid memory semantic search request")
+	}
+	return r, nil
+}
+
+func memorySemanticVector(values []float64) string {
+	parts := make([]string, len(values))
+	for i, value := range values {
+		parts[i] = strconv.FormatFloat(value, 'g', -1, 64)
+	}
+	return "[" + strings.Join(parts, ",") + "]"
+}
+
+// SearchMemorySemanticCandidates returns authorized exact cosine candidates
+// from the active generation only. It deliberately has no ANN index, lexical
+// fusion, provider call, or client-facing route.
+func (d *Database) SearchMemorySemanticCandidates(ctx context.Context, raw MemorySemanticSearchRequest) (MemorySemanticSearchPage, error) {
+	request, err := raw.normalized()
+	if err != nil {
+		return MemorySemanticSearchPage{}, err
+	}
+	searchCtx, cancel := context.WithTimeout(ctx, memorySearchTimeout)
+	defer cancel()
+	tx, err := d.brainPool().BeginTx(searchCtx, &sql.TxOptions{Isolation: sql.LevelRepeatableRead, ReadOnly: true})
+	if err != nil {
+		return MemorySemanticSearchPage{}, errors.New("memory semantic search transaction cannot start")
+	}
+	defer func() { _ = tx.Rollback() }()
+	projectID, err := resolveCanonicalActiveProject(searchCtx, tx, request.ProjectID)
+	if err != nil {
+		return MemorySemanticSearchPage{}, ErrNotFound
+	}
+	allowed, err := hasCapability(searchCtx, tx, request.PrincipalID, projectID, CapabilityMemorySearch)
+	if err != nil {
+		return MemorySemanticSearchPage{}, err
+	}
+	if !allowed {
+		return MemorySemanticSearchPage{}, ErrNotFound
+	}
+	if _, err := tx.ExecContext(searchCtx, `SET LOCAL statement_timeout = '2s'`); err != nil {
+		return MemorySemanticSearchPage{}, errors.New("memory semantic search timeout cannot be installed")
+	}
+	var dimensions int
+	if err := tx.QueryRowContext(searchCtx, `SELECT dimensions FROM brain.embedding_generations WHERE state='active'`).Scan(&dimensions); errors.Is(err, sql.ErrNoRows) {
+		return MemorySemanticSearchPage{}, ErrMemorySemanticNotConfigured
+	} else if err != nil || dimensions < 1 || dimensions > maxMemoryEmbeddingDimensions {
+		return MemorySemanticSearchPage{}, errors.New("memory semantic generation is unavailable")
+	}
+	if len(request.Embedding) != dimensions {
+		return MemorySemanticSearchPage{}, errors.New("memory semantic embedding dimensions do not match the active generation")
+	}
+	rows, err := tx.QueryContext(searchCtx, `WITH active_generation AS MATERIALIZED (
+    SELECT id FROM brain.embedding_generations WHERE state='active'
+), candidates AS MATERIALIZED (
+    SELECT item.id,item.current_revision,MIN(chunk.embedding <=> $2::public.vector) AS distance,item.updated_at
+    FROM active_generation AS generation
+    JOIN brain.embedding_chunks AS chunk ON chunk.generation_id=generation.id
+    JOIN brain.embedding_jobs AS job ON job.generation_id=chunk.generation_id AND job.item_id=chunk.item_id
+        AND job.revision=chunk.revision AND job.state='succeeded'
+    JOIN brain.memory_items AS item ON item.id=chunk.item_id AND item.current_revision=chunk.revision
+    JOIN brain.scopes AS scope ON scope.id=item.scope_id AND scope.project_id=$1
+    WHERE item.state='active'
+      AND public.vector_norm(chunk.embedding) > 0
+      AND NOT EXISTS (SELECT 1 FROM brain.memory_quarantines AS quarantine WHERE quarantine.item_id=item.id AND quarantine.released_at IS NULL)
+    GROUP BY item.id,item.current_revision,item.updated_at
+    ORDER BY distance ASC,item.updated_at DESC,item.id
+    LIMIT $3
+)
+SELECT id::text,current_revision,distance FROM candidates ORDER BY distance ASC,updated_at DESC,id`, projectID, memorySemanticVector(request.Embedding), request.Limit+1)
+	if err != nil {
+		return MemorySemanticSearchPage{}, errors.New("memory semantic search is unavailable")
+	}
+	defer func() { _ = rows.Close() }()
+	page := MemorySemanticSearchPage{Results: make([]MemorySemanticSearchResult, 0, request.Limit)}
+	for rows.Next() {
+		var result MemorySemanticSearchResult
+		if err := rows.Scan(&result.ItemID, &result.Revision, &result.Distance); err != nil || !validOpaqueID(result.ItemID) || result.Revision < 1 || math.IsNaN(result.Distance) || math.IsInf(result.Distance, 0) || result.Distance < 0 {
+			return MemorySemanticSearchPage{}, errors.New("memory semantic search result is invalid")
+		}
+		if len(page.Results) == request.Limit {
+			page.More = true
+			continue
+		}
+		page.Results = append(page.Results, result)
+	}
+	if err := rows.Err(); err != nil {
+		return MemorySemanticSearchPage{}, errors.New("memory semantic search is unavailable")
+	}
+	if err := tx.Commit(); err != nil {
+		return MemorySemanticSearchPage{}, errors.New("memory semantic search transaction could not finish")
+	}
+	return page, nil
+}

--- a/internal/postgres/brain_semantic_integration_test.go
+++ b/internal/postgres/brain_semantic_integration_test.go
@@ -1,0 +1,77 @@
+package postgres
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"testing"
+)
+
+func testMemorySemanticCandidateIntegration(ctx context.Context, t *testing.T, app *Database, ownerDB *sql.DB) {
+	t.Helper()
+	actor, err := app.CreatePrincipal(ctx, PrincipalKindDevice, "semantic candidate actor")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var projectID, generationID string
+	var dimensions int
+	if err := ownerDB.QueryRowContext(ctx, `INSERT INTO relay.projects(display_name,created_by) VALUES ('semantic candidate project',$1) RETURNING id::text`, actor.ID).Scan(&projectID); err != nil {
+		t.Fatal(err)
+	}
+	for _, capability := range []Capability{CapabilityMemoryWrite, CapabilityMemorySearch} {
+		if _, err := ownerDB.ExecContext(ctx, `INSERT INTO auth.capability_grants(principal_id,scope,project_id,capability) VALUES ($1,'project',$2,$3)`, actor.ID, projectID, capability); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := ownerDB.QueryRowContext(ctx, `SELECT id::text,dimensions FROM brain.embedding_generations WHERE state='active'`).Scan(&generationID, &dimensions); err != nil {
+		t.Fatal(err)
+	}
+	query := make([]float64, dimensions)
+	query[0] = 1
+	farthestVector := make([]float64, dimensions)
+	if dimensions > 1 {
+		farthestVector[1] = 1
+	} else {
+		farthestVector[0] = -1
+	}
+	create := func(key, title string) MemoryMutationResult {
+		t.Helper()
+		result, createErr := app.CreateMemory(ctx, MemoryCreateRequest{PrincipalID: actor.ID, ProjectID: projectID, IdempotencyKey: key, LogicalKey: "semantic-" + key, Kind: "decision", Trust: "curated", Document: json.RawMessage(`{"title":` + strconvQuote(title) + `}`)})
+		if createErr != nil {
+			t.Fatal(createErr)
+		}
+		return result
+	}
+	nearest := create("28282828-2828-4282-8282-282828282801", "nearest semantic result")
+	farthest := create("28282828-2828-4282-8282-282828282802", "farthest semantic result")
+	zeroNorm := create("28282828-2828-4282-8282-282828282803", "zero norm semantic result")
+	zeroVector := make([]float64, dimensions)
+	for _, fixture := range []struct {
+		item   MemoryMutationResult
+		vector string
+	}{
+		{nearest, memorySemanticVector(query)},
+		{farthest, memorySemanticVector(farthestVector)},
+		{zeroNorm, memorySemanticVector(zeroVector)},
+	} {
+		if _, err := ownerDB.ExecContext(ctx, `INSERT INTO brain.embedding_chunks(generation_id,item_id,revision,ordinal,content_sha256,start_offset,end_offset,embedding)
+VALUES ($1,$2,$3,0,decode('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa','hex'),0,1,$4::public.vector)`, generationID, fixture.item.ItemID, fixture.item.Revision, fixture.vector); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := ownerDB.ExecContext(ctx, `UPDATE brain.embedding_jobs SET state='succeeded',completed_at=statement_timestamp(),updated_at=statement_timestamp() WHERE generation_id=$1 AND item_id=$2 AND revision=$3`, generationID, fixture.item.ItemID, fixture.item.Revision); err != nil {
+			t.Fatal(err)
+		}
+	}
+	page, err := app.SearchMemorySemanticCandidates(ctx, MemorySemanticSearchRequest{PrincipalID: actor.ID, ProjectID: projectID, Embedding: query, Limit: 2})
+	if err != nil || len(page.Results) != 2 || page.Results[0].ItemID != nearest.ItemID || page.Results[1].ItemID != farthest.ItemID || page.Results[0].Distance != 0 || page.Results[1].Distance <= page.Results[0].Distance {
+		t.Fatalf("semantic candidates=%#v err=%v", page, err)
+	}
+	outsider, err := app.CreatePrincipal(ctx, PrincipalKindDevice, "semantic candidate outsider")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := app.SearchMemorySemanticCandidates(ctx, MemorySemanticSearchRequest{PrincipalID: outsider.ID, ProjectID: projectID, Embedding: query, Limit: 2}); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("unauthorized semantic candidates error=%v", err)
+	}
+}

--- a/internal/postgres/brain_semantic_test.go
+++ b/internal/postgres/brain_semantic_test.go
@@ -1,0 +1,36 @@
+package postgres
+
+import (
+	"math"
+	"testing"
+)
+
+func TestMemorySemanticSearchRequestValidation(t *testing.T) {
+	valid := MemorySemanticSearchRequest{
+		PrincipalID: "11111111-1111-4111-8111-111111111111",
+		ProjectID:   "22222222-2222-4222-8222-222222222222",
+		Embedding:   []float64{0.25, 0.5, 0.75},
+		Limit:       10,
+	}
+	if _, err := valid.normalized(); err != nil {
+		t.Fatalf("valid semantic search rejected: %v", err)
+	}
+	for name, request := range map[string]MemorySemanticSearchRequest{
+		"zero vector": {PrincipalID: valid.PrincipalID, ProjectID: valid.ProjectID, Embedding: []float64{0, 0, 0}, Limit: 1},
+		"nan":         {PrincipalID: valid.PrincipalID, ProjectID: valid.ProjectID, Embedding: []float64{math.NaN()}, Limit: 1},
+		"overflow":    {PrincipalID: valid.PrincipalID, ProjectID: valid.ProjectID, Embedding: []float64{math.MaxFloat64}, Limit: 1},
+		"no limit":    {PrincipalID: valid.PrincipalID, ProjectID: valid.ProjectID, Embedding: valid.Embedding},
+	} {
+		t.Run(name, func(t *testing.T) {
+			if _, err := request.normalized(); err == nil {
+				t.Fatal("invalid semantic search accepted")
+			}
+		})
+	}
+}
+
+func TestMemorySemanticVector(t *testing.T) {
+	if got := memorySemanticVector([]float64{0.25, -1, 0}); got != "[0.25,-1,0]" {
+		t.Fatalf("semantic vector=%q", got)
+	}
+}

--- a/internal/postgres/postgres_integration_test.go
+++ b/internal/postgres/postgres_integration_test.go
@@ -461,6 +461,7 @@ RETURNS boolean LANGUAGE plpgsql SECURITY DEFINER SET search_path=pg_catalog AS 
 	testMemoryConsistencyIntegration(ctx, t, app, ownerDB)
 	testMemoryEmbeddingQueueIntegration(ctx, t, app, ownerDB)
 	testMemoryEmbeddingGenerationRebuildIntegration(ctx, t, app, ownerDB)
+	testMemorySemanticCandidateIntegration(ctx, t, app, ownerDB)
 	testMemoryEvidenceIntegration(ctx, t, app, ownerDB)
 	testMemoryProposalIntegration(ctx, t, app, ownerDB)
 	testBackupRestoreIntegration(ctx, t, app, ownerDB, ownerFile, appFile)


### PR DESCRIPTION
## Summary
- add an internal, bounded exact cosine candidate read over active pgvector chunks
- preserve project authorization, current-revision, active-state, and quarantine filtering
- document the no-provider/no-ANN/no-route boundary and add unit plus PostgreSQL integration coverage

## Validation
- make test
- make test-race
- make staticcheck
- make security
- make lint

make test-postgres is not runnable locally because Docker Compose v2 is absent; CI remains the integration execution environment.