### PR TITLE
Add bounded embedding executor

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -453,6 +453,22 @@ it never invokes a provider, exposes a route, changes core readiness, or fuses
 lexical and semantic ranks. With no active generation it reports semantic
 `not_configured`, so callers keep lexical retrieval available.
 
+The bounded embedding executor is provider-agnostic. It claims only existing
+fenced work, re-reads the exact live generation/item/revision/hash/lease before
+passing a bounded canonical JSON document to an injected provider, validates
+all source bounds, offsets, hashes, and generation metadata before the provider
+call, binds the reconstructed source bytes and generation to the claimed lease,
+then validates the returned chunk count and dimensions before using the existing
+fenced publication routine. Active quarantines are excluded both at claim and
+source-read time; a race into quarantine durably returns the exact lease to
+queued state without spending an attempt only when the owner routine confirms
+the active quarantine, so release makes its work claimable again. Stale source
+or publication leases are no-ops; source,
+provider, and publication outages become bounded code-only retries, and a
+failed retry write is surfaced to the executor caller. Provider selection,
+credentials, network configuration, and any public semantic route remain
+separate deployment and API slices.
+
 Schema version 15 places one deterministic secret guard inside the authorized
 create/update transaction before any scope, revision, change, audit,
 idempotency result, or derived job can be written. Findings contain only the

--- a/internal/postgres/brain_embedding_activation_schema.go
+++ b/internal/postgres/brain_embedding_activation_schema.go
@@ -5,7 +5,11 @@ import "context"
 // memoryEmbeddingActivationControlsAvailable verifies the schema-v28 promotion
 // fence: only the owner may retire an active derived generation and activate a
 // fully rebuilt generation.
-func memoryEmbeddingActivationControlsAvailable(ctx context.Context, q queryer) (bool, error) {
+func memoryEmbeddingActivationControlsAvailable(ctx context.Context, q queryer, schemaVersion int64) (bool, error) {
+	activationMD5 := memoryEmbeddingActivationRoutineV28MD5
+	if schemaVersion >= 31 {
+		activationMD5 = memoryEmbeddingActivationRoutineV31MD5
+	}
 	var available bool
 	err := q.QueryRowContext(ctx, `WITH objects AS (
     SELECT to_regprocedure('brain.activate_embedding_generation(uuid)') AS activate_oid,
@@ -34,12 +38,13 @@ func memoryEmbeddingActivationControlsAvailable(ctx context.Context, q queryer) 
 )
 SELECT activate_oid IS NOT NULL AND delete_guard_oid IS NOT NULL AND immutable_oid IS NOT NULL
    AND routines.exact AND activation_acl.exact AND triggers.exact
-FROM objects,routines,activation_acl,triggers`, memoryEmbeddingActivationRoutineMD5, memoryEmbeddingChunkDeleteGuardRoutineMD5, memoryEmbeddingGenerationMutationRoutineMD5).Scan(&available)
+FROM objects,routines,activation_acl,triggers`, activationMD5, memoryEmbeddingChunkDeleteGuardRoutineMD5, memoryEmbeddingGenerationMutationRoutineMD5).Scan(&available)
 	return available, err
 }
 
 const (
-	memoryEmbeddingActivationRoutineMD5         = "514944767b34823edaabb23ae868dd16"
+	memoryEmbeddingActivationRoutineV28MD5      = "514944767b34823edaabb23ae868dd16"
+	memoryEmbeddingActivationRoutineV31MD5      = "f427432d68f08abd6012be9a9cf6a37d"
 	memoryEmbeddingChunkDeleteGuardRoutineMD5   = "8e425c1cc346a818814c2903f8d52786"
 	memoryEmbeddingGenerationMutationRoutineMD5 = "5ba945bbb850d7f58c7a7ce2cea1516d"
 )

--- a/internal/postgres/brain_embedding_executor.go
+++ b/internal/postgres/brain_embedding_executor.go
@@ -189,7 +189,7 @@ func (e *MemoryEmbeddingExecutor) executeLease(ctx context.Context, lease Memory
 			if err := e.retry(ctx, lease, "quarantined", result); err != nil {
 				return err
 			}
-		} else if errors.Is(sourceCtx.Err(), context.DeadlineExceeded) {
+		} else if !time.Now().Before(leaseDeadline) {
 			// A held advisory fence can outlive this lease while a quarantine
 			// writer is still uncommitted. Leave the running lease for safe
 			// expiry/reclamation rather than terminally retrying it blind.

--- a/internal/postgres/brain_embedding_executor.go
+++ b/internal/postgres/brain_embedding_executor.go
@@ -285,7 +285,7 @@ func (e *MemoryEmbeddingExecutor) retry(ctx context.Context, lease MemoryEmbeddi
 	retryCtx, cancel := context.WithDeadline(ctx, lease.LeaseUntil)
 	defer cancel()
 	if err := e.store.RetryMemoryEmbeddingWork(retryCtx, MemoryEmbeddingRetry{Lease: lease, ErrorCode: code, Delay: time.Second}); err != nil {
-		if errors.Is(err, ErrStaleEmbeddingLease) || (!time.Now().Before(lease.LeaseUntil) && errors.Is(err, context.DeadlineExceeded)) {
+		if errors.Is(err, ErrStaleEmbeddingLease) || !time.Now().Before(lease.LeaseUntil) {
 			return nil
 		}
 		return err

--- a/internal/postgres/brain_embedding_executor.go
+++ b/internal/postgres/brain_embedding_executor.go
@@ -189,6 +189,11 @@ func (e *MemoryEmbeddingExecutor) executeLease(ctx context.Context, lease Memory
 			if err := e.retry(ctx, lease, "quarantined", result); err != nil {
 				return err
 			}
+		} else if errors.Is(sourceCtx.Err(), context.DeadlineExceeded) {
+			// A held advisory fence can outlive this lease while a quarantine
+			// writer is still uncommitted. Leave the running lease for safe
+			// expiry/reclamation rather than terminally retrying it blind.
+			return nil
 		} else if !errors.Is(loadErr, ErrStaleEmbeddingLease) {
 			if err := e.retry(ctx, lease, "source_unavailable", result); err != nil {
 				return err

--- a/internal/postgres/brain_embedding_executor.go
+++ b/internal/postgres/brain_embedding_executor.go
@@ -1,0 +1,281 @@
+package postgres
+
+import (
+	"context"
+	"crypto/sha256"
+	"database/sql"
+	"encoding/hex"
+	"errors"
+	"math"
+	"time"
+)
+
+const maxMemoryEmbeddingSourceBytes = 256 << 10
+
+// MemoryEmbeddingSourceChunk is bounded canonical text supplied to a provider.
+type MemoryEmbeddingSourceChunk struct {
+	Ordinal                int
+	ContentSHA256          string
+	StartOffset, EndOffset int
+	Text                   string
+}
+
+// MemoryEmbeddingProvider generates one vector for each supplied source chunk.
+type MemoryEmbeddingProvider interface {
+	Embed(context.Context, MemoryEmbeddingGeneration, []MemoryEmbeddingSourceChunk) ([][]float64, error)
+}
+type memoryEmbeddingExecutorStore interface {
+	ClaimMemoryEmbeddingWork(context.Context, MemoryEmbeddingClaimRequest) ([]MemoryEmbeddingLease, error)
+	PublishMemoryEmbeddingWork(context.Context, MemoryEmbeddingPublication) error
+	RetryMemoryEmbeddingWork(context.Context, MemoryEmbeddingRetry) error
+}
+
+// MemoryEmbeddingSource materializes only a live, fenced lease coordinate.
+type MemoryEmbeddingSource interface {
+	OpenMemoryEmbeddingSource(context.Context, MemoryEmbeddingLease) (MemoryEmbeddingGeneration, []MemoryEmbeddingSourceChunk, func(), error)
+}
+
+// MemoryEmbeddingExecutor claims, embeds, and fence-publishes bounded work.
+type MemoryEmbeddingExecutor struct {
+	store    memoryEmbeddingExecutorStore
+	source   MemoryEmbeddingSource
+	provider MemoryEmbeddingProvider
+}
+
+// MemoryEmbeddingExecutionResult reports one bounded executor pass.
+type MemoryEmbeddingExecutionResult struct{ Claimed, Published, Retried int }
+
+// LoadMemoryEmbeddingSource reads only the exact, live lease coordinate. It
+// returns one bounded canonical-document chunk; later chunking policies can
+// refine this derived boundary without changing the lease fence.
+func (d *Database) LoadMemoryEmbeddingSource(ctx context.Context, lease MemoryEmbeddingLease) (MemoryEmbeddingGeneration, []MemoryEmbeddingSourceChunk, error) {
+	return d.loadMemoryEmbeddingSource(ctx, d.db, lease)
+}
+
+// OpenMemoryEmbeddingSource holds the item fence until its returned release
+// function runs, preventing a quarantine transition from racing provider use.
+func (d *Database) OpenMemoryEmbeddingSource(ctx context.Context, lease MemoryEmbeddingLease) (MemoryEmbeddingGeneration, []MemoryEmbeddingSourceChunk, func(), error) {
+	// The fence must survive cancellation of the worker operation: the provider
+	// can still unwind after its context is cancelled, and its source must remain
+	// protected until executeLease calls release.
+	conn, err := d.embeddingPool().Conn(ctx)
+	if err != nil {
+		return MemoryEmbeddingGeneration{}, nil, nil, errors.New("memory embedding source is unavailable")
+	}
+	if _, err := conn.ExecContext(ctx, "BEGIN READ ONLY"); err != nil {
+		_ = conn.Close()
+		return MemoryEmbeddingGeneration{}, nil, nil, errors.New("memory embedding source is unavailable")
+	}
+	release := func() {
+		cleanupCtx, cancel := context.WithTimeout(context.Background(), operationTimeout)
+		defer cancel()
+		_, _ = conn.ExecContext(cleanupCtx, "ROLLBACK")
+		_ = conn.Close()
+	}
+	// Acquisition follows the worker context so a blocked advisory lock does not
+	// outlive a cancelled pass. Once acquired, the transaction remains bound to
+	// fenceCtx until release so cancellation cannot drop the provider fence.
+	if _, err := conn.ExecContext(ctx, `SELECT pg_advisory_xact_lock(hashtextextended($1::text, 801337))`, lease.ItemID); err != nil {
+		release()
+		return MemoryEmbeddingGeneration{}, nil, nil, errors.New("memory embedding source is unavailable")
+	}
+	generation, chunks, err := d.loadMemoryEmbeddingSource(ctx, conn, lease)
+	if err != nil {
+		if errors.Is(err, ErrMemoryEmbeddingQuarantined) {
+			return MemoryEmbeddingGeneration{}, nil, release, err
+		}
+		release()
+		return MemoryEmbeddingGeneration{}, nil, nil, err
+	}
+	return generation, chunks, release, nil
+}
+
+func (d *Database) embeddingPool() *sql.DB {
+	if d.embeddingDB != nil {
+		return d.embeddingDB
+	}
+	return d.db
+}
+
+func (d *Database) loadMemoryEmbeddingSource(ctx context.Context, q queryer, lease MemoryEmbeddingLease) (MemoryEmbeddingGeneration, []MemoryEmbeddingSourceChunk, error) {
+	if !lease.valid() {
+		return MemoryEmbeddingGeneration{}, nil, errors.New("invalid memory embedding lease")
+	}
+	digest, _ := hex.DecodeString(lease.ContentSHA256)
+	var generation MemoryEmbeddingGeneration
+	var document []byte
+	var storedHash sql.NullString
+	var quarantined bool
+	err := q.QueryRowContext(ctx, `SELECT generation.id::text,generation.model,generation.model_revision,generation.dimensions,generation.state,revision.document,encode(revision.content_sha256,'hex'),quarantine.active
+FROM brain.embedding_jobs AS job
+JOIN brain.embedding_generations AS generation ON generation.id=job.generation_id
+JOIN brain.memory_items AS item ON item.id=job.item_id AND item.current_revision=job.revision
+CROSS JOIN LATERAL (SELECT EXISTS (SELECT 1 FROM brain.memory_quarantines AS record WHERE record.item_id=job.item_id AND record.released_at IS NULL) AS active) AS quarantine
+LEFT JOIN brain.memory_revisions AS revision ON revision.item_id=job.item_id AND revision.revision=job.revision AND NOT quarantine.active
+WHERE job.generation_id=$1 AND job.item_id=$2 AND job.revision=$3 AND job.content_sha256=$4
+	AND job.state='running' AND job.lease_token=$5 AND job.lease_generation=$6 AND job.lease_until>statement_timestamp()`, lease.GenerationID, lease.ItemID, lease.Revision, digest, lease.Token, lease.LeaseGeneration).Scan(&generation.ID, &generation.Model, &generation.Revision, &generation.Dimensions, &generation.State, &document, &storedHash, &quarantined)
+	if errors.Is(err, sql.ErrNoRows) {
+		return MemoryEmbeddingGeneration{}, nil, ErrStaleEmbeddingLease
+	}
+	if err != nil {
+		return MemoryEmbeddingGeneration{}, nil, errors.New("memory embedding source is unavailable")
+	}
+	if quarantined {
+		return MemoryEmbeddingGeneration{}, nil, ErrMemoryEmbeddingQuarantined
+	}
+	documentHash := sha256.Sum256(document)
+	if generation.Validate() != nil || len(document) == 0 || len(document) > maxMemoryEmbeddingSourceBytes || !storedHash.Valid || hex.EncodeToString(documentHash[:]) != storedHash.String || storedHash.String != lease.ContentSHA256 {
+		return MemoryEmbeddingGeneration{}, nil, errors.New("memory embedding source is invalid")
+	}
+	chunkHash := sha256.Sum256(document)
+	return generation, []MemoryEmbeddingSourceChunk{{Ordinal: 0, ContentSHA256: hex.EncodeToString(chunkHash[:]), StartOffset: 0, EndOffset: len(document), Text: string(document)}}, nil
+}
+
+// NewMemoryEmbeddingExecutor constructs a bounded provider-agnostic executor.
+func NewMemoryEmbeddingExecutor(store memoryEmbeddingExecutorStore, source MemoryEmbeddingSource, provider MemoryEmbeddingProvider) (*MemoryEmbeddingExecutor, error) {
+	if store == nil || source == nil || provider == nil {
+		return nil, errors.New("memory embedding executor is invalid")
+	}
+	return &MemoryEmbeddingExecutor{store: store, source: source, provider: provider}, nil
+}
+
+// Execute claims and processes at most the request's bounded lease batch.
+func (e *MemoryEmbeddingExecutor) Execute(ctx context.Context, request MemoryEmbeddingClaimRequest) (MemoryEmbeddingExecutionResult, error) {
+	var err error
+	request, err = request.normalized()
+	if err != nil {
+		return MemoryEmbeddingExecutionResult{}, err
+	}
+	result := MemoryEmbeddingExecutionResult{}
+	for claimed := 0; claimed < request.Limit; claimed++ {
+		one := request
+		one.Limit = 1
+		leases, err := e.store.ClaimMemoryEmbeddingWork(ctx, one)
+		if err != nil {
+			return result, err
+		}
+		if len(leases) == 0 {
+			break
+		}
+		result.Claimed++
+		lease := leases[0]
+		if err := e.executeLease(ctx, lease, &result); err != nil {
+			return result, err
+		}
+	}
+	return result, nil
+}
+
+func (e *MemoryEmbeddingExecutor) executeLease(ctx context.Context, lease MemoryEmbeddingLease, result *MemoryEmbeddingExecutionResult) error {
+	var generation MemoryEmbeddingGeneration
+	var chunks []MemoryEmbeddingSourceChunk
+	var release func()
+	var loadErr error
+	generation, chunks, release, loadErr = e.source.OpenMemoryEmbeddingSource(ctx, lease)
+	if loadErr == nil && release == nil {
+		loadErr = errors.New("memory embedding source fence is unavailable")
+	}
+	if release != nil {
+		defer release()
+	}
+	if loadErr != nil {
+		if errors.Is(loadErr, ErrMemoryEmbeddingQuarantined) {
+			if err := e.retry(ctx, lease, "quarantined", result); err != nil {
+				return err
+			}
+		} else if !errors.Is(loadErr, ErrStaleEmbeddingLease) {
+			if err := e.retry(ctx, lease, "source_unavailable", result); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+	if !validMemoryEmbeddingSource(lease, generation, chunks) {
+		if err := e.retry(ctx, lease, "provider_invalid", result); err != nil {
+			return err
+		}
+		return nil
+	}
+	providerCtx, cancel := context.WithDeadline(ctx, lease.LeaseUntil)
+	defer cancel()
+	providerChunks := append([]MemoryEmbeddingSourceChunk(nil), chunks...)
+	vectors, embedErr := e.provider.Embed(providerCtx, generation, providerChunks)
+	if embedErr != nil {
+		if err := e.retry(ctx, lease, "provider_unavailable", result); err != nil {
+			return err
+		}
+		return nil
+	}
+	if len(vectors) != len(chunks) {
+		if err := e.retry(ctx, lease, "provider_invalid", result); err != nil {
+			return err
+		}
+		return nil
+	}
+	publication := MemoryEmbeddingPublication{Lease: lease, Chunks: make([]MemoryEmbeddingChunk, len(chunks))}
+	valid := generation.Validate() == nil
+	for i, chunk := range chunks {
+		publication.Chunks[i] = MemoryEmbeddingChunk{Ordinal: chunk.Ordinal, ContentSHA256: chunk.ContentSHA256, StartOffset: chunk.StartOffset, EndOffset: chunk.EndOffset, Vector: vectors[i]}
+		valid = valid && validMemoryEmbeddingVector(vectors[i], generation.Dimensions)
+	}
+	if !valid || publication.Validate() != nil {
+		if err := e.retry(ctx, lease, "provider_invalid", result); err != nil {
+			return err
+		}
+		return nil
+	}
+	if err := e.store.PublishMemoryEmbeddingWork(ctx, publication); err == nil {
+		result.Published++
+	} else if !errors.Is(err, ErrStaleEmbeddingLease) {
+		if err := e.retry(ctx, lease, "publish_unavailable", result); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validMemoryEmbeddingVector(vector []float64, dimensions int) bool {
+	if len(vector) != dimensions {
+		return false
+	}
+	normSquared := 0.0
+	for _, value := range vector {
+		if math.IsNaN(value) || math.IsInf(value, 0) {
+			return false
+		}
+		normSquared += value * value
+	}
+	return normSquared > 0 && !math.IsInf(normSquared, 0)
+}
+
+func validMemoryEmbeddingSource(lease MemoryEmbeddingLease, generation MemoryEmbeddingGeneration, chunks []MemoryEmbeddingSourceChunk) bool {
+	if generation.ID != lease.GenerationID || generation.Validate() != nil || len(chunks) < 1 || len(chunks) > maxMemoryEmbeddingChunks {
+		return false
+	}
+	end := 0
+	document := make([]byte, 0, maxMemoryEmbeddingSourceBytes)
+	for ordinal, chunk := range chunks {
+		if chunk.Ordinal != ordinal || chunk.StartOffset != end || chunk.EndOffset <= chunk.StartOffset || chunk.EndOffset > maxMemoryEmbeddingSourceBytes || chunk.EndOffset-chunk.StartOffset != len(chunk.Text) {
+			return false
+		}
+		digest := sha256.Sum256([]byte(chunk.Text))
+		if chunk.ContentSHA256 != hex.EncodeToString(digest[:]) {
+			return false
+		}
+		end = chunk.EndOffset
+		document = append(document, chunk.Text...)
+	}
+	digest := sha256.Sum256(document)
+	return hex.EncodeToString(digest[:]) == lease.ContentSHA256
+}
+
+func (e *MemoryEmbeddingExecutor) retry(ctx context.Context, lease MemoryEmbeddingLease, code string, result *MemoryEmbeddingExecutionResult) error {
+	if err := e.store.RetryMemoryEmbeddingWork(ctx, MemoryEmbeddingRetry{Lease: lease, ErrorCode: code, Delay: time.Second}); err != nil {
+		if errors.Is(err, ErrStaleEmbeddingLease) {
+			return nil
+		}
+		return err
+	}
+	result.Retried++
+	return nil
+}

--- a/internal/postgres/brain_embedding_executor.go
+++ b/internal/postgres/brain_embedding_executor.go
@@ -234,7 +234,7 @@ func (e *MemoryEmbeddingExecutor) executeLease(ctx context.Context, lease Memory
 		}
 		return nil
 	}
-	if err := e.store.PublishMemoryEmbeddingWork(ctx, publication); err == nil {
+	if err := e.store.PublishMemoryEmbeddingWork(sourceCtx, publication); err == nil {
 		result.Published++
 	} else if !errors.Is(err, ErrStaleEmbeddingLease) {
 		if err := e.retry(ctx, lease, "publish_unavailable", result); err != nil {

--- a/internal/postgres/brain_embedding_executor.go
+++ b/internal/postgres/brain_embedding_executor.go
@@ -234,7 +234,9 @@ func (e *MemoryEmbeddingExecutor) executeLease(ctx context.Context, lease Memory
 		}
 		return nil
 	}
-	if err := e.store.PublishMemoryEmbeddingWork(sourceCtx, publication); err == nil {
+	publicationCtx, cancelPublication := context.WithDeadline(ctx, lease.LeaseUntil)
+	defer cancelPublication()
+	if err := e.store.PublishMemoryEmbeddingWork(publicationCtx, publication); err == nil {
 		result.Published++
 	} else if !errors.Is(err, ErrStaleEmbeddingLease) {
 		if err := e.retry(ctx, lease, "publish_unavailable", result); err != nil {

--- a/internal/postgres/brain_embedding_executor.go
+++ b/internal/postgres/brain_embedding_executor.go
@@ -185,16 +185,17 @@ func (e *MemoryEmbeddingExecutor) executeLease(ctx context.Context, lease Memory
 		defer release()
 	}
 	if loadErr != nil {
-		if errors.Is(loadErr, ErrMemoryEmbeddingQuarantined) {
+		switch {
+		case errors.Is(loadErr, ErrMemoryEmbeddingQuarantined):
 			if err := e.retry(ctx, lease, "quarantined", result); err != nil {
 				return err
 			}
-		} else if !time.Now().Before(leaseDeadline) {
+		case !time.Now().Before(leaseDeadline):
 			// A held advisory fence can outlive this lease while a quarantine
 			// writer is still uncommitted. Leave the running lease for safe
 			// expiry/reclamation rather than terminally retrying it blind.
 			return nil
-		} else if !errors.Is(loadErr, ErrStaleEmbeddingLease) {
+		case !errors.Is(loadErr, ErrStaleEmbeddingLease):
 			if err := e.retry(ctx, lease, "source_unavailable", result); err != nil {
 				return err
 			}

--- a/internal/postgres/brain_embedding_executor.go
+++ b/internal/postgres/brain_embedding_executor.go
@@ -285,7 +285,7 @@ func (e *MemoryEmbeddingExecutor) retry(ctx context.Context, lease MemoryEmbeddi
 	retryCtx, cancel := context.WithDeadline(ctx, lease.LeaseUntil)
 	defer cancel()
 	if err := e.store.RetryMemoryEmbeddingWork(retryCtx, MemoryEmbeddingRetry{Lease: lease, ErrorCode: code, Delay: time.Second}); err != nil {
-		if errors.Is(err, ErrStaleEmbeddingLease) {
+		if errors.Is(err, ErrStaleEmbeddingLease) || (!time.Now().Before(lease.LeaseUntil) && errors.Is(err, context.DeadlineExceeded)) {
 			return nil
 		}
 		return err

--- a/internal/postgres/brain_embedding_executor.go
+++ b/internal/postgres/brain_embedding_executor.go
@@ -249,7 +249,7 @@ func validMemoryEmbeddingVector(vector []float64, dimensions int) bool {
 }
 
 func validMemoryEmbeddingSource(lease MemoryEmbeddingLease, generation MemoryEmbeddingGeneration, chunks []MemoryEmbeddingSourceChunk) bool {
-	if generation.ID != lease.GenerationID || generation.Validate() != nil || len(chunks) < 1 || len(chunks) > maxMemoryEmbeddingChunks {
+	if lease.Generation.Validate() != nil || generation != lease.Generation || generation.ID != lease.GenerationID || len(chunks) < 1 || len(chunks) > maxMemoryEmbeddingChunks {
 		return false
 	}
 	end := 0

--- a/internal/postgres/brain_embedding_executor.go
+++ b/internal/postgres/brain_embedding_executor.go
@@ -174,7 +174,10 @@ func (e *MemoryEmbeddingExecutor) executeLease(ctx context.Context, lease Memory
 	var chunks []MemoryEmbeddingSourceChunk
 	var release func()
 	var loadErr error
-	generation, chunks, release, loadErr = e.source.OpenMemoryEmbeddingSource(ctx, lease)
+	leaseDeadline := lease.LeaseUntil.Add(-memoryEmbeddingPublicationReserve)
+	sourceCtx, cancelSource := context.WithDeadline(ctx, leaseDeadline)
+	defer cancelSource()
+	generation, chunks, release, loadErr = e.source.OpenMemoryEmbeddingSource(sourceCtx, lease)
 	if loadErr == nil && release == nil {
 		loadErr = errors.New("memory embedding source fence is unavailable")
 	}
@@ -199,10 +202,8 @@ func (e *MemoryEmbeddingExecutor) executeLease(ctx context.Context, lease Memory
 		}
 		return nil
 	}
-	providerCtx, cancel := context.WithDeadline(ctx, lease.LeaseUntil.Add(-memoryEmbeddingPublicationReserve))
-	defer cancel()
 	providerChunks := append([]MemoryEmbeddingSourceChunk(nil), chunks...)
-	vectors, embedErr := e.provider.Embed(providerCtx, generation, providerChunks)
+	vectors, embedErr := e.provider.Embed(sourceCtx, generation, providerChunks)
 	if embedErr != nil {
 		if err := e.retry(ctx, lease, "provider_unavailable", result); err != nil {
 			return err

--- a/internal/postgres/brain_embedding_executor.go
+++ b/internal/postgres/brain_embedding_executor.go
@@ -10,7 +10,10 @@ import (
 	"time"
 )
 
-const maxMemoryEmbeddingSourceBytes = 256 << 10
+const (
+	maxMemoryEmbeddingSourceBytes     = 256 << 10
+	memoryEmbeddingPublicationReserve = time.Second
+)
 
 // MemoryEmbeddingSourceChunk is bounded canonical text supplied to a provider.
 type MemoryEmbeddingSourceChunk struct {
@@ -196,7 +199,7 @@ func (e *MemoryEmbeddingExecutor) executeLease(ctx context.Context, lease Memory
 		}
 		return nil
 	}
-	providerCtx, cancel := context.WithDeadline(ctx, lease.LeaseUntil)
+	providerCtx, cancel := context.WithDeadline(ctx, lease.LeaseUntil.Add(-memoryEmbeddingPublicationReserve))
 	defer cancel()
 	providerChunks := append([]MemoryEmbeddingSourceChunk(nil), chunks...)
 	vectors, embedErr := e.provider.Embed(providerCtx, generation, providerChunks)

--- a/internal/postgres/brain_embedding_executor.go
+++ b/internal/postgres/brain_embedding_executor.go
@@ -282,7 +282,9 @@ func validMemoryEmbeddingSource(lease MemoryEmbeddingLease, generation MemoryEmb
 }
 
 func (e *MemoryEmbeddingExecutor) retry(ctx context.Context, lease MemoryEmbeddingLease, code string, result *MemoryEmbeddingExecutionResult) error {
-	if err := e.store.RetryMemoryEmbeddingWork(ctx, MemoryEmbeddingRetry{Lease: lease, ErrorCode: code, Delay: time.Second}); err != nil {
+	retryCtx, cancel := context.WithDeadline(ctx, lease.LeaseUntil)
+	defer cancel()
+	if err := e.store.RetryMemoryEmbeddingWork(retryCtx, MemoryEmbeddingRetry{Lease: lease, ErrorCode: code, Delay: time.Second}); err != nil {
 		if errors.Is(err, ErrStaleEmbeddingLease) {
 			return nil
 		}

--- a/internal/postgres/brain_embedding_executor_test.go
+++ b/internal/postgres/brain_embedding_executor_test.go
@@ -114,6 +114,19 @@ func TestMemoryEmbeddingExecutorRetainsSourceFenceThroughQuarantineRetry(t *test
 	}
 }
 
+func TestMemoryEmbeddingExecutorLetsExpiredSourceFenceLeaseReclaim(t *testing.T) {
+	lease := MemoryEmbeddingLease{MemoryEmbeddingWork: MemoryEmbeddingWork{GenerationID: "11111111-1111-4111-8111-111111111111", ItemID: "22222222-2222-4222-8222-222222222222", Revision: 1, ContentSHA256: "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08"}, Generation: MemoryEmbeddingGeneration{ID: "11111111-1111-4111-8111-111111111111", Model: "local.e5", Revision: "2026-07-01", Dimensions: 2, State: MemoryEmbeddingGenerationActive}, Attempts: 25, Holder: "33333333-3333-4333-8333-333333333333", Token: "44444444-4444-4444-8444-444444444444", LeaseGeneration: 1, LeaseUntil: time.Now()}
+	store := &fakeEmbeddingExecutorStore{leases: []MemoryEmbeddingLease{lease}}
+	executor, err := NewMemoryEmbeddingExecutor(store, fakeEmbeddingSource{err: errors.New("source fence unavailable")}, fakeEmbeddingProvider{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	result, err := executor.Execute(context.Background(), MemoryEmbeddingClaimRequest{WorkerID: lease.Holder, Limit: 1, LeaseDuration: time.Minute})
+	if err != nil || result.Retried != 0 || len(store.retries) != 0 {
+		t.Fatalf("result=%#v retries=%#v err=%v", result, store.retries, err)
+	}
+}
+
 type fakeEmbeddingExecutorStore struct {
 	leases    []MemoryEmbeddingLease
 	published []MemoryEmbeddingPublication

--- a/internal/postgres/brain_embedding_executor_test.go
+++ b/internal/postgres/brain_embedding_executor_test.go
@@ -11,13 +11,17 @@ func TestMemoryEmbeddingExecutorPublishesAndRetriesBoundedly(t *testing.T) {
 	lease := MemoryEmbeddingLease{MemoryEmbeddingWork: MemoryEmbeddingWork{GenerationID: "11111111-1111-4111-8111-111111111111", ItemID: "22222222-2222-4222-8222-222222222222", Revision: 1, ContentSHA256: "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08"}, Generation: MemoryEmbeddingGeneration{ID: "11111111-1111-4111-8111-111111111111", Model: "local.e5", Revision: "2026-07-01", Dimensions: 2, State: MemoryEmbeddingGenerationActive}, Attempts: 1, Holder: "33333333-3333-4333-8333-333333333333", Token: "44444444-4444-4444-8444-444444444444", LeaseGeneration: 1, LeaseUntil: time.Now().Add(time.Minute)}
 	store := &fakeEmbeddingExecutorStore{leases: []MemoryEmbeddingLease{lease}}
 	source := fakeEmbeddingSource{generation: MemoryEmbeddingGeneration{ID: lease.GenerationID, Model: "local.e5", Revision: "2026-07-01", Dimensions: 2, State: MemoryEmbeddingGenerationActive}, chunks: []MemoryEmbeddingSourceChunk{{Ordinal: 0, ContentSHA256: "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08", StartOffset: 0, EndOffset: 4, Text: "test"}}}
-	executor, err := NewMemoryEmbeddingExecutor(store, source, fakeEmbeddingProvider{vectors: [][]float64{{0.25, 0.75}}})
+	providerDeadline := time.Time{}
+	executor, err := NewMemoryEmbeddingExecutor(store, source, fakeEmbeddingProvider{vectors: [][]float64{{0.25, 0.75}}, deadline: &providerDeadline})
 	if err != nil {
 		t.Fatal(err)
 	}
 	result, err := executor.Execute(context.Background(), MemoryEmbeddingClaimRequest{WorkerID: lease.Holder, Limit: 1, LeaseDuration: time.Minute})
 	if err != nil || result.Published != 1 || len(store.published) != 1 || len(store.retries) != 0 {
 		t.Fatalf("result=%#v published=%#v retries=%#v err=%v", result, store.published, store.retries, err)
+	}
+	if providerDeadline.IsZero() || providerDeadline.After(lease.LeaseUntil.Add(-memoryEmbeddingPublicationReserve)) {
+		t.Fatalf("provider deadline=%v lease until=%v", providerDeadline, lease.LeaseUntil)
 	}
 	store.leases = []MemoryEmbeddingLease{lease}
 	executor, err = NewMemoryEmbeddingExecutor(store, source, fakeEmbeddingProvider{vectors: [][]float64{{0.25}}})
@@ -163,14 +167,18 @@ func (s fencedEmbeddingSource) OpenMemoryEmbeddingSource(context.Context, Memory
 }
 
 type fakeEmbeddingProvider struct {
-	vectors [][]float64
-	err     error
-	calls   *int
+	vectors  [][]float64
+	err      error
+	calls    *int
+	deadline *time.Time
 }
 
-func (p fakeEmbeddingProvider) Embed(context.Context, MemoryEmbeddingGeneration, []MemoryEmbeddingSourceChunk) ([][]float64, error) {
+func (p fakeEmbeddingProvider) Embed(ctx context.Context, _ MemoryEmbeddingGeneration, _ []MemoryEmbeddingSourceChunk) ([][]float64, error) {
 	if p.calls != nil {
 		*p.calls++
+	}
+	if p.deadline != nil {
+		*p.deadline, _ = ctx.Deadline()
 	}
 	return p.vectors, p.err
 }

--- a/internal/postgres/brain_embedding_executor_test.go
+++ b/internal/postgres/brain_embedding_executor_test.go
@@ -11,6 +11,8 @@ func TestMemoryEmbeddingExecutorPublishesAndRetriesBoundedly(t *testing.T) {
 	lease := MemoryEmbeddingLease{MemoryEmbeddingWork: MemoryEmbeddingWork{GenerationID: "11111111-1111-4111-8111-111111111111", ItemID: "22222222-2222-4222-8222-222222222222", Revision: 1, ContentSHA256: "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08"}, Generation: MemoryEmbeddingGeneration{ID: "11111111-1111-4111-8111-111111111111", Model: "local.e5", Revision: "2026-07-01", Dimensions: 2, State: MemoryEmbeddingGenerationActive}, Attempts: 1, Holder: "33333333-3333-4333-8333-333333333333", Token: "44444444-4444-4444-8444-444444444444", LeaseGeneration: 1, LeaseUntil: time.Now().Add(time.Minute)}
 	store := &fakeEmbeddingExecutorStore{leases: []MemoryEmbeddingLease{lease}}
 	source := fakeEmbeddingSource{generation: MemoryEmbeddingGeneration{ID: lease.GenerationID, Model: "local.e5", Revision: "2026-07-01", Dimensions: 2, State: MemoryEmbeddingGenerationActive}, chunks: []MemoryEmbeddingSourceChunk{{Ordinal: 0, ContentSHA256: "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08", StartOffset: 0, EndOffset: 4, Text: "test"}}}
+	sourceDeadline := time.Time{}
+	source.deadline = &sourceDeadline
 	providerDeadline := time.Time{}
 	executor, err := NewMemoryEmbeddingExecutor(store, source, fakeEmbeddingProvider{vectors: [][]float64{{0.25, 0.75}}, deadline: &providerDeadline})
 	if err != nil {
@@ -22,6 +24,9 @@ func TestMemoryEmbeddingExecutorPublishesAndRetriesBoundedly(t *testing.T) {
 	}
 	if providerDeadline.IsZero() || providerDeadline.After(lease.LeaseUntil.Add(-memoryEmbeddingPublicationReserve)) {
 		t.Fatalf("provider deadline=%v lease until=%v", providerDeadline, lease.LeaseUntil)
+	}
+	if sourceDeadline.IsZero() || sourceDeadline.After(lease.LeaseUntil.Add(-memoryEmbeddingPublicationReserve)) {
+		t.Fatalf("source deadline=%v lease until=%v", sourceDeadline, lease.LeaseUntil)
 	}
 	store.leases = []MemoryEmbeddingLease{lease}
 	executor, err = NewMemoryEmbeddingExecutor(store, source, fakeEmbeddingProvider{vectors: [][]float64{{0.25}}})
@@ -143,13 +148,17 @@ type fakeEmbeddingSource struct {
 	generation MemoryEmbeddingGeneration
 	chunks     []MemoryEmbeddingSourceChunk
 	err        error
+	deadline   *time.Time
 }
 
 func (s fakeEmbeddingSource) LoadMemoryEmbeddingSource(context.Context, MemoryEmbeddingLease) (MemoryEmbeddingGeneration, []MemoryEmbeddingSourceChunk, error) {
 	return s.generation, s.chunks, s.err
 }
 
-func (s fakeEmbeddingSource) OpenMemoryEmbeddingSource(context.Context, MemoryEmbeddingLease) (MemoryEmbeddingGeneration, []MemoryEmbeddingSourceChunk, func(), error) {
+func (s fakeEmbeddingSource) OpenMemoryEmbeddingSource(ctx context.Context, _ MemoryEmbeddingLease) (MemoryEmbeddingGeneration, []MemoryEmbeddingSourceChunk, func(), error) {
+	if s.deadline != nil {
+		*s.deadline, _ = ctx.Deadline()
+	}
 	return s.generation, s.chunks, func() {}, s.err
 }
 

--- a/internal/postgres/brain_embedding_executor_test.go
+++ b/internal/postgres/brain_embedding_executor_test.go
@@ -1,0 +1,164 @@
+package postgres
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestMemoryEmbeddingExecutorPublishesAndRetriesBoundedly(t *testing.T) {
+	lease := MemoryEmbeddingLease{MemoryEmbeddingWork: MemoryEmbeddingWork{GenerationID: "11111111-1111-4111-8111-111111111111", ItemID: "22222222-2222-4222-8222-222222222222", Revision: 1, ContentSHA256: "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08"}, Attempts: 1, Holder: "33333333-3333-4333-8333-333333333333", Token: "44444444-4444-4444-8444-444444444444", LeaseGeneration: 1, LeaseUntil: time.Now().Add(time.Minute)}
+	store := &fakeEmbeddingExecutorStore{leases: []MemoryEmbeddingLease{lease}}
+	source := fakeEmbeddingSource{generation: MemoryEmbeddingGeneration{ID: lease.GenerationID, Model: "local.e5", Revision: "2026-07-01", Dimensions: 2, State: MemoryEmbeddingGenerationActive}, chunks: []MemoryEmbeddingSourceChunk{{Ordinal: 0, ContentSHA256: "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08", StartOffset: 0, EndOffset: 4, Text: "test"}}}
+	executor, err := NewMemoryEmbeddingExecutor(store, source, fakeEmbeddingProvider{vectors: [][]float64{{0.25, 0.75}}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	result, err := executor.Execute(context.Background(), MemoryEmbeddingClaimRequest{WorkerID: lease.Holder, Limit: 1, LeaseDuration: time.Minute})
+	if err != nil || result.Published != 1 || len(store.published) != 1 || len(store.retries) != 0 {
+		t.Fatalf("result=%#v published=%#v retries=%#v err=%v", result, store.published, store.retries, err)
+	}
+	store.leases = []MemoryEmbeddingLease{lease}
+	executor, err = NewMemoryEmbeddingExecutor(store, source, fakeEmbeddingProvider{vectors: [][]float64{{0.25}}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	result, err = executor.Execute(context.Background(), MemoryEmbeddingClaimRequest{WorkerID: lease.Holder, Limit: 1, LeaseDuration: time.Minute})
+	if err != nil || result.Retried != 1 || len(store.retries) != 1 || store.retries[0].ErrorCode != "provider_invalid" {
+		t.Fatalf("result=%#v retries=%#v err=%v", result, store.retries, err)
+	}
+	store.leases = []MemoryEmbeddingLease{lease}
+	store.retryErr = errors.New("retry unavailable")
+	executor, err = NewMemoryEmbeddingExecutor(store, source, fakeEmbeddingProvider{err: errors.New("provider unavailable")})
+	if err != nil {
+		t.Fatal(err)
+	}
+	result, err = executor.Execute(context.Background(), MemoryEmbeddingClaimRequest{WorkerID: lease.Holder, Limit: 1, LeaseDuration: time.Minute})
+	if !errors.Is(err, store.retryErr) || result.Retried != 0 {
+		t.Fatalf("result=%#v err=%v", result, err)
+	}
+	store.leases = []MemoryEmbeddingLease{lease}
+	store.retryErr = ErrStaleEmbeddingLease
+	result, err = executor.Execute(context.Background(), MemoryEmbeddingClaimRequest{WorkerID: lease.Holder, Limit: 1, LeaseDuration: time.Minute})
+	if err != nil || result.Retried != 0 {
+		t.Fatalf("stale retry result=%#v err=%v", result, err)
+	}
+	store.retryErr = nil
+	store.leases = []MemoryEmbeddingLease{lease}
+	source.err = ErrMemoryEmbeddingQuarantined
+	executor, err = NewMemoryEmbeddingExecutor(store, source, fakeEmbeddingProvider{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	result, err = executor.Execute(context.Background(), MemoryEmbeddingClaimRequest{WorkerID: lease.Holder, Limit: 1, LeaseDuration: time.Minute})
+	if err != nil || result.Retried != 1 || store.retries[len(store.retries)-1].ErrorCode != "quarantined" {
+		t.Fatalf("result=%#v retries=%#v err=%v", result, store.retries, err)
+	}
+	store.leases = []MemoryEmbeddingLease{lease}
+	source.err = nil
+	source.generation = MemoryEmbeddingGeneration{ID: "55555555-5555-4555-8555-555555555555", Model: "local.e5", Revision: "2026-07-01", Dimensions: 2, State: MemoryEmbeddingGenerationActive}
+	calls := 0
+	executor, err = NewMemoryEmbeddingExecutor(store, source, fakeEmbeddingProvider{calls: &calls})
+	if err != nil {
+		t.Fatal(err)
+	}
+	result, err = executor.Execute(context.Background(), MemoryEmbeddingClaimRequest{WorkerID: lease.Holder, Limit: 1, LeaseDuration: time.Minute})
+	if err != nil || calls != 0 || result.Retried != 1 || store.retries[len(store.retries)-1].ErrorCode != "provider_invalid" {
+		t.Fatalf("result=%#v calls=%d retries=%#v err=%v", result, calls, store.retries, err)
+	}
+	store.leases = []MemoryEmbeddingLease{lease}
+	if _, err := executor.Execute(context.Background(), MemoryEmbeddingClaimRequest{WorkerID: lease.Holder, Limit: maxMemoryEmbeddingClaimBatch + 1, LeaseDuration: time.Minute}); err == nil || len(store.leases) != 1 {
+		t.Fatalf("unbounded executor request err=%v leases=%#v", err, store.leases)
+	}
+}
+
+func TestMemoryEmbeddingExecutorRetainsSourceFenceThroughQuarantineRetry(t *testing.T) {
+	lease := MemoryEmbeddingLease{MemoryEmbeddingWork: MemoryEmbeddingWork{GenerationID: "11111111-1111-4111-8111-111111111111", ItemID: "22222222-2222-4222-8222-222222222222", Revision: 1, ContentSHA256: "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08"}, Attempts: 1, Holder: "33333333-3333-4333-8333-333333333333", Token: "44444444-4444-4444-8444-444444444444", LeaseGeneration: 1, LeaseUntil: time.Now().Add(time.Minute)}
+	released := false
+	store := &fakeEmbeddingExecutorStore{leases: []MemoryEmbeddingLease{lease}, onRetry: func() error {
+		if released {
+			return errors.New("quarantine fence released before retry")
+		}
+		return nil
+	}}
+	source := fencedEmbeddingSource{err: ErrMemoryEmbeddingQuarantined, release: func() { released = true }}
+	executor, err := NewMemoryEmbeddingExecutor(store, source, fakeEmbeddingProvider{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	result, err := executor.Execute(context.Background(), MemoryEmbeddingClaimRequest{WorkerID: lease.Holder, Limit: 1, LeaseDuration: time.Minute})
+	if err != nil || result.Retried != 1 || !released {
+		t.Fatalf("result=%#v released=%t err=%v", result, released, err)
+	}
+}
+
+type fakeEmbeddingExecutorStore struct {
+	leases    []MemoryEmbeddingLease
+	published []MemoryEmbeddingPublication
+	retries   []MemoryEmbeddingRetry
+	retryErr  error
+	onRetry   func() error
+}
+
+func (s *fakeEmbeddingExecutorStore) ClaimMemoryEmbeddingWork(context.Context, MemoryEmbeddingClaimRequest) ([]MemoryEmbeddingLease, error) {
+	result := s.leases
+	s.leases = nil
+	return result, nil
+}
+func (s *fakeEmbeddingExecutorStore) PublishMemoryEmbeddingWork(_ context.Context, value MemoryEmbeddingPublication) error {
+	s.published = append(s.published, value)
+	return nil
+}
+func (s *fakeEmbeddingExecutorStore) RetryMemoryEmbeddingWork(_ context.Context, value MemoryEmbeddingRetry) error {
+	if s.retryErr != nil {
+		return s.retryErr
+	}
+	if s.onRetry != nil {
+		if err := s.onRetry(); err != nil {
+			return err
+		}
+	}
+	s.retries = append(s.retries, value)
+	return nil
+}
+
+type fakeEmbeddingSource struct {
+	generation MemoryEmbeddingGeneration
+	chunks     []MemoryEmbeddingSourceChunk
+	err        error
+}
+
+func (s fakeEmbeddingSource) LoadMemoryEmbeddingSource(context.Context, MemoryEmbeddingLease) (MemoryEmbeddingGeneration, []MemoryEmbeddingSourceChunk, error) {
+	return s.generation, s.chunks, s.err
+}
+
+func (s fakeEmbeddingSource) OpenMemoryEmbeddingSource(context.Context, MemoryEmbeddingLease) (MemoryEmbeddingGeneration, []MemoryEmbeddingSourceChunk, func(), error) {
+	return s.generation, s.chunks, func() {}, s.err
+}
+
+type fencedEmbeddingSource struct {
+	err     error
+	release func()
+}
+
+func (s fencedEmbeddingSource) LoadMemoryEmbeddingSource(context.Context, MemoryEmbeddingLease) (MemoryEmbeddingGeneration, []MemoryEmbeddingSourceChunk, error) {
+	return MemoryEmbeddingGeneration{}, nil, s.err
+}
+
+func (s fencedEmbeddingSource) OpenMemoryEmbeddingSource(context.Context, MemoryEmbeddingLease) (MemoryEmbeddingGeneration, []MemoryEmbeddingSourceChunk, func(), error) {
+	return MemoryEmbeddingGeneration{}, nil, s.release, s.err
+}
+
+type fakeEmbeddingProvider struct {
+	vectors [][]float64
+	err     error
+	calls   *int
+}
+
+func (p fakeEmbeddingProvider) Embed(context.Context, MemoryEmbeddingGeneration, []MemoryEmbeddingSourceChunk) ([][]float64, error) {
+	if p.calls != nil {
+		*p.calls++
+	}
+	return p.vectors, p.err
+}

--- a/internal/postgres/brain_embedding_executor_test.go
+++ b/internal/postgres/brain_embedding_executor_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestMemoryEmbeddingExecutorPublishesAndRetriesBoundedly(t *testing.T) {
-	lease := MemoryEmbeddingLease{MemoryEmbeddingWork: MemoryEmbeddingWork{GenerationID: "11111111-1111-4111-8111-111111111111", ItemID: "22222222-2222-4222-8222-222222222222", Revision: 1, ContentSHA256: "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08"}, Attempts: 1, Holder: "33333333-3333-4333-8333-333333333333", Token: "44444444-4444-4444-8444-444444444444", LeaseGeneration: 1, LeaseUntil: time.Now().Add(time.Minute)}
+	lease := MemoryEmbeddingLease{MemoryEmbeddingWork: MemoryEmbeddingWork{GenerationID: "11111111-1111-4111-8111-111111111111", ItemID: "22222222-2222-4222-8222-222222222222", Revision: 1, ContentSHA256: "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08"}, Generation: MemoryEmbeddingGeneration{ID: "11111111-1111-4111-8111-111111111111", Model: "local.e5", Revision: "2026-07-01", Dimensions: 2, State: MemoryEmbeddingGenerationActive}, Attempts: 1, Holder: "33333333-3333-4333-8333-333333333333", Token: "44444444-4444-4444-8444-444444444444", LeaseGeneration: 1, LeaseUntil: time.Now().Add(time.Minute)}
 	store := &fakeEmbeddingExecutorStore{leases: []MemoryEmbeddingLease{lease}}
 	source := fakeEmbeddingSource{generation: MemoryEmbeddingGeneration{ID: lease.GenerationID, Model: "local.e5", Revision: "2026-07-01", Dimensions: 2, State: MemoryEmbeddingGenerationActive}, chunks: []MemoryEmbeddingSourceChunk{{Ordinal: 0, ContentSHA256: "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08", StartOffset: 0, EndOffset: 4, Text: "test"}}}
 	executor, err := NewMemoryEmbeddingExecutor(store, source, fakeEmbeddingProvider{vectors: [][]float64{{0.25, 0.75}}})
@@ -68,13 +68,25 @@ func TestMemoryEmbeddingExecutorPublishesAndRetriesBoundedly(t *testing.T) {
 		t.Fatalf("result=%#v calls=%d retries=%#v err=%v", result, calls, store.retries, err)
 	}
 	store.leases = []MemoryEmbeddingLease{lease}
+	source.generation = lease.Generation
+	source.generation.Model = "local.other"
+	calls = 0
+	executor, err = NewMemoryEmbeddingExecutor(store, source, fakeEmbeddingProvider{calls: &calls})
+	if err != nil {
+		t.Fatal(err)
+	}
+	result, err = executor.Execute(context.Background(), MemoryEmbeddingClaimRequest{WorkerID: lease.Holder, Limit: 1, LeaseDuration: time.Minute})
+	if err != nil || calls != 0 || result.Retried != 1 || store.retries[len(store.retries)-1].ErrorCode != "provider_invalid" {
+		t.Fatalf("substituted generation result=%#v calls=%d retries=%#v err=%v", result, calls, store.retries, err)
+	}
+	store.leases = []MemoryEmbeddingLease{lease}
 	if _, err := executor.Execute(context.Background(), MemoryEmbeddingClaimRequest{WorkerID: lease.Holder, Limit: maxMemoryEmbeddingClaimBatch + 1, LeaseDuration: time.Minute}); err == nil || len(store.leases) != 1 {
 		t.Fatalf("unbounded executor request err=%v leases=%#v", err, store.leases)
 	}
 }
 
 func TestMemoryEmbeddingExecutorRetainsSourceFenceThroughQuarantineRetry(t *testing.T) {
-	lease := MemoryEmbeddingLease{MemoryEmbeddingWork: MemoryEmbeddingWork{GenerationID: "11111111-1111-4111-8111-111111111111", ItemID: "22222222-2222-4222-8222-222222222222", Revision: 1, ContentSHA256: "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08"}, Attempts: 1, Holder: "33333333-3333-4333-8333-333333333333", Token: "44444444-4444-4444-8444-444444444444", LeaseGeneration: 1, LeaseUntil: time.Now().Add(time.Minute)}
+	lease := MemoryEmbeddingLease{MemoryEmbeddingWork: MemoryEmbeddingWork{GenerationID: "11111111-1111-4111-8111-111111111111", ItemID: "22222222-2222-4222-8222-222222222222", Revision: 1, ContentSHA256: "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08"}, Generation: MemoryEmbeddingGeneration{ID: "11111111-1111-4111-8111-111111111111", Model: "local.e5", Revision: "2026-07-01", Dimensions: 2, State: MemoryEmbeddingGenerationActive}, Attempts: 1, Holder: "33333333-3333-4333-8333-333333333333", Token: "44444444-4444-4444-8444-444444444444", LeaseGeneration: 1, LeaseUntil: time.Now().Add(time.Minute)}
 	released := false
 	store := &fakeEmbeddingExecutorStore{leases: []MemoryEmbeddingLease{lease}, onRetry: func() error {
 		if released {

--- a/internal/postgres/brain_embedding_integration_test.go
+++ b/internal/postgres/brain_embedding_integration_test.go
@@ -435,7 +435,7 @@ func testMemoryEmbeddingQuarantineDeferralIntegration(ctx context.Context, t *te
 		t.Fatal(err)
 	}
 	if _, err := ownerDB.ExecContext(ctx, `INSERT INTO brain.memory_quarantines(item_id,detected_revision,rule_version,rule_id,field_path,value_fingerprint,quarantined_by)
-VALUES ($1,$2,1,'embedding.test','/title',decode(repeat('7f',32),'hex'),$3)`, created.ItemID, created.Revision, actor.ID); err != nil {
+VALUES ($1,$2,1,'private-key','/title',decode(repeat('7f',32),'hex'),$3)`, created.ItemID, created.Revision, actor.ID); err != nil {
 		t.Fatal(err)
 	}
 	claimed, err := app.ClaimMemoryEmbeddingWork(ctx, MemoryEmbeddingClaimRequest{WorkerID: "19191919-1919-4191-8191-191919191932", Limit: 32, LeaseDuration: memoryEmbeddingMinLease})
@@ -490,7 +490,7 @@ VALUES ($1,$2,1,'embedding.test','/title',decode(repeat('7f',32),'hex'),$3)`, cr
 		t.Fatalf("unquarantined retry did not remain claimable: %#v", claimed)
 	}
 	if _, err := ownerDB.ExecContext(ctx, `INSERT INTO brain.memory_quarantines(item_id,detected_revision,rule_version,rule_id,field_path,value_fingerprint,quarantined_by)
-VALUES ($1,$2,1,'embedding.test','/title',decode(repeat('7e',32),'hex'),$3)`, created.ItemID, created.Revision, actor.ID); err != nil {
+VALUES ($1,$2,1,'private-key','/title',decode(repeat('7e',32),'hex'),$3)`, created.ItemID, created.Revision, actor.ID); err != nil {
 		t.Fatal(err)
 	}
 	if _, _, err := app.LoadMemoryEmbeddingSource(ctx, lease); !errors.Is(err, ErrMemoryEmbeddingQuarantined) {
@@ -535,7 +535,7 @@ VALUES ($1,$2,1,'embedding.test','/title',decode(repeat('7e',32),'hex'),$3)`, cr
 		t.Fatalf("final-attempt quarantine lease=%#v", lease)
 	}
 	if _, err := ownerDB.ExecContext(ctx, `INSERT INTO brain.memory_quarantines(item_id,detected_revision,rule_version,rule_id,field_path,value_fingerprint,quarantined_by)
-VALUES ($1,$2,1,'embedding.test','/title',decode(repeat('7d',32),'hex'),$3)`, created.ItemID, created.Revision, actor.ID); err != nil {
+VALUES ($1,$2,1,'private-key','/title',decode(repeat('7d',32),'hex'),$3)`, created.ItemID, created.Revision, actor.ID); err != nil {
 		t.Fatal(err)
 	}
 	if _, err := ownerDB.ExecContext(ctx, `UPDATE brain.embedding_jobs SET lease_until=statement_timestamp()-interval '1 second' WHERE generation_id=$1 AND item_id=$2`, lease.GenerationID, lease.ItemID); err != nil {

--- a/internal/postgres/brain_embedding_integration_test.go
+++ b/internal/postgres/brain_embedding_integration_test.go
@@ -541,14 +541,24 @@ VALUES ($1,$2,1,'embedding.test','/title',decode(repeat('7d',32),'hex'),$3)`, cr
 	if _, err := ownerDB.ExecContext(ctx, `UPDATE brain.embedding_jobs SET lease_until=statement_timestamp()-interval '1 second' WHERE generation_id=$1 AND item_id=$2`, lease.GenerationID, lease.ItemID); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := app.ClaimMemoryEmbeddingWork(ctx, MemoryEmbeddingClaimRequest{WorkerID: "19191919-1919-4191-8191-191919191938", Limit: 32, LeaseDuration: memoryEmbeddingMinLease}); err != nil {
+	releaseTx, err := beginMutation(ctx, app.db)
+	if err != nil {
+		t.Fatal(err)
+	}
+	released, err := releaseActiveMemoryQuarantine(ctx, releaseTx, actor.ID, created.ItemID)
+	if err != nil {
+		_ = releaseTx.Rollback()
+		t.Fatal(err)
+	}
+	if !released {
+		_ = releaseTx.Rollback()
+		t.Fatal("active quarantine was not released")
+	}
+	if err := releaseTx.Commit(); err != nil {
 		t.Fatal(err)
 	}
 	if err := ownerDB.QueryRowContext(ctx, `SELECT state,attempts FROM brain.embedding_jobs WHERE generation_id=$1 AND item_id=$2`, lease.GenerationID, lease.ItemID).Scan(&state, &attempts); err != nil || state != "queued" || attempts != 24 {
-		t.Fatalf("expired quarantined lease state=%q attempts=%d err=%v", state, attempts, err)
-	}
-	if _, err := ownerDB.ExecContext(ctx, `UPDATE brain.memory_quarantines SET released_by=$2,released_at=statement_timestamp() WHERE item_id=$1 AND released_at IS NULL`, created.ItemID, actor.ID); err != nil {
-		t.Fatal(err)
+		t.Fatalf("released expired quarantined lease state=%q attempts=%d err=%v", state, attempts, err)
 	}
 	claimed, err = app.ClaimMemoryEmbeddingWork(ctx, MemoryEmbeddingClaimRequest{WorkerID: "19191919-1919-4191-8191-191919191937", Limit: 32, LeaseDuration: memoryEmbeddingMinLease})
 	if err != nil {

--- a/internal/postgres/brain_embedding_integration_test.go
+++ b/internal/postgres/brain_embedding_integration_test.go
@@ -200,6 +200,10 @@ func testMemoryEmbeddingQueueIntegration(ctx context.Context, t *testing.T, app 
 		t.Fatalf("claimed embedding work=%#v err=%v", claimed, err)
 	}
 	firstLease := claimed[0]
+	sourceGeneration, sourceChunks, err := app.LoadMemoryEmbeddingSource(ctx, firstLease)
+	if err != nil || sourceGeneration.ID != generationID || sourceGeneration.Dimensions != 3 || len(sourceChunks) != 1 || sourceChunks[0].Ordinal != 0 || sourceChunks[0].ContentSHA256 != firstLease.ContentSHA256 || sourceChunks[0].StartOffset != 0 || sourceChunks[0].EndOffset != len(sourceChunks[0].Text) || !strings.Contains(sourceChunks[0].Text, "queue first") {
+		t.Fatalf("embedding source generation=%#v chunks=%#v err=%v", sourceGeneration, sourceChunks, err)
+	}
 	if err := app.RetryMemoryEmbeddingWork(ctx, MemoryEmbeddingRetry{Lease: firstLease, ErrorCode: "provider_unavailable", Delay: time.Second}); err != nil {
 		t.Fatalf("embedding retry: %v", err)
 	}
@@ -410,6 +414,150 @@ func testMemoryEmbeddingQueueIntegration(ctx context.Context, t *testing.T, app 
 	}
 	if err := ownerDB.QueryRowContext(ctx, `SELECT count(*) FROM brain.embedding_chunks WHERE generation_id=$1 AND item_id=$2`, generationID, superseded.ItemID).Scan(&count); err != nil || count != 0 {
 		t.Fatalf("superseded embedding chunks=%d err=%v", count, err)
+	}
+}
+
+func testMemoryEmbeddingQuarantineDeferralIntegration(ctx context.Context, t *testing.T, app *Database, ownerDB *sql.DB) {
+	t.Helper()
+	actor, err := app.CreatePrincipal(ctx, PrincipalKindDevice, "embedding quarantine actor")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var projectID string
+	if err := ownerDB.QueryRowContext(ctx, `INSERT INTO relay.projects(display_name,created_by) VALUES ('embedding quarantine project',$1) RETURNING id::text`, actor.ID).Scan(&projectID); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ownerDB.ExecContext(ctx, `INSERT INTO auth.capability_grants(principal_id,scope,project_id,capability) VALUES ($1,'project',$2,$3)`, actor.ID, projectID, CapabilityMemoryWrite); err != nil {
+		t.Fatal(err)
+	}
+	created, err := app.CreateMemory(ctx, MemoryCreateRequest{PrincipalID: actor.ID, ProjectID: projectID, IdempotencyKey: "19191919-1919-4191-8191-191919191931", LogicalKey: "embedding-quarantine", Kind: "decision", Trust: "curated", Document: json.RawMessage(`{"title":"deferred quarantine"}`)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ownerDB.ExecContext(ctx, `INSERT INTO brain.memory_quarantines(item_id,detected_revision,rule_version,rule_id,field_path,value_fingerprint,quarantined_by)
+VALUES ($1,$2,1,'embedding.test','/title',decode(repeat('7f',32),'hex'),$3)`, created.ItemID, created.Revision, actor.ID); err != nil {
+		t.Fatal(err)
+	}
+	claimed, err := app.ClaimMemoryEmbeddingWork(ctx, MemoryEmbeddingClaimRequest{WorkerID: "19191919-1919-4191-8191-191919191932", Limit: 32, LeaseDuration: memoryEmbeddingMinLease})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, lease := range claimed {
+		if lease.ItemID == created.ItemID {
+			t.Fatal("claim leased an actively quarantined embedding job")
+		}
+	}
+	if _, err := ownerDB.ExecContext(ctx, `UPDATE brain.memory_quarantines SET released_by=$2,released_at=statement_timestamp() WHERE item_id=$1 AND released_at IS NULL`, created.ItemID, actor.ID); err != nil {
+		t.Fatal(err)
+	}
+	claimed, err = app.ClaimMemoryEmbeddingWork(ctx, MemoryEmbeddingClaimRequest{WorkerID: "19191919-1919-4191-8191-191919191933", Limit: 32, LeaseDuration: memoryEmbeddingMinLease})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var lease MemoryEmbeddingLease
+	for _, candidate := range claimed {
+		if candidate.ItemID == created.ItemID {
+			lease = candidate
+			break
+		}
+	}
+	if !lease.valid() {
+		t.Fatalf("released quarantine was not claimable: %#v", claimed)
+	}
+	if err := app.RetryMemoryEmbeddingWork(ctx, MemoryEmbeddingRetry{Lease: lease, ErrorCode: "quarantined", Delay: 0}); err != nil {
+		t.Fatal(err)
+	}
+	var state string
+	var attempts int
+	if err := ownerDB.QueryRowContext(ctx, `SELECT state,attempts FROM brain.embedding_jobs WHERE generation_id=$1 AND item_id=$2`, lease.GenerationID, lease.ItemID).Scan(&state, &attempts); err != nil || state != "queued" || attempts != lease.Attempts {
+		t.Fatalf("unquarantined retry state=%q attempts=%d lease=%#v err=%v", state, attempts, lease, err)
+	}
+	if _, err := ownerDB.ExecContext(ctx, `UPDATE brain.embedding_jobs SET available_at=statement_timestamp() WHERE generation_id=$1 AND item_id=$2`, lease.GenerationID, lease.ItemID); err != nil {
+		t.Fatal(err)
+	}
+	claimed, err = app.ClaimMemoryEmbeddingWork(ctx, MemoryEmbeddingClaimRequest{WorkerID: "19191919-1919-4191-8191-191919191935", Limit: 32, LeaseDuration: memoryEmbeddingMinLease})
+	if err != nil {
+		t.Fatal(err)
+	}
+	lease = MemoryEmbeddingLease{}
+	for _, candidate := range claimed {
+		if candidate.ItemID == created.ItemID {
+			lease = candidate
+			break
+		}
+	}
+	if !lease.valid() {
+		t.Fatalf("unquarantined retry did not remain claimable: %#v", claimed)
+	}
+	if _, err := ownerDB.ExecContext(ctx, `INSERT INTO brain.memory_quarantines(item_id,detected_revision,rule_version,rule_id,field_path,value_fingerprint,quarantined_by)
+VALUES ($1,$2,1,'embedding.test','/title',decode(repeat('7e',32),'hex'),$3)`, created.ItemID, created.Revision, actor.ID); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := app.LoadMemoryEmbeddingSource(ctx, lease); !errors.Is(err, ErrMemoryEmbeddingQuarantined) {
+		t.Fatalf("quarantined embedding source error=%v", err)
+	}
+	if err := app.RetryMemoryEmbeddingWork(ctx, MemoryEmbeddingRetry{Lease: lease, ErrorCode: "quarantined", Delay: time.Second}); err != nil {
+		t.Fatal(err)
+	}
+	if err := ownerDB.QueryRowContext(ctx, `SELECT state,attempts FROM brain.embedding_jobs WHERE generation_id=$1 AND item_id=$2`, lease.GenerationID, lease.ItemID).Scan(&state, &attempts); err != nil || state != "queued" || attempts != lease.Attempts-1 {
+		t.Fatalf("quarantine deferral state=%q attempts=%d lease=%#v err=%v", state, attempts, lease, err)
+	}
+	claimed, err = app.ClaimMemoryEmbeddingWork(ctx, MemoryEmbeddingClaimRequest{WorkerID: "19191919-1919-4191-8191-191919191934", Limit: 32, LeaseDuration: memoryEmbeddingMinLease})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, candidate := range claimed {
+		if candidate.ItemID == created.ItemID {
+			t.Fatal("deferred quarantined job was claimed")
+		}
+	}
+	if _, err := ownerDB.ExecContext(ctx, `UPDATE brain.embedding_jobs SET attempts=24 WHERE generation_id=$1 AND item_id=$2`, lease.GenerationID, lease.ItemID); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ownerDB.ExecContext(ctx, `UPDATE brain.memory_quarantines SET released_by=$2,released_at=statement_timestamp() WHERE item_id=$1 AND released_at IS NULL`, created.ItemID, actor.ID); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ownerDB.ExecContext(ctx, `UPDATE brain.embedding_jobs SET available_at=statement_timestamp() WHERE generation_id=$1 AND item_id=$2`, lease.GenerationID, lease.ItemID); err != nil {
+		t.Fatal(err)
+	}
+	claimed, err = app.ClaimMemoryEmbeddingWork(ctx, MemoryEmbeddingClaimRequest{WorkerID: "19191919-1919-4191-8191-191919191936", Limit: 32, LeaseDuration: memoryEmbeddingMinLease})
+	if err != nil {
+		t.Fatal(err)
+	}
+	lease = MemoryEmbeddingLease{}
+	for _, candidate := range claimed {
+		if candidate.ItemID == created.ItemID {
+			lease = candidate
+			break
+		}
+	}
+	if !lease.valid() || lease.Attempts != 25 {
+		t.Fatalf("final-attempt quarantine lease=%#v", lease)
+	}
+	if _, err := ownerDB.ExecContext(ctx, `INSERT INTO brain.memory_quarantines(item_id,detected_revision,rule_version,rule_id,field_path,value_fingerprint,quarantined_by)
+VALUES ($1,$2,1,'embedding.test','/title',decode(repeat('7d',32),'hex'),$3)`, created.ItemID, created.Revision, actor.ID); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ownerDB.ExecContext(ctx, `UPDATE brain.embedding_jobs SET lease_until=statement_timestamp()-interval '1 second' WHERE generation_id=$1 AND item_id=$2`, lease.GenerationID, lease.ItemID); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := app.ClaimMemoryEmbeddingWork(ctx, MemoryEmbeddingClaimRequest{WorkerID: "19191919-1919-4191-8191-191919191938", Limit: 32, LeaseDuration: memoryEmbeddingMinLease}); err != nil {
+		t.Fatal(err)
+	}
+	if err := ownerDB.QueryRowContext(ctx, `SELECT state,attempts FROM brain.embedding_jobs WHERE generation_id=$1 AND item_id=$2`, lease.GenerationID, lease.ItemID).Scan(&state, &attempts); err != nil || state != "queued" || attempts != 24 {
+		t.Fatalf("expired quarantined lease state=%q attempts=%d err=%v", state, attempts, err)
+	}
+	if _, err := ownerDB.ExecContext(ctx, `UPDATE brain.memory_quarantines SET released_by=$2,released_at=statement_timestamp() WHERE item_id=$1 AND released_at IS NULL`, created.ItemID, actor.ID); err != nil {
+		t.Fatal(err)
+	}
+	claimed, err = app.ClaimMemoryEmbeddingWork(ctx, MemoryEmbeddingClaimRequest{WorkerID: "19191919-1919-4191-8191-191919191937", Limit: 32, LeaseDuration: memoryEmbeddingMinLease})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, candidate := range claimed {
+		if candidate.ItemID == created.ItemID && candidate.Attempts != 25 {
+			t.Fatalf("released final-attempt lease=%#v", candidate)
+		}
 	}
 }
 

--- a/internal/postgres/brain_embedding_quarantine_release_schema.go
+++ b/internal/postgres/brain_embedding_quarantine_release_schema.go
@@ -44,4 +44,4 @@ FROM objects,routine_safety,routine_acl`, memoryEmbeddingQuarantineReleaseRoutin
 	return available, err
 }
 
-const memoryEmbeddingQuarantineReleaseRoutineV32MD5 = "89deeaec7da8da82eaab25ff4f706000"
+const memoryEmbeddingQuarantineReleaseRoutineV32MD5 = "ad3f304093f38450a08d63d500bd7bc1"

--- a/internal/postgres/brain_embedding_quarantine_release_schema.go
+++ b/internal/postgres/brain_embedding_quarantine_release_schema.go
@@ -42,4 +42,4 @@ FROM objects,routine_safety,routine_acl,trigger_safety`, memoryEmbeddingQuaranti
 	return available, err
 }
 
-const memoryEmbeddingQuarantineReleaseRoutineV32MD5 = "08026175c35c150fff31a00d16127082"
+const memoryEmbeddingQuarantineReleaseRoutineV32MD5 = "5b469b462d0c7f10f70a4d0a50230d3c"

--- a/internal/postgres/brain_embedding_quarantine_release_schema.go
+++ b/internal/postgres/brain_embedding_quarantine_release_schema.go
@@ -40,7 +40,8 @@ func memoryEmbeddingQuarantineReleaseControlsAvailable(ctx context.Context, q qu
           AND trigger.tgfoid=requeue_oid AND trigger.tgtype=17
           AND trigger.tgattr=ARRAY[(SELECT attribute.attnum FROM pg_attribute AS attribute
               WHERE attribute.attrelid=quarantines_oid AND attribute.attname='released_at' AND attribute.attnum>0 AND NOT attribute.attisdropped)]::int2vector
-          AND position('WHEN ((old.released_at IS NULL) AND (new.released_at IS NOT NULL))' IN pg_get_triggerdef(trigger.oid,true))>0) AS exact
+          AND pg_get_triggerdef(trigger.oid,true) ~
+              'WHEN \(*\(old\.released_at IS NULL\) AND \(new\.released_at IS NOT NULL\)\)* EXECUTE FUNCTION brain\.requeue_expired_quarantined_embedding_jobs\(\)') AS exact
 )
 SELECT requeue_oid IS NOT NULL AND quarantines_oid IS NOT NULL AND routine_safety.exact AND routine_acl.exact AND trigger_safety.exact
 FROM objects,routine_safety,routine_acl,trigger_safety`, memoryEmbeddingQuarantineReleaseRoutineV32MD5).Scan(&available)

--- a/internal/postgres/brain_embedding_quarantine_release_schema.go
+++ b/internal/postgres/brain_embedding_quarantine_release_schema.go
@@ -34,9 +34,8 @@ func memoryEmbeddingQuarantineReleaseControlsAvailable(ctx context.Context, q qu
     WHERE proc.oid=requeue_oid
     EXCEPT SELECT * FROM (VALUES ('punaro_owner','EXECUTE',false)) AS expected(grantee,privilege_type,is_grantable)) AS exact
 ), trigger_safety AS (
-    SELECT count(*)=1 AND bool_and(tgname='memory_quarantine_embedding_release' AND tgenabled='O'
-        AND tgfoid=requeue_oid AND tgtype=17)
-    FROM pg_trigger,objects WHERE tgrelid=quarantines_oid AND NOT tgisinternal
+    SELECT EXISTS (SELECT 1 FROM pg_trigger,objects WHERE tgrelid=quarantines_oid AND NOT tgisinternal
+        AND tgname='memory_quarantine_embedding_release' AND tgenabled='O' AND tgfoid=requeue_oid AND tgtype=17)
 )
 SELECT requeue_oid IS NOT NULL AND quarantines_oid IS NOT NULL AND routine_safety.exact AND routine_acl.exact AND trigger_safety.exact
 FROM objects,routine_safety,routine_acl,trigger_safety`, memoryEmbeddingQuarantineReleaseRoutineV32MD5).Scan(&available)

--- a/internal/postgres/brain_embedding_quarantine_release_schema.go
+++ b/internal/postgres/brain_embedding_quarantine_release_schema.go
@@ -41,7 +41,7 @@ func memoryEmbeddingQuarantineReleaseControlsAvailable(ctx context.Context, q qu
           AND trigger.tgattr=ARRAY[(SELECT attribute.attnum FROM pg_attribute AS attribute
               WHERE attribute.attrelid=quarantines_oid AND attribute.attname='released_at' AND attribute.attnum>0 AND NOT attribute.attisdropped)]::int2vector
           AND pg_get_triggerdef(trigger.oid,true) ~
-              'WHEN \(*\(old\.released_at IS NULL\) AND \(new\.released_at IS NOT NULL\)\)* EXECUTE FUNCTION brain\.requeue_expired_quarantined_embedding_jobs\(\)') AS exact
+              'WHEN \(+old\.released_at IS NULL AND new\.released_at IS NOT NULL\)+ EXECUTE FUNCTION brain\.requeue_expired_quarantined_embedding_jobs\(\)') AS exact
 )
 SELECT requeue_oid IS NOT NULL AND quarantines_oid IS NOT NULL AND routine_safety.exact AND routine_acl.exact AND trigger_safety.exact
 FROM objects,routine_safety,routine_acl,trigger_safety`, memoryEmbeddingQuarantineReleaseRoutineV32MD5).Scan(&available)

--- a/internal/postgres/brain_embedding_quarantine_release_schema.go
+++ b/internal/postgres/brain_embedding_quarantine_release_schema.go
@@ -35,7 +35,7 @@ func memoryEmbeddingQuarantineReleaseControlsAvailable(ctx context.Context, q qu
     EXCEPT SELECT * FROM (VALUES ('punaro_owner','EXECUTE',false)) AS expected(grantee,privilege_type,is_grantable)) AS exact
 ), trigger_safety AS (
     SELECT EXISTS (SELECT 1 FROM pg_trigger,objects WHERE tgrelid=quarantines_oid AND NOT tgisinternal
-        AND tgname='memory_quarantine_embedding_release' AND tgenabled='O' AND tgfoid=requeue_oid AND tgtype=17)
+        AND tgname='memory_quarantine_embedding_release' AND tgenabled='O' AND tgfoid=requeue_oid AND tgtype=17) AS exact
 )
 SELECT requeue_oid IS NOT NULL AND quarantines_oid IS NOT NULL AND routine_safety.exact AND routine_acl.exact AND trigger_safety.exact
 FROM objects,routine_safety,routine_acl,trigger_safety`, memoryEmbeddingQuarantineReleaseRoutineV32MD5).Scan(&available)

--- a/internal/postgres/brain_embedding_quarantine_release_schema.go
+++ b/internal/postgres/brain_embedding_quarantine_release_schema.go
@@ -34,8 +34,13 @@ func memoryEmbeddingQuarantineReleaseControlsAvailable(ctx context.Context, q qu
     WHERE proc.oid=requeue_oid
     EXCEPT SELECT * FROM (VALUES ('punaro_owner','EXECUTE',false)) AS expected(grantee,privilege_type,is_grantable)) AS exact
 ), trigger_safety AS (
-    SELECT EXISTS (SELECT 1 FROM pg_trigger,objects WHERE tgrelid=quarantines_oid AND NOT tgisinternal
-        AND tgname='memory_quarantine_embedding_release' AND tgenabled='O' AND tgfoid=requeue_oid AND tgtype=17) AS exact
+    SELECT EXISTS (SELECT 1 FROM pg_trigger AS trigger,objects
+        WHERE trigger.tgrelid=quarantines_oid AND NOT trigger.tgisinternal
+          AND trigger.tgname='memory_quarantine_embedding_release' AND trigger.tgenabled='O'
+          AND trigger.tgfoid=requeue_oid AND trigger.tgtype=17
+          AND trigger.tgattr=ARRAY[(SELECT attribute.attnum FROM pg_attribute AS attribute
+              WHERE attribute.attrelid=quarantines_oid AND attribute.attname='released_at' AND attribute.attnum>0 AND NOT attribute.attisdropped)]::int2vector
+          AND pg_get_expr(trigger.tgqual,trigger.tgrelid)='(old.released_at IS NULL) AND (new.released_at IS NOT NULL)') AS exact
 )
 SELECT requeue_oid IS NOT NULL AND quarantines_oid IS NOT NULL AND routine_safety.exact AND routine_acl.exact AND trigger_safety.exact
 FROM objects,routine_safety,routine_acl,trigger_safety`, memoryEmbeddingQuarantineReleaseRoutineV32MD5).Scan(&available)

--- a/internal/postgres/brain_embedding_quarantine_release_schema.go
+++ b/internal/postgres/brain_embedding_quarantine_release_schema.go
@@ -44,4 +44,4 @@ FROM objects,routine_safety,routine_acl`, memoryEmbeddingQuarantineReleaseRoutin
 	return available, err
 }
 
-const memoryEmbeddingQuarantineReleaseRoutineV32MD5 = "ad3f304093f38450a08d63d500bd7bc1"
+const memoryEmbeddingQuarantineReleaseRoutineV32MD5 = "167dd1b3ce2103b6ec4d7e7809e516e7"

--- a/internal/postgres/brain_embedding_quarantine_release_schema.go
+++ b/internal/postgres/brain_embedding_quarantine_release_schema.go
@@ -3,45 +3,44 @@ package postgres
 import "context"
 
 // memoryEmbeddingQuarantineReleaseControlsAvailable verifies the schema-v32
-// owner routine that atomically releases quarantine and requeues an expired
-// lease whose final attempt was held behind that quarantine fence.
+// quarantine-release trigger that requeues an expired lease whose final
+// attempt was held behind that quarantine fence.
 func memoryEmbeddingQuarantineReleaseControlsAvailable(ctx context.Context, q queryer) (bool, error) {
 	var available bool
 	err := q.QueryRowContext(ctx, `WITH objects AS (
-    SELECT to_regprocedure('brain.release_memory_quarantine(uuid,uuid)') AS release_oid
+    SELECT to_regprocedure('brain.requeue_expired_quarantined_embedding_jobs()') AS requeue_oid,
+           'brain.memory_quarantines'::regclass AS quarantines_oid
 ), routine_safety AS (
     SELECT count(*)=1 AND bool_and(pg_get_userbyid(proc.proowner)='punaro_owner'
         AND proc.prokind='f' AND proc.prosecdef AND proc.provolatile='v'
         AND proc.prolang=(SELECT oid FROM pg_language WHERE lanname='plpgsql')
         AND proc.proconfig=ARRAY['search_path=pg_catalog']::text[]
-        AND pg_get_function_result(proc.oid)='boolean'
+        AND pg_get_function_result(proc.oid)='trigger'
         AND md5(btrim(proc.prosrc,E' \n\r\t'))=$1) AS exact
-    FROM pg_proc AS proc,objects WHERE proc.oid=release_oid
+    FROM pg_proc AS proc,objects WHERE proc.oid=requeue_oid
 ), routine_acl AS (
-    SELECT NOT EXISTS (SELECT * FROM (VALUES
-        ('punaro_owner','EXECUTE',false),
-        ('punaro_app','EXECUTE',false)
-    ) AS expected(grantee,privilege_type,is_grantable)
+    SELECT NOT EXISTS (SELECT * FROM (VALUES ('punaro_owner','EXECUTE',false)) AS expected(grantee,privilege_type,is_grantable)
     EXCEPT
     SELECT COALESCE(role.rolname,'PUBLIC'),entry.privilege_type,entry.is_grantable
     FROM pg_proc AS proc
     CROSS JOIN LATERAL aclexplode(COALESCE(proc.proacl,acldefault('f',proc.proowner))) AS entry
     LEFT JOIN pg_roles AS role ON role.oid=entry.grantee,objects
-    WHERE proc.oid=release_oid)
+    WHERE proc.oid=requeue_oid)
     AND NOT EXISTS (
     SELECT COALESCE(role.rolname,'PUBLIC'),entry.privilege_type,entry.is_grantable
     FROM pg_proc AS proc
     CROSS JOIN LATERAL aclexplode(COALESCE(proc.proacl,acldefault('f',proc.proowner))) AS entry
     LEFT JOIN pg_roles AS role ON role.oid=entry.grantee,objects
-    WHERE proc.oid=release_oid
-    EXCEPT SELECT * FROM (VALUES
-        ('punaro_owner','EXECUTE',false),
-        ('punaro_app','EXECUTE',false)
-    ) AS expected(grantee,privilege_type,is_grantable)) AS exact
+    WHERE proc.oid=requeue_oid
+    EXCEPT SELECT * FROM (VALUES ('punaro_owner','EXECUTE',false)) AS expected(grantee,privilege_type,is_grantable)) AS exact
+), trigger_safety AS (
+    SELECT count(*)=1 AND bool_and(tgname='memory_quarantine_embedding_release' AND tgenabled='O'
+        AND tgfoid=requeue_oid AND tgtype=17)
+    FROM pg_trigger,objects WHERE tgrelid=quarantines_oid AND NOT tgisinternal
 )
-SELECT release_oid IS NOT NULL AND routine_safety.exact AND routine_acl.exact
-FROM objects,routine_safety,routine_acl`, memoryEmbeddingQuarantineReleaseRoutineV32MD5).Scan(&available)
+SELECT requeue_oid IS NOT NULL AND quarantines_oid IS NOT NULL AND routine_safety.exact AND routine_acl.exact AND trigger_safety.exact
+FROM objects,routine_safety,routine_acl,trigger_safety`, memoryEmbeddingQuarantineReleaseRoutineV32MD5).Scan(&available)
 	return available, err
 }
 
-const memoryEmbeddingQuarantineReleaseRoutineV32MD5 = "167dd1b3ce2103b6ec4d7e7809e516e7"
+const memoryEmbeddingQuarantineReleaseRoutineV32MD5 = "08026175c35c150fff31a00d16127082"

--- a/internal/postgres/brain_embedding_quarantine_release_schema.go
+++ b/internal/postgres/brain_embedding_quarantine_release_schema.go
@@ -34,7 +34,7 @@ func memoryEmbeddingQuarantineReleaseControlsAvailable(ctx context.Context, q qu
     WHERE proc.oid=requeue_oid
     EXCEPT SELECT * FROM (VALUES ('punaro_owner','EXECUTE',false)) AS expected(grantee,privilege_type,is_grantable)) AS exact
 ), trigger_safety AS (
-    SELECT EXISTS (SELECT 1 FROM pg_trigger AS trigger,objects
+    SELECT count(*)=2 AND EXISTS (SELECT 1 FROM pg_trigger AS trigger,objects
         WHERE trigger.tgrelid=quarantines_oid AND NOT trigger.tgisinternal
           AND trigger.tgname='memory_quarantine_embedding_release' AND trigger.tgenabled='O'
           AND trigger.tgfoid=requeue_oid AND trigger.tgtype=17
@@ -42,6 +42,7 @@ func memoryEmbeddingQuarantineReleaseControlsAvailable(ctx context.Context, q qu
               WHERE attribute.attrelid=quarantines_oid AND attribute.attname='released_at' AND attribute.attnum>0 AND NOT attribute.attisdropped)]::int2[]
           AND pg_get_triggerdef(trigger.oid,true) ~
               'WHEN \(+old\.released_at IS NULL AND new\.released_at IS NOT NULL\)+ EXECUTE FUNCTION brain\.requeue_expired_quarantined_embedding_jobs\(\)') AS exact
+    FROM pg_trigger,objects WHERE pg_trigger.tgrelid=quarantines_oid AND NOT pg_trigger.tgisinternal
 )
 SELECT requeue_oid IS NOT NULL AND quarantines_oid IS NOT NULL AND routine_safety.exact AND routine_acl.exact AND trigger_safety.exact
 FROM objects,routine_safety,routine_acl,trigger_safety`, memoryEmbeddingQuarantineReleaseRoutineV32MD5).Scan(&available)

--- a/internal/postgres/brain_embedding_quarantine_release_schema.go
+++ b/internal/postgres/brain_embedding_quarantine_release_schema.go
@@ -38,8 +38,8 @@ func memoryEmbeddingQuarantineReleaseControlsAvailable(ctx context.Context, q qu
         WHERE trigger.tgrelid=quarantines_oid AND NOT trigger.tgisinternal
           AND trigger.tgname='memory_quarantine_embedding_release' AND trigger.tgenabled='O'
           AND trigger.tgfoid=requeue_oid AND trigger.tgtype=17
-          AND trigger.tgattr=ARRAY[(SELECT attribute.attnum FROM pg_attribute AS attribute
-              WHERE attribute.attrelid=quarantines_oid AND attribute.attname='released_at' AND attribute.attnum>0 AND NOT attribute.attisdropped)]::int2vector
+          AND ARRAY(SELECT unnest(trigger.tgattr))=ARRAY[(SELECT attribute.attnum FROM pg_attribute AS attribute
+              WHERE attribute.attrelid=quarantines_oid AND attribute.attname='released_at' AND attribute.attnum>0 AND NOT attribute.attisdropped)]::int2[]
           AND pg_get_triggerdef(trigger.oid,true) ~
               'WHEN \(+old\.released_at IS NULL AND new\.released_at IS NOT NULL\)+ EXECUTE FUNCTION brain\.requeue_expired_quarantined_embedding_jobs\(\)') AS exact
 )

--- a/internal/postgres/brain_embedding_quarantine_release_schema.go
+++ b/internal/postgres/brain_embedding_quarantine_release_schema.go
@@ -40,7 +40,7 @@ func memoryEmbeddingQuarantineReleaseControlsAvailable(ctx context.Context, q qu
           AND trigger.tgfoid=requeue_oid AND trigger.tgtype=17
           AND trigger.tgattr=ARRAY[(SELECT attribute.attnum FROM pg_attribute AS attribute
               WHERE attribute.attrelid=quarantines_oid AND attribute.attname='released_at' AND attribute.attnum>0 AND NOT attribute.attisdropped)]::int2vector
-          AND pg_get_expr(trigger.tgqual,trigger.tgrelid)='(old.released_at IS NULL) AND (new.released_at IS NOT NULL)') AS exact
+          AND position('WHEN ((old.released_at IS NULL) AND (new.released_at IS NOT NULL))' IN pg_get_triggerdef(trigger.oid,true))>0) AS exact
 )
 SELECT requeue_oid IS NOT NULL AND quarantines_oid IS NOT NULL AND routine_safety.exact AND routine_acl.exact AND trigger_safety.exact
 FROM objects,routine_safety,routine_acl,trigger_safety`, memoryEmbeddingQuarantineReleaseRoutineV32MD5).Scan(&available)

--- a/internal/postgres/brain_embedding_quarantine_release_schema.go
+++ b/internal/postgres/brain_embedding_quarantine_release_schema.go
@@ -1,0 +1,47 @@
+package postgres
+
+import "context"
+
+// memoryEmbeddingQuarantineReleaseControlsAvailable verifies the schema-v32
+// owner routine that atomically releases quarantine and requeues an expired
+// lease whose final attempt was held behind that quarantine fence.
+func memoryEmbeddingQuarantineReleaseControlsAvailable(ctx context.Context, q queryer) (bool, error) {
+	var available bool
+	err := q.QueryRowContext(ctx, `WITH objects AS (
+    SELECT to_regprocedure('brain.release_memory_quarantine(uuid,uuid)') AS release_oid
+), routine_safety AS (
+    SELECT count(*)=1 AND bool_and(pg_get_userbyid(proc.proowner)='punaro_owner'
+        AND proc.prokind='f' AND proc.prosecdef AND proc.provolatile='v'
+        AND proc.prolang=(SELECT oid FROM pg_language WHERE lanname='plpgsql')
+        AND proc.proconfig=ARRAY['search_path=pg_catalog']::text[]
+        AND pg_get_function_result(proc.oid)='boolean'
+        AND md5(btrim(proc.prosrc,E' \n\r\t'))=$1) AS exact
+    FROM pg_proc AS proc,objects WHERE proc.oid=release_oid
+), routine_acl AS (
+    SELECT NOT EXISTS (SELECT * FROM (VALUES
+        ('punaro_owner','EXECUTE',false),
+        ('punaro_app','EXECUTE',false)
+    ) AS expected(grantee,privilege_type,is_grantable)
+    EXCEPT
+    SELECT COALESCE(role.rolname,'PUBLIC'),entry.privilege_type,entry.is_grantable
+    FROM pg_proc AS proc
+    CROSS JOIN LATERAL aclexplode(COALESCE(proc.proacl,acldefault('f',proc.proowner))) AS entry
+    LEFT JOIN pg_roles AS role ON role.oid=entry.grantee,objects
+    WHERE proc.oid=release_oid)
+    AND NOT EXISTS (
+    SELECT COALESCE(role.rolname,'PUBLIC'),entry.privilege_type,entry.is_grantable
+    FROM pg_proc AS proc
+    CROSS JOIN LATERAL aclexplode(COALESCE(proc.proacl,acldefault('f',proc.proowner))) AS entry
+    LEFT JOIN pg_roles AS role ON role.oid=entry.grantee,objects
+    WHERE proc.oid=release_oid
+    EXCEPT SELECT * FROM (VALUES
+        ('punaro_owner','EXECUTE',false),
+        ('punaro_app','EXECUTE',false)
+    ) AS expected(grantee,privilege_type,is_grantable)) AS exact
+)
+SELECT release_oid IS NOT NULL AND routine_safety.exact AND routine_acl.exact
+FROM objects,routine_safety,routine_acl`, memoryEmbeddingQuarantineReleaseRoutineV32MD5).Scan(&available)
+	return available, err
+}
+
+const memoryEmbeddingQuarantineReleaseRoutineV32MD5 = "89deeaec7da8da82eaab25ff4f706000"

--- a/internal/postgres/brain_embedding_worker.go
+++ b/internal/postgres/brain_embedding_worker.go
@@ -18,6 +18,9 @@ var ErrMemoryEmbeddingQuarantined = errors.New("memory embedding is quarantined"
 // MemoryEmbeddingLease is one exact, content-free worker lease coordinate.
 type MemoryEmbeddingLease struct {
 	MemoryEmbeddingWork
+	// Generation is the immutable model identity observed when this lease was
+	// claimed. The executor binds a fenced source to it before provider use.
+	Generation      MemoryEmbeddingGeneration
 	Attempts        int
 	Holder          string
 	Token           string
@@ -55,7 +58,10 @@ func (d *Database) ClaimMemoryEmbeddingWork(ctx context.Context, raw MemoryEmbed
 		return nil, mutationStartError(err, "embedding claim transaction cannot start")
 	}
 	defer func() { _ = tx.Rollback() }()
-	rows, err := tx.QueryContext(ctx, `SELECT generation_id::text,item_id::text,revision,encode(content_sha256,'hex'),attempts,lease_holder::text,lease_token::text,lease_generation,lease_until FROM brain.claim_embedding_jobs($1,$2,$3)`, request.WorkerID, request.Limit, request.LeaseDuration.Microseconds())
+	rows, err := tx.QueryContext(ctx, `SELECT claim.generation_id::text,claim.item_id::text,claim.revision,encode(claim.content_sha256,'hex'),claim.attempts,claim.lease_holder::text,claim.lease_token::text,claim.lease_generation,claim.lease_until,
+generation.model,generation.model_revision,generation.dimensions,generation.state
+FROM brain.claim_embedding_jobs($1,$2,$3) AS claim
+JOIN brain.embedding_generations AS generation ON generation.id=claim.generation_id`, request.WorkerID, request.Limit, request.LeaseDuration.Microseconds())
 	if err != nil {
 		return nil, errors.New("embedding work could not be claimed")
 	}
@@ -63,7 +69,14 @@ func (d *Database) ClaimMemoryEmbeddingWork(ctx context.Context, raw MemoryEmbed
 	leases := make([]MemoryEmbeddingLease, 0, request.Limit)
 	for rows.Next() {
 		var lease MemoryEmbeddingLease
-		if err := rows.Scan(&lease.GenerationID, &lease.ItemID, &lease.Revision, &lease.ContentSHA256, &lease.Attempts, &lease.Holder, &lease.Token, &lease.LeaseGeneration, &lease.LeaseUntil); err != nil || !lease.valid() {
+		var generationState MemoryEmbeddingGenerationState
+		if err := rows.Scan(&lease.GenerationID, &lease.ItemID, &lease.Revision, &lease.ContentSHA256, &lease.Attempts, &lease.Holder, &lease.Token, &lease.LeaseGeneration, &lease.LeaseUntil,
+			&lease.Generation.Model, &lease.Generation.Revision, &lease.Generation.Dimensions, &generationState); err != nil {
+			return nil, errors.New("claimed embedding work is malformed")
+		}
+		lease.Generation.ID = lease.GenerationID
+		lease.Generation.State = generationState
+		if !lease.valid() || lease.Generation.Validate() != nil {
 			return nil, errors.New("claimed embedding work is malformed")
 		}
 		leases = append(leases, lease)

--- a/internal/postgres/brain_embedding_worker.go
+++ b/internal/postgres/brain_embedding_worker.go
@@ -11,6 +11,10 @@ import (
 // which has expired, been reclaimed, or been superseded by a newer revision.
 var ErrStaleEmbeddingLease = errors.New("embedding lease is stale")
 
+// ErrMemoryEmbeddingQuarantined reports that a live lease cannot safely expose
+// its canonical content while the item is under an active quarantine.
+var ErrMemoryEmbeddingQuarantined = errors.New("memory embedding is quarantined")
+
 // MemoryEmbeddingLease is one exact, content-free worker lease coordinate.
 type MemoryEmbeddingLease struct {
 	MemoryEmbeddingWork
@@ -27,7 +31,8 @@ func (lease MemoryEmbeddingLease) valid() bool {
 }
 
 // MemoryEmbeddingRetry releases a leased coordinate after a bounded delay or
-// records a terminal diagnostic when its final attempt has been consumed.
+// records a terminal diagnostic when its final attempt has been consumed. The
+// quarantined code durably defers work without consuming an attempt.
 type MemoryEmbeddingRetry struct {
 	Lease     MemoryEmbeddingLease
 	ErrorCode string

--- a/internal/postgres/brain_embedding_worker_schema.go
+++ b/internal/postgres/brain_embedding_worker_schema.go
@@ -4,7 +4,11 @@ import "context"
 
 // memoryEmbeddingWorkerControlsAvailable verifies that the only application
 // mutation path for embedding jobs remains the bounded owner routines.
-func memoryEmbeddingWorkerControlsAvailable(ctx context.Context, q queryer) (bool, error) {
+func memoryEmbeddingWorkerControlsAvailable(ctx context.Context, q queryer, schemaVersion int64) (bool, error) {
+	claimMD5, retryMD5 := memoryEmbeddingClaimRoutineV24MD5, memoryEmbeddingRetryRoutineV24MD5
+	if schemaVersion >= 30 {
+		claimMD5, retryMD5 = memoryEmbeddingClaimRoutineV30MD5, memoryEmbeddingRetryRoutineV30MD5
+	}
 	var available bool
 	err := q.QueryRowContext(ctx, `WITH objects AS (
     SELECT to_regprocedure('brain.claim_embedding_jobs(uuid,integer,bigint)') AS claim_oid,
@@ -47,11 +51,13 @@ func memoryEmbeddingWorkerControlsAvailable(ctx context.Context, q queryer) (boo
     FROM pg_proc AS proc,objects WHERE proc.oid=ANY(ARRAY[claim_oid,retry_oid])
 )
 SELECT claim_oid IS NOT NULL AND retry_oid IS NOT NULL AND routine_safety.exact AND routine_acl.exact
-FROM objects,routine_safety,routine_acl`, memoryEmbeddingClaimRoutineMD5, memoryEmbeddingRetryRoutineMD5).Scan(&available)
+FROM objects,routine_safety,routine_acl`, claimMD5, retryMD5).Scan(&available)
 	return available, err
 }
 
 const (
-	memoryEmbeddingClaimRoutineMD5 = "d211877029240bc95f35abb2b00df576"
-	memoryEmbeddingRetryRoutineMD5 = "06f3d49f9ba794dd42ccdfe0ddfd9e0a"
+	memoryEmbeddingClaimRoutineV24MD5 = "d211877029240bc95f35abb2b00df576"
+	memoryEmbeddingRetryRoutineV24MD5 = "06f3d49f9ba794dd42ccdfe0ddfd9e0a"
+	memoryEmbeddingClaimRoutineV30MD5 = "87ed4326d12c02c92a5ecc01e8518404"
+	memoryEmbeddingRetryRoutineV30MD5 = "4cadc2c5cbcd899d2a9ef5a8d380e110"
 )

--- a/internal/postgres/brain_integration_test.go
+++ b/internal/postgres/brain_integration_test.go
@@ -3087,6 +3087,9 @@ func testMemoryLexicalSearchIntegration(ctx context.Context, t *testing.T, app *
 	if app.brainDB == nil || app.brainDB.Stats().MaxOpenConnections != 2 {
 		t.Fatalf("brain search pool is not independently capped: %#v", app.brainDB)
 	}
+	if app.embeddingDB == nil || app.embeddingDB.Stats().MaxOpenConnections != 4 {
+		t.Fatalf("embedding fence pool is not independently capped: %#v", app.embeddingDB)
+	}
 	actor, err := app.CreatePrincipal(ctx, PrincipalKindDevice, "lexical memory actor")
 	if err != nil {
 		t.Fatal(err)

--- a/internal/postgres/brain_quarantine.go
+++ b/internal/postgres/brain_quarantine.go
@@ -219,6 +219,9 @@ exception_generation=EXCLUDED.exception_generation,outcome=EXCLUDED.outcome,scan
 }
 
 func storeActiveMemoryQuarantine(ctx context.Context, tx *sql.Tx, principalID, itemID string, revision int64, finding secretguard.Finding) (bool, error) {
+	if _, err := tx.ExecContext(ctx, `SELECT pg_advisory_xact_lock(hashtextextended($1::text, 801337))`, itemID); err != nil {
+		return false, errors.New("memory quarantine is unavailable")
+	}
 	var activeID, ruleID, fieldPath string
 	var ruleVersion int64
 	var fingerprint []byte
@@ -244,6 +247,9 @@ VALUES ($1,$2,$3,$4,$5,$6,$7)`, itemID, revision, finding.RuleVersion, finding.R
 }
 
 func releaseActiveMemoryQuarantine(ctx context.Context, tx *sql.Tx, principalID, itemID string) (bool, error) {
+	if _, err := tx.ExecContext(ctx, `SELECT pg_advisory_xact_lock(hashtextextended($1::text, 801337))`, itemID); err != nil {
+		return false, errors.New("memory quarantine release is unavailable")
+	}
 	result, err := tx.ExecContext(ctx, `UPDATE brain.memory_quarantines SET released_by=$2,released_at=statement_timestamp()
 WHERE item_id=$1 AND released_at IS NULL`, itemID, principalID)
 	if err != nil {

--- a/internal/postgres/brain_quarantine.go
+++ b/internal/postgres/brain_quarantine.go
@@ -250,11 +250,16 @@ func releaseActiveMemoryQuarantine(ctx context.Context, tx *sql.Tx, principalID,
 	if _, err := tx.ExecContext(ctx, `SELECT pg_advisory_xact_lock(hashtextextended($1::text, 801337))`, itemID); err != nil {
 		return false, errors.New("memory quarantine release is unavailable")
 	}
-	var released bool
-	if err := tx.QueryRowContext(ctx, `SELECT brain.release_memory_quarantine($1,$2)`, itemID, principalID).Scan(&released); err != nil {
+	result, err := tx.ExecContext(ctx, `UPDATE brain.memory_quarantines SET released_by=$2,released_at=statement_timestamp()
+WHERE item_id=$1 AND released_at IS NULL`, itemID, principalID)
+	if err != nil {
 		return false, errors.New("memory quarantine could not be released")
 	}
-	return released, nil
+	count, err := result.RowsAffected()
+	if err != nil || count > 1 {
+		return false, errors.New("memory quarantine release is unavailable")
+	}
+	return count == 1, nil
 }
 
 // ReviewMemorySecretQuarantine explicitly exposes one active quarantined item to an administrator.

--- a/internal/postgres/brain_quarantine.go
+++ b/internal/postgres/brain_quarantine.go
@@ -250,16 +250,11 @@ func releaseActiveMemoryQuarantine(ctx context.Context, tx *sql.Tx, principalID,
 	if _, err := tx.ExecContext(ctx, `SELECT pg_advisory_xact_lock(hashtextextended($1::text, 801337))`, itemID); err != nil {
 		return false, errors.New("memory quarantine release is unavailable")
 	}
-	result, err := tx.ExecContext(ctx, `UPDATE brain.memory_quarantines SET released_by=$2,released_at=statement_timestamp()
-WHERE item_id=$1 AND released_at IS NULL`, itemID, principalID)
-	if err != nil {
+	var released bool
+	if err := tx.QueryRowContext(ctx, `SELECT brain.release_memory_quarantine($1,$2)`, itemID, principalID).Scan(&released); err != nil {
 		return false, errors.New("memory quarantine could not be released")
 	}
-	count, err := result.RowsAffected()
-	if err != nil || count > 1 {
-		return false, errors.New("memory quarantine release is unavailable")
-	}
-	return count == 1, nil
+	return released, nil
 }
 
 // ReviewMemorySecretQuarantine explicitly exposes one active quarantined item to an administrator.

--- a/internal/postgres/brain_store.go
+++ b/internal/postgres/brain_store.go
@@ -377,6 +377,9 @@ ON CONFLICT (project_id) DO NOTHING RETURNING id::text`, projectID, principalID)
 }
 
 func insertMemoryRevision(ctx context.Context, tx *sql.Tx, itemID string, revision int64, document []byte, principalID string, operation MemoryChangeType) error {
+	if _, err := tx.ExecContext(ctx, `SELECT pg_advisory_xact_lock(hashtextextended($1::text, 801337))`, itemID); err != nil {
+		return errors.New("memory revision fence is unavailable")
+	}
 	var storedDocument string
 	if err := tx.QueryRowContext(ctx, `SELECT $1::jsonb::text`, string(document)).Scan(&storedDocument); err != nil || len(storedDocument) > maxMemoryDocumentBytes {
 		return errors.New("memory document could not be normalized")

--- a/internal/postgres/brain_store.go
+++ b/internal/postgres/brain_store.go
@@ -287,6 +287,9 @@ func (d *Database) DeleteMemory(ctx context.Context, request MemoryDeleteRequest
 		}
 		var scopeID, timelineID string
 		var revision, changeSequence int64
+		if _, err := tx.ExecContext(ctx, `SELECT pg_advisory_xact_lock(hashtextextended($1::text, 801337))`, request.ItemID); err != nil {
+			return MemoryMutationResult{}, errors.New("memory purge fence is unavailable")
+		}
 		if err := tx.QueryRowContext(ctx, `SELECT scope_id::text,revision,timeline_id::text,change_sequence
 FROM brain.purge_memory($1::uuid,$2::uuid,$3::uuid,$4)`, request.PrincipalID, locked.ProjectID, request.ItemID, locked.Revision).Scan(&scopeID, &revision, &timelineID, &changeSequence); err != nil {
 			return MemoryMutationResult{}, errors.New("memory item could not be purged")

--- a/internal/postgres/db.go
+++ b/internal/postgres/db.go
@@ -25,6 +25,7 @@ type Database struct {
 	db                        *sql.DB
 	relayDB                   *sql.DB
 	brainDB                   *sql.DB
+	embeddingDB               *sql.DB
 	manifest                  Manifest
 	attachmentPhysicalGCSlots chan struct{}
 	memoryUsageWrites         chan memoryUsageWrite
@@ -76,8 +77,22 @@ func OpenApplication(ctx context.Context, cfg Config) (*Database, error) {
 		_ = db.Close()
 		return nil, err
 	}
+	embeddingDB, err := openPool(ctx, dsn, 4, 1)
+	if err != nil {
+		_ = brainDB.Close()
+		_ = relayDB.Close()
+		_ = db.Close()
+		return nil, err
+	}
+	if err := verifyApplicationRole(ctx, embeddingDB); err != nil {
+		_ = embeddingDB.Close()
+		_ = brainDB.Close()
+		_ = relayDB.Close()
+		_ = db.Close()
+		return nil, err
+	}
 	database := &Database{
-		db: db, relayDB: relayDB, brainDB: brainDB, manifest: CurrentManifest(),
+		db: db, relayDB: relayDB, brainDB: brainDB, embeddingDB: embeddingDB, manifest: CurrentManifest(),
 		attachmentPhysicalGCSlots: make(chan struct{}, 1),
 		memoryUsageWrites:         make(chan memoryUsageWrite, maxMemoryRecallQueue),
 		memoryUsageStop:           make(chan struct{}),
@@ -118,10 +133,14 @@ func (d *Database) Close() error {
 	if d.relayDB == nil {
 		return d.db.Close()
 	}
-	if d.brainDB == nil {
-		return errors.Join(d.relayDB.Close(), d.db.Close())
+	closers := []error{d.relayDB.Close(), d.db.Close()}
+	if d.brainDB != nil {
+		closers = append(closers, d.brainDB.Close())
 	}
-	return errors.Join(d.brainDB.Close(), d.relayDB.Close(), d.db.Close())
+	if d.embeddingDB != nil {
+		closers = append(closers, d.embeddingDB.Close())
+	}
+	return errors.Join(closers...)
 }
 
 // SchemaState inspects schema history, required objects, and role safety atomically.
@@ -1140,7 +1159,7 @@ FROM objects, table_ownership, routine_safety, routine_acl, table_acl, schema_ac
 		snapshot.CurrentObjectsPresent = embeddingObjectsPresent
 	}
 	if snapshot.CurrentObjectsPresent && len(snapshot.Records) > 0 && snapshot.Records[len(snapshot.Records)-1].Version >= 24 {
-		embeddingWorkerObjectsPresent, err := memoryEmbeddingWorkerControlsAvailable(ctx, q)
+		embeddingWorkerObjectsPresent, err := memoryEmbeddingWorkerControlsAvailable(ctx, q, snapshot.Records[len(snapshot.Records)-1].Version)
 		if err != nil {
 			return Snapshot{}, errors.New("PostgreSQL memory embedding worker schema cannot be inspected")
 		}
@@ -1168,7 +1187,7 @@ FROM objects, table_ownership, routine_safety, routine_acl, table_acl, schema_ac
 		snapshot.CurrentObjectsPresent = embeddingRebuildBatchObjectsPresent
 	}
 	if snapshot.CurrentObjectsPresent && len(snapshot.Records) > 0 && snapshot.Records[len(snapshot.Records)-1].Version >= 28 {
-		embeddingActivationObjectsPresent, err := memoryEmbeddingActivationControlsAvailable(ctx, q)
+		embeddingActivationObjectsPresent, err := memoryEmbeddingActivationControlsAvailable(ctx, q, snapshot.Records[len(snapshot.Records)-1].Version)
 		if err != nil {
 			return Snapshot{}, errors.New("PostgreSQL memory embedding activation schema cannot be inspected")
 		}

--- a/internal/postgres/db.go
+++ b/internal/postgres/db.go
@@ -1200,6 +1200,13 @@ FROM objects, table_ownership, routine_safety, routine_acl, table_acl, schema_ac
 		}
 		snapshot.CurrentObjectsPresent = embeddingVectorObjectsPresent
 	}
+	if snapshot.CurrentObjectsPresent && len(snapshot.Records) > 0 && snapshot.Records[len(snapshot.Records)-1].Version >= 32 {
+		embeddingQuarantineReleaseObjectsPresent, err := memoryEmbeddingQuarantineReleaseControlsAvailable(ctx, q)
+		if err != nil {
+			return Snapshot{}, errors.New("PostgreSQL memory embedding quarantine-release schema cannot be inspected")
+		}
+		snapshot.CurrentObjectsPresent = embeddingQuarantineReleaseObjectsPresent
+	}
 	return snapshot, nil
 }
 

--- a/internal/postgres/migrate.go
+++ b/internal/postgres/migrate.go
@@ -64,6 +64,7 @@ var migrationCompatibilityFloors = map[int64]int64{
 	29: 10,
 	30: 10,
 	31: 10,
+	32: 10,
 }
 
 // CurrentManifest returns the immutable migrations embedded in this binary.

--- a/internal/postgres/migrate.go
+++ b/internal/postgres/migrate.go
@@ -62,6 +62,8 @@ var migrationCompatibilityFloors = map[int64]int64{
 	27: 10,
 	28: 10,
 	29: 10,
+	30: 10,
+	31: 10,
 }
 
 // CurrentManifest returns the immutable migrations embedded in this binary.

--- a/internal/postgres/migrations/030_memory_embedding_quarantine_deferral.sql
+++ b/internal/postgres/migrations/030_memory_embedding_quarantine_deferral.sql
@@ -1,0 +1,95 @@
+CREATE OR REPLACE FUNCTION brain.claim_embedding_jobs(requested_holder uuid, requested_limit integer, requested_lease_micros bigint)
+RETURNS TABLE(generation_id uuid, item_id uuid, revision bigint, content_sha256 bytea, attempts integer, lease_holder uuid, lease_token uuid, lease_generation bigint, lease_until timestamptz)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog
+AS $function$
+BEGIN
+    PERFORM jobs.assert_application_mutation();
+    IF requested_holder IS NULL OR requested_limit IS NULL OR requested_lease_micros IS NULL
+       OR requested_limit < 1 OR requested_limit > 32 OR requested_lease_micros < 5000000 OR requested_lease_micros > 300000000 THEN
+        RAISE EXCEPTION USING ERRCODE = '22023', MESSAGE = 'invalid embedding claim request';
+    END IF;
+    RETURN QUERY WITH quarantined_expired AS MATERIALIZED (
+        SELECT job.generation_id, job.item_id
+        FROM brain.embedding_jobs AS job
+        WHERE job.state='running' AND job.lease_until <= statement_timestamp() AND job.attempts > 0
+          AND EXISTS (SELECT 1 FROM brain.memory_quarantines AS quarantine WHERE quarantine.item_id=job.item_id AND quarantine.released_at IS NULL)
+        ORDER BY job.lease_until, job.created_at, job.item_id
+        FOR UPDATE SKIP LOCKED
+        LIMIT requested_limit
+    ), deferred AS (
+        UPDATE brain.embedding_jobs AS job
+        SET state='queued', attempts=job.attempts-1, lease_holder=NULL, lease_token=NULL, lease_until=NULL,
+            available_at=statement_timestamp(), last_error_code='quarantined', completed_at=NULL, updated_at=statement_timestamp()
+        FROM quarantined_expired
+        WHERE job.generation_id=quarantined_expired.generation_id AND job.item_id=quarantined_expired.item_id
+    ), expired_terminal AS MATERIALIZED (
+        SELECT job.generation_id, job.item_id
+        FROM brain.embedding_jobs AS job
+        WHERE job.state='running' AND job.lease_until <= statement_timestamp() AND job.attempts >= 25
+        ORDER BY job.lease_until, job.created_at, job.item_id
+        FOR UPDATE SKIP LOCKED
+        LIMIT requested_limit
+    ), locked_terminal AS MATERIALIZED (
+        SELECT expired_terminal.generation_id, expired_terminal.item_id
+        FROM expired_terminal
+        WHERE pg_try_advisory_xact_lock(hashtextextended(expired_terminal.item_id::text, 801337))
+    ), exhausted AS MATERIALIZED (
+        SELECT locked_terminal.generation_id, locked_terminal.item_id
+        FROM locked_terminal
+        WHERE NOT EXISTS (SELECT 1 FROM brain.memory_quarantines AS quarantine WHERE quarantine.item_id=locked_terminal.item_id AND quarantine.released_at IS NULL)
+    ), failed AS (
+        UPDATE brain.embedding_jobs AS job
+        SET state='failed', lease_holder=NULL, lease_token=NULL, lease_until=NULL,
+            last_error_code='attempts_exhausted', completed_at=statement_timestamp(), updated_at=statement_timestamp()
+        FROM exhausted
+        WHERE job.generation_id=exhausted.generation_id AND job.item_id=exhausted.item_id
+    ), candidates AS MATERIALIZED (
+        SELECT job.generation_id, job.item_id
+        FROM brain.embedding_jobs AS job
+        WHERE job.attempts < 25 AND ((job.state='queued' AND job.available_at <= statement_timestamp()) OR (job.state='running' AND job.lease_until <= statement_timestamp()))
+          AND NOT EXISTS (SELECT 1 FROM brain.memory_quarantines AS quarantine WHERE quarantine.item_id=job.item_id AND quarantine.released_at IS NULL)
+        ORDER BY COALESCE(job.lease_until, job.available_at), job.created_at, job.item_id
+        FOR UPDATE SKIP LOCKED
+        LIMIT requested_limit
+    )
+    UPDATE brain.embedding_jobs AS job
+    SET state='running', attempts=job.attempts+1, lease_holder=requested_holder, lease_token=gen_random_uuid(),
+        lease_generation=job.lease_generation+1, lease_until=statement_timestamp() + (requested_lease_micros * interval '1 microsecond'),
+        last_error_code=NULL, completed_at=NULL, updated_at=statement_timestamp()
+    FROM candidates
+    WHERE job.generation_id=candidates.generation_id AND job.item_id=candidates.item_id
+    RETURNING job.generation_id,job.item_id,job.revision,job.content_sha256,job.attempts,job.lease_holder,job.lease_token,job.lease_generation,job.lease_until;
+END
+$function$;
+
+CREATE OR REPLACE FUNCTION brain.retry_embedding_job(requested_generation uuid, requested_item uuid, requested_revision bigint, requested_sha256 bytea, requested_token uuid, requested_lease_generation bigint, requested_delay_micros bigint, requested_error_code text)
+RETURNS boolean
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog
+AS $function$
+BEGIN
+    PERFORM jobs.assert_application_mutation();
+    IF requested_generation IS NULL OR requested_item IS NULL OR requested_revision IS NULL OR requested_sha256 IS NULL
+       OR requested_token IS NULL OR requested_lease_generation IS NULL OR requested_delay_micros IS NULL OR requested_error_code IS NULL
+       OR requested_revision < 1 OR octet_length(requested_sha256) <> 32 OR requested_lease_generation < 1
+       OR requested_delay_micros < 0 OR requested_delay_micros > 3600000000
+       OR requested_error_code !~ '^[a-z][a-z0-9_.:-]{0,127}$' THEN
+        RAISE EXCEPTION USING ERRCODE = '22023', MESSAGE = 'invalid embedding retry request';
+    END IF;
+    UPDATE brain.embedding_jobs
+    SET state=CASE WHEN attempts >= 25 AND NOT (requested_error_code='quarantined' AND EXISTS (SELECT 1 FROM brain.memory_quarantines AS quarantine WHERE quarantine.item_id=brain.embedding_jobs.item_id AND quarantine.released_at IS NULL)) THEN 'failed' ELSE 'queued' END,
+        attempts=CASE WHEN requested_error_code='quarantined' AND EXISTS (SELECT 1 FROM brain.memory_quarantines AS quarantine WHERE quarantine.item_id=brain.embedding_jobs.item_id AND quarantine.released_at IS NULL) THEN attempts-1 ELSE attempts END,
+        available_at=CASE WHEN attempts >= 25 AND NOT (requested_error_code='quarantined' AND EXISTS (SELECT 1 FROM brain.memory_quarantines AS quarantine WHERE quarantine.item_id=brain.embedding_jobs.item_id AND quarantine.released_at IS NULL)) THEN available_at ELSE statement_timestamp() + (requested_delay_micros * interval '1 microsecond') END,
+        lease_holder=NULL, lease_token=NULL, lease_until=NULL,
+        last_error_code=requested_error_code,
+        completed_at=CASE WHEN attempts >= 25 AND NOT (requested_error_code='quarantined' AND EXISTS (SELECT 1 FROM brain.memory_quarantines AS quarantine WHERE quarantine.item_id=brain.embedding_jobs.item_id AND quarantine.released_at IS NULL)) THEN statement_timestamp() ELSE NULL END,
+        updated_at=statement_timestamp()
+    WHERE generation_id=requested_generation AND item_id=requested_item AND revision=requested_revision
+      AND content_sha256=requested_sha256 AND state='running' AND lease_token=requested_token
+      AND lease_generation=requested_lease_generation AND lease_until > statement_timestamp();
+    RETURN FOUND;
+END
+$function$;

--- a/internal/postgres/migrations/031_embedding_activation_quarantine_deferral.sql
+++ b/internal/postgres/migrations/031_embedding_activation_quarantine_deferral.sql
@@ -1,0 +1,44 @@
+CREATE OR REPLACE FUNCTION brain.activate_embedding_generation(requested_generation uuid)
+RETURNS TABLE (generation_id uuid)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog
+AS $function$
+DECLARE
+    prior_generation uuid;
+BEGIN
+    PERFORM jobs.assert_application_mutation();
+    IF requested_generation IS NULL THEN
+        RAISE EXCEPTION USING ERRCODE = '22023', MESSAGE = 'invalid embedding generation activation';
+    END IF;
+    PERFORM pg_advisory_xact_lock(5788618938515408205);
+    PERFORM 1 FROM jobs.server_state WHERE singleton FOR UPDATE;
+    SELECT generation.id INTO prior_generation FROM brain.embedding_generations AS generation WHERE generation.state = 'active' FOR UPDATE;
+    IF prior_generation IS NULL THEN
+        RAISE EXCEPTION USING ERRCODE = '23514', MESSAGE = 'active embedding generation is required';
+    END IF;
+    PERFORM 1 FROM brain.embedding_generations AS generation JOIN brain.embedding_rebuild_progress AS progress ON progress.generation_id = generation.id
+    WHERE generation.id = requested_generation AND generation.state = 'building' AND progress.complete FOR UPDATE OF generation, progress;
+    IF NOT FOUND THEN
+        RAISE EXCEPTION USING ERRCODE = '23514', MESSAGE = 'embedding rebuild generation is not complete';
+    END IF;
+    IF EXISTS (
+        SELECT 1 FROM brain.embedding_jobs AS job
+        WHERE job.generation_id = requested_generation AND job.state <> 'succeeded'
+          AND (job.state <> 'queued' OR NOT EXISTS (SELECT 1 FROM brain.memory_quarantines AS quarantine WHERE quarantine.item_id=job.item_id AND quarantine.released_at IS NULL))
+    ) THEN
+        RAISE EXCEPTION USING ERRCODE = '23514', MESSAGE = 'embedding rebuild generation is not caught up';
+    END IF;
+    PERFORM set_config('punaro.embedding_activation_old_generation', prior_generation::text, true);
+    PERFORM 1 FROM brain.embedding_jobs AS job WHERE job.generation_id = prior_generation FOR UPDATE;
+    DELETE FROM brain.embedding_chunks AS chunk WHERE chunk.generation_id = prior_generation;
+    DELETE FROM brain.embedding_jobs AS job WHERE job.generation_id = prior_generation;
+    PERFORM set_config('punaro.embedding_activation_generation', prior_generation::text, true);
+    DELETE FROM brain.embedding_generations WHERE id = prior_generation;
+    DELETE FROM brain.embedding_rebuild_progress AS progress WHERE progress.generation_id = requested_generation;
+    PERFORM set_config('punaro.embedding_activation_generation', requested_generation::text, true);
+    UPDATE brain.embedding_generations SET state = 'active', start_change_sequence = NULL, start_timeline_id = NULL WHERE id = requested_generation;
+    generation_id := requested_generation;
+    RETURN NEXT;
+END
+$function$;

--- a/internal/postgres/migrations/032_memory_embedding_quarantine_release.sql
+++ b/internal/postgres/migrations/032_memory_embedding_quarantine_release.sql
@@ -1,0 +1,35 @@
+CREATE FUNCTION brain.release_memory_quarantine(requested_item uuid, requested_principal uuid)
+RETURNS boolean
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog
+AS $function$
+DECLARE
+    was_released boolean;
+BEGIN
+    PERFORM jobs.assert_application_mutation();
+    IF requested_item IS NULL OR requested_principal IS NULL THEN
+        RAISE EXCEPTION USING ERRCODE = '22023', MESSAGE = 'invalid memory quarantine release';
+    END IF;
+    PERFORM pg_advisory_xact_lock(hashtextextended(requested_item::text, 801337));
+    WITH released AS MATERIALIZED (
+        UPDATE brain.memory_quarantines
+        SET released_by=requested_principal,released_at=statement_timestamp()
+        WHERE item_id=requested_item AND released_at IS NULL
+        RETURNING item_id,quarantined_at
+    ), requeued AS (
+        UPDATE brain.embedding_jobs AS job
+        SET state='queued', attempts=job.attempts-1,
+            lease_holder=NULL, lease_token=NULL, lease_until=NULL,
+            available_at=statement_timestamp(), last_error_code='quarantined', completed_at=NULL, updated_at=statement_timestamp()
+        FROM released
+        WHERE job.item_id=released.item_id AND job.state='running' AND job.attempts>0
+          AND job.lease_until <= statement_timestamp() AND job.lease_until >= released.quarantined_at
+    )
+    SELECT EXISTS (SELECT 1 FROM released) INTO was_released;
+    RETURN was_released;
+END
+$function$;
+
+REVOKE ALL ON FUNCTION brain.release_memory_quarantine(uuid,uuid) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION brain.release_memory_quarantine(uuid,uuid) TO punaro_app;

--- a/internal/postgres/migrations/032_memory_embedding_quarantine_release.sql
+++ b/internal/postgres/migrations/032_memory_embedding_quarantine_release.sql
@@ -24,7 +24,7 @@ BEGIN
             available_at=statement_timestamp(), last_error_code='quarantined', completed_at=NULL, updated_at=statement_timestamp()
         FROM released
         WHERE job.item_id=released.item_id AND job.state='running' AND job.attempts>0
-          AND job.lease_until <= statement_timestamp() AND job.lease_until >= released.quarantined_at
+          AND job.lease_until <= statement_timestamp()
     )
     SELECT EXISTS (SELECT 1 FROM released) INTO was_released;
     RETURN was_released;

--- a/internal/postgres/migrations/032_memory_embedding_quarantine_release.sql
+++ b/internal/postgres/migrations/032_memory_embedding_quarantine_release.sql
@@ -1,35 +1,26 @@
-CREATE FUNCTION brain.release_memory_quarantine(requested_item uuid, requested_principal uuid)
-RETURNS boolean
+CREATE FUNCTION brain.requeue_expired_quarantined_embedding_jobs()
+RETURNS trigger
 LANGUAGE plpgsql
 SECURITY DEFINER
 SET search_path = pg_catalog
 AS $function$
-DECLARE
-    was_released boolean;
 BEGIN
     PERFORM jobs.assert_application_mutation();
-    IF requested_item IS NULL OR requested_principal IS NULL THEN
-        RAISE EXCEPTION USING ERRCODE = '22023', MESSAGE = 'invalid memory quarantine release';
-    END IF;
-    PERFORM pg_advisory_xact_lock(hashtextextended(requested_item::text, 801337));
-    WITH released AS MATERIALIZED (
-        UPDATE brain.memory_quarantines
-        SET released_by=requested_principal,released_at=statement_timestamp()
-        WHERE item_id=requested_item AND released_at IS NULL
-        RETURNING item_id,quarantined_at
-    ), requeued AS (
-        UPDATE brain.embedding_jobs AS job
-        SET state='queued', attempts=job.attempts-1,
-            lease_holder=NULL, lease_token=NULL, lease_until=NULL,
-            available_at=statement_timestamp(), last_error_code='quarantined', completed_at=NULL, updated_at=statement_timestamp()
-        FROM released
-        WHERE job.item_id=released.item_id AND job.state='running' AND job.attempts>0
-          AND job.lease_until <= statement_timestamp()
-    )
-    SELECT EXISTS (SELECT 1 FROM released) INTO was_released;
-    RETURN was_released;
+    PERFORM pg_advisory_xact_lock(hashtextextended(NEW.item_id::text, 801337));
+    UPDATE brain.embedding_jobs AS job
+    SET state='queued', attempts=job.attempts-1,
+        lease_holder=NULL, lease_token=NULL, lease_until=NULL,
+        available_at=statement_timestamp(), last_error_code='quarantined', completed_at=NULL, updated_at=statement_timestamp()
+    WHERE job.item_id=NEW.item_id AND job.state='running' AND job.attempts>0
+      AND job.lease_until <= statement_timestamp();
+    RETURN NEW;
 END
 $function$;
 
-REVOKE ALL ON FUNCTION brain.release_memory_quarantine(uuid,uuid) FROM PUBLIC;
-GRANT EXECUTE ON FUNCTION brain.release_memory_quarantine(uuid,uuid) TO punaro_app;
+CREATE TRIGGER memory_quarantine_embedding_release
+AFTER UPDATE OF released_at ON brain.memory_quarantines
+FOR EACH ROW WHEN (OLD.released_at IS NULL AND NEW.released_at IS NOT NULL)
+EXECUTE FUNCTION brain.requeue_expired_quarantined_embedding_jobs();
+
+REVOKE ALL ON FUNCTION brain.requeue_expired_quarantined_embedding_jobs() FROM PUBLIC, punaro_app;
+GRANT EXECUTE ON FUNCTION brain.requeue_expired_quarantined_embedding_jobs() TO punaro_owner;

--- a/internal/postgres/postgres_integration_test.go
+++ b/internal/postgres/postgres_integration_test.go
@@ -460,6 +460,7 @@ RETURNS boolean LANGUAGE plpgsql SECURITY DEFINER SET search_path=pg_catalog AS 
 	testMemoryReferenceReconciliationRaces(ctx, t, app, ownerDB)
 	testMemoryConsistencyIntegration(ctx, t, app, ownerDB)
 	testMemoryEmbeddingQueueIntegration(ctx, t, app, ownerDB)
+	testMemoryEmbeddingQuarantineDeferralIntegration(ctx, t, app, ownerDB)
 	testMemoryEmbeddingGenerationRebuildIntegration(ctx, t, app, ownerDB)
 	testMemorySemanticCandidateIntegration(ctx, t, app, ownerDB)
 	testMemoryEvidenceIntegration(ctx, t, app, ownerDB)

--- a/internal/postgres/state_test.go
+++ b/internal/postgres/state_test.go
@@ -69,8 +69,8 @@ func TestManifestValidationRejectsMutableOrNonContiguousHistory(t *testing.T) {
 
 func TestCurrentManifestRequiresControlPlaneSchema(t *testing.T) {
 	manifest := CurrentManifest()
-	if manifest.MinSupported != 10 || manifest.MaxSupported != 29 || len(manifest.Migrations) != 29 {
-		t.Fatalf("manifest=%#v, want exact v10-v29 compatibility window", manifest)
+	if manifest.MinSupported != 10 || manifest.MaxSupported != 31 || len(manifest.Migrations) != 31 {
+		t.Fatalf("manifest=%#v, want exact v10-v31 compatibility window", manifest)
 	}
 	embedding := manifest.Migrations[23]
 	if embedding.Version != 24 || embedding.Name != "024_memory_embedding_worker_control" ||
@@ -88,7 +88,7 @@ func TestCurrentManifestRequiresControlPlaneSchema(t *testing.T) {
 			want = 10
 		case 12, 13:
 			want = 10
-		case 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29:
+		case 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31:
 			want = 10
 		}
 		if migration.CompatibilityFloor != want {
@@ -174,7 +174,13 @@ func TestCompatibleSchemaCanStillHavePendingMigrations(t *testing.T) {
 	if !migrationPending(SchemaState{Classification: Compatible, Version: 28}, manifest) {
 		t.Fatal("compatible v28 schema must still apply the pending v29 migration")
 	}
-	if migrationPending(SchemaState{Classification: Compatible, Version: 29}, manifest) {
-		t.Fatal("current v29 schema reported a pending migration")
+	if !migrationPending(SchemaState{Classification: Compatible, Version: 29}, manifest) {
+		t.Fatal("compatible v29 schema must still apply the pending v30 migration")
+	}
+	if !migrationPending(SchemaState{Classification: Compatible, Version: 30}, manifest) {
+		t.Fatal("compatible v30 schema must still apply the pending v31 migration")
+	}
+	if migrationPending(SchemaState{Classification: Compatible, Version: 31}, manifest) {
+		t.Fatal("current v31 schema reported a pending migration")
 	}
 }

--- a/internal/postgres/state_test.go
+++ b/internal/postgres/state_test.go
@@ -69,8 +69,8 @@ func TestManifestValidationRejectsMutableOrNonContiguousHistory(t *testing.T) {
 
 func TestCurrentManifestRequiresControlPlaneSchema(t *testing.T) {
 	manifest := CurrentManifest()
-	if manifest.MinSupported != 10 || manifest.MaxSupported != 31 || len(manifest.Migrations) != 31 {
-		t.Fatalf("manifest=%#v, want exact v10-v31 compatibility window", manifest)
+	if manifest.MinSupported != 10 || manifest.MaxSupported != 32 || len(manifest.Migrations) != 32 {
+		t.Fatalf("manifest=%#v, want exact v10-v32 compatibility window", manifest)
 	}
 	embedding := manifest.Migrations[23]
 	if embedding.Version != 24 || embedding.Name != "024_memory_embedding_worker_control" ||
@@ -88,7 +88,7 @@ func TestCurrentManifestRequiresControlPlaneSchema(t *testing.T) {
 			want = 10
 		case 12, 13:
 			want = 10
-		case 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31:
+		case 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32:
 			want = 10
 		}
 		if migration.CompatibilityFloor != want {
@@ -180,7 +180,10 @@ func TestCompatibleSchemaCanStillHavePendingMigrations(t *testing.T) {
 	if !migrationPending(SchemaState{Classification: Compatible, Version: 30}, manifest) {
 		t.Fatal("compatible v30 schema must still apply the pending v31 migration")
 	}
-	if migrationPending(SchemaState{Classification: Compatible, Version: 31}, manifest) {
-		t.Fatal("current v31 schema reported a pending migration")
+	if !migrationPending(SchemaState{Classification: Compatible, Version: 31}, manifest) {
+		t.Fatal("compatible v31 schema must still apply the pending v32 migration")
+	}
+	if migrationPending(SchemaState{Classification: Compatible, Version: 32}, manifest) {
+		t.Fatal("current v32 schema reported a pending migration")
 	}
 }


### PR DESCRIPTION
## Summary
- add a provider-agnostic bounded embedding executor over existing lease fences
- materialize only an exact, live canonical revision before provider invocation
- validate provider output and preserve code-only retry diagnostics

## Validation
- make test
- make test-race
- make staticcheck
- make security
- make lint