### PR TITLE
Authorize hybrid memory query preparation

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -457,6 +457,12 @@ coordinates/ranks, not summaries or a client surface. With no active generation
 it reports semantic `not_configured`, so callers keep lexical retrieval
 available.
 
+Before any provider may derive a query embedding, the server authorizes the
+caller for `memory.search` and returns only the active generation's non-secret
+identity. The provider result must carry that exact generation ID into hybrid
+retrieval; if activation changed it meanwhile, retrieval rejects it rather than
+comparing a vector against a different model's chunks.
+
 The bounded embedding executor is provider-agnostic. It claims only existing
 fenced work, re-reads the exact live generation/item/revision/hash/lease before
 passing a bounded canonical JSON document to an injected provider, validates

--- a/internal/postgres/brain_hybrid.go
+++ b/internal/postgres/brain_hybrid.go
@@ -27,11 +27,12 @@ type MemoryHybridSearchResult struct {
 // MemoryHybridSearchRequest combines a normalized lexical query and an
 // already-derived query embedding. It never invokes an embedding provider.
 type MemoryHybridSearchRequest struct {
-	PrincipalID string
-	ProjectID   string
-	Query       string
-	Embedding   []float64
-	Limit       int
+	PrincipalID  string
+	ProjectID    string
+	GenerationID string
+	Query        string
+	Embedding    []float64
+	Limit        int
 }
 
 // MemoryHybridSearchPage carries bounded fused candidate coordinates. A later
@@ -40,6 +41,50 @@ type MemoryHybridSearchPage struct {
 	Results        []MemoryHybridSearchResult       `json:"results"`
 	More           bool                             `json:"more"`
 	SemanticStatus MemoryHybridSearchSemanticStatus `json:"semantic_status"`
+}
+
+// PrepareMemoryHybridSearch authorizes one normalized query before a later
+// provider call and returns only the active generation's non-secret identity.
+// The caller must pass a vector for this exact generation to the subsequent
+// retrieval fence; a generation change is never silently accepted.
+func (d *Database) PrepareMemoryHybridSearch(ctx context.Context, raw MemorySearchRequest) (MemoryEmbeddingGeneration, error) {
+	request, err := raw.normalized()
+	if err != nil {
+		return MemoryEmbeddingGeneration{}, err
+	}
+	searchCtx, cancel := context.WithTimeout(ctx, memorySearchTimeout)
+	defer cancel()
+	tx, err := d.brainPool().BeginTx(searchCtx, &sql.TxOptions{Isolation: sql.LevelRepeatableRead, ReadOnly: true})
+	if err != nil {
+		return MemoryEmbeddingGeneration{}, errors.New("memory hybrid preparation transaction cannot start")
+	}
+	defer func() { _ = tx.Rollback() }()
+	projectID, err := resolveCanonicalActiveProject(searchCtx, tx, request.ProjectID)
+	if err != nil {
+		return MemoryEmbeddingGeneration{}, ErrNotFound
+	}
+	allowed, err := hasCapability(searchCtx, tx, request.PrincipalID, projectID, CapabilityMemorySearch)
+	if err != nil {
+		return MemoryEmbeddingGeneration{}, err
+	}
+	if !allowed {
+		return MemoryEmbeddingGeneration{}, ErrNotFound
+	}
+	if _, err := tx.ExecContext(searchCtx, `SET LOCAL statement_timeout = '2s'`); err != nil {
+		return MemoryEmbeddingGeneration{}, errors.New("memory hybrid preparation timeout cannot be installed")
+	}
+	var generation MemoryEmbeddingGeneration
+	err = tx.QueryRowContext(searchCtx, `SELECT id::text,model,model_revision,dimensions,state FROM brain.embedding_generations WHERE state='active'`).Scan(&generation.ID, &generation.Model, &generation.Revision, &generation.Dimensions, &generation.State)
+	if errors.Is(err, sql.ErrNoRows) {
+		return MemoryEmbeddingGeneration{}, ErrMemorySemanticNotConfigured
+	}
+	if err != nil || generation.Validate() != nil || generation.State != MemoryEmbeddingGenerationActive {
+		return MemoryEmbeddingGeneration{}, errors.New("memory hybrid generation is unavailable")
+	}
+	if err := tx.Commit(); err != nil {
+		return MemoryEmbeddingGeneration{}, errors.New("memory hybrid preparation transaction could not finish")
+	}
+	return generation, nil
 }
 
 // MemoryHybridSearchSemanticStatus reports whether semantic candidates were
@@ -60,6 +105,9 @@ func (r MemoryHybridSearchRequest) normalized() (MemoryHybridSearchRequest, erro
 	}
 	semantic, err := (MemorySemanticSearchRequest{PrincipalID: r.PrincipalID, ProjectID: r.ProjectID, Embedding: r.Embedding, Limit: r.Limit}).normalized()
 	if err != nil {
+		return MemoryHybridSearchRequest{}, errors.New("invalid memory hybrid search request")
+	}
+	if r.GenerationID != "" && !validOpaqueID(r.GenerationID) {
 		return MemoryHybridSearchRequest{}, errors.New("invalid memory hybrid search request")
 	}
 	r.PrincipalID, r.ProjectID, r.Query, r.Embedding, r.Limit = lexical.PrincipalID, lexical.ProjectID, lexical.Query, semantic.Embedding, lexical.Limit
@@ -100,7 +148,7 @@ func (d *Database) SearchMemoryHybridCandidates(ctx context.Context, raw MemoryH
 	if err != nil {
 		return MemoryHybridSearchPage{}, err
 	}
-	semantic, semanticErr := searchMemorySemanticCandidatesInTx(searchCtx, tx, projectID, request.Embedding, memoryHybridCandidateLimit)
+	semantic, semanticErr := searchMemorySemanticCandidatesInTx(searchCtx, tx, projectID, request.Embedding, memoryHybridCandidateLimit, request.GenerationID)
 	status := MemoryHybridSearchSemanticReady
 	if errors.Is(semanticErr, ErrMemorySemanticNotConfigured) {
 		status = MemoryHybridSearchSemanticNotConfigured

--- a/internal/postgres/brain_hybrid.go
+++ b/internal/postgres/brain_hybrid.go
@@ -107,7 +107,7 @@ func (r MemoryHybridSearchRequest) normalized() (MemoryHybridSearchRequest, erro
 	if err != nil {
 		return MemoryHybridSearchRequest{}, errors.New("invalid memory hybrid search request")
 	}
-	if r.GenerationID != "" && !validOpaqueID(r.GenerationID) {
+	if !validOpaqueID(r.GenerationID) {
 		return MemoryHybridSearchRequest{}, errors.New("invalid memory hybrid search request")
 	}
 	r.PrincipalID, r.ProjectID, r.Query, r.Embedding, r.Limit = lexical.PrincipalID, lexical.ProjectID, lexical.Query, semantic.Embedding, lexical.Limit

--- a/internal/postgres/brain_hybrid_test.go
+++ b/internal/postgres/brain_hybrid_test.go
@@ -94,11 +94,12 @@ func TestMemoryHybridSearchTimeoutCoversBothStatements(t *testing.T) {
 
 func TestMemoryHybridSearchRequestValidation(t *testing.T) {
 	valid := MemoryHybridSearchRequest{
-		PrincipalID: "11111111-1111-4111-8111-111111111111",
-		ProjectID:   "22222222-2222-4222-8222-222222222222",
-		Query:       "release decision",
-		Embedding:   []float64{1, 0.5},
-		Limit:       2,
+		PrincipalID:  "11111111-1111-4111-8111-111111111111",
+		ProjectID:    "22222222-2222-4222-8222-222222222222",
+		GenerationID: "33333333-3333-4333-8333-333333333333",
+		Query:        "release decision",
+		Embedding:    []float64{1, 0.5},
+		Limit:        2,
 	}
 	if _, err := valid.normalized(); err != nil {
 		t.Fatalf("valid hybrid request rejected: %v", err)
@@ -106,5 +107,10 @@ func TestMemoryHybridSearchRequestValidation(t *testing.T) {
 	valid.Embedding = []float64{0, 0}
 	if _, err := valid.normalized(); err == nil {
 		t.Fatal("zero hybrid embedding accepted")
+	}
+	valid.Embedding = []float64{1, 0.5}
+	valid.GenerationID = ""
+	if _, err := valid.normalized(); err == nil {
+		t.Fatal("unfenced hybrid request accepted")
 	}
 }

--- a/internal/postgres/brain_semantic.go
+++ b/internal/postgres/brain_semantic.go
@@ -13,6 +13,10 @@ import (
 // is available. Callers can continue with lexical retrieval.
 var ErrMemorySemanticNotConfigured = errors.New("memory semantic retrieval is not configured")
 
+// ErrMemorySemanticGenerationChanged reports that a prepared provider vector
+// no longer matches the currently active embedding generation.
+var ErrMemorySemanticGenerationChanged = errors.New("memory semantic generation changed")
+
 // MemorySemanticSearchRequest is the bounded, provider-free input to exact
 // semantic candidate retrieval. A later hybrid layer supplies the query
 // embedding; this primitive never invokes a provider.
@@ -92,7 +96,7 @@ func (d *Database) SearchMemorySemanticCandidates(ctx context.Context, raw Memor
 	if _, err := tx.ExecContext(searchCtx, `SET LOCAL statement_timeout = '2s'`); err != nil {
 		return MemorySemanticSearchPage{}, errors.New("memory semantic search timeout cannot be installed")
 	}
-	page, err := searchMemorySemanticCandidatesInTx(searchCtx, tx, projectID, request.Embedding, request.Limit)
+	page, err := searchMemorySemanticCandidatesInTx(searchCtx, tx, projectID, request.Embedding, request.Limit, "")
 	if err != nil {
 		return MemorySemanticSearchPage{}, err
 	}
@@ -102,9 +106,12 @@ func (d *Database) SearchMemorySemanticCandidates(ctx context.Context, raw Memor
 	return page, nil
 }
 
-func searchMemorySemanticCandidatesInTx(ctx context.Context, tx *sql.Tx, projectID string, embedding []float64, limit int) (MemorySemanticSearchPage, error) {
+func searchMemorySemanticCandidatesInTx(ctx context.Context, tx *sql.Tx, projectID string, embedding []float64, limit int, expectedGenerationID string) (MemorySemanticSearchPage, error) {
 	var dimensions int
-	if err := tx.QueryRowContext(ctx, `SELECT dimensions FROM brain.embedding_generations WHERE state='active'`).Scan(&dimensions); errors.Is(err, sql.ErrNoRows) {
+	if err := tx.QueryRowContext(ctx, `SELECT dimensions FROM brain.embedding_generations WHERE state='active' AND ($1='' OR id::text=$1)`, expectedGenerationID).Scan(&dimensions); errors.Is(err, sql.ErrNoRows) {
+		if expectedGenerationID != "" {
+			return MemorySemanticSearchPage{}, ErrMemorySemanticGenerationChanged
+		}
 		return MemorySemanticSearchPage{}, ErrMemorySemanticNotConfigured
 	} else if err != nil || dimensions < 1 || dimensions > maxMemoryEmbeddingDimensions {
 		return MemorySemanticSearchPage{}, errors.New("memory semantic generation is unavailable")

--- a/internal/postgres/brain_semantic.go
+++ b/internal/postgres/brain_semantic.go
@@ -107,14 +107,15 @@ func (d *Database) SearchMemorySemanticCandidates(ctx context.Context, raw Memor
 }
 
 func searchMemorySemanticCandidatesInTx(ctx context.Context, tx *sql.Tx, projectID string, embedding []float64, limit int, expectedGenerationID string) (MemorySemanticSearchPage, error) {
+	var activeGenerationID string
 	var dimensions int
-	if err := tx.QueryRowContext(ctx, `SELECT dimensions FROM brain.embedding_generations WHERE state='active' AND ($1='' OR id::text=$1)`, expectedGenerationID).Scan(&dimensions); errors.Is(err, sql.ErrNoRows) {
-		if expectedGenerationID != "" {
-			return MemorySemanticSearchPage{}, ErrMemorySemanticGenerationChanged
-		}
+	if err := tx.QueryRowContext(ctx, `SELECT id::text,dimensions FROM brain.embedding_generations WHERE state='active'`).Scan(&activeGenerationID, &dimensions); errors.Is(err, sql.ErrNoRows) {
 		return MemorySemanticSearchPage{}, ErrMemorySemanticNotConfigured
 	} else if err != nil || dimensions < 1 || dimensions > maxMemoryEmbeddingDimensions {
 		return MemorySemanticSearchPage{}, errors.New("memory semantic generation is unavailable")
+	}
+	if expectedGenerationID != "" && activeGenerationID != expectedGenerationID {
+		return MemorySemanticSearchPage{}, ErrMemorySemanticGenerationChanged
 	}
 	if len(embedding) != dimensions {
 		return MemorySemanticSearchPage{}, errors.New("memory semantic embedding dimensions do not match the active generation")

--- a/internal/postgres/brain_semantic_integration_test.go
+++ b/internal/postgres/brain_semantic_integration_test.go
@@ -30,6 +30,9 @@ func testMemoryHybridDegradedIntegration(ctx context.Context, t *testing.T, app 
 	if err != nil || len(page.Results) != 1 || page.SemanticStatus != MemoryHybridSearchSemanticNotConfigured {
 		t.Fatalf("degraded hybrid candidates=%#v err=%v", page, err)
 	}
+	if _, err := app.PrepareMemoryHybridSearch(ctx, MemorySearchRequest{PrincipalID: actor.ID, ProjectID: projectID, Query: "hybrid", Limit: 1}); !errors.Is(err, ErrMemorySemanticNotConfigured) {
+		t.Fatalf("unconfigured hybrid preparation error=%v", err)
+	}
 }
 
 func testMemorySemanticCandidateIntegration(ctx context.Context, t *testing.T, app *Database, ownerDB *sql.DB) {
@@ -50,6 +53,10 @@ func testMemorySemanticCandidateIntegration(ctx context.Context, t *testing.T, a
 	}
 	if err := ownerDB.QueryRowContext(ctx, `SELECT id::text,dimensions FROM brain.embedding_generations WHERE state='active'`).Scan(&generationID, &dimensions); err != nil {
 		t.Fatal(err)
+	}
+	generation, err := app.PrepareMemoryHybridSearch(ctx, MemorySearchRequest{PrincipalID: actor.ID, ProjectID: projectID, Query: "semantic", Limit: 2})
+	if err != nil || generation.ID != generationID || generation.Dimensions != dimensions || generation.State != MemoryEmbeddingGenerationActive {
+		t.Fatalf("hybrid preparation=%#v err=%v", generation, err)
 	}
 	query := make([]float64, dimensions)
 	query[0] = 1
@@ -104,5 +111,8 @@ VALUES ($1,$2,$3,0,decode('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 	}
 	if _, err := app.SearchMemoryHybridCandidates(ctx, MemoryHybridSearchRequest{PrincipalID: outsider.ID, ProjectID: projectID, Query: "semantic", Embedding: query, Limit: 2}); !errors.Is(err, ErrNotFound) {
 		t.Fatalf("unauthorized hybrid candidates error=%v", err)
+	}
+	if _, err := app.PrepareMemoryHybridSearch(ctx, MemorySearchRequest{PrincipalID: outsider.ID, ProjectID: projectID, Query: "semantic", Limit: 2}); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("unauthorized hybrid preparation error=%v", err)
 	}
 }

--- a/internal/postgres/brain_semantic_integration_test.go
+++ b/internal/postgres/brain_semantic_integration_test.go
@@ -26,7 +26,7 @@ func testMemoryHybridDegradedIntegration(ctx context.Context, t *testing.T, app 
 	if _, err := app.CreateMemory(ctx, MemoryCreateRequest{PrincipalID: actor.ID, ProjectID: projectID, IdempotencyKey: "27272727-2727-4272-8272-272727272701", LogicalKey: "hybrid-degradation", Kind: "decision", Trust: "curated", Document: json.RawMessage(`{"title":"hybrid degradation lexical result"}`)}); err != nil {
 		t.Fatal(err)
 	}
-	page, err := app.SearchMemoryHybridCandidates(ctx, MemoryHybridSearchRequest{PrincipalID: actor.ID, ProjectID: projectID, Query: "hybrid", Embedding: []float64{1}, Limit: 1})
+	page, err := app.SearchMemoryHybridCandidates(ctx, MemoryHybridSearchRequest{PrincipalID: actor.ID, ProjectID: projectID, GenerationID: "11111111-1111-4111-8111-111111111111", Query: "hybrid", Embedding: []float64{1}, Limit: 1})
 	if err != nil || len(page.Results) != 1 || page.SemanticStatus != MemoryHybridSearchSemanticNotConfigured {
 		t.Fatalf("degraded hybrid candidates=%#v err=%v", page, err)
 	}
@@ -98,9 +98,12 @@ VALUES ($1,$2,$3,0,decode('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 	if err != nil || len(page.Results) != 2 || page.Results[0].ItemID != nearest.ItemID || page.Results[1].ItemID != farthest.ItemID || page.Results[0].Distance != 0 || page.Results[1].Distance <= page.Results[0].Distance {
 		t.Fatalf("semantic candidates=%#v err=%v", page, err)
 	}
-	hybrid, err := app.SearchMemoryHybridCandidates(ctx, MemoryHybridSearchRequest{PrincipalID: actor.ID, ProjectID: projectID, Query: "semantic", Embedding: query, Limit: 2})
+	hybrid, err := app.SearchMemoryHybridCandidates(ctx, MemoryHybridSearchRequest{PrincipalID: actor.ID, ProjectID: projectID, GenerationID: generation.ID, Query: "semantic", Embedding: query, Limit: 2})
 	if err != nil || len(hybrid.Results) != 2 || hybrid.Results[0].ItemID != nearest.ItemID || hybrid.Results[0].LexicalRank != 3 || hybrid.Results[0].SemanticRank != 1 || hybrid.Results[0].Score <= 0 {
 		t.Fatalf("hybrid candidates=%#v err=%v", hybrid, err)
+	}
+	if _, err := app.SearchMemoryHybridCandidates(ctx, MemoryHybridSearchRequest{PrincipalID: actor.ID, ProjectID: projectID, GenerationID: "33333333-3333-4333-8333-333333333333", Query: "semantic", Embedding: query, Limit: 2}); !errors.Is(err, ErrMemorySemanticGenerationChanged) {
+		t.Fatalf("stale hybrid generation error=%v", err)
 	}
 	outsider, err := app.CreatePrincipal(ctx, PrincipalKindDevice, "semantic candidate outsider")
 	if err != nil {
@@ -109,7 +112,7 @@ VALUES ($1,$2,$3,0,decode('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 	if _, err := app.SearchMemorySemanticCandidates(ctx, MemorySemanticSearchRequest{PrincipalID: outsider.ID, ProjectID: projectID, Embedding: query, Limit: 2}); !errors.Is(err, ErrNotFound) {
 		t.Fatalf("unauthorized semantic candidates error=%v", err)
 	}
-	if _, err := app.SearchMemoryHybridCandidates(ctx, MemoryHybridSearchRequest{PrincipalID: outsider.ID, ProjectID: projectID, Query: "semantic", Embedding: query, Limit: 2}); !errors.Is(err, ErrNotFound) {
+	if _, err := app.SearchMemoryHybridCandidates(ctx, MemoryHybridSearchRequest{PrincipalID: outsider.ID, ProjectID: projectID, GenerationID: generation.ID, Query: "semantic", Embedding: query, Limit: 2}); !errors.Is(err, ErrNotFound) {
 		t.Fatalf("unauthorized hybrid candidates error=%v", err)
 	}
 	if _, err := app.PrepareMemoryHybridSearch(ctx, MemorySearchRequest{PrincipalID: outsider.ID, ProjectID: projectID, Query: "semantic", Limit: 2}); !errors.Is(err, ErrNotFound) {


### PR DESCRIPTION
Adds the internal authorization and active-generation preparation boundary needed before a provider can embed a hybrid memory query. No route or provider credential is added.\n\nValidation: make test; make lint.