### PR TITLE
Materialize fenced consolidation sources

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -589,7 +589,9 @@ than a cursor gap, so a worker cannot advance past a current revision until it
 is clear under the current scanner and exception state. The read holds its
 matching checkpoint lease fence through materialization, so a new generation
 cannot reclaim the checkpoint while the old generation is still being returned
-work.
+work. Restores record fresh clear scan coverage for their copied revision, and
+the provider boundary rejects any document whose stored content hash no longer
+matches its canonical bytes.
 
 Schema version 16 adds bounded, operator-driven rescan and retained quarantine.
 Every current revision carries scan coverage bound to its revision, the compiled

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -575,6 +575,13 @@ and approval remains separately fenced. Timeline rotation invalidates every
 live consolidation lease and advances its generation, so a token resurrected
 from a restored backup cannot act on the recovered checkpoint.
 
+Schema version 35 materializes each selected consolidation source's canonical
+JSON document in the same security-definer statement as the live lease fence
+and exact `(item, revision)` coordinate. Fence and cursor rows carry no
+document; a missing or malformed document invalidates the whole read. This
+internal provider boundary remains read-only and has no proposal, approval, or
+canonical-mutation authority.
+
 Schema version 16 adds bounded, operator-driven rescan and retained quarantine.
 Every current revision carries scan coverage bound to its revision, the compiled
 rule identity, and a per-project exact-exception generation. Exception changes

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -589,9 +589,9 @@ than a cursor gap, so a worker cannot advance past a current revision until it
 is clear under the current scanner and exception state. The read holds its
 matching checkpoint lease fence through materialization, so a new generation
 cannot reclaim the checkpoint while the old generation is still being returned
-work. Restores record fresh clear scan coverage for their copied revision, and
-the provider boundary rejects any document whose stored content hash no longer
-matches its canonical bytes.
+work. Restores rescan their copied revision and record current clear or
+quarantined coverage, and the provider boundary rejects any document whose
+stored content hash no longer matches its canonical bytes.
 
 Schema version 16 adds bounded, operator-driven rescan and retained quarantine.
 Every current revision carries scan coverage bound to its revision, the compiled

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -586,7 +586,10 @@ Schema version 37 additionally materializes only each item's current active
 revision as a consolidation source; superseded changes remain cursor gaps. A
 stale or non-clear scan for a selected source is a failed provider read rather
 than a cursor gap, so a worker cannot advance past a current revision until it
-is clear under the current scanner and exception state.
+is clear under the current scanner and exception state. The read holds its
+matching checkpoint lease fence through materialization, so a new generation
+cannot reclaim the checkpoint while the old generation is still being returned
+work.
 
 Schema version 16 adds bounded, operator-driven rescan and retained quarantine.
 Every current revision carries scan coverage bound to its revision, the compiled

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -582,6 +582,12 @@ document; a missing or malformed document invalidates the whole read. This
 internal provider boundary remains read-only and has no proposal, approval, or
 canonical-mutation authority.
 
+Schema version 37 additionally materializes only each item's current active
+revision as a consolidation source; superseded changes remain cursor gaps. A
+stale or non-clear scan for a selected source is a failed provider read rather
+than a cursor gap, so a worker cannot advance past a current revision until it
+is clear under the current scanner and exception state.
+
 Schema version 16 adds bounded, operator-driven rescan and retained quarantine.
 Every current revision carries scan coverage bound to its revision, the compiled
 rule identity, and a per-project exact-exception generation. Exception changes

--- a/internal/postgres/brain_consolidation.go
+++ b/internal/postgres/brain_consolidation.go
@@ -119,8 +119,8 @@ func (d *Database) ReadMemoryConsolidationInput(ctx context.Context, lease Memor
 			input.NextSequence = sequence.Int64
 			continue
 		}
+		digest := sha256.Sum256([]byte(document.String))
 		canonical, err := canonicalMemoryDocument(json.RawMessage(document.String))
-		digest := sha256.Sum256(canonical)
 		if err != nil || len(contentHash) != sha256.Size || !bytes.Equal(digest[:], contentHash) {
 			return MemoryConsolidationInput{}, errors.New("consolidation source is malformed")
 		}

--- a/internal/postgres/brain_consolidation.go
+++ b/internal/postgres/brain_consolidation.go
@@ -3,6 +3,7 @@ package postgres
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
 	"errors"
 	"time"
 )
@@ -37,13 +38,14 @@ type MemoryConsolidationLease struct {
 	Until      time.Time
 }
 
-// MemoryConsolidationSource identifies one exact revision selected under a
-// live consolidation lease. Its document is intentionally deferred until a
-// later provider boundary; this selection record cannot itself create output.
+// MemoryConsolidationSource identifies one exact revision and its canonical
+// document selected under a live consolidation lease. It cannot itself create
+// output or change canonical memory.
 type MemoryConsolidationSource struct {
 	ItemID         string
 	Revision       int64
 	ChangeSequence int64
+	Document       json.RawMessage
 }
 
 // MemoryConsolidationInput is the bounded, lease-fenced source coordinate
@@ -68,7 +70,8 @@ func (input MemoryConsolidationInput) valid() bool {
 		return false
 	}
 	for _, source := range input.Sources {
-		if !validOpaqueID(source.ItemID) || source.Revision < 1 || source.ChangeSequence <= input.Lease.Sequence || source.ChangeSequence > input.NextSequence {
+		document, err := canonicalMemoryDocument(source.Document)
+		if !validOpaqueID(source.ItemID) || source.Revision < 1 || source.ChangeSequence <= input.Lease.Sequence || source.ChangeSequence > input.NextSequence || err != nil || !json.Valid(document) {
 			return false
 		}
 	}
@@ -83,7 +86,7 @@ func (d *Database) ReadMemoryConsolidationInput(ctx context.Context, lease Memor
 	if !lease.valid() {
 		return MemoryConsolidationInput{}, errors.New("invalid consolidation lease")
 	}
-	rows, err := d.db.QueryContext(ctx, `SELECT timeline_id::text,item_id::text,revision,change_sequence,is_fence FROM brain.read_memory_consolidation_sources($1,$2,$3)`, lease.ScopeID, lease.Token, lease.Generation)
+	rows, err := d.db.QueryContext(ctx, `SELECT timeline_id::text,item_id::text,revision,change_sequence,document::text,is_fence FROM brain.read_memory_consolidation_documents($1,$2,$3)`, lease.ScopeID, lease.Token, lease.Generation)
 	if err != nil {
 		return MemoryConsolidationInput{}, errors.New("consolidation sources are unavailable")
 	}
@@ -94,25 +97,30 @@ func (d *Database) ReadMemoryConsolidationInput(ctx context.Context, lease Memor
 		var timelineID string
 		var itemID sql.NullString
 		var revision, sequence sql.NullInt64
+		var document sql.NullString
 		var fence bool
-		if err := rows.Scan(&timelineID, &itemID, &revision, &sequence, &fence); err != nil || timelineID != lease.TimelineID {
+		if err := rows.Scan(&timelineID, &itemID, &revision, &sequence, &document, &fence); err != nil || timelineID != lease.TimelineID {
 			return MemoryConsolidationInput{}, errors.New("consolidation source is malformed")
 		}
 		if fence {
-			if !sequence.Valid || sequence.Int64 != lease.Sequence {
+			if itemID.Valid || revision.Valid || document.Valid || !sequence.Valid || sequence.Int64 != lease.Sequence {
 				return MemoryConsolidationInput{}, ErrStaleMemoryConsolidationLease
 			}
 			live = true
 			continue
 		}
-		if !itemID.Valid || !revision.Valid || !sequence.Valid {
-			if itemID.Valid || revision.Valid || !sequence.Valid {
+		if !itemID.Valid || !revision.Valid || !document.Valid || !sequence.Valid {
+			if itemID.Valid || revision.Valid || document.Valid || !sequence.Valid {
 				return MemoryConsolidationInput{}, errors.New("consolidation source is malformed")
 			}
 			input.NextSequence = sequence.Int64
 			continue
 		}
-		source := MemoryConsolidationSource{ItemID: itemID.String, Revision: revision.Int64, ChangeSequence: sequence.Int64}
+		canonical, err := canonicalMemoryDocument(json.RawMessage(document.String))
+		if err != nil {
+			return MemoryConsolidationInput{}, errors.New("consolidation source is malformed")
+		}
+		source := MemoryConsolidationSource{ItemID: itemID.String, Revision: revision.Int64, ChangeSequence: sequence.Int64, Document: canonical}
 		input.Sources = append(input.Sources, source)
 		input.NextSequence = source.ChangeSequence
 	}

--- a/internal/postgres/brain_consolidation.go
+++ b/internal/postgres/brain_consolidation.go
@@ -1,7 +1,9 @@
 package postgres
 
 import (
+	"bytes"
 	"context"
+	"crypto/sha256"
 	"database/sql"
 	"encoding/json"
 	"errors"
@@ -86,7 +88,7 @@ func (d *Database) ReadMemoryConsolidationInput(ctx context.Context, lease Memor
 	if !lease.valid() {
 		return MemoryConsolidationInput{}, errors.New("invalid consolidation lease")
 	}
-	rows, err := d.db.QueryContext(ctx, `SELECT timeline_id::text,item_id::text,revision,change_sequence,document::text,is_fence FROM brain.read_memory_consolidation_documents($1,$2,$3)`, lease.ScopeID, lease.Token, lease.Generation)
+	rows, err := d.db.QueryContext(ctx, `SELECT timeline_id::text,item_id::text,revision,change_sequence,document::text,content_sha256,is_fence FROM brain.read_memory_consolidation_documents($1,$2,$3)`, lease.ScopeID, lease.Token, lease.Generation)
 	if err != nil {
 		return MemoryConsolidationInput{}, errors.New("consolidation sources are unavailable")
 	}
@@ -98,26 +100,28 @@ func (d *Database) ReadMemoryConsolidationInput(ctx context.Context, lease Memor
 		var itemID sql.NullString
 		var revision, sequence sql.NullInt64
 		var document sql.NullString
+		var contentHash []byte
 		var fence bool
-		if err := rows.Scan(&timelineID, &itemID, &revision, &sequence, &document, &fence); err != nil || timelineID != lease.TimelineID {
+		if err := rows.Scan(&timelineID, &itemID, &revision, &sequence, &document, &contentHash, &fence); err != nil || timelineID != lease.TimelineID {
 			return MemoryConsolidationInput{}, errors.New("consolidation source is malformed")
 		}
 		if fence {
-			if itemID.Valid || revision.Valid || document.Valid || !sequence.Valid || sequence.Int64 != lease.Sequence {
+			if itemID.Valid || revision.Valid || document.Valid || len(contentHash) != 0 || !sequence.Valid || sequence.Int64 != lease.Sequence {
 				return MemoryConsolidationInput{}, ErrStaleMemoryConsolidationLease
 			}
 			live = true
 			continue
 		}
 		if !itemID.Valid || !revision.Valid || !document.Valid || !sequence.Valid {
-			if itemID.Valid || revision.Valid || document.Valid || !sequence.Valid {
+			if itemID.Valid || revision.Valid || document.Valid || len(contentHash) != 0 || !sequence.Valid {
 				return MemoryConsolidationInput{}, errors.New("consolidation source is malformed")
 			}
 			input.NextSequence = sequence.Int64
 			continue
 		}
 		canonical, err := canonicalMemoryDocument(json.RawMessage(document.String))
-		if err != nil {
+		digest := sha256.Sum256(canonical)
+		if err != nil || len(contentHash) != sha256.Size || !bytes.Equal(digest[:], contentHash) {
 			return MemoryConsolidationInput{}, errors.New("consolidation source is malformed")
 		}
 		source := MemoryConsolidationSource{ItemID: itemID.String, Revision: revision.Int64, ChangeSequence: sequence.Int64, Document: canonical}

--- a/internal/postgres/brain_consolidation_integration_test.go
+++ b/internal/postgres/brain_consolidation_integration_test.go
@@ -44,6 +44,10 @@ func testMemoryConsolidationCheckpointIntegration(ctx context.Context, t *testin
 	if err != nil || len(input.Sources) != len(created) || input.NextSequence != created[len(created)-1].ChangeSequence || input.Sources[0].ItemID != created[0].ItemID || input.Sources[1].Revision != created[1].Revision {
 		t.Fatalf("post-claim consolidation input=%#v created=%#v err=%v", input, created, err)
 	}
+	var firstDocument, secondDocument map[string]bool
+	if json.Unmarshal(input.Sources[0].Document, &firstDocument) != nil || json.Unmarshal(input.Sources[1].Document, &secondDocument) != nil || !firstDocument["source"] || !secondDocument["source"] {
+		t.Fatalf("consolidation source documents=%#v", input.Sources)
+	}
 	initialSequence := input.NextSequence
 	if _, claimed, err := app.ClaimMemoryConsolidationCheckpoint(ctx, scopeID, "22222222-2222-4222-8222-222222222222", memoryEmbeddingMinLease); err != nil || claimed {
 		t.Fatalf("duplicate consolidation claim claimed=%t err=%v", claimed, err)
@@ -241,6 +245,7 @@ func testMemoryConsolidationSchemaDriftIntegration(ctx context.Context, t *testi
 	for _, drift := range []struct{ apply, restore string }{
 		{`GRANT SELECT ON brain.memory_consolidation_checkpoints TO punaro_app`, `REVOKE SELECT ON brain.memory_consolidation_checkpoints FROM punaro_app`},
 		{`GRANT EXECUTE ON FUNCTION brain.claim_memory_consolidation_checkpoint(uuid,uuid,bigint) TO PUBLIC`, `REVOKE EXECUTE ON FUNCTION brain.claim_memory_consolidation_checkpoint(uuid,uuid,bigint) FROM PUBLIC`},
+		{`GRANT EXECUTE ON FUNCTION brain.read_memory_consolidation_documents(uuid,uuid,bigint) TO PUBLIC`, `REVOKE EXECUTE ON FUNCTION brain.read_memory_consolidation_documents(uuid,uuid,bigint) FROM PUBLIC`},
 	} {
 		if _, err := ownerDB.ExecContext(ctx, drift.apply); err != nil {
 			t.Fatal(err)

--- a/internal/postgres/brain_consolidation_integration_test.go
+++ b/internal/postgres/brain_consolidation_integration_test.go
@@ -2,6 +2,7 @@ package postgres
 
 import (
 	"context"
+	"crypto/sha256"
 	"database/sql"
 	"encoding/json"
 	"errors"
@@ -77,7 +78,12 @@ func testMemoryConsolidationCheckpointIntegration(ctx context.Context, t *testin
 	if _, err := app.ReadMemoryConsolidationInput(ctx, first); err == nil {
 		t.Fatal("corrupt consolidation source hash allowed consolidation input")
 	}
-	if result, err := ownerDB.ExecContext(ctx, `UPDATE brain.memory_revisions SET content_sha256=public.digest(document::text,'sha256') WHERE item_id=$1 AND revision=$2`, created[1].ItemID, created[1].Revision); err != nil {
+	var storedSecondDocument string
+	if err := ownerDB.QueryRowContext(ctx, `SELECT document::text FROM brain.memory_revisions WHERE item_id=$1 AND revision=$2`, created[1].ItemID, created[1].Revision).Scan(&storedSecondDocument); err != nil {
+		t.Fatal(err)
+	}
+	secondHash := sha256.Sum256([]byte(storedSecondDocument))
+	if result, err := ownerDB.ExecContext(ctx, `UPDATE brain.memory_revisions SET content_sha256=$3 WHERE item_id=$1 AND revision=$2`, created[1].ItemID, created[1].Revision, secondHash[:]); err != nil {
 		t.Fatal(err)
 	} else if changed, err := result.RowsAffected(); err != nil || changed != 1 {
 		t.Fatalf("restore consolidation source hash changed=%d err=%v", changed, err)

--- a/internal/postgres/brain_consolidation_integration_test.go
+++ b/internal/postgres/brain_consolidation_integration_test.go
@@ -77,7 +77,7 @@ func testMemoryConsolidationCheckpointIntegration(ctx context.Context, t *testin
 	if _, err := app.ReadMemoryConsolidationInput(ctx, first); err == nil {
 		t.Fatal("corrupt consolidation source hash allowed consolidation input")
 	}
-	if result, err := ownerDB.ExecContext(ctx, `UPDATE brain.memory_revisions SET content_sha256=public.digest(convert_to(document::text,'UTF8'),'sha256') WHERE item_id=$1 AND revision=$2`, created[1].ItemID, created[1].Revision); err != nil {
+	if result, err := ownerDB.ExecContext(ctx, `UPDATE brain.memory_revisions SET content_sha256=public.digest(document::text,'sha256') WHERE item_id=$1 AND revision=$2`, created[1].ItemID, created[1].Revision); err != nil {
 		t.Fatal(err)
 	} else if changed, err := result.RowsAffected(); err != nil || changed != 1 {
 		t.Fatalf("restore consolidation source hash changed=%d err=%v", changed, err)

--- a/internal/postgres/brain_consolidation_integration_test.go
+++ b/internal/postgres/brain_consolidation_integration_test.go
@@ -40,13 +40,34 @@ func testMemoryConsolidationCheckpointIntegration(ctx context.Context, t *testin
 		}
 		created = append(created, result)
 	}
+	lagged, err := app.CreateMemory(ctx, MemoryCreateRequest{PrincipalID: actor.ID, ProjectID: projectID, IdempotencyKey: "11111111-1111-4111-8111-111111111130", LogicalKey: "consolidation.lagged", Kind: "fact", Trust: "curated", Document: json.RawMessage(`{"source":"before-update"}`)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	lagged, err = app.UpdateMemory(ctx, MemoryUpdateRequest{PrincipalID: actor.ID, ProjectID: projectID, ItemID: lagged.ItemID, IdempotencyKey: "11111111-1111-4111-8111-111111111131", ExpectedETag: lagged.ETag, LogicalKey: "consolidation.lagged", Kind: "fact", Trust: "curated", Document: json.RawMessage(`{"source":"after-update"}`)})
+	if err != nil {
+		t.Fatal(err)
+	}
 	input, err = app.ReadMemoryConsolidationInput(ctx, first)
-	if err != nil || len(input.Sources) != len(created) || input.NextSequence != created[len(created)-1].ChangeSequence || input.Sources[0].ItemID != created[0].ItemID || input.Sources[1].Revision != created[1].Revision {
-		t.Fatalf("post-claim consolidation input=%#v created=%#v err=%v", input, created, err)
+	if err != nil || len(input.Sources) != len(created)+1 || input.NextSequence != lagged.ChangeSequence || input.Sources[0].ItemID != created[0].ItemID || input.Sources[1].Revision != created[1].Revision || input.Sources[2].ItemID != lagged.ItemID || input.Sources[2].Revision != lagged.Revision {
+		t.Fatalf("post-claim consolidation input=%#v created=%#v lagged=%#v err=%v", input, created, lagged, err)
 	}
 	var firstDocument, secondDocument map[string]bool
 	if json.Unmarshal(input.Sources[0].Document, &firstDocument) != nil || json.Unmarshal(input.Sources[1].Document, &secondDocument) != nil || !firstDocument["source"] || !secondDocument["source"] {
 		t.Fatalf("consolidation source documents=%#v", input.Sources)
+	}
+	if result, err := ownerDB.ExecContext(ctx, `UPDATE brain.memory_secret_scans SET rule_version=rule_version+1 WHERE item_id=$1`, created[0].ItemID); err != nil {
+		t.Fatal(err)
+	} else if changed, err := result.RowsAffected(); err != nil || changed != 1 {
+		t.Fatalf("stale consolidation scan seed changed=%d err=%v", changed, err)
+	}
+	if _, err := app.ReadMemoryConsolidationInput(ctx, first); err == nil {
+		t.Fatal("stale secret scan coverage allowed consolidation input")
+	}
+	if result, err := ownerDB.ExecContext(ctx, `UPDATE brain.memory_secret_scans SET rule_version=rule_version-1 WHERE item_id=$1`, created[0].ItemID); err != nil {
+		t.Fatal(err)
+	} else if changed, err := result.RowsAffected(); err != nil || changed != 1 {
+		t.Fatalf("restore consolidation scan seed changed=%d err=%v", changed, err)
 	}
 	initialSequence := input.NextSequence
 	if _, claimed, err := app.ClaimMemoryConsolidationCheckpoint(ctx, scopeID, "22222222-2222-4222-8222-222222222222", memoryEmbeddingMinLease); err != nil || claimed {

--- a/internal/postgres/brain_consolidation_integration_test.go
+++ b/internal/postgres/brain_consolidation_integration_test.go
@@ -69,6 +69,19 @@ func testMemoryConsolidationCheckpointIntegration(ctx context.Context, t *testin
 	} else if changed, err := result.RowsAffected(); err != nil || changed != 1 {
 		t.Fatalf("restore consolidation scan seed changed=%d err=%v", changed, err)
 	}
+	if result, err := ownerDB.ExecContext(ctx, `UPDATE brain.memory_revisions SET content_sha256=decode(repeat('00',32),'hex') WHERE item_id=$1 AND revision=$2`, created[1].ItemID, created[1].Revision); err != nil {
+		t.Fatal(err)
+	} else if changed, err := result.RowsAffected(); err != nil || changed != 1 {
+		t.Fatalf("corrupt consolidation source hash changed=%d err=%v", changed, err)
+	}
+	if _, err := app.ReadMemoryConsolidationInput(ctx, first); err == nil {
+		t.Fatal("corrupt consolidation source hash allowed consolidation input")
+	}
+	if result, err := ownerDB.ExecContext(ctx, `UPDATE brain.memory_revisions SET content_sha256=public.digest(convert_to(document::text,'UTF8'),'sha256') WHERE item_id=$1 AND revision=$2`, created[1].ItemID, created[1].Revision); err != nil {
+		t.Fatal(err)
+	} else if changed, err := result.RowsAffected(); err != nil || changed != 1 {
+		t.Fatalf("restore consolidation source hash changed=%d err=%v", changed, err)
+	}
 	initialSequence := input.NextSequence
 	if _, claimed, err := app.ClaimMemoryConsolidationCheckpoint(ctx, scopeID, "22222222-2222-4222-8222-222222222222", memoryEmbeddingMinLease); err != nil || claimed {
 		t.Fatalf("duplicate consolidation claim claimed=%t err=%v", claimed, err)
@@ -162,6 +175,14 @@ VALUES ($1,$2,1,'sensitive-field','/source',decode(repeat('11',32),'hex'),$3)`, 
 	}
 	if err := app.AdvanceMemoryConsolidationCheckpoint(ctx, second, second.TimelineID, 3); !errors.Is(err, ErrStaleMemoryConsolidationLease) {
 		t.Fatalf("expired consolidation lease advance error=%v", err)
+	}
+	restored, err := app.ArchiveMemory(ctx, MemoryArchiveRequest{PrincipalID: actor.ID, ProjectID: projectID, ItemID: archived.ItemID, IdempotencyKey: "11111111-1111-4111-8111-111111111132", ExpectedETag: archived.ETag, Archived: false})
+	if err != nil {
+		t.Fatal(err)
+	}
+	input, err = app.ReadMemoryConsolidationInput(ctx, fourth)
+	if err != nil || len(input.Sources) != 1 || input.Sources[0].ItemID != restored.ItemID || input.Sources[0].Revision != restored.Revision || input.NextSequence != restored.ChangeSequence {
+		t.Fatalf("restored revision lacked consolidation scan coverage input=%#v restored=%#v err=%v", input, restored, err)
 	}
 	testMemoryConsolidationRestoreLineageIntegration(ctx, t, app, ownerDB, actor.ID)
 }

--- a/internal/postgres/brain_consolidation_schema.go
+++ b/internal/postgres/brain_consolidation_schema.go
@@ -7,8 +7,12 @@ import "context"
 func memoryConsolidationControlsAvailable(ctx context.Context, q queryer, version int64) (bool, error) {
 	var available bool
 	claimMD5, advanceMD5 := memoryConsolidationClaimRoutineMD5, memoryConsolidationAdvanceRoutineMD5
+	documentsMD5 := memoryConsolidationDocumentsRoutineMD5
 	if version == 33 {
 		claimMD5, advanceMD5 = memoryConsolidationV33ClaimRoutineMD5, memoryConsolidationV33AdvanceRoutineMD5
+	}
+	if version == 35 {
+		documentsMD5 = memoryConsolidationV35DocumentsRoutineMD5
 	}
 	err := q.QueryRowContext(ctx, `
 WITH objects AS (
@@ -99,15 +103,16 @@ SELECT table_oid IS NOT NULL AND claim_oid IS NOT NULL AND advance_oid IS NOT NU
    AND table_acl_safety.exact
    AND NOT has_table_privilege('punaro_app',table_oid,'SELECT,INSERT,UPDATE,DELETE,TRUNCATE,REFERENCES,TRIGGER')
    AND NOT EXISTS (SELECT 1 FROM pg_attribute,objects WHERE attrelid=table_oid AND attnum>0 AND NOT attisdropped AND attacl IS NOT NULL)
-FROM objects,routine_safety,constraint_safety,table_acl_safety`, claimMD5, advanceMD5, memoryConsolidationSourcesRoutineMD5, memoryConsolidationDocumentsRoutineMD5, version >= 34, version >= 35).Scan(&available)
+FROM objects,routine_safety,constraint_safety,table_acl_safety`, claimMD5, advanceMD5, memoryConsolidationSourcesRoutineMD5, documentsMD5, version >= 34, version >= 35).Scan(&available)
 	return available, err
 }
 
 const (
-	memoryConsolidationClaimRoutineMD5      = "121df7d09493be8662f4618208aaf342"
-	memoryConsolidationAdvanceRoutineMD5    = "5666d576e054c6b06999a0b6ce7b6c62"
-	memoryConsolidationSourcesRoutineMD5    = "2b180c012d8c1ae7332b81456845a8bf"
-	memoryConsolidationDocumentsRoutineMD5  = "8eac22d68c0b50c43de1f8892c925c55"
-	memoryConsolidationV33ClaimRoutineMD5   = "32e95c7fb6a9e73522c73b825bc3dcea"
-	memoryConsolidationV33AdvanceRoutineMD5 = "cce038c3cca8f3c4f48da8b5e155443c"
+	memoryConsolidationClaimRoutineMD5        = "121df7d09493be8662f4618208aaf342"
+	memoryConsolidationAdvanceRoutineMD5      = "5666d576e054c6b06999a0b6ce7b6c62"
+	memoryConsolidationSourcesRoutineMD5      = "2b180c012d8c1ae7332b81456845a8bf"
+	memoryConsolidationDocumentsRoutineMD5    = "8eac22d68c0b50c43de1f8892c925c55"
+	memoryConsolidationV35DocumentsRoutineMD5 = "578fc76b7dd1ed66ccdd7895cd50e07c"
+	memoryConsolidationV33ClaimRoutineMD5     = "32e95c7fb6a9e73522c73b825bc3dcea"
+	memoryConsolidationV33AdvanceRoutineMD5   = "cce038c3cca8f3c4f48da8b5e155443c"
 )

--- a/internal/postgres/brain_consolidation_schema.go
+++ b/internal/postgres/brain_consolidation_schema.go
@@ -59,9 +59,9 @@ WITH objects AS (
             AND md5(btrim(routine.prosrc,E' \n\r\t'))=$3)
         OR (routine.oid=documents_oid AND routine.proretset AND routine.prorettype='record'::regtype
             AND routine.pronargs=3 AND routine.proargtypes='2950 2950 20'::oidvector
-            AND routine.proallargtypes=ARRAY['uuid'::regtype,'uuid'::regtype,'bigint'::regtype,'uuid'::regtype,'uuid'::regtype,'bigint'::regtype,'bigint'::regtype,'jsonb'::regtype,'boolean'::regtype]::oid[]
-            AND routine.proargmodes=ARRAY['i','i','i','t','t','t','t','t','t']::"char"[]
-            AND routine.proargnames=ARRAY['requested_scope','requested_token','requested_generation','timeline_id','item_id','revision','change_sequence','document','is_fence']::text[]
+            AND routine.proallargtypes=ARRAY['uuid'::regtype,'uuid'::regtype,'bigint'::regtype,'uuid'::regtype,'uuid'::regtype,'bigint'::regtype,'bigint'::regtype,'jsonb'::regtype,'bytea'::regtype,'boolean'::regtype]::oid[]
+            AND routine.proargmodes=ARRAY['i','i','i','t','t','t','t','t','t','t']::"char"[]
+            AND routine.proargnames=ARRAY['requested_scope','requested_token','requested_generation','timeline_id','item_id','revision','change_sequence','document','content_sha256','is_fence']::text[]
             AND md5(btrim(routine.prosrc,E' \n\r\t'))=$4))) AS exact
     FROM pg_proc AS routine,objects
     WHERE routine.oid=ANY(ARRAY[claim_oid,advance_oid,sources_oid,documents_oid])
@@ -114,7 +114,7 @@ const (
 	memoryConsolidationClaimRoutineMD5        = "121df7d09493be8662f4618208aaf342"
 	memoryConsolidationAdvanceRoutineMD5      = "5666d576e054c6b06999a0b6ce7b6c62"
 	memoryConsolidationSourcesRoutineMD5      = "2b180c012d8c1ae7332b81456845a8bf"
-	memoryConsolidationDocumentsRoutineMD5    = "9c73323daea6c4a1c9cbf8daaa79516a"
+	memoryConsolidationDocumentsRoutineMD5    = "0b284fa1e93f9b8cd62604d4e2a3821c"
 	memoryConsolidationV35DocumentsRoutineMD5 = "578fc76b7dd1ed66ccdd7895cd50e07c"
 	memoryConsolidationV36DocumentsRoutineMD5 = "8eac22d68c0b50c43de1f8892c925c55"
 	memoryConsolidationV33ClaimRoutineMD5     = "32e95c7fb6a9e73522c73b825bc3dcea"

--- a/internal/postgres/brain_consolidation_schema.go
+++ b/internal/postgres/brain_consolidation_schema.go
@@ -114,7 +114,7 @@ const (
 	memoryConsolidationClaimRoutineMD5        = "121df7d09493be8662f4618208aaf342"
 	memoryConsolidationAdvanceRoutineMD5      = "5666d576e054c6b06999a0b6ce7b6c62"
 	memoryConsolidationSourcesRoutineMD5      = "2b180c012d8c1ae7332b81456845a8bf"
-	memoryConsolidationDocumentsRoutineMD5    = "26e4a63eca02df463325f703fe52c486"
+	memoryConsolidationDocumentsRoutineMD5    = "0c74489be9d1e1385fce36962591da88"
 	memoryConsolidationV35DocumentsRoutineMD5 = "578fc76b7dd1ed66ccdd7895cd50e07c"
 	memoryConsolidationV36DocumentsRoutineMD5 = "8eac22d68c0b50c43de1f8892c925c55"
 	memoryConsolidationV33ClaimRoutineMD5     = "32e95c7fb6a9e73522c73b825bc3dcea"

--- a/internal/postgres/brain_consolidation_schema.go
+++ b/internal/postgres/brain_consolidation_schema.go
@@ -16,7 +16,9 @@ WITH objects AS (
            to_regprocedure('brain.claim_memory_consolidation_checkpoint(uuid,uuid,bigint)') AS claim_oid,
            to_regprocedure('brain.advance_memory_consolidation_checkpoint(uuid,uuid,bigint,uuid,bigint)') AS advance_oid,
            to_regprocedure('brain.read_memory_consolidation_sources(uuid,uuid,bigint)') AS sources_oid,
-           $4::boolean AS sources_required
+           to_regprocedure('brain.read_memory_consolidation_documents(uuid,uuid,bigint)') AS documents_oid,
+           $4::boolean AS sources_required,
+           $5::boolean AS documents_required
 ), expected_columns(name,type_name,required,default_expression) AS (
     VALUES
       ('scope_id','uuid',true,''),('timeline_id','uuid',true,''),('change_sequence','bigint',true,'0'),
@@ -28,7 +30,7 @@ WITH objects AS (
     LEFT JOIN pg_attrdef AS default_value ON default_value.adrelid=attribute.attrelid AND default_value.adnum=attribute.attnum
     WHERE attribute.attrelid=table_oid AND attribute.attnum>0 AND NOT attribute.attisdropped
 ), routine_safety AS (
-    SELECT count(*)=(CASE WHEN sources_required THEN 3 ELSE 2 END) AND bool_and(pg_get_userbyid(routine.proowner)='punaro_owner'
+    SELECT count(*)=(CASE WHEN documents_required THEN 4 WHEN sources_required THEN 3 ELSE 2 END) AND bool_and(pg_get_userbyid(routine.proowner)='punaro_owner'
       AND routine.prokind='f' AND routine.prosecdef AND routine.provolatile='v'
       AND routine.prolang=(SELECT oid FROM pg_language WHERE lanname='plpgsql')
       AND routine.proconfig=ARRAY['search_path=pg_catalog']::text[] AND NOT routine.proisstrict
@@ -47,10 +49,16 @@ WITH objects AS (
             AND routine.proallargtypes=ARRAY['uuid'::regtype,'uuid'::regtype,'bigint'::regtype,'uuid'::regtype,'uuid'::regtype,'bigint'::regtype,'bigint'::regtype,'boolean'::regtype]::oid[]
             AND routine.proargmodes=ARRAY['i','i','i','t','t','t','t','t']::"char"[]
             AND routine.proargnames=ARRAY['requested_scope','requested_token','requested_generation','timeline_id','item_id','revision','change_sequence','is_fence']::text[]
-            AND md5(btrim(routine.prosrc,E' \n\r\t'))=$3))) AS exact
+            AND md5(btrim(routine.prosrc,E' \n\r\t'))=$3)
+        OR (routine.oid=documents_oid AND routine.proretset AND routine.prorettype='record'::regtype
+            AND routine.pronargs=3 AND routine.proargtypes='2950 2950 20'::oidvector
+            AND routine.proallargtypes=ARRAY['uuid'::regtype,'uuid'::regtype,'bigint'::regtype,'uuid'::regtype,'uuid'::regtype,'bigint'::regtype,'bigint'::regtype,'jsonb'::regtype,'boolean'::regtype]::oid[]
+            AND routine.proargmodes=ARRAY['i','i','i','t','t','t','t','t','t']::"char"[]
+            AND routine.proargnames=ARRAY['requested_scope','requested_token','requested_generation','timeline_id','item_id','revision','change_sequence','document','is_fence']::text[]
+            AND md5(btrim(routine.prosrc,E' \n\r\t'))=$4)) AS exact
     FROM pg_proc AS routine,objects
-    WHERE routine.oid=ANY(ARRAY[claim_oid,advance_oid,sources_oid])
-    GROUP BY sources_required
+    WHERE routine.oid=ANY(ARRAY[claim_oid,advance_oid,sources_oid,documents_oid])
+    GROUP BY sources_required,documents_required
 ), constraint_safety AS (
     SELECT count(*)=5
        AND count(*) FILTER (WHERE contype='p' AND conkey=ARRAY[1]::smallint[])=1
@@ -65,12 +73,14 @@ WITH objects AS (
     SELECT advance_oid,'punaro_owner','EXECUTE',false FROM objects UNION ALL
     SELECT advance_oid,'punaro_app','EXECUTE',false FROM objects UNION ALL
     SELECT sources_oid,'punaro_owner','EXECUTE',false FROM objects WHERE sources_required UNION ALL
-    SELECT sources_oid,'punaro_app','EXECUTE',false FROM objects WHERE sources_required
+    SELECT sources_oid,'punaro_app','EXECUTE',false FROM objects WHERE sources_required UNION ALL
+    SELECT documents_oid,'punaro_owner','EXECUTE',false FROM objects WHERE documents_required UNION ALL
+    SELECT documents_oid,'punaro_app','EXECUTE',false FROM objects WHERE documents_required
 ), actual_acl AS (
     SELECT routine.oid,COALESCE(grantee.rolname,'PUBLIC'),entry.privilege_type,entry.is_grantable
     FROM pg_proc AS routine CROSS JOIN LATERAL aclexplode(COALESCE(routine.proacl,acldefault('f',routine.proowner))) AS entry
     LEFT JOIN pg_roles AS grantee ON grantee.oid=entry.grantee,objects
-    WHERE routine.oid=ANY(ARRAY[claim_oid,advance_oid,sources_oid])
+    WHERE routine.oid=ANY(ARRAY[claim_oid,advance_oid,sources_oid,documents_oid])
 ), table_acl_safety AS (
     SELECT NOT EXISTS (
         SELECT 1
@@ -78,7 +88,7 @@ WITH objects AS (
         WHERE relation.oid=table_oid AND entry.grantee<>relation.relowner
     ) AS exact
 )
-SELECT table_oid IS NOT NULL AND claim_oid IS NOT NULL AND advance_oid IS NOT NULL AND (NOT sources_required OR sources_oid IS NOT NULL)
+SELECT table_oid IS NOT NULL AND claim_oid IS NOT NULL AND advance_oid IS NOT NULL AND (NOT sources_required OR sources_oid IS NOT NULL) AND (NOT documents_required OR documents_oid IS NOT NULL)
    AND (SELECT count(*)=1 AND bool_and(pg_get_userbyid(relowner)='punaro_owner' AND relkind='r' AND relpersistence='p' AND NOT relrowsecurity AND NOT relforcerowsecurity) FROM pg_class WHERE oid=table_oid)
    AND NOT EXISTS (SELECT * FROM expected_columns EXCEPT SELECT * FROM actual_columns)
    AND NOT EXISTS (SELECT * FROM actual_columns EXCEPT SELECT * FROM expected_columns)
@@ -89,7 +99,7 @@ SELECT table_oid IS NOT NULL AND claim_oid IS NOT NULL AND advance_oid IS NOT NU
    AND table_acl_safety.exact
    AND NOT has_table_privilege('punaro_app',table_oid,'SELECT,INSERT,UPDATE,DELETE,TRUNCATE,REFERENCES,TRIGGER')
    AND NOT EXISTS (SELECT 1 FROM pg_attribute,objects WHERE attrelid=table_oid AND attnum>0 AND NOT attisdropped AND attacl IS NOT NULL)
-FROM objects,routine_safety,constraint_safety,table_acl_safety`, claimMD5, advanceMD5, memoryConsolidationSourcesRoutineMD5, version >= 34).Scan(&available)
+FROM objects,routine_safety,constraint_safety,table_acl_safety`, claimMD5, advanceMD5, memoryConsolidationSourcesRoutineMD5, memoryConsolidationDocumentsRoutineMD5, version >= 34, version >= 35).Scan(&available)
 	return available, err
 }
 
@@ -97,6 +107,7 @@ const (
 	memoryConsolidationClaimRoutineMD5      = "121df7d09493be8662f4618208aaf342"
 	memoryConsolidationAdvanceRoutineMD5    = "5666d576e054c6b06999a0b6ce7b6c62"
 	memoryConsolidationSourcesRoutineMD5    = "2b180c012d8c1ae7332b81456845a8bf"
+	memoryConsolidationDocumentsRoutineMD5  = "578fc76b7dd1ed66ccdd7895cd50e07c"
 	memoryConsolidationV33ClaimRoutineMD5   = "32e95c7fb6a9e73522c73b825bc3dcea"
 	memoryConsolidationV33AdvanceRoutineMD5 = "cce038c3cca8f3c4f48da8b5e155443c"
 )

--- a/internal/postgres/brain_consolidation_schema.go
+++ b/internal/postgres/brain_consolidation_schema.go
@@ -107,7 +107,7 @@ const (
 	memoryConsolidationClaimRoutineMD5      = "121df7d09493be8662f4618208aaf342"
 	memoryConsolidationAdvanceRoutineMD5    = "5666d576e054c6b06999a0b6ce7b6c62"
 	memoryConsolidationSourcesRoutineMD5    = "2b180c012d8c1ae7332b81456845a8bf"
-	memoryConsolidationDocumentsRoutineMD5  = "578fc76b7dd1ed66ccdd7895cd50e07c"
+	memoryConsolidationDocumentsRoutineMD5  = "8eac22d68c0b50c43de1f8892c925c55"
 	memoryConsolidationV33ClaimRoutineMD5   = "32e95c7fb6a9e73522c73b825bc3dcea"
 	memoryConsolidationV33AdvanceRoutineMD5 = "cce038c3cca8f3c4f48da8b5e155443c"
 )

--- a/internal/postgres/brain_consolidation_schema.go
+++ b/internal/postgres/brain_consolidation_schema.go
@@ -25,7 +25,8 @@ WITH objects AS (
            to_regprocedure('brain.read_memory_consolidation_sources(uuid,uuid,bigint)') AS sources_oid,
            to_regprocedure('brain.read_memory_consolidation_documents(uuid,uuid,bigint)') AS documents_oid,
            $5::boolean AS sources_required,
-           $6::boolean AS documents_required
+           $6::boolean AS documents_required,
+           $7::boolean AS document_hash_required
 ), expected_columns(name,type_name,required,default_expression) AS (
     VALUES
       ('scope_id','uuid',true,''),('timeline_id','uuid',true,''),('change_sequence','bigint',true,'0'),
@@ -59,13 +60,18 @@ WITH objects AS (
             AND md5(btrim(routine.prosrc,E' \n\r\t'))=$3)
         OR (routine.oid=documents_oid AND routine.proretset AND routine.prorettype='record'::regtype
             AND routine.pronargs=3 AND routine.proargtypes='2950 2950 20'::oidvector
-            AND routine.proallargtypes=ARRAY['uuid'::regtype,'uuid'::regtype,'bigint'::regtype,'uuid'::regtype,'uuid'::regtype,'bigint'::regtype,'bigint'::regtype,'jsonb'::regtype,'bytea'::regtype,'boolean'::regtype]::oid[]
-            AND routine.proargmodes=ARRAY['i','i','i','t','t','t','t','t','t','t']::"char"[]
-            AND routine.proargnames=ARRAY['requested_scope','requested_token','requested_generation','timeline_id','item_id','revision','change_sequence','document','content_sha256','is_fence']::text[]
+            AND ((document_hash_required
+                  AND routine.proallargtypes=ARRAY['uuid'::regtype,'uuid'::regtype,'bigint'::regtype,'uuid'::regtype,'uuid'::regtype,'bigint'::regtype,'bigint'::regtype,'jsonb'::regtype,'bytea'::regtype,'boolean'::regtype]::oid[]
+                  AND routine.proargmodes=ARRAY['i','i','i','t','t','t','t','t','t','t']::"char"[]
+                  AND routine.proargnames=ARRAY['requested_scope','requested_token','requested_generation','timeline_id','item_id','revision','change_sequence','document','content_sha256','is_fence']::text[])
+                 OR (NOT document_hash_required
+                  AND routine.proallargtypes=ARRAY['uuid'::regtype,'uuid'::regtype,'bigint'::regtype,'uuid'::regtype,'uuid'::regtype,'bigint'::regtype,'bigint'::regtype,'jsonb'::regtype,'boolean'::regtype]::oid[]
+                  AND routine.proargmodes=ARRAY['i','i','i','t','t','t','t','t','t']::"char"[]
+                  AND routine.proargnames=ARRAY['requested_scope','requested_token','requested_generation','timeline_id','item_id','revision','change_sequence','document','is_fence']::text[]))
             AND md5(btrim(routine.prosrc,E' \n\r\t'))=$4))) AS exact
     FROM pg_proc AS routine,objects
     WHERE routine.oid=ANY(ARRAY[claim_oid,advance_oid,sources_oid,documents_oid])
-    GROUP BY sources_required,documents_required
+    GROUP BY sources_required,documents_required,document_hash_required
 ), constraint_safety AS (
     SELECT count(*)=5
        AND count(*) FILTER (WHERE contype='p' AND conkey=ARRAY[1]::smallint[])=1
@@ -106,7 +112,7 @@ SELECT table_oid IS NOT NULL AND claim_oid IS NOT NULL AND advance_oid IS NOT NU
    AND table_acl_safety.exact
    AND NOT has_table_privilege('punaro_app',table_oid,'SELECT,INSERT,UPDATE,DELETE,TRUNCATE,REFERENCES,TRIGGER')
    AND NOT EXISTS (SELECT 1 FROM pg_attribute,objects WHERE attrelid=table_oid AND attnum>0 AND NOT attisdropped AND attacl IS NOT NULL)
-FROM objects,routine_safety,constraint_safety,table_acl_safety`, claimMD5, advanceMD5, memoryConsolidationSourcesRoutineMD5, documentsMD5, version >= 34, version >= 35).Scan(&available)
+FROM objects,routine_safety,constraint_safety,table_acl_safety`, claimMD5, advanceMD5, memoryConsolidationSourcesRoutineMD5, documentsMD5, version >= 34, version >= 35, version >= 37).Scan(&available)
 	return available, err
 }
 

--- a/internal/postgres/brain_consolidation_schema.go
+++ b/internal/postgres/brain_consolidation_schema.go
@@ -114,7 +114,7 @@ const (
 	memoryConsolidationClaimRoutineMD5        = "121df7d09493be8662f4618208aaf342"
 	memoryConsolidationAdvanceRoutineMD5      = "5666d576e054c6b06999a0b6ce7b6c62"
 	memoryConsolidationSourcesRoutineMD5      = "2b180c012d8c1ae7332b81456845a8bf"
-	memoryConsolidationDocumentsRoutineMD5    = "de0861cb29e11e85faea5ceb685fdf0c"
+	memoryConsolidationDocumentsRoutineMD5    = "9c73323daea6c4a1c9cbf8daaa79516a"
 	memoryConsolidationV35DocumentsRoutineMD5 = "578fc76b7dd1ed66ccdd7895cd50e07c"
 	memoryConsolidationV36DocumentsRoutineMD5 = "8eac22d68c0b50c43de1f8892c925c55"
 	memoryConsolidationV33ClaimRoutineMD5     = "32e95c7fb6a9e73522c73b825bc3dcea"

--- a/internal/postgres/brain_consolidation_schema.go
+++ b/internal/postgres/brain_consolidation_schema.go
@@ -14,6 +14,9 @@ func memoryConsolidationControlsAvailable(ctx context.Context, q queryer, versio
 	if version == 35 {
 		documentsMD5 = memoryConsolidationV35DocumentsRoutineMD5
 	}
+	if version == 36 {
+		documentsMD5 = memoryConsolidationV36DocumentsRoutineMD5
+	}
 	err := q.QueryRowContext(ctx, `
 WITH objects AS (
     SELECT to_regclass('brain.memory_consolidation_checkpoints') AS table_oid,
@@ -21,8 +24,8 @@ WITH objects AS (
            to_regprocedure('brain.advance_memory_consolidation_checkpoint(uuid,uuid,bigint,uuid,bigint)') AS advance_oid,
            to_regprocedure('brain.read_memory_consolidation_sources(uuid,uuid,bigint)') AS sources_oid,
            to_regprocedure('brain.read_memory_consolidation_documents(uuid,uuid,bigint)') AS documents_oid,
-           $4::boolean AS sources_required,
-           $5::boolean AS documents_required
+           $5::boolean AS sources_required,
+           $6::boolean AS documents_required
 ), expected_columns(name,type_name,required,default_expression) AS (
     VALUES
       ('scope_id','uuid',true,''),('timeline_id','uuid',true,''),('change_sequence','bigint',true,'0'),
@@ -59,7 +62,7 @@ WITH objects AS (
             AND routine.proallargtypes=ARRAY['uuid'::regtype,'uuid'::regtype,'bigint'::regtype,'uuid'::regtype,'uuid'::regtype,'bigint'::regtype,'bigint'::regtype,'jsonb'::regtype,'boolean'::regtype]::oid[]
             AND routine.proargmodes=ARRAY['i','i','i','t','t','t','t','t','t']::"char"[]
             AND routine.proargnames=ARRAY['requested_scope','requested_token','requested_generation','timeline_id','item_id','revision','change_sequence','document','is_fence']::text[]
-            AND md5(btrim(routine.prosrc,E' \n\r\t'))=$4)) AS exact
+            AND md5(btrim(routine.prosrc,E' \n\r\t'))=$4))) AS exact
     FROM pg_proc AS routine,objects
     WHERE routine.oid=ANY(ARRAY[claim_oid,advance_oid,sources_oid,documents_oid])
     GROUP BY sources_required,documents_required
@@ -111,8 +114,9 @@ const (
 	memoryConsolidationClaimRoutineMD5        = "121df7d09493be8662f4618208aaf342"
 	memoryConsolidationAdvanceRoutineMD5      = "5666d576e054c6b06999a0b6ce7b6c62"
 	memoryConsolidationSourcesRoutineMD5      = "2b180c012d8c1ae7332b81456845a8bf"
-	memoryConsolidationDocumentsRoutineMD5    = "8eac22d68c0b50c43de1f8892c925c55"
+	memoryConsolidationDocumentsRoutineMD5    = "26e4a63eca02df463325f703fe52c486"
 	memoryConsolidationV35DocumentsRoutineMD5 = "578fc76b7dd1ed66ccdd7895cd50e07c"
+	memoryConsolidationV36DocumentsRoutineMD5 = "8eac22d68c0b50c43de1f8892c925c55"
 	memoryConsolidationV33ClaimRoutineMD5     = "32e95c7fb6a9e73522c73b825bc3dcea"
 	memoryConsolidationV33AdvanceRoutineMD5   = "cce038c3cca8f3c4f48da8b5e155443c"
 )

--- a/internal/postgres/brain_consolidation_schema.go
+++ b/internal/postgres/brain_consolidation_schema.go
@@ -114,7 +114,7 @@ const (
 	memoryConsolidationClaimRoutineMD5        = "121df7d09493be8662f4618208aaf342"
 	memoryConsolidationAdvanceRoutineMD5      = "5666d576e054c6b06999a0b6ce7b6c62"
 	memoryConsolidationSourcesRoutineMD5      = "2b180c012d8c1ae7332b81456845a8bf"
-	memoryConsolidationDocumentsRoutineMD5    = "0c74489be9d1e1385fce36962591da88"
+	memoryConsolidationDocumentsRoutineMD5    = "de0861cb29e11e85faea5ceb685fdf0c"
 	memoryConsolidationV35DocumentsRoutineMD5 = "578fc76b7dd1ed66ccdd7895cd50e07c"
 	memoryConsolidationV36DocumentsRoutineMD5 = "8eac22d68c0b50c43de1f8892c925c55"
 	memoryConsolidationV33ClaimRoutineMD5     = "32e95c7fb6a9e73522c73b825bc3dcea"

--- a/internal/postgres/brain_consolidation_test.go
+++ b/internal/postgres/brain_consolidation_test.go
@@ -1,6 +1,7 @@
 package postgres
 
 import (
+	"encoding/json"
 	"testing"
 	"time"
 )
@@ -41,7 +42,7 @@ func TestMemoryConsolidationPolicyRejectsUnboundedOrMutatingPlans(t *testing.T) 
 
 func TestMemoryConsolidationInputRejectsUnfencedOrUnboundedPages(t *testing.T) {
 	lease := MemoryConsolidationLease{ScopeID: "11111111-1111-4111-8111-111111111111", Holder: "22222222-2222-4222-8222-222222222222", Token: "33333333-3333-4333-8333-333333333333", Generation: 1, Until: time.Now().Add(time.Minute)}
-	valid := MemoryConsolidationInput{Lease: lease, TimelineID: "44444444-4444-4444-8444-444444444444", NextSequence: 2, Sources: []MemoryConsolidationSource{{ItemID: "55555555-5555-4555-8555-555555555555", Revision: 1, ChangeSequence: 2}}}
+	valid := MemoryConsolidationInput{Lease: lease, TimelineID: "44444444-4444-4444-8444-444444444444", NextSequence: 2, Sources: []MemoryConsolidationSource{{ItemID: "55555555-5555-4555-8555-555555555555", Revision: 1, ChangeSequence: 2, Document: json.RawMessage(`{"source":true}`)}}}
 	if !valid.valid() {
 		t.Fatal("valid consolidation input rejected")
 	}
@@ -49,6 +50,7 @@ func TestMemoryConsolidationInputRejectsUnfencedOrUnboundedPages(t *testing.T) {
 		"missing lease":    func() MemoryConsolidationInput { value := valid; value.Lease.Token = ""; return value }(),
 		"foreign timeline": func() MemoryConsolidationInput { value := valid; value.TimelineID = ""; return value }(),
 		"unfenced source":  func() MemoryConsolidationInput { value := valid; value.Sources[0].Revision = 0; return value }(),
+		"missing document": func() MemoryConsolidationInput { value := valid; value.Sources[0].Document = nil; return value }(),
 		"cursor replay": func() MemoryConsolidationInput {
 			value := valid
 			value.Sources[0].ChangeSequence = value.Lease.Sequence

--- a/internal/postgres/brain_integration_test.go
+++ b/internal/postgres/brain_integration_test.go
@@ -3824,9 +3824,32 @@ WHERE item_id=$1 AND revision=1`, second.ItemID, secondLegacyDocument, secondLeg
 	if page, err := app.SearchMemory(ctx, MemorySearchRequest{PrincipalID: readerID, ProjectID: projectID, Query: "legacy.secret", Limit: 2}); err != nil || len(page.Results) != 0 {
 		t.Fatalf("requarantined memory search=%#v err=%v", page, err)
 	}
+	if _, err := app.ApproveMemorySecretException(ctx, MemorySecretExceptionRequest{
+		PrincipalID: actorID, ProjectID: projectID, IdempotencyKey: "16161616-1616-4616-8616-161616161615",
+		RuleID: review.Finding.RuleID, FieldPath: review.Finding.FieldPath, RuleVersion: review.Finding.RuleVersion, Fingerprint: review.Finding.Fingerprint,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	archivedAgain, err := app.ArchiveMemory(ctx, MemoryArchiveRequest{
+		PrincipalID: actorID, ProjectID: projectID, ItemID: created.ItemID,
+		IdempotencyKey: "16161616-1616-4616-8616-161616161616", ExpectedETag: restored.ETag, Archived: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	restoredAfterException, err := app.ArchiveMemory(ctx, MemoryArchiveRequest{
+		PrincipalID: actorID, ProjectID: projectID, ItemID: created.ItemID,
+		IdempotencyKey: "16161616-1616-4616-8616-161616161617", ExpectedETag: archivedAgain.ETag, Archived: false,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if item, err := app.GetMemory(ctx, readerID, projectID, created.ItemID); err != nil || item.Revision != restoredAfterException.Revision {
+		t.Fatalf("excepted restore left memory quarantined item=%#v err=%v", item, err)
+	}
 	cleaned, err := app.UpdateMemory(ctx, MemoryUpdateRequest{
 		PrincipalID: actorID, ProjectID: projectID, ItemID: created.ItemID,
-		IdempotencyKey: "16161616-1616-4616-8616-161616161609", ExpectedETag: restored.ETag,
+		IdempotencyKey: "16161616-1616-4616-8616-161616161609", ExpectedETag: restoredAfterException.ETag,
 		LogicalKey: "legacy.secret", Kind: "preference", Trust: "curated", Document: json.RawMessage(`{"title":"clean replacement"}`),
 	})
 	if err != nil {

--- a/internal/postgres/brain_store.go
+++ b/internal/postgres/brain_store.go
@@ -263,17 +263,33 @@ FROM jobs.server_state AS state WHERE state.singleton`, locked.ScopeID, request.
 		if _, err := tx.ExecContext(ctx, `UPDATE brain.memory_items SET state=$2,current_revision=$3,updated_at=statement_timestamp() WHERE id=$1`, request.ItemID, target, next); err != nil {
 			return MemoryMutationResult{}, errors.New("memory archive state could not be updated")
 		}
+		secretScanOutcome := "clear"
+		becameQuarantined := false
 		if target == MemoryActive {
-			if err := guardMemoryDocument(ctx, tx, locked.ProjectID, locked.Document); err != nil {
+			finding, err := firstUnexceptedMemorySecretFinding(ctx, tx, locked.ProjectID, locked.Document)
+			if err != nil {
 				return MemoryMutationResult{}, err
 			}
-			if err := recordMemorySecretScan(ctx, tx, locked.ProjectID, request.ItemID, next, request.PrincipalID, "clear"); err != nil {
+			if finding != nil {
+				becameQuarantined, err = storeActiveMemoryQuarantine(ctx, tx, request.PrincipalID, request.ItemID, next, *finding)
+				if err != nil {
+					return MemoryMutationResult{}, err
+				}
+				secretScanOutcome = "quarantined"
+			}
+			if err := recordMemorySecretScan(ctx, tx, locked.ProjectID, request.ItemID, next, request.PrincipalID, secretScanOutcome); err != nil {
 				return MemoryMutationResult{}, err
 			}
 		}
 		state, err := commitMemoryChange(ctx, tx, control, request.PrincipalID, locked.ProjectID, locked.ScopeID, request.ItemID, next, change, action)
 		if err != nil {
 			return MemoryMutationResult{}, err
+		}
+		if becameQuarantined {
+			state, err = commitMemoryChange(ctx, tx, control, request.PrincipalID, locked.ProjectID, locked.ScopeID, request.ItemID, next, MemoryChangeQuarantine, AuditMemoryQuarantine)
+			if err != nil {
+				return MemoryMutationResult{}, err
+			}
 		}
 		return MemoryMutationResult{ItemID: request.ItemID, Revision: next, ETag: memoryETag(request.ItemID, next), State: target, ChangeSequence: state.ChangeSequence}, nil
 	})

--- a/internal/postgres/brain_store.go
+++ b/internal/postgres/brain_store.go
@@ -263,6 +263,14 @@ FROM jobs.server_state AS state WHERE state.singleton`, locked.ScopeID, request.
 		if _, err := tx.ExecContext(ctx, `UPDATE brain.memory_items SET state=$2,current_revision=$3,updated_at=statement_timestamp() WHERE id=$1`, request.ItemID, target, next); err != nil {
 			return MemoryMutationResult{}, errors.New("memory archive state could not be updated")
 		}
+		if target == MemoryActive {
+			if err := guardMemoryDocument(ctx, tx, locked.ProjectID, locked.Document); err != nil {
+				return MemoryMutationResult{}, err
+			}
+			if err := recordMemorySecretScan(ctx, tx, locked.ProjectID, request.ItemID, next, request.PrincipalID, "clear"); err != nil {
+				return MemoryMutationResult{}, err
+			}
+		}
 		state, err := commitMemoryChange(ctx, tx, control, request.PrincipalID, locked.ProjectID, locked.ScopeID, request.ItemID, next, change, action)
 		if err != nil {
 			return MemoryMutationResult{}, err

--- a/internal/postgres/brain_store.go
+++ b/internal/postgres/brain_store.go
@@ -265,6 +265,7 @@ FROM jobs.server_state AS state WHERE state.singleton`, locked.ScopeID, request.
 		}
 		secretScanOutcome := "clear"
 		becameQuarantined := false
+		releasedQuarantine := false
 		if target == MemoryActive {
 			finding, err := firstUnexceptedMemorySecretFinding(ctx, tx, locked.ProjectID, locked.Document)
 			if err != nil {
@@ -276,9 +277,11 @@ FROM jobs.server_state AS state WHERE state.singleton`, locked.ScopeID, request.
 					return MemoryMutationResult{}, err
 				}
 				secretScanOutcome = "quarantined"
-			}
-			if err := recordMemorySecretScan(ctx, tx, locked.ProjectID, request.ItemID, next, request.PrincipalID, secretScanOutcome); err != nil {
-				return MemoryMutationResult{}, err
+			} else {
+				releasedQuarantine, err = releaseActiveMemoryQuarantine(ctx, tx, request.PrincipalID, request.ItemID)
+				if err != nil {
+					return MemoryMutationResult{}, err
+				}
 			}
 		}
 		state, err := commitMemoryChange(ctx, tx, control, request.PrincipalID, locked.ProjectID, locked.ScopeID, request.ItemID, next, change, action)
@@ -288,6 +291,17 @@ FROM jobs.server_state AS state WHERE state.singleton`, locked.ScopeID, request.
 		if becameQuarantined {
 			state, err = commitMemoryChange(ctx, tx, control, request.PrincipalID, locked.ProjectID, locked.ScopeID, request.ItemID, next, MemoryChangeQuarantine, AuditMemoryQuarantine)
 			if err != nil {
+				return MemoryMutationResult{}, err
+			}
+		}
+		if releasedQuarantine {
+			state, err = commitMemoryChange(ctx, tx, control, request.PrincipalID, locked.ProjectID, locked.ScopeID, request.ItemID, next, MemoryChangeQuarantineRelease, AuditMemoryQuarantineRelease)
+			if err != nil {
+				return MemoryMutationResult{}, err
+			}
+		}
+		if target == MemoryActive {
+			if err := recordMemorySecretScan(ctx, tx, locked.ProjectID, request.ItemID, next, request.PrincipalID, secretScanOutcome); err != nil {
 				return MemoryMutationResult{}, err
 			}
 		}

--- a/internal/postgres/migrate.go
+++ b/internal/postgres/migrate.go
@@ -68,6 +68,7 @@ var migrationCompatibilityFloors = map[int64]int64{
 	33: 10,
 	34: 10,
 	35: 10,
+	36: 10,
 }
 
 // CurrentManifest returns the immutable migrations embedded in this binary.

--- a/internal/postgres/migrate.go
+++ b/internal/postgres/migrate.go
@@ -69,6 +69,7 @@ var migrationCompatibilityFloors = map[int64]int64{
 	34: 10,
 	35: 10,
 	36: 10,
+	37: 10,
 }
 
 // CurrentManifest returns the immutable migrations embedded in this binary.

--- a/internal/postgres/migrate.go
+++ b/internal/postgres/migrate.go
@@ -67,6 +67,7 @@ var migrationCompatibilityFloors = map[int64]int64{
 	32: 10,
 	33: 10,
 	34: 10,
+	35: 10,
 }
 
 // CurrentManifest returns the immutable migrations embedded in this binary.

--- a/internal/postgres/migrations/035_memory_consolidation_documents.sql
+++ b/internal/postgres/migrations/035_memory_consolidation_documents.sql
@@ -1,0 +1,17 @@
+CREATE FUNCTION brain.read_memory_consolidation_documents(requested_scope uuid, requested_token uuid, requested_generation bigint)
+RETURNS TABLE(timeline_id uuid,item_id uuid,revision bigint,change_sequence bigint,document jsonb,is_fence boolean)
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = pg_catalog
+AS $function$
+BEGIN
+    RETURN QUERY
+    SELECT source.timeline_id,source.item_id,source.revision,source.change_sequence,
+           revision.document,source.is_fence
+    FROM brain.read_memory_consolidation_sources(requested_scope,requested_token,requested_generation) AS source
+    LEFT JOIN brain.memory_revisions AS revision
+      ON revision.item_id=source.item_id AND revision.revision=source.revision
+    ORDER BY source.change_sequence,source.item_id;
+END
+$function$;
+
+REVOKE ALL ON FUNCTION brain.read_memory_consolidation_documents(uuid,uuid,bigint) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION brain.read_memory_consolidation_documents(uuid,uuid,bigint) TO punaro_app;

--- a/internal/postgres/migrations/036_memory_consolidation_secret_fence.sql
+++ b/internal/postgres/migrations/036_memory_consolidation_secret_fence.sql
@@ -1,0 +1,40 @@
+CREATE OR REPLACE FUNCTION brain.read_memory_consolidation_documents(requested_scope uuid, requested_token uuid, requested_generation bigint)
+RETURNS TABLE(timeline_id uuid,item_id uuid,revision bigint,change_sequence bigint,document jsonb,is_fence boolean)
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = pg_catalog
+AS $function$
+BEGIN
+    RETURN QUERY
+    SELECT source.timeline_id,
+           CASE WHEN source.item_id IS NOT NULL
+                     AND scan.revision=source.revision
+                     AND scan.rule_version=guard.rule_version
+                     AND scan.rule_digest=guard.rule_digest
+                     AND scan.exception_generation=COALESCE(project_state.exception_generation,0)
+                     AND scan.outcome='clear'
+                THEN source.item_id END,
+           CASE WHEN source.item_id IS NOT NULL
+                     AND scan.revision=source.revision
+                     AND scan.rule_version=guard.rule_version
+                     AND scan.rule_digest=guard.rule_digest
+                     AND scan.exception_generation=COALESCE(project_state.exception_generation,0)
+                     AND scan.outcome='clear'
+                THEN source.revision END,
+           source.change_sequence,
+           CASE WHEN source.item_id IS NOT NULL
+                     AND scan.revision=source.revision
+                     AND scan.rule_version=guard.rule_version
+                     AND scan.rule_digest=guard.rule_digest
+                     AND scan.exception_generation=COALESCE(project_state.exception_generation,0)
+                     AND scan.outcome='clear'
+                THEN revision.document END,
+           source.is_fence
+    FROM brain.read_memory_consolidation_sources(requested_scope,requested_token,requested_generation) AS source
+    CROSS JOIN brain.secret_guard_state AS guard
+    LEFT JOIN brain.memory_revisions AS revision ON revision.item_id=source.item_id AND revision.revision=source.revision
+    LEFT JOIN brain.memory_items AS item ON item.id=source.item_id
+    LEFT JOIN brain.scopes AS scope ON scope.id=item.scope_id
+    LEFT JOIN brain.memory_secret_scans AS scan ON scan.item_id=source.item_id
+    LEFT JOIN brain.secret_project_state AS project_state ON project_state.project_id=scope.project_id
+    ORDER BY source.change_sequence,source.item_id;
+END
+$function$;

--- a/internal/postgres/migrations/037_memory_consolidation_scan_barrier.sql
+++ b/internal/postgres/migrations/037_memory_consolidation_scan_barrier.sql
@@ -65,7 +65,7 @@ BEGIN
         FROM jsonb_to_recordset(source_page) AS source(timeline_id uuid,item_id uuid,revision bigint,change_sequence bigint,is_fence boolean)
         LEFT JOIN brain.memory_revisions AS revision ON revision.item_id=source.item_id AND revision.revision=source.revision
         WHERE source.item_id IS NOT NULL
-          AND (revision.document IS NULL OR revision.content_sha256 IS DISTINCT FROM public.digest(convert_to(revision.document::text,'UTF8'),'sha256'))
+          AND (revision.document IS NULL OR revision.content_sha256 IS DISTINCT FROM public.digest(revision.document::text,'sha256'))
     ) THEN
         RAISE EXCEPTION USING ERRCODE='55000', MESSAGE='consolidation source content hash is invalid';
     END IF;

--- a/internal/postgres/migrations/037_memory_consolidation_scan_barrier.sql
+++ b/internal/postgres/migrations/037_memory_consolidation_scan_barrier.sql
@@ -6,6 +6,16 @@ DECLARE
     raw_page jsonb;
     source_page jsonb;
 BEGIN
+    PERFORM 1
+    FROM brain.memory_consolidation_checkpoints AS checkpoint
+    WHERE checkpoint.scope_id=requested_scope
+      AND checkpoint.lease_token=requested_token
+      AND checkpoint.lease_generation=requested_generation
+      AND checkpoint.lease_until>statement_timestamp()
+    FOR SHARE OF checkpoint;
+    IF NOT FOUND THEN
+        RETURN;
+    END IF;
     LOCK TABLE brain.secret_guard_state IN SHARE MODE;
     LOCK TABLE brain.secret_project_state IN SHARE MODE;
     WITH raw_source AS MATERIALIZED (

--- a/internal/postgres/migrations/037_memory_consolidation_scan_barrier.sql
+++ b/internal/postgres/migrations/037_memory_consolidation_scan_barrier.sql
@@ -60,6 +60,15 @@ BEGIN
     ) THEN
         RAISE EXCEPTION USING ERRCODE='55000', MESSAGE='consolidation source scan coverage is stale';
     END IF;
+    IF EXISTS (
+        SELECT 1
+        FROM jsonb_to_recordset(source_page) AS source(timeline_id uuid,item_id uuid,revision bigint,change_sequence bigint,is_fence boolean)
+        LEFT JOIN brain.memory_revisions AS revision ON revision.item_id=source.item_id AND revision.revision=source.revision
+        WHERE source.item_id IS NOT NULL
+          AND (revision.document IS NULL OR revision.content_sha256 IS DISTINCT FROM public.digest(convert_to(revision.document::text,'UTF8'),'sha256'))
+    ) THEN
+        RAISE EXCEPTION USING ERRCODE='55000', MESSAGE='consolidation source content hash is invalid';
+    END IF;
     RETURN QUERY
     SELECT source.timeline_id,source.item_id,source.revision,source.change_sequence,revision.document,source.is_fence
     FROM jsonb_to_recordset(source_page) AS source(timeline_id uuid,item_id uuid,revision bigint,change_sequence bigint,is_fence boolean)

--- a/internal/postgres/migrations/037_memory_consolidation_scan_barrier.sql
+++ b/internal/postgres/migrations/037_memory_consolidation_scan_barrier.sql
@@ -1,5 +1,5 @@
 CREATE OR REPLACE FUNCTION brain.read_memory_consolidation_documents(requested_scope uuid, requested_token uuid, requested_generation bigint)
-RETURNS TABLE(timeline_id uuid,item_id uuid,revision bigint,change_sequence bigint,document jsonb,is_fence boolean)
+RETURNS TABLE(timeline_id uuid,item_id uuid,revision bigint,change_sequence bigint,document jsonb,content_sha256 bytea,is_fence boolean)
 LANGUAGE plpgsql SECURITY DEFINER SET search_path = pg_catalog
 AS $function$
 DECLARE
@@ -60,17 +60,8 @@ BEGIN
     ) THEN
         RAISE EXCEPTION USING ERRCODE='55000', MESSAGE='consolidation source scan coverage is stale';
     END IF;
-    IF EXISTS (
-        SELECT 1
-        FROM jsonb_to_recordset(source_page) AS source(timeline_id uuid,item_id uuid,revision bigint,change_sequence bigint,is_fence boolean)
-        LEFT JOIN brain.memory_revisions AS revision ON revision.item_id=source.item_id AND revision.revision=source.revision
-        WHERE source.item_id IS NOT NULL
-          AND (revision.document IS NULL OR revision.content_sha256 IS DISTINCT FROM public.digest(revision.document::text,'sha256'))
-    ) THEN
-        RAISE EXCEPTION USING ERRCODE='55000', MESSAGE='consolidation source content hash is invalid';
-    END IF;
     RETURN QUERY
-    SELECT source.timeline_id,source.item_id,source.revision,source.change_sequence,revision.document,source.is_fence
+    SELECT source.timeline_id,source.item_id,source.revision,source.change_sequence,revision.document,revision.content_sha256,source.is_fence
     FROM jsonb_to_recordset(source_page) AS source(timeline_id uuid,item_id uuid,revision bigint,change_sequence bigint,is_fence boolean)
     LEFT JOIN brain.memory_revisions AS revision ON revision.item_id=source.item_id AND revision.revision=source.revision
     ORDER BY source.change_sequence,source.item_id;

--- a/internal/postgres/migrations/037_memory_consolidation_scan_barrier.sql
+++ b/internal/postgres/migrations/037_memory_consolidation_scan_barrier.sql
@@ -1,4 +1,9 @@
-CREATE OR REPLACE FUNCTION brain.read_memory_consolidation_documents(requested_scope uuid, requested_token uuid, requested_generation bigint)
+-- PostgreSQL cannot change a function's OUT parameter list with CREATE OR
+-- REPLACE. The v36 routine lacks content_sha256, so replace it atomically
+-- within this migration before creating the v37 signature.
+DROP FUNCTION brain.read_memory_consolidation_documents(uuid,uuid,bigint);
+
+CREATE FUNCTION brain.read_memory_consolidation_documents(requested_scope uuid, requested_token uuid, requested_generation bigint)
 RETURNS TABLE(timeline_id uuid,item_id uuid,revision bigint,change_sequence bigint,document jsonb,content_sha256 bytea,is_fence boolean)
 LANGUAGE plpgsql SECURITY DEFINER SET search_path = pg_catalog
 AS $function$
@@ -67,3 +72,6 @@ BEGIN
     ORDER BY source.change_sequence,source.item_id;
 END
 $function$;
+
+REVOKE ALL ON FUNCTION brain.read_memory_consolidation_documents(uuid,uuid,bigint) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION brain.read_memory_consolidation_documents(uuid,uuid,bigint) TO punaro_app;

--- a/internal/postgres/migrations/037_memory_consolidation_scan_barrier.sql
+++ b/internal/postgres/migrations/037_memory_consolidation_scan_barrier.sql
@@ -1,0 +1,59 @@
+CREATE OR REPLACE FUNCTION brain.read_memory_consolidation_documents(requested_scope uuid, requested_token uuid, requested_generation bigint)
+RETURNS TABLE(timeline_id uuid,item_id uuid,revision bigint,change_sequence bigint,document jsonb,is_fence boolean)
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = pg_catalog
+AS $function$
+DECLARE
+    raw_page jsonb;
+    source_page jsonb;
+BEGIN
+    LOCK TABLE brain.secret_guard_state IN SHARE MODE;
+    LOCK TABLE brain.secret_project_state IN SHARE MODE;
+    WITH raw_source AS MATERIALIZED (
+        SELECT * FROM brain.read_memory_consolidation_sources(requested_scope,requested_token,requested_generation)
+    ) SELECT COALESCE(jsonb_agg(jsonb_build_object('timeline_id',raw_source.timeline_id,'item_id',raw_source.item_id,'revision',raw_source.revision,'change_sequence',raw_source.change_sequence,'is_fence',raw_source.is_fence) ORDER BY raw_source.change_sequence,raw_source.item_id),'[]'::jsonb)
+    INTO raw_page FROM raw_source;
+    PERFORM 1
+    FROM brain.memory_items AS item
+    JOIN jsonb_to_recordset(raw_page) AS raw(timeline_id uuid,item_id uuid,revision bigint,change_sequence bigint,is_fence boolean) ON raw.item_id=item.id
+    ORDER BY item.id
+    FOR SHARE OF item;
+    LOCK TABLE brain.memory_quarantines IN SHARE MODE;
+    PERFORM 1
+    FROM brain.memory_secret_scans AS scan
+    JOIN jsonb_to_recordset(raw_page) AS raw(timeline_id uuid,item_id uuid,revision bigint,change_sequence bigint,is_fence boolean) ON raw.item_id=scan.item_id
+    ORDER BY scan.item_id
+    FOR SHARE OF scan;
+    WITH raw AS MATERIALIZED (
+        SELECT * FROM jsonb_to_recordset(raw_page) AS record(timeline_id uuid,item_id uuid,revision bigint,change_sequence bigint,is_fence boolean)
+    ), source AS MATERIALIZED (
+        SELECT raw.timeline_id,
+               CASE WHEN raw.item_id IS NOT NULL AND item.state='active' AND item.current_revision=raw.revision AND NOT EXISTS (SELECT 1 FROM brain.memory_quarantines AS quarantine WHERE quarantine.item_id=raw.item_id AND (quarantine.released_at IS NULL OR raw.revision<>item.current_revision)) THEN raw.item_id END AS item_id,
+               CASE WHEN raw.item_id IS NOT NULL AND item.state='active' AND item.current_revision=raw.revision AND NOT EXISTS (SELECT 1 FROM brain.memory_quarantines AS quarantine WHERE quarantine.item_id=raw.item_id AND (quarantine.released_at IS NULL OR raw.revision<>item.current_revision)) THEN raw.revision END AS revision,
+               raw.change_sequence,raw.is_fence
+        FROM raw LEFT JOIN brain.memory_items AS item ON item.id=raw.item_id
+    ) SELECT COALESCE(jsonb_agg(jsonb_build_object('timeline_id',source.timeline_id,'item_id',source.item_id,'revision',source.revision,'change_sequence',source.change_sequence,'is_fence',source.is_fence) ORDER BY source.change_sequence,source.item_id),'[]'::jsonb)
+    INTO source_page FROM source;
+    IF EXISTS (
+        SELECT 1
+        FROM jsonb_to_recordset(source_page) AS source(timeline_id uuid,item_id uuid,revision bigint,change_sequence bigint,is_fence boolean)
+        CROSS JOIN brain.secret_guard_state AS guard
+        LEFT JOIN brain.memory_items AS item ON item.id=source.item_id
+        LEFT JOIN brain.scopes AS scope ON scope.id=item.scope_id
+        LEFT JOIN brain.memory_secret_scans AS scan ON scan.item_id=source.item_id
+        LEFT JOIN brain.secret_project_state AS project_state ON project_state.project_id=scope.project_id
+        WHERE source.item_id IS NOT NULL
+          AND (scan.revision IS DISTINCT FROM source.revision
+               OR scan.rule_version IS DISTINCT FROM guard.rule_version
+               OR scan.rule_digest IS DISTINCT FROM guard.rule_digest
+               OR scan.exception_generation IS DISTINCT FROM COALESCE(project_state.exception_generation,0)
+               OR scan.outcome IS DISTINCT FROM 'clear')
+    ) THEN
+        RAISE EXCEPTION USING ERRCODE='55000', MESSAGE='consolidation source scan coverage is stale';
+    END IF;
+    RETURN QUERY
+    SELECT source.timeline_id,source.item_id,source.revision,source.change_sequence,revision.document,source.is_fence
+    FROM jsonb_to_recordset(source_page) AS source(timeline_id uuid,item_id uuid,revision bigint,change_sequence bigint,is_fence boolean)
+    LEFT JOIN brain.memory_revisions AS revision ON revision.item_id=source.item_id AND revision.revision=source.revision
+    ORDER BY source.change_sequence,source.item_id;
+END
+$function$;

--- a/internal/postgres/state_test.go
+++ b/internal/postgres/state_test.go
@@ -69,8 +69,8 @@ func TestManifestValidationRejectsMutableOrNonContiguousHistory(t *testing.T) {
 
 func TestCurrentManifestRequiresControlPlaneSchema(t *testing.T) {
 	manifest := CurrentManifest()
-	if manifest.MinSupported != 10 || manifest.MaxSupported != 35 || len(manifest.Migrations) != 35 {
-		t.Fatalf("manifest=%#v, want exact v35 compatibility window", manifest)
+	if manifest.MinSupported != 10 || manifest.MaxSupported != 36 || len(manifest.Migrations) != 36 {
+		t.Fatalf("manifest=%#v, want exact v36 compatibility window", manifest)
 	}
 	embedding := manifest.Migrations[23]
 	if embedding.Version != 24 || embedding.Name != "024_memory_embedding_worker_control" ||
@@ -88,7 +88,7 @@ func TestCurrentManifestRequiresControlPlaneSchema(t *testing.T) {
 			want = 10
 		case 12, 13:
 			want = 10
-		case 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35:
+		case 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36:
 			want = 10
 		}
 		if migration.CompatibilityFloor != want {
@@ -189,7 +189,10 @@ func TestCompatibleSchemaCanStillHavePendingMigrations(t *testing.T) {
 	if !migrationPending(SchemaState{Classification: Compatible, Version: 34}, manifest) {
 		t.Fatal("compatible v34 schema must still apply the pending v35 migration")
 	}
-	if migrationPending(SchemaState{Classification: Compatible, Version: 35}, manifest) {
-		t.Fatal("current v35 schema reported a pending migration")
+	if !migrationPending(SchemaState{Classification: Compatible, Version: 35}, manifest) {
+		t.Fatal("compatible v35 schema must still apply the pending v36 migration")
+	}
+	if migrationPending(SchemaState{Classification: Compatible, Version: 36}, manifest) {
+		t.Fatal("current v36 schema reported a pending migration")
 	}
 }

--- a/internal/postgres/state_test.go
+++ b/internal/postgres/state_test.go
@@ -69,8 +69,8 @@ func TestManifestValidationRejectsMutableOrNonContiguousHistory(t *testing.T) {
 
 func TestCurrentManifestRequiresControlPlaneSchema(t *testing.T) {
 	manifest := CurrentManifest()
-	if manifest.MinSupported != 10 || manifest.MaxSupported != 36 || len(manifest.Migrations) != 36 {
-		t.Fatalf("manifest=%#v, want exact v36 compatibility window", manifest)
+	if manifest.MinSupported != 10 || manifest.MaxSupported != 37 || len(manifest.Migrations) != 37 {
+		t.Fatalf("manifest=%#v, want exact v37 compatibility window", manifest)
 	}
 	embedding := manifest.Migrations[23]
 	if embedding.Version != 24 || embedding.Name != "024_memory_embedding_worker_control" ||
@@ -88,7 +88,7 @@ func TestCurrentManifestRequiresControlPlaneSchema(t *testing.T) {
 			want = 10
 		case 12, 13:
 			want = 10
-		case 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36:
+		case 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37:
 			want = 10
 		}
 		if migration.CompatibilityFloor != want {
@@ -192,7 +192,10 @@ func TestCompatibleSchemaCanStillHavePendingMigrations(t *testing.T) {
 	if !migrationPending(SchemaState{Classification: Compatible, Version: 35}, manifest) {
 		t.Fatal("compatible v35 schema must still apply the pending v36 migration")
 	}
-	if migrationPending(SchemaState{Classification: Compatible, Version: 36}, manifest) {
-		t.Fatal("current v36 schema reported a pending migration")
+	if !migrationPending(SchemaState{Classification: Compatible, Version: 36}, manifest) {
+		t.Fatal("compatible v36 schema must still apply the pending v37 migration")
+	}
+	if migrationPending(SchemaState{Classification: Compatible, Version: 37}, manifest) {
+		t.Fatal("current v37 schema reported a pending migration")
 	}
 }

--- a/internal/postgres/state_test.go
+++ b/internal/postgres/state_test.go
@@ -69,8 +69,8 @@ func TestManifestValidationRejectsMutableOrNonContiguousHistory(t *testing.T) {
 
 func TestCurrentManifestRequiresControlPlaneSchema(t *testing.T) {
 	manifest := CurrentManifest()
-	if manifest.MinSupported != 10 || manifest.MaxSupported != 34 || len(manifest.Migrations) != 34 {
-		t.Fatalf("manifest=%#v, want exact v34 compatibility window", manifest)
+	if manifest.MinSupported != 10 || manifest.MaxSupported != 35 || len(manifest.Migrations) != 35 {
+		t.Fatalf("manifest=%#v, want exact v35 compatibility window", manifest)
 	}
 	embedding := manifest.Migrations[23]
 	if embedding.Version != 24 || embedding.Name != "024_memory_embedding_worker_control" ||
@@ -88,7 +88,7 @@ func TestCurrentManifestRequiresControlPlaneSchema(t *testing.T) {
 			want = 10
 		case 12, 13:
 			want = 10
-		case 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34:
+		case 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35:
 			want = 10
 		}
 		if migration.CompatibilityFloor != want {
@@ -186,7 +186,10 @@ func TestCompatibleSchemaCanStillHavePendingMigrations(t *testing.T) {
 	if !migrationPending(SchemaState{Classification: Compatible, Version: 32}, manifest) {
 		t.Fatal("compatible v32 schema must still apply pending migrations")
 	}
-	if migrationPending(SchemaState{Classification: Compatible, Version: 34}, manifest) {
-		t.Fatal("current v34 schema reported a pending migration")
+	if !migrationPending(SchemaState{Classification: Compatible, Version: 34}, manifest) {
+		t.Fatal("compatible v34 schema must still apply the pending v35 migration")
+	}
+	if migrationPending(SchemaState{Classification: Compatible, Version: 35}, manifest) {
+		t.Fatal("current v35 schema reported a pending migration")
 	}
 }


### PR DESCRIPTION
## What changed

- materializes canonical documents for live, fenced consolidation input
- adds exact revision/document readiness fingerprints and migration compatibility coverage
- blocks stale or non-clear scan coverage for a current consolidation source
- preserves ordinary cursor advancement for superseded revisions, deletes, archives, and quarantined revisions

## Why

Consolidation input must never materialize a document without current secret-scan coverage, while a lagged checkpoint must still drain normal history safely.

## Validation

- go test -covermode=atomic ./...
ok  	github.com/rock3r/punaro/cmd/punaro	3.720s	coverage: 39.1% of statements
ok  	github.com/rock3r/punaro/cmd/punaro-adapter	(cached)	coverage: 37.2% of statements
ok  	github.com/rock3r/punaro/cmd/punaro-admin	0.501s	coverage: 23.6% of statements
ok  	github.com/rock3r/punaro/cmd/punaro-attachment	(cached)	coverage: 19.8% of statements
ok  	github.com/rock3r/punaro/cmd/punaro-directory	(cached)	coverage: 56.2% of statements
	github.com/rock3r/punaro/cmd/punaro-dpapi		coverage: 0.0% of statements
ok  	github.com/rock3r/punaro/cmd/punaro-keychain	(cached)	coverage: 38.9% of statements
ok  	github.com/rock3r/punaro/cmd/punaro-keygen	(cached)	coverage: 47.4% of statements
ok  	github.com/rock3r/punaro/cmd/punaro-memory	(cached)	coverage: 75.0% of statements
ok  	github.com/rock3r/punaro/cmd/punaro-migrate	1.257s	coverage: 96.7% of statements
ok  	github.com/rock3r/punaro/cmd/punaro-telegram	(cached)	coverage: 51.1% of statements
ok  	github.com/rock3r/punaro/cmd/punaro-trusted-attachment	(cached)	coverage: 69.2% of statements
ok  	github.com/rock3r/punaro/cmd/punarod	1.741s	coverage: 52.9% of statements
ok  	github.com/rock3r/punaro/internal/access	(cached)	coverage: 83.3% of statements
ok  	github.com/rock3r/punaro/internal/adapter	(cached)	coverage: 75.3% of statements
ok  	github.com/rock3r/punaro/internal/attachment	(cached)	coverage: 72.0% of statements
ok  	github.com/rock3r/punaro/internal/attachment/v2	(cached)	coverage: 69.9% of statements
ok  	github.com/rock3r/punaro/internal/attachment/v3	(cached)	coverage: 70.2% of statements
ok  	github.com/rock3r/punaro/internal/attachment/v3/controller	(cached)	coverage: 69.0% of statements
ok  	github.com/rock3r/punaro/internal/backup	(cached)	coverage: 76.8% of statements
ok  	github.com/rock3r/punaro/internal/config	(cached)	coverage: 86.6% of statements
ok  	github.com/rock3r/punaro/internal/cutover	(cached)	coverage: 68.6% of statements
ok  	github.com/rock3r/punaro/internal/devicehttp	(cached)	coverage: 81.0% of statements
ok  	github.com/rock3r/punaro/internal/embeddingprovider	(cached)	coverage: 89.7% of statements
ok  	github.com/rock3r/punaro/internal/ingress	(cached)	coverage: 82.5% of statements
ok  	github.com/rock3r/punaro/internal/listener	(cached)	coverage: 93.3% of statements
ok  	github.com/rock3r/punaro/internal/memoryclient	(cached)	coverage: 79.3% of statements
ok  	github.com/rock3r/punaro/internal/memoryhttp	(cached)	coverage: 77.3% of statements
ok  	github.com/rock3r/punaro/internal/operator	(cached)	coverage: 75.1% of statements
ok  	github.com/rock3r/punaro/internal/postgres	1.061s	coverage: 14.7% of statements
ok  	github.com/rock3r/punaro/internal/relay	(cached)	coverage: 77.0% of statements
	github.com/rock3r/punaro/internal/relay/contracttest		coverage: 0.0% of statements
ok  	github.com/rock3r/punaro/internal/release	(cached)	coverage: 83.3% of statements
ok  	github.com/rock3r/punaro/internal/secretguard	(cached)	coverage: 98.6% of statements
ok  	github.com/rock3r/punaro/internal/telegram	(cached)	coverage: 76.8% of statements
ok  	github.com/rock3r/punaro/internal/trustedattachment	(cached)	coverage: 76.5% of statements
ok  	github.com/rock3r/punaro/internal/trustedattachmentclient	(cached)	coverage: 78.2% of statements
ok  	github.com/rock3r/punaro/internal/trustedattachmenthttp	(cached)	coverage: 81.5% of statements
go test -race -count=1 ./...
ok  	github.com/rock3r/punaro/cmd/punaro	8.686s
ok  	github.com/rock3r/punaro/cmd/punaro-adapter	2.267s
ok  	github.com/rock3r/punaro/cmd/punaro-admin	3.381s
ok  	github.com/rock3r/punaro/cmd/punaro-attachment	1.451s
ok  	github.com/rock3r/punaro/cmd/punaro-directory	2.668s
?   	github.com/rock3r/punaro/cmd/punaro-dpapi	[no test files]
ok  	github.com/rock3r/punaro/cmd/punaro-keychain	2.897s
ok  	github.com/rock3r/punaro/cmd/punaro-keygen	3.739s
ok  	github.com/rock3r/punaro/cmd/punaro-memory	4.144s
ok  	github.com/rock3r/punaro/cmd/punaro-migrate	4.492s
ok  	github.com/rock3r/punaro/cmd/punaro-telegram	3.587s
ok  	github.com/rock3r/punaro/cmd/punaro-trusted-attachment	3.452s
ok  	github.com/rock3r/punaro/cmd/punarod	4.245s
ok  	github.com/rock3r/punaro/internal/access	3.841s
ok  	github.com/rock3r/punaro/internal/adapter	4.071s
ok  	github.com/rock3r/punaro/internal/attachment	4.163s
ok  	github.com/rock3r/punaro/internal/attachment/v2	4.417s
ok  	github.com/rock3r/punaro/internal/attachment/v3	7.490s
ok  	github.com/rock3r/punaro/internal/attachment/v3/controller	13.868s
ok  	github.com/rock3r/punaro/internal/backup	4.879s
ok  	github.com/rock3r/punaro/internal/config	3.552s
ok  	github.com/rock3r/punaro/internal/cutover	2.819s
ok  	github.com/rock3r/punaro/internal/devicehttp	3.237s
ok  	github.com/rock3r/punaro/internal/embeddingprovider	3.263s
ok  	github.com/rock3r/punaro/internal/ingress	2.865s
ok  	github.com/rock3r/punaro/internal/listener	2.508s
ok  	github.com/rock3r/punaro/internal/memoryclient	2.363s
ok  	github.com/rock3r/punaro/internal/memoryhttp	4.200s
ok  	github.com/rock3r/punaro/internal/operator	10.298s
ok  	github.com/rock3r/punaro/internal/postgres	2.440s
ok  	github.com/rock3r/punaro/internal/relay	8.446s
?   	github.com/rock3r/punaro/internal/relay/contracttest	[no test files]
ok  	github.com/rock3r/punaro/internal/release	2.807s
ok  	github.com/rock3r/punaro/internal/secretguard	2.898s
ok  	github.com/rock3r/punaro/internal/telegram	3.115s
ok  	github.com/rock3r/punaro/internal/trustedattachment	5.242s
ok  	github.com/rock3r/punaro/internal/trustedattachmentclient	8.506s
ok  	github.com/rock3r/punaro/internal/trustedattachmenthttp	2.367s
go run honnef.co/go/tools/cmd/staticcheck@v0.6.1 ./...
go run golang.org/x/vuln/cmd/govulncheck@v1.1.4 ./...
=== Symbol Results ===

No vulnerabilities found.

Your code is affected by 0 vulnerabilities.
This scan also found 1 vulnerability in packages you import and 7
vulnerabilities in modules you require, but your code doesn't appear to call
these vulnerabilities.
Use '-show verbose' for more details.
CGO_ENABLED=0 go run github.com/securego/gosec/v2/cmd/gosec@v2.22.10 -exclude-generated ./...
Results:


Summary:
  Gosec  : dev
  Files  : 223
  Lines  : 56601
  Nosec  : 194
  Issues : 0

go run github.com/zricethezav/gitleaks/v8@v8.27.2 detect --source . --no-git
go vet ./...
0 issues.
0 issues.
0 issues.
GOOS=windows go build ./...
./scripts/verify-deployment-files.sh
install_adapter_tests_passed
install_server_tests_passed
attachment_v3_relay_retirement_tests_passed
Punaro agent guidance and project-local skills installed in /var/folders/10/534j41jj6_sg2tygjm9_crl80000gn/T/punaro-guidance-test.tYPc62Tl/project
Punaro agent guidance and project-local skills installed in /var/folders/10/534j41jj6_sg2tygjm9_crl80000gn/T/punaro-guidance-test.tYPc62Tl/project
install_agent_guidance_tests_passed
install_client_windows_tests_passed
- focused PostgreSQL manifest/consolidation package tests
- Pi GPT-5.4 final review: no findings

Hosted CI will run PostgreSQL integration coverage; local ./scripts/test-postgres-integration.sh is unavailable because Docker Compose v2 is not installed.