### PR TITLE
Add hybrid semantic memory ranking

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -449,9 +449,13 @@ the database, and no vector index. An internal exact cosine-candidate read may
 use only the active generation's succeeded chunks and the same project,
 `memory.search`, current-revision, active, and quarantine boundaries as
 lexical search. It accepts an already-derived, dimension-matched query vector;
-it never invokes a provider, exposes a route, changes core readiness, or fuses
-lexical and semantic ranks. With no active generation it reports semantic
-`not_configured`, so callers keep lexical retrieval available.
+it never invokes a provider, exposes a route, or changes core readiness. An
+internal hybrid primitive reads both bounded candidate lists under one
+repeatable-read authorization snapshot and deterministically applies
+reciprocal-rank fusion with a fixed offset of 60; it returns only current item
+coordinates/ranks, not summaries or a client surface. With no active generation
+it reports semantic `not_configured`, so callers keep lexical retrieval
+available.
 
 The bounded embedding executor is provider-agnostic. It claims only existing
 fenced work, re-reads the exact live generation/item/revision/hash/lease before

--- a/docs/platform-contracts.md
+++ b/docs/platform-contracts.md
@@ -392,9 +392,12 @@ invalid dimensionality or numeric values leave both chunks and the job
 unchanged. Upgrade drops only prior coordinate-only chunk output and requeues
 previously succeeded or interrupted derived jobs, while preserving terminal
 failures as explicit degradation evidence. The application role remains unable
-to mutate vector rows, no provider configuration or text is stored, and no
-vector index, semantic query, route, client surface, hybrid ranking, or RRF is
-introduced.
+to mutate vector rows, and no provider configuration, fragment text, vector
+index, route, or client surface is introduced. The internal retrieval slice
+reads only active, succeeded, current, non-quarantined authorized coordinates
+and fuses separately bounded lexical and exact semantic lists in one
+repeatable-read snapshot with reciprocal-rank fusion at a fixed offset of 60;
+it returns ranks and opaque coordinates only.
 
 The dark prompt-brief read adds no schema and exposes no route or client. It
 accepts the same bounded normalized query as lexical search, resolves the

--- a/internal/postgres/brain_hybrid.go
+++ b/internal/postgres/brain_hybrid.go
@@ -1,0 +1,186 @@
+package postgres
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"sort"
+)
+
+const (
+	memorySearchRRFOffset      = 60
+	memoryHybridCandidateLimit = maxMemorySearchCandidates
+	memoryHybridSearchTimeout  = 2 * memorySearchTimeout
+)
+
+// MemoryHybridSearchResult records the deterministic reciprocal-rank fusion
+// coordinate for one current item. Zero means that retrieval mode did not
+// select the item.
+type MemoryHybridSearchResult struct {
+	ItemID       string  `json:"item_id"`
+	Revision     int64   `json:"revision"`
+	LexicalRank  int     `json:"lexical_rank"`
+	SemanticRank int     `json:"semantic_rank"`
+	Score        float64 `json:"score"`
+}
+
+// MemoryHybridSearchRequest combines a normalized lexical query and an
+// already-derived query embedding. It never invokes an embedding provider.
+type MemoryHybridSearchRequest struct {
+	PrincipalID string
+	ProjectID   string
+	Query       string
+	Embedding   []float64
+	Limit       int
+}
+
+// MemoryHybridSearchPage carries bounded fused candidate coordinates. A later
+// presentation layer reads authorized summaries from the same snapshot.
+type MemoryHybridSearchPage struct {
+	Results        []MemoryHybridSearchResult       `json:"results"`
+	More           bool                             `json:"more"`
+	SemanticStatus MemoryHybridSearchSemanticStatus `json:"semantic_status"`
+}
+
+// MemoryHybridSearchSemanticStatus reports whether semantic candidates were
+// available without making lexical retrieval depend on them.
+type MemoryHybridSearchSemanticStatus string
+
+const (
+	// MemoryHybridSearchSemanticReady reports that both candidate paths ran.
+	MemoryHybridSearchSemanticReady MemoryHybridSearchSemanticStatus = "ready"
+	// MemoryHybridSearchSemanticNotConfigured reports lexical-only degradation.
+	MemoryHybridSearchSemanticNotConfigured MemoryHybridSearchSemanticStatus = "not_configured"
+)
+
+func (r MemoryHybridSearchRequest) normalized() (MemoryHybridSearchRequest, error) {
+	lexical, err := (MemorySearchRequest{PrincipalID: r.PrincipalID, ProjectID: r.ProjectID, Query: r.Query, Limit: r.Limit}).normalized()
+	if err != nil {
+		return MemoryHybridSearchRequest{}, errors.New("invalid memory hybrid search request")
+	}
+	semantic, err := (MemorySemanticSearchRequest{PrincipalID: r.PrincipalID, ProjectID: r.ProjectID, Embedding: r.Embedding, Limit: r.Limit}).normalized()
+	if err != nil {
+		return MemoryHybridSearchRequest{}, errors.New("invalid memory hybrid search request")
+	}
+	r.PrincipalID, r.ProjectID, r.Query, r.Embedding, r.Limit = lexical.PrincipalID, lexical.ProjectID, lexical.Query, semantic.Embedding, lexical.Limit
+	return r, nil
+}
+
+// SearchMemoryHybridCandidates fuses authorized lexical and exact semantic
+// candidates in one repeatable-read snapshot. It has no provider call, route,
+// or client-facing summary projection. A missing active generation degrades to
+// lexical-only results and reports not_configured.
+func (d *Database) SearchMemoryHybridCandidates(ctx context.Context, raw MemoryHybridSearchRequest) (MemoryHybridSearchPage, error) {
+	request, err := raw.normalized()
+	if err != nil {
+		return MemoryHybridSearchPage{}, err
+	}
+	searchCtx, cancel := context.WithTimeout(ctx, memoryHybridSearchTimeout)
+	defer cancel()
+	tx, err := d.brainPool().BeginTx(searchCtx, &sql.TxOptions{Isolation: sql.LevelRepeatableRead, ReadOnly: true})
+	if err != nil {
+		return MemoryHybridSearchPage{}, errors.New("memory hybrid search transaction cannot start")
+	}
+	defer func() { _ = tx.Rollback() }()
+	projectID, err := resolveCanonicalActiveProject(searchCtx, tx, request.ProjectID)
+	if err != nil {
+		return MemoryHybridSearchPage{}, ErrNotFound
+	}
+	allowed, err := hasCapability(searchCtx, tx, request.PrincipalID, projectID, CapabilityMemorySearch)
+	if err != nil {
+		return MemoryHybridSearchPage{}, err
+	}
+	if !allowed {
+		return MemoryHybridSearchPage{}, ErrNotFound
+	}
+	if _, err := tx.ExecContext(searchCtx, `SET LOCAL statement_timeout = '2s'`); err != nil {
+		return MemoryHybridSearchPage{}, errors.New("memory hybrid search timeout cannot be installed")
+	}
+	lexical, err := searchMemoryInTx(searchCtx, tx, projectID, request.Query, memoryHybridCandidateLimit, false, false)
+	if err != nil {
+		return MemoryHybridSearchPage{}, err
+	}
+	semantic, semanticErr := searchMemorySemanticCandidatesInTx(searchCtx, tx, projectID, request.Embedding, memoryHybridCandidateLimit)
+	status := MemoryHybridSearchSemanticReady
+	if errors.Is(semanticErr, ErrMemorySemanticNotConfigured) {
+		status = MemoryHybridSearchSemanticNotConfigured
+		semantic = MemorySemanticSearchPage{}
+	} else if semanticErr != nil {
+		return MemoryHybridSearchPage{}, semanticErr
+	}
+	results, fusedMore, err := fuseMemorySearchRanks(lexical.Results, semantic.Results, request.Limit)
+	if err != nil {
+		return MemoryHybridSearchPage{}, errors.New("memory hybrid search candidates are unavailable")
+	}
+	if err := tx.Commit(); err != nil {
+		return MemoryHybridSearchPage{}, errors.New("memory hybrid search transaction could not finish")
+	}
+	return MemoryHybridSearchPage{Results: results, More: lexical.More || semantic.More || fusedMore, SemanticStatus: status}, nil
+}
+
+// fuseMemorySearchRanks combines independently bounded, already-authorized
+// candidate lists. It deliberately performs no database read, provider call,
+// or result projection; a later search surface supplies one snapshot and the
+// canonical memory summaries.
+func fuseMemorySearchRanks(lexical []MemorySearchResult, semantic []MemorySemanticSearchResult, limit int) ([]MemoryHybridSearchResult, bool, error) {
+	if limit < 1 || limit > maxMemorySearchResults {
+		return nil, false, errors.New("invalid memory hybrid search limit")
+	}
+	results := make(map[string]MemoryHybridSearchResult, len(lexical)+len(semantic))
+	for index, candidate := range lexical {
+		if !validOpaqueID(candidate.ItemID) || candidate.Revision < 1 {
+			return nil, false, errors.New("invalid lexical memory search result")
+		}
+		if _, exists := results[candidate.ItemID]; exists {
+			return nil, false, errors.New("duplicate lexical memory search result")
+		}
+		results[candidate.ItemID] = MemoryHybridSearchResult{
+			ItemID: candidate.ItemID, Revision: candidate.Revision, LexicalRank: index + 1,
+			Score: 1.0 / float64(memorySearchRRFOffset+index+1),
+		}
+	}
+	for index, candidate := range semantic {
+		if !validOpaqueID(candidate.ItemID) || candidate.Revision < 1 {
+			return nil, false, errors.New("invalid semantic memory search result")
+		}
+		result, exists := results[candidate.ItemID]
+		if exists && result.Revision != candidate.Revision {
+			return nil, false, errors.New("memory hybrid search result revision mismatch")
+		}
+		if result.SemanticRank != 0 {
+			return nil, false, errors.New("duplicate semantic memory search result")
+		}
+		result.ItemID = candidate.ItemID
+		result.Revision = candidate.Revision
+		result.SemanticRank = index + 1
+		result.Score += 1.0 / float64(memorySearchRRFOffset+index+1)
+		results[candidate.ItemID] = result
+	}
+	fused := make([]MemoryHybridSearchResult, 0, len(results))
+	for _, result := range results {
+		fused = append(fused, result)
+	}
+	sort.Slice(fused, func(i, j int) bool {
+		if fused[i].Score != fused[j].Score {
+			return fused[i].Score > fused[j].Score
+		}
+		if fused[i].LexicalRank != fused[j].LexicalRank {
+			if fused[i].LexicalRank == 0 || fused[j].LexicalRank == 0 {
+				return fused[j].LexicalRank == 0
+			}
+			return fused[i].LexicalRank < fused[j].LexicalRank
+		}
+		if fused[i].SemanticRank != fused[j].SemanticRank {
+			if fused[i].SemanticRank == 0 || fused[j].SemanticRank == 0 {
+				return fused[j].SemanticRank == 0
+			}
+			return fused[i].SemanticRank < fused[j].SemanticRank
+		}
+		return fused[i].ItemID < fused[j].ItemID
+	})
+	more := len(fused) > limit
+	if more {
+		fused = fused[:limit]
+	}
+	return fused, more, nil
+}

--- a/internal/postgres/brain_hybrid_test.go
+++ b/internal/postgres/brain_hybrid_test.go
@@ -1,0 +1,110 @@
+package postgres
+
+import "testing"
+
+func TestFuseMemorySearchRanks(t *testing.T) {
+	lexical := []MemorySearchResult{
+		{ItemID: "11111111-1111-4111-8111-111111111111", Revision: 1},
+		{ItemID: "22222222-2222-4222-8222-222222222222", Revision: 2},
+	}
+	semantic := []MemorySemanticSearchResult{
+		{ItemID: "22222222-2222-4222-8222-222222222222", Revision: 2},
+		{ItemID: "33333333-3333-4333-8333-333333333333", Revision: 3},
+		{ItemID: "11111111-1111-4111-8111-111111111111", Revision: 1},
+	}
+
+	got, more, err := fuseMemorySearchRanks(lexical, semantic, 3)
+	if err != nil {
+		t.Fatalf("fuse ranks: %v", err)
+	}
+	if more {
+		t.Fatal("complete fused candidates reported more")
+	}
+	if len(got) != 3 {
+		t.Fatalf("fused result count=%d", len(got))
+	}
+	if got[0].ItemID != lexical[1].ItemID || got[0].LexicalRank != 2 || got[0].SemanticRank != 1 {
+		t.Fatalf("first fused result=%#v", got[0])
+	}
+	if got[1].ItemID != lexical[0].ItemID || got[1].LexicalRank != 1 || got[1].SemanticRank != 3 {
+		t.Fatalf("second fused result=%#v", got[1])
+	}
+	if got[2].ItemID != semantic[1].ItemID || got[2].LexicalRank != 0 || got[2].SemanticRank != 2 {
+		t.Fatalf("third fused result=%#v", got[2])
+	}
+}
+
+func TestFuseMemorySearchRanksRejectsInconsistentCandidates(t *testing.T) {
+	itemID := "11111111-1111-4111-8111-111111111111"
+	if _, _, err := fuseMemorySearchRanks(
+		[]MemorySearchResult{{ItemID: itemID, Revision: 1}},
+		[]MemorySemanticSearchResult{{ItemID: itemID, Revision: 2}},
+		1,
+	); err == nil {
+		t.Fatal("revision-mismatched candidate lists were fused")
+	}
+	if _, _, err := fuseMemorySearchRanks(
+		[]MemorySearchResult{{ItemID: itemID, Revision: 1}, {ItemID: itemID, Revision: 1}},
+		nil,
+		1,
+	); err == nil {
+		t.Fatal("duplicate lexical candidate was fused")
+	}
+}
+
+func TestFuseMemorySearchRanksReportsUnionTruncation(t *testing.T) {
+	got, more, err := fuseMemorySearchRanks(
+		[]MemorySearchResult{{ItemID: "11111111-1111-4111-8111-111111111111", Revision: 1}},
+		[]MemorySemanticSearchResult{{ItemID: "22222222-2222-4222-8222-222222222222", Revision: 1}},
+		1,
+	)
+	if err != nil || len(got) != 1 || !more {
+		t.Fatalf("truncated fused candidates=%#v more=%t err=%v", got, more, err)
+	}
+}
+
+func TestFuseMemorySearchRanksRanksBeforeTruncating(t *testing.T) {
+	got, more, err := fuseMemorySearchRanks(
+		[]MemorySearchResult{
+			{ItemID: "11111111-1111-4111-8111-111111111111", Revision: 1},
+			{ItemID: "22222222-2222-4222-8222-222222222222", Revision: 1},
+		},
+		[]MemorySemanticSearchResult{
+			{ItemID: "33333333-3333-4333-8333-333333333333", Revision: 1},
+			{ItemID: "22222222-2222-4222-8222-222222222222", Revision: 1},
+		},
+		1,
+	)
+	if err != nil || len(got) != 1 || !more || got[0].ItemID != "22222222-2222-4222-8222-222222222222" {
+		t.Fatalf("ranked then truncated candidates=%#v more=%t err=%v", got, more, err)
+	}
+}
+
+func TestMemoryHybridCandidateWindowExceedsOutputPage(t *testing.T) {
+	if memoryHybridCandidateLimit <= maxMemorySearchResults || memoryHybridCandidateLimit > maxMemorySearchCandidates {
+		t.Fatalf("invalid hybrid candidate window=%d", memoryHybridCandidateLimit)
+	}
+}
+
+func TestMemoryHybridSearchTimeoutCoversBothStatements(t *testing.T) {
+	if memoryHybridSearchTimeout != 2*memorySearchTimeout {
+		t.Fatalf("hybrid timeout=%s", memoryHybridSearchTimeout)
+	}
+}
+
+func TestMemoryHybridSearchRequestValidation(t *testing.T) {
+	valid := MemoryHybridSearchRequest{
+		PrincipalID: "11111111-1111-4111-8111-111111111111",
+		ProjectID:   "22222222-2222-4222-8222-222222222222",
+		Query:       "release decision",
+		Embedding:   []float64{1, 0.5},
+		Limit:       2,
+	}
+	if _, err := valid.normalized(); err != nil {
+		t.Fatalf("valid hybrid request rejected: %v", err)
+	}
+	valid.Embedding = []float64{0, 0}
+	if _, err := valid.normalized(); err == nil {
+		t.Fatal("zero hybrid embedding accepted")
+	}
+}

--- a/internal/postgres/brain_semantic.go
+++ b/internal/postgres/brain_semantic.go
@@ -92,16 +92,27 @@ func (d *Database) SearchMemorySemanticCandidates(ctx context.Context, raw Memor
 	if _, err := tx.ExecContext(searchCtx, `SET LOCAL statement_timeout = '2s'`); err != nil {
 		return MemorySemanticSearchPage{}, errors.New("memory semantic search timeout cannot be installed")
 	}
+	page, err := searchMemorySemanticCandidatesInTx(searchCtx, tx, projectID, request.Embedding, request.Limit)
+	if err != nil {
+		return MemorySemanticSearchPage{}, err
+	}
+	if err := tx.Commit(); err != nil {
+		return MemorySemanticSearchPage{}, errors.New("memory semantic search transaction could not finish")
+	}
+	return page, nil
+}
+
+func searchMemorySemanticCandidatesInTx(ctx context.Context, tx *sql.Tx, projectID string, embedding []float64, limit int) (MemorySemanticSearchPage, error) {
 	var dimensions int
-	if err := tx.QueryRowContext(searchCtx, `SELECT dimensions FROM brain.embedding_generations WHERE state='active'`).Scan(&dimensions); errors.Is(err, sql.ErrNoRows) {
+	if err := tx.QueryRowContext(ctx, `SELECT dimensions FROM brain.embedding_generations WHERE state='active'`).Scan(&dimensions); errors.Is(err, sql.ErrNoRows) {
 		return MemorySemanticSearchPage{}, ErrMemorySemanticNotConfigured
 	} else if err != nil || dimensions < 1 || dimensions > maxMemoryEmbeddingDimensions {
 		return MemorySemanticSearchPage{}, errors.New("memory semantic generation is unavailable")
 	}
-	if len(request.Embedding) != dimensions {
+	if len(embedding) != dimensions {
 		return MemorySemanticSearchPage{}, errors.New("memory semantic embedding dimensions do not match the active generation")
 	}
-	rows, err := tx.QueryContext(searchCtx, `WITH active_generation AS MATERIALIZED (
+	rows, err := tx.QueryContext(ctx, `WITH active_generation AS MATERIALIZED (
     SELECT id FROM brain.embedding_generations WHERE state='active'
 ), candidates AS MATERIALIZED (
     SELECT item.id,item.current_revision,MIN(chunk.embedding <=> $2::public.vector) AS distance,item.updated_at
@@ -118,18 +129,18 @@ func (d *Database) SearchMemorySemanticCandidates(ctx context.Context, raw Memor
     ORDER BY distance ASC,item.updated_at DESC,item.id
     LIMIT $3
 )
-SELECT id::text,current_revision,distance FROM candidates ORDER BY distance ASC,updated_at DESC,id`, projectID, memorySemanticVector(request.Embedding), request.Limit+1)
+SELECT id::text,current_revision,distance FROM candidates ORDER BY distance ASC,updated_at DESC,id`, projectID, memorySemanticVector(embedding), limit+1)
 	if err != nil {
 		return MemorySemanticSearchPage{}, errors.New("memory semantic search is unavailable")
 	}
 	defer func() { _ = rows.Close() }()
-	page := MemorySemanticSearchPage{Results: make([]MemorySemanticSearchResult, 0, request.Limit)}
+	page := MemorySemanticSearchPage{Results: make([]MemorySemanticSearchResult, 0, limit)}
 	for rows.Next() {
 		var result MemorySemanticSearchResult
 		if err := rows.Scan(&result.ItemID, &result.Revision, &result.Distance); err != nil || !validOpaqueID(result.ItemID) || result.Revision < 1 || math.IsNaN(result.Distance) || math.IsInf(result.Distance, 0) || result.Distance < 0 {
 			return MemorySemanticSearchPage{}, errors.New("memory semantic search result is invalid")
 		}
-		if len(page.Results) == request.Limit {
+		if len(page.Results) == limit {
 			page.More = true
 			continue
 		}
@@ -137,9 +148,6 @@ SELECT id::text,current_revision,distance FROM candidates ORDER BY distance ASC,
 	}
 	if err := rows.Err(); err != nil {
 		return MemorySemanticSearchPage{}, errors.New("memory semantic search is unavailable")
-	}
-	if err := tx.Commit(); err != nil {
-		return MemorySemanticSearchPage{}, errors.New("memory semantic search transaction could not finish")
 	}
 	return page, nil
 }

--- a/internal/postgres/brain_semantic_integration_test.go
+++ b/internal/postgres/brain_semantic_integration_test.go
@@ -8,6 +8,30 @@ import (
 	"testing"
 )
 
+func testMemoryHybridDegradedIntegration(ctx context.Context, t *testing.T, app *Database, ownerDB *sql.DB) {
+	t.Helper()
+	actor, err := app.CreatePrincipal(ctx, PrincipalKindDevice, "hybrid degradation actor")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var projectID string
+	if err := ownerDB.QueryRowContext(ctx, `INSERT INTO relay.projects(display_name,created_by) VALUES ('hybrid degradation project',$1) RETURNING id::text`, actor.ID).Scan(&projectID); err != nil {
+		t.Fatal(err)
+	}
+	for _, capability := range []Capability{CapabilityMemoryWrite, CapabilityMemorySearch} {
+		if _, err := ownerDB.ExecContext(ctx, `INSERT INTO auth.capability_grants(principal_id,scope,project_id,capability) VALUES ($1,'project',$2,$3)`, actor.ID, projectID, capability); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if _, err := app.CreateMemory(ctx, MemoryCreateRequest{PrincipalID: actor.ID, ProjectID: projectID, IdempotencyKey: "27272727-2727-4272-8272-272727272701", LogicalKey: "hybrid-degradation", Kind: "decision", Trust: "curated", Document: json.RawMessage(`{"title":"hybrid degradation lexical result"}`)}); err != nil {
+		t.Fatal(err)
+	}
+	page, err := app.SearchMemoryHybridCandidates(ctx, MemoryHybridSearchRequest{PrincipalID: actor.ID, ProjectID: projectID, Query: "hybrid", Embedding: []float64{1}, Limit: 1})
+	if err != nil || len(page.Results) != 1 || page.SemanticStatus != MemoryHybridSearchSemanticNotConfigured {
+		t.Fatalf("degraded hybrid candidates=%#v err=%v", page, err)
+	}
+}
+
 func testMemorySemanticCandidateIntegration(ctx context.Context, t *testing.T, app *Database, ownerDB *sql.DB) {
 	t.Helper()
 	actor, err := app.CreatePrincipal(ctx, PrincipalKindDevice, "semantic candidate actor")
@@ -67,11 +91,18 @@ VALUES ($1,$2,$3,0,decode('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 	if err != nil || len(page.Results) != 2 || page.Results[0].ItemID != nearest.ItemID || page.Results[1].ItemID != farthest.ItemID || page.Results[0].Distance != 0 || page.Results[1].Distance <= page.Results[0].Distance {
 		t.Fatalf("semantic candidates=%#v err=%v", page, err)
 	}
+	hybrid, err := app.SearchMemoryHybridCandidates(ctx, MemoryHybridSearchRequest{PrincipalID: actor.ID, ProjectID: projectID, Query: "semantic", Embedding: query, Limit: 2})
+	if err != nil || len(hybrid.Results) != 2 || hybrid.Results[0].ItemID != nearest.ItemID || hybrid.Results[0].LexicalRank != 3 || hybrid.Results[0].SemanticRank != 1 || hybrid.Results[0].Score <= 0 {
+		t.Fatalf("hybrid candidates=%#v err=%v", hybrid, err)
+	}
 	outsider, err := app.CreatePrincipal(ctx, PrincipalKindDevice, "semantic candidate outsider")
 	if err != nil {
 		t.Fatal(err)
 	}
 	if _, err := app.SearchMemorySemanticCandidates(ctx, MemorySemanticSearchRequest{PrincipalID: outsider.ID, ProjectID: projectID, Embedding: query, Limit: 2}); !errors.Is(err, ErrNotFound) {
 		t.Fatalf("unauthorized semantic candidates error=%v", err)
+	}
+	if _, err := app.SearchMemoryHybridCandidates(ctx, MemoryHybridSearchRequest{PrincipalID: outsider.ID, ProjectID: projectID, Query: "semantic", Embedding: query, Limit: 2}); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("unauthorized hybrid candidates error=%v", err)
 	}
 }

--- a/internal/postgres/postgres_integration_test.go
+++ b/internal/postgres/postgres_integration_test.go
@@ -454,6 +454,7 @@ RETURNS boolean LANGUAGE plpgsql SECURITY DEFINER SET search_path=pg_catalog AS 
 	testCanonicalBrainIntegration(ctx, t, app, ownerDB)
 	testMemoryLexicalSearchIntegration(ctx, t, app, ownerDB)
 	testMemoryPromptBriefIntegration(ctx, t, app, ownerDB)
+	testMemoryHybridDegradedIntegration(ctx, t, app, ownerDB)
 	testMemoryDuplicateDetectionIntegration(ctx, t, app, ownerDB)
 	testMemoryUsageAndArchiveCandidatesIntegration(ctx, t, app, ownerDB)
 	testMemoryReferenceReconciliationIntegration(ctx, t, app, ownerDB)


### PR DESCRIPTION
Adds deterministic, provider-free reciprocal-rank fusion over authorized lexical and semantic candidates. The operation falls back to lexical results when semantic retrieval is not configured. Validated with make test, make lint, and make security; PostgreSQL integration requires CI because Docker Compose v2 is unavailable locally.