### PR TITLE
Run bounded embedding worker in daemon

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -511,6 +511,13 @@ or publication leases are no-ops; source,
 provider, and publication outages become bounded code-only retries, and a
 failed retry write is surfaced to the executor caller. Provider selection,
 credentials, and network configuration remain separate deployment slices.
+When an embedding provider is explicitly configured, `punarod` starts one
+best-effort background worker with a fresh opaque holder ID. Each pass claims
+at most one minute-leased item; the executor preserves that lease's own
+deadline through durable retry/publication handling. Provider, database, or
+publication failures are retained in the fenced job lifecycle and never fail
+request serving or readiness. No provider configuration means no worker or
+provider call.
 
 The optional native hybrid-search surface is mounted only when the dark memory
 API is enabled and daemon startup has successfully constructed the bounded

--- a/cmd/punarod/embedding_runtime.go
+++ b/cmd/punarod/embedding_runtime.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	punaropostgres "github.com/rock3r/punaro/internal/postgres"
+)
+
+const (
+	embeddingRuntimeBatch       = 1
+	embeddingRuntimeLease       = time.Minute
+	embeddingRuntimePassTimeout = 30 * time.Second
+)
+
+type embeddingExecutor interface {
+	Execute(context.Context, punaropostgres.MemoryEmbeddingClaimRequest) (punaropostgres.MemoryEmbeddingExecutionResult, error)
+}
+
+// embeddingRuntime runs one bounded, best-effort embedding pass at a time.
+// Its failures deliberately do not affect request serving or daemon readiness.
+type embeddingRuntime struct {
+	cancel context.CancelFunc
+	done   chan struct{}
+	once   sync.Once
+}
+
+func newEmbeddingRuntime(executor embeddingExecutor, workerID string, interval time.Duration) *embeddingRuntime {
+	//nolint:gosec // Close owns this cancellation function for the runtime lifetime.
+	ctx, cancel := context.WithCancel(context.Background())
+	runtime := &embeddingRuntime{cancel: cancel, done: make(chan struct{})}
+	go func() {
+		defer cancel()
+		defer close(runtime.done)
+		pass := func() {
+			passCtx, passCancel := context.WithTimeout(ctx, embeddingRuntimePassTimeout)
+			_, _ = executor.Execute(passCtx, punaropostgres.MemoryEmbeddingClaimRequest{WorkerID: workerID, Limit: embeddingRuntimeBatch, LeaseDuration: embeddingRuntimeLease})
+			passCancel()
+		}
+		pass()
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				pass()
+			}
+		}
+	}()
+	return runtime
+}
+
+func (runtime *embeddingRuntime) Close() {
+	if runtime == nil {
+		return
+	}
+	runtime.once.Do(func() { runtime.cancel(); <-runtime.done })
+}

--- a/cmd/punarod/embedding_runtime.go
+++ b/cmd/punarod/embedding_runtime.go
@@ -35,6 +35,7 @@ func newEmbeddingRuntime(executor embeddingExecutor, workerID string, interval t
 		defer close(runtime.done)
 		pass := func() {
 			passCtx, passCancel := context.WithTimeout(ctx, embeddingRuntimePassTimeout)
+			passCtx = punaropostgres.WithMemoryEmbeddingCleanupContext(passCtx, ctx)
 			_, _ = executor.Execute(passCtx, punaropostgres.MemoryEmbeddingClaimRequest{WorkerID: workerID, Limit: embeddingRuntimeBatch, LeaseDuration: embeddingRuntimeLease})
 			passCancel()
 		}

--- a/cmd/punarod/embedding_runtime_test.go
+++ b/cmd/punarod/embedding_runtime_test.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	punaropostgres "github.com/rock3r/punaro/internal/postgres"
+)
+
+type scriptedEmbeddingExecutor struct {
+	mu       sync.Mutex
+	calls    int
+	requests []punaropostgres.MemoryEmbeddingClaimRequest
+	started  chan struct{}
+}
+
+func (executor *scriptedEmbeddingExecutor) Execute(_ context.Context, request punaropostgres.MemoryEmbeddingClaimRequest) (punaropostgres.MemoryEmbeddingExecutionResult, error) {
+	executor.mu.Lock()
+	executor.calls++
+	executor.requests = append(executor.requests, request)
+	executor.mu.Unlock()
+	select {
+	case executor.started <- struct{}{}:
+	default:
+	}
+	return punaropostgres.MemoryEmbeddingExecutionResult{}, nil
+}
+
+func TestEmbeddingRuntimeRunsBoundedPassAndStops(t *testing.T) {
+	executor := &scriptedEmbeddingExecutor{started: make(chan struct{}, 1)}
+	runtime := newEmbeddingRuntime(executor, "11111111-1111-4111-8111-111111111111", time.Hour)
+	select {
+	case <-executor.started:
+	case <-time.After(time.Second):
+		t.Fatal("embedding pass did not start")
+	}
+	runtime.Close()
+	executor.mu.Lock()
+	defer executor.mu.Unlock()
+	if executor.calls != 1 || len(executor.requests) != 1 || executor.requests[0].Limit != 1 || executor.requests[0].LeaseDuration != time.Minute {
+		t.Fatalf("calls=%d requests=%#v", executor.calls, executor.requests)
+	}
+}

--- a/cmd/punarod/main.go
+++ b/cmd/punarod/main.go
@@ -19,6 +19,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/rock3r/punaro/internal/access"
 	"github.com/rock3r/punaro/internal/config"
 	"github.com/rock3r/punaro/internal/devicehttp"
@@ -75,6 +76,14 @@ type memoryDatabase interface {
 	PrepareMemoryHybridSearch(context.Context, punaropostgres.MemorySearchRequest) (punaropostgres.MemoryEmbeddingGeneration, error)
 	SearchMemoryHybridLexical(context.Context, punaropostgres.MemorySearchRequest) (punaropostgres.MemoryHybridSearchSurfacePage, error)
 	SearchMemoryHybrid(context.Context, punaropostgres.MemoryHybridSearchRequest) (punaropostgres.MemoryHybridSearchSurfacePage, error)
+}
+
+type embeddingRuntimeDatabase interface {
+	CanonicalBrainRuntimeReady(context.Context) error
+	ClaimMemoryEmbeddingWork(context.Context, punaropostgres.MemoryEmbeddingClaimRequest) ([]punaropostgres.MemoryEmbeddingLease, error)
+	PublishMemoryEmbeddingWork(context.Context, punaropostgres.MemoryEmbeddingPublication) error
+	RetryMemoryEmbeddingWork(context.Context, punaropostgres.MemoryEmbeddingRetry) error
+	OpenMemoryEmbeddingSource(context.Context, punaropostgres.MemoryEmbeddingLease) (punaropostgres.MemoryEmbeddingGeneration, []punaropostgres.MemoryEmbeddingSourceChunk, func(), error)
 }
 
 type credentialTransitionDatabase interface {
@@ -250,6 +259,16 @@ func run(args []string, stderr io.Writer) int {
 		logger.Printf("health listener bind failed error=%v", err)
 		return 1
 	}
+	embeddingRuntime, err := buildEmbeddingRuntime(cfg, platformDB)
+	if err != nil {
+		_ = healthListener.Close()
+		_ = publicListener.Close()
+		_, _ = fmt.Fprintf(stderr, "punarod embedding worker configuration error: %v\n", err)
+		return 2
+	}
+	if embeddingRuntime != nil {
+		defer embeddingRuntime.Close()
+	}
 	type serverResult struct {
 		name string
 		err  error
@@ -332,6 +351,34 @@ func buildMemoryHandler(cfg config.Config, platformDB platformDatabase) (http.Ha
 		return nil, errors.New("memory hybrid retrieval is unavailable")
 	}
 	return memoryhttp.NewWithHybrid(database, policy, cfg.MemoryMutationsEnabled, hybrid), nil
+}
+
+func buildEmbeddingRuntime(cfg config.Config, platformDB platformDatabase) (*embeddingRuntime, error) {
+	if cfg.MemoryOpenAIEmbeddingsURL == "" {
+		return nil, nil
+	}
+	database, ok := platformDB.(embeddingRuntimeDatabase)
+	if !ok {
+		return nil, errors.New("PostgreSQL embedding database authority is unavailable")
+	}
+	readinessCtx, readinessCancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer readinessCancel()
+	if err := database.CanonicalBrainRuntimeReady(readinessCtx); err != nil {
+		return nil, errors.New("PostgreSQL canonical brain schema is unavailable")
+	}
+	key, err := readEmbeddingAPIKey(cfg.MemoryOpenAIAPIKeyFile)
+	if err != nil {
+		return nil, errors.New("memory embedding provider credential is unavailable")
+	}
+	provider, err := embeddingprovider.NewOpenAICompatible(cfg.MemoryOpenAIEmbeddingsURL, key, &http.Client{})
+	if err != nil {
+		return nil, errors.New("memory embedding provider is unavailable")
+	}
+	executor, err := punaropostgres.NewMemoryEmbeddingExecutor(database, database, provider)
+	if err != nil {
+		return nil, errors.New("memory embedding executor is unavailable")
+	}
+	return newEmbeddingRuntime(executor, uuid.NewString(), time.Minute), nil
 }
 
 func validateEmbeddingProvider(cfg config.Config) error {

--- a/cmd/punarod/main_test.go
+++ b/cmd/punarod/main_test.go
@@ -82,6 +82,17 @@ func TestBuildMemoryHandlerFailsClosedWhenConfiguredProviderCredentialCannotLoad
 	}
 }
 
+func TestBuildEmbeddingRuntimeIsDarkWithoutProviderAndRequiresAuthority(t *testing.T) {
+	runtime, err := buildEmbeddingRuntime(config.Config{}, &refusingPlatformDatabase{})
+	if err != nil || runtime != nil {
+		t.Fatalf("disabled runtime=%v err=%v", runtime, err)
+	}
+	_, err = buildEmbeddingRuntime(config.Config{MemoryOpenAIEmbeddingsURL: "https://embeddings.example/v1/embeddings", MemoryOpenAIAPIKeyFile: "/run/secrets/provider-key"}, &refusingPlatformDatabase{})
+	if err == nil || !strings.Contains(err.Error(), "embedding database authority") {
+		t.Fatalf("incomplete authority error=%v", err)
+	}
+}
+
 type unavailableMemoryDatabase struct {
 	deviceDatabase
 	readyCalled bool

--- a/internal/postgres/brain_embedding_executor.go
+++ b/internal/postgres/brain_embedding_executor.go
@@ -234,7 +234,10 @@ func (e *MemoryEmbeddingExecutor) executeLease(ctx context.Context, lease Memory
 		}
 		return nil
 	}
-	publicationCtx, cancelPublication := context.WithDeadline(ctx, lease.LeaseUntil)
+	// Publication is the other lease-bound durable cleanup path. A completed
+	// provider result remains publishable until the exact lease expires even if
+	// the runtime's per-pass budget has elapsed.
+	publicationCtx, cancelPublication := context.WithDeadline(context.Background(), lease.LeaseUntil.Add(-memoryEmbeddingPublicationReserve))
 	defer cancelPublication()
 	if err := e.store.PublishMemoryEmbeddingWork(publicationCtx, publication); err == nil {
 		result.Published++
@@ -281,8 +284,11 @@ func validMemoryEmbeddingSource(lease MemoryEmbeddingLease, generation MemoryEmb
 	return hex.EncodeToString(digest[:]) == lease.ContentSHA256
 }
 
-func (e *MemoryEmbeddingExecutor) retry(ctx context.Context, lease MemoryEmbeddingLease, code string, result *MemoryEmbeddingExecutionResult) error {
-	retryCtx, cancel := context.WithDeadline(ctx, lease.LeaseUntil)
+func (e *MemoryEmbeddingExecutor) retry(_ context.Context, lease MemoryEmbeddingLease, code string, result *MemoryEmbeddingExecutionResult) error {
+	// Retry is the lease's durable cleanup path. It cannot inherit a pass
+	// deadline that has already fired, but it remains strictly bounded by the
+	// exact lease that authorized this worker mutation.
+	retryCtx, cancel := context.WithDeadline(context.Background(), lease.LeaseUntil)
 	defer cancel()
 	if err := e.store.RetryMemoryEmbeddingWork(retryCtx, MemoryEmbeddingRetry{Lease: lease, ErrorCode: code, Delay: time.Second}); err != nil {
 		if errors.Is(err, ErrStaleEmbeddingLease) || !time.Now().Before(lease.LeaseUntil) {

--- a/internal/postgres/brain_embedding_executor.go
+++ b/internal/postgres/brain_embedding_executor.go
@@ -48,6 +48,24 @@ type MemoryEmbeddingExecutor struct {
 // MemoryEmbeddingExecutionResult reports one bounded executor pass.
 type MemoryEmbeddingExecutionResult struct{ Claimed, Published, Retried int }
 
+type memoryEmbeddingCleanupContextKey struct{}
+
+// WithMemoryEmbeddingCleanupContext attaches the long-lived runtime context
+// used for lease-bound durable cleanup after a shorter execution pass expires.
+func WithMemoryEmbeddingCleanupContext(ctx, cleanupCtx context.Context) context.Context {
+	if cleanupCtx == nil {
+		cleanupCtx = ctx
+	}
+	return context.WithValue(ctx, memoryEmbeddingCleanupContextKey{}, cleanupCtx)
+}
+
+func memoryEmbeddingCleanupContext(ctx context.Context) context.Context {
+	if cleanupCtx, ok := ctx.Value(memoryEmbeddingCleanupContextKey{}).(context.Context); ok && cleanupCtx != nil {
+		return cleanupCtx
+	}
+	return ctx
+}
+
 // LoadMemoryEmbeddingSource reads only the exact, live lease coordinate. It
 // returns one bounded canonical-document chunk; later chunking policies can
 // refine this derived boundary without changing the lease fence.
@@ -174,6 +192,7 @@ func (e *MemoryEmbeddingExecutor) executeLease(ctx context.Context, lease Memory
 	var chunks []MemoryEmbeddingSourceChunk
 	var release func()
 	var loadErr error
+	cleanupCtx := memoryEmbeddingCleanupContext(ctx)
 	leaseDeadline := lease.LeaseUntil.Add(-memoryEmbeddingPublicationReserve)
 	sourceCtx, cancelSource := context.WithDeadline(ctx, leaseDeadline)
 	defer cancelSource()
@@ -237,7 +256,7 @@ func (e *MemoryEmbeddingExecutor) executeLease(ctx context.Context, lease Memory
 	// Publication is the other lease-bound durable cleanup path. A completed
 	// provider result remains publishable until the exact lease expires even if
 	// the runtime's per-pass budget has elapsed.
-	publicationCtx, cancelPublication := context.WithDeadline(context.Background(), lease.LeaseUntil.Add(-memoryEmbeddingPublicationReserve))
+	publicationCtx, cancelPublication := context.WithDeadline(cleanupCtx, lease.LeaseUntil.Add(-memoryEmbeddingPublicationReserve))
 	defer cancelPublication()
 	if err := e.store.PublishMemoryEmbeddingWork(publicationCtx, publication); err == nil {
 		result.Published++
@@ -284,11 +303,11 @@ func validMemoryEmbeddingSource(lease MemoryEmbeddingLease, generation MemoryEmb
 	return hex.EncodeToString(digest[:]) == lease.ContentSHA256
 }
 
-func (e *MemoryEmbeddingExecutor) retry(_ context.Context, lease MemoryEmbeddingLease, code string, result *MemoryEmbeddingExecutionResult) error {
+func (e *MemoryEmbeddingExecutor) retry(ctx context.Context, lease MemoryEmbeddingLease, code string, result *MemoryEmbeddingExecutionResult) error {
 	// Retry is the lease's durable cleanup path. It cannot inherit a pass
 	// deadline that has already fired, but it remains strictly bounded by the
 	// exact lease that authorized this worker mutation.
-	retryCtx, cancel := context.WithDeadline(context.Background(), lease.LeaseUntil)
+	retryCtx, cancel := context.WithDeadline(memoryEmbeddingCleanupContext(ctx), lease.LeaseUntil)
 	defer cancel()
 	if err := e.store.RetryMemoryEmbeddingWork(retryCtx, MemoryEmbeddingRetry{Lease: lease, ErrorCode: code, Delay: time.Second}); err != nil {
 		if errors.Is(err, ErrStaleEmbeddingLease) || !time.Now().Before(lease.LeaseUntil) {

--- a/internal/postgres/brain_embedding_executor_test.go
+++ b/internal/postgres/brain_embedding_executor_test.go
@@ -127,12 +127,44 @@ func TestMemoryEmbeddingExecutorLetsExpiredSourceFenceLeaseReclaim(t *testing.T)
 	}
 }
 
+func TestMemoryEmbeddingExecutorRetryUsesRuntimeCleanupContext(t *testing.T) {
+	lease := MemoryEmbeddingLease{MemoryEmbeddingWork: MemoryEmbeddingWork{GenerationID: "11111111-1111-4111-8111-111111111111", ItemID: "22222222-2222-4222-8222-222222222222", Revision: 1, ContentSHA256: "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08"}, Generation: MemoryEmbeddingGeneration{ID: "11111111-1111-4111-8111-111111111111", Model: "local.e5", Revision: "2026-07-01", Dimensions: 2, State: MemoryEmbeddingGenerationActive}, Attempts: 1, Holder: "33333333-3333-4333-8333-333333333333", Token: "44444444-4444-4444-8444-444444444444", LeaseGeneration: 1, LeaseUntil: time.Now().Add(time.Minute)}
+	retryStarted := make(chan struct{})
+	store := &fakeEmbeddingExecutorStore{leases: []MemoryEmbeddingLease{lease}, onRetryContext: func(ctx context.Context) error {
+		close(retryStarted)
+		<-ctx.Done()
+		return ctx.Err()
+	}}
+	executor, err := NewMemoryEmbeddingExecutor(store, fakeEmbeddingSource{generation: lease.Generation, chunks: []MemoryEmbeddingSourceChunk{{Ordinal: 0, ContentSHA256: lease.ContentSHA256, EndOffset: 4, Text: "test"}}}, fakeEmbeddingProvider{err: errors.New("provider unavailable")})
+	if err != nil {
+		t.Fatal(err)
+	}
+	runtimeCtx, stopRuntime := context.WithCancel(context.Background())
+	passCtx, stopPass := context.WithCancel(WithMemoryEmbeddingCleanupContext(context.Background(), runtimeCtx))
+	stopPass()
+	result := make(chan error, 1)
+	go func() {
+		_, err := executor.Execute(passCtx, MemoryEmbeddingClaimRequest{WorkerID: lease.Holder, Limit: 1, LeaseDuration: time.Minute})
+		result <- err
+	}()
+	select {
+	case <-retryStarted:
+	case <-time.After(time.Second):
+		t.Fatal("retry did not begin")
+	}
+	stopRuntime()
+	if err := <-result; !errors.Is(err, context.Canceled) {
+		t.Fatalf("retry should stop with runtime shutdown, got %v", err)
+	}
+}
+
 type fakeEmbeddingExecutorStore struct {
-	leases    []MemoryEmbeddingLease
-	published []MemoryEmbeddingPublication
-	retries   []MemoryEmbeddingRetry
-	retryErr  error
-	onRetry   func() error
+	leases         []MemoryEmbeddingLease
+	published      []MemoryEmbeddingPublication
+	retries        []MemoryEmbeddingRetry
+	retryErr       error
+	onRetry        func() error
+	onRetryContext func(context.Context) error
 }
 
 func (s *fakeEmbeddingExecutorStore) ClaimMemoryEmbeddingWork(context.Context, MemoryEmbeddingClaimRequest) ([]MemoryEmbeddingLease, error) {
@@ -144,12 +176,17 @@ func (s *fakeEmbeddingExecutorStore) PublishMemoryEmbeddingWork(_ context.Contex
 	s.published = append(s.published, value)
 	return nil
 }
-func (s *fakeEmbeddingExecutorStore) RetryMemoryEmbeddingWork(_ context.Context, value MemoryEmbeddingRetry) error {
+func (s *fakeEmbeddingExecutorStore) RetryMemoryEmbeddingWork(ctx context.Context, value MemoryEmbeddingRetry) error {
 	if s.retryErr != nil {
 		return s.retryErr
 	}
 	if s.onRetry != nil {
 		if err := s.onRetry(); err != nil {
+			return err
+		}
+	}
+	if s.onRetryContext != nil {
+		if err := s.onRetryContext(ctx); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
## Summary

- start a best-effort bounded embedding runtime only with explicitly configured provider settings
- cap each pass to one minute-leased work item under a 30-second local deadline
- isolate worker failures from request serving and readiness

## Validation

- `make test`
- `make test-race`
- `make staticcheck`
- `make security`
- `make lint`