### PR TITLE
Return hybrid summary surfaces

### DIFF
--- a/internal/postgres/brain_hybrid_provider.go
+++ b/internal/postgres/brain_hybrid_provider.go
@@ -25,8 +25,8 @@ type memoryHybridQueryStore interface {
 
 type memoryHybridRetrievalStore interface {
 	memoryHybridQueryStore
-	SearchMemoryHybridLexicalCandidates(context.Context, MemorySearchRequest) (MemoryHybridSearchPage, error)
-	SearchMemoryHybridCandidates(context.Context, MemoryHybridSearchRequest) (MemoryHybridSearchPage, error)
+	SearchMemoryHybridLexical(context.Context, MemorySearchRequest) (MemoryHybridSearchSurfacePage, error)
+	SearchMemoryHybrid(context.Context, MemoryHybridSearchRequest) (MemoryHybridSearchSurfacePage, error)
 }
 
 // MemoryHybridQueryExecutor authorizes before exposing a normalized query to a
@@ -73,14 +73,14 @@ func (e *MemoryHybridQueryExecutor) Embed(ctx context.Context, raw MemorySearchR
 }
 
 // MemoryHybridRetrievalExecutor derives a fenced query vector and consumes it
-// immediately in the provider-free hybrid candidate boundary.
+// immediately in the provider-free hybrid summary surface.
 type MemoryHybridRetrievalExecutor struct {
 	query     *MemoryHybridQueryExecutor
 	retrieval memoryHybridRetrievalStore
 }
 
 // NewMemoryHybridRetrievalExecutor constructs the complete internal
-// authorization, query-embedding, and hybrid-candidate sequence.
+// authorization, query-embedding, and hybrid summary sequence.
 func NewMemoryHybridRetrievalExecutor(store memoryHybridRetrievalStore, provider MemoryHybridQueryEmbeddingProvider) (*MemoryHybridRetrievalExecutor, error) {
 	query, err := NewMemoryHybridQueryExecutor(store, provider)
 	if err != nil {
@@ -89,21 +89,21 @@ func NewMemoryHybridRetrievalExecutor(store memoryHybridRetrievalStore, provider
 	return &MemoryHybridRetrievalExecutor{query: query, retrieval: store}, nil
 }
 
-// Search runs the fenced embedding sequence and retrieves hybrid candidate
-// coordinates. It neither configures a provider nor exposes a client route.
-func (e *MemoryHybridRetrievalExecutor) Search(ctx context.Context, raw MemorySearchRequest) (MemoryHybridSearchPage, error) {
+// Search runs the fenced embedding sequence and retrieves authorized hybrid
+// summaries. It neither configures a provider nor exposes a client route.
+func (e *MemoryHybridRetrievalExecutor) Search(ctx context.Context, raw MemorySearchRequest) (MemoryHybridSearchSurfacePage, error) {
 	request, err := raw.normalized()
 	if err != nil {
-		return MemoryHybridSearchPage{}, err
+		return MemoryHybridSearchSurfacePage{}, err
 	}
 	embedding, err := e.query.Embed(ctx, request)
 	if err != nil {
 		if errors.Is(err, ErrMemorySemanticNotConfigured) {
-			return e.retrieval.SearchMemoryHybridLexicalCandidates(ctx, request)
+			return e.retrieval.SearchMemoryHybridLexical(ctx, request)
 		}
-		return MemoryHybridSearchPage{}, err
+		return MemoryHybridSearchSurfacePage{}, err
 	}
-	return e.retrieval.SearchMemoryHybridCandidates(ctx, MemoryHybridSearchRequest{
+	return e.retrieval.SearchMemoryHybrid(ctx, MemoryHybridSearchRequest{
 		PrincipalID: request.PrincipalID, ProjectID: request.ProjectID, GenerationID: embedding.GenerationID,
 		Query: request.Query, Embedding: embedding.Vector, Limit: request.Limit,
 	})

--- a/internal/postgres/brain_hybrid_provider_test.go
+++ b/internal/postgres/brain_hybrid_provider_test.go
@@ -62,9 +62,9 @@ func TestMemoryHybridQueryExecutorDoesNotCallProviderWhenPreparationFails(t *tes
 	}
 }
 
-func TestMemoryHybridRetrievalExecutorCarriesPreparedFenceIntoCandidates(t *testing.T) {
+func TestMemoryHybridRetrievalExecutorCarriesPreparedFenceIntoSurface(t *testing.T) {
 	generation := MemoryEmbeddingGeneration{ID: "11111111-1111-4111-8111-111111111111", Model: "local.e5", Revision: "2026-07-27", Dimensions: 2, State: MemoryEmbeddingGenerationActive}
-	store := &fakeMemoryHybridRetrievalStore{fakeMemoryHybridQueryStore: fakeMemoryHybridQueryStore{generation: generation}, page: MemoryHybridSearchPage{SemanticStatus: MemoryHybridSearchSemanticReady}}
+	store := &fakeMemoryHybridRetrievalStore{fakeMemoryHybridQueryStore: fakeMemoryHybridQueryStore{generation: generation}, page: MemoryHybridSearchSurfacePage{SemanticStatus: MemoryHybridSearchSemanticReady}}
 	executor, err := NewMemoryHybridRetrievalExecutor(store, &fakeMemoryHybridQueryProvider{vector: []float64{0.25, 0.75}})
 	if err != nil {
 		t.Fatal(err)
@@ -79,7 +79,7 @@ func TestMemoryHybridRetrievalExecutorCarriesPreparedFenceIntoCandidates(t *test
 }
 
 func TestMemoryHybridRetrievalExecutorDegradesWithoutConfiguredGeneration(t *testing.T) {
-	store := &fakeMemoryHybridRetrievalStore{fakeMemoryHybridQueryStore: fakeMemoryHybridQueryStore{err: ErrMemorySemanticNotConfigured}, lexical: MemoryHybridSearchPage{SemanticStatus: MemoryHybridSearchSemanticNotConfigured}}
+	store := &fakeMemoryHybridRetrievalStore{fakeMemoryHybridQueryStore: fakeMemoryHybridQueryStore{err: ErrMemorySemanticNotConfigured}, lexical: MemoryHybridSearchSurfacePage{SemanticStatus: MemoryHybridSearchSemanticNotConfigured}}
 	provider := &fakeMemoryHybridQueryProvider{vector: []float64{0.25, 0.75}}
 	executor, err := NewMemoryHybridRetrievalExecutor(store, provider)
 	if err != nil {
@@ -113,20 +113,20 @@ type fakeMemoryHybridQueryProvider struct {
 type fakeMemoryHybridRetrievalStore struct {
 	fakeMemoryHybridQueryStore
 	request      MemoryHybridSearchRequest
-	lexical      MemoryHybridSearchPage
+	lexical      MemoryHybridSearchSurfacePage
 	lexicalErr   error
 	lexicalCalls int
-	page         MemoryHybridSearchPage
+	page         MemoryHybridSearchSurfacePage
 	err          error
 	hybridCalls  int
 }
 
-func (s *fakeMemoryHybridRetrievalStore) SearchMemoryHybridLexicalCandidates(_ context.Context, _ MemorySearchRequest) (MemoryHybridSearchPage, error) {
+func (s *fakeMemoryHybridRetrievalStore) SearchMemoryHybridLexical(_ context.Context, _ MemorySearchRequest) (MemoryHybridSearchSurfacePage, error) {
 	s.lexicalCalls++
 	return s.lexical, s.lexicalErr
 }
 
-func (s *fakeMemoryHybridRetrievalStore) SearchMemoryHybridCandidates(_ context.Context, request MemoryHybridSearchRequest) (MemoryHybridSearchPage, error) {
+func (s *fakeMemoryHybridRetrievalStore) SearchMemoryHybrid(_ context.Context, request MemoryHybridSearchRequest) (MemoryHybridSearchSurfacePage, error) {
 	s.hybridCalls++
 	s.request = request
 	return s.page, s.err


### PR DESCRIPTION
## Summary
- make the fenced query executor consume the authorized hybrid summary surface
- preserve lexical-only degradation when no active embedding generation exists
- retain provider-free surface and generation-fence boundaries

## Validation
- make test
- make test-race
- make staticcheck
- make security
- make lint