### PR TITLE
Load protected embedding provider keys

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -482,6 +482,15 @@ declare the exact pinned model. Provider failures are content-free and never
 log credentials, query text, or raw response data. Credential-file loading,
 provider selection, and daemon wiring remain separate deployment slices.
 
+Provider API-key files use canonical absolute paths only. On Unix, every
+ancestor must be a non-symlinked directory owned by the daemon user or root
+and not writable by group or others; the key file itself must be a single-link,
+regular `0600`-or-stricter file owned by the daemon user and is opened with
+`O_NOFOLLOW` before its identity and permissions are rechecked. Keys are one
+bounded, non-empty header-safe line and are never included in diagnostics. On
+Windows, loading fails closed until equivalent ACL and reparse-point checks
+exist.
+
 The bounded embedding executor is provider-agnostic. It claims only existing
 fenced work, re-reads the exact live generation/item/revision/hash/lease before
 passing a bounded canonical JSON document to an injected provider, validates

--- a/internal/embeddingprovider/credential.go
+++ b/internal/embeddingprovider/credential.go
@@ -1,0 +1,47 @@
+package embeddingprovider
+
+import (
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+const maxAPIKeyFileBytes = 512
+
+// ReadAPIKeyFile loads one non-empty, owner-protected provider API key without
+// exposing its contents through errors.
+func ReadAPIKeyFile(path string) (string, error) {
+	if !filepath.IsAbs(path) || filepath.Clean(path) != path || !privateAPIKeyPath(path) {
+		return "", errors.New("provider API key file is unsafe")
+	}
+	info, err := os.Lstat(path)
+	if err != nil || !info.Mode().IsRegular() || !privateAPIKeyFile(info) {
+		return "", errors.New("provider API key file is unsafe")
+	}
+	file, err := openAPIKeyFile(path)
+	if err != nil {
+		return "", errors.New("provider API key file is unavailable")
+	}
+	defer func() { _ = file.Close() }()
+	opened, err := file.Stat()
+	if err != nil || !opened.Mode().IsRegular() || !privateAPIKeyFile(opened) || !os.SameFile(info, opened) {
+		return "", errors.New("provider API key file changed while opening")
+	}
+	raw, err := io.ReadAll(io.LimitReader(file, maxAPIKeyFileBytes+1))
+	key := strings.TrimSuffix(string(raw), "\n")
+	if err != nil || len(raw) == 0 || len(raw) > maxAPIKeyFileBytes || key == "" || invalidAPIKey(key) {
+		return "", errors.New("provider API key file is invalid")
+	}
+	return key, nil
+}
+
+func invalidAPIKey(key string) bool {
+	for _, value := range []byte(key) {
+		if value <= 0x20 || value == 0x7f {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/embeddingprovider/credential_file_unix.go
+++ b/internal/embeddingprovider/credential_file_unix.go
@@ -1,0 +1,48 @@
+//go:build !windows
+
+package embeddingprovider
+
+import (
+	"os"
+	"path/filepath"
+	"syscall"
+)
+
+func privateAPIKeyPath(path string) bool {
+	uid := os.Getuid()
+	if uid < 0 {
+		return false
+	}
+	currentUID := uint32(uid) // #nosec G115 -- nonnegative OS UID fits the platform field.
+	for directory := filepath.Dir(path); ; directory = filepath.Dir(directory) {
+		info, err := os.Lstat(directory)
+		if err != nil {
+			return false
+		}
+		if !trustedAPIKeyDirectory(info, currentUID) {
+			return false
+		}
+		if directory == filepath.Dir(directory) {
+			return true
+		}
+	}
+}
+
+func trustedAPIKeyDirectory(info os.FileInfo, currentUID uint32) bool {
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	return ok && info.IsDir() && info.Mode()&os.ModeSymlink == 0 && info.Mode().Perm()&0o022 == 0 && (stat.Uid == currentUID || stat.Uid == 0)
+}
+
+func privateAPIKeyFile(info os.FileInfo) bool {
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	uid := os.Getuid()
+	return ok && uid >= 0 && stat.Uid == uint32(uid) && stat.Nlink == 1 && info.Mode().Perm()&0o077 == 0 && info.Mode().Perm()&0o400 != 0 // #nosec G115 -- nonnegative OS UID fits the platform field.
+}
+
+func openAPIKeyFile(path string) (*os.File, error) {
+	descriptor, err := syscall.Open(path, syscall.O_RDONLY|syscall.O_CLOEXEC|syscall.O_NOFOLLOW, 0)
+	if err != nil {
+		return nil, err
+	}
+	return os.NewFile(uintptr(descriptor), path), nil // #nosec G115 -- successful syscall descriptors are nonnegative.
+}

--- a/internal/embeddingprovider/credential_file_windows.go
+++ b/internal/embeddingprovider/credential_file_windows.go
@@ -1,0 +1,18 @@
+//go:build windows
+
+package embeddingprovider
+
+import (
+	"errors"
+	"os"
+)
+
+// Windows ACL verification is not implemented yet, so provider credentials
+// fail closed rather than accepting an unverified file.
+func privateAPIKeyFile(os.FileInfo) bool { return false }
+
+func privateAPIKeyPath(string) bool { return false }
+
+func openAPIKeyFile(string) (*os.File, error) {
+	return nil, errors.New("protected provider credential loading is unavailable on Windows")
+}

--- a/internal/embeddingprovider/credential_test.go
+++ b/internal/embeddingprovider/credential_test.go
@@ -1,0 +1,235 @@
+//go:build !windows
+
+package embeddingprovider
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"testing"
+)
+
+func TestReadAPIKeyFileReadsOwnerOnlySingleLineKey(t *testing.T) {
+	directory := secureAPIKeyDir(t)
+	path := filepath.Join(directory, "provider-key")
+	if err := os.WriteFile(path, []byte("provider-key\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	key, err := ReadAPIKeyFile(path)
+	if err != nil || key != "provider-key" {
+		t.Fatalf("key=%q err=%v", key, err)
+	}
+	hardlink := filepath.Join(directory, "provider-key-copy")
+	if err := os.Link(path, hardlink); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ReadAPIKeyFile(path); err == nil {
+		t.Fatal("multiply linked provider key accepted")
+	}
+}
+
+func TestReadAPIKeyFileRejectsUnsafeInput(t *testing.T) {
+	root := secureAPIKeyDir(t)
+	unsafe := filepath.Join(root, "unsafe")
+	if err := os.WriteFile(unsafe, []byte("provider-key"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	// #nosec G302 -- deliberately relax permissions to verify rejection.
+	if err := os.Chmod(unsafe, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	canonical := filepath.Join(root, "canonical")
+	if err := os.WriteFile(canonical, []byte("provider-key"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	for name, path := range map[string]string{
+		"relative":    "provider-key",
+		"non-clean":   root + "/./canonical",
+		"unsafe mode": unsafe,
+		"missing":     filepath.Join(root, "missing"),
+	} {
+		t.Run(name, func(t *testing.T) {
+			if _, err := ReadAPIKeyFile(path); err == nil {
+				t.Fatal("ReadAPIKeyFile accepted unsafe input")
+			}
+		})
+	}
+}
+
+func TestPrivateAPIKeyFileRejectsPermissionsRelaxedAfterOpen(t *testing.T) {
+	path := filepath.Join(secureAPIKeyDir(t), "provider-key")
+	if err := os.WriteFile(path, []byte("provider-key"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	// #nosec G304 -- this controlled temporary path models a file changed after open.
+	file, err := os.Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = file.Close() }()
+	// #nosec G302 -- deliberately relax permissions to verify post-open validation.
+	if err := os.Chmod(path, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	info, err := file.Stat()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if privateAPIKeyFile(info) {
+		t.Fatal("privateAPIKeyFile accepted relaxed permissions after open")
+	}
+}
+
+func TestReadAPIKeyFileRejectsWritableParent(t *testing.T) {
+	directory := secureAPIKeyDir(t)
+	path := filepath.Join(directory, "provider-key")
+	if err := os.WriteFile(path, []byte("provider-key"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	// #nosec G302 -- deliberately unsafe parent verifies rejection.
+	if err := os.Chmod(directory, 0o770); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ReadAPIKeyFile(path); err == nil {
+		t.Fatal("provider key beneath writable directory accepted")
+	}
+}
+
+func TestReadAPIKeyFileRejectsInvalidContents(t *testing.T) {
+	directory := secureAPIKeyDir(t)
+	path := filepath.Join(directory, "provider-key")
+	for name, value := range map[string]string{
+		"empty":      "",
+		"whitespace": "two words",
+		"multiline":  "first\nsecond",
+		"nul":        "provider\x00key",
+		"delete":     "provider\x7fkey",
+		"oversized":  strings.Repeat("a", maxAPIKeyFileBytes+1),
+	} {
+		t.Run(name, func(t *testing.T) {
+			if err := os.WriteFile(path, []byte(value), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			if _, err := ReadAPIKeyFile(path); err == nil {
+				t.Fatalf("ReadAPIKeyFile accepted invalid %s key", name)
+			}
+		})
+	}
+}
+
+func TestReadAPIKeyFileRejectsSymlinkedParent(t *testing.T) {
+	directory := secureAPIKeyDir(t)
+	target := filepath.Join(directory, "target")
+	if err := os.Mkdir(target, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(target, "provider-key")
+	if err := os.WriteFile(path, []byte("provider-key"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	linkedParent := filepath.Join(directory, "linked-parent")
+	if err := os.Symlink(target, linkedParent); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ReadAPIKeyFile(filepath.Join(linkedParent, "provider-key")); err == nil {
+		t.Fatal("provider key below symlinked parent accepted")
+	}
+}
+
+func TestReadAPIKeyFileRejectsSymlinkedFile(t *testing.T) {
+	directory := secureAPIKeyDir(t)
+	target := filepath.Join(directory, "provider-key-target")
+	if err := os.WriteFile(target, []byte("provider-key"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(directory, "provider-key")
+	if err := os.Symlink(target, path); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ReadAPIKeyFile(path); err == nil {
+		t.Fatal("symlinked provider key accepted")
+	}
+}
+
+func TestPrivateAPIKeyFileRejectsForeignOwner(t *testing.T) {
+	path := filepath.Join(secureAPIKeyDir(t), "provider-key")
+	if err := os.WriteFile(path, []byte("provider-key"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		t.Fatal("provider key metadata did not contain syscall.Stat_t")
+	}
+	foreign := *stat
+	foreign.Uid++
+	if !privateAPIKeyFile(apiKeyFileInfo{FileInfo: info, sys: &foreign}) {
+		return
+	}
+	t.Fatal("provider key with foreign owner accepted")
+}
+
+func TestTrustedAPIKeyDirectoryRejectsForeignOwner(t *testing.T) {
+	directory := secureAPIKeyDir(t)
+	info, err := os.Stat(directory)
+	if err != nil {
+		t.Fatal(err)
+	}
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		t.Fatal("provider key directory metadata did not contain syscall.Stat_t")
+	}
+	foreign := *stat
+	foreign.Uid++
+	uid := os.Getuid()
+	if uid < 0 {
+		t.Fatal("current UID is negative")
+	}
+	currentUID := uint32(uid) // #nosec G115 -- nonnegative OS UID fits the platform field.
+	if trustedAPIKeyDirectory(apiKeyFileInfo{FileInfo: info, sys: &foreign}, currentUID) {
+		t.Fatal("foreign-owned provider key directory accepted")
+	}
+}
+
+func secureAPIKeyDir(t *testing.T) string {
+	t.Helper()
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Fatal(err)
+	}
+	directory, err := os.MkdirTemp(home, ".embeddingprovider-key-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := os.RemoveAll(directory); err != nil {
+			t.Errorf("remove temporary API key directory: %v", err)
+		}
+	})
+	directory, err = filepath.Abs(directory)
+	if err != nil {
+		t.Fatal(err)
+	}
+	directory, err = filepath.EvalSymlinks(directory)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(directory, 0o700); err != nil { // #nosec G302 -- test directory must be owner-only.
+		t.Fatal(err)
+	}
+	if !privateAPIKeyPath(filepath.Join(directory, "provider-key")) {
+		t.Fatal("temporary API key directory has unsafe ancestry")
+	}
+	return directory
+}
+
+type apiKeyFileInfo struct {
+	os.FileInfo
+	sys any
+}
+
+func (info apiKeyFileInfo) Sys() any { return info.sys }

--- a/internal/embeddingprovider/credential_windows_test.go
+++ b/internal/embeddingprovider/credential_windows_test.go
@@ -1,0 +1,19 @@
+//go:build windows
+
+package embeddingprovider
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestReadAPIKeyFileFailsClosedOnWindows(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "provider-key")
+	if err := os.WriteFile(path, []byte("provider-key"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ReadAPIKeyFile(path); err == nil {
+		t.Fatal("provider key loading unexpectedly succeeded on Windows")
+	}
+}


### PR DESCRIPTION
Adds a bounded, race-aware API-key file loader for the OpenAI-compatible embedding transport.

It requires an absolute owner-only regular file, rechecks identity after open, bounds the read, and returns content-free errors. Provider construction and the public hybrid route remain separate slices.

Validation: make test, make test-race, make staticcheck, make security, make lint.