### PR TITLE
Validate embedding provider credentials at startup

### DIFF
--- a/cmd/punarod/main.go
+++ b/cmd/punarod/main.go
@@ -22,6 +22,7 @@ import (
 	"github.com/rock3r/punaro/internal/access"
 	"github.com/rock3r/punaro/internal/config"
 	"github.com/rock3r/punaro/internal/devicehttp"
+	"github.com/rock3r/punaro/internal/embeddingprovider"
 	"github.com/rock3r/punaro/internal/ingress"
 	"github.com/rock3r/punaro/internal/memoryhttp"
 	punaropostgres "github.com/rock3r/punaro/internal/postgres"
@@ -128,6 +129,8 @@ var openPlatformDatabase = func(ctx context.Context, cfg punaropostgres.Config) 
 }
 
 var listenTCP = net.Listen
+
+var readEmbeddingAPIKey = embeddingprovider.ReadAPIKeyFile
 
 func main() {
 	os.Exit(run(os.Args[1:], os.Stderr))
@@ -291,6 +294,9 @@ func registerProductionRoutes(mux *http.ServeMux, memoryHandler http.Handler, tr
 }
 
 func buildMemoryHandler(cfg config.Config, platformDB platformDatabase) (http.Handler, error) {
+	if err := validateEmbeddingProvider(cfg); err != nil {
+		return nil, err
+	}
 	if !cfg.MemoryAPIEnabled {
 		return nil, nil
 	}
@@ -308,6 +314,20 @@ func buildMemoryHandler(cfg config.Config, platformDB platformDatabase) (http.Ha
 		return nil, errors.New("memory credential transport policy is invalid")
 	}
 	return memoryhttp.New(database, policy, cfg.MemoryMutationsEnabled), nil
+}
+
+func validateEmbeddingProvider(cfg config.Config) error {
+	if cfg.MemoryOpenAIEmbeddingsURL == "" {
+		return nil
+	}
+	key, err := readEmbeddingAPIKey(cfg.MemoryOpenAIAPIKeyFile)
+	if err != nil {
+		return errors.New("memory embedding provider credential is unavailable")
+	}
+	if _, err := embeddingprovider.NewOpenAICompatible(cfg.MemoryOpenAIEmbeddingsURL, key, &http.Client{}); err != nil {
+		return errors.New("memory embedding provider is unavailable")
+	}
+	return nil
 }
 
 func buildTrustedAttachmentHandler(cfg config.Config, platformDB platformDatabase) (*trustedAttachmentRuntime, error) {

--- a/cmd/punarod/main_test.go
+++ b/cmd/punarod/main_test.go
@@ -72,16 +72,27 @@ func TestBuildMemoryHandlerIsDarkByDefaultAndRequiresCompleteAuthority(t *testin
 	}
 }
 
+func TestBuildMemoryHandlerFailsClosedWhenConfiguredProviderCredentialCannotLoad(t *testing.T) {
+	original := readEmbeddingAPIKey
+	t.Cleanup(func() { readEmbeddingAPIKey = original })
+	readEmbeddingAPIKey = func(string) (string, error) { return "", errors.New("unsafe") }
+	_, err := buildMemoryHandler(config.Config{MemoryOpenAIEmbeddingsURL: "https://embeddings.example/v1/embeddings", MemoryOpenAIAPIKeyFile: "/run/secrets/provider-key"}, &refusingPlatformDatabase{})
+	if err == nil || !strings.Contains(err.Error(), "provider credential") {
+		t.Fatalf("error=%v", err)
+	}
+}
+
 type unavailableMemoryDatabase struct {
 	deviceDatabase
 	readyCalled bool
+	readyErr    error
 }
 
 func (*unavailableMemoryDatabase) Ready(context.Context) error { return nil }
 func (*unavailableMemoryDatabase) Close() error                { return nil }
 func (database *unavailableMemoryDatabase) CanonicalBrainRuntimeReady(context.Context) error {
 	database.readyCalled = true
-	return errors.New("schema 14 is unavailable")
+	return database.readyErr
 }
 func (*unavailableMemoryDatabase) ResolveProjectIdentity(context.Context, string, punaropostgres.ProjectIdentityKind, string) (punaropostgres.ProjectIdentityResolution, error) {
 	return punaropostgres.ProjectIdentityResolution{}, errors.New("unused")
@@ -124,7 +135,7 @@ func (*unavailableMemoryDatabase) RejectMemoryProposal(context.Context, punaropo
 }
 
 func TestBuildMemoryHandlerRejectsCompatibleHistoricalSchema(t *testing.T) {
-	database := &unavailableMemoryDatabase{}
+	database := &unavailableMemoryDatabase{readyErr: errors.New("schema 14 is unavailable")}
 	_, err := buildMemoryHandler(config.Config{MemoryAPIEnabled: true, IngressMode: "internet", ListenAddr: "127.0.0.1:8080", PublicURL: "https://punaro.example"}, database)
 	if err == nil || !database.readyCalled || !strings.Contains(err.Error(), "schema is unavailable") {
 		t.Fatalf("ready=%t error=%v", database.readyCalled, err)


### PR DESCRIPTION
Milestone: Big Brain provider activation boundary.\n\nLoads the configured provider API key through the protected credential loader before exposing the memory handler, and validates the bounded OpenAI-compatible transport configuration.\n\nExcludes the authenticated hybrid search route; that remains a separate vertical slice.\n\nValidation: make test, make test-race, make staticcheck, make security, make lint.