### PR TITLE
Compose fenced hybrid query retrieval

### DIFF
--- a/internal/postgres/brain_hybrid.go
+++ b/internal/postgres/brain_hybrid.go
@@ -43,6 +43,49 @@ type MemoryHybridSearchPage struct {
 	SemanticStatus MemoryHybridSearchSemanticStatus `json:"semantic_status"`
 }
 
+// SearchMemoryHybridLexicalCandidates returns authorized lexical candidate
+// coordinates when semantic retrieval is unavailable. Like the hybrid path it
+// deliberately does not record recall usage; a presentation layer owns that.
+func (d *Database) SearchMemoryHybridLexicalCandidates(ctx context.Context, raw MemorySearchRequest) (MemoryHybridSearchPage, error) {
+	request, err := raw.normalized()
+	if err != nil {
+		return MemoryHybridSearchPage{}, err
+	}
+	searchCtx, cancel := context.WithTimeout(ctx, memorySearchTimeout)
+	defer cancel()
+	tx, err := d.brainPool().BeginTx(searchCtx, &sql.TxOptions{Isolation: sql.LevelRepeatableRead, ReadOnly: true})
+	if err != nil {
+		return MemoryHybridSearchPage{}, errors.New("memory hybrid lexical search transaction cannot start")
+	}
+	defer func() { _ = tx.Rollback() }()
+	projectID, err := resolveCanonicalActiveProject(searchCtx, tx, request.ProjectID)
+	if err != nil {
+		return MemoryHybridSearchPage{}, ErrNotFound
+	}
+	allowed, err := hasCapability(searchCtx, tx, request.PrincipalID, projectID, CapabilityMemorySearch)
+	if err != nil {
+		return MemoryHybridSearchPage{}, err
+	}
+	if !allowed {
+		return MemoryHybridSearchPage{}, ErrNotFound
+	}
+	if _, err := tx.ExecContext(searchCtx, `SET LOCAL statement_timeout = '2s'`); err != nil {
+		return MemoryHybridSearchPage{}, errors.New("memory hybrid lexical search timeout cannot be installed")
+	}
+	lexical, err := searchMemoryInTx(searchCtx, tx, projectID, request.Query, memoryHybridCandidateLimit, false, false)
+	if err != nil {
+		return MemoryHybridSearchPage{}, err
+	}
+	results, more, err := fuseMemorySearchRanks(lexical.Results, nil, request.Limit)
+	if err != nil {
+		return MemoryHybridSearchPage{}, errors.New("memory hybrid search candidates are unavailable")
+	}
+	if err := tx.Commit(); err != nil {
+		return MemoryHybridSearchPage{}, errors.New("memory hybrid lexical search transaction could not finish")
+	}
+	return MemoryHybridSearchPage{Results: results, More: lexical.More || more, SemanticStatus: MemoryHybridSearchSemanticNotConfigured}, nil
+}
+
 // PrepareMemoryHybridSearch authorizes one normalized query before a later
 // provider call and returns only the active generation's non-secret identity.
 // The caller must pass a vector for this exact generation to the subsequent

--- a/internal/postgres/brain_hybrid_provider.go
+++ b/internal/postgres/brain_hybrid_provider.go
@@ -5,8 +5,6 @@ import (
 	"errors"
 )
 
-const unconfiguredMemoryHybridGenerationID = "00000000-0000-4000-8000-000000000000"
-
 // MemoryHybridQueryEmbedding is a bounded provider result tied to the exact
 // generation authorized before the provider received the query.
 type MemoryHybridQueryEmbedding struct {
@@ -27,6 +25,7 @@ type memoryHybridQueryStore interface {
 
 type memoryHybridRetrievalStore interface {
 	memoryHybridQueryStore
+	SearchMemory(context.Context, MemorySearchRequest) (MemorySearchPage, error)
 	SearchMemoryHybridCandidates(context.Context, MemoryHybridSearchRequest) (MemoryHybridSearchPage, error)
 }
 
@@ -100,10 +99,15 @@ func (e *MemoryHybridRetrievalExecutor) Search(ctx context.Context, raw MemorySe
 	embedding, err := e.query.Embed(ctx, request)
 	if err != nil {
 		if errors.Is(err, ErrMemorySemanticNotConfigured) {
-			return e.retrieval.SearchMemoryHybridCandidates(ctx, MemoryHybridSearchRequest{
-				PrincipalID: request.PrincipalID, ProjectID: request.ProjectID, GenerationID: unconfiguredMemoryHybridGenerationID,
-				Query: request.Query, Embedding: []float64{1}, Limit: request.Limit,
-			})
+			lexical, lexicalErr := e.retrieval.SearchMemory(ctx, request)
+			if lexicalErr != nil {
+				return MemoryHybridSearchPage{}, lexicalErr
+			}
+			results, more, fuseErr := fuseMemorySearchRanks(lexical.Results, nil, request.Limit)
+			if fuseErr != nil {
+				return MemoryHybridSearchPage{}, errors.New("memory hybrid search candidates are unavailable")
+			}
+			return MemoryHybridSearchPage{Results: results, More: lexical.More || more, SemanticStatus: MemoryHybridSearchSemanticNotConfigured}, nil
 		}
 		return MemoryHybridSearchPage{}, err
 	}

--- a/internal/postgres/brain_hybrid_provider.go
+++ b/internal/postgres/brain_hybrid_provider.go
@@ -25,7 +25,7 @@ type memoryHybridQueryStore interface {
 
 type memoryHybridRetrievalStore interface {
 	memoryHybridQueryStore
-	SearchMemory(context.Context, MemorySearchRequest) (MemorySearchPage, error)
+	SearchMemoryHybridLexicalCandidates(context.Context, MemorySearchRequest) (MemoryHybridSearchPage, error)
 	SearchMemoryHybridCandidates(context.Context, MemoryHybridSearchRequest) (MemoryHybridSearchPage, error)
 }
 
@@ -99,15 +99,7 @@ func (e *MemoryHybridRetrievalExecutor) Search(ctx context.Context, raw MemorySe
 	embedding, err := e.query.Embed(ctx, request)
 	if err != nil {
 		if errors.Is(err, ErrMemorySemanticNotConfigured) {
-			lexical, lexicalErr := e.retrieval.SearchMemory(ctx, request)
-			if lexicalErr != nil {
-				return MemoryHybridSearchPage{}, lexicalErr
-			}
-			results, more, fuseErr := fuseMemorySearchRanks(lexical.Results, nil, request.Limit)
-			if fuseErr != nil {
-				return MemoryHybridSearchPage{}, errors.New("memory hybrid search candidates are unavailable")
-			}
-			return MemoryHybridSearchPage{Results: results, More: lexical.More || more, SemanticStatus: MemoryHybridSearchSemanticNotConfigured}, nil
+			return e.retrieval.SearchMemoryHybridLexicalCandidates(ctx, request)
 		}
 		return MemoryHybridSearchPage{}, err
 	}

--- a/internal/postgres/brain_hybrid_provider.go
+++ b/internal/postgres/brain_hybrid_provider.go
@@ -23,6 +23,11 @@ type memoryHybridQueryStore interface {
 	PrepareMemoryHybridSearch(context.Context, MemorySearchRequest) (MemoryEmbeddingGeneration, error)
 }
 
+type memoryHybridRetrievalStore interface {
+	memoryHybridQueryStore
+	SearchMemoryHybridCandidates(context.Context, MemoryHybridSearchRequest) (MemoryHybridSearchPage, error)
+}
+
 // MemoryHybridQueryExecutor authorizes before exposing a normalized query to a
 // provider and preserves the resulting generation fence for hybrid retrieval.
 type MemoryHybridQueryExecutor struct {
@@ -64,4 +69,38 @@ func (e *MemoryHybridQueryExecutor) Embed(ctx context.Context, raw MemorySearchR
 		return MemoryHybridQueryEmbedding{}, errors.New("memory query embedding is invalid")
 	}
 	return MemoryHybridQueryEmbedding{GenerationID: generation.ID, Vector: semantic.Embedding}, nil
+}
+
+// MemoryHybridRetrievalExecutor derives a fenced query vector and consumes it
+// immediately in the provider-free hybrid candidate boundary.
+type MemoryHybridRetrievalExecutor struct {
+	query     *MemoryHybridQueryExecutor
+	retrieval memoryHybridRetrievalStore
+}
+
+// NewMemoryHybridRetrievalExecutor constructs the complete internal
+// authorization, query-embedding, and hybrid-candidate sequence.
+func NewMemoryHybridRetrievalExecutor(store memoryHybridRetrievalStore, provider MemoryHybridQueryEmbeddingProvider) (*MemoryHybridRetrievalExecutor, error) {
+	query, err := NewMemoryHybridQueryExecutor(store, provider)
+	if err != nil {
+		return nil, err
+	}
+	return &MemoryHybridRetrievalExecutor{query: query, retrieval: store}, nil
+}
+
+// Search runs the fenced embedding sequence and retrieves hybrid candidate
+// coordinates. It neither configures a provider nor exposes a client route.
+func (e *MemoryHybridRetrievalExecutor) Search(ctx context.Context, raw MemorySearchRequest) (MemoryHybridSearchPage, error) {
+	request, err := raw.normalized()
+	if err != nil {
+		return MemoryHybridSearchPage{}, err
+	}
+	embedding, err := e.query.Embed(ctx, request)
+	if err != nil {
+		return MemoryHybridSearchPage{}, err
+	}
+	return e.retrieval.SearchMemoryHybridCandidates(ctx, MemoryHybridSearchRequest{
+		PrincipalID: request.PrincipalID, ProjectID: request.ProjectID, GenerationID: embedding.GenerationID,
+		Query: request.Query, Embedding: embedding.Vector, Limit: request.Limit,
+	})
 }

--- a/internal/postgres/brain_hybrid_provider.go
+++ b/internal/postgres/brain_hybrid_provider.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 )
 
+const unconfiguredMemoryHybridGenerationID = "00000000-0000-4000-8000-000000000000"
+
 // MemoryHybridQueryEmbedding is a bounded provider result tied to the exact
 // generation authorized before the provider received the query.
 type MemoryHybridQueryEmbedding struct {
@@ -97,6 +99,12 @@ func (e *MemoryHybridRetrievalExecutor) Search(ctx context.Context, raw MemorySe
 	}
 	embedding, err := e.query.Embed(ctx, request)
 	if err != nil {
+		if errors.Is(err, ErrMemorySemanticNotConfigured) {
+			return e.retrieval.SearchMemoryHybridCandidates(ctx, MemoryHybridSearchRequest{
+				PrincipalID: request.PrincipalID, ProjectID: request.ProjectID, GenerationID: unconfiguredMemoryHybridGenerationID,
+				Query: request.Query, Embedding: []float64{1}, Limit: request.Limit,
+			})
+		}
 		return MemoryHybridSearchPage{}, err
 	}
 	return e.retrieval.SearchMemoryHybridCandidates(ctx, MemoryHybridSearchRequest{

--- a/internal/postgres/brain_hybrid_provider_test.go
+++ b/internal/postgres/brain_hybrid_provider_test.go
@@ -62,6 +62,22 @@ func TestMemoryHybridQueryExecutorDoesNotCallProviderWhenPreparationFails(t *tes
 	}
 }
 
+func TestMemoryHybridRetrievalExecutorCarriesPreparedFenceIntoCandidates(t *testing.T) {
+	generation := MemoryEmbeddingGeneration{ID: "11111111-1111-4111-8111-111111111111", Model: "local.e5", Revision: "2026-07-27", Dimensions: 2, State: MemoryEmbeddingGenerationActive}
+	store := &fakeMemoryHybridRetrievalStore{fakeMemoryHybridQueryStore: fakeMemoryHybridQueryStore{generation: generation}, page: MemoryHybridSearchPage{SemanticStatus: MemoryHybridSearchSemanticReady}}
+	executor, err := NewMemoryHybridRetrievalExecutor(store, &fakeMemoryHybridQueryProvider{vector: []float64{0.25, 0.75}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	page, err := executor.Search(context.Background(), MemorySearchRequest{PrincipalID: "22222222-2222-4222-8222-222222222222", ProjectID: "33333333-3333-4333-8333-333333333333", Query: "  release  ", Limit: 2})
+	if err != nil || page.SemanticStatus != MemoryHybridSearchSemanticReady {
+		t.Fatalf("page=%#v err=%v", page, err)
+	}
+	if store.hybridCalls != 1 || store.request.GenerationID != generation.ID || store.request.Query != "release" || len(store.request.Embedding) != generation.Dimensions {
+		t.Fatalf("hybrid calls=%d request=%#v", store.hybridCalls, store.request)
+	}
+}
+
 type fakeMemoryHybridQueryStore struct {
 	generation   MemoryEmbeddingGeneration
 	err          error
@@ -79,6 +95,20 @@ type fakeMemoryHybridQueryProvider struct {
 	vector     []float64
 	err        error
 	calls      int
+}
+
+type fakeMemoryHybridRetrievalStore struct {
+	fakeMemoryHybridQueryStore
+	request     MemoryHybridSearchRequest
+	page        MemoryHybridSearchPage
+	err         error
+	hybridCalls int
+}
+
+func (s *fakeMemoryHybridRetrievalStore) SearchMemoryHybridCandidates(_ context.Context, request MemoryHybridSearchRequest) (MemoryHybridSearchPage, error) {
+	s.hybridCalls++
+	s.request = request
+	return s.page, s.err
 }
 
 func (p *fakeMemoryHybridQueryProvider) EmbedMemoryQuery(_ context.Context, generation MemoryEmbeddingGeneration, query string) ([]float64, error) {

--- a/internal/postgres/brain_hybrid_provider_test.go
+++ b/internal/postgres/brain_hybrid_provider_test.go
@@ -78,6 +78,19 @@ func TestMemoryHybridRetrievalExecutorCarriesPreparedFenceIntoCandidates(t *test
 	}
 }
 
+func TestMemoryHybridRetrievalExecutorDegradesWithoutConfiguredGeneration(t *testing.T) {
+	store := &fakeMemoryHybridRetrievalStore{fakeMemoryHybridQueryStore: fakeMemoryHybridQueryStore{err: ErrMemorySemanticNotConfigured}, page: MemoryHybridSearchPage{SemanticStatus: MemoryHybridSearchSemanticNotConfigured}}
+	provider := &fakeMemoryHybridQueryProvider{vector: []float64{0.25, 0.75}}
+	executor, err := NewMemoryHybridRetrievalExecutor(store, provider)
+	if err != nil {
+		t.Fatal(err)
+	}
+	page, err := executor.Search(context.Background(), MemorySearchRequest{PrincipalID: "22222222-2222-4222-8222-222222222222", ProjectID: "33333333-3333-4333-8333-333333333333", Query: "release", Limit: 2})
+	if err != nil || page.SemanticStatus != MemoryHybridSearchSemanticNotConfigured || provider.calls != 0 || store.hybridCalls != 1 {
+		t.Fatalf("page=%#v err=%v provider=%d hybrid=%d", page, err, provider.calls, store.hybridCalls)
+	}
+}
+
 type fakeMemoryHybridQueryStore struct {
 	generation   MemoryEmbeddingGeneration
 	err          error

--- a/internal/postgres/brain_hybrid_provider_test.go
+++ b/internal/postgres/brain_hybrid_provider_test.go
@@ -86,8 +86,8 @@ func TestMemoryHybridRetrievalExecutorDegradesWithoutConfiguredGeneration(t *tes
 		t.Fatal(err)
 	}
 	page, err := executor.Search(context.Background(), MemorySearchRequest{PrincipalID: "22222222-2222-4222-8222-222222222222", ProjectID: "33333333-3333-4333-8333-333333333333", Query: "release", Limit: 2})
-	if err != nil || page.SemanticStatus != MemoryHybridSearchSemanticNotConfigured || provider.calls != 0 || store.hybridCalls != 1 {
-		t.Fatalf("page=%#v err=%v provider=%d hybrid=%d", page, err, provider.calls, store.hybridCalls)
+	if err != nil || page.SemanticStatus != MemoryHybridSearchSemanticNotConfigured || provider.calls != 0 || store.hybridCalls != 0 || store.lexicalCalls != 1 {
+		t.Fatalf("page=%#v err=%v provider=%d hybrid=%d lexical=%d", page, err, provider.calls, store.hybridCalls, store.lexicalCalls)
 	}
 }
 
@@ -112,10 +112,18 @@ type fakeMemoryHybridQueryProvider struct {
 
 type fakeMemoryHybridRetrievalStore struct {
 	fakeMemoryHybridQueryStore
-	request     MemoryHybridSearchRequest
-	page        MemoryHybridSearchPage
-	err         error
-	hybridCalls int
+	request      MemoryHybridSearchRequest
+	lexical      MemorySearchPage
+	lexicalErr   error
+	lexicalCalls int
+	page         MemoryHybridSearchPage
+	err          error
+	hybridCalls  int
+}
+
+func (s *fakeMemoryHybridRetrievalStore) SearchMemory(_ context.Context, _ MemorySearchRequest) (MemorySearchPage, error) {
+	s.lexicalCalls++
+	return s.lexical, s.lexicalErr
 }
 
 func (s *fakeMemoryHybridRetrievalStore) SearchMemoryHybridCandidates(_ context.Context, request MemoryHybridSearchRequest) (MemoryHybridSearchPage, error) {

--- a/internal/postgres/brain_hybrid_provider_test.go
+++ b/internal/postgres/brain_hybrid_provider_test.go
@@ -79,7 +79,7 @@ func TestMemoryHybridRetrievalExecutorCarriesPreparedFenceIntoCandidates(t *test
 }
 
 func TestMemoryHybridRetrievalExecutorDegradesWithoutConfiguredGeneration(t *testing.T) {
-	store := &fakeMemoryHybridRetrievalStore{fakeMemoryHybridQueryStore: fakeMemoryHybridQueryStore{err: ErrMemorySemanticNotConfigured}, page: MemoryHybridSearchPage{SemanticStatus: MemoryHybridSearchSemanticNotConfigured}}
+	store := &fakeMemoryHybridRetrievalStore{fakeMemoryHybridQueryStore: fakeMemoryHybridQueryStore{err: ErrMemorySemanticNotConfigured}, lexical: MemoryHybridSearchPage{SemanticStatus: MemoryHybridSearchSemanticNotConfigured}}
 	provider := &fakeMemoryHybridQueryProvider{vector: []float64{0.25, 0.75}}
 	executor, err := NewMemoryHybridRetrievalExecutor(store, provider)
 	if err != nil {
@@ -113,7 +113,7 @@ type fakeMemoryHybridQueryProvider struct {
 type fakeMemoryHybridRetrievalStore struct {
 	fakeMemoryHybridQueryStore
 	request      MemoryHybridSearchRequest
-	lexical      MemorySearchPage
+	lexical      MemoryHybridSearchPage
 	lexicalErr   error
 	lexicalCalls int
 	page         MemoryHybridSearchPage
@@ -121,7 +121,7 @@ type fakeMemoryHybridRetrievalStore struct {
 	hybridCalls  int
 }
 
-func (s *fakeMemoryHybridRetrievalStore) SearchMemory(_ context.Context, _ MemorySearchRequest) (MemorySearchPage, error) {
+func (s *fakeMemoryHybridRetrievalStore) SearchMemoryHybridLexicalCandidates(_ context.Context, _ MemorySearchRequest) (MemoryHybridSearchPage, error) {
 	s.lexicalCalls++
 	return s.lexical, s.lexicalErr
 }


### PR DESCRIPTION
Composes the authorized query-embedding executor with hybrid candidate retrieval, preserving the prepared generation ID and normalized query across the provider boundary. No provider configuration or client route is added.\n\nValidated with make test, make test-race, make staticcheck, make security, and make lint.