### PR TITLE
Stage fenced consolidation proposals

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -593,6 +593,15 @@ work. Restores rescan their copied revision and record current clear or
 quarantined coverage, and the provider boundary rejects any document whose
 stored content hash no longer matches its canonical bytes.
 
+Schema version 38 records the source page of each staged consolidation proposal
+as immutable `(timeline, item, revision, change-sequence)` bindings. Staging
+rechecks the exact live checkpoint token and generation inside its proposal
+transaction, requires ordinary `memory.propose` authority, and creates only a
+pending proposal: it neither advances the checkpoint nor changes canonical
+memory. Generic proposal evidence remains restricted to evidence-layer records;
+consolidation provenance is a separate scope-bound relation so curated source
+revisions remain auditable without weakening that invariant.
+
 Schema version 16 adds bounded, operator-driven rescan and retained quarantine.
 Every current revision carries scan coverage bound to its revision, the compiled
 rule identity, and a per-project exact-exception generation. Exception changes

--- a/internal/postgres/brain_consolidation.go
+++ b/internal/postgres/brain_consolidation.go
@@ -59,6 +59,14 @@ type MemoryConsolidationInput struct {
 	Sources      []MemoryConsolidationSource
 }
 
+// MemoryConsolidationProposalRequest stages one ordinary proposal together
+// with the immutable source page that produced it. It never approves or
+// directly changes canonical memory.
+type MemoryConsolidationProposalRequest struct {
+	Input    MemoryConsolidationInput
+	Proposal MemoryProposalCreateRequest
+}
+
 // ErrStaleMemoryConsolidationLease reports a failed consolidation fence.
 var ErrStaleMemoryConsolidationLease = errors.New("consolidation lease is stale")
 
@@ -78,6 +86,26 @@ func (input MemoryConsolidationInput) valid() bool {
 		}
 	}
 	return true
+}
+
+func (request MemoryConsolidationProposalRequest) normalized() (MemoryConsolidationProposalRequest, error) {
+	if !request.Input.valid() || len(request.Input.Sources) == 0 {
+		return MemoryConsolidationProposalRequest{}, errors.New("invalid consolidation proposal")
+	}
+	request.Input.Sources = append([]MemoryConsolidationSource(nil), request.Input.Sources...)
+	for index := range request.Input.Sources {
+		document, err := canonicalMemoryDocument(request.Input.Sources[index].Document)
+		if err != nil {
+			return MemoryConsolidationProposalRequest{}, errors.New("invalid consolidation proposal")
+		}
+		request.Input.Sources[index].Document = document
+	}
+	proposal, err := request.Proposal.normalized()
+	if err != nil {
+		return MemoryConsolidationProposalRequest{}, err
+	}
+	request.Proposal = proposal
+	return request, nil
 }
 
 // ReadMemoryConsolidationInput returns at most one bounded page of exact

--- a/internal/postgres/brain_consolidation_integration_test.go
+++ b/internal/postgres/brain_consolidation_integration_test.go
@@ -22,7 +22,7 @@ func testMemoryConsolidationCheckpointIntegration(ctx context.Context, t *testin
 	if err := ownerDB.QueryRowContext(ctx, `INSERT INTO brain.scopes(project_id,created_by) VALUES ($1,$2) RETURNING id::text`, projectID, actor.ID).Scan(&scopeID); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := ownerDB.ExecContext(ctx, `INSERT INTO auth.capability_grants(principal_id,scope,project_id,capability) VALUES ($1,'project',$2,$3),($1,'project',$2,$4)`, actor.ID, projectID, CapabilityMemoryWrite, CapabilityMemoryPurge); err != nil {
+	if _, err := ownerDB.ExecContext(ctx, `INSERT INTO auth.capability_grants(principal_id,scope,project_id,capability) VALUES ($1,'project',$2,$3),($1,'project',$2,$4),($1,'project',$2,$5),($1,'project',$2,$6)`, actor.ID, projectID, CapabilityMemoryWrite, CapabilityMemoryPurge, CapabilityMemoryPropose, CapabilityMemoryRead); err != nil {
 		t.Fatal(err)
 	}
 	first, claimed, err := app.ClaimMemoryConsolidationCheckpoint(ctx, scopeID, "11111111-1111-4111-8111-111111111111", memoryEmbeddingMinLease)
@@ -88,6 +88,25 @@ func testMemoryConsolidationCheckpointIntegration(ctx context.Context, t *testin
 	} else if changed, err := result.RowsAffected(); err != nil || changed != 1 {
 		t.Fatalf("restore consolidation source hash changed=%d err=%v", changed, err)
 	}
+	stagedRequest := MemoryConsolidationProposalRequest{Input: input, Proposal: MemoryProposalCreateRequest{
+		PrincipalID: actor.ID, ProjectID: projectID, IdempotencyKey: "11111111-1111-4111-8111-111111111133", Action: MemoryProposalCreate,
+		Steps: []MemoryProposalStepInput{{Operation: MemoryProposalStepCreate, LogicalKey: "consolidation.brief", Kind: "brief", Trust: "proposed", Document: json.RawMessage(`{"summary":"staged"}`)}},
+	}}
+	staged, err := app.StageMemoryConsolidationProposal(ctx, stagedRequest)
+	if err != nil || staged.State != MemoryProposalPending || staged.ProposalID == "" || len(staged.Mutations) != 0 {
+		t.Fatalf("stage consolidation proposal=%#v err=%v", staged, err)
+	}
+	if retry, err := app.StageMemoryConsolidationProposal(ctx, stagedRequest); err != nil || retry.ProposalID != staged.ProposalID || retry.State != staged.State || retry.ETag != staged.ETag || len(retry.Mutations) != 0 {
+		t.Fatalf("stage consolidation retry=%#v first=%#v err=%v", retry, staged, err)
+	}
+	var sourceCount int
+	if err := ownerDB.QueryRowContext(ctx, `SELECT count(*) FROM brain.memory_consolidation_proposal_sources WHERE proposal_id=$1`, staged.ProposalID).Scan(&sourceCount); err != nil || sourceCount != len(input.Sources) {
+		t.Fatalf("staged consolidation sources=%d want=%d err=%v", sourceCount, len(input.Sources), err)
+	}
+	storedProposal, err := app.GetMemoryProposal(ctx, actor.ID, projectID, staged.ProposalID)
+	if err != nil || len(storedProposal.Sources) != len(input.Sources) || storedProposal.Sources[0].ItemID != input.Sources[0].ItemID || storedProposal.Sources[0].Revision != input.Sources[0].Revision || storedProposal.Sources[0].TimelineID != input.TimelineID {
+		t.Fatalf("staged consolidation proposal provenance=%#v input=%#v err=%v", storedProposal.Sources, input, err)
+	}
 	initialSequence := input.NextSequence
 	if _, claimed, err := app.ClaimMemoryConsolidationCheckpoint(ctx, scopeID, "22222222-2222-4222-8222-222222222222", memoryEmbeddingMinLease); err != nil || claimed {
 		t.Fatalf("duplicate consolidation claim claimed=%t err=%v", claimed, err)
@@ -100,6 +119,10 @@ func testMemoryConsolidationCheckpointIntegration(ctx context.Context, t *testin
 	}
 	if err := app.AdvanceMemoryConsolidationCheckpoint(ctx, first, first.TimelineID, initialSequence); err != nil {
 		t.Fatalf("advance consolidation checkpoint: %v", err)
+	}
+	stagedRequest.Proposal.IdempotencyKey = "11111111-1111-4111-8111-111111111134"
+	if _, err := app.StageMemoryConsolidationProposal(ctx, stagedRequest); !errors.Is(err, ErrStaleMemoryConsolidationLease) {
+		t.Fatalf("stale consolidation proposal error=%v", err)
 	}
 	if _, err := app.ReadMemoryConsolidationInput(ctx, first); !errors.Is(err, ErrStaleMemoryConsolidationLease) {
 		t.Fatalf("released consolidation input error=%v", err)
@@ -294,6 +317,7 @@ func testMemoryConsolidationSchemaDriftIntegration(ctx context.Context, t *testi
 		{`GRANT SELECT ON brain.memory_consolidation_checkpoints TO punaro_app`, `REVOKE SELECT ON brain.memory_consolidation_checkpoints FROM punaro_app`},
 		{`GRANT EXECUTE ON FUNCTION brain.claim_memory_consolidation_checkpoint(uuid,uuid,bigint) TO PUBLIC`, `REVOKE EXECUTE ON FUNCTION brain.claim_memory_consolidation_checkpoint(uuid,uuid,bigint) FROM PUBLIC`},
 		{`GRANT EXECUTE ON FUNCTION brain.read_memory_consolidation_documents(uuid,uuid,bigint) TO PUBLIC`, `REVOKE EXECUTE ON FUNCTION brain.read_memory_consolidation_documents(uuid,uuid,bigint) FROM PUBLIC`},
+		{`GRANT UPDATE ON brain.memory_consolidation_proposal_sources TO punaro_app`, `REVOKE UPDATE ON brain.memory_consolidation_proposal_sources FROM punaro_app`},
 	} {
 		if _, err := ownerDB.ExecContext(ctx, drift.apply); err != nil {
 			t.Fatal(err)

--- a/internal/postgres/brain_consolidation_integration_test.go
+++ b/internal/postgres/brain_consolidation_integration_test.go
@@ -22,7 +22,7 @@ func testMemoryConsolidationCheckpointIntegration(ctx context.Context, t *testin
 	if err := ownerDB.QueryRowContext(ctx, `INSERT INTO brain.scopes(project_id,created_by) VALUES ($1,$2) RETURNING id::text`, projectID, actor.ID).Scan(&scopeID); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := ownerDB.ExecContext(ctx, `INSERT INTO auth.capability_grants(principal_id,scope,project_id,capability) VALUES ($1,'project',$2,$3),($1,'project',$2,$4),($1,'project',$2,$5),($1,'project',$2,$6)`, actor.ID, projectID, CapabilityMemoryWrite, CapabilityMemoryPurge, CapabilityMemoryPropose, CapabilityMemoryRead); err != nil {
+	if _, err := ownerDB.ExecContext(ctx, `INSERT INTO auth.capability_grants(principal_id,scope,project_id,capability) VALUES ($1,'project',$2,$3),($1,'project',$2,$4),($1,'project',$2,$5),($1,'project',$2,$6),($1,'project',$2,$7)`, actor.ID, projectID, CapabilityMemoryWrite, CapabilityMemoryPurge, CapabilityMemoryPropose, CapabilityMemoryRead, CapabilityMemoryAdminister); err != nil {
 		t.Fatal(err)
 	}
 	first, claimed, err := app.ClaimMemoryConsolidationCheckpoint(ctx, scopeID, "11111111-1111-4111-8111-111111111111", memoryEmbeddingMinLease)
@@ -212,6 +212,17 @@ VALUES ($1,$2,1,'sensitive-field','/source',decode(repeat('11',32),'hex'),$3)`, 
 	input, err = app.ReadMemoryConsolidationInput(ctx, fourth)
 	if err != nil || len(input.Sources) != 1 || input.Sources[0].ItemID != restored.ItemID || input.Sources[0].Revision != restored.Revision || input.NextSequence != restored.ChangeSequence {
 		t.Fatalf("restored revision lacked consolidation scan coverage input=%#v restored=%#v err=%v", input, restored, err)
+	}
+	staleRequest := MemoryConsolidationProposalRequest{Input: input, Proposal: MemoryProposalCreateRequest{PrincipalID: actor.ID, ProjectID: projectID, IdempotencyKey: "11111111-1111-4111-8111-111111111135", Action: MemoryProposalCreate, Steps: []MemoryProposalStepInput{{Operation: MemoryProposalStepCreate, LogicalKey: "consolidation.stale-brief", Kind: "brief", Trust: "proposed", Document: json.RawMessage(`{"summary":"stale"}`)}}}}
+	staleProposal, err := app.StageMemoryConsolidationProposal(ctx, staleRequest)
+	if err != nil {
+		t.Fatalf("stage stale-boundary proposal: %v", err)
+	}
+	if _, err := app.UpdateMemory(ctx, MemoryUpdateRequest{PrincipalID: actor.ID, ProjectID: projectID, ItemID: input.Sources[0].ItemID, IdempotencyKey: "11111111-1111-4111-8111-111111111136", ExpectedETag: memoryETag(input.Sources[0].ItemID, input.Sources[0].Revision), LogicalKey: "consolidation.archived", Kind: "fact", Trust: "curated", Document: json.RawMessage(`{"source":"changed-after-stage"}`)}); err != nil {
+		t.Fatalf("change staged source: %v", err)
+	}
+	if _, err := app.ApproveMemoryProposal(ctx, MemoryProposalDecisionRequest{PrincipalID: actor.ID, ProjectID: projectID, ProposalID: staleProposal.ProposalID, IdempotencyKey: "11111111-1111-4111-8111-111111111137", ExpectedETag: staleProposal.ETag}); !errors.Is(err, ErrStaleMemoryProposal) {
+		t.Fatalf("stale consolidation proposal approval error=%v", err)
 	}
 	testMemoryConsolidationRestoreLineageIntegration(ctx, t, app, ownerDB, actor.ID)
 }

--- a/internal/postgres/brain_consolidation_integration_test.go
+++ b/internal/postgres/brain_consolidation_integration_test.go
@@ -318,6 +318,8 @@ func testMemoryConsolidationSchemaDriftIntegration(ctx context.Context, t *testi
 		{`GRANT EXECUTE ON FUNCTION brain.claim_memory_consolidation_checkpoint(uuid,uuid,bigint) TO PUBLIC`, `REVOKE EXECUTE ON FUNCTION brain.claim_memory_consolidation_checkpoint(uuid,uuid,bigint) FROM PUBLIC`},
 		{`GRANT EXECUTE ON FUNCTION brain.read_memory_consolidation_documents(uuid,uuid,bigint) TO PUBLIC`, `REVOKE EXECUTE ON FUNCTION brain.read_memory_consolidation_documents(uuid,uuid,bigint) FROM PUBLIC`},
 		{`GRANT UPDATE ON brain.memory_consolidation_proposal_sources TO punaro_app`, `REVOKE UPDATE ON brain.memory_consolidation_proposal_sources FROM punaro_app`},
+		{`ALTER TABLE brain.memory_consolidation_proposal_sources DISABLE TRIGGER memory_consolidation_proposal_source_insert_guard`, `ALTER TABLE brain.memory_consolidation_proposal_sources ENABLE TRIGGER memory_consolidation_proposal_source_insert_guard`},
+		{`ALTER TABLE brain.memory_consolidation_proposal_sources DISABLE TRIGGER application_mutation_fence`, `ALTER TABLE brain.memory_consolidation_proposal_sources ENABLE TRIGGER application_mutation_fence`},
 	} {
 		if _, err := ownerDB.ExecContext(ctx, drift.apply); err != nil {
 			t.Fatal(err)

--- a/internal/postgres/brain_consolidation_integration_test.go
+++ b/internal/postgres/brain_consolidation_integration_test.go
@@ -6,6 +6,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"errors"
+	"strings"
 	"testing"
 )
 
@@ -41,6 +42,14 @@ func testMemoryConsolidationCheckpointIntegration(ctx context.Context, t *testin
 		}
 		created = append(created, result)
 	}
+	evidence, err := app.CreateMemoryEvidence(ctx, MemoryEvidenceCreateRequest{
+		PrincipalID: actor.ID, ProjectID: projectID, IdempotencyKey: "11111111-1111-4111-8111-111111111139",
+		LogicalKey: "consolidation.evidence", Kind: "evidence.excerpt", Trust: "observed", Document: json.RawMessage(`{"source":"evidence"}`),
+		Sources: []MemoryEvidenceSourceInput{{Mode: MemorySourceCopied, Kind: MemorySourceExternal, ReferenceSHA256: strings.Repeat("12", 32)}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
 	lagged, err := app.CreateMemory(ctx, MemoryCreateRequest{PrincipalID: actor.ID, ProjectID: projectID, IdempotencyKey: "11111111-1111-4111-8111-111111111130", LogicalKey: "consolidation.lagged", Kind: "fact", Trust: "curated", Document: json.RawMessage(`{"source":"before-update"}`)})
 	if err != nil {
 		t.Fatal(err)
@@ -52,6 +61,11 @@ func testMemoryConsolidationCheckpointIntegration(ctx context.Context, t *testin
 	input, err = app.ReadMemoryConsolidationInput(ctx, first)
 	if err != nil || len(input.Sources) != len(created)+1 || input.NextSequence != lagged.ChangeSequence || input.Sources[0].ItemID != created[0].ItemID || input.Sources[1].Revision != created[1].Revision || input.Sources[2].ItemID != lagged.ItemID || input.Sources[2].Revision != lagged.Revision {
 		t.Fatalf("post-claim consolidation input=%#v created=%#v lagged=%#v err=%v", input, created, lagged, err)
+	}
+	for _, source := range input.Sources {
+		if source.ItemID == evidence.ItemID {
+			t.Fatalf("consolidation input included evidence source=%#v", source)
+		}
 	}
 	var firstDocument, secondDocument map[string]bool
 	if json.Unmarshal(input.Sources[0].Document, &firstDocument) != nil || json.Unmarshal(input.Sources[1].Document, &secondDocument) != nil || !firstDocument["source"] || !secondDocument["source"] {
@@ -347,6 +361,7 @@ func testMemoryConsolidationSchemaDriftIntegration(ctx context.Context, t *testi
 		{`GRANT EXECUTE ON FUNCTION brain.claim_memory_consolidation_checkpoint(uuid,uuid,bigint) TO PUBLIC`, `REVOKE EXECUTE ON FUNCTION brain.claim_memory_consolidation_checkpoint(uuid,uuid,bigint) FROM PUBLIC`},
 		{`GRANT EXECUTE ON FUNCTION brain.read_memory_consolidation_documents(uuid,uuid,bigint) TO PUBLIC`, `REVOKE EXECUTE ON FUNCTION brain.read_memory_consolidation_documents(uuid,uuid,bigint) FROM PUBLIC`},
 		{`GRANT UPDATE ON brain.memory_consolidation_proposal_sources TO punaro_app`, `REVOKE UPDATE ON brain.memory_consolidation_proposal_sources FROM punaro_app`},
+		{`GRANT SELECT ON brain.memory_consolidation_proposal_sources TO PUBLIC`, `REVOKE SELECT ON brain.memory_consolidation_proposal_sources FROM PUBLIC`},
 		{`ALTER TABLE brain.memory_consolidation_proposal_sources DISABLE TRIGGER memory_consolidation_proposal_source_insert_guard`, `ALTER TABLE brain.memory_consolidation_proposal_sources ENABLE TRIGGER memory_consolidation_proposal_source_insert_guard`},
 		{`ALTER TABLE brain.memory_consolidation_proposal_sources DISABLE TRIGGER application_mutation_fence`, `ALTER TABLE brain.memory_consolidation_proposal_sources ENABLE TRIGGER application_mutation_fence`},
 		{`ALTER TABLE brain.memory_consolidation_proposal_sources SET UNLOGGED`, `ALTER TABLE brain.memory_consolidation_proposal_sources SET LOGGED`},

--- a/internal/postgres/brain_consolidation_integration_test.go
+++ b/internal/postgres/brain_consolidation_integration_test.go
@@ -320,6 +320,7 @@ func testMemoryConsolidationSchemaDriftIntegration(ctx context.Context, t *testi
 		{`GRANT UPDATE ON brain.memory_consolidation_proposal_sources TO punaro_app`, `REVOKE UPDATE ON brain.memory_consolidation_proposal_sources FROM punaro_app`},
 		{`ALTER TABLE brain.memory_consolidation_proposal_sources DISABLE TRIGGER memory_consolidation_proposal_source_insert_guard`, `ALTER TABLE brain.memory_consolidation_proposal_sources ENABLE TRIGGER memory_consolidation_proposal_source_insert_guard`},
 		{`ALTER TABLE brain.memory_consolidation_proposal_sources DISABLE TRIGGER application_mutation_fence`, `ALTER TABLE brain.memory_consolidation_proposal_sources ENABLE TRIGGER application_mutation_fence`},
+		{`ALTER TABLE brain.memory_consolidation_proposal_sources SET UNLOGGED`, `ALTER TABLE brain.memory_consolidation_proposal_sources SET LOGGED`},
 	} {
 		if _, err := ownerDB.ExecContext(ctx, drift.apply); err != nil {
 			t.Fatal(err)

--- a/internal/postgres/brain_consolidation_integration_test.go
+++ b/internal/postgres/brain_consolidation_integration_test.go
@@ -92,6 +92,24 @@ func testMemoryConsolidationCheckpointIntegration(ctx context.Context, t *testin
 		PrincipalID: actor.ID, ProjectID: projectID, IdempotencyKey: "11111111-1111-4111-8111-111111111133", Action: MemoryProposalCreate,
 		Steps: []MemoryProposalStepInput{{Operation: MemoryProposalStepCreate, LogicalKey: "consolidation.brief", Kind: "brief", Trust: "proposed", Document: json.RawMessage(`{"summary":"staged"}`)}},
 	}}
+	outsider, err := app.CreatePrincipal(ctx, PrincipalKindDevice, "consolidation proposal outsider")
+	if err != nil {
+		t.Fatal(err)
+	}
+	unauthorized := stagedRequest
+	unauthorized.Proposal.PrincipalID = outsider.ID
+	unauthorized.Proposal.IdempotencyKey = "11111111-1111-4111-8111-111111111138"
+	var proposalsBefore int
+	if err := ownerDB.QueryRowContext(ctx, `SELECT count(*) FROM brain.memory_proposals WHERE scope_id=$1`, scopeID).Scan(&proposalsBefore); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := app.StageMemoryConsolidationProposal(ctx, unauthorized); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("unauthorized consolidation proposal error=%v", err)
+	}
+	var proposalsAfter int
+	if err := ownerDB.QueryRowContext(ctx, `SELECT count(*) FROM brain.memory_proposals WHERE scope_id=$1`, scopeID).Scan(&proposalsAfter); err != nil || proposalsAfter != proposalsBefore {
+		t.Fatalf("unauthorized consolidation proposal created rows before=%d after=%d err=%v", proposalsBefore, proposalsAfter, err)
+	}
 	staged, err := app.StageMemoryConsolidationProposal(ctx, stagedRequest)
 	if err != nil || staged.State != MemoryProposalPending || staged.ProposalID == "" || len(staged.Mutations) != 0 {
 		t.Fatalf("stage consolidation proposal=%#v err=%v", staged, err)

--- a/internal/postgres/brain_consolidation_proposal_store.go
+++ b/internal/postgres/brain_consolidation_proposal_store.go
@@ -1,0 +1,149 @@
+package postgres
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+)
+
+// StageMemoryConsolidationProposal stages a proposal and its exact source page
+// only while the supplied consolidation lease remains live. It deliberately
+// does not advance the checkpoint: a later bounded runner decides when the
+// complete page has been handled.
+func (d *Database) StageMemoryConsolidationProposal(ctx context.Context, raw MemoryConsolidationProposalRequest) (MemoryProposalResult, error) {
+	request, err := raw.normalized()
+	if err != nil {
+		return MemoryProposalResult{}, err
+	}
+	proposal := request.Proposal
+	body, payloadSHA := memoryProposalPayloadSHA(proposal.ProjectID, proposal.Action, proposal.Steps, proposal.Evidence)
+	inputBody, err := json.Marshal(struct {
+		Proposal json.RawMessage             `json:"proposal"`
+		Timeline string                      `json:"timeline"`
+		Sequence int64                       `json:"sequence"`
+		Sources  []MemoryConsolidationSource `json:"sources"`
+	}{Proposal: body, Timeline: request.Input.TimelineID, Sequence: request.Input.NextSequence, Sources: request.Input.Sources})
+	if err != nil {
+		return MemoryProposalResult{}, errors.New("consolidation proposal cannot be encoded")
+	}
+	idempotency := IdempotencyRequest{PrincipalID: proposal.PrincipalID, Operation: "memory.consolidation.proposal.create", Key: proposal.IdempotencyKey, Body: inputBody}
+	tx, err := beginMutation(ctx, d.db)
+	if err != nil {
+		return MemoryProposalResult{}, mutationStartError(err, "consolidation proposal transaction cannot start")
+	}
+	defer func() { _ = tx.Rollback() }()
+	outcome, err := executeIdempotentTx(ctx, tx, idempotency, func(control *ControlTx) (IdempotencyOutcome, error) {
+		var timelineID string
+		var sequence int64
+		err := tx.QueryRowContext(ctx, `SELECT timeline_id::text,change_sequence FROM brain.memory_consolidation_checkpoints
+WHERE scope_id=$1 AND lease_token=$2 AND lease_generation=$3 AND lease_until>statement_timestamp() FOR UPDATE`, request.Input.Lease.ScopeID, request.Input.Lease.Token, request.Input.Lease.Generation).Scan(&timelineID, &sequence)
+		if errors.Is(err, sql.ErrNoRows) {
+			return IdempotencyOutcome{}, ErrStaleMemoryConsolidationLease
+		}
+		if err != nil || timelineID != request.Input.TimelineID || sequence != request.Input.Lease.Sequence {
+			return IdempotencyOutcome{}, ErrStaleMemoryConsolidationLease
+		}
+		project, err := lockDirectActiveProject(ctx, tx, proposal.ProjectID)
+		if err != nil {
+			return IdempotencyOutcome{}, ErrNotFound
+		}
+		var scopeProjectID string
+		if err := tx.QueryRowContext(ctx, `SELECT project_id::text FROM brain.scopes WHERE id=$1 FOR SHARE`, request.Input.Lease.ScopeID).Scan(&scopeProjectID); err != nil || scopeProjectID != project.ID {
+			return IdempotencyOutcome{}, ErrNotFound
+		}
+		allowed, err := lockCapability(ctx, tx, proposal.PrincipalID, project.ID, CapabilityMemoryPropose)
+		if err != nil || !allowed {
+			return IdempotencyOutcome{}, ErrNotFound
+		}
+		if err := lockAndValidateConsolidationInputSources(ctx, tx, project.ID, request.Input); err != nil {
+			if errors.Is(err, ErrNotFound) || errors.Is(err, ErrStaleMemoryETag) {
+				return IdempotencyOutcome{}, ErrStaleMemoryConsolidationLease
+			}
+			return IdempotencyOutcome{}, err
+		}
+		items, err := lockAndValidateProposalItems(ctx, tx, project.ID, proposal.Steps, proposal.Evidence)
+		if err != nil {
+			return IdempotencyOutcome{}, err
+		}
+		for _, step := range proposal.Steps {
+			if step.Operation == MemoryProposalStepCreate || step.Operation == MemoryProposalStepUpdate {
+				if err := guardMemoryDocument(ctx, tx, project.ID, step.Document); err != nil {
+					return IdempotencyOutcome{}, err
+				}
+			}
+			if step.Operation == MemoryProposalStepArchive && (items[step.ItemID].State == MemoryArchived) == step.Archived {
+				return IdempotencyOutcome{}, ErrMemoryProposalAlreadySatisfied
+			}
+		}
+		if err := checkMemoryProposalCapacity(ctx, tx, request.Input.Lease.ScopeID, proposal.PrincipalID); err != nil {
+			return IdempotencyOutcome{}, err
+		}
+		var proposalID string
+		if err := tx.QueryRowContext(ctx, `INSERT INTO brain.memory_proposals(scope_id,action,proposed_by,payload_sha256,payload) VALUES ($1,$2,$3,$4,$5) RETURNING id::text`, request.Input.Lease.ScopeID, proposal.Action, proposal.PrincipalID, payloadSHA, body).Scan(&proposalID); err != nil {
+			return IdempotencyOutcome{}, errors.New("consolidation proposal could not be created")
+		}
+		for ordinal, step := range proposal.Steps {
+			var targetRevision any
+			if step.ItemID != "" {
+				targetRevision = items[step.ItemID].Revision
+			}
+			var archived any
+			if step.Operation == MemoryProposalStepArchive {
+				archived = step.Archived
+			}
+			if _, err := tx.ExecContext(ctx, `INSERT INTO brain.memory_proposal_steps
+(proposal_id,ordinal,operation,item_id,target_revision,logical_key,kind,trust,document,archived)
+VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10)`, proposalID, ordinal, step.Operation, nullableString(step.ItemID), targetRevision, nullableMemoryKey(step.LogicalKey), nullableString(step.Kind), nullableString(step.Trust), nullableJSON(step.Document), archived); err != nil {
+				return IdempotencyOutcome{}, errors.New("consolidation proposal step could not be created")
+			}
+		}
+		for ordinal, evidence := range proposal.Evidence {
+			if _, err := tx.ExecContext(ctx, `INSERT INTO brain.memory_proposal_evidence(proposal_id,ordinal,item_id,revision) VALUES ($1,$2,$3,$4)`, proposalID, ordinal, evidence.ItemID, evidence.Revision); err != nil {
+				return IdempotencyOutcome{}, errors.New("consolidation proposal evidence could not be created")
+			}
+		}
+		for ordinal, source := range request.Input.Sources {
+			if _, err := tx.ExecContext(ctx, `INSERT INTO brain.memory_consolidation_proposal_sources(proposal_id,ordinal,timeline_id,item_id,revision,change_sequence) VALUES ($1,$2,$3,$4,$5,$6)`, proposalID, ordinal, request.Input.TimelineID, source.ItemID, source.Revision, source.ChangeSequence); err != nil {
+				return IdempotencyOutcome{}, errors.New("consolidation proposal source could not be recorded")
+			}
+		}
+		if err := advanceProposalGeneration(ctx, tx, project.ID); err != nil {
+			return IdempotencyOutcome{}, err
+		}
+		if err := control.AppendAudit(ctx, AuditEvent{PrincipalID: proposal.PrincipalID, ProjectID: project.ID, Action: AuditMemoryProposalCreate, Outcome: AuditSucceeded, TargetKind: AuditTargetMemoryProposal, TargetID: proposalID}); err != nil {
+			return IdempotencyOutcome{}, err
+		}
+		return memoryProposalOutcome(MemoryProposalResult{ProposalID: proposalID, State: MemoryProposalPending, ETag: memoryProposalETag(proposalID, MemoryProposalPending, payloadSHA)})
+	})
+	if err != nil {
+		return MemoryProposalResult{}, err
+	}
+	if err := tx.Commit(); err != nil {
+		return MemoryProposalResult{}, errors.New("consolidation proposal transaction could not commit")
+	}
+	return decodeMemoryProposalOutcome(outcome)
+}
+
+// lockAndValidateConsolidationInputSources rejects forged or superseded source
+// coordinates before they can become durable proposal provenance.
+func lockAndValidateConsolidationInputSources(ctx context.Context, tx *sql.Tx, projectID string, input MemoryConsolidationInput) error {
+	for _, source := range input.Sources {
+		var itemID string
+		err := tx.QueryRowContext(ctx, `SELECT item.id::text
+FROM brain.memory_changes AS change
+JOIN brain.memory_items AS item ON item.id=change.item_id
+JOIN brain.scopes AS scope ON scope.id=item.scope_id
+WHERE change.timeline_id=$1 AND change.change_sequence=$2 AND change.scope_id=$3
+  AND change.item_id=$4 AND change.revision=$5 AND scope.project_id=$6
+  AND item.current_revision=$5 AND item.state='active' AND item.layer='curated'
+FOR SHARE OF item`, input.TimelineID, source.ChangeSequence, input.Lease.ScopeID, source.ItemID, source.Revision, projectID).Scan(&itemID)
+		if errors.Is(err, sql.ErrNoRows) {
+			return ErrStaleMemoryETag
+		}
+		if err != nil || itemID != source.ItemID {
+			return errors.New("consolidation source cannot be validated")
+		}
+	}
+	return nil
+}

--- a/internal/postgres/brain_consolidation_proposal_store.go
+++ b/internal/postgres/brain_consolidation_proposal_store.go
@@ -19,7 +19,10 @@ func (d *Database) StageMemoryConsolidationProposal(ctx context.Context, raw Mem
 		return MemoryProposalResult{}, err
 	}
 	proposal := request.Proposal
-	body, payloadSHA := memoryProposalPayloadSHA(proposal.ProjectID, proposal.Action, proposal.Steps, proposal.Evidence)
+	// The request body fences idempotency before the lease transaction. The
+	// stored proposal payload is derived later from the scope's physical project
+	// ID so it remains reproducible after that project becomes an alias.
+	idempotencyPayload, _ := memoryProposalPayloadSHA(proposal.ProjectID, proposal.Action, proposal.Steps, proposal.Evidence)
 	type sourceDigest struct {
 		ItemID         string            `json:"item_id"`
 		Revision       int64             `json:"revision"`
@@ -35,7 +38,7 @@ func (d *Database) StageMemoryConsolidationProposal(ctx context.Context, raw Mem
 		Timeline string          `json:"timeline"`
 		Sequence int64           `json:"sequence"`
 		Sources  []sourceDigest  `json:"sources"`
-	}{Proposal: body, Timeline: request.Input.TimelineID, Sequence: request.Input.NextSequence, Sources: sources})
+	}{Proposal: idempotencyPayload, Timeline: request.Input.TimelineID, Sequence: request.Input.NextSequence, Sources: sources})
 	if err != nil {
 		return MemoryProposalResult{}, errors.New("consolidation proposal cannot be encoded")
 	}
@@ -68,13 +71,14 @@ WHERE scope_id=$1 AND lease_token=$2 AND lease_generation=$3 AND lease_until>sta
 		if err != nil {
 			return IdempotencyOutcome{}, ErrNotFound
 		}
-		var scopeProjectID string
-		if err := tx.QueryRowContext(ctx, `SELECT COALESCE(alias.canonical_project_id,scope.project_id)::text
+		var scopeProjectID, canonicalScopeProjectID string
+		if err := tx.QueryRowContext(ctx, `SELECT scope.project_id::text,COALESCE(alias.canonical_project_id,scope.project_id)::text
 FROM brain.scopes AS scope
 LEFT JOIN relay.project_lookup_aliases AS alias ON alias.alias_project_id=scope.project_id
-WHERE scope.id=$1 FOR SHARE OF scope`, request.Input.Lease.ScopeID).Scan(&scopeProjectID); err != nil || scopeProjectID != project.ID {
+WHERE scope.id=$1 FOR SHARE OF scope`, request.Input.Lease.ScopeID).Scan(&scopeProjectID, &canonicalScopeProjectID); err != nil || canonicalScopeProjectID != project.ID {
 			return IdempotencyOutcome{}, ErrNotFound
 		}
+		body, payloadSHA := memoryProposalPayloadSHA(scopeProjectID, proposal.Action, proposal.Steps, proposal.Evidence)
 		allowed, err := lockCapability(ctx, tx, proposal.PrincipalID, project.ID, CapabilityMemoryPropose)
 		if err != nil || !allowed {
 			return IdempotencyOutcome{}, ErrNotFound

--- a/internal/postgres/brain_consolidation_proposal_store.go
+++ b/internal/postgres/brain_consolidation_proposal_store.go
@@ -3,6 +3,7 @@ package postgres
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
 	"database/sql"
 	"encoding/json"
 	"errors"
@@ -18,13 +19,26 @@ func (d *Database) StageMemoryConsolidationProposal(ctx context.Context, raw Mem
 		return MemoryProposalResult{}, err
 	}
 	proposal := request.Proposal
+	if err := d.maintainMemoryProposals(ctx, proposal.PrincipalID, proposal.ProjectID); err != nil {
+		return MemoryProposalResult{}, err
+	}
 	body, payloadSHA := memoryProposalPayloadSHA(proposal.ProjectID, proposal.Action, proposal.Steps, proposal.Evidence)
+	type sourceDigest struct {
+		ItemID         string            `json:"item_id"`
+		Revision       int64             `json:"revision"`
+		ChangeSequence int64             `json:"change_sequence"`
+		ContentSHA256  [sha256.Size]byte `json:"content_sha256"`
+	}
+	sources := make([]sourceDigest, len(request.Input.Sources))
+	for index, source := range request.Input.Sources {
+		sources[index] = sourceDigest{ItemID: source.ItemID, Revision: source.Revision, ChangeSequence: source.ChangeSequence, ContentSHA256: sha256.Sum256(source.Document)}
+	}
 	inputBody, err := json.Marshal(struct {
-		Proposal json.RawMessage             `json:"proposal"`
-		Timeline string                      `json:"timeline"`
-		Sequence int64                       `json:"sequence"`
-		Sources  []MemoryConsolidationSource `json:"sources"`
-	}{Proposal: body, Timeline: request.Input.TimelineID, Sequence: request.Input.NextSequence, Sources: request.Input.Sources})
+		Proposal json.RawMessage `json:"proposal"`
+		Timeline string          `json:"timeline"`
+		Sequence int64           `json:"sequence"`
+		Sources  []sourceDigest  `json:"sources"`
+	}{Proposal: body, Timeline: request.Input.TimelineID, Sequence: request.Input.NextSequence, Sources: sources})
 	if err != nil {
 		return MemoryProposalResult{}, errors.New("consolidation proposal cannot be encoded")
 	}

--- a/internal/postgres/brain_consolidation_proposal_store.go
+++ b/internal/postgres/brain_consolidation_proposal_store.go
@@ -149,7 +149,7 @@ VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10)`, proposalID, ordinal, step.Operation, n
 // page under the live lease. This preserves the exact source page and applies
 // the retrieval path's quarantine and scan-coverage fences at staging time.
 func validateConsolidationInputSources(ctx context.Context, tx *sql.Tx, input MemoryConsolidationInput) error {
-	rows, err := tx.QueryContext(ctx, `SELECT timeline_id::text,item_id::text,revision,change_sequence,document::text,is_fence
+	rows, err := tx.QueryContext(ctx, `SELECT timeline_id::text,item_id::text,revision,change_sequence,document::text,content_sha256,is_fence
 FROM brain.read_memory_consolidation_documents($1,$2,$3)`, input.Lease.ScopeID, input.Lease.Token, input.Lease.Generation)
 	if err != nil {
 		return ErrStaleMemoryConsolidationLease
@@ -160,8 +160,9 @@ FROM brain.read_memory_consolidation_documents($1,$2,$3)`, input.Lease.ScopeID, 
 		var timelineID string
 		var itemID, document sql.NullString
 		var revision, sequence sql.NullInt64
+		var contentHash []byte
 		var fence bool
-		if err := rows.Scan(&timelineID, &itemID, &revision, &sequence, &document, &fence); err != nil || timelineID != input.TimelineID || !sequence.Valid {
+		if err := rows.Scan(&timelineID, &itemID, &revision, &sequence, &document, &contentHash, &fence); err != nil || timelineID != input.TimelineID || !sequence.Valid {
 			return ErrStaleMemoryConsolidationLease
 		}
 		if fence {
@@ -179,7 +180,8 @@ FROM brain.read_memory_consolidation_documents($1,$2,$3)`, input.Lease.ScopeID, 
 		}
 		source := input.Sources[index]
 		canonical, err := canonicalMemoryDocument(json.RawMessage(document.String))
-		if err != nil || source.ItemID != itemID.String || source.Revision != revision.Int64 || source.ChangeSequence != sequence.Int64 || !bytes.Equal(source.Document, canonical) {
+		digest := sha256.Sum256([]byte(document.String))
+		if err != nil || len(contentHash) != sha256.Size || !bytes.Equal(digest[:], contentHash) || source.ItemID != itemID.String || source.Revision != revision.Int64 || source.ChangeSequence != sequence.Int64 || !bytes.Equal(source.Document, canonical) {
 			return ErrStaleMemoryConsolidationLease
 		}
 		index++

--- a/internal/postgres/brain_consolidation_proposal_store.go
+++ b/internal/postgres/brain_consolidation_proposal_store.go
@@ -57,16 +57,6 @@ func (d *Database) StageMemoryConsolidationProposal(ctx context.Context, raw Mem
 	}
 	defer func() { _ = tx.Rollback() }()
 	outcome, err := executeIdempotentTx(ctx, tx, idempotency, func(control *ControlTx) (IdempotencyOutcome, error) {
-		var timelineID string
-		var sequence int64
-		err := tx.QueryRowContext(ctx, `SELECT timeline_id::text,change_sequence FROM brain.memory_consolidation_checkpoints
-WHERE scope_id=$1 AND lease_token=$2 AND lease_generation=$3 AND lease_until>statement_timestamp() FOR UPDATE`, request.Input.Lease.ScopeID, request.Input.Lease.Token, request.Input.Lease.Generation).Scan(&timelineID, &sequence)
-		if errors.Is(err, sql.ErrNoRows) {
-			return IdempotencyOutcome{}, ErrStaleMemoryConsolidationLease
-		}
-		if err != nil || timelineID != request.Input.TimelineID || sequence != request.Input.Lease.Sequence {
-			return IdempotencyOutcome{}, ErrStaleMemoryConsolidationLease
-		}
 		project, err := lockDirectActiveProject(ctx, tx, proposal.ProjectID)
 		if err != nil {
 			return IdempotencyOutcome{}, ErrNotFound

--- a/internal/postgres/brain_consolidation_proposal_store.go
+++ b/internal/postgres/brain_consolidation_proposal_store.go
@@ -1,6 +1,7 @@
 package postgres
 
 import (
+	"bytes"
 	"context"
 	"database/sql"
 	"encoding/json"
@@ -56,7 +57,7 @@ WHERE scope_id=$1 AND lease_token=$2 AND lease_generation=$3 AND lease_until>sta
 		if err != nil || !allowed {
 			return IdempotencyOutcome{}, ErrNotFound
 		}
-		if err := lockAndValidateConsolidationInputSources(ctx, tx, project.ID, request.Input); err != nil {
+		if err := validateConsolidationInputSources(ctx, tx, request.Input); err != nil {
 			if errors.Is(err, ErrNotFound) || errors.Is(err, ErrStaleMemoryETag) {
 				return IdempotencyOutcome{}, ErrStaleMemoryConsolidationLease
 			}
@@ -125,25 +126,47 @@ VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10)`, proposalID, ordinal, step.Operation, n
 	return decodeMemoryProposalOutcome(outcome)
 }
 
-// lockAndValidateConsolidationInputSources rejects forged or superseded source
-// coordinates before they can become durable proposal provenance.
-func lockAndValidateConsolidationInputSources(ctx context.Context, tx *sql.Tx, projectID string, input MemoryConsolidationInput) error {
-	for _, source := range input.Sources {
-		var itemID string
-		err := tx.QueryRowContext(ctx, `SELECT item.id::text
-FROM brain.memory_changes AS change
-JOIN brain.memory_items AS item ON item.id=change.item_id
-JOIN brain.scopes AS scope ON scope.id=item.scope_id
-WHERE change.timeline_id=$1 AND change.change_sequence=$2 AND change.scope_id=$3
-  AND change.item_id=$4 AND change.revision=$5 AND scope.project_id=$6
-  AND item.current_revision=$5 AND item.state='active' AND item.layer='curated'
-FOR SHARE OF item`, input.TimelineID, source.ChangeSequence, input.Lease.ScopeID, source.ItemID, source.Revision, projectID).Scan(&itemID)
-		if errors.Is(err, sql.ErrNoRows) {
-			return ErrStaleMemoryETag
+// validateConsolidationInputSources re-reads the complete security-definer
+// page under the live lease. This preserves the exact source page and applies
+// the retrieval path's quarantine and scan-coverage fences at staging time.
+func validateConsolidationInputSources(ctx context.Context, tx *sql.Tx, input MemoryConsolidationInput) error {
+	rows, err := tx.QueryContext(ctx, `SELECT timeline_id::text,item_id::text,revision,change_sequence,document::text,is_fence
+FROM brain.read_memory_consolidation_documents($1,$2,$3)`, input.Lease.ScopeID, input.Lease.Token, input.Lease.Generation)
+	if err != nil {
+		return ErrStaleMemoryConsolidationLease
+	}
+	defer func() { _ = rows.Close() }()
+	index, next := 0, input.Lease.Sequence
+	for rows.Next() {
+		var timelineID string
+		var itemID, document sql.NullString
+		var revision, sequence sql.NullInt64
+		var fence bool
+		if err := rows.Scan(&timelineID, &itemID, &revision, &sequence, &document, &fence); err != nil || timelineID != input.TimelineID || !sequence.Valid {
+			return ErrStaleMemoryConsolidationLease
 		}
-		if err != nil || itemID != source.ItemID {
-			return errors.New("consolidation source cannot be validated")
+		if fence {
+			if sequence.Int64 != input.Lease.Sequence {
+				return ErrStaleMemoryConsolidationLease
+			}
+			continue
 		}
+		next = sequence.Int64
+		if !itemID.Valid {
+			continue
+		}
+		if index >= len(input.Sources) || !revision.Valid || !document.Valid {
+			return ErrStaleMemoryConsolidationLease
+		}
+		source := input.Sources[index]
+		canonical, err := canonicalMemoryDocument(json.RawMessage(document.String))
+		if err != nil || source.ItemID != itemID.String || source.Revision != revision.Int64 || source.ChangeSequence != sequence.Int64 || !bytes.Equal(source.Document, canonical) {
+			return ErrStaleMemoryConsolidationLease
+		}
+		index++
+	}
+	if rows.Err() != nil || index != len(input.Sources) || next != input.NextSequence {
+		return ErrStaleMemoryConsolidationLease
 	}
 	return nil
 }

--- a/internal/postgres/brain_consolidation_proposal_store.go
+++ b/internal/postgres/brain_consolidation_proposal_store.go
@@ -70,7 +70,10 @@ WHERE scope.id=$1`, request.Input.Lease.ScopeID).Scan(&scopeProjectID, &canonica
 		}
 		body, payloadSHA := memoryProposalPayloadSHA(scopeProjectID, proposal.Action, proposal.Steps, proposal.Evidence)
 		allowed, err := lockCapability(ctx, tx, proposal.PrincipalID, project.ID, CapabilityMemoryPropose)
-		if err != nil || !allowed {
+		if err != nil {
+			return IdempotencyOutcome{}, err
+		}
+		if !allowed {
 			return IdempotencyOutcome{}, ErrNotFound
 		}
 		if err := validateConsolidationInputSources(ctx, tx, request.Input); err != nil {

--- a/internal/postgres/brain_consolidation_proposal_store.go
+++ b/internal/postgres/brain_consolidation_proposal_store.go
@@ -19,7 +19,14 @@ func (d *Database) StageMemoryConsolidationProposal(ctx context.Context, raw Mem
 		return MemoryProposalResult{}, err
 	}
 	proposal := request.Proposal
-	body, payloadSHA := memoryProposalPayloadSHA(proposal.ProjectID, proposal.Action, proposal.Steps, proposal.Evidence)
+	// Proposals persist under the scope's physical project ID. The caller may
+	// authorize through a canonical alias, but payload verification later reads
+	// the physical scope project and must reproduce this exact digest.
+	var scopeProjectID string
+	if err := d.db.QueryRowContext(ctx, `SELECT project_id::text FROM brain.scopes WHERE id=$1`, request.Input.Lease.ScopeID).Scan(&scopeProjectID); err != nil {
+		return MemoryProposalResult{}, ErrNotFound
+	}
+	body, payloadSHA := memoryProposalPayloadSHA(scopeProjectID, proposal.Action, proposal.Steps, proposal.Evidence)
 	type sourceDigest struct {
 		ItemID         string            `json:"item_id"`
 		Revision       int64             `json:"revision"`

--- a/internal/postgres/brain_consolidation_proposal_store.go
+++ b/internal/postgres/brain_consolidation_proposal_store.go
@@ -150,9 +150,12 @@ VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10)`, proposalID, ordinal, step.Operation, n
 // the retrieval path's quarantine and scan-coverage fences at staging time.
 func validateConsolidationInputSources(ctx context.Context, tx *sql.Tx, input MemoryConsolidationInput) error {
 	rows, err := tx.QueryContext(ctx, `SELECT timeline_id::text,item_id::text,revision,change_sequence,document::text,content_sha256,is_fence
-FROM brain.read_memory_consolidation_documents($1,$2,$3)`, input.Lease.ScopeID, input.Lease.Token, input.Lease.Generation)
+	FROM brain.read_memory_consolidation_documents($1,$2,$3)`, input.Lease.ScopeID, input.Lease.Token, input.Lease.Generation)
 	if err != nil {
-		return ErrStaleMemoryConsolidationLease
+		if isSQLState(err, "55000") {
+			return ErrStaleMemoryConsolidationLease
+		}
+		return errors.New("consolidation proposal sources are unavailable")
 	}
 	defer func() { _ = rows.Close() }()
 	index, next := 0, input.Lease.Sequence
@@ -186,7 +189,13 @@ FROM brain.read_memory_consolidation_documents($1,$2,$3)`, input.Lease.ScopeID, 
 		}
 		index++
 	}
-	if rows.Err() != nil || index != len(input.Sources) || next != input.NextSequence {
+	if err := rows.Err(); err != nil {
+		if isSQLState(err, "55000") {
+			return ErrStaleMemoryConsolidationLease
+		}
+		return errors.New("consolidation proposal sources are unavailable")
+	}
+	if index != len(input.Sources) || next != input.NextSequence {
 		return ErrStaleMemoryConsolidationLease
 	}
 	return nil

--- a/internal/postgres/brain_consolidation_proposal_store.go
+++ b/internal/postgres/brain_consolidation_proposal_store.go
@@ -69,7 +69,10 @@ WHERE scope_id=$1 AND lease_token=$2 AND lease_generation=$3 AND lease_until>sta
 			return IdempotencyOutcome{}, ErrNotFound
 		}
 		var scopeProjectID string
-		if err := tx.QueryRowContext(ctx, `SELECT project_id::text FROM brain.scopes WHERE id=$1 FOR SHARE`, request.Input.Lease.ScopeID).Scan(&scopeProjectID); err != nil || scopeProjectID != project.ID {
+		if err := tx.QueryRowContext(ctx, `SELECT COALESCE(alias.canonical_project_id,scope.project_id)::text
+FROM brain.scopes AS scope
+LEFT JOIN relay.project_lookup_aliases AS alias ON alias.alias_project_id=scope.project_id
+WHERE scope.id=$1 FOR SHARE OF scope`, request.Input.Lease.ScopeID).Scan(&scopeProjectID); err != nil || scopeProjectID != project.ID {
 			return IdempotencyOutcome{}, ErrNotFound
 		}
 		allowed, err := lockCapability(ctx, tx, proposal.PrincipalID, project.ID, CapabilityMemoryPropose)

--- a/internal/postgres/brain_consolidation_proposal_store.go
+++ b/internal/postgres/brain_consolidation_proposal_store.go
@@ -19,9 +19,6 @@ func (d *Database) StageMemoryConsolidationProposal(ctx context.Context, raw Mem
 		return MemoryProposalResult{}, err
 	}
 	proposal := request.Proposal
-	if err := d.maintainMemoryProposals(ctx, proposal.PrincipalID, proposal.ProjectID); err != nil {
-		return MemoryProposalResult{}, err
-	}
 	body, payloadSHA := memoryProposalPayloadSHA(proposal.ProjectID, proposal.Action, proposal.Steps, proposal.Evidence)
 	type sourceDigest struct {
 		ItemID         string            `json:"item_id"`
@@ -43,6 +40,14 @@ func (d *Database) StageMemoryConsolidationProposal(ctx context.Context, raw Mem
 		return MemoryProposalResult{}, errors.New("consolidation proposal cannot be encoded")
 	}
 	idempotency := IdempotencyRequest{PrincipalID: proposal.PrincipalID, Operation: "memory.consolidation.proposal.create", Key: proposal.IdempotencyKey, Body: inputBody}
+	if outcome, completed, err := completedIdempotencyOutcome(ctx, d.db, idempotency); err != nil {
+		return MemoryProposalResult{}, err
+	} else if completed {
+		return decodeMemoryProposalOutcome(outcome)
+	}
+	if err := d.maintainMemoryProposals(ctx, proposal.PrincipalID, proposal.ProjectID); err != nil {
+		return MemoryProposalResult{}, err
+	}
 	tx, err := beginMutation(ctx, d.db)
 	if err != nil {
 		return MemoryProposalResult{}, mutationStartError(err, "consolidation proposal transaction cannot start")

--- a/internal/postgres/brain_consolidation_proposal_store.go
+++ b/internal/postgres/brain_consolidation_proposal_store.go
@@ -65,7 +65,7 @@ func (d *Database) StageMemoryConsolidationProposal(ctx context.Context, raw Mem
 		if err := tx.QueryRowContext(ctx, `SELECT scope.project_id::text,COALESCE(alias.canonical_project_id,scope.project_id)::text
 FROM brain.scopes AS scope
 LEFT JOIN relay.project_lookup_aliases AS alias ON alias.alias_project_id=scope.project_id
-WHERE scope.id=$1 FOR SHARE OF scope`, request.Input.Lease.ScopeID).Scan(&scopeProjectID, &canonicalScopeProjectID); err != nil || canonicalScopeProjectID != project.ID {
+WHERE scope.id=$1`, request.Input.Lease.ScopeID).Scan(&scopeProjectID, &canonicalScopeProjectID); err != nil || canonicalScopeProjectID != project.ID {
 			return IdempotencyOutcome{}, ErrNotFound
 		}
 		body, payloadSHA := memoryProposalPayloadSHA(scopeProjectID, proposal.Action, proposal.Steps, proposal.Evidence)

--- a/internal/postgres/brain_consolidation_proposal_store.go
+++ b/internal/postgres/brain_consolidation_proposal_store.go
@@ -19,14 +19,7 @@ func (d *Database) StageMemoryConsolidationProposal(ctx context.Context, raw Mem
 		return MemoryProposalResult{}, err
 	}
 	proposal := request.Proposal
-	// Proposals persist under the scope's physical project ID. The caller may
-	// authorize through a canonical alias, but payload verification later reads
-	// the physical scope project and must reproduce this exact digest.
-	var scopeProjectID string
-	if err := d.db.QueryRowContext(ctx, `SELECT project_id::text FROM brain.scopes WHERE id=$1`, request.Input.Lease.ScopeID).Scan(&scopeProjectID); err != nil {
-		return MemoryProposalResult{}, ErrNotFound
-	}
-	body, payloadSHA := memoryProposalPayloadSHA(scopeProjectID, proposal.Action, proposal.Steps, proposal.Evidence)
+	body, payloadSHA := memoryProposalPayloadSHA(proposal.ProjectID, proposal.Action, proposal.Steps, proposal.Evidence)
 	type sourceDigest struct {
 		ItemID         string            `json:"item_id"`
 		Revision       int64             `json:"revision"`

--- a/internal/postgres/brain_consolidation_schema.go
+++ b/internal/postgres/brain_consolidation_schema.go
@@ -145,13 +145,21 @@ WITH relation AS (
            NOT has_table_privilege('punaro_app',oid,'UPDATE,DELETE,TRUNCATE,REFERENCES,TRIGGER')
              AND NOT has_any_column_privilege('punaro_app',oid,'UPDATE,REFERENCES') AS no_writes
     FROM relation
-), table_acl_safety AS (
-    SELECT count(*)=9 AND bool_and(NOT entry.is_grantable)
-       AND bool_and(role.rolname='punaro_owner' OR (role.rolname='punaro_app' AND entry.privilege_type='SELECT')) AS exact
+), expected_table_acl(grantee,privilege_type,is_grantable) AS (
+    VALUES
+      ('punaro_owner','SELECT',false),('punaro_owner','INSERT',false),('punaro_owner','UPDATE',false),
+      ('punaro_owner','DELETE',false),('punaro_owner','TRUNCATE',false),('punaro_owner','REFERENCES',false),
+      ('punaro_owner','TRIGGER',false),('punaro_app','SELECT',false)
+    UNION ALL SELECT 'punaro_owner','MAINTAIN',false WHERE current_setting('server_version_num')::integer >= 170000
+), actual_table_acl AS (
+    SELECT role.rolname,entry.privilege_type,entry.is_grantable
     FROM pg_class AS table_row
     CROSS JOIN LATERAL aclexplode(COALESCE(table_row.relacl,acldefault('r',table_row.relowner))) AS entry
     LEFT JOIN pg_roles AS role ON role.oid=entry.grantee,relation
     WHERE table_row.oid=relation.oid
+), table_acl_safety AS (
+    SELECT NOT EXISTS (SELECT * FROM expected_table_acl EXCEPT SELECT * FROM actual_table_acl)
+       AND NOT EXISTS (SELECT * FROM actual_table_acl EXCEPT SELECT * FROM expected_table_acl) AS exact
 ), column_acl_safety AS (
     SELECT count(*)=6 AND bool_and(role.rolname='punaro_app' AND entry.privilege_type='INSERT' AND NOT entry.is_grantable) AS exact
     FROM pg_attribute AS attribute
@@ -202,7 +210,7 @@ const (
 	memoryConsolidationAdvanceRoutineMD5             = "5666d576e054c6b06999a0b6ce7b6c62"
 	memoryConsolidationSourcesRoutineMD5             = "2b180c012d8c1ae7332b81456845a8bf"
 	memoryConsolidationDocumentsRoutineMD5           = "0b284fa1e93f9b8cd62604d4e2a3821c"
-	memoryConsolidationV38DocumentsRoutineMD5        = "f34725c0ab56059bbaef422677f37357"
+	memoryConsolidationV38DocumentsRoutineMD5        = "d2d9593918a866b633499a2619609ce3"
 	memoryConsolidationV35DocumentsRoutineMD5        = "578fc76b7dd1ed66ccdd7895cd50e07c"
 	memoryConsolidationV36DocumentsRoutineMD5        = "8eac22d68c0b50c43de1f8892c925c55"
 	memoryConsolidationV33ClaimRoutineMD5            = "32e95c7fb6a9e73522c73b825bc3dcea"

--- a/internal/postgres/brain_consolidation_schema.go
+++ b/internal/postgres/brain_consolidation_schema.go
@@ -187,6 +187,14 @@ WITH relation AS (
     FROM pg_constraint AS constraint_row,relation
     WHERE constraint_row.conrelid=relation.oid AND constraint_row.contype='c'
       AND constraint_row.convalidated AND NOT constraint_row.condeferrable AND NOT constraint_row.condeferred
+), expected_lock_guard_acl(grantee,privilege_type,is_grantable) AS (
+    VALUES ('punaro_owner','EXECUTE',false),('punaro_app','EXECUTE',false)
+), actual_lock_guard_acl AS (
+    SELECT role.rolname,entry.privilege_type,entry.is_grantable
+    FROM pg_proc AS routine
+    CROSS JOIN LATERAL aclexplode(COALESCE(routine.proacl,acldefault('f',routine.proowner))) AS entry
+    LEFT JOIN pg_roles AS role ON role.oid=entry.grantee,relation
+    WHERE routine.oid=lock_guard_oid
 ), guard_safety AS (
     SELECT count(*)=1 AND bool_and(pg_get_userbyid(proowner)='punaro_owner' AND prokind='f' AND prolang=(SELECT oid FROM pg_language WHERE lanname='plpgsql')
       AND proconfig=ARRAY['search_path=pg_catalog']::text[] AND md5(btrim(prosrc,E' \n\r\t'))=$1 AND NOT has_function_privilege('public',pg_proc.oid,'EXECUTE')) AS exact
@@ -196,7 +204,8 @@ WITH relation AS (
       AND NOT proretset AND prorettype='void'::regtype AND pronargs=0
       AND prolang=(SELECT oid FROM pg_language WHERE lanname='plpgsql')
       AND proconfig=ARRAY['search_path=pg_catalog']::text[] AND md5(btrim(prosrc,E' \n\r\t'))=$2
-      AND has_function_privilege('punaro_app',pg_proc.oid,'EXECUTE') AND NOT has_function_privilege('public',pg_proc.oid,'EXECUTE')) AS exact
+      AND NOT EXISTS (SELECT * FROM expected_lock_guard_acl EXCEPT SELECT * FROM actual_lock_guard_acl)
+      AND NOT EXISTS (SELECT * FROM actual_lock_guard_acl EXCEPT SELECT * FROM expected_lock_guard_acl)) AS exact
     FROM pg_proc,relation WHERE pg_proc.oid=lock_guard_oid
 )
 SELECT relation.oid IS NOT NULL AND relation.guard_oid IS NOT NULL AND relation.lock_guard_oid IS NOT NULL

--- a/internal/postgres/brain_consolidation_schema.go
+++ b/internal/postgres/brain_consolidation_schema.go
@@ -181,7 +181,7 @@ WITH relation AS (
 ), guard_safety AS (
     SELECT count(*)=1 AND bool_and(pg_get_userbyid(proowner)='punaro_owner' AND prokind='f' AND prolang=(SELECT oid FROM pg_language WHERE lanname='plpgsql')
       AND proconfig=ARRAY['search_path=pg_catalog']::text[] AND md5(btrim(prosrc,E' \n\r\t'))=$1 AND NOT has_function_privilege('public',oid,'EXECUTE')) AS exact
-    FROM pg_proc,relation WHERE oid=guard_oid
+    FROM pg_proc,relation WHERE pg_proc.oid=guard_oid
 )
 SELECT relation.oid IS NOT NULL AND relation.guard_oid IS NOT NULL
    AND (SELECT count(*)=1 AND bool_and(pg_get_userbyid(relowner)='punaro_owner' AND relkind='r' AND relpersistence='p' AND NOT relrowsecurity AND NOT relforcerowsecurity) FROM pg_class WHERE oid=relation.oid)

--- a/internal/postgres/brain_consolidation_schema.go
+++ b/internal/postgres/brain_consolidation_schema.go
@@ -17,6 +17,9 @@ func memoryConsolidationControlsAvailable(ctx context.Context, q queryer, versio
 	if version == 36 {
 		documentsMD5 = memoryConsolidationV36DocumentsRoutineMD5
 	}
+	if version >= 38 {
+		documentsMD5 = memoryConsolidationV38DocumentsRoutineMD5
+	}
 	err := q.QueryRowContext(ctx, `
 WITH objects AS (
     SELECT to_regclass('brain.memory_consolidation_checkpoints') AS table_oid,
@@ -142,6 +145,10 @@ WITH relation AS (
            NOT has_table_privilege('punaro_app',oid,'UPDATE,DELETE,TRUNCATE,REFERENCES,TRIGGER')
              AND NOT has_any_column_privilege('punaro_app',oid,'UPDATE,REFERENCES') AS no_writes
     FROM relation
+), public_acl_safety AS (
+    SELECT NOT has_table_privilege('public',oid,'SELECT,INSERT,UPDATE,DELETE,TRUNCATE,REFERENCES,TRIGGER')
+       AND NOT has_any_column_privilege('public',oid,'SELECT,INSERT,UPDATE,REFERENCES') AS exact
+    FROM relation
 ), trigger_safety AS (
     SELECT count(*)=2
        AND count(*) FILTER (WHERE tgname='memory_consolidation_proposal_source_insert_guard' AND tgtype=7 AND tgfoid=guard_oid AND tgenabled='O')=1
@@ -164,8 +171,9 @@ SELECT relation.oid IS NOT NULL AND relation.guard_oid IS NOT NULL
    AND NOT EXISTS (SELECT * FROM expected_columns EXCEPT SELECT * FROM actual_columns)
    AND NOT EXISTS (SELECT * FROM actual_columns EXCEPT SELECT * FROM expected_columns)
    AND application_privileges.selects AND application_privileges.inserts AND application_privileges.no_writes
+   AND public_acl_safety.exact
    AND trigger_safety.exact AND constraint_safety.exact AND guard_safety.exact
-FROM relation,application_privileges,trigger_safety,constraint_safety,guard_safety`, memoryConsolidationProposalSourceGuardRoutineMD5).Scan(&available)
+FROM relation,application_privileges,public_acl_safety,trigger_safety,constraint_safety,guard_safety`, memoryConsolidationProposalSourceGuardRoutineMD5).Scan(&available)
 	return available, err
 }
 
@@ -175,6 +183,7 @@ const (
 	memoryConsolidationAdvanceRoutineMD5             = "5666d576e054c6b06999a0b6ce7b6c62"
 	memoryConsolidationSourcesRoutineMD5             = "2b180c012d8c1ae7332b81456845a8bf"
 	memoryConsolidationDocumentsRoutineMD5           = "0b284fa1e93f9b8cd62604d4e2a3821c"
+	memoryConsolidationV38DocumentsRoutineMD5        = "da1f0cf7611c37604f98fa33529748df"
 	memoryConsolidationV35DocumentsRoutineMD5        = "578fc76b7dd1ed66ccdd7895cd50e07c"
 	memoryConsolidationV36DocumentsRoutineMD5        = "8eac22d68c0b50c43de1f8892c925c55"
 	memoryConsolidationV33ClaimRoutineMD5            = "32e95c7fb6a9e73522c73b825bc3dcea"

--- a/internal/postgres/brain_consolidation_schema.go
+++ b/internal/postgres/brain_consolidation_schema.go
@@ -177,7 +177,7 @@ FROM relation,application_privileges,public_acl_safety,trigger_safety,constraint
 }
 
 const (
-	memoryConsolidationProposalSourceGuardRoutineMD5 = "df081efa031414be22850049f25430b5"
+	memoryConsolidationProposalSourceGuardRoutineMD5 = "aaa45e19ae18202e97772cb7096ad117"
 	memoryConsolidationClaimRoutineMD5               = "121df7d09493be8662f4618208aaf342"
 	memoryConsolidationAdvanceRoutineMD5             = "5666d576e054c6b06999a0b6ce7b6c62"
 	memoryConsolidationSourcesRoutineMD5             = "2b180c012d8c1ae7332b81456845a8bf"

--- a/internal/postgres/brain_consolidation_schema.go
+++ b/internal/postgres/brain_consolidation_schema.go
@@ -200,7 +200,7 @@ WITH relation AS (
       AND proconfig=ARRAY['search_path=pg_catalog']::text[] AND md5(btrim(prosrc,E' \n\r\t'))=$1 AND NOT has_function_privilege('public',pg_proc.oid,'EXECUTE')) AS exact
     FROM pg_proc,relation WHERE pg_proc.oid=guard_oid
 ), lock_guard_safety AS (
-    SELECT count(*)=1 AND bool_and(pg_get_userbyid(proowner)='punaro_owner' AND prokind='f' AND prosecdef
+    SELECT count(*)=1 AND bool_and(pg_get_userbyid(proowner)='punaro_owner' AND prokind='f' AND prosecdef AND provolatile='v'
       AND NOT proretset AND prorettype='void'::regtype AND pronargs=0
       AND prolang=(SELECT oid FROM pg_language WHERE lanname='plpgsql')
       AND proconfig=ARRAY['search_path=pg_catalog']::text[] AND md5(btrim(prosrc,E' \n\r\t'))=$2

--- a/internal/postgres/brain_consolidation_schema.go
+++ b/internal/postgres/brain_consolidation_schema.go
@@ -126,7 +126,8 @@ func memoryConsolidationProposalSourcesAvailable(ctx context.Context, q queryer)
 	err := q.QueryRowContext(ctx, `
 WITH relation AS (
     SELECT to_regclass('brain.memory_consolidation_proposal_sources') AS oid,
-           to_regprocedure('brain.guard_memory_consolidation_proposal_source()') AS guard_oid
+           to_regprocedure('brain.guard_memory_consolidation_proposal_source()') AS guard_oid,
+           to_regprocedure('brain.lock_memory_consolidation_source_guards()') AS lock_guard_oid
 ), expected_columns(name,type_name,required) AS (
     VALUES ('proposal_id','uuid',true),('ordinal','smallint',true),('timeline_id','uuid',true),
            ('item_id','uuid',true),('revision','bigint',true),('change_sequence','bigint',true)
@@ -190,29 +191,37 @@ WITH relation AS (
     SELECT count(*)=1 AND bool_and(pg_get_userbyid(proowner)='punaro_owner' AND prokind='f' AND prolang=(SELECT oid FROM pg_language WHERE lanname='plpgsql')
       AND proconfig=ARRAY['search_path=pg_catalog']::text[] AND md5(btrim(prosrc,E' \n\r\t'))=$1 AND NOT has_function_privilege('public',pg_proc.oid,'EXECUTE')) AS exact
     FROM pg_proc,relation WHERE pg_proc.oid=guard_oid
+), lock_guard_safety AS (
+    SELECT count(*)=1 AND bool_and(pg_get_userbyid(proowner)='punaro_owner' AND prokind='f' AND prosecdef
+      AND NOT proretset AND prorettype='void'::regtype AND pronargs=0
+      AND prolang=(SELECT oid FROM pg_language WHERE lanname='plpgsql')
+      AND proconfig=ARRAY['search_path=pg_catalog']::text[] AND md5(btrim(prosrc,E' \n\r\t'))=$2
+      AND has_function_privilege('punaro_app',pg_proc.oid,'EXECUTE') AND NOT has_function_privilege('public',pg_proc.oid,'EXECUTE')) AS exact
+    FROM pg_proc,relation WHERE pg_proc.oid=lock_guard_oid
 )
-SELECT relation.oid IS NOT NULL AND relation.guard_oid IS NOT NULL
+SELECT relation.oid IS NOT NULL AND relation.guard_oid IS NOT NULL AND relation.lock_guard_oid IS NOT NULL
    AND (SELECT count(*)=1 AND bool_and(pg_get_userbyid(relowner)='punaro_owner' AND relkind='r' AND relpersistence='p' AND NOT relrowsecurity AND NOT relforcerowsecurity) FROM pg_class WHERE oid=relation.oid)
    AND NOT EXISTS (SELECT * FROM expected_columns EXCEPT SELECT * FROM actual_columns)
    AND NOT EXISTS (SELECT * FROM actual_columns EXCEPT SELECT * FROM expected_columns)
    AND application_privileges.selects AND application_privileges.inserts AND application_privileges.no_writes
    AND table_acl_safety.exact AND column_acl_safety.exact
-   AND trigger_safety.exact AND constraint_safety.exact AND guard_safety.exact
+   AND trigger_safety.exact AND constraint_safety.exact AND guard_safety.exact AND lock_guard_safety.exact
    AND NOT EXISTS (SELECT * FROM expected_checks EXCEPT SELECT * FROM actual_checks)
    AND NOT EXISTS (SELECT * FROM actual_checks EXCEPT SELECT * FROM expected_checks)
-FROM relation,application_privileges,table_acl_safety,column_acl_safety,trigger_safety,constraint_safety,guard_safety`, memoryConsolidationProposalSourceGuardRoutineMD5).Scan(&available)
+FROM relation,application_privileges,table_acl_safety,column_acl_safety,trigger_safety,constraint_safety,guard_safety,lock_guard_safety`, memoryConsolidationProposalSourceGuardRoutineMD5, memoryConsolidationProposalSourceLockGuardRoutineMD5).Scan(&available)
 	return available, err
 }
 
 const (
-	memoryConsolidationProposalSourceGuardRoutineMD5 = "aaa45e19ae18202e97772cb7096ad117"
-	memoryConsolidationClaimRoutineMD5               = "121df7d09493be8662f4618208aaf342"
-	memoryConsolidationAdvanceRoutineMD5             = "5666d576e054c6b06999a0b6ce7b6c62"
-	memoryConsolidationSourcesRoutineMD5             = "2b180c012d8c1ae7332b81456845a8bf"
-	memoryConsolidationDocumentsRoutineMD5           = "0b284fa1e93f9b8cd62604d4e2a3821c"
-	memoryConsolidationV38DocumentsRoutineMD5        = "d2d9593918a866b633499a2619609ce3"
-	memoryConsolidationV35DocumentsRoutineMD5        = "578fc76b7dd1ed66ccdd7895cd50e07c"
-	memoryConsolidationV36DocumentsRoutineMD5        = "8eac22d68c0b50c43de1f8892c925c55"
-	memoryConsolidationV33ClaimRoutineMD5            = "32e95c7fb6a9e73522c73b825bc3dcea"
-	memoryConsolidationV33AdvanceRoutineMD5          = "cce038c3cca8f3c4f48da8b5e155443c"
+	memoryConsolidationProposalSourceGuardRoutineMD5     = "aaa45e19ae18202e97772cb7096ad117"
+	memoryConsolidationProposalSourceLockGuardRoutineMD5 = "88c2c1cf6aabfec6303afb7a155f3de0"
+	memoryConsolidationClaimRoutineMD5                   = "121df7d09493be8662f4618208aaf342"
+	memoryConsolidationAdvanceRoutineMD5                 = "5666d576e054c6b06999a0b6ce7b6c62"
+	memoryConsolidationSourcesRoutineMD5                 = "2b180c012d8c1ae7332b81456845a8bf"
+	memoryConsolidationDocumentsRoutineMD5               = "0b284fa1e93f9b8cd62604d4e2a3821c"
+	memoryConsolidationV38DocumentsRoutineMD5            = "d2d9593918a866b633499a2619609ce3"
+	memoryConsolidationV35DocumentsRoutineMD5            = "578fc76b7dd1ed66ccdd7895cd50e07c"
+	memoryConsolidationV36DocumentsRoutineMD5            = "8eac22d68c0b50c43de1f8892c925c55"
+	memoryConsolidationV33ClaimRoutineMD5                = "32e95c7fb6a9e73522c73b825bc3dcea"
+	memoryConsolidationV33AdvanceRoutineMD5              = "cce038c3cca8f3c4f48da8b5e155443c"
 )

--- a/internal/postgres/brain_consolidation_schema.go
+++ b/internal/postgres/brain_consolidation_schema.go
@@ -160,7 +160,7 @@ WITH relation AS (
     FROM pg_proc,relation WHERE oid=guard_oid
 )
 SELECT relation.oid IS NOT NULL AND relation.guard_oid IS NOT NULL
-   AND (SELECT count(*)=1 AND bool_and(pg_get_userbyid(relowner)='punaro_owner' AND relkind='r' AND NOT relrowsecurity AND NOT relforcerowsecurity) FROM pg_class WHERE oid=relation.oid)
+   AND (SELECT count(*)=1 AND bool_and(pg_get_userbyid(relowner)='punaro_owner' AND relkind='r' AND relpersistence='p' AND NOT relrowsecurity AND NOT relforcerowsecurity) FROM pg_class WHERE oid=relation.oid)
    AND NOT EXISTS (SELECT * FROM expected_columns EXCEPT SELECT * FROM actual_columns)
    AND NOT EXISTS (SELECT * FROM actual_columns EXCEPT SELECT * FROM expected_columns)
    AND application_privileges.selects AND application_privileges.inserts AND application_privileges.no_writes

--- a/internal/postgres/brain_consolidation_schema.go
+++ b/internal/postgres/brain_consolidation_schema.go
@@ -180,7 +180,7 @@ WITH relation AS (
       AND constraint_row.convalidated AND NOT constraint_row.condeferrable AND NOT constraint_row.condeferred
 ), guard_safety AS (
     SELECT count(*)=1 AND bool_and(pg_get_userbyid(proowner)='punaro_owner' AND prokind='f' AND prolang=(SELECT oid FROM pg_language WHERE lanname='plpgsql')
-      AND proconfig=ARRAY['search_path=pg_catalog']::text[] AND md5(btrim(prosrc,E' \n\r\t'))=$1 AND NOT has_function_privilege('public',oid,'EXECUTE')) AS exact
+      AND proconfig=ARRAY['search_path=pg_catalog']::text[] AND md5(btrim(prosrc,E' \n\r\t'))=$1 AND NOT has_function_privilege('public',pg_proc.oid,'EXECUTE')) AS exact
     FROM pg_proc,relation WHERE pg_proc.oid=guard_oid
 )
 SELECT relation.oid IS NOT NULL AND relation.guard_oid IS NOT NULL

--- a/internal/postgres/brain_consolidation_schema.go
+++ b/internal/postgres/brain_consolidation_schema.go
@@ -145,21 +145,39 @@ WITH relation AS (
            NOT has_table_privilege('punaro_app',oid,'UPDATE,DELETE,TRUNCATE,REFERENCES,TRIGGER')
              AND NOT has_any_column_privilege('punaro_app',oid,'UPDATE,REFERENCES') AS no_writes
     FROM relation
-), public_acl_safety AS (
-    SELECT NOT has_table_privilege('public',oid,'SELECT,INSERT,UPDATE,DELETE,TRUNCATE,REFERENCES,TRIGGER')
-       AND NOT has_any_column_privilege('public',oid,'SELECT,INSERT,UPDATE,REFERENCES') AS exact
-    FROM relation
+), table_acl_safety AS (
+    SELECT count(*)=9 AND bool_and(NOT entry.is_grantable)
+       AND bool_and(role.rolname='punaro_owner' OR (role.rolname='punaro_app' AND entry.privilege_type='SELECT')) AS exact
+    FROM pg_class AS table_row
+    CROSS JOIN LATERAL aclexplode(COALESCE(table_row.relacl,acldefault('r',table_row.relowner))) AS entry
+    LEFT JOIN pg_roles AS role ON role.oid=entry.grantee,relation
+    WHERE table_row.oid=relation.oid
+), column_acl_safety AS (
+    SELECT count(*)=6 AND bool_and(role.rolname='punaro_app' AND entry.privilege_type='INSERT' AND NOT entry.is_grantable) AS exact
+    FROM pg_attribute AS attribute
+    CROSS JOIN LATERAL aclexplode(attribute.attacl) AS entry
+    LEFT JOIN pg_roles AS role ON role.oid=entry.grantee,relation
+    WHERE attribute.attrelid=relation.oid AND attribute.attnum>0 AND NOT attribute.attisdropped AND attribute.attacl IS NOT NULL
 ), trigger_safety AS (
     SELECT count(*)=2
-       AND count(*) FILTER (WHERE tgname='memory_consolidation_proposal_source_insert_guard' AND tgtype=7 AND tgfoid=guard_oid AND tgenabled='O')=1
-       AND count(*) FILTER (WHERE tgname='application_mutation_fence' AND tgtype=62 AND tgfoid='jobs.guard_application_mutation()'::regprocedure AND tgenabled='O')=1 AS exact
+       AND count(*) FILTER (WHERE tgname='memory_consolidation_proposal_source_insert_guard' AND tgtype=7 AND tgfoid=guard_oid AND tgenabled='O' AND tgattr=''::int2vector AND tgqual IS NULL)=1
+       AND count(*) FILTER (WHERE tgname='application_mutation_fence' AND tgtype=62 AND tgfoid='jobs.guard_application_mutation()'::regprocedure AND tgenabled='O' AND tgattr=''::int2vector AND tgqual IS NULL)=1 AS exact
     FROM pg_trigger,relation WHERE tgrelid=relation.oid AND NOT tgisinternal
 ), constraint_safety AS (
-    SELECT count(*)=5
+    SELECT count(*)=5 AND bool_and(convalidated AND NOT condeferrable AND NOT condeferred)
        AND count(*) FILTER (WHERE contype='p' AND conkey=ARRAY[1,2]::smallint[])=1
        AND count(*) FILTER (WHERE contype='f' AND conkey=ARRAY[1]::smallint[] AND confrelid='brain.memory_proposals'::regclass AND confdeltype='c')=1
        AND count(*) FILTER (WHERE contype='c')=3 AS exact
     FROM pg_constraint,relation WHERE conrelid=relation.oid AND contype<>'n'
+), expected_checks(name,expression) AS (
+    VALUES ('memory_consolidation_proposal_sources_ordinal_check','((ordinal >= 0) AND (ordinal <= 127))'),
+           ('memory_consolidation_proposal_sources_revision_check','(revision >= 1)'),
+           ('memory_consolidation_proposal_sources_sequence_check','(change_sequence >= 0)')
+), actual_checks AS (
+    SELECT constraint_row.conname,pg_get_expr(constraint_row.conbin,constraint_row.conrelid)
+    FROM pg_constraint AS constraint_row,relation
+    WHERE constraint_row.conrelid=relation.oid AND constraint_row.contype='c'
+      AND constraint_row.convalidated AND NOT constraint_row.condeferrable AND NOT constraint_row.condeferred
 ), guard_safety AS (
     SELECT count(*)=1 AND bool_and(pg_get_userbyid(proowner)='punaro_owner' AND prokind='f' AND prolang=(SELECT oid FROM pg_language WHERE lanname='plpgsql')
       AND proconfig=ARRAY['search_path=pg_catalog']::text[] AND md5(btrim(prosrc,E' \n\r\t'))=$1 AND NOT has_function_privilege('public',oid,'EXECUTE')) AS exact
@@ -170,9 +188,11 @@ SELECT relation.oid IS NOT NULL AND relation.guard_oid IS NOT NULL
    AND NOT EXISTS (SELECT * FROM expected_columns EXCEPT SELECT * FROM actual_columns)
    AND NOT EXISTS (SELECT * FROM actual_columns EXCEPT SELECT * FROM expected_columns)
    AND application_privileges.selects AND application_privileges.inserts AND application_privileges.no_writes
-   AND public_acl_safety.exact
+   AND table_acl_safety.exact AND column_acl_safety.exact
    AND trigger_safety.exact AND constraint_safety.exact AND guard_safety.exact
-FROM relation,application_privileges,public_acl_safety,trigger_safety,constraint_safety,guard_safety`, memoryConsolidationProposalSourceGuardRoutineMD5).Scan(&available)
+   AND NOT EXISTS (SELECT * FROM expected_checks EXCEPT SELECT * FROM actual_checks)
+   AND NOT EXISTS (SELECT * FROM actual_checks EXCEPT SELECT * FROM expected_checks)
+FROM relation,application_privileges,table_acl_safety,column_acl_safety,trigger_safety,constraint_safety,guard_safety`, memoryConsolidationProposalSourceGuardRoutineMD5).Scan(&available)
 	return available, err
 }
 

--- a/internal/postgres/brain_consolidation_schema.go
+++ b/internal/postgres/brain_consolidation_schema.go
@@ -156,7 +156,7 @@ WITH relation AS (
     FROM pg_constraint,relation WHERE conrelid=relation.oid AND contype<>'n'
 ), guard_safety AS (
     SELECT count(*)=1 AND bool_and(pg_get_userbyid(proowner)='punaro_owner' AND prokind='f' AND prolang=(SELECT oid FROM pg_language WHERE lanname='plpgsql')
-      AND proconfig=ARRAY['search_path=pg_catalog']::text[] AND NOT has_function_privilege('public',oid,'EXECUTE')) AS exact
+      AND proconfig=ARRAY['search_path=pg_catalog']::text[] AND md5(btrim(prosrc,E' \n\r\t'))=$1 AND NOT has_function_privilege('public',oid,'EXECUTE')) AS exact
     FROM pg_proc,relation WHERE oid=guard_oid
 )
 SELECT relation.oid IS NOT NULL AND relation.guard_oid IS NOT NULL
@@ -165,17 +165,18 @@ SELECT relation.oid IS NOT NULL AND relation.guard_oid IS NOT NULL
    AND NOT EXISTS (SELECT * FROM actual_columns EXCEPT SELECT * FROM expected_columns)
    AND application_privileges.selects AND application_privileges.inserts AND application_privileges.no_writes
    AND trigger_safety.exact AND constraint_safety.exact AND guard_safety.exact
-FROM relation,application_privileges,trigger_safety,constraint_safety,guard_safety`).Scan(&available)
+FROM relation,application_privileges,trigger_safety,constraint_safety,guard_safety`, memoryConsolidationProposalSourceGuardRoutineMD5).Scan(&available)
 	return available, err
 }
 
 const (
-	memoryConsolidationClaimRoutineMD5        = "121df7d09493be8662f4618208aaf342"
-	memoryConsolidationAdvanceRoutineMD5      = "5666d576e054c6b06999a0b6ce7b6c62"
-	memoryConsolidationSourcesRoutineMD5      = "2b180c012d8c1ae7332b81456845a8bf"
-	memoryConsolidationDocumentsRoutineMD5    = "0b284fa1e93f9b8cd62604d4e2a3821c"
-	memoryConsolidationV35DocumentsRoutineMD5 = "578fc76b7dd1ed66ccdd7895cd50e07c"
-	memoryConsolidationV36DocumentsRoutineMD5 = "8eac22d68c0b50c43de1f8892c925c55"
-	memoryConsolidationV33ClaimRoutineMD5     = "32e95c7fb6a9e73522c73b825bc3dcea"
-	memoryConsolidationV33AdvanceRoutineMD5   = "cce038c3cca8f3c4f48da8b5e155443c"
+	memoryConsolidationProposalSourceGuardRoutineMD5 = "df081efa031414be22850049f25430b5"
+	memoryConsolidationClaimRoutineMD5               = "121df7d09493be8662f4618208aaf342"
+	memoryConsolidationAdvanceRoutineMD5             = "5666d576e054c6b06999a0b6ce7b6c62"
+	memoryConsolidationSourcesRoutineMD5             = "2b180c012d8c1ae7332b81456845a8bf"
+	memoryConsolidationDocumentsRoutineMD5           = "0b284fa1e93f9b8cd62604d4e2a3821c"
+	memoryConsolidationV35DocumentsRoutineMD5        = "578fc76b7dd1ed66ccdd7895cd50e07c"
+	memoryConsolidationV36DocumentsRoutineMD5        = "8eac22d68c0b50c43de1f8892c925c55"
+	memoryConsolidationV33ClaimRoutineMD5            = "32e95c7fb6a9e73522c73b825bc3dcea"
+	memoryConsolidationV33AdvanceRoutineMD5          = "cce038c3cca8f3c4f48da8b5e155443c"
 )

--- a/internal/postgres/brain_consolidation_schema.go
+++ b/internal/postgres/brain_consolidation_schema.go
@@ -188,7 +188,7 @@ WITH relation AS (
     WHERE constraint_row.conrelid=relation.oid AND constraint_row.contype='c'
       AND constraint_row.convalidated AND NOT constraint_row.condeferrable AND NOT constraint_row.condeferred
 ), expected_lock_guard_acl(grantee,privilege_type,is_grantable) AS (
-    VALUES ('punaro_app','EXECUTE',false)
+    VALUES ('punaro_owner','EXECUTE',false),('punaro_app','EXECUTE',false)
 ), actual_lock_guard_acl AS (
     SELECT role.rolname,entry.privilege_type,entry.is_grantable
     FROM pg_proc AS routine

--- a/internal/postgres/brain_consolidation_schema.go
+++ b/internal/postgres/brain_consolidation_schema.go
@@ -144,15 +144,14 @@ WITH relation AS (
     FROM relation
 ), trigger_safety AS (
     SELECT count(*)=2
-       AND count(*) FILTER (WHERE tgname='memory_consolidation_proposal_source_insert_guard' AND tgtype=7 AND tgfoid=guard_oid)=1
-       AND count(*) FILTER (WHERE tgname='application_mutation_fence' AND tgtype=62)=1 AS exact
+       AND count(*) FILTER (WHERE tgname='memory_consolidation_proposal_source_insert_guard' AND tgtype=7 AND tgfoid=guard_oid AND tgenabled='O')=1
+       AND count(*) FILTER (WHERE tgname='application_mutation_fence' AND tgtype=62 AND tgfoid='jobs.guard_application_mutation()'::regprocedure AND tgenabled='O')=1 AS exact
     FROM pg_trigger,relation WHERE tgrelid=relation.oid AND NOT tgisinternal
 ), constraint_safety AS (
-    SELECT count(*)=7
+    SELECT count(*)=6
        AND count(*) FILTER (WHERE contype='p' AND conkey=ARRAY[1,2]::smallint[])=1
        AND count(*) FILTER (WHERE contype='u' AND conkey=ARRAY[1,4]::smallint[])=1
        AND count(*) FILTER (WHERE contype='f' AND conkey=ARRAY[1]::smallint[] AND confrelid='brain.memory_proposals'::regclass AND confdeltype='c')=1
-       AND count(*) FILTER (WHERE contype='f' AND conkey=ARRAY[4,5]::smallint[] AND confrelid='brain.memory_revisions'::regclass)=1
        AND count(*) FILTER (WHERE contype='c')=3 AS exact
     FROM pg_constraint,relation WHERE conrelid=relation.oid AND contype<>'n'
 ), guard_safety AS (

--- a/internal/postgres/brain_consolidation_schema.go
+++ b/internal/postgres/brain_consolidation_schema.go
@@ -183,7 +183,7 @@ const (
 	memoryConsolidationAdvanceRoutineMD5             = "5666d576e054c6b06999a0b6ce7b6c62"
 	memoryConsolidationSourcesRoutineMD5             = "2b180c012d8c1ae7332b81456845a8bf"
 	memoryConsolidationDocumentsRoutineMD5           = "0b284fa1e93f9b8cd62604d4e2a3821c"
-	memoryConsolidationV38DocumentsRoutineMD5        = "da1f0cf7611c37604f98fa33529748df"
+	memoryConsolidationV38DocumentsRoutineMD5        = "f34725c0ab56059bbaef422677f37357"
 	memoryConsolidationV35DocumentsRoutineMD5        = "578fc76b7dd1ed66ccdd7895cd50e07c"
 	memoryConsolidationV36DocumentsRoutineMD5        = "8eac22d68c0b50c43de1f8892c925c55"
 	memoryConsolidationV33ClaimRoutineMD5            = "32e95c7fb6a9e73522c73b825bc3dcea"

--- a/internal/postgres/brain_consolidation_schema.go
+++ b/internal/postgres/brain_consolidation_schema.go
@@ -188,7 +188,7 @@ WITH relation AS (
     WHERE constraint_row.conrelid=relation.oid AND constraint_row.contype='c'
       AND constraint_row.convalidated AND NOT constraint_row.condeferrable AND NOT constraint_row.condeferred
 ), expected_lock_guard_acl(grantee,privilege_type,is_grantable) AS (
-    VALUES ('punaro_owner','EXECUTE',false),('punaro_app','EXECUTE',false)
+    VALUES ('punaro_app','EXECUTE',false)
 ), actual_lock_guard_acl AS (
     SELECT role.rolname,entry.privilege_type,entry.is_grantable
     FROM pg_proc AS routine

--- a/internal/postgres/brain_consolidation_schema.go
+++ b/internal/postgres/brain_consolidation_schema.go
@@ -155,9 +155,8 @@ WITH relation AS (
        AND count(*) FILTER (WHERE tgname='application_mutation_fence' AND tgtype=62 AND tgfoid='jobs.guard_application_mutation()'::regprocedure AND tgenabled='O')=1 AS exact
     FROM pg_trigger,relation WHERE tgrelid=relation.oid AND NOT tgisinternal
 ), constraint_safety AS (
-    SELECT count(*)=6
+    SELECT count(*)=5
        AND count(*) FILTER (WHERE contype='p' AND conkey=ARRAY[1,2]::smallint[])=1
-       AND count(*) FILTER (WHERE contype='u' AND conkey=ARRAY[1,4]::smallint[])=1
        AND count(*) FILTER (WHERE contype='f' AND conkey=ARRAY[1]::smallint[] AND confrelid='brain.memory_proposals'::regclass AND confdeltype='c')=1
        AND count(*) FILTER (WHERE contype='c')=3 AS exact
     FROM pg_constraint,relation WHERE conrelid=relation.oid AND contype<>'n'

--- a/internal/postgres/brain_consolidation_schema.go
+++ b/internal/postgres/brain_consolidation_schema.go
@@ -116,6 +116,60 @@ FROM objects,routine_safety,constraint_safety,table_acl_safety`, claimMD5, advan
 	return available, err
 }
 
+// memoryConsolidationProposalSourcesAvailable verifies the v38 immutable
+// provenance relation and the narrow application-role boundary around it.
+func memoryConsolidationProposalSourcesAvailable(ctx context.Context, q queryer) (bool, error) {
+	var available bool
+	err := q.QueryRowContext(ctx, `
+WITH relation AS (
+    SELECT to_regclass('brain.memory_consolidation_proposal_sources') AS oid,
+           to_regprocedure('brain.guard_memory_consolidation_proposal_source()') AS guard_oid
+), expected_columns(name,type_name,required) AS (
+    VALUES ('proposal_id','uuid',true),('ordinal','smallint',true),('timeline_id','uuid',true),
+           ('item_id','uuid',true),('revision','bigint',true),('change_sequence','bigint',true)
+), actual_columns AS (
+    SELECT attribute.attname,attribute.atttypid::regtype::text,attribute.attnotnull
+    FROM pg_attribute AS attribute,relation
+    WHERE attribute.attrelid=relation.oid AND attribute.attnum>0 AND NOT attribute.attisdropped
+), application_privileges AS (
+    SELECT has_table_privilege('punaro_app',oid,'SELECT') AS selects,
+           has_column_privilege('punaro_app',oid,'proposal_id','INSERT')
+             AND has_column_privilege('punaro_app',oid,'ordinal','INSERT')
+             AND has_column_privilege('punaro_app',oid,'timeline_id','INSERT')
+             AND has_column_privilege('punaro_app',oid,'item_id','INSERT')
+             AND has_column_privilege('punaro_app',oid,'revision','INSERT')
+             AND has_column_privilege('punaro_app',oid,'change_sequence','INSERT') AS inserts,
+           NOT has_table_privilege('punaro_app',oid,'UPDATE,DELETE,TRUNCATE,REFERENCES,TRIGGER')
+             AND NOT has_any_column_privilege('punaro_app',oid,'UPDATE,REFERENCES') AS no_writes
+    FROM relation
+), trigger_safety AS (
+    SELECT count(*)=2
+       AND count(*) FILTER (WHERE tgname='memory_consolidation_proposal_source_insert_guard' AND tgtype=7 AND tgfoid=guard_oid)=1
+       AND count(*) FILTER (WHERE tgname='application_mutation_fence' AND tgtype=62)=1 AS exact
+    FROM pg_trigger,relation WHERE tgrelid=relation.oid AND NOT tgisinternal
+), constraint_safety AS (
+    SELECT count(*)=7
+       AND count(*) FILTER (WHERE contype='p' AND conkey=ARRAY[1,2]::smallint[])=1
+       AND count(*) FILTER (WHERE contype='u' AND conkey=ARRAY[1,4]::smallint[])=1
+       AND count(*) FILTER (WHERE contype='f' AND conkey=ARRAY[1]::smallint[] AND confrelid='brain.memory_proposals'::regclass AND confdeltype='c')=1
+       AND count(*) FILTER (WHERE contype='f' AND conkey=ARRAY[4,5]::smallint[] AND confrelid='brain.memory_revisions'::regclass)=1
+       AND count(*) FILTER (WHERE contype='c')=3 AS exact
+    FROM pg_constraint,relation WHERE conrelid=relation.oid AND contype<>'n'
+), guard_safety AS (
+    SELECT count(*)=1 AND bool_and(pg_get_userbyid(proowner)='punaro_owner' AND prokind='f' AND prolang=(SELECT oid FROM pg_language WHERE lanname='plpgsql')
+      AND proconfig=ARRAY['search_path=pg_catalog']::text[] AND NOT has_function_privilege('public',oid,'EXECUTE')) AS exact
+    FROM pg_proc,relation WHERE oid=guard_oid
+)
+SELECT relation.oid IS NOT NULL AND relation.guard_oid IS NOT NULL
+   AND (SELECT count(*)=1 AND bool_and(pg_get_userbyid(relowner)='punaro_owner' AND relkind='r' AND NOT relrowsecurity AND NOT relforcerowsecurity) FROM pg_class WHERE oid=relation.oid)
+   AND NOT EXISTS (SELECT * FROM expected_columns EXCEPT SELECT * FROM actual_columns)
+   AND NOT EXISTS (SELECT * FROM actual_columns EXCEPT SELECT * FROM expected_columns)
+   AND application_privileges.selects AND application_privileges.inserts AND application_privileges.no_writes
+   AND trigger_safety.exact AND constraint_safety.exact AND guard_safety.exact
+FROM relation,application_privileges,trigger_safety,constraint_safety,guard_safety`).Scan(&available)
+	return available, err
+}
+
 const (
 	memoryConsolidationClaimRoutineMD5        = "121df7d09493be8662f4618208aaf342"
 	memoryConsolidationAdvanceRoutineMD5      = "5666d576e054c6b06999a0b6ce7b6c62"

--- a/internal/postgres/brain_consolidation_test.go
+++ b/internal/postgres/brain_consolidation_test.go
@@ -67,3 +67,11 @@ func TestMemoryConsolidationInputRejectsUnfencedOrUnboundedPages(t *testing.T) {
 		}
 	}
 }
+
+func TestMemoryConsolidationProposalRequestRequiresMaterializedSources(t *testing.T) {
+	lease := MemoryConsolidationLease{ScopeID: "11111111-1111-4111-8111-111111111111", Holder: "22222222-2222-4222-8222-222222222222", Token: "33333333-3333-4333-8333-333333333333", Generation: 1, Until: time.Now().Add(time.Minute)}
+	request := MemoryConsolidationProposalRequest{Input: MemoryConsolidationInput{Lease: lease, TimelineID: "44444444-4444-4444-8444-444444444444", NextSequence: 0}, Proposal: MemoryProposalCreateRequest{PrincipalID: "55555555-5555-4555-8555-555555555555", ProjectID: "66666666-6666-4666-8666-666666666666", IdempotencyKey: "77777777-7777-4777-8777-777777777777", Action: MemoryProposalCreate, Steps: []MemoryProposalStepInput{{Operation: MemoryProposalStepCreate, LogicalKey: "brief.current", Kind: "brief", Trust: "proposed", Document: json.RawMessage(`{"summary":true}`)}}}}
+	if _, err := request.normalized(); err == nil {
+		t.Fatal("empty consolidation page created a proposal request")
+	}
+}

--- a/internal/postgres/brain_proposal.go
+++ b/internal/postgres/brain_proposal.go
@@ -122,6 +122,16 @@ type MemoryProposalEvidence struct {
 	MemoryProposalEvidenceInput
 }
 
+// MemoryConsolidationProposalSource is immutable provenance for a proposal
+// staged from a fenced consolidation page.
+type MemoryConsolidationProposalSource struct {
+	Ordinal        int    `json:"ordinal"`
+	TimelineID     string `json:"timeline_id"`
+	ItemID         string `json:"item_id"`
+	Revision       int64  `json:"revision"`
+	ChangeSequence int64  `json:"change_sequence"`
+}
+
 // MemoryProposalAppliedStep durably links one approved primitive to its canonical revision.
 type MemoryProposalAppliedStep struct {
 	Ordinal  int    `json:"ordinal"`
@@ -131,20 +141,21 @@ type MemoryProposalAppliedStep struct {
 
 // MemoryProposal is one authorized proposal and its immutable payload.
 type MemoryProposal struct {
-	ProposalID string                      `json:"proposal_id"`
-	ScopeID    string                      `json:"scope_id"`
-	ProjectID  string                      `json:"project_id"`
-	Action     MemoryProposalAction        `json:"action"`
-	State      MemoryProposalState         `json:"state"`
-	ETag       string                      `json:"etag"`
-	ProposedBy string                      `json:"proposed_by"`
-	DecidedBy  string                      `json:"decided_by,omitempty"`
-	CreatedAt  time.Time                   `json:"created_at"`
-	ExpiresAt  time.Time                   `json:"expires_at"`
-	DecidedAt  *time.Time                  `json:"decided_at,omitempty"`
-	Steps      []MemoryProposalStep        `json:"steps"`
-	Evidence   []MemoryProposalEvidence    `json:"evidence"`
-	Results    []MemoryProposalAppliedStep `json:"results,omitempty"`
+	ProposalID string                              `json:"proposal_id"`
+	ScopeID    string                              `json:"scope_id"`
+	ProjectID  string                              `json:"project_id"`
+	Action     MemoryProposalAction                `json:"action"`
+	State      MemoryProposalState                 `json:"state"`
+	ETag       string                              `json:"etag"`
+	ProposedBy string                              `json:"proposed_by"`
+	DecidedBy  string                              `json:"decided_by,omitempty"`
+	CreatedAt  time.Time                           `json:"created_at"`
+	ExpiresAt  time.Time                           `json:"expires_at"`
+	DecidedAt  *time.Time                          `json:"decided_at,omitempty"`
+	Steps      []MemoryProposalStep                `json:"steps"`
+	Evidence   []MemoryProposalEvidence            `json:"evidence"`
+	Sources    []MemoryConsolidationProposalSource `json:"sources,omitempty"`
+	Results    []MemoryProposalAppliedStep         `json:"results,omitempty"`
 	payloadSHA []byte
 	payload    []byte
 }

--- a/internal/postgres/brain_proposal_store.go
+++ b/internal/postgres/brain_proposal_store.go
@@ -405,7 +405,7 @@ func lockAndValidateConsolidationProposalSources(ctx context.Context, tx *sql.Tx
 	// Match the read boundary: approval must hold the mutable scan coverage
 	// relations through commit, otherwise a concurrent rescan or exception
 	// update could invalidate a source after this transaction validates it.
-	if _, err := tx.ExecContext(ctx, `LOCK TABLE brain.memory_secret_scans,brain.secret_guard_state,brain.secret_project_state IN SHARE MODE`); err != nil {
+	if _, err := tx.ExecContext(ctx, `LOCK TABLE brain.secret_guard_state,brain.secret_project_state IN SHARE MODE`); err != nil {
 		return errors.New("consolidation proposal sources are unavailable")
 	}
 	rows, err := tx.QueryContext(ctx, `SELECT source.item_id::text,source.revision,item.current_revision,item.state,item.layer,scope.id::text,revision.document::text,revision.content_sha256,
@@ -417,10 +417,10 @@ JOIN brain.memory_items AS item ON item.id=source.item_id
 JOIN brain.scopes AS scope ON scope.id=item.scope_id
 JOIN brain.memory_revisions AS revision ON revision.item_id=item.id AND revision.revision=item.current_revision
 JOIN brain.secret_guard_state AS guard ON true
-LEFT JOIN brain.memory_secret_scans AS scan ON scan.item_id=item.id
+JOIN brain.memory_secret_scans AS scan ON scan.item_id=item.id
 LEFT JOIN brain.secret_project_state AS project_state ON project_state.project_id=scope.project_id
 WHERE source.proposal_id=$1 AND scope.project_id=$2
-ORDER BY source.ordinal FOR SHARE OF item`, proposalID, projectID)
+ORDER BY source.ordinal FOR SHARE OF item,scan`, proposalID, projectID)
 	if err != nil {
 		return errors.New("consolidation proposal sources are unavailable")
 	}

--- a/internal/postgres/brain_proposal_store.go
+++ b/internal/postgres/brain_proposal_store.go
@@ -389,13 +389,16 @@ func (d *Database) decideMemoryProposal(ctx context.Context, request MemoryPropo
 // Ordinary proposals have no rows here and retain their existing semantics.
 func lockAndValidateConsolidationProposalSources(ctx context.Context, tx *sql.Tx, projectID, proposalID, scopeID string) error {
 	var expected int
-	if err := tx.QueryRowContext(ctx, `SELECT count(*) FROM brain.memory_consolidation_proposal_sources WHERE proposal_id=$1`, proposalID).Scan(&expected); err != nil || expected == 0 {
+	if err := tx.QueryRowContext(ctx, `SELECT count(*) FROM brain.memory_consolidation_proposal_sources WHERE proposal_id=$1`, proposalID).Scan(&expected); err != nil {
 		return errors.New("consolidation proposal sources are unavailable")
+	}
+	if expected == 0 {
+		return nil
 	}
 	rows, err := tx.QueryContext(ctx, `SELECT source.item_id::text,source.revision,item.current_revision,item.state,item.layer,scope.id::text,
 EXISTS (SELECT 1 FROM brain.memory_quarantines AS quarantine WHERE quarantine.item_id=item.id AND quarantine.released_at IS NULL),
-scan.revision=source.revision AND scan.rule_version=guard.rule_version AND scan.rule_digest=guard.rule_digest
-  AND scan.exception_generation=COALESCE(project_state.exception_generation,0) AND scan.outcome='clear'
+COALESCE(scan.revision=source.revision AND scan.rule_version=guard.rule_version AND scan.rule_digest=guard.rule_digest
+  AND scan.exception_generation=COALESCE(project_state.exception_generation,0) AND scan.outcome='clear',false)
 FROM brain.memory_consolidation_proposal_sources AS source
 JOIN brain.memory_items AS item ON item.id=source.item_id
 JOIN brain.scopes AS scope ON scope.id=item.scope_id

--- a/internal/postgres/brain_proposal_store.go
+++ b/internal/postgres/brain_proposal_store.go
@@ -469,7 +469,8 @@ EXISTS (SELECT 1 FROM brain.memory_quarantines AS quarantine WHERE quarantine.it
 FROM brain.memory_items AS item
 JOIN brain.scopes AS scope ON scope.id=item.scope_id
 JOIN brain.memory_revisions AS revision ON revision.item_id=item.id AND revision.revision=item.current_revision
-WHERE item.id=$1 AND scope.project_id=$2
+LEFT JOIN relay.project_lookup_aliases AS alias ON alias.alias_project_id=scope.project_id
+WHERE item.id=$1 AND COALESCE(alias.canonical_project_id,scope.project_id)=$2
 FOR SHARE OF item`, itemID, projectID).Scan(&item.ScopeID, &item.Revision, &item.State, &item.Layer, &item.Document, &item.ContentHash, &item.Quarantined)
 		if errors.Is(err, sql.ErrNoRows) || item.Quarantined {
 			return nil, ErrNotFound

--- a/internal/postgres/brain_proposal_store.go
+++ b/internal/postgres/brain_proposal_store.go
@@ -402,6 +402,12 @@ func lockAndValidateConsolidationProposalSources(ctx context.Context, tx *sql.Tx
 	if expected == 0 {
 		return nil
 	}
+	// Match the read boundary: approval must hold the mutable scan coverage
+	// relations through commit, otherwise a concurrent rescan or exception
+	// update could invalidate a source after this transaction validates it.
+	if _, err := tx.ExecContext(ctx, `LOCK TABLE brain.memory_secret_scans,brain.secret_guard_state,brain.secret_project_state IN SHARE MODE`); err != nil {
+		return errors.New("consolidation proposal sources are unavailable")
+	}
 	rows, err := tx.QueryContext(ctx, `SELECT source.item_id::text,source.revision,item.current_revision,item.state,item.layer,scope.id::text,revision.document::text,revision.content_sha256,
 EXISTS (SELECT 1 FROM brain.memory_quarantines AS quarantine WHERE quarantine.item_id=item.id AND quarantine.released_at IS NULL),
 COALESCE(scan.revision=source.revision AND scan.rule_version=guard.rule_version AND scan.rule_digest=guard.rule_digest

--- a/internal/postgres/brain_proposal_store.go
+++ b/internal/postgres/brain_proposal_store.go
@@ -585,7 +585,7 @@ func readMemoryProposal(ctx context.Context, tx *sql.Tx, projectID, proposalID s
 	var proposal MemoryProposal
 	var decidedBy sql.NullString
 	var decidedAt sql.NullTime
-	query := `SELECT proposal.id::text,proposal.scope_id::text,COALESCE(alias.canonical_project_id,scope.project_id)::text,proposal.action,proposal.state,proposal.proposed_by::text,proposal.decided_by::text,proposal.created_at,proposal.decided_at,proposal.expires_at,proposal.payload_sha256,proposal.payload
+	query := `SELECT proposal.id::text,proposal.scope_id::text,scope.project_id::text,proposal.action,proposal.state,proposal.proposed_by::text,proposal.decided_by::text,proposal.created_at,proposal.decided_at,proposal.expires_at,proposal.payload_sha256,proposal.payload
 FROM brain.memory_proposals AS proposal
 JOIN brain.scopes AS scope ON scope.id=proposal.scope_id
 LEFT JOIN relay.project_lookup_aliases AS alias ON alias.alias_project_id=scope.project_id

--- a/internal/postgres/brain_proposal_store.go
+++ b/internal/postgres/brain_proposal_store.go
@@ -657,8 +657,11 @@ WHERE proposal.id=$1 AND COALESCE(alias.canonical_project_id,scope.project_id)=$
 	if err := evidenceRows.Close(); err != nil {
 		return MemoryProposal{}, errors.New("memory proposal evidence cannot close")
 	}
-	available, _, err := consolidationProposalSourcesAvailable(ctx, tx)
+	available, required, err := consolidationProposalSourcesAvailable(ctx, tx)
 	if err != nil {
+		return MemoryProposal{}, errors.New("memory proposal sources are unavailable")
+	}
+	if required && !available {
 		return MemoryProposal{}, errors.New("memory proposal sources are unavailable")
 	}
 	if available {

--- a/internal/postgres/brain_proposal_store.go
+++ b/internal/postgres/brain_proposal_store.go
@@ -388,29 +388,42 @@ func (d *Database) decideMemoryProposal(ctx context.Context, request MemoryPropo
 // proposal stale when any bound curated source is no longer its live revision.
 // Ordinary proposals have no rows here and retain their existing semantics.
 func lockAndValidateConsolidationProposalSources(ctx context.Context, tx *sql.Tx, projectID, proposalID, scopeID string) error {
-	rows, err := tx.QueryContext(ctx, `SELECT source.item_id::text,source.revision,item.current_revision,item.state,item.layer,scope.id::text
+	var expected int
+	if err := tx.QueryRowContext(ctx, `SELECT count(*) FROM brain.memory_consolidation_proposal_sources WHERE proposal_id=$1`, proposalID).Scan(&expected); err != nil || expected == 0 {
+		return errors.New("consolidation proposal sources are unavailable")
+	}
+	rows, err := tx.QueryContext(ctx, `SELECT source.item_id::text,source.revision,item.current_revision,item.state,item.layer,scope.id::text,
+EXISTS (SELECT 1 FROM brain.memory_quarantines AS quarantine WHERE quarantine.item_id=item.id AND quarantine.released_at IS NULL),
+scan.revision=source.revision AND scan.rule_version=guard.rule_version AND scan.rule_digest=guard.rule_digest
+  AND scan.exception_generation=COALESCE(project_state.exception_generation,0) AND scan.outcome='clear'
 FROM brain.memory_consolidation_proposal_sources AS source
 JOIN brain.memory_items AS item ON item.id=source.item_id
 JOIN brain.scopes AS scope ON scope.id=item.scope_id
+JOIN brain.secret_guard_state AS guard ON true
+LEFT JOIN brain.memory_secret_scans AS scan ON scan.item_id=item.id
+LEFT JOIN brain.secret_project_state AS project_state ON project_state.project_id=scope.project_id
 WHERE source.proposal_id=$1 AND scope.project_id=$2
 ORDER BY source.ordinal FOR SHARE OF item`, proposalID, projectID)
 	if err != nil {
 		return errors.New("consolidation proposal sources are unavailable")
 	}
 	defer func() { _ = rows.Close() }()
+	seen := 0
 	for rows.Next() {
 		var itemID, itemScopeID string
 		var revision, currentRevision int64
 		var state MemoryState
 		var layer MemoryLayer
-		if err := rows.Scan(&itemID, &revision, &currentRevision, &state, &layer, &itemScopeID); err != nil {
+		var quarantined, scanClear bool
+		if err := rows.Scan(&itemID, &revision, &currentRevision, &state, &layer, &itemScopeID, &quarantined, &scanClear); err != nil {
 			return errors.New("consolidation proposal source is malformed")
 		}
-		if !validOpaqueID(itemID) || itemScopeID != scopeID || revision != currentRevision || state != MemoryActive || layer != MemoryLayerCurated {
+		if !validOpaqueID(itemID) || itemScopeID != scopeID || revision != currentRevision || state != MemoryActive || layer != MemoryLayerCurated || quarantined || !scanClear {
 			return ErrStaleMemoryETag
 		}
+		seen++
 	}
-	if err := rows.Err(); err != nil {
+	if err := rows.Err(); err != nil || seen != expected {
 		return errors.New("consolidation proposal sources are unavailable")
 	}
 	return nil

--- a/internal/postgres/brain_proposal_store.go
+++ b/internal/postgres/brain_proposal_store.go
@@ -585,7 +585,7 @@ func readMemoryProposal(ctx context.Context, tx *sql.Tx, projectID, proposalID s
 	var proposal MemoryProposal
 	var decidedBy sql.NullString
 	var decidedAt sql.NullTime
-	query := `SELECT proposal.id::text,proposal.scope_id::text,scope.project_id::text,proposal.action,proposal.state,proposal.proposed_by::text,proposal.decided_by::text,proposal.created_at,proposal.decided_at,proposal.expires_at,proposal.payload_sha256,proposal.payload
+	query := `SELECT proposal.id::text,proposal.scope_id::text,COALESCE(alias.canonical_project_id,scope.project_id)::text,proposal.action,proposal.state,proposal.proposed_by::text,proposal.decided_by::text,proposal.created_at,proposal.decided_at,proposal.expires_at,proposal.payload_sha256,proposal.payload
 FROM brain.memory_proposals AS proposal
 JOIN brain.scopes AS scope ON scope.id=proposal.scope_id
 LEFT JOIN relay.project_lookup_aliases AS alias ON alias.alias_project_id=scope.project_id

--- a/internal/postgres/brain_proposal_store.go
+++ b/internal/postgres/brain_proposal_store.go
@@ -388,6 +388,13 @@ func (d *Database) decideMemoryProposal(ctx context.Context, request MemoryPropo
 // proposal stale when any bound curated source is no longer its live revision.
 // Ordinary proposals have no rows here and retain their existing semantics.
 func lockAndValidateConsolidationProposalSources(ctx context.Context, tx *sql.Tx, projectID, proposalID, scopeID string) error {
+	available, err := consolidationProposalSourcesAvailable(ctx, tx)
+	if err != nil {
+		return errors.New("consolidation proposal sources are unavailable")
+	}
+	if !available {
+		return nil
+	}
 	var expected int
 	if err := tx.QueryRowContext(ctx, `SELECT count(*) FROM brain.memory_consolidation_proposal_sources WHERE proposal_id=$1`, proposalID).Scan(&expected); err != nil {
 		return errors.New("consolidation proposal sources are unavailable")
@@ -437,6 +444,12 @@ ORDER BY source.ordinal FOR SHARE OF item`, proposalID, projectID)
 		return ErrStaleMemoryETag
 	}
 	return nil
+}
+
+func consolidationProposalSourcesAvailable(ctx context.Context, tx *sql.Tx) (bool, error) {
+	var available bool
+	err := tx.QueryRowContext(ctx, `SELECT to_regclass('brain.memory_consolidation_proposal_sources') IS NOT NULL`).Scan(&available)
+	return available, err
 }
 
 func lockAndValidateProposalItems(ctx context.Context, tx *sql.Tx, projectID string, steps []MemoryProposalStepInput, evidence []MemoryProposalEvidenceInput) (map[string]lockedProposalItem, error) {
@@ -633,24 +646,30 @@ WHERE proposal.id=$1 AND COALESCE(alias.canonical_project_id,scope.project_id)=$
 	if err := evidenceRows.Close(); err != nil {
 		return MemoryProposal{}, errors.New("memory proposal evidence cannot close")
 	}
-	sourceRows, err := tx.QueryContext(ctx, `SELECT ordinal,timeline_id::text,item_id::text,revision,change_sequence FROM brain.memory_consolidation_proposal_sources WHERE proposal_id=$1 ORDER BY ordinal`, proposalID)
+	available, err := consolidationProposalSourcesAvailable(ctx, tx)
 	if err != nil {
 		return MemoryProposal{}, errors.New("memory proposal sources are unavailable")
 	}
-	for sourceRows.Next() {
-		var source MemoryConsolidationProposalSource
-		if err := sourceRows.Scan(&source.Ordinal, &source.TimelineID, &source.ItemID, &source.Revision, &source.ChangeSequence); err != nil {
-			_ = sourceRows.Close()
-			return MemoryProposal{}, errors.New("memory proposal source is malformed")
+	if available {
+		sourceRows, err := tx.QueryContext(ctx, `SELECT ordinal,timeline_id::text,item_id::text,revision,change_sequence FROM brain.memory_consolidation_proposal_sources WHERE proposal_id=$1 ORDER BY ordinal`, proposalID)
+		if err != nil {
+			return MemoryProposal{}, errors.New("memory proposal sources are unavailable")
 		}
-		proposal.Sources = append(proposal.Sources, source)
-	}
-	if err := sourceRows.Err(); err != nil {
-		_ = sourceRows.Close()
-		return MemoryProposal{}, errors.New("memory proposal sources are unavailable")
-	}
-	if err := sourceRows.Close(); err != nil {
-		return MemoryProposal{}, errors.New("memory proposal sources cannot close")
+		for sourceRows.Next() {
+			var source MemoryConsolidationProposalSource
+			if err := sourceRows.Scan(&source.Ordinal, &source.TimelineID, &source.ItemID, &source.Revision, &source.ChangeSequence); err != nil {
+				_ = sourceRows.Close()
+				return MemoryProposal{}, errors.New("memory proposal source is malformed")
+			}
+			proposal.Sources = append(proposal.Sources, source)
+		}
+		if err := sourceRows.Err(); err != nil {
+			_ = sourceRows.Close()
+			return MemoryProposal{}, errors.New("memory proposal sources are unavailable")
+		}
+		if err := sourceRows.Close(); err != nil {
+			return MemoryProposal{}, errors.New("memory proposal sources cannot close")
+		}
 	}
 	resultRows, err := tx.QueryContext(ctx, `SELECT ordinal,item_id::text,revision FROM brain.memory_proposal_results WHERE proposal_id=$1 ORDER BY ordinal`, proposalID)
 	if err != nil {

--- a/internal/postgres/brain_proposal_store.go
+++ b/internal/postgres/brain_proposal_store.go
@@ -430,8 +430,11 @@ ORDER BY source.ordinal FOR SHARE OF item`, proposalID, projectID)
 		}
 		seen++
 	}
-	if err := rows.Err(); err != nil || seen != expected {
+	if err := rows.Err(); err != nil {
 		return errors.New("consolidation proposal sources are unavailable")
+	}
+	if seen != expected {
+		return ErrStaleMemoryETag
 	}
 	return nil
 }

--- a/internal/postgres/brain_proposal_store.go
+++ b/internal/postgres/brain_proposal_store.go
@@ -418,8 +418,8 @@ JOIN brain.scopes AS scope ON scope.id=item.scope_id
 JOIN brain.memory_revisions AS revision ON revision.item_id=item.id AND revision.revision=item.current_revision
 JOIN brain.secret_guard_state AS guard ON true
 JOIN brain.memory_secret_scans AS scan ON scan.item_id=item.id
-LEFT JOIN brain.secret_project_state AS project_state ON project_state.project_id=scope.project_id
 LEFT JOIN relay.project_lookup_aliases AS alias ON alias.alias_project_id=scope.project_id
+LEFT JOIN brain.secret_project_state AS project_state ON project_state.project_id=COALESCE(alias.canonical_project_id,scope.project_id)
 WHERE source.proposal_id=$1 AND COALESCE(alias.canonical_project_id,scope.project_id)=$2
 ORDER BY source.ordinal FOR SHARE OF item,scan`, proposalID, projectID)
 	if err != nil {

--- a/internal/postgres/brain_proposal_store.go
+++ b/internal/postgres/brain_proposal_store.go
@@ -408,7 +408,7 @@ func lockAndValidateConsolidationProposalSources(ctx context.Context, tx *sql.Tx
 	// Match the read boundary: approval must hold the mutable scan coverage
 	// relations through commit, otherwise a concurrent rescan or exception
 	// update could invalidate a source after this transaction validates it.
-	if _, err := tx.ExecContext(ctx, `LOCK TABLE brain.secret_guard_state,brain.secret_project_state IN SHARE MODE`); err != nil {
+	if _, err := tx.ExecContext(ctx, `SELECT brain.lock_memory_consolidation_source_guards()`); err != nil {
 		return errors.New("consolidation proposal sources are unavailable")
 	}
 	rows, err := tx.QueryContext(ctx, `SELECT source.item_id::text,source.revision,item.current_revision,item.state,item.layer,scope.id::text,revision.document::text,revision.content_sha256,

--- a/internal/postgres/brain_proposal_store.go
+++ b/internal/postgres/brain_proposal_store.go
@@ -457,8 +457,10 @@ ORDER BY source.ordinal FOR SHARE OF item,scan`, proposalID, projectID)
 }
 
 func consolidationProposalSourcesAvailable(ctx context.Context, tx *sql.Tx) (available, required bool, err error) {
-	err = tx.QueryRowContext(ctx, `SELECT to_regclass('brain.memory_consolidation_proposal_sources') IS NOT NULL,
-EXISTS (SELECT 1 FROM jobs.schema_migrations WHERE version>=38 AND status='applied')`).Scan(&available, &required)
+	if err = tx.QueryRowContext(ctx, `SELECT EXISTS (SELECT 1 FROM jobs.schema_migrations WHERE version>=38 AND status='applied')`).Scan(&required); err != nil || !required {
+		return false, required, err
+	}
+	available, err = memoryConsolidationProposalSourcesAvailable(ctx, tx)
 	return available, required, err
 }
 

--- a/internal/postgres/brain_proposal_store.go
+++ b/internal/postgres/brain_proposal_store.go
@@ -336,6 +336,12 @@ func (d *Database) decideMemoryProposal(ctx context.Context, request MemoryPropo
 		}
 		mutations := []MemoryMutationResult(nil)
 		if approve {
+			if err := lockAndValidateConsolidationProposalSources(ctx, tx, project.ID, proposal.ProposalID, proposal.ScopeID); err != nil {
+				if errors.Is(err, ErrNotFound) || errors.Is(err, ErrStaleMemoryETag) {
+					return IdempotencyOutcome{}, ErrStaleMemoryProposal
+				}
+				return IdempotencyOutcome{}, err
+			}
 			steps := proposalStepInputs(proposal.Steps)
 			evidence := proposalEvidenceInputs(proposal.Evidence)
 			items, err := lockAndValidateProposalItems(ctx, tx, project.ID, steps, evidence)
@@ -376,6 +382,38 @@ func (d *Database) decideMemoryProposal(ctx context.Context, request MemoryPropo
 		return MemoryProposalResult{}, errors.New("memory proposal decision cannot commit")
 	}
 	return decodeMemoryProposalOutcome(outcome)
+}
+
+// lockAndValidateConsolidationProposalSources makes a consolidation-derived
+// proposal stale when any bound curated source is no longer its live revision.
+// Ordinary proposals have no rows here and retain their existing semantics.
+func lockAndValidateConsolidationProposalSources(ctx context.Context, tx *sql.Tx, projectID, proposalID, scopeID string) error {
+	rows, err := tx.QueryContext(ctx, `SELECT source.item_id::text,source.revision,item.current_revision,item.state,item.layer,scope.id::text
+FROM brain.memory_consolidation_proposal_sources AS source
+JOIN brain.memory_items AS item ON item.id=source.item_id
+JOIN brain.scopes AS scope ON scope.id=item.scope_id
+WHERE source.proposal_id=$1 AND scope.project_id=$2
+ORDER BY source.ordinal FOR SHARE OF item`, proposalID, projectID)
+	if err != nil {
+		return errors.New("consolidation proposal sources are unavailable")
+	}
+	defer func() { _ = rows.Close() }()
+	for rows.Next() {
+		var itemID, itemScopeID string
+		var revision, currentRevision int64
+		var state MemoryState
+		var layer MemoryLayer
+		if err := rows.Scan(&itemID, &revision, &currentRevision, &state, &layer, &itemScopeID); err != nil {
+			return errors.New("consolidation proposal source is malformed")
+		}
+		if !validOpaqueID(itemID) || itemScopeID != scopeID || revision != currentRevision || state != MemoryActive || layer != MemoryLayerCurated {
+			return ErrStaleMemoryETag
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return errors.New("consolidation proposal sources are unavailable")
+	}
+	return nil
 }
 
 func lockAndValidateProposalItems(ctx context.Context, tx *sql.Tx, projectID string, steps []MemoryProposalStepInput, evidence []MemoryProposalEvidenceInput) (map[string]lockedProposalItem, error) {
@@ -571,6 +609,25 @@ WHERE proposal.id=$1 AND COALESCE(alias.canonical_project_id,scope.project_id)=$
 	}
 	if err := evidenceRows.Close(); err != nil {
 		return MemoryProposal{}, errors.New("memory proposal evidence cannot close")
+	}
+	sourceRows, err := tx.QueryContext(ctx, `SELECT ordinal,timeline_id::text,item_id::text,revision,change_sequence FROM brain.memory_consolidation_proposal_sources WHERE proposal_id=$1 ORDER BY ordinal`, proposalID)
+	if err != nil {
+		return MemoryProposal{}, errors.New("memory proposal sources are unavailable")
+	}
+	for sourceRows.Next() {
+		var source MemoryConsolidationProposalSource
+		if err := sourceRows.Scan(&source.Ordinal, &source.TimelineID, &source.ItemID, &source.Revision, &source.ChangeSequence); err != nil {
+			_ = sourceRows.Close()
+			return MemoryProposal{}, errors.New("memory proposal source is malformed")
+		}
+		proposal.Sources = append(proposal.Sources, source)
+	}
+	if err := sourceRows.Err(); err != nil {
+		_ = sourceRows.Close()
+		return MemoryProposal{}, errors.New("memory proposal sources are unavailable")
+	}
+	if err := sourceRows.Close(); err != nil {
+		return MemoryProposal{}, errors.New("memory proposal sources cannot close")
 	}
 	resultRows, err := tx.QueryContext(ctx, `SELECT ordinal,item_id::text,revision FROM brain.memory_proposal_results WHERE proposal_id=$1 ORDER BY ordinal`, proposalID)
 	if err != nil {

--- a/internal/postgres/brain_proposal_store.go
+++ b/internal/postgres/brain_proposal_store.go
@@ -419,7 +419,8 @@ JOIN brain.memory_revisions AS revision ON revision.item_id=item.id AND revision
 JOIN brain.secret_guard_state AS guard ON true
 JOIN brain.memory_secret_scans AS scan ON scan.item_id=item.id
 LEFT JOIN brain.secret_project_state AS project_state ON project_state.project_id=scope.project_id
-WHERE source.proposal_id=$1 AND scope.project_id=$2
+LEFT JOIN relay.project_lookup_aliases AS alias ON alias.alias_project_id=scope.project_id
+WHERE source.proposal_id=$1 AND COALESCE(alias.canonical_project_id,scope.project_id)=$2
 ORDER BY source.ordinal FOR SHARE OF item,scan`, proposalID, projectID)
 	if err != nil {
 		return errors.New("consolidation proposal sources are unavailable")

--- a/internal/postgres/brain_proposal_store.go
+++ b/internal/postgres/brain_proposal_store.go
@@ -395,13 +395,14 @@ func lockAndValidateConsolidationProposalSources(ctx context.Context, tx *sql.Tx
 	if expected == 0 {
 		return nil
 	}
-	rows, err := tx.QueryContext(ctx, `SELECT source.item_id::text,source.revision,item.current_revision,item.state,item.layer,scope.id::text,
+	rows, err := tx.QueryContext(ctx, `SELECT source.item_id::text,source.revision,item.current_revision,item.state,item.layer,scope.id::text,revision.document::text,revision.content_sha256,
 EXISTS (SELECT 1 FROM brain.memory_quarantines AS quarantine WHERE quarantine.item_id=item.id AND quarantine.released_at IS NULL),
 COALESCE(scan.revision=source.revision AND scan.rule_version=guard.rule_version AND scan.rule_digest=guard.rule_digest
   AND scan.exception_generation=COALESCE(project_state.exception_generation,0) AND scan.outcome='clear',false)
 FROM brain.memory_consolidation_proposal_sources AS source
 JOIN brain.memory_items AS item ON item.id=source.item_id
 JOIN brain.scopes AS scope ON scope.id=item.scope_id
+JOIN brain.memory_revisions AS revision ON revision.item_id=item.id AND revision.revision=item.current_revision
 JOIN brain.secret_guard_state AS guard ON true
 LEFT JOIN brain.memory_secret_scans AS scan ON scan.item_id=item.id
 LEFT JOIN brain.secret_project_state AS project_state ON project_state.project_id=scope.project_id
@@ -418,10 +419,13 @@ ORDER BY source.ordinal FOR SHARE OF item`, proposalID, projectID)
 		var state MemoryState
 		var layer MemoryLayer
 		var quarantined, scanClear bool
-		if err := rows.Scan(&itemID, &revision, &currentRevision, &state, &layer, &itemScopeID, &quarantined, &scanClear); err != nil {
+		var document string
+		var contentHash []byte
+		if err := rows.Scan(&itemID, &revision, &currentRevision, &state, &layer, &itemScopeID, &document, &contentHash, &quarantined, &scanClear); err != nil {
 			return errors.New("consolidation proposal source is malformed")
 		}
-		if !validOpaqueID(itemID) || itemScopeID != scopeID || revision != currentRevision || state != MemoryActive || layer != MemoryLayerCurated || quarantined || !scanClear {
+		digest := sha256.Sum256([]byte(document))
+		if !validOpaqueID(itemID) || itemScopeID != scopeID || revision != currentRevision || state != MemoryActive || layer != MemoryLayerCurated || quarantined || !scanClear || len(contentHash) != sha256.Size || !bytes.Equal(digest[:], contentHash) {
 			return ErrStaleMemoryETag
 		}
 		seen++

--- a/internal/postgres/brain_proposal_store.go
+++ b/internal/postgres/brain_proposal_store.go
@@ -388,11 +388,14 @@ func (d *Database) decideMemoryProposal(ctx context.Context, request MemoryPropo
 // proposal stale when any bound curated source is no longer its live revision.
 // Ordinary proposals have no rows here and retain their existing semantics.
 func lockAndValidateConsolidationProposalSources(ctx context.Context, tx *sql.Tx, projectID, proposalID, scopeID string) error {
-	available, err := consolidationProposalSourcesAvailable(ctx, tx)
+	available, required, err := consolidationProposalSourcesAvailable(ctx, tx)
 	if err != nil {
 		return errors.New("consolidation proposal sources are unavailable")
 	}
 	if !available {
+		if required {
+			return errors.New("consolidation proposal sources are unavailable")
+		}
 		return nil
 	}
 	var expected int
@@ -453,10 +456,10 @@ ORDER BY source.ordinal FOR SHARE OF item,scan`, proposalID, projectID)
 	return nil
 }
 
-func consolidationProposalSourcesAvailable(ctx context.Context, tx *sql.Tx) (bool, error) {
-	var available bool
-	err := tx.QueryRowContext(ctx, `SELECT to_regclass('brain.memory_consolidation_proposal_sources') IS NOT NULL`).Scan(&available)
-	return available, err
+func consolidationProposalSourcesAvailable(ctx context.Context, tx *sql.Tx) (available, required bool, err error) {
+	err = tx.QueryRowContext(ctx, `SELECT to_regclass('brain.memory_consolidation_proposal_sources') IS NOT NULL,
+EXISTS (SELECT 1 FROM jobs.schema_migrations WHERE version>=38 AND status='applied')`).Scan(&available, &required)
+	return available, required, err
 }
 
 func lockAndValidateProposalItems(ctx context.Context, tx *sql.Tx, projectID string, steps []MemoryProposalStepInput, evidence []MemoryProposalEvidenceInput) (map[string]lockedProposalItem, error) {
@@ -654,7 +657,7 @@ WHERE proposal.id=$1 AND COALESCE(alias.canonical_project_id,scope.project_id)=$
 	if err := evidenceRows.Close(); err != nil {
 		return MemoryProposal{}, errors.New("memory proposal evidence cannot close")
 	}
-	available, err := consolidationProposalSourcesAvailable(ctx, tx)
+	available, _, err := consolidationProposalSourcesAvailable(ctx, tx)
 	if err != nil {
 		return MemoryProposal{}, errors.New("memory proposal sources are unavailable")
 	}

--- a/internal/postgres/db.go
+++ b/internal/postgres/db.go
@@ -1214,6 +1214,13 @@ FROM objects, table_ownership, routine_safety, routine_acl, table_acl, schema_ac
 		}
 		snapshot.CurrentObjectsPresent = consolidationObjectsPresent
 	}
+	if snapshot.CurrentObjectsPresent && len(snapshot.Records) > 0 && snapshot.Records[len(snapshot.Records)-1].Version >= 38 {
+		proposalSourceObjectsPresent, err := memoryConsolidationProposalSourcesAvailable(ctx, q)
+		if err != nil {
+			return Snapshot{}, errors.New("PostgreSQL memory consolidation proposal-source schema cannot be inspected")
+		}
+		snapshot.CurrentObjectsPresent = proposalSourceObjectsPresent
+	}
 	return snapshot, nil
 }
 

--- a/internal/postgres/migrate.go
+++ b/internal/postgres/migrate.go
@@ -70,6 +70,7 @@ var migrationCompatibilityFloors = map[int64]int64{
 	35: 10,
 	36: 10,
 	37: 10,
+	38: 10,
 }
 
 // CurrentManifest returns the immutable migrations embedded in this binary.

--- a/internal/postgres/migrations/038_memory_consolidation_proposal_sources.sql
+++ b/internal/postgres/migrations/038_memory_consolidation_proposal_sources.sql
@@ -5,8 +5,7 @@ CREATE TABLE brain.memory_consolidation_proposal_sources (
     item_id uuid NOT NULL,
     revision bigint NOT NULL CONSTRAINT memory_consolidation_proposal_sources_revision_check CHECK (revision >= 1),
     change_sequence bigint NOT NULL CONSTRAINT memory_consolidation_proposal_sources_sequence_check CHECK (change_sequence >= 0),
-    PRIMARY KEY (proposal_id, ordinal),
-    CONSTRAINT memory_consolidation_proposal_sources_item_key UNIQUE (proposal_id, item_id)
+    PRIMARY KEY (proposal_id, ordinal)
     -- Provenance retains opaque historical coordinates. It must not prevent
     -- an authorized irreversible purge of the referenced item or revision.
 );

--- a/internal/postgres/migrations/038_memory_consolidation_proposal_sources.sql
+++ b/internal/postgres/migrations/038_memory_consolidation_proposal_sources.sql
@@ -1,0 +1,50 @@
+CREATE TABLE brain.memory_consolidation_proposal_sources (
+    proposal_id uuid NOT NULL REFERENCES brain.memory_proposals(id) ON DELETE CASCADE,
+    ordinal smallint NOT NULL CONSTRAINT memory_consolidation_proposal_sources_ordinal_check CHECK (ordinal BETWEEN 0 AND 127),
+    timeline_id uuid NOT NULL,
+    item_id uuid NOT NULL,
+    revision bigint NOT NULL CONSTRAINT memory_consolidation_proposal_sources_revision_check CHECK (revision >= 1),
+    change_sequence bigint NOT NULL CONSTRAINT memory_consolidation_proposal_sources_sequence_check CHECK (change_sequence >= 0),
+    PRIMARY KEY (proposal_id, ordinal),
+    CONSTRAINT memory_consolidation_proposal_sources_item_key UNIQUE (proposal_id, item_id),
+    CONSTRAINT memory_consolidation_proposal_sources_revision_fkey FOREIGN KEY (item_id, revision)
+        REFERENCES brain.memory_revisions(item_id, revision)
+);
+
+CREATE INDEX memory_consolidation_proposal_sources_item_revision
+ON brain.memory_consolidation_proposal_sources (item_id, revision, proposal_id);
+
+CREATE FUNCTION brain.guard_memory_consolidation_proposal_source()
+RETURNS trigger
+LANGUAGE plpgsql
+SET search_path = pg_catalog
+AS $function$
+BEGIN
+    PERFORM 1
+    FROM brain.memory_proposals AS proposal
+    JOIN brain.scopes AS proposal_scope ON proposal_scope.id=proposal.scope_id
+    JOIN brain.memory_items AS item ON item.id=NEW.item_id
+    JOIN brain.scopes AS item_scope ON item_scope.id=item.scope_id AND item_scope.id=proposal_scope.id
+    WHERE proposal.id=NEW.proposal_id
+      AND proposal.state='pending'
+      AND proposal.assembly_xid=pg_current_xact_id();
+    IF NOT FOUND THEN
+        RAISE EXCEPTION USING ERRCODE='23514', MESSAGE='consolidation proposal source is immutable or outside its scope';
+    END IF;
+    RETURN NEW;
+END
+$function$;
+
+CREATE TRIGGER memory_consolidation_proposal_source_insert_guard
+BEFORE INSERT ON brain.memory_consolidation_proposal_sources
+FOR EACH ROW EXECUTE FUNCTION brain.guard_memory_consolidation_proposal_source();
+
+CREATE TRIGGER application_mutation_fence
+BEFORE INSERT OR UPDATE OR DELETE OR TRUNCATE ON brain.memory_consolidation_proposal_sources
+FOR EACH STATEMENT EXECUTE FUNCTION jobs.guard_application_mutation();
+
+REVOKE ALL ON brain.memory_consolidation_proposal_sources FROM PUBLIC, punaro_app;
+REVOKE ALL ON FUNCTION brain.guard_memory_consolidation_proposal_source() FROM PUBLIC;
+GRANT SELECT ON brain.memory_consolidation_proposal_sources TO punaro_app;
+GRANT INSERT (proposal_id, ordinal, timeline_id, item_id, revision, change_sequence)
+    ON brain.memory_consolidation_proposal_sources TO punaro_app;

--- a/internal/postgres/migrations/038_memory_consolidation_proposal_sources.sql
+++ b/internal/postgres/migrations/038_memory_consolidation_proposal_sources.sql
@@ -48,6 +48,20 @@ GRANT SELECT ON brain.memory_consolidation_proposal_sources TO punaro_app;
 GRANT INSERT (proposal_id, ordinal, timeline_id, item_id, revision, change_sequence)
     ON brain.memory_consolidation_proposal_sources TO punaro_app;
 
+CREATE FUNCTION brain.lock_memory_consolidation_source_guards()
+RETURNS void
+LANGUAGE plpgsql SECURITY DEFINER
+SET search_path = pg_catalog
+AS $function$
+BEGIN
+    LOCK TABLE brain.secret_guard_state IN SHARE MODE;
+    LOCK TABLE brain.secret_project_state IN SHARE MODE;
+END
+$function$;
+
+REVOKE ALL ON FUNCTION brain.lock_memory_consolidation_source_guards() FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION brain.lock_memory_consolidation_source_guards() TO punaro_app;
+
 -- Consolidation is restricted to the curated canonical layer. Evidence is
 -- immutable, revision-bound supporting material and cannot be applied by an
 -- ordinary consolidation proposal. Preserve it as a non-actionable gap in

--- a/internal/postgres/migrations/038_memory_consolidation_proposal_sources.sql
+++ b/internal/postgres/migrations/038_memory_consolidation_proposal_sources.sql
@@ -6,9 +6,9 @@ CREATE TABLE brain.memory_consolidation_proposal_sources (
     revision bigint NOT NULL CONSTRAINT memory_consolidation_proposal_sources_revision_check CHECK (revision >= 1),
     change_sequence bigint NOT NULL CONSTRAINT memory_consolidation_proposal_sources_sequence_check CHECK (change_sequence >= 0),
     PRIMARY KEY (proposal_id, ordinal),
-    CONSTRAINT memory_consolidation_proposal_sources_item_key UNIQUE (proposal_id, item_id),
-    CONSTRAINT memory_consolidation_proposal_sources_revision_fkey FOREIGN KEY (item_id, revision)
-        REFERENCES brain.memory_revisions(item_id, revision)
+    CONSTRAINT memory_consolidation_proposal_sources_item_key UNIQUE (proposal_id, item_id)
+    -- Provenance retains opaque historical coordinates. It must not prevent
+    -- an authorized irreversible purge of the referenced item or revision.
 );
 
 CREATE INDEX memory_consolidation_proposal_sources_item_revision

--- a/internal/postgres/migrations/038_memory_consolidation_proposal_sources.sql
+++ b/internal/postgres/migrations/038_memory_consolidation_proposal_sources.sql
@@ -105,7 +105,8 @@ BEGIN
         LEFT JOIN brain.memory_items AS item ON item.id=source.item_id
         LEFT JOIN brain.scopes AS scope ON scope.id=item.scope_id
         LEFT JOIN brain.memory_secret_scans AS scan ON scan.item_id=source.item_id
-        LEFT JOIN brain.secret_project_state AS project_state ON project_state.project_id=scope.project_id
+        LEFT JOIN relay.project_lookup_aliases AS alias ON alias.alias_project_id=scope.project_id
+        LEFT JOIN brain.secret_project_state AS project_state ON project_state.project_id=COALESCE(alias.canonical_project_id,scope.project_id)
         WHERE source.item_id IS NOT NULL
           AND (scan.revision IS DISTINCT FROM source.revision
                OR scan.rule_version IS DISTINCT FROM guard.rule_version

--- a/internal/postgres/migrations/038_memory_consolidation_proposal_sources.sql
+++ b/internal/postgres/migrations/038_memory_consolidation_proposal_sources.sql
@@ -48,3 +48,83 @@ REVOKE ALL ON FUNCTION brain.guard_memory_consolidation_proposal_source() FROM P
 GRANT SELECT ON brain.memory_consolidation_proposal_sources TO punaro_app;
 GRANT INSERT (proposal_id, ordinal, timeline_id, item_id, revision, change_sequence)
     ON brain.memory_consolidation_proposal_sources TO punaro_app;
+
+-- Consolidation is restricted to the curated canonical layer. Evidence is
+-- immutable, revision-bound supporting material and cannot be applied by an
+-- ordinary consolidation proposal. Filter it before building the fenced page
+-- so a mixed change stream remains stageable and its cursor can advance.
+CREATE OR REPLACE FUNCTION brain.read_memory_consolidation_documents(requested_scope uuid, requested_token uuid, requested_generation bigint)
+RETURNS TABLE(timeline_id uuid,item_id uuid,revision bigint,change_sequence bigint,document jsonb,content_sha256 bytea,is_fence boolean)
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = pg_catalog
+AS $function$
+DECLARE
+    raw_page jsonb;
+    source_page jsonb;
+BEGIN
+    PERFORM 1
+    FROM brain.memory_consolidation_checkpoints AS checkpoint
+    WHERE checkpoint.scope_id=requested_scope
+      AND checkpoint.lease_token=requested_token
+      AND checkpoint.lease_generation=requested_generation
+      AND checkpoint.lease_until>statement_timestamp()
+    FOR SHARE OF checkpoint;
+    IF NOT FOUND THEN
+        RETURN;
+    END IF;
+    LOCK TABLE brain.secret_guard_state IN SHARE MODE;
+    LOCK TABLE brain.secret_project_state IN SHARE MODE;
+    WITH raw_source AS MATERIALIZED (
+        SELECT source.*
+        FROM brain.read_memory_consolidation_sources(requested_scope,requested_token,requested_generation) AS source
+        LEFT JOIN brain.memory_items AS item ON item.id=source.item_id
+        WHERE source.is_fence OR item.layer='curated'
+    ) SELECT COALESCE(jsonb_agg(jsonb_build_object('timeline_id',raw_source.timeline_id,'item_id',raw_source.item_id,'revision',raw_source.revision,'change_sequence',raw_source.change_sequence,'is_fence',raw_source.is_fence) ORDER BY raw_source.change_sequence,raw_source.item_id),'[]'::jsonb)
+    INTO raw_page FROM raw_source;
+    PERFORM 1
+    FROM brain.memory_items AS item
+    JOIN jsonb_to_recordset(raw_page) AS raw(timeline_id uuid,item_id uuid,revision bigint,change_sequence bigint,is_fence boolean) ON raw.item_id=item.id
+    ORDER BY item.id
+    FOR SHARE OF item;
+    LOCK TABLE brain.memory_quarantines IN SHARE MODE;
+    PERFORM 1
+    FROM brain.memory_secret_scans AS scan
+    JOIN jsonb_to_recordset(raw_page) AS raw(timeline_id uuid,item_id uuid,revision bigint,change_sequence bigint,is_fence boolean) ON raw.item_id=scan.item_id
+    ORDER BY scan.item_id
+    FOR SHARE OF scan;
+    WITH raw AS MATERIALIZED (
+        SELECT * FROM jsonb_to_recordset(raw_page) AS record(timeline_id uuid,item_id uuid,revision bigint,change_sequence bigint,is_fence boolean)
+    ), source AS MATERIALIZED (
+        SELECT raw.timeline_id,
+               CASE WHEN raw.item_id IS NOT NULL AND item.state='active' AND item.current_revision=raw.revision AND NOT EXISTS (SELECT 1 FROM brain.memory_quarantines AS quarantine WHERE quarantine.item_id=raw.item_id AND (quarantine.released_at IS NULL OR raw.revision<>item.current_revision)) THEN raw.item_id END AS item_id,
+               CASE WHEN raw.item_id IS NOT NULL AND item.state='active' AND item.current_revision=raw.revision AND NOT EXISTS (SELECT 1 FROM brain.memory_quarantines AS quarantine WHERE quarantine.item_id=raw.item_id AND (quarantine.released_at IS NULL OR raw.revision<>item.current_revision)) THEN raw.revision END AS revision,
+               raw.change_sequence,raw.is_fence
+        FROM raw LEFT JOIN brain.memory_items AS item ON item.id=raw.item_id
+    ) SELECT COALESCE(jsonb_agg(jsonb_build_object('timeline_id',source.timeline_id,'item_id',source.item_id,'revision',source.revision,'change_sequence',source.change_sequence,'is_fence',source.is_fence) ORDER BY source.change_sequence,source.item_id),'[]'::jsonb)
+    INTO source_page FROM source;
+    IF EXISTS (
+        SELECT 1
+        FROM jsonb_to_recordset(source_page) AS source(timeline_id uuid,item_id uuid,revision bigint,change_sequence bigint,is_fence boolean)
+        CROSS JOIN brain.secret_guard_state AS guard
+        LEFT JOIN brain.memory_items AS item ON item.id=source.item_id
+        LEFT JOIN brain.scopes AS scope ON scope.id=item.scope_id
+        LEFT JOIN brain.memory_secret_scans AS scan ON scan.item_id=source.item_id
+        LEFT JOIN brain.secret_project_state AS project_state ON project_state.project_id=scope.project_id
+        WHERE source.item_id IS NOT NULL
+          AND (scan.revision IS DISTINCT FROM source.revision
+               OR scan.rule_version IS DISTINCT FROM guard.rule_version
+               OR scan.rule_digest IS DISTINCT FROM guard.rule_digest
+               OR scan.exception_generation IS DISTINCT FROM COALESCE(project_state.exception_generation,0)
+               OR scan.outcome IS DISTINCT FROM 'clear')
+    ) THEN
+        RAISE EXCEPTION USING ERRCODE='55000', MESSAGE='consolidation source scan coverage is stale';
+    END IF;
+    RETURN QUERY
+    SELECT source.timeline_id,source.item_id,source.revision,source.change_sequence,revision.document,revision.content_sha256,source.is_fence
+    FROM jsonb_to_recordset(source_page) AS source(timeline_id uuid,item_id uuid,revision bigint,change_sequence bigint,is_fence boolean)
+    LEFT JOIN brain.memory_revisions AS revision ON revision.item_id=source.item_id AND revision.revision=source.revision
+    ORDER BY source.change_sequence,source.item_id;
+END
+$function$;
+
+REVOKE ALL ON FUNCTION brain.read_memory_consolidation_documents(uuid,uuid,bigint) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION brain.read_memory_consolidation_documents(uuid,uuid,bigint) TO punaro_app;

--- a/internal/postgres/migrations/038_memory_consolidation_proposal_sources.sql
+++ b/internal/postgres/migrations/038_memory_consolidation_proposal_sources.sql
@@ -51,8 +51,9 @@ GRANT INSERT (proposal_id, ordinal, timeline_id, item_id, revision, change_seque
 
 -- Consolidation is restricted to the curated canonical layer. Evidence is
 -- immutable, revision-bound supporting material and cannot be applied by an
--- ordinary consolidation proposal. Filter it before building the fenced page
--- so a mixed change stream remains stageable and its cursor can advance.
+-- ordinary consolidation proposal. Preserve it as a non-actionable gap in
+-- the fenced page so a mixed change stream remains stageable and its cursor
+-- can advance.
 CREATE OR REPLACE FUNCTION brain.read_memory_consolidation_documents(requested_scope uuid, requested_token uuid, requested_generation bigint)
 RETURNS TABLE(timeline_id uuid,item_id uuid,revision bigint,change_sequence bigint,document jsonb,content_sha256 bytea,is_fence boolean)
 LANGUAGE plpgsql SECURITY DEFINER SET search_path = pg_catalog
@@ -74,10 +75,7 @@ BEGIN
     LOCK TABLE brain.secret_guard_state IN SHARE MODE;
     LOCK TABLE brain.secret_project_state IN SHARE MODE;
     WITH raw_source AS MATERIALIZED (
-        SELECT source.*
-        FROM brain.read_memory_consolidation_sources(requested_scope,requested_token,requested_generation) AS source
-        LEFT JOIN brain.memory_items AS item ON item.id=source.item_id
-        WHERE source.is_fence OR item.layer='curated'
+        SELECT * FROM brain.read_memory_consolidation_sources(requested_scope,requested_token,requested_generation)
     ) SELECT COALESCE(jsonb_agg(jsonb_build_object('timeline_id',raw_source.timeline_id,'item_id',raw_source.item_id,'revision',raw_source.revision,'change_sequence',raw_source.change_sequence,'is_fence',raw_source.is_fence) ORDER BY raw_source.change_sequence,raw_source.item_id),'[]'::jsonb)
     INTO raw_page FROM raw_source;
     PERFORM 1
@@ -95,8 +93,8 @@ BEGIN
         SELECT * FROM jsonb_to_recordset(raw_page) AS record(timeline_id uuid,item_id uuid,revision bigint,change_sequence bigint,is_fence boolean)
     ), source AS MATERIALIZED (
         SELECT raw.timeline_id,
-               CASE WHEN raw.item_id IS NOT NULL AND item.state='active' AND item.current_revision=raw.revision AND NOT EXISTS (SELECT 1 FROM brain.memory_quarantines AS quarantine WHERE quarantine.item_id=raw.item_id AND (quarantine.released_at IS NULL OR raw.revision<>item.current_revision)) THEN raw.item_id END AS item_id,
-               CASE WHEN raw.item_id IS NOT NULL AND item.state='active' AND item.current_revision=raw.revision AND NOT EXISTS (SELECT 1 FROM brain.memory_quarantines AS quarantine WHERE quarantine.item_id=raw.item_id AND (quarantine.released_at IS NULL OR raw.revision<>item.current_revision)) THEN raw.revision END AS revision,
+               CASE WHEN raw.item_id IS NOT NULL AND item.layer='curated' AND item.state='active' AND item.current_revision=raw.revision AND NOT EXISTS (SELECT 1 FROM brain.memory_quarantines AS quarantine WHERE quarantine.item_id=raw.item_id AND (quarantine.released_at IS NULL OR raw.revision<>item.current_revision)) THEN raw.item_id END AS item_id,
+               CASE WHEN raw.item_id IS NOT NULL AND item.layer='curated' AND item.state='active' AND item.current_revision=raw.revision AND NOT EXISTS (SELECT 1 FROM brain.memory_quarantines AS quarantine WHERE quarantine.item_id=raw.item_id AND (quarantine.released_at IS NULL OR raw.revision<>item.current_revision)) THEN raw.revision END AS revision,
                raw.change_sequence,raw.is_fence
         FROM raw LEFT JOIN brain.memory_items AS item ON item.id=raw.item_id
     ) SELECT COALESCE(jsonb_agg(jsonb_build_object('timeline_id',source.timeline_id,'item_id',source.item_id,'revision',source.revision,'change_sequence',source.change_sequence,'is_fence',source.is_fence) ORDER BY source.change_sequence,source.item_id),'[]'::jsonb)

--- a/internal/postgres/state_test.go
+++ b/internal/postgres/state_test.go
@@ -69,8 +69,8 @@ func TestManifestValidationRejectsMutableOrNonContiguousHistory(t *testing.T) {
 
 func TestCurrentManifestRequiresControlPlaneSchema(t *testing.T) {
 	manifest := CurrentManifest()
-	if manifest.MinSupported != 10 || manifest.MaxSupported != 37 || len(manifest.Migrations) != 37 {
-		t.Fatalf("manifest=%#v, want exact v37 compatibility window", manifest)
+	if manifest.MinSupported != 10 || manifest.MaxSupported != 38 || len(manifest.Migrations) != 38 {
+		t.Fatalf("manifest=%#v, want exact v38 compatibility window", manifest)
 	}
 	embedding := manifest.Migrations[23]
 	if embedding.Version != 24 || embedding.Name != "024_memory_embedding_worker_control" ||
@@ -88,7 +88,7 @@ func TestCurrentManifestRequiresControlPlaneSchema(t *testing.T) {
 			want = 10
 		case 12, 13:
 			want = 10
-		case 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37:
+		case 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38:
 			want = 10
 		}
 		if migration.CompatibilityFloor != want {
@@ -195,7 +195,10 @@ func TestCompatibleSchemaCanStillHavePendingMigrations(t *testing.T) {
 	if !migrationPending(SchemaState{Classification: Compatible, Version: 36}, manifest) {
 		t.Fatal("compatible v36 schema must still apply the pending v37 migration")
 	}
-	if migrationPending(SchemaState{Classification: Compatible, Version: 37}, manifest) {
-		t.Fatal("current v37 schema reported a pending migration")
+	if !migrationPending(SchemaState{Classification: Compatible, Version: 37}, manifest) {
+		t.Fatal("compatible v37 schema must still apply the pending v38 migration")
+	}
+	if migrationPending(SchemaState{Classification: Compatible, Version: 38}, manifest) {
+		t.Fatal("current v38 schema reported a pending migration")
 	}
 }


### PR DESCRIPTION
## Summary
- add a v38 immutable source-provenance relation for fenced consolidation proposal staging
- bind staged proposals to a live lease and exact curated source coordinates without advancing canonical memory or the checkpoint
- expose provenance through proposal reads, reject approval after a source revision changes, and verify the v38 relation during readiness

## Validation
- go test -covermode=atomic ./...
ok  	github.com/rock3r/punaro/cmd/punaro	3.393s	coverage: 39.1% of statements
ok  	github.com/rock3r/punaro/cmd/punaro-adapter	(cached)	coverage: 37.2% of statements
ok  	github.com/rock3r/punaro/cmd/punaro-admin	0.816s	coverage: 23.6% of statements
ok  	github.com/rock3r/punaro/cmd/punaro-attachment	(cached)	coverage: 19.8% of statements
ok  	github.com/rock3r/punaro/cmd/punaro-directory	(cached)	coverage: 56.2% of statements
	github.com/rock3r/punaro/cmd/punaro-dpapi		coverage: 0.0% of statements
ok  	github.com/rock3r/punaro/cmd/punaro-keychain	(cached)	coverage: 38.9% of statements
ok  	github.com/rock3r/punaro/cmd/punaro-keygen	(cached)	coverage: 47.4% of statements
ok  	github.com/rock3r/punaro/cmd/punaro-memory	(cached)	coverage: 75.0% of statements
ok  	github.com/rock3r/punaro/cmd/punaro-migrate	1.194s	coverage: 96.7% of statements
ok  	github.com/rock3r/punaro/cmd/punaro-telegram	(cached)	coverage: 51.1% of statements
ok  	github.com/rock3r/punaro/cmd/punaro-trusted-attachment	(cached)	coverage: 69.2% of statements
ok  	github.com/rock3r/punaro/cmd/punarod	1.695s	coverage: 52.9% of statements
ok  	github.com/rock3r/punaro/internal/access	(cached)	coverage: 83.3% of statements
ok  	github.com/rock3r/punaro/internal/adapter	(cached)	coverage: 75.3% of statements
ok  	github.com/rock3r/punaro/internal/attachment	(cached)	coverage: 72.0% of statements
ok  	github.com/rock3r/punaro/internal/attachment/v2	(cached)	coverage: 70.0% of statements
ok  	github.com/rock3r/punaro/internal/attachment/v3	(cached)	coverage: 70.2% of statements
ok  	github.com/rock3r/punaro/internal/attachment/v3/controller	(cached)	coverage: 69.3% of statements
ok  	github.com/rock3r/punaro/internal/backup	(cached)	coverage: 76.8% of statements
ok  	github.com/rock3r/punaro/internal/config	(cached)	coverage: 86.6% of statements
ok  	github.com/rock3r/punaro/internal/cutover	(cached)	coverage: 68.6% of statements
ok  	github.com/rock3r/punaro/internal/devicehttp	(cached)	coverage: 81.0% of statements
ok  	github.com/rock3r/punaro/internal/embeddingprovider	(cached)	coverage: 89.7% of statements
ok  	github.com/rock3r/punaro/internal/ingress	(cached)	coverage: 82.5% of statements
ok  	github.com/rock3r/punaro/internal/listener	(cached)	coverage: 93.3% of statements
ok  	github.com/rock3r/punaro/internal/memoryclient	(cached)	coverage: 79.3% of statements
ok  	github.com/rock3r/punaro/internal/memoryhttp	(cached)	coverage: 77.3% of statements
ok  	github.com/rock3r/punaro/internal/operator	(cached)	coverage: 75.1% of statements
ok  	github.com/rock3r/punaro/internal/postgres	1.016s	coverage: 14.4% of statements
ok  	github.com/rock3r/punaro/internal/relay	(cached)	coverage: 77.0% of statements
	github.com/rock3r/punaro/internal/relay/contracttest		coverage: 0.0% of statements
ok  	github.com/rock3r/punaro/internal/release	(cached)	coverage: 83.3% of statements
ok  	github.com/rock3r/punaro/internal/secretguard	(cached)	coverage: 98.6% of statements
ok  	github.com/rock3r/punaro/internal/telegram	(cached)	coverage: 76.8% of statements
ok  	github.com/rock3r/punaro/internal/trustedattachment	(cached)	coverage: 76.5% of statements
ok  	github.com/rock3r/punaro/internal/trustedattachmentclient	(cached)	coverage: 78.2% of statements
ok  	github.com/rock3r/punaro/internal/trustedattachmenthttp	(cached)	coverage: 81.5% of statements
go test -race -count=1 ./...
ok  	github.com/rock3r/punaro/cmd/punaro	7.441s
ok  	github.com/rock3r/punaro/cmd/punaro-adapter	2.933s
ok  	github.com/rock3r/punaro/cmd/punaro-admin	1.957s
ok  	github.com/rock3r/punaro/cmd/punaro-attachment	2.670s
ok  	github.com/rock3r/punaro/cmd/punaro-directory	3.223s
?   	github.com/rock3r/punaro/cmd/punaro-dpapi	[no test files]
ok  	github.com/rock3r/punaro/cmd/punaro-keychain	3.840s
ok  	github.com/rock3r/punaro/cmd/punaro-keygen	3.698s
ok  	github.com/rock3r/punaro/cmd/punaro-memory	3.500s
ok  	github.com/rock3r/punaro/cmd/punaro-migrate	2.376s
ok  	github.com/rock3r/punaro/cmd/punaro-telegram	2.693s
ok  	github.com/rock3r/punaro/cmd/punaro-trusted-attachment	2.513s
ok  	github.com/rock3r/punaro/cmd/punarod	3.242s
ok  	github.com/rock3r/punaro/internal/access	2.740s
ok  	github.com/rock3r/punaro/internal/adapter	3.647s
ok  	github.com/rock3r/punaro/internal/attachment	3.610s
ok  	github.com/rock3r/punaro/internal/attachment/v2	3.509s
ok  	github.com/rock3r/punaro/internal/attachment/v3	8.298s
ok  	github.com/rock3r/punaro/internal/attachment/v3/controller	15.088s
ok  	github.com/rock3r/punaro/internal/backup	4.297s
ok  	github.com/rock3r/punaro/internal/config	2.775s
ok  	github.com/rock3r/punaro/internal/cutover	2.224s
ok  	github.com/rock3r/punaro/internal/devicehttp	2.426s
ok  	github.com/rock3r/punaro/internal/embeddingprovider	1.992s
ok  	github.com/rock3r/punaro/internal/ingress	1.763s
ok  	github.com/rock3r/punaro/internal/listener	1.777s
ok  	github.com/rock3r/punaro/internal/memoryclient	1.805s
ok  	github.com/rock3r/punaro/internal/memoryhttp	3.693s
ok  	github.com/rock3r/punaro/internal/operator	11.075s
ok  	github.com/rock3r/punaro/internal/postgres	2.284s
ok  	github.com/rock3r/punaro/internal/relay	7.660s
?   	github.com/rock3r/punaro/internal/relay/contracttest	[no test files]
ok  	github.com/rock3r/punaro/internal/release	2.199s
ok  	github.com/rock3r/punaro/internal/secretguard	2.375s
ok  	github.com/rock3r/punaro/internal/telegram	2.630s
ok  	github.com/rock3r/punaro/internal/trustedattachment	5.061s
ok  	github.com/rock3r/punaro/internal/trustedattachmentclient	9.263s
ok  	github.com/rock3r/punaro/internal/trustedattachmenthttp	1.657s
go run honnef.co/go/tools/cmd/staticcheck@v0.6.1 ./...
go run golang.org/x/vuln/cmd/govulncheck@v1.1.4 ./...
=== Symbol Results ===

No vulnerabilities found.

Your code is affected by 0 vulnerabilities.
This scan also found 1 vulnerability in packages you import and 7
vulnerabilities in modules you require, but your code doesn't appear to call
these vulnerabilities.
Use '-show verbose' for more details.
CGO_ENABLED=0 go run github.com/securego/gosec/v2/cmd/gosec@v2.22.10 -exclude-generated ./...
Results:


Summary:
  Gosec  : dev
  Files  : 224
  Lines  : 56956
  Nosec  : 194
  Issues : 0

go run github.com/zricethezav/gitleaks/v8@v8.27.2 detect --source . --no-git
go vet ./...
0 issues.
0 issues.
0 issues.
GOOS=windows go build ./...
./scripts/verify-deployment-files.sh
install_adapter_tests_passed
install_server_tests_passed
attachment_v3_relay_retirement_tests_passed
Punaro agent guidance and project-local skills installed in /var/folders/10/534j41jj6_sg2tygjm9_crl80000gn/T/punaro-guidance-test.kpVsMOlm/project
Punaro agent guidance and project-local skills installed in /var/folders/10/534j41jj6_sg2tygjm9_crl80000gn/T/punaro-guidance-test.kpVsMOlm/project
install_agent_guidance_tests_passed
install_client_windows_tests_passed
- ok  	github.com/rock3r/punaro/internal/postgres	0.360s
- ./scripts/test-postgres-integration.sh is unavailable locally because Docker Compose v2 is not installed; hosted PostgreSQL integration CI covers the registered integration tests.

## Review
- Pioneer GPT-5.4 review was started but its wrapper returned no terminal report, so it is intentionally not represented as a clean review result.