### PR TITLE
Add fenced hybrid query embedding

### DIFF
--- a/internal/postgres/brain_hybrid_provider.go
+++ b/internal/postgres/brain_hybrid_provider.go
@@ -1,0 +1,66 @@
+package postgres
+
+import (
+	"context"
+	"errors"
+)
+
+// MemoryHybridQueryEmbedding is a bounded provider result tied to the exact
+// generation authorized before the provider received the query.
+type MemoryHybridQueryEmbedding struct {
+	GenerationID string
+	Vector       []float64
+}
+
+// MemoryHybridQueryEmbeddingProvider derives one query vector for a prepared
+// active generation. Provider credentials and configuration stay outside this
+// provider-agnostic package.
+type MemoryHybridQueryEmbeddingProvider interface {
+	EmbedMemoryQuery(context.Context, MemoryEmbeddingGeneration, string) ([]float64, error)
+}
+
+type memoryHybridQueryStore interface {
+	PrepareMemoryHybridSearch(context.Context, MemorySearchRequest) (MemoryEmbeddingGeneration, error)
+}
+
+// MemoryHybridQueryExecutor authorizes before exposing a normalized query to a
+// provider and preserves the resulting generation fence for hybrid retrieval.
+type MemoryHybridQueryExecutor struct {
+	store    memoryHybridQueryStore
+	provider MemoryHybridQueryEmbeddingProvider
+}
+
+// NewMemoryHybridQueryExecutor constructs a provider-agnostic, authorization-
+// first query embedding executor.
+func NewMemoryHybridQueryExecutor(store memoryHybridQueryStore, provider MemoryHybridQueryEmbeddingProvider) (*MemoryHybridQueryExecutor, error) {
+	if store == nil || provider == nil {
+		return nil, errors.New("memory hybrid query executor is invalid")
+	}
+	return &MemoryHybridQueryExecutor{store: store, provider: provider}, nil
+}
+
+// Embed authorizes the query, derives a bounded vector for the returned active
+// generation, and returns that generation ID for fenced hybrid retrieval.
+func (e *MemoryHybridQueryExecutor) Embed(ctx context.Context, raw MemorySearchRequest) (MemoryHybridQueryEmbedding, error) {
+	request, err := raw.normalized()
+	if err != nil {
+		return MemoryHybridQueryEmbedding{}, err
+	}
+	generation, err := e.store.PrepareMemoryHybridSearch(ctx, request)
+	if err != nil {
+		return MemoryHybridQueryEmbedding{}, err
+	}
+	if generation.Validate() != nil || generation.State != MemoryEmbeddingGenerationActive {
+		return MemoryHybridQueryEmbedding{}, errors.New("memory hybrid generation is unavailable")
+	}
+	providerCtx, cancel := context.WithTimeout(ctx, memorySearchTimeout)
+	defer cancel()
+	vector, err := e.provider.EmbedMemoryQuery(providerCtx, generation, request.Query)
+	if err != nil {
+		return MemoryHybridQueryEmbedding{}, errors.New("memory query embedding is unavailable")
+	}
+	if !validMemoryEmbeddingVector(vector, generation.Dimensions) {
+		return MemoryHybridQueryEmbedding{}, errors.New("memory query embedding is invalid")
+	}
+	return MemoryHybridQueryEmbedding{GenerationID: generation.ID, Vector: append([]float64(nil), vector...)}, nil
+}

--- a/internal/postgres/brain_hybrid_provider.go
+++ b/internal/postgres/brain_hybrid_provider.go
@@ -59,8 +59,9 @@ func (e *MemoryHybridQueryExecutor) Embed(ctx context.Context, raw MemorySearchR
 	if err != nil {
 		return MemoryHybridQueryEmbedding{}, errors.New("memory query embedding is unavailable")
 	}
-	if !validMemoryEmbeddingVector(vector, generation.Dimensions) {
+	semantic, err := (MemorySemanticSearchRequest{PrincipalID: request.PrincipalID, ProjectID: request.ProjectID, Embedding: vector, Limit: request.Limit}).normalized()
+	if err != nil || len(semantic.Embedding) != generation.Dimensions {
 		return MemoryHybridQueryEmbedding{}, errors.New("memory query embedding is invalid")
 	}
-	return MemoryHybridQueryEmbedding{GenerationID: generation.ID, Vector: append([]float64(nil), vector...)}, nil
+	return MemoryHybridQueryEmbedding{GenerationID: generation.ID, Vector: semantic.Embedding}, nil
 }

--- a/internal/postgres/brain_hybrid_provider_test.go
+++ b/internal/postgres/brain_hybrid_provider_test.go
@@ -1,0 +1,72 @@
+package postgres
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+func TestMemoryHybridQueryExecutorPreparesBeforeProviderUse(t *testing.T) {
+	generation := MemoryEmbeddingGeneration{ID: "11111111-1111-4111-8111-111111111111", Model: "local.e5", Revision: "2026-07-27", Dimensions: 2, State: MemoryEmbeddingGenerationActive}
+	store := &fakeMemoryHybridQueryStore{generation: generation}
+	provider := &fakeMemoryHybridQueryProvider{vector: []float64{0.25, 0.75}}
+	executor, err := NewMemoryHybridQueryExecutor(store, provider)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := executor.Embed(context.Background(), MemorySearchRequest{PrincipalID: "22222222-2222-4222-8222-222222222222", ProjectID: "33333333-3333-4333-8333-333333333333", Query: "  release decision  ", Limit: 2})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if store.prepareCalls != 1 || provider.calls != 1 || provider.query != "release decision" || provider.generation != generation || got.GenerationID != generation.ID {
+		t.Fatalf("prepared=%d provider=%d query=%q generation=%#v result=%#v", store.prepareCalls, provider.calls, provider.query, provider.generation, got)
+	}
+}
+
+func TestMemoryHybridQueryExecutorRejectsProviderVectorOutsidePreparedGeneration(t *testing.T) {
+	generation := MemoryEmbeddingGeneration{ID: "11111111-1111-4111-8111-111111111111", Model: "local.e5", Revision: "2026-07-27", Dimensions: 2, State: MemoryEmbeddingGenerationActive}
+	provider := &fakeMemoryHybridQueryProvider{vector: []float64{1}}
+	executor, err := NewMemoryHybridQueryExecutor(&fakeMemoryHybridQueryStore{generation: generation}, provider)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := executor.Embed(context.Background(), MemorySearchRequest{PrincipalID: "22222222-2222-4222-8222-222222222222", ProjectID: "33333333-3333-4333-8333-333333333333", Query: "release", Limit: 1}); err == nil {
+		t.Fatal("dimension-mismatched provider vector accepted")
+	}
+}
+
+func TestMemoryHybridQueryExecutorDoesNotCallProviderWhenPreparationFails(t *testing.T) {
+	provider := &fakeMemoryHybridQueryProvider{vector: []float64{1}}
+	executor, err := NewMemoryHybridQueryExecutor(&fakeMemoryHybridQueryStore{err: ErrNotFound}, provider)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := executor.Embed(context.Background(), MemorySearchRequest{PrincipalID: "22222222-2222-4222-8222-222222222222", ProjectID: "33333333-3333-4333-8333-333333333333", Query: "release", Limit: 1}); !errors.Is(err, ErrNotFound) || provider.calls != 0 {
+		t.Fatalf("preparation error=%v provider calls=%d", err, provider.calls)
+	}
+}
+
+type fakeMemoryHybridQueryStore struct {
+	generation   MemoryEmbeddingGeneration
+	err          error
+	prepareCalls int
+}
+
+func (s *fakeMemoryHybridQueryStore) PrepareMemoryHybridSearch(_ context.Context, _ MemorySearchRequest) (MemoryEmbeddingGeneration, error) {
+	s.prepareCalls++
+	return s.generation, s.err
+}
+
+type fakeMemoryHybridQueryProvider struct {
+	generation MemoryEmbeddingGeneration
+	query      string
+	vector     []float64
+	err        error
+	calls      int
+}
+
+func (p *fakeMemoryHybridQueryProvider) EmbedMemoryQuery(_ context.Context, generation MemoryEmbeddingGeneration, query string) ([]float64, error) {
+	p.calls++
+	p.generation, p.query = generation, query
+	return p.vector, p.err
+}

--- a/internal/postgres/brain_hybrid_provider_test.go
+++ b/internal/postgres/brain_hybrid_provider_test.go
@@ -3,6 +3,7 @@ package postgres
 import (
 	"context"
 	"errors"
+	"math"
 	"testing"
 )
 
@@ -32,6 +33,21 @@ func TestMemoryHybridQueryExecutorRejectsProviderVectorOutsidePreparedGeneration
 	}
 	if _, err := executor.Embed(context.Background(), MemorySearchRequest{PrincipalID: "22222222-2222-4222-8222-222222222222", ProjectID: "33333333-3333-4333-8333-333333333333", Query: "release", Limit: 1}); err == nil {
 		t.Fatal("dimension-mismatched provider vector accepted")
+	}
+}
+
+func TestMemoryHybridQueryExecutorRejectsProviderVectorHybridWouldReject(t *testing.T) {
+	generation := MemoryEmbeddingGeneration{ID: "11111111-1111-4111-8111-111111111111", Model: "local.e5", Revision: "2026-07-27", Dimensions: 2, State: MemoryEmbeddingGenerationActive}
+	for name, vector := range map[string][]float64{"float32 overflow": {math.MaxFloat64, 1}, "float32 underflow": {math.SmallestNonzeroFloat64, 1}} {
+		t.Run(name, func(t *testing.T) {
+			executor, err := NewMemoryHybridQueryExecutor(&fakeMemoryHybridQueryStore{generation: generation}, &fakeMemoryHybridQueryProvider{vector: vector})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if _, err := executor.Embed(context.Background(), MemorySearchRequest{PrincipalID: "22222222-2222-4222-8222-222222222222", ProjectID: "33333333-3333-4333-8333-333333333333", Query: "release", Limit: 1}); err == nil {
+				t.Fatalf("provider vector accepted: %v", vector)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## What changed

Adds a provider-agnostic hybrid-query embedding executor.

It normalizes and authorizes a query before provider use, passes the active generation identity with that query, validates the provider vector against the generation dimensions, and returns the matching generation ID for the existing hybrid retrieval fence.

## Why

This is the next retrieval slice after PR #70's authorization and generation fence. It lets a later search surface safely obtain a provider vector without exposing a route or provider credentials here.

## Validation

- `make test`
- `make test-race`
- `make staticcheck`
- `make security`
- `make lint`
