### PR TITLE
Expose authenticated hybrid memory search

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -504,8 +504,23 @@ the active quarantine, so release makes its work claimable again. Stale source
 or publication leases are no-ops; source,
 provider, and publication outages become bounded code-only retries, and a
 failed retry write is surfaced to the executor caller. Provider selection,
-credentials, network configuration, and any public semantic route remain
-separate deployment and API slices.
+credentials, and network configuration remain separate deployment slices.
+
+The optional native hybrid-search surface is mounted only when the dark memory
+API is enabled and daemon startup has successfully constructed the bounded
+OpenAI-compatible query provider and hybrid retrieval executor. It is a
+device-authenticated `POST /v1/projects/{project}/memories/hybrid-search`
+route with the same strict `query` and 1--50 `limit` bounds as lexical search.
+Authentication and project `memory.search` authorization occur before any
+provider invocation; denied, missing, and revoked credentials therefore never
+send a query to the provider. Its 15-second end-to-end request budget covers
+the independently bounded preparation, embedding, and retrieval phases. The
+response is the existing bounded title/summary hybrid surface and reports a
+semantic status: retrieval remains available with lexical-only
+`not_configured` degradation when no active generation exists. If the provider
+endpoint is not configured, the route is unmounted; invalid provider
+configuration prevents daemon startup rather than accepting a request or
+exposing provider configuration.
 
 Schema version 15 places one deterministic secret guard inside the authorized
 create/update transaction before any scope, revision, change, audit,

--- a/cmd/punarod/main.go
+++ b/cmd/punarod/main.go
@@ -72,6 +72,9 @@ type memoryDatabase interface {
 	ProposeMemory(context.Context, punaropostgres.MemoryProposalCreateRequest) (punaropostgres.MemoryProposalResult, error)
 	ApproveMemoryProposal(context.Context, punaropostgres.MemoryProposalDecisionRequest) (punaropostgres.MemoryProposalResult, error)
 	RejectMemoryProposal(context.Context, punaropostgres.MemoryProposalDecisionRequest) (punaropostgres.MemoryProposalResult, error)
+	PrepareMemoryHybridSearch(context.Context, punaropostgres.MemorySearchRequest) (punaropostgres.MemoryEmbeddingGeneration, error)
+	SearchMemoryHybridLexical(context.Context, punaropostgres.MemorySearchRequest) (punaropostgres.MemoryHybridSearchSurfacePage, error)
+	SearchMemoryHybrid(context.Context, punaropostgres.MemoryHybridSearchRequest) (punaropostgres.MemoryHybridSearchSurfacePage, error)
 }
 
 type credentialTransitionDatabase interface {
@@ -313,7 +316,22 @@ func buildMemoryHandler(cfg config.Config, platformDB platformDatabase) (http.Ha
 	if err := policy.Validate(); err != nil {
 		return nil, errors.New("memory credential transport policy is invalid")
 	}
-	return memoryhttp.New(database, policy, cfg.MemoryMutationsEnabled), nil
+	if cfg.MemoryOpenAIEmbeddingsURL == "" {
+		return memoryhttp.New(database, policy, cfg.MemoryMutationsEnabled), nil
+	}
+	key, err := readEmbeddingAPIKey(cfg.MemoryOpenAIAPIKeyFile)
+	if err != nil {
+		return nil, errors.New("memory embedding provider credential is unavailable")
+	}
+	provider, err := embeddingprovider.NewOpenAICompatible(cfg.MemoryOpenAIEmbeddingsURL, key, &http.Client{})
+	if err != nil {
+		return nil, errors.New("memory embedding provider is unavailable")
+	}
+	hybrid, err := punaropostgres.NewMemoryHybridRetrievalExecutor(database, provider)
+	if err != nil {
+		return nil, errors.New("memory hybrid retrieval is unavailable")
+	}
+	return memoryhttp.NewWithHybrid(database, policy, cfg.MemoryMutationsEnabled, hybrid), nil
 }
 
 func validateEmbeddingProvider(cfg config.Config) error {

--- a/cmd/punarod/main_test.go
+++ b/cmd/punarod/main_test.go
@@ -133,6 +133,15 @@ func (*unavailableMemoryDatabase) ApproveMemoryProposal(context.Context, punarop
 func (*unavailableMemoryDatabase) RejectMemoryProposal(context.Context, punaropostgres.MemoryProposalDecisionRequest) (punaropostgres.MemoryProposalResult, error) {
 	return punaropostgres.MemoryProposalResult{}, errors.New("unused")
 }
+func (*unavailableMemoryDatabase) PrepareMemoryHybridSearch(context.Context, punaropostgres.MemorySearchRequest) (punaropostgres.MemoryEmbeddingGeneration, error) {
+	return punaropostgres.MemoryEmbeddingGeneration{}, errors.New("unused")
+}
+func (*unavailableMemoryDatabase) SearchMemoryHybridLexical(context.Context, punaropostgres.MemorySearchRequest) (punaropostgres.MemoryHybridSearchSurfacePage, error) {
+	return punaropostgres.MemoryHybridSearchSurfacePage{}, errors.New("unused")
+}
+func (*unavailableMemoryDatabase) SearchMemoryHybrid(context.Context, punaropostgres.MemoryHybridSearchRequest) (punaropostgres.MemoryHybridSearchSurfacePage, error) {
+	return punaropostgres.MemoryHybridSearchSurfacePage{}, errors.New("unused")
+}
 
 func TestBuildMemoryHandlerRejectsCompatibleHistoricalSchema(t *testing.T) {
 	database := &unavailableMemoryDatabase{readyErr: errors.New("schema 14 is unavailable")}

--- a/internal/memoryhttp/handler.go
+++ b/internal/memoryhttp/handler.go
@@ -28,6 +28,7 @@ const (
 	maxProposalBytes        = 1 << 20
 	maxConcurrentOperations = 32
 	operationTimeout        = 5 * time.Second
+	hybridOperationTimeout  = 15 * time.Second
 )
 
 type store interface {
@@ -47,28 +48,42 @@ type store interface {
 	RejectMemoryProposal(context.Context, postgres.MemoryProposalDecisionRequest) (postgres.MemoryProposalResult, error)
 }
 
+type hybridSearcher interface {
+	Search(context.Context, postgres.MemorySearchRequest) (postgres.MemoryHybridSearchSurfacePage, error)
+}
+
 type handler struct {
 	store   store
 	policy  *ingress.Policy
 	mux     *http.ServeMux
 	slots   chan struct{}
 	timeout time.Duration
+	hybrid  hybridSearcher
 }
 
 // New constructs the native memory handler. The caller independently decides
 // whether the dark read surface and its mutation extension are mounted.
 func New(database store, policy *ingress.Policy, mutationsEnabled bool) http.Handler {
-	return newHandler(database, policy, maxConcurrentOperations, operationTimeout, mutationsEnabled)
+	return NewWithHybrid(database, policy, mutationsEnabled, nil)
 }
 
-func newHandler(database store, policy *ingress.Policy, concurrency int, timeout time.Duration, mutationsEnabled bool) http.Handler {
+// NewWithHybrid constructs the native memory handler with an optional
+// authorization-first hybrid retrieval capability.
+func NewWithHybrid(database store, policy *ingress.Policy, mutationsEnabled bool, hybrid hybridSearcher) http.Handler {
+	return newHandler(database, policy, maxConcurrentOperations, operationTimeout, mutationsEnabled, hybrid)
+}
+
+func newHandler(database store, policy *ingress.Policy, concurrency int, timeout time.Duration, mutationsEnabled bool, hybrid hybridSearcher) http.Handler {
 	if concurrency < 1 {
 		concurrency = 1
 	}
-	h := &handler{store: database, policy: policy, mux: http.NewServeMux(), slots: make(chan struct{}, concurrency), timeout: timeout}
+	h := &handler{store: database, policy: policy, mux: http.NewServeMux(), slots: make(chan struct{}, concurrency), timeout: timeout, hybrid: hybrid}
 	h.mux.HandleFunc("POST /v1/projects/resolve", h.resolveProject)
 	h.mux.HandleFunc("GET /v1/projects/{project}/memories/{item}", h.getMemory)
 	h.mux.HandleFunc("POST /v1/projects/{project}/memories/search", h.searchMemory)
+	if hybrid != nil {
+		h.mux.HandleFunc("POST /v1/projects/{project}/memories/hybrid-search", h.searchHybridMemory)
+	}
 	h.mux.HandleFunc("POST /v1/projects/{project}/memories/brief", h.promptBrief)
 	h.mux.HandleFunc("POST /v1/projects/{project}/memories/changes", h.memoryChanges)
 	h.mux.HandleFunc("GET /v1/projects/{project}/memory-proposals/{proposal}", h.getProposal)
@@ -82,6 +97,29 @@ func newHandler(database store, policy *ingress.Policy, concurrency int, timeout
 		h.mux.HandleFunc("POST /v1/projects/{project}/memory-proposals/{proposal}/reject", h.rejectProposal)
 	}
 	return h
+}
+
+func (h *handler) searchHybridMemory(response http.ResponseWriter, request *http.Request) {
+	device, projectID, ok := deviceProject(response, request)
+	if !ok {
+		return
+	}
+	fields, ok := readObject(response, request, "query", "limit")
+	if !ok {
+		return
+	}
+	var query string
+	var limit int
+	if !decodeString(fields["query"], &query) || !decodeInt(fields["limit"], &limit) || !validQuery(query) || limit < 1 || limit > 50 {
+		writeError(response, http.StatusBadRequest, "request is invalid")
+		return
+	}
+	page, err := h.hybrid.Search(request.Context(), postgres.MemorySearchRequest{PrincipalID: device.PrincipalID, ProjectID: projectID, Query: query, Limit: limit})
+	if err != nil {
+		writeStoreError(response, err)
+		return
+	}
+	writeJSON(response, http.StatusOK, page)
 }
 
 type memoryWriteBody struct {
@@ -276,7 +314,7 @@ func (h *handler) ServeHTTP(response http.ResponseWriter, request *http.Request)
 		unauthenticated(response)
 		return
 	}
-	operationCtx, cancel := context.WithTimeout(request.Context(), h.timeout)
+	operationCtx, cancel := context.WithTimeout(request.Context(), h.timeoutFor(request))
 	defer cancel()
 	device, err := h.store.AuthenticateDevice(operationCtx, credential)
 	if err != nil || !validID(device.PrincipalID) || !validID(device.LookupID) || device.Generation < 1 {
@@ -284,6 +322,13 @@ func (h *handler) ServeHTTP(response http.ResponseWriter, request *http.Request)
 		return
 	}
 	h.mux.ServeHTTP(response, request.WithContext(context.WithValue(operationCtx, authenticatedDeviceKey{}, device)))
+}
+
+func (h *handler) timeoutFor(request *http.Request) time.Duration {
+	if h.hybrid != nil && request.Method == http.MethodPost && strings.HasSuffix(request.URL.Path, "/memories/hybrid-search") {
+		return hybridOperationTimeout
+	}
+	return h.timeout
 }
 
 type authenticatedDeviceKey struct{}

--- a/internal/memoryhttp/handler_test.go
+++ b/internal/memoryhttp/handler_test.go
@@ -62,6 +62,17 @@ type fakeStore struct {
 	entered chan struct{}
 }
 
+type fakeHybridSearcher struct {
+	request postgres.MemorySearchRequest
+	calls   int
+}
+
+func (searcher *fakeHybridSearcher) Search(_ context.Context, request postgres.MemorySearchRequest) (postgres.MemoryHybridSearchSurfacePage, error) {
+	searcher.request = request
+	searcher.calls++
+	return postgres.MemoryHybridSearchSurfacePage{SemanticStatus: postgres.MemoryHybridSearchSemanticNotConfigured}, nil
+}
+
 func (s *fakeStore) mutationResult(item string, state postgres.MemoryState) postgres.MemoryMutationResult {
 	return postgres.MemoryMutationResult{ItemID: item, Revision: 3, ETag: testMemoryETag, State: state, ChangeSequence: 10}
 }
@@ -516,6 +527,31 @@ func TestHandlerBindsAuthenticatedPrincipalAcrossBoundedReadRoutes(t *testing.T)
 	}
 }
 
+func TestHybridSearchBindsAuthenticatedPrincipalAndIsDarkWithoutCapability(t *testing.T) {
+	store := newFakeStore()
+	path := "/v1/projects/" + testProjectID + "/memories/hybrid-search"
+	darkRequest := request(http.MethodPost, path, `{"query":"needle","limit":3}`)
+	response := httptest.NewRecorder()
+	newTestHandler(store).ServeHTTP(response, darkRequest)
+	if response.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("dark route status=%d", response.Code)
+	}
+
+	hybrid := &fakeHybridSearcher{}
+	policy := &ingress.Policy{Mode: ingress.LAN, ListenAddr: "127.0.0.1:8443", PublicURL: "https://punaro.test"}
+	handler := NewWithHybrid(store, policy, false, hybrid)
+	unauthorized := request(http.MethodPost, path, `{"query":"needle","limit":3}`)
+	unauthorized.Header.Del("Authorization")
+	serve(t, handler, unauthorized, http.StatusUnauthorized)
+	if hybrid.calls != 0 {
+		t.Fatalf("unauthorized hybrid search reached provider: calls=%d", hybrid.calls)
+	}
+	response = serve(t, handler, request(http.MethodPost, path, `{"query":"needle","limit":3}`), http.StatusOK)
+	if hybrid.calls != 1 || hybrid.request.PrincipalID != testPrincipalID || hybrid.request.ProjectID != testProjectID || hybrid.request.Query != "needle" || hybrid.request.Limit != 3 || !strings.Contains(response.Body.String(), `"semantic_status":"not_configured"`) {
+		t.Fatalf("hybrid request=%#v response=%s", hybrid.request, response.Body.String())
+	}
+}
+
 func TestHandlerRejectsAuthenticationTransportAndStrictInputBeforeStore(t *testing.T) {
 	store := newFakeStore()
 	handler := newTestHandler(store)
@@ -619,7 +655,7 @@ func TestHandlerBoundsConcurrencyAndCancelsBlockedStoreWork(t *testing.T) {
 	store.block = make(chan struct{})
 	store.entered = make(chan struct{}, 1)
 	policy := &ingress.Policy{Mode: ingress.LAN, ListenAddr: "127.0.0.1:8443", PublicURL: "https://punaro.test"}
-	handler := newHandler(store, policy, 1, 20*time.Millisecond, true)
+	handler := newHandler(store, policy, 1, 20*time.Millisecond, true, nil)
 	done := make(chan *httptest.ResponseRecorder, 1)
 	go func() {
 		w := httptest.NewRecorder()


### PR DESCRIPTION
Adds a bounded device-authenticated hybrid memory route backed by the existing authorization-first fenced retrieval executor. The route remains dark unless the daemon has a configured provider.\n\nValidation: make test, make test-race, make staticcheck, make security, make lint.