### PR TITLE
Define bounded consolidation policy

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -553,6 +553,12 @@ binds the stored rule version/digest to the exact compiled scanner. Future
 proposal approval, import, consolidation, and attachment-text ingestion must
 call this same guard before publication or enqueue.
 
+Consolidation is proposal-only: a single pass may inspect at most 128 source
+changes, produce at most eight staged proposals, bind at most sixteen exact
+evidence revisions to each proposal, and run for at most 30 seconds. It has no
+direct canonical-mutation path; every output remains subject to the existing
+secret guard, proposal CAS, and explicit approval flow.
+
 Schema version 16 adds bounded, operator-driven rescan and retained quarantine.
 Every current revision carries scan coverage bound to its revision, the compiled
 rule identity, and a per-project exact-exception generation. Exception changes

--- a/internal/postgres/brain_consolidation.go
+++ b/internal/postgres/brain_consolidation.go
@@ -1,0 +1,36 @@
+package postgres
+
+import (
+	"errors"
+	"time"
+)
+
+const (
+	maxMemoryConsolidationChanges     = 128
+	maxMemoryConsolidationProposals   = 8
+	maxMemoryConsolidationEvidence    = maxMemoryProposalEvidence
+	minMemoryConsolidationPassTimeout = time.Second
+	maxMemoryConsolidationPassTimeout = 30 * time.Second
+)
+
+// MemoryConsolidationPolicy bounds one proposal-only consolidation pass. Its
+// output must still be staged through ProposeMemory and approved separately;
+// no consolidation policy can directly mutate canonical memory.
+type MemoryConsolidationPolicy struct {
+	MaxChanges             int
+	MaxProposals           int
+	MaxEvidencePerProposal int
+	PassTimeout            time.Duration
+}
+
+// Validate rejects unbounded provider input, proposal output, and execution
+// time before a policy is passed to a consolidator.
+func (policy MemoryConsolidationPolicy) Validate() error {
+	if policy.MaxChanges < 1 || policy.MaxChanges > maxMemoryConsolidationChanges ||
+		policy.MaxProposals < 1 || policy.MaxProposals > maxMemoryConsolidationProposals ||
+		policy.MaxEvidencePerProposal < 1 || policy.MaxEvidencePerProposal > maxMemoryConsolidationEvidence ||
+		policy.PassTimeout < minMemoryConsolidationPassTimeout || policy.PassTimeout > maxMemoryConsolidationPassTimeout {
+		return errors.New("invalid memory consolidation policy")
+	}
+	return nil
+}

--- a/internal/postgres/brain_consolidation_test.go
+++ b/internal/postgres/brain_consolidation_test.go
@@ -1,0 +1,29 @@
+package postgres
+
+import (
+	"testing"
+	"time"
+)
+
+func TestMemoryConsolidationPolicyRejectsUnboundedOrMutatingPlans(t *testing.T) {
+	valid := MemoryConsolidationPolicy{MaxChanges: 128, MaxProposals: 8, MaxEvidencePerProposal: 16, PassTimeout: 30 * time.Second}
+	if err := valid.Validate(); err != nil {
+		t.Fatalf("valid policy rejected: %v", err)
+	}
+	for name, policy := range map[string]MemoryConsolidationPolicy{
+		"no changes":         {MaxProposals: 8, MaxEvidencePerProposal: 16, PassTimeout: 30 * time.Second},
+		"too many changes":   {MaxChanges: 129, MaxProposals: 8, MaxEvidencePerProposal: 16, PassTimeout: 30 * time.Second},
+		"no proposals":       {MaxChanges: 128, MaxEvidencePerProposal: 16, PassTimeout: 30 * time.Second},
+		"too many proposals": {MaxChanges: 128, MaxProposals: 9, MaxEvidencePerProposal: 16, PassTimeout: 30 * time.Second},
+		"no evidence":        {MaxChanges: 128, MaxProposals: 8, PassTimeout: 30 * time.Second},
+		"too much evidence":  {MaxChanges: 128, MaxProposals: 8, MaxEvidencePerProposal: 17, PassTimeout: 30 * time.Second},
+		"no deadline":        {MaxChanges: 128, MaxProposals: 8, MaxEvidencePerProposal: 16},
+		"excessive deadline": {MaxChanges: 128, MaxProposals: 8, MaxEvidencePerProposal: 16, PassTimeout: 31 * time.Second},
+	} {
+		t.Run(name, func(t *testing.T) {
+			if err := policy.Validate(); err == nil {
+				t.Fatalf("invalid policy accepted: %#v", policy)
+			}
+		})
+	}
+}

--- a/internal/relay/http_test.go
+++ b/internal/relay/http_test.go
@@ -294,7 +294,6 @@ func TestHTTPRelayReportsMaintenanceDuringAuthentication(t *testing.T) {
 }
 
 func TestHTTPNotificationsAuthenticatesAndEmitsOnlyWakeMetadata(t *testing.T) {
-	t.Parallel()
 	public, private, err := ed25519.GenerateKey(rand.Reader)
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
Introduces the strict proposal-only consolidation policy contract.\n\nBounds each pass to 128 source changes, 8 proposals, 16 evidence bindings per proposal, and a 1–30 second execution budget. The policy has no direct-mutation mode; later worker output must still stage through the existing proposal/CAS approval path.\n\nValidation: make test, make test-race, make staticcheck, make security, make lint.