### PR TITLE
Add hybrid ranking evaluation metrics

### DIFF
--- a/internal/postgres/brain_hybrid_evaluation.go
+++ b/internal/postgres/brain_hybrid_evaluation.go
@@ -30,10 +30,15 @@ func EvaluateMemoryHybridRanking(cases []MemoryHybridRankingEvaluationCase) (Mem
 		return MemoryHybridRankingEvaluation{}, errors.New("memory hybrid ranking evaluation is empty")
 	}
 	var evaluation MemoryHybridRankingEvaluation
+	seenCases := make(map[string]struct{}, len(cases))
 	for _, fixture := range cases {
 		if !validOpaqueID(fixture.ID) || len(fixture.Relevance) < 1 {
 			return MemoryHybridRankingEvaluation{}, errors.New("invalid memory hybrid ranking evaluation")
 		}
+		if _, duplicate := seenCases[fixture.ID]; duplicate {
+			return MemoryHybridRankingEvaluation{}, errors.New("invalid memory hybrid ranking evaluation")
+		}
+		seenCases[fixture.ID] = struct{}{}
 		ideal := make([]int, 0, len(fixture.Relevance))
 		for itemID, grade := range fixture.Relevance {
 			if !validOpaqueID(itemID) || grade < 1 || grade > 3 {

--- a/internal/postgres/brain_hybrid_evaluation.go
+++ b/internal/postgres/brain_hybrid_evaluation.go
@@ -61,7 +61,7 @@ func EvaluateMemoryHybridRanking(cases []MemoryHybridRankingEvaluationCase) (Mem
 			}
 		}
 		var idealGain float64
-		for index, grade := range ideal {
+		for index, grade := range ideal[:min(len(ideal), len(fixture.Results))] {
 			idealGain += (math.Pow(2, float64(grade)) - 1) / math.Log2(float64(index+2))
 		}
 		evaluation.Queries++

--- a/internal/postgres/brain_hybrid_evaluation.go
+++ b/internal/postgres/brain_hybrid_evaluation.go
@@ -74,7 +74,9 @@ func EvaluateMemoryHybridRanking(cases []MemoryHybridRankingEvaluationCase) (Mem
 			evaluation.HitsAtOne++
 		}
 		evaluation.MeanReciprocalRank += reciprocalRank
-		evaluation.NormalizedDiscountedCumulativeGain += discountedGain / idealGain
+		if idealGain > 0 {
+			evaluation.NormalizedDiscountedCumulativeGain += discountedGain / idealGain
+		}
 	}
 	evaluation.MeanReciprocalRank /= float64(evaluation.Queries)
 	evaluation.NormalizedDiscountedCumulativeGain /= float64(evaluation.Queries)

--- a/internal/postgres/brain_hybrid_evaluation.go
+++ b/internal/postgres/brain_hybrid_evaluation.go
@@ -1,0 +1,77 @@
+package postgres
+
+import (
+	"errors"
+	"math"
+	"sort"
+)
+
+// MemoryHybridRankingEvaluationCase is one content-free relevance judgment for
+// deterministic hybrid candidate ranking evaluation.
+type MemoryHybridRankingEvaluationCase struct {
+	ID        string
+	Results   []MemoryHybridSearchResult
+	Relevance map[string]int
+}
+
+// MemoryHybridRankingEvaluation aggregates rank-quality metrics across a
+// fixed corpus. It contains no query text, memory summaries, or provider data.
+type MemoryHybridRankingEvaluation struct {
+	Queries                            int     `json:"queries"`
+	HitsAtOne                          int     `json:"hits_at_one"`
+	MeanReciprocalRank                 float64 `json:"mean_reciprocal_rank"`
+	NormalizedDiscountedCumulativeGain float64 `json:"normalized_discounted_cumulative_gain"`
+}
+
+// EvaluateMemoryHybridRanking reports deterministic MRR, hit@1, and NDCG for
+// a relevance-judged hybrid candidate corpus.
+func EvaluateMemoryHybridRanking(cases []MemoryHybridRankingEvaluationCase) (MemoryHybridRankingEvaluation, error) {
+	if len(cases) < 1 {
+		return MemoryHybridRankingEvaluation{}, errors.New("memory hybrid ranking evaluation is empty")
+	}
+	var evaluation MemoryHybridRankingEvaluation
+	for _, fixture := range cases {
+		if !validOpaqueID(fixture.ID) || len(fixture.Relevance) < 1 {
+			return MemoryHybridRankingEvaluation{}, errors.New("invalid memory hybrid ranking evaluation")
+		}
+		ideal := make([]int, 0, len(fixture.Relevance))
+		for itemID, grade := range fixture.Relevance {
+			if !validOpaqueID(itemID) || grade < 1 || grade > 3 {
+				return MemoryHybridRankingEvaluation{}, errors.New("invalid memory hybrid ranking evaluation")
+			}
+			ideal = append(ideal, grade)
+		}
+		sort.Sort(sort.Reverse(sort.IntSlice(ideal)))
+		seen := make(map[string]struct{}, len(fixture.Results))
+		var reciprocalRank, discountedGain float64
+		for index, result := range fixture.Results {
+			if !validOpaqueID(result.ItemID) || result.Revision < 1 {
+				return MemoryHybridRankingEvaluation{}, errors.New("invalid memory hybrid ranking evaluation")
+			}
+			if _, duplicate := seen[result.ItemID]; duplicate {
+				return MemoryHybridRankingEvaluation{}, errors.New("invalid memory hybrid ranking evaluation")
+			}
+			seen[result.ItemID] = struct{}{}
+			grade := fixture.Relevance[result.ItemID]
+			if grade > 0 {
+				if reciprocalRank == 0 {
+					reciprocalRank = 1 / float64(index+1)
+				}
+				discountedGain += (math.Pow(2, float64(grade)) - 1) / math.Log2(float64(index+2))
+			}
+		}
+		var idealGain float64
+		for index, grade := range ideal {
+			idealGain += (math.Pow(2, float64(grade)) - 1) / math.Log2(float64(index+2))
+		}
+		evaluation.Queries++
+		if len(fixture.Results) > 0 && fixture.Relevance[fixture.Results[0].ItemID] > 0 {
+			evaluation.HitsAtOne++
+		}
+		evaluation.MeanReciprocalRank += reciprocalRank
+		evaluation.NormalizedDiscountedCumulativeGain += discountedGain / idealGain
+	}
+	evaluation.MeanReciprocalRank /= float64(evaluation.Queries)
+	evaluation.NormalizedDiscountedCumulativeGain /= float64(evaluation.Queries)
+	return evaluation, nil
+}

--- a/internal/postgres/brain_hybrid_evaluation_test.go
+++ b/internal/postgres/brain_hybrid_evaluation_test.go
@@ -1,0 +1,30 @@
+package postgres
+
+import (
+	"math"
+	"testing"
+)
+
+func TestEvaluateMemoryHybridRanking(t *testing.T) {
+	evaluation, err := EvaluateMemoryHybridRanking([]MemoryHybridRankingEvaluationCase{
+		{
+			ID: "11111111-1111-4111-8111-111111111111",
+			Results: []MemoryHybridSearchResult{
+				{ItemID: "22222222-2222-4222-8222-222222222222", Revision: 1},
+				{ItemID: "33333333-3333-4333-8333-333333333333", Revision: 1},
+			},
+			Relevance: map[string]int{"33333333-3333-4333-8333-333333333333": 2},
+		},
+		{
+			ID:        "44444444-4444-4444-8444-444444444444",
+			Results:   []MemoryHybridSearchResult{{ItemID: "55555555-5555-4555-8555-555555555555", Revision: 1}},
+			Relevance: map[string]int{"55555555-5555-4555-8555-555555555555": 1},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if evaluation.Queries != 2 || evaluation.HitsAtOne != 1 || math.Abs(evaluation.MeanReciprocalRank-0.75) > 1e-9 || math.Abs(evaluation.NormalizedDiscountedCumulativeGain-0.8154648768) > 1e-9 {
+		t.Fatalf("evaluation=%#v", evaluation)
+	}
+}

--- a/internal/postgres/brain_hybrid_evaluation_test.go
+++ b/internal/postgres/brain_hybrid_evaluation_test.go
@@ -28,3 +28,17 @@ func TestEvaluateMemoryHybridRanking(t *testing.T) {
 		t.Fatalf("evaluation=%#v", evaluation)
 	}
 }
+
+func TestEvaluateMemoryHybridRankingUsesResultCutoffForNDCG(t *testing.T) {
+	evaluation, err := EvaluateMemoryHybridRanking([]MemoryHybridRankingEvaluationCase{{
+		ID:      "66666666-6666-4666-8666-666666666666",
+		Results: []MemoryHybridSearchResult{{ItemID: "77777777-7777-4777-8777-777777777777", Revision: 1}},
+		Relevance: map[string]int{
+			"77777777-7777-4777-8777-777777777777": 3,
+			"88888888-8888-4888-8888-888888888888": 1,
+		},
+	}})
+	if err != nil || evaluation.NormalizedDiscountedCumulativeGain != 1 {
+		t.Fatalf("evaluation=%#v err=%v", evaluation, err)
+	}
+}

--- a/internal/postgres/brain_hybrid_evaluation_test.go
+++ b/internal/postgres/brain_hybrid_evaluation_test.go
@@ -49,3 +49,13 @@ func TestEvaluateMemoryHybridRankingRejectsDuplicateCaseIDs(t *testing.T) {
 		t.Fatal("duplicate evaluation case ID accepted")
 	}
 }
+
+func TestEvaluateMemoryHybridRankingScoresEmptyResultsAsZero(t *testing.T) {
+	evaluation, err := EvaluateMemoryHybridRanking([]MemoryHybridRankingEvaluationCase{{
+		ID:        "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+		Relevance: map[string]int{"cccccccc-cccc-4ccc-8ccc-cccccccccccc": 1},
+	}})
+	if err != nil || evaluation.NormalizedDiscountedCumulativeGain != 0 || math.IsNaN(evaluation.NormalizedDiscountedCumulativeGain) {
+		t.Fatalf("evaluation=%#v err=%v", evaluation, err)
+	}
+}

--- a/internal/postgres/brain_hybrid_evaluation_test.go
+++ b/internal/postgres/brain_hybrid_evaluation_test.go
@@ -42,3 +42,10 @@ func TestEvaluateMemoryHybridRankingUsesResultCutoffForNDCG(t *testing.T) {
 		t.Fatalf("evaluation=%#v err=%v", evaluation, err)
 	}
 }
+
+func TestEvaluateMemoryHybridRankingRejectsDuplicateCaseIDs(t *testing.T) {
+	fixture := MemoryHybridRankingEvaluationCase{ID: "99999999-9999-4999-8999-999999999999", Relevance: map[string]int{"aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa": 1}}
+	if _, err := EvaluateMemoryHybridRanking([]MemoryHybridRankingEvaluationCase{fixture, fixture}); err == nil {
+		t.Fatal("duplicate evaluation case ID accepted")
+	}
+}


### PR DESCRIPTION
Adds deterministic, content-free hybrid ranking evaluation metrics: hit@1, mean reciprocal rank, and normalized discounted cumulative gain. This provides a regression-gated Phase G retrieval-evaluation primitive without enabling a provider or public semantic route.\n\nValidated with make test, make test-race, make staticcheck, make security, and make lint.