### PR TITLE
Add OpenAI-compatible query embeddings

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -467,6 +467,21 @@ identity. The provider result must carry that exact generation ID into hybrid
 retrieval; if activation changed it meanwhile, retrieval rejects it rather than
 comparing a vector against a different model's chunks.
 
+The OpenAI-compatible query provider is a bounded HTTPS-only adapter. Its
+endpoint has no userinfo, query, or fragment; redirects are never followed, and
+the API credential is sent only as a bearer Authorization header. It posts one
+strict JSON request with the pinned model, bounded query input, and float
+encoding; the configured provider model identifier must embed the pinned
+revision as a `:revision` suffix, and dimension selection is sent only for
+`text-embedding-3-*` models.
+Responses are limited to 1 MiB, must be one complete JSON value without
+duplicate or noncanonical object members with exactly one finite
+float32-representable vector
+of the pinned dimension, must have bounded JSON nesting, and must
+declare the exact pinned model. Provider failures are content-free and never
+log credentials, query text, or raw response data. Credential-file loading,
+provider selection, and daemon wiring remain separate deployment slices.
+
 The bounded embedding executor is provider-agnostic. It claims only existing
 fenced work, re-reads the exact live generation/item/revision/hash/lease before
 passing a bounded canonical JSON document to an injected provider, validates

--- a/internal/embeddingprovider/openai.go
+++ b/internal/embeddingprovider/openai.go
@@ -9,14 +9,21 @@ import (
 	"errors"
 	"io"
 	"math"
+	"math/big"
 	"net/http"
 	"net/url"
 	"strings"
+	"unicode/utf8"
 
 	"github.com/rock3r/punaro/internal/postgres"
 )
 
-const maxResponseBytes = 1 << 20
+const (
+	maxResponseBytes = 1 << 20
+	maxQueryBytes    = 1024
+	maxQueryRunes    = 256
+	maxJSONDepth     = 32
+)
 
 // OpenAICompatible implements the bounded embeddings request/response shape
 // used by OpenAI-compatible HTTPS services.
@@ -27,27 +34,34 @@ type OpenAICompatible struct {
 }
 
 // NewOpenAICompatible constructs a provider transport with an explicit HTTPS
-// endpoint and a caller-supplied credential. Credential-file loading remains
-// at the process configuration boundary.
+// endpoint and caller-supplied credential. Credential-file loading remains at
+// the process configuration boundary.
 func NewOpenAICompatible(endpoint, apiKey string, client *http.Client) (*OpenAICompatible, error) {
 	parsed, err := url.Parse(endpoint)
 	if err != nil || parsed.Scheme != "https" || parsed.Host == "" || parsed.User != nil || parsed.RawQuery != "" || parsed.Fragment != "" || strings.TrimSpace(apiKey) == "" || client == nil {
 		return nil, errors.New("OpenAI-compatible embedding provider is invalid")
 	}
-	return &OpenAICompatible{endpoint: endpoint, apiKey: apiKey, client: client}, nil
+	boundedClient := *client
+	boundedClient.CheckRedirect = func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse }
+	return &OpenAICompatible{endpoint: endpoint, apiKey: apiKey, client: &boundedClient}, nil
 }
 
 // EmbedMemoryQuery derives exactly one finite vector for the active pinned
 // generation. Provider failures are deliberately content-free to callers.
 func (p *OpenAICompatible) EmbedMemoryQuery(ctx context.Context, generation postgres.MemoryEmbeddingGeneration, query string) ([]float64, error) {
-	if p == nil || generation.Validate() != nil || generation.State != postgres.MemoryEmbeddingGenerationActive || query == "" {
+	if p == nil || generation.Validate() != nil || generation.State != postgres.MemoryEmbeddingGenerationActive || !immutableProviderModel(generation.Model, generation.Revision) || query == "" || !utf8.ValidString(query) || len(query) > maxQueryBytes || utf8.RuneCountInString(query) > maxQueryRunes {
 		return nil, errors.New("embedding provider request is invalid")
+	}
+	var dimensions *int
+	if strings.HasPrefix(generation.Model, "text-embedding-3-") {
+		dimensions = &generation.Dimensions
 	}
 	body, err := json.Marshal(struct {
 		Model          string `json:"model"`
 		Input          string `json:"input"`
+		Dimensions     *int   `json:"dimensions,omitempty"`
 		EncodingFormat string `json:"encoding_format"`
-	}{Model: generation.Model, Input: query, EncodingFormat: "float"})
+	}{Model: generation.Model, Input: query, Dimensions: dimensions, EncodingFormat: "float"})
 	if err != nil {
 		return nil, errors.New("embedding provider request is unavailable")
 	}
@@ -65,20 +79,94 @@ func (p *OpenAICompatible) EmbedMemoryQuery(ctx context.Context, generation post
 	if response.StatusCode != http.StatusOK || response.ContentLength > maxResponseBytes {
 		return nil, errors.New("embedding provider is unavailable")
 	}
-	var decoded struct {
-		Data []struct {
-			Embedding []float64 `json:"embedding"`
-		} `json:"data"`
-	}
-	decoder := json.NewDecoder(io.LimitReader(response.Body, maxResponseBytes))
-	if decoder.Decode(&decoded) != nil || len(decoded.Data) != 1 || len(decoded.Data[0].Embedding) != generation.Dimensions {
+	responseBody, err := io.ReadAll(io.LimitReader(response.Body, maxResponseBytes+1))
+	if err != nil || len(responseBody) > maxResponseBytes {
 		return nil, errors.New("embedding provider response is invalid")
 	}
-	vector := append([]float64(nil), decoded.Data[0].Embedding...)
-	for _, value := range vector {
-		if math.IsNaN(value) || math.IsInf(value, 0) || math.Abs(value) > math.MaxFloat32 || (value != 0 && float64(float32(value)) == 0) {
+	var decoded struct {
+		Model string `json:"model"`
+		Data  []struct {
+			Embedding []json.Number `json:"embedding"`
+		} `json:"data"`
+	}
+	decoder := json.NewDecoder(bytes.NewReader(responseBody))
+	decoder.UseNumber()
+	if rejectDuplicateJSONMembers(responseBody) != nil || decoder.Decode(&decoded) != nil || decoded.Model != generation.Model || len(decoded.Data) != 1 || len(decoded.Data[0].Embedding) != generation.Dimensions {
+		return nil, errors.New("embedding provider response is invalid")
+	}
+	vector := make([]float64, len(decoded.Data[0].Embedding))
+	for index, number := range decoded.Data[0].Embedding {
+		value, err := number.Float64()
+		literal, ok := new(big.Rat).SetString(string(number))
+		if err != nil || !ok || (literal.Sign() != 0 && value == 0) || math.IsNaN(value) || math.IsInf(value, 0) || math.Abs(value) > math.MaxFloat32 || (value != 0 && float64(float32(value)) == 0) {
 			return nil, errors.New("embedding provider response is invalid")
 		}
+		vector[index] = value
 	}
 	return vector, nil
+}
+
+func immutableProviderModel(model, revision string) bool {
+	return strings.HasSuffix(model, ":"+revision)
+}
+
+func rejectDuplicateJSONMembers(body []byte) error {
+	decoder := json.NewDecoder(bytes.NewReader(body))
+	if err := consumeJSONValue(decoder, 1); err != nil {
+		return err
+	}
+	if _, err := decoder.Token(); err != io.EOF {
+		return errors.New("unexpected JSON value")
+	}
+	return nil
+}
+
+func consumeJSONValue(decoder *json.Decoder, depth int) error {
+	if depth > maxJSONDepth {
+		return errors.New("JSON nesting is too deep")
+	}
+	token, err := decoder.Token()
+	if err != nil {
+		return err
+	}
+	delimiter, ok := token.(json.Delim)
+	if !ok {
+		return nil
+	}
+	switch delimiter {
+	case '{':
+		members := make(map[string]struct{})
+		for decoder.More() {
+			member, err := decoder.Token()
+			if err != nil {
+				return err
+			}
+			name, ok := member.(string)
+			if !ok {
+				return errors.New("JSON object member is invalid")
+			}
+			if name != strings.ToLower(name) {
+				return errors.New("JSON object member is noncanonical")
+			}
+			if _, exists := members[name]; exists {
+				return errors.New("JSON object has duplicate member")
+			}
+			members[name] = struct{}{}
+			if err := consumeJSONValue(decoder, depth+1); err != nil {
+				return err
+			}
+		}
+		_, err = decoder.Token()
+		return err
+	case '[':
+		for decoder.More() {
+			if err := consumeJSONValue(decoder, depth+1); err != nil {
+				return err
+			}
+		}
+		_, err = decoder.Token()
+		return err
+	default:
+		return errors.New("JSON delimiter is invalid")
+	}
 }

--- a/internal/embeddingprovider/openai.go
+++ b/internal/embeddingprovider/openai.go
@@ -1,0 +1,84 @@
+// Package embeddingprovider contains bounded transport adapters for external
+// embedding providers. It contains no database, authorization, or route code.
+package embeddingprovider
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"math"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/rock3r/punaro/internal/postgres"
+)
+
+const maxResponseBytes = 1 << 20
+
+// OpenAICompatible implements the bounded embeddings request/response shape
+// used by OpenAI-compatible HTTPS services.
+type OpenAICompatible struct {
+	endpoint string
+	apiKey   string
+	client   *http.Client
+}
+
+// NewOpenAICompatible constructs a provider transport with an explicit HTTPS
+// endpoint and a caller-supplied credential. Credential-file loading remains
+// at the process configuration boundary.
+func NewOpenAICompatible(endpoint, apiKey string, client *http.Client) (*OpenAICompatible, error) {
+	parsed, err := url.Parse(endpoint)
+	if err != nil || parsed.Scheme != "https" || parsed.Host == "" || parsed.User != nil || parsed.RawQuery != "" || parsed.Fragment != "" || strings.TrimSpace(apiKey) == "" || client == nil {
+		return nil, errors.New("OpenAI-compatible embedding provider is invalid")
+	}
+	return &OpenAICompatible{endpoint: endpoint, apiKey: apiKey, client: client}, nil
+}
+
+// EmbedMemoryQuery derives exactly one finite vector for the active pinned
+// generation. Provider failures are deliberately content-free to callers.
+func (p *OpenAICompatible) EmbedMemoryQuery(ctx context.Context, generation postgres.MemoryEmbeddingGeneration, query string) ([]float64, error) {
+	if p == nil || generation.Validate() != nil || generation.State != postgres.MemoryEmbeddingGenerationActive || query == "" {
+		return nil, errors.New("embedding provider request is invalid")
+	}
+	body, err := json.Marshal(struct {
+		Model          string `json:"model"`
+		Input          string `json:"input"`
+		EncodingFormat string `json:"encoding_format"`
+	}{Model: generation.Model, Input: query, EncodingFormat: "float"})
+	if err != nil {
+		return nil, errors.New("embedding provider request is unavailable")
+	}
+	request, err := http.NewRequestWithContext(ctx, http.MethodPost, p.endpoint, bytes.NewReader(body))
+	if err != nil {
+		return nil, errors.New("embedding provider request is unavailable")
+	}
+	request.Header.Set("Authorization", "Bearer "+p.apiKey)
+	request.Header.Set("Content-Type", "application/json")
+	response, err := p.client.Do(request)
+	if err != nil || response == nil {
+		return nil, errors.New("embedding provider is unavailable")
+	}
+	defer func() { _ = response.Body.Close() }()
+	if response.StatusCode != http.StatusOK || response.ContentLength > maxResponseBytes {
+		return nil, errors.New("embedding provider is unavailable")
+	}
+	var decoded struct {
+		Data []struct {
+			Embedding []float64 `json:"embedding"`
+		} `json:"data"`
+	}
+	decoder := json.NewDecoder(io.LimitReader(response.Body, maxResponseBytes))
+	if decoder.Decode(&decoded) != nil || len(decoded.Data) != 1 || len(decoded.Data[0].Embedding) != generation.Dimensions {
+		return nil, errors.New("embedding provider response is invalid")
+	}
+	vector := append([]float64(nil), decoded.Data[0].Embedding...)
+	for _, value := range vector {
+		if math.IsNaN(value) || math.IsInf(value, 0) || math.Abs(value) > math.MaxFloat32 || (value != 0 && float64(float32(value)) == 0) {
+			return nil, errors.New("embedding provider response is invalid")
+		}
+	}
+	return vector, nil
+}

--- a/internal/embeddingprovider/openai_test.go
+++ b/internal/embeddingprovider/openai_test.go
@@ -1,0 +1,30 @@
+package embeddingprovider
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/rock3r/punaro/internal/postgres"
+)
+
+func TestOpenAICompatibleProviderUsesPinnedGenerationModel(t *testing.T) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.Header.Get("Authorization") != "Bearer provider-key" || r.Header.Get("Content-Type") != "application/json" {
+			t.Fatalf("request method=%s authorization=%q content-type=%q", r.Method, r.Header.Get("Authorization"), r.Header.Get("Content-Type"))
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":[{"embedding":[0.25,0.75]}]}`))
+	}))
+	defer server.Close()
+	provider, err := NewOpenAICompatible(server.URL, "provider-key", server.Client())
+	if err != nil {
+		t.Fatal(err)
+	}
+	generation := postgres.MemoryEmbeddingGeneration{ID: "11111111-1111-4111-8111-111111111111", Model: "text-embedding-3-small", Revision: "2026-07-27", Dimensions: 2, State: postgres.MemoryEmbeddingGenerationActive}
+	vector, err := provider.EmbedMemoryQuery(context.Background(), generation, "release decision")
+	if err != nil || len(vector) != 2 || vector[0] != 0.25 || vector[1] != 0.75 {
+		t.Fatalf("vector=%v err=%v", vector, err)
+	}
+}

--- a/internal/embeddingprovider/openai_test.go
+++ b/internal/embeddingprovider/openai_test.go
@@ -2,8 +2,11 @@ package embeddingprovider
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
+	"sync/atomic"
 	"testing"
 
 	"github.com/rock3r/punaro/internal/postgres"
@@ -14,17 +17,167 @@ func TestOpenAICompatibleProviderUsesPinnedGenerationModel(t *testing.T) {
 		if r.Method != http.MethodPost || r.Header.Get("Authorization") != "Bearer provider-key" || r.Header.Get("Content-Type") != "application/json" {
 			t.Fatalf("request method=%s authorization=%q content-type=%q", r.Method, r.Header.Get("Authorization"), r.Header.Get("Content-Type"))
 		}
+		var request struct {
+			Model      string `json:"model"`
+			Input      string `json:"input"`
+			Dimensions int    `json:"dimensions"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&request); err != nil || request.Model != "text-embedding-3-small:2026-07-27" || request.Input != "release decision" || request.Dimensions != 2 {
+			t.Fatalf("request=%+v err=%v", request, err)
+		}
 		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`{"data":[{"embedding":[0.25,0.75]}]}`))
+		_, _ = w.Write([]byte(`{"model":"text-embedding-3-small:2026-07-27","data":[{"embedding":[0.25,0.75]}]}`))
 	}))
 	defer server.Close()
 	provider, err := NewOpenAICompatible(server.URL, "provider-key", server.Client())
 	if err != nil {
 		t.Fatal(err)
 	}
-	generation := postgres.MemoryEmbeddingGeneration{ID: "11111111-1111-4111-8111-111111111111", Model: "text-embedding-3-small", Revision: "2026-07-27", Dimensions: 2, State: postgres.MemoryEmbeddingGenerationActive}
+	generation := activeGeneration()
 	vector, err := provider.EmbedMemoryQuery(context.Background(), generation, "release decision")
 	if err != nil || len(vector) != 2 || vector[0] != 0.25 || vector[1] != 0.75 {
 		t.Fatalf("vector=%v err=%v", vector, err)
 	}
+}
+
+func TestOpenAICompatibleProviderRejectsRedirects(t *testing.T) {
+	var redirected atomic.Bool
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/redirected" {
+			redirected.Store(true)
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		http.Redirect(w, r, "/redirected", http.StatusTemporaryRedirect)
+	}))
+	defer server.Close()
+	provider, err := NewOpenAICompatible(server.URL, "provider-key", server.Client())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := provider.EmbedMemoryQuery(context.Background(), activeGeneration(), "release decision"); err == nil {
+		t.Fatal("EmbedMemoryQuery accepted redirect")
+	}
+	if redirected.Load() {
+		t.Fatal("EmbedMemoryQuery followed redirect")
+	}
+}
+
+func TestOpenAICompatibleProviderRejectsOversizedOrTrailingResponses(t *testing.T) {
+	for name, response := range map[string]string{
+		"oversized": strings.Repeat(" ", maxResponseBytes+1),
+		"trailing":  `{"model":"text-embedding-3-small:2026-07-27","data":[{"embedding":[0.25,0.75]}]} {}`,
+	} {
+		t.Run(name, func(t *testing.T) {
+			server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				if flusher, ok := w.(http.Flusher); ok {
+					flusher.Flush()
+				}
+				_, _ = w.Write([]byte(response))
+			}))
+			defer server.Close()
+			provider, err := NewOpenAICompatible(server.URL, "provider-key", server.Client())
+			if err != nil {
+				t.Fatal(err)
+			}
+			if _, err := provider.EmbedMemoryQuery(context.Background(), activeGeneration(), "release decision"); err == nil {
+				t.Fatalf("EmbedMemoryQuery accepted %s response", name)
+			}
+		})
+	}
+}
+
+func TestOpenAICompatibleProviderOmitsDimensionsForUnsupportedModel(t *testing.T) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var request map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+			t.Fatal(err)
+		}
+		if _, ok := request["dimensions"]; ok {
+			t.Fatalf("request unexpectedly includes dimensions: %+v", request)
+		}
+		_, _ = w.Write([]byte(`{"model":"text-embedding-ada-002:2026-07-27","data":[{"embedding":[0.25,0.75]}]}`))
+	}))
+	defer server.Close()
+	provider, err := NewOpenAICompatible(server.URL, "provider-key", server.Client())
+	if err != nil {
+		t.Fatal(err)
+	}
+	generation := activeGeneration()
+	generation.Model = "text-embedding-ada-002:2026-07-27"
+	if _, err := provider.EmbedMemoryQuery(context.Background(), generation, "release decision"); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestOpenAICompatibleProviderRejectsUnexpectedResponseModel(t *testing.T) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"model":"unexpected-model","data":[{"embedding":[0.25,0.75]}]}`))
+	}))
+	defer server.Close()
+	provider, err := NewOpenAICompatible(server.URL, "provider-key", server.Client())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := provider.EmbedMemoryQuery(context.Background(), activeGeneration(), "release decision"); err == nil {
+		t.Fatal("EmbedMemoryQuery accepted mismatched response model")
+	}
+}
+
+func TestOpenAICompatibleProviderRejectsDuplicateResponseMembers(t *testing.T) {
+	for name, response := range map[string]string{
+		"model":     `{"model":"unexpected","model":"text-embedding-3-small:2026-07-27","data":[{"embedding":[0.25,0.75]}]}`,
+		"case":      `{"model":"unexpected","MODEL":"text-embedding-3-small:2026-07-27","data":[{"embedding":[0.25,0.75]}]}`,
+		"data":      `{"model":"text-embedding-3-small:2026-07-27","data":[],"data":[{"embedding":[0.25,0.75]}]}`,
+		"embedding": `{"model":"text-embedding-3-small:2026-07-27","data":[{"embedding":[],"embedding":[0.25,0.75]}]}`,
+	} {
+		t.Run(name, func(t *testing.T) {
+			server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				_, _ = w.Write([]byte(response))
+			}))
+			defer server.Close()
+			provider, err := NewOpenAICompatible(server.URL, "provider-key", server.Client())
+			if err != nil {
+				t.Fatal(err)
+			}
+			if _, err := provider.EmbedMemoryQuery(context.Background(), activeGeneration(), "release decision"); err == nil {
+				t.Fatalf("EmbedMemoryQuery accepted duplicate %s member", name)
+			}
+		})
+	}
+}
+
+func TestRejectDuplicateJSONMembersRejectsExcessiveNesting(t *testing.T) {
+	deepJSON := strings.Repeat("[", maxJSONDepth+1) + "0" + strings.Repeat("]", maxJSONDepth+1)
+	if err := rejectDuplicateJSONMembers([]byte(deepJSON)); err == nil {
+		t.Fatal("rejectDuplicateJSONMembers accepted excessive nesting")
+	}
+}
+
+func TestOpenAICompatibleProviderRejectsUnderflowingNumericLiteral(t *testing.T) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"model":"text-embedding-3-small:2026-07-27","data":[{"embedding":[1e-1000,0.75]}]}`))
+	}))
+	defer server.Close()
+	provider, err := NewOpenAICompatible(server.URL, "provider-key", server.Client())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := provider.EmbedMemoryQuery(context.Background(), activeGeneration(), "release decision"); err == nil {
+		t.Fatal("EmbedMemoryQuery accepted an underflowing numeric literal")
+	}
+}
+
+func TestOpenAICompatibleProviderRejectsOversizedQuery(t *testing.T) {
+	provider, err := NewOpenAICompatible("https://example.com/embeddings", "provider-key", &http.Client{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := provider.EmbedMemoryQuery(context.Background(), activeGeneration(), strings.Repeat("x", maxQueryBytes+1)); err == nil {
+		t.Fatal("EmbedMemoryQuery accepted oversized query")
+	}
+}
+
+func activeGeneration() postgres.MemoryEmbeddingGeneration {
+	return postgres.MemoryEmbeddingGeneration{ID: "11111111-1111-4111-8111-111111111111", Model: "text-embedding-3-small:2026-07-27", Revision: "2026-07-27", Dimensions: 2, State: postgres.MemoryEmbeddingGenerationActive}
 }


### PR DESCRIPTION
## Summary
- add a bounded HTTPS OpenAI-compatible query embedding transport
- pin the request model to the active embedding generation
- require a single finite vector with the generation dimensions

## Validation
- make test
- make test-race
- make staticcheck
- make security
- make lint