### PR TITLE
Add hybrid memory search route

### DIFF
--- a/internal/memoryhttp/handler.go
+++ b/internal/memoryhttp/handler.go
@@ -47,8 +47,15 @@ type store interface {
 	RejectMemoryProposal(context.Context, postgres.MemoryProposalDecisionRequest) (postgres.MemoryProposalResult, error)
 }
 
+// HybridSearcher returns bounded, authorization-filtered hybrid summaries for
+// one already device-authenticated memory search request.
+type HybridSearcher interface {
+	Search(context.Context, postgres.MemorySearchRequest) (postgres.MemoryHybridSearchSurfacePage, error)
+}
+
 type handler struct {
 	store   store
+	hybrid  HybridSearcher
 	policy  *ingress.Policy
 	mux     *http.ServeMux
 	slots   chan struct{}
@@ -58,17 +65,31 @@ type handler struct {
 // New constructs the native memory handler. The caller independently decides
 // whether the dark read surface and its mutation extension are mounted.
 func New(database store, policy *ingress.Policy, mutationsEnabled bool) http.Handler {
-	return newHandler(database, policy, maxConcurrentOperations, operationTimeout, mutationsEnabled)
+	return newHandlerWithHybrid(database, policy, maxConcurrentOperations, operationTimeout, mutationsEnabled, nil)
+}
+
+// NewWithHybridSearch additionally mounts the explicit hybrid-search route.
+// Callers supply the fenced executor; the default handler keeps lexical search
+// behavior unchanged and does not mount this optional surface.
+func NewWithHybridSearch(database store, policy *ingress.Policy, mutationsEnabled bool, hybrid HybridSearcher) http.Handler {
+	return newHandlerWithHybrid(database, policy, maxConcurrentOperations, operationTimeout, mutationsEnabled, hybrid)
 }
 
 func newHandler(database store, policy *ingress.Policy, concurrency int, timeout time.Duration, mutationsEnabled bool) http.Handler {
+	return newHandlerWithHybrid(database, policy, concurrency, timeout, mutationsEnabled, nil)
+}
+
+func newHandlerWithHybrid(database store, policy *ingress.Policy, concurrency int, timeout time.Duration, mutationsEnabled bool, hybrid HybridSearcher) http.Handler {
 	if concurrency < 1 {
 		concurrency = 1
 	}
-	h := &handler{store: database, policy: policy, mux: http.NewServeMux(), slots: make(chan struct{}, concurrency), timeout: timeout}
+	h := &handler{store: database, hybrid: hybrid, policy: policy, mux: http.NewServeMux(), slots: make(chan struct{}, concurrency), timeout: timeout}
 	h.mux.HandleFunc("POST /v1/projects/resolve", h.resolveProject)
 	h.mux.HandleFunc("GET /v1/projects/{project}/memories/{item}", h.getMemory)
 	h.mux.HandleFunc("POST /v1/projects/{project}/memories/search", h.searchMemory)
+	if hybrid != nil {
+		h.mux.HandleFunc("POST /v1/projects/{project}/memories/hybrid-search", h.searchHybridMemory)
+	}
 	h.mux.HandleFunc("POST /v1/projects/{project}/memories/brief", h.promptBrief)
 	h.mux.HandleFunc("POST /v1/projects/{project}/memories/changes", h.memoryChanges)
 	h.mux.HandleFunc("GET /v1/projects/{project}/memory-proposals/{proposal}", h.getProposal)
@@ -386,6 +407,29 @@ func (h *handler) searchMemory(response http.ResponseWriter, request *http.Reque
 		return
 	}
 	page, err := h.store.SearchMemory(request.Context(), postgres.MemorySearchRequest{PrincipalID: device.PrincipalID, ProjectID: projectID, Query: query, Limit: limit})
+	if err != nil {
+		writeStoreError(response, err)
+		return
+	}
+	writeJSON(response, http.StatusOK, page)
+}
+
+func (h *handler) searchHybridMemory(response http.ResponseWriter, request *http.Request) {
+	device, projectID, ok := deviceProject(response, request)
+	if !ok {
+		return
+	}
+	fields, ok := readObject(response, request, "query", "limit")
+	if !ok {
+		return
+	}
+	var query string
+	var limit int
+	if !decodeString(fields["query"], &query) || !decodeInt(fields["limit"], &limit) || !validQuery(query) || limit < 1 || limit > 50 {
+		writeError(response, http.StatusBadRequest, "request is invalid")
+		return
+	}
+	page, err := h.hybrid.Search(request.Context(), postgres.MemorySearchRequest{PrincipalID: device.PrincipalID, ProjectID: projectID, Query: query, Limit: limit})
 	if err != nil {
 		writeStoreError(response, err)
 		return

--- a/internal/memoryhttp/handler.go
+++ b/internal/memoryhttp/handler.go
@@ -28,6 +28,7 @@ const (
 	maxProposalBytes        = 1 << 20
 	maxConcurrentOperations = 32
 	operationTimeout        = 5 * time.Second
+	hybridOperationTimeout  = 12 * time.Second
 )
 
 type store interface {
@@ -297,7 +298,11 @@ func (h *handler) ServeHTTP(response http.ResponseWriter, request *http.Request)
 		unauthenticated(response)
 		return
 	}
-	operationCtx, cancel := context.WithTimeout(request.Context(), h.timeout)
+	timeout := h.timeout
+	if request.Method == http.MethodPost && strings.HasSuffix(request.URL.Path, "/memories/hybrid-search") {
+		timeout = hybridOperationTimeout
+	}
+	operationCtx, cancel := context.WithTimeout(request.Context(), timeout)
 	defer cancel()
 	device, err := h.store.AuthenticateDevice(operationCtx, credential)
 	if err != nil || !validID(device.PrincipalID) || !validID(device.LookupID) || device.Generation < 1 {

--- a/internal/memoryhttp/handler_test.go
+++ b/internal/memoryhttp/handler_test.go
@@ -231,11 +231,13 @@ func newTestHandler(store *fakeStore) http.Handler {
 }
 
 type fakeHybridSearcher struct {
-	request postgres.MemorySearchRequest
+	request  postgres.MemorySearchRequest
+	deadline time.Time
 }
 
-func (s *fakeHybridSearcher) Search(_ context.Context, request postgres.MemorySearchRequest) (postgres.MemoryHybridSearchSurfacePage, error) {
+func (s *fakeHybridSearcher) Search(ctx context.Context, request postgres.MemorySearchRequest) (postgres.MemoryHybridSearchSurfacePage, error) {
 	s.request = request
+	s.deadline, _ = ctx.Deadline()
 	return postgres.MemoryHybridSearchSurfacePage{Results: []postgres.MemoryHybridSearchSurfaceResult{{ItemID: testItemID, Revision: 2, ETag: `"memory:2"`, Kind: "decision", Trust: "curated", Layer: postgres.MemoryLayerCurated, Title: "Hybrid decision", Summary: "Bounded hybrid summary", LexicalRank: 1, SemanticRank: 2, Match: postgres.MemorySearchMatchLexical, Score: 0.03}}, SemanticStatus: postgres.MemoryHybridSearchSemanticReady}, nil
 }
 
@@ -534,6 +536,9 @@ func TestHybridSearchRouteUsesConfiguredFencedSearcher(t *testing.T) {
 	w := serve(t, handler, request(http.MethodPost, "/v1/projects/"+testProjectID+"/memories/hybrid-search", `{"query":"needle","limit":3}`), http.StatusOK)
 	if searcher.request.PrincipalID != testPrincipalID || searcher.request.ProjectID != testProjectID || searcher.request.Query != "needle" || searcher.request.Limit != 3 {
 		t.Fatalf("hybrid request=%#v", searcher.request)
+	}
+	if searcher.deadline.IsZero() || time.Until(searcher.deadline) < 10*time.Second {
+		t.Fatalf("hybrid deadline=%s", searcher.deadline)
 	}
 	var page postgres.MemoryHybridSearchSurfacePage
 	if err := json.Unmarshal(w.Body.Bytes(), &page); err != nil || len(page.Results) != 1 || page.Results[0].Title != "Hybrid decision" || page.Results[0].SemanticRank != 2 || page.SemanticStatus != postgres.MemoryHybridSearchSemanticReady || strings.Contains(w.Body.String(), "document") {

--- a/internal/memoryhttp/handler_test.go
+++ b/internal/memoryhttp/handler_test.go
@@ -230,6 +230,15 @@ func newTestHandler(store *fakeStore) http.Handler {
 	return New(store, policy, true)
 }
 
+type fakeHybridSearcher struct {
+	request postgres.MemorySearchRequest
+}
+
+func (s *fakeHybridSearcher) Search(_ context.Context, request postgres.MemorySearchRequest) (postgres.MemoryHybridSearchSurfacePage, error) {
+	s.request = request
+	return postgres.MemoryHybridSearchSurfacePage{Results: []postgres.MemoryHybridSearchSurfaceResult{{ItemID: testItemID, Revision: 2, ETag: `"memory:2"`, Kind: "decision", Trust: "curated", Layer: postgres.MemoryLayerCurated, Title: "Hybrid decision", Summary: "Bounded hybrid summary", LexicalRank: 1, SemanticRank: 2, Match: postgres.MemorySearchMatchLexical, Score: 0.03}}, SemanticStatus: postgres.MemoryHybridSearchSemanticReady}, nil
+}
+
 func request(method, path, body string) *http.Request {
 	r := httptest.NewRequestWithContext(context.Background(), method, "https://punaro.test"+path, strings.NewReader(body))
 	r.Header.Set("Authorization", "Bearer device-credential")
@@ -513,6 +522,22 @@ func TestHandlerBindsAuthenticatedPrincipalAcrossBoundedReadRoutes(t *testing.T)
 		if _, ok := proposal[field]; !ok {
 			t.Fatalf("proposal missing %s: %s", field, w.Body.String())
 		}
+	}
+}
+
+func TestHybridSearchRouteUsesConfiguredFencedSearcher(t *testing.T) {
+	store := newFakeStore()
+	searcher := &fakeHybridSearcher{}
+	policy := &ingress.Policy{Mode: ingress.LAN, ListenAddr: "127.0.0.1:8443", PublicURL: "https://punaro.test"}
+	handler := NewWithHybridSearch(store, policy, true, searcher)
+
+	w := serve(t, handler, request(http.MethodPost, "/v1/projects/"+testProjectID+"/memories/hybrid-search", `{"query":"needle","limit":3}`), http.StatusOK)
+	if searcher.request.PrincipalID != testPrincipalID || searcher.request.ProjectID != testProjectID || searcher.request.Query != "needle" || searcher.request.Limit != 3 {
+		t.Fatalf("hybrid request=%#v", searcher.request)
+	}
+	var page postgres.MemoryHybridSearchSurfacePage
+	if err := json.Unmarshal(w.Body.Bytes(), &page); err != nil || len(page.Results) != 1 || page.Results[0].Title != "Hybrid decision" || page.Results[0].SemanticRank != 2 || page.SemanticStatus != postgres.MemoryHybridSearchSemanticReady || strings.Contains(w.Body.String(), "document") {
+		t.Fatalf("hybrid projection=%#v err=%v body=%s", page, err, w.Body.String())
 	}
 }
 


### PR DESCRIPTION
## Summary
- add an opt-in explicit native hybrid-search route backed by the fenced executor
- preserve the existing lexical search route unchanged
- validate and bind device principal, project, query, and limit before invoking the hybrid surface

## Validation
- make test
- make test-race
- make staticcheck
- make security
- make lint