### PR TITLE
Support fenced worker embedding requests

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -481,6 +481,12 @@ of the pinned dimension, must have bounded JSON nesting, and must
 declare the exact pinned model. Provider failures are content-free and never
 log credentials, query text, or raw response data. Credential-file loading,
 provider selection, and daemon wiring remain separate deployment slices.
+The same transport also accepts the worker's current one fenced canonical
+document chunk for either validated active or building generation, preserving
+its exact SHA-256 and byte-range boundary before a provider request. It
+deliberately rejects multiple chunks: later chunking must add an explicitly
+bounded request and response contract rather than silently widening provider
+exposure.
 
 Provider API-key files use canonical absolute paths only. On Unix, every
 ancestor must be a non-symlinked directory owned by the daemon user or root

--- a/internal/embeddingprovider/openai.go
+++ b/internal/embeddingprovider/openai.go
@@ -5,6 +5,8 @@ package embeddingprovider
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"io"
@@ -22,6 +24,7 @@ const (
 	maxResponseBytes = 1 << 20
 	maxQueryBytes    = 1024
 	maxQueryRunes    = 256
+	maxSourceBytes   = 256 << 10
 	maxJSONDepth     = 32
 )
 
@@ -52,6 +55,29 @@ func (p *OpenAICompatible) EmbedMemoryQuery(ctx context.Context, generation post
 	if p == nil || generation.Validate() != nil || generation.State != postgres.MemoryEmbeddingGenerationActive || !immutableProviderModel(generation.Model, generation.Revision) || query == "" || !utf8.ValidString(query) || len(query) > maxQueryBytes || utf8.RuneCountInString(query) > maxQueryRunes {
 		return nil, errors.New("embedding provider request is invalid")
 	}
+	return p.embed(ctx, generation, query)
+}
+
+// Embed derives one vector for the current single, fenced canonical-document
+// chunk. Later source chunking must extend this transport deliberately rather
+// than silently increasing a provider request's content or response bounds.
+func (p *OpenAICompatible) Embed(ctx context.Context, generation postgres.MemoryEmbeddingGeneration, chunks []postgres.MemoryEmbeddingSourceChunk) ([][]float64, error) {
+	if p == nil || generation.Validate() != nil || !immutableProviderModel(generation.Model, generation.Revision) || len(chunks) != 1 {
+		return nil, errors.New("embedding provider request is invalid")
+	}
+	chunk := chunks[0]
+	digest := sha256.Sum256([]byte(chunk.Text))
+	if chunk.Ordinal != 0 || chunk.StartOffset != 0 || chunk.EndOffset != len(chunk.Text) || chunk.EndOffset < 1 || len(chunk.Text) > maxSourceBytes || !utf8.ValidString(chunk.Text) || len(chunk.ContentSHA256) != 64 || hex.EncodeToString(digest[:]) != chunk.ContentSHA256 {
+		return nil, errors.New("embedding provider request is invalid")
+	}
+	vector, err := p.embed(ctx, generation, chunk.Text)
+	if err != nil {
+		return nil, err
+	}
+	return [][]float64{vector}, nil
+}
+
+func (p *OpenAICompatible) embed(ctx context.Context, generation postgres.MemoryEmbeddingGeneration, input string) ([]float64, error) {
 	var dimensions *int
 	if strings.HasPrefix(generation.Model, "text-embedding-3-") {
 		dimensions = &generation.Dimensions
@@ -61,7 +87,7 @@ func (p *OpenAICompatible) EmbedMemoryQuery(ctx context.Context, generation post
 		Input          string `json:"input"`
 		Dimensions     *int   `json:"dimensions,omitempty"`
 		EncodingFormat string `json:"encoding_format"`
-	}{Model: generation.Model, Input: query, Dimensions: dimensions, EncodingFormat: "float"})
+	}{Model: generation.Model, Input: input, Dimensions: dimensions, EncodingFormat: "float"})
 	if err != nil {
 		return nil, errors.New("embedding provider request is unavailable")
 	}

--- a/internal/embeddingprovider/openai_test.go
+++ b/internal/embeddingprovider/openai_test.go
@@ -2,6 +2,8 @@ package embeddingprovider
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -37,6 +39,52 @@ func TestOpenAICompatibleProviderUsesPinnedGenerationModel(t *testing.T) {
 	vector, err := provider.EmbedMemoryQuery(context.Background(), generation, "release decision")
 	if err != nil || len(vector) != 2 || vector[0] != 0.25 || vector[1] != 0.75 {
 		t.Fatalf("vector=%v err=%v", vector, err)
+	}
+}
+
+func TestOpenAICompatibleProviderEmbedsOneFencedCanonicalChunk(t *testing.T) {
+	const document = `{"title":"release decision"}`
+	digest := sha256.Sum256([]byte(document))
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var request struct {
+			Model      string `json:"model"`
+			Input      string `json:"input"`
+			Dimensions int    `json:"dimensions"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&request); err != nil || request.Model != "text-embedding-3-small:2026-07-27" || request.Input != document || request.Dimensions != 2 {
+			t.Fatalf("request=%+v err=%v", request, err)
+		}
+		_, _ = w.Write([]byte(`{"model":"text-embedding-3-small:2026-07-27","data":[{"embedding":[0.25,0.75]}]}`))
+	}))
+	defer server.Close()
+	provider, err := NewOpenAICompatible(server.URL, "provider-key", server.Client())
+	if err != nil {
+		t.Fatal(err)
+	}
+	generation := activeGeneration()
+	generation.State = postgres.MemoryEmbeddingGenerationBuilding
+	vectors, err := provider.Embed(context.Background(), generation, []postgres.MemoryEmbeddingSourceChunk{{Ordinal: 0, ContentSHA256: hex.EncodeToString(digest[:]), StartOffset: 0, EndOffset: len(document), Text: document}})
+	if err != nil || len(vectors) != 1 || len(vectors[0]) != 2 || vectors[0][0] != 0.25 || vectors[0][1] != 0.75 {
+		t.Fatalf("vectors=%v err=%v", vectors, err)
+	}
+}
+
+func TestOpenAICompatibleProviderRejectsUnfencedWorkerChunksBeforeNetwork(t *testing.T) {
+	provider, err := NewOpenAICompatible("https://example.com/embeddings", "provider-key", &http.Client{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for name, chunks := range map[string][]postgres.MemoryEmbeddingSourceChunk{
+		"multiple":  {{}, {}},
+		"empty":     {{Ordinal: 0, ContentSHA256: strings.Repeat("0", 64), StartOffset: 0, EndOffset: 1, Text: ""}},
+		"bad hash":  {{Ordinal: 0, ContentSHA256: strings.Repeat("0", 64), StartOffset: 0, EndOffset: 1, Text: "x"}},
+		"oversized": {{Ordinal: 0, ContentSHA256: strings.Repeat("0", 64), StartOffset: 0, EndOffset: maxSourceBytes + 1, Text: strings.Repeat("x", maxSourceBytes+1)}},
+	} {
+		t.Run(name, func(t *testing.T) {
+			if _, err := provider.Embed(context.Background(), activeGeneration(), chunks); err == nil {
+				t.Fatal("Embed accepted an unfenced worker chunk")
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary

- allow the bounded OpenAI-compatible transport to embed the current single fenced canonical-document chunk
- reject unfenced, oversized, and multi-chunk worker input before any provider call
- document the explicit single-chunk boundary

## Validation

- `make test`
- `make test-race`
- `make staticcheck`
- `make security`
- `make lint`