### PR TITLE
Run fenced consolidation proposal passes

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -613,7 +613,10 @@ succeeds. Planner, validation, staging, or checkpoint failure leaves the page
 unadvanced for fenced replay; the executor has no canonical mutation or
 approval authority. Planner output cannot choose a principal, project, or
 idempotency key: the trusted executor caller binds the authorized
-principal/project.
+principal/project. A source page that becomes stale, or immutable planner
+output that is permanently rejected by item, evidence, or secret validation,
+is fenced-retired and advanced without staging a replacement plan; transient
+operational and capacity failures remain replayable.
 Consolidation staging also proves that the requested project is the leased
 scope's canonical project before expiry/retention maintenance can touch any
 proposal rows, so a wrong-project request has no cross-project side effects.

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -602,15 +602,18 @@ memory. Generic proposal evidence remains restricted to evidence-layer records;
 consolidation provenance is a separate scope-bound relation so curated source
 revisions remain auditable without weakening that invariant.
 
-The bounded consolidation executor is provider-agnostic: it reads one live
-page, validates the complete proposal/evidence budget before staging any
-output, and stages every validated output through that same source-bound path.
-It advances the exact checkpoint only after all staging succeeds. Planner, validation, staging, or
-checkpoint failure leaves the page unadvanced for fenced replay; the executor
-has no canonical mutation or approval authority. Planner output cannot choose
-a principal, project, or idempotency key: the trusted executor caller binds
-the authorized principal/project, while page coordinates plus each normalized
-proposal payload derive stable idempotency keys for partial-stage replay.
+Schema version 39 adds one immutable, lease-fenced pass record for each exact
+source page and authorized proposer/project. The bounded, provider-agnostic
+executor first loads that record; only an absent record permits planner output,
+which is fully validated and durably reserved before any proposal is staged.
+Every retry consequently reuses the original proposal bodies and ordinal-based
+idempotency keys even if a later planner response differs. It advances the
+exact checkpoint and removes that pass atomically only after all staging
+succeeds. Planner, validation, staging, or checkpoint failure leaves the page
+unadvanced for fenced replay; the executor has no canonical mutation or
+approval authority. Planner output cannot choose a principal, project, or
+idempotency key: the trusted executor caller binds the authorized
+principal/project.
 Consolidation staging also proves that the requested project is the leased
 scope's canonical project before expiry/retention maintenance can touch any
 proposal rows, so a wrong-project request has no cross-project side effects.

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -602,6 +602,19 @@ memory. Generic proposal evidence remains restricted to evidence-layer records;
 consolidation provenance is a separate scope-bound relation so curated source
 revisions remain auditable without weakening that invariant.
 
+The bounded consolidation executor is provider-agnostic: it reads one live
+page, validates the complete proposal/evidence budget before staging any
+output, and stages every validated output through that same source-bound path.
+It advances the exact checkpoint only after all staging succeeds. Planner, validation, staging, or
+checkpoint failure leaves the page unadvanced for fenced replay; the executor
+has no canonical mutation or approval authority. Planner output cannot choose
+a principal, project, or idempotency key: the trusted executor caller binds
+the authorized principal/project, while page coordinates plus each normalized
+proposal payload derive stable idempotency keys for partial-stage replay.
+Consolidation staging also proves that the requested project is the leased
+scope's canonical project before expiry/retention maintenance can touch any
+proposal rows, so a wrong-project request has no cross-project side effects.
+
 Schema version 16 adds bounded, operator-driven rescan and retained quarantine.
 Every current revision carries scan coverage bound to its revision, the compiled
 rule identity, and a per-project exact-exception generation. Exception changes

--- a/internal/postgres/brain_consolidation.go
+++ b/internal/postgres/brain_consolidation.go
@@ -113,7 +113,11 @@ func (request MemoryConsolidationProposalRequest) normalized() (MemoryConsolidat
 // read-only: advancing the cursor and staging proposals remain separate,
 // independently fenced operations.
 func (d *Database) ReadMemoryConsolidationInput(ctx context.Context, lease MemoryConsolidationLease) (MemoryConsolidationInput, error) {
-	if !lease.valid() {
+	return d.readMemoryConsolidationInput(ctx, lease, maxMemoryConsolidationChanges)
+}
+
+func (d *Database) readMemoryConsolidationInput(ctx context.Context, lease MemoryConsolidationLease, maxChanges int) (MemoryConsolidationInput, error) {
+	if !lease.valid() || maxChanges < 1 || maxChanges > maxMemoryConsolidationChanges {
 		return MemoryConsolidationInput{}, errors.New("invalid consolidation lease")
 	}
 	rows, err := d.db.QueryContext(ctx, `SELECT timeline_id::text,item_id::text,revision,change_sequence,document::text,content_sha256,is_fence FROM brain.read_memory_consolidation_documents($1,$2,$3)`, lease.ScopeID, lease.Token, lease.Generation)
@@ -121,7 +125,7 @@ func (d *Database) ReadMemoryConsolidationInput(ctx context.Context, lease Memor
 		return MemoryConsolidationInput{}, errors.New("consolidation sources are unavailable")
 	}
 	defer func() { _ = rows.Close() }()
-	input := MemoryConsolidationInput{Lease: lease, TimelineID: lease.TimelineID, NextSequence: lease.Sequence, Sources: make([]MemoryConsolidationSource, 0, maxMemoryConsolidationChanges)}
+	input := MemoryConsolidationInput{Lease: lease, TimelineID: lease.TimelineID, NextSequence: lease.Sequence, Sources: make([]MemoryConsolidationSource, 0, maxChanges)}
 	live := false
 	for rows.Next() {
 		var timelineID string
@@ -138,6 +142,9 @@ func (d *Database) ReadMemoryConsolidationInput(ctx context.Context, lease Memor
 				return MemoryConsolidationInput{}, ErrStaleMemoryConsolidationLease
 			}
 			live = true
+			continue
+		}
+		if len(input.Sources) >= maxChanges {
 			continue
 		}
 		if !itemID.Valid || !revision.Valid || !document.Valid || !sequence.Valid {

--- a/internal/postgres/brain_consolidation.go
+++ b/internal/postgres/brain_consolidation.go
@@ -126,7 +126,7 @@ func (d *Database) readMemoryConsolidationInput(ctx context.Context, lease Memor
 	}
 	defer func() { _ = rows.Close() }()
 	input := MemoryConsolidationInput{Lease: lease, TimelineID: lease.TimelineID, NextSequence: lease.Sequence, Sources: make([]MemoryConsolidationSource, 0, maxChanges)}
-	live := false
+	live, changes := false, 0
 	for rows.Next() {
 		var timelineID string
 		var itemID sql.NullString
@@ -144,9 +144,12 @@ func (d *Database) readMemoryConsolidationInput(ctx context.Context, lease Memor
 			live = true
 			continue
 		}
-		if len(input.Sources) >= maxChanges {
-			continue
+		// The policy bounds the number of source changes consumed, including
+		// gaps produced by deleted, quarantined, or superseded documents.
+		if changes >= maxChanges {
+			break
 		}
+		changes++
 		if !itemID.Valid || !revision.Valid || !document.Valid || !sequence.Valid {
 			if itemID.Valid || revision.Valid || document.Valid || len(contentHash) != 0 || !sequence.Valid {
 				return MemoryConsolidationInput{}, errors.New("consolidation source is malformed")

--- a/internal/postgres/brain_consolidation_executor.go
+++ b/internal/postgres/brain_consolidation_executor.go
@@ -138,8 +138,10 @@ func (e *MemoryConsolidationExecutor) Execute(ctx context.Context, request Memor
 	if err != nil {
 		return MemoryConsolidationExecutionResult{}, err
 	}
-	if err := e.store.CheckMemoryConsolidationPassCapacity(passCtx, input, effectiveRequest, len(proposals)); err != nil {
-		return MemoryConsolidationExecutionResult{}, err
+	if !found {
+		if err := e.store.CheckMemoryConsolidationPassCapacity(passCtx, input, effectiveRequest, len(proposals)); err != nil {
+			return MemoryConsolidationExecutionResult{}, err
+		}
 	}
 	for ordinal, proposal := range proposals {
 		staged := MemoryProposalCreateRequest{PrincipalID: effectiveRequest.PrincipalID, ProjectID: effectiveRequest.ProjectID, IdempotencyKey: memoryConsolidationProposalIdempotencyKey(input, effectiveRequest.PrincipalID, effectiveRequest.ProjectID, ordinal), Action: proposal.Action, Steps: proposal.Steps, Evidence: proposal.Evidence}

--- a/internal/postgres/brain_consolidation_executor.go
+++ b/internal/postgres/brain_consolidation_executor.go
@@ -141,6 +141,12 @@ func (e *MemoryConsolidationExecutor) Execute(ctx context.Context, request Memor
 	// A pass is durable before its first capacity check. Recheck it on every
 	// replay so a capacity-rejected pass cannot later begin partial staging.
 	if err := e.store.CheckMemoryConsolidationPassCapacity(passCtx, input, effectiveRequest, len(proposals)); err != nil {
+		if errors.Is(err, errMemoryConsolidationProposalRejected) {
+			if abandonErr := e.store.AbandonMemoryConsolidationPass(passCtx, input, effectiveRequest); abandonErr != nil {
+				return MemoryConsolidationExecutionResult{}, abandonErr
+			}
+			return MemoryConsolidationExecutionResult{}, ErrStaleMemoryConsolidationLease
+		}
 		return MemoryConsolidationExecutionResult{}, err
 	}
 	for ordinal, proposal := range proposals {

--- a/internal/postgres/brain_consolidation_executor.go
+++ b/internal/postgres/brain_consolidation_executor.go
@@ -57,6 +57,7 @@ type memoryConsolidationExecutorStore interface {
 	readMemoryConsolidationInput(context.Context, MemoryConsolidationLease, int) (MemoryConsolidationInput, error)
 	LoadMemoryConsolidationPass(context.Context, MemoryConsolidationLease, MemoryConsolidationExecutionRequest) (MemoryConsolidationInput, MemoryConsolidationExecutionRequest, []MemoryConsolidationProposal, bool, error)
 	ReserveMemoryConsolidationPass(context.Context, MemoryConsolidationInput, MemoryConsolidationExecutionRequest, []MemoryConsolidationProposal) (MemoryConsolidationInput, MemoryConsolidationExecutionRequest, []MemoryConsolidationProposal, error)
+	CheckMemoryConsolidationPassCapacity(context.Context, MemoryConsolidationInput, MemoryConsolidationExecutionRequest, int) error
 	StageMemoryConsolidationProposal(context.Context, MemoryConsolidationProposalRequest) (MemoryProposalResult, error)
 	AbandonMemoryConsolidationPass(context.Context, MemoryConsolidationInput, MemoryConsolidationExecutionRequest) error
 	CompleteMemoryConsolidationPass(context.Context, MemoryConsolidationInput, MemoryConsolidationExecutionRequest) error
@@ -135,6 +136,9 @@ func (e *MemoryConsolidationExecutor) Execute(ctx context.Context, request Memor
 		proposals, err = e.normalizeMemoryConsolidationProposals(proposals)
 	}
 	if err != nil {
+		return MemoryConsolidationExecutionResult{}, err
+	}
+	if err := e.store.CheckMemoryConsolidationPassCapacity(passCtx, input, effectiveRequest, len(proposals)); err != nil {
 		return MemoryConsolidationExecutionResult{}, err
 	}
 	for ordinal, proposal := range proposals {

--- a/internal/postgres/brain_consolidation_executor.go
+++ b/internal/postgres/brain_consolidation_executor.go
@@ -136,7 +136,7 @@ func (e *MemoryConsolidationExecutor) Execute(ctx context.Context, request Memor
 	for ordinal, proposal := range proposals {
 		staged := MemoryProposalCreateRequest{PrincipalID: effectiveRequest.PrincipalID, ProjectID: effectiveRequest.ProjectID, IdempotencyKey: memoryConsolidationProposalIdempotencyKey(input, effectiveRequest.PrincipalID, effectiveRequest.ProjectID, ordinal), Action: proposal.Action, Steps: proposal.Steps, Evidence: proposal.Evidence}
 		if _, err := e.store.StageMemoryConsolidationProposal(passCtx, MemoryConsolidationProposalRequest{Input: input, Proposal: staged}); err != nil {
-			if errors.Is(err, errMemoryConsolidationSourceStale) {
+			if errors.Is(err, errMemoryConsolidationSourceStale) || errors.Is(err, errMemoryConsolidationProposalRejected) {
 				if abandonErr := e.store.AbandonMemoryConsolidationPass(passCtx, input, effectiveRequest); abandonErr != nil {
 					return MemoryConsolidationExecutionResult{}, abandonErr
 				}

--- a/internal/postgres/brain_consolidation_executor.go
+++ b/internal/postgres/brain_consolidation_executor.go
@@ -58,7 +58,7 @@ type memoryConsolidationExecutorStore interface {
 	readMemoryConsolidationInput(context.Context, MemoryConsolidationLease, int) (MemoryConsolidationInput, error)
 	LoadMemoryConsolidationPass(context.Context, MemoryConsolidationLease, MemoryConsolidationExecutionRequest) (MemoryConsolidationInput, MemoryConsolidationExecutionRequest, []MemoryConsolidationProposal, bool, error)
 	ReserveMemoryConsolidationPass(context.Context, MemoryConsolidationInput, MemoryConsolidationExecutionRequest, []MemoryConsolidationProposal) (MemoryConsolidationInput, MemoryConsolidationExecutionRequest, []MemoryConsolidationProposal, error)
-	CheckMemoryConsolidationPassCapacity(context.Context, MemoryConsolidationInput, MemoryConsolidationExecutionRequest, int) error
+	CheckMemoryConsolidationPassCapacity(context.Context, MemoryConsolidationInput, MemoryConsolidationExecutionRequest, []MemoryConsolidationProposal) error
 	StageMemoryConsolidationProposal(context.Context, MemoryConsolidationProposalRequest) (MemoryProposalResult, error)
 	AbandonMemoryConsolidationPass(context.Context, MemoryConsolidationInput, MemoryConsolidationExecutionRequest) error
 	CompleteMemoryConsolidationPass(context.Context, MemoryConsolidationInput, MemoryConsolidationExecutionRequest) error
@@ -141,7 +141,7 @@ func (e *MemoryConsolidationExecutor) Execute(ctx context.Context, request Memor
 	}
 	// A pass is durable before its first capacity check. Recheck it on every
 	// replay so a capacity-rejected pass cannot later begin partial staging.
-	if err := e.store.CheckMemoryConsolidationPassCapacity(passCtx, input, effectiveRequest, len(proposals)); err != nil {
+	if err := e.store.CheckMemoryConsolidationPassCapacity(passCtx, input, effectiveRequest, proposals); err != nil {
 		if errors.Is(err, errMemoryConsolidationProposalRejected) {
 			if abandonErr := e.store.AbandonMemoryConsolidationPass(passCtx, input, effectiveRequest); abandonErr != nil {
 				return MemoryConsolidationExecutionResult{}, abandonErr

--- a/internal/postgres/brain_consolidation_executor.go
+++ b/internal/postgres/brain_consolidation_executor.go
@@ -1,0 +1,143 @@
+package postgres
+
+import (
+	"context"
+	"crypto/sha256"
+	"errors"
+	"strconv"
+
+	"github.com/google/uuid"
+)
+
+// MemoryConsolidationPlanner turns one bounded, lease-fenced source page into
+// zero or more proposal bodies. It cannot choose an authorization principal,
+// project, or idempotency identity; the executor owns those control fields.
+type MemoryConsolidationPlanner interface {
+	Propose(context.Context, MemoryConsolidationInput) ([]MemoryConsolidationProposal, error)
+}
+
+// MemoryConsolidationProposal is untrusted planner output. It deliberately
+// excludes principal, project, and idempotency fields so it cannot gain
+// proposal authority by choosing those values.
+type MemoryConsolidationProposal struct {
+	Action   MemoryProposalAction
+	Steps    []MemoryProposalStepInput
+	Evidence []MemoryProposalEvidenceInput
+}
+
+func (proposal MemoryConsolidationProposal) normalized() (MemoryConsolidationProposal, error) {
+	validated, err := (MemoryProposalCreateRequest{
+		PrincipalID:    "00000000-0000-4000-8000-000000000001",
+		ProjectID:      "00000000-0000-4000-8000-000000000002",
+		IdempotencyKey: "00000000-0000-4000-8000-000000000003",
+		Action:         proposal.Action,
+		Steps:          proposal.Steps,
+		Evidence:       proposal.Evidence,
+	}).normalized()
+	if err != nil {
+		return MemoryConsolidationProposal{}, err
+	}
+	return MemoryConsolidationProposal{Action: validated.Action, Steps: validated.Steps, Evidence: validated.Evidence}, nil
+}
+
+// MemoryConsolidationExecutionRequest binds one pass to the caller-selected
+// authorized proposer and direct canonical project. The planner never sees or
+// controls these fields.
+type MemoryConsolidationExecutionRequest struct {
+	Lease       MemoryConsolidationLease
+	PrincipalID string
+	ProjectID   string
+}
+
+func (request MemoryConsolidationExecutionRequest) valid() bool {
+	return request.Lease.valid() && validOpaqueID(request.PrincipalID) && validOpaqueID(request.ProjectID)
+}
+
+type memoryConsolidationExecutorStore interface {
+	ReadMemoryConsolidationInput(context.Context, MemoryConsolidationLease) (MemoryConsolidationInput, error)
+	StageMemoryConsolidationProposal(context.Context, MemoryConsolidationProposalRequest) (MemoryProposalResult, error)
+	AdvanceMemoryConsolidationCheckpoint(context.Context, MemoryConsolidationLease, string, int64) error
+}
+
+// MemoryConsolidationExecutor runs one bounded proposal-only pass. Its only
+// durable effects are staged proposals and, after all staging succeeds, an
+// exact fenced checkpoint advance.
+type MemoryConsolidationExecutor struct {
+	store   memoryConsolidationExecutorStore
+	planner MemoryConsolidationPlanner
+	policy  MemoryConsolidationPolicy
+}
+
+// MemoryConsolidationExecutionResult reports one completed bounded pass.
+type MemoryConsolidationExecutionResult struct {
+	Sources  int
+	Staged   int
+	Advanced bool
+}
+
+// NewMemoryConsolidationExecutor constructs a provider-agnostic, bounded
+// proposal orchestrator. A concrete model client belongs in a later adapter.
+func NewMemoryConsolidationExecutor(store memoryConsolidationExecutorStore, planner MemoryConsolidationPlanner, policy MemoryConsolidationPolicy) (*MemoryConsolidationExecutor, error) {
+	if store == nil || planner == nil || policy.Validate() != nil {
+		return nil, errors.New("memory consolidation executor is invalid")
+	}
+	return &MemoryConsolidationExecutor{store: store, planner: planner, policy: policy}, nil
+}
+
+// Execute reads one live page, stages every validated output, and only then
+// advances the exact checkpoint. Any failure leaves the checkpoint leased for
+// expiry/reclaim, so a later worker can safely replay the page.
+func (e *MemoryConsolidationExecutor) Execute(ctx context.Context, request MemoryConsolidationExecutionRequest) (MemoryConsolidationExecutionResult, error) {
+	if !request.valid() {
+		return MemoryConsolidationExecutionResult{}, errors.New("invalid consolidation lease")
+	}
+	lease := request.Lease
+	passCtx, cancel := context.WithTimeout(ctx, e.policy.PassTimeout)
+	defer cancel()
+	input, err := e.store.ReadMemoryConsolidationInput(passCtx, lease)
+	if err != nil {
+		return MemoryConsolidationExecutionResult{}, err
+	}
+	if input.Lease != lease || input.TimelineID != lease.TimelineID || !input.valid() || len(input.Sources) > e.policy.MaxChanges {
+		return MemoryConsolidationExecutionResult{}, errors.New("consolidation input is invalid")
+	}
+	proposals, err := e.planner.Propose(passCtx, input)
+	if err != nil {
+		return MemoryConsolidationExecutionResult{}, err
+	}
+	if len(proposals) > e.policy.MaxProposals {
+		return MemoryConsolidationExecutionResult{}, errors.New("consolidation output exceeds policy")
+	}
+	normalized := make([]MemoryConsolidationProposal, 0, len(proposals))
+	keys := make([]string, 0, len(proposals))
+	seen := make(map[string]struct{}, len(proposals))
+	for _, raw := range proposals {
+		proposal, err := raw.normalized()
+		if err != nil || len(proposal.Evidence) > e.policy.MaxEvidencePerProposal {
+			return MemoryConsolidationExecutionResult{}, errors.New("consolidation output is invalid")
+		}
+		key := memoryConsolidationProposalIdempotencyKey(input, request.PrincipalID, request.ProjectID, proposal)
+		if _, duplicate := seen[key]; duplicate {
+			return MemoryConsolidationExecutionResult{}, errors.New("consolidation output is invalid")
+		}
+		seen[key] = struct{}{}
+		normalized = append(normalized, proposal)
+		keys = append(keys, key)
+	}
+	for ordinal, proposal := range normalized {
+		staged := MemoryProposalCreateRequest{PrincipalID: request.PrincipalID, ProjectID: request.ProjectID, IdempotencyKey: keys[ordinal], Action: proposal.Action, Steps: proposal.Steps, Evidence: proposal.Evidence}
+		if _, err := e.store.StageMemoryConsolidationProposal(passCtx, MemoryConsolidationProposalRequest{Input: input, Proposal: staged}); err != nil {
+			return MemoryConsolidationExecutionResult{}, err
+		}
+	}
+	if err := e.store.AdvanceMemoryConsolidationCheckpoint(passCtx, lease, input.TimelineID, input.NextSequence); err != nil {
+		return MemoryConsolidationExecutionResult{}, err
+	}
+	return MemoryConsolidationExecutionResult{Sources: len(input.Sources), Staged: len(proposals), Advanced: true}, nil
+}
+
+func memoryConsolidationProposalIdempotencyKey(input MemoryConsolidationInput, principalID, projectID string, proposal MemoryConsolidationProposal) string {
+	_, payloadSHA := memoryProposalPayloadSHA(projectID, proposal.Action, proposal.Steps, proposal.Evidence)
+	digest := sha256.Sum256([]byte(input.Lease.ScopeID + "\x00" + input.TimelineID + "\x00" + strconv.FormatInt(input.Lease.Sequence, 10) + "\x00" + strconv.FormatInt(input.NextSequence, 10) + "\x00" + principalID + "\x00" + projectID + "\x00" + string(payloadSHA)))
+	return uuid.NewSHA1(uuid.NameSpaceOID, digest[:]).String()
+}

--- a/internal/postgres/brain_consolidation_executor.go
+++ b/internal/postgres/brain_consolidation_executor.go
@@ -58,6 +58,7 @@ type memoryConsolidationExecutorStore interface {
 	LoadMemoryConsolidationPass(context.Context, MemoryConsolidationLease, MemoryConsolidationExecutionRequest) (MemoryConsolidationInput, []MemoryConsolidationProposal, bool, error)
 	ReserveMemoryConsolidationPass(context.Context, MemoryConsolidationInput, MemoryConsolidationExecutionRequest, []MemoryConsolidationProposal) (MemoryConsolidationInput, []MemoryConsolidationProposal, error)
 	StageMemoryConsolidationProposal(context.Context, MemoryConsolidationProposalRequest) (MemoryProposalResult, error)
+	AbandonMemoryConsolidationPass(context.Context, MemoryConsolidationInput, MemoryConsolidationExecutionRequest) error
 	CompleteMemoryConsolidationPass(context.Context, MemoryConsolidationInput, MemoryConsolidationExecutionRequest) error
 }
 
@@ -119,6 +120,9 @@ func (e *MemoryConsolidationExecutor) Execute(ctx context.Context, request Memor
 		if err != nil {
 			return MemoryConsolidationExecutionResult{}, err
 		}
+		if len(input.Sources) == 0 && len(proposals) != 0 {
+			return MemoryConsolidationExecutionResult{}, errors.New("consolidation output requires source documents")
+		}
 		input, proposals, err = e.store.ReserveMemoryConsolidationPass(passCtx, input, request, proposals)
 		if err != nil {
 			return MemoryConsolidationExecutionResult{}, err
@@ -131,6 +135,11 @@ func (e *MemoryConsolidationExecutor) Execute(ctx context.Context, request Memor
 	for ordinal, proposal := range proposals {
 		staged := MemoryProposalCreateRequest{PrincipalID: request.PrincipalID, ProjectID: request.ProjectID, IdempotencyKey: memoryConsolidationProposalIdempotencyKey(input, request.PrincipalID, request.ProjectID, ordinal), Action: proposal.Action, Steps: proposal.Steps, Evidence: proposal.Evidence}
 		if _, err := e.store.StageMemoryConsolidationProposal(passCtx, MemoryConsolidationProposalRequest{Input: input, Proposal: staged}); err != nil {
+			if errors.Is(err, ErrStaleMemoryConsolidationLease) {
+				if abandonErr := e.store.AbandonMemoryConsolidationPass(passCtx, input, request); abandonErr != nil {
+					return MemoryConsolidationExecutionResult{}, abandonErr
+				}
+			}
 			return MemoryConsolidationExecutionResult{}, err
 		}
 	}

--- a/internal/postgres/brain_consolidation_executor.go
+++ b/internal/postgres/brain_consolidation_executor.go
@@ -135,10 +135,11 @@ func (e *MemoryConsolidationExecutor) Execute(ctx context.Context, request Memor
 	for ordinal, proposal := range proposals {
 		staged := MemoryProposalCreateRequest{PrincipalID: request.PrincipalID, ProjectID: request.ProjectID, IdempotencyKey: memoryConsolidationProposalIdempotencyKey(input, request.PrincipalID, request.ProjectID, ordinal), Action: proposal.Action, Steps: proposal.Steps, Evidence: proposal.Evidence}
 		if _, err := e.store.StageMemoryConsolidationProposal(passCtx, MemoryConsolidationProposalRequest{Input: input, Proposal: staged}); err != nil {
-			if errors.Is(err, ErrStaleMemoryConsolidationLease) {
+			if errors.Is(err, errMemoryConsolidationSourceStale) {
 				if abandonErr := e.store.AbandonMemoryConsolidationPass(passCtx, input, request); abandonErr != nil {
 					return MemoryConsolidationExecutionResult{}, abandonErr
 				}
+				return MemoryConsolidationExecutionResult{}, ErrStaleMemoryConsolidationLease
 			}
 			return MemoryConsolidationExecutionResult{}, err
 		}

--- a/internal/postgres/brain_consolidation_executor.go
+++ b/internal/postgres/brain_consolidation_executor.go
@@ -55,7 +55,7 @@ func (request MemoryConsolidationExecutionRequest) valid() bool {
 
 type memoryConsolidationExecutorStore interface {
 	ReadMemoryConsolidationInput(context.Context, MemoryConsolidationLease) (MemoryConsolidationInput, error)
-	LoadMemoryConsolidationPass(context.Context, MemoryConsolidationInput, MemoryConsolidationExecutionRequest) ([]MemoryConsolidationProposal, bool, error)
+	LoadMemoryConsolidationPass(context.Context, MemoryConsolidationLease, MemoryConsolidationExecutionRequest) (MemoryConsolidationInput, []MemoryConsolidationProposal, bool, error)
 	ReserveMemoryConsolidationPass(context.Context, MemoryConsolidationInput, MemoryConsolidationExecutionRequest, []MemoryConsolidationProposal) ([]MemoryConsolidationProposal, error)
 	StageMemoryConsolidationProposal(context.Context, MemoryConsolidationProposalRequest) (MemoryProposalResult, error)
 	CompleteMemoryConsolidationPass(context.Context, MemoryConsolidationInput, MemoryConsolidationExecutionRequest) error
@@ -97,16 +97,18 @@ func (e *MemoryConsolidationExecutor) Execute(ctx context.Context, request Memor
 	lease := request.Lease
 	passCtx, cancel := context.WithTimeout(ctx, e.policy.PassTimeout)
 	defer cancel()
-	input, err := e.store.ReadMemoryConsolidationInput(passCtx, lease)
+	input, proposals, found, err := e.store.LoadMemoryConsolidationPass(passCtx, lease, request)
 	if err != nil {
 		return MemoryConsolidationExecutionResult{}, err
+	}
+	if !found {
+		input, err = e.store.ReadMemoryConsolidationInput(passCtx, lease)
+		if err != nil {
+			return MemoryConsolidationExecutionResult{}, err
+		}
 	}
 	if input.Lease != lease || input.TimelineID != lease.TimelineID || !input.valid() || len(input.Sources) > e.policy.MaxChanges {
 		return MemoryConsolidationExecutionResult{}, errors.New("consolidation input is invalid")
-	}
-	proposals, found, err := e.store.LoadMemoryConsolidationPass(passCtx, input, request)
-	if err != nil {
-		return MemoryConsolidationExecutionResult{}, err
 	}
 	if !found {
 		proposals, err = e.planner.Propose(passCtx, input)

--- a/internal/postgres/brain_consolidation_executor.go
+++ b/internal/postgres/brain_consolidation_executor.go
@@ -171,13 +171,13 @@ func (e *MemoryConsolidationExecutor) Execute(ctx context.Context, request Memor
 // cloneMemoryConsolidationInput isolates the executor's fenced source page
 // from untrusted planner mutation.
 func cloneMemoryConsolidationInput(input MemoryConsolidationInput) MemoryConsolidationInput {
-	copy := input
-	copy.Sources = make([]MemoryConsolidationSource, len(input.Sources))
+	cloned := input
+	cloned.Sources = make([]MemoryConsolidationSource, len(input.Sources))
 	for index, source := range input.Sources {
 		source.Document = append(json.RawMessage(nil), source.Document...)
-		copy.Sources[index] = source
+		cloned.Sources[index] = source
 	}
-	return copy
+	return cloned
 }
 
 func (e *MemoryConsolidationExecutor) normalizeMemoryConsolidationProposals(raw []MemoryConsolidationProposal) ([]MemoryConsolidationProposal, error) {

--- a/internal/postgres/brain_consolidation_executor.go
+++ b/internal/postgres/brain_consolidation_executor.go
@@ -55,8 +55,10 @@ func (request MemoryConsolidationExecutionRequest) valid() bool {
 
 type memoryConsolidationExecutorStore interface {
 	ReadMemoryConsolidationInput(context.Context, MemoryConsolidationLease) (MemoryConsolidationInput, error)
+	LoadMemoryConsolidationPass(context.Context, MemoryConsolidationInput, MemoryConsolidationExecutionRequest) ([]MemoryConsolidationProposal, bool, error)
+	ReserveMemoryConsolidationPass(context.Context, MemoryConsolidationInput, MemoryConsolidationExecutionRequest, []MemoryConsolidationProposal) ([]MemoryConsolidationProposal, error)
 	StageMemoryConsolidationProposal(context.Context, MemoryConsolidationProposalRequest) (MemoryProposalResult, error)
-	AdvanceMemoryConsolidationCheckpoint(context.Context, MemoryConsolidationLease, string, int64) error
+	CompleteMemoryConsolidationPass(context.Context, MemoryConsolidationInput, MemoryConsolidationExecutionRequest) error
 }
 
 // MemoryConsolidationExecutor runs one bounded proposal-only pass. Its only
@@ -84,9 +86,10 @@ func NewMemoryConsolidationExecutor(store memoryConsolidationExecutorStore, plan
 	return &MemoryConsolidationExecutor{store: store, planner: planner, policy: policy}, nil
 }
 
-// Execute reads one live page, stages every validated output, and only then
-// advances the exact checkpoint. Any failure leaves the checkpoint leased for
-// expiry/reclaim, so a later worker can safely replay the page.
+// Execute reads one live page, durably fixes its validated planner output,
+// stages every entry, and only then completes the exact checkpoint. Any
+// failure leaves that immutable pass available for a later worker to replay
+// without asking a planner to produce a replacement proposal set.
 func (e *MemoryConsolidationExecutor) Execute(ctx context.Context, request MemoryConsolidationExecutionRequest) (MemoryConsolidationExecutionResult, error) {
 	if !request.valid() {
 		return MemoryConsolidationExecutionResult{}, errors.New("invalid consolidation lease")
@@ -101,43 +104,62 @@ func (e *MemoryConsolidationExecutor) Execute(ctx context.Context, request Memor
 	if input.Lease != lease || input.TimelineID != lease.TimelineID || !input.valid() || len(input.Sources) > e.policy.MaxChanges {
 		return MemoryConsolidationExecutionResult{}, errors.New("consolidation input is invalid")
 	}
-	proposals, err := e.planner.Propose(passCtx, input)
+	proposals, found, err := e.store.LoadMemoryConsolidationPass(passCtx, input, request)
 	if err != nil {
 		return MemoryConsolidationExecutionResult{}, err
 	}
-	if len(proposals) > e.policy.MaxProposals {
-		return MemoryConsolidationExecutionResult{}, errors.New("consolidation output exceeds policy")
-	}
-	normalized := make([]MemoryConsolidationProposal, 0, len(proposals))
-	keys := make([]string, 0, len(proposals))
-	seen := make(map[string]struct{}, len(proposals))
-	for _, raw := range proposals {
-		proposal, err := raw.normalized()
-		if err != nil || len(proposal.Evidence) > e.policy.MaxEvidencePerProposal {
-			return MemoryConsolidationExecutionResult{}, errors.New("consolidation output is invalid")
+	if !found {
+		proposals, err = e.planner.Propose(passCtx, input)
+		if err != nil {
+			return MemoryConsolidationExecutionResult{}, err
 		}
-		key := memoryConsolidationProposalIdempotencyKey(input, request.PrincipalID, request.ProjectID, proposal)
-		if _, duplicate := seen[key]; duplicate {
-			return MemoryConsolidationExecutionResult{}, errors.New("consolidation output is invalid")
+		proposals, err = e.normalizeMemoryConsolidationProposals(proposals)
+		if err != nil {
+			return MemoryConsolidationExecutionResult{}, err
 		}
-		seen[key] = struct{}{}
-		normalized = append(normalized, proposal)
-		keys = append(keys, key)
+		proposals, err = e.store.ReserveMemoryConsolidationPass(passCtx, input, request, proposals)
+		if err != nil {
+			return MemoryConsolidationExecutionResult{}, err
+		}
 	}
-	for ordinal, proposal := range normalized {
-		staged := MemoryProposalCreateRequest{PrincipalID: request.PrincipalID, ProjectID: request.ProjectID, IdempotencyKey: keys[ordinal], Action: proposal.Action, Steps: proposal.Steps, Evidence: proposal.Evidence}
+	proposals, err = e.normalizeMemoryConsolidationProposals(proposals)
+	if err != nil {
+		return MemoryConsolidationExecutionResult{}, err
+	}
+	for ordinal, proposal := range proposals {
+		staged := MemoryProposalCreateRequest{PrincipalID: request.PrincipalID, ProjectID: request.ProjectID, IdempotencyKey: memoryConsolidationProposalIdempotencyKey(input, request.PrincipalID, request.ProjectID, ordinal), Action: proposal.Action, Steps: proposal.Steps, Evidence: proposal.Evidence}
 		if _, err := e.store.StageMemoryConsolidationProposal(passCtx, MemoryConsolidationProposalRequest{Input: input, Proposal: staged}); err != nil {
 			return MemoryConsolidationExecutionResult{}, err
 		}
 	}
-	if err := e.store.AdvanceMemoryConsolidationCheckpoint(passCtx, lease, input.TimelineID, input.NextSequence); err != nil {
+	if err := e.store.CompleteMemoryConsolidationPass(passCtx, input, request); err != nil {
 		return MemoryConsolidationExecutionResult{}, err
 	}
 	return MemoryConsolidationExecutionResult{Sources: len(input.Sources), Staged: len(proposals), Advanced: true}, nil
 }
 
-func memoryConsolidationProposalIdempotencyKey(input MemoryConsolidationInput, principalID, projectID string, proposal MemoryConsolidationProposal) string {
-	_, payloadSHA := memoryProposalPayloadSHA(projectID, proposal.Action, proposal.Steps, proposal.Evidence)
-	digest := sha256.Sum256([]byte(input.Lease.ScopeID + "\x00" + input.TimelineID + "\x00" + strconv.FormatInt(input.Lease.Sequence, 10) + "\x00" + strconv.FormatInt(input.NextSequence, 10) + "\x00" + principalID + "\x00" + projectID + "\x00" + string(payloadSHA)))
+func (e *MemoryConsolidationExecutor) normalizeMemoryConsolidationProposals(raw []MemoryConsolidationProposal) ([]MemoryConsolidationProposal, error) {
+	if len(raw) > e.policy.MaxProposals {
+		return nil, errors.New("consolidation output exceeds policy")
+	}
+	normalized := make([]MemoryConsolidationProposal, 0, len(raw))
+	seen := make(map[string]struct{}, len(raw))
+	for _, value := range raw {
+		proposal, err := value.normalized()
+		if err != nil || len(proposal.Evidence) > e.policy.MaxEvidencePerProposal {
+			return nil, errors.New("consolidation output is invalid")
+		}
+		_, payloadSHA := memoryProposalPayloadSHA("00000000-0000-4000-8000-000000000001", proposal.Action, proposal.Steps, proposal.Evidence)
+		if _, duplicate := seen[string(payloadSHA)]; duplicate {
+			return nil, errors.New("consolidation output is invalid")
+		}
+		seen[string(payloadSHA)] = struct{}{}
+		normalized = append(normalized, proposal)
+	}
+	return normalized, nil
+}
+
+func memoryConsolidationProposalIdempotencyKey(input MemoryConsolidationInput, principalID, projectID string, ordinal int) string {
+	digest := sha256.Sum256([]byte(input.Lease.ScopeID + "\x00" + input.TimelineID + "\x00" + strconv.FormatInt(input.Lease.Sequence, 10) + "\x00" + strconv.FormatInt(input.NextSequence, 10) + "\x00" + principalID + "\x00" + projectID + "\x00" + strconv.Itoa(ordinal)))
 	return uuid.NewSHA1(uuid.NameSpaceOID, digest[:]).String()
 }

--- a/internal/postgres/brain_consolidation_executor.go
+++ b/internal/postgres/brain_consolidation_executor.go
@@ -3,6 +3,7 @@ package postgres
 import (
 	"context"
 	"crypto/sha256"
+	"encoding/json"
 	"errors"
 	"strconv"
 
@@ -114,7 +115,7 @@ func (e *MemoryConsolidationExecutor) Execute(ctx context.Context, request Memor
 		return MemoryConsolidationExecutionResult{}, errors.New("consolidation input is invalid")
 	}
 	if !found {
-		proposals, err = e.planner.Propose(passCtx, input)
+		proposals, err = e.planner.Propose(passCtx, cloneMemoryConsolidationInput(input))
 		if err != nil {
 			return MemoryConsolidationExecutionResult{}, err
 		}
@@ -165,6 +166,18 @@ func (e *MemoryConsolidationExecutor) Execute(ctx context.Context, request Memor
 		return MemoryConsolidationExecutionResult{}, err
 	}
 	return MemoryConsolidationExecutionResult{Sources: len(input.Sources), Staged: len(proposals), Advanced: true}, nil
+}
+
+// cloneMemoryConsolidationInput isolates the executor's fenced source page
+// from untrusted planner mutation.
+func cloneMemoryConsolidationInput(input MemoryConsolidationInput) MemoryConsolidationInput {
+	copy := input
+	copy.Sources = make([]MemoryConsolidationSource, len(input.Sources))
+	for index, source := range input.Sources {
+		source.Document = append(json.RawMessage(nil), source.Document...)
+		copy.Sources[index] = source
+	}
+	return copy
 }
 
 func (e *MemoryConsolidationExecutor) normalizeMemoryConsolidationProposals(raw []MemoryConsolidationProposal) ([]MemoryConsolidationProposal, error) {

--- a/internal/postgres/brain_consolidation_executor.go
+++ b/internal/postgres/brain_consolidation_executor.go
@@ -56,7 +56,7 @@ func (request MemoryConsolidationExecutionRequest) valid() bool {
 type memoryConsolidationExecutorStore interface {
 	ReadMemoryConsolidationInput(context.Context, MemoryConsolidationLease) (MemoryConsolidationInput, error)
 	LoadMemoryConsolidationPass(context.Context, MemoryConsolidationLease, MemoryConsolidationExecutionRequest) (MemoryConsolidationInput, []MemoryConsolidationProposal, bool, error)
-	ReserveMemoryConsolidationPass(context.Context, MemoryConsolidationInput, MemoryConsolidationExecutionRequest, []MemoryConsolidationProposal) ([]MemoryConsolidationProposal, error)
+	ReserveMemoryConsolidationPass(context.Context, MemoryConsolidationInput, MemoryConsolidationExecutionRequest, []MemoryConsolidationProposal) (MemoryConsolidationInput, []MemoryConsolidationProposal, error)
 	StageMemoryConsolidationProposal(context.Context, MemoryConsolidationProposalRequest) (MemoryProposalResult, error)
 	CompleteMemoryConsolidationPass(context.Context, MemoryConsolidationInput, MemoryConsolidationExecutionRequest) error
 }
@@ -119,7 +119,7 @@ func (e *MemoryConsolidationExecutor) Execute(ctx context.Context, request Memor
 		if err != nil {
 			return MemoryConsolidationExecutionResult{}, err
 		}
-		proposals, err = e.store.ReserveMemoryConsolidationPass(passCtx, input, request, proposals)
+		input, proposals, err = e.store.ReserveMemoryConsolidationPass(passCtx, input, request, proposals)
 		if err != nil {
 			return MemoryConsolidationExecutionResult{}, err
 		}

--- a/internal/postgres/brain_consolidation_executor.go
+++ b/internal/postgres/brain_consolidation_executor.go
@@ -109,7 +109,7 @@ func (e *MemoryConsolidationExecutor) Execute(ctx context.Context, request Memor
 			return MemoryConsolidationExecutionResult{}, err
 		}
 	}
-	if input.Lease != lease || input.TimelineID != lease.TimelineID || !input.valid() || len(input.Sources) > e.policy.MaxChanges {
+	if input.Lease != lease || input.TimelineID != lease.TimelineID || !input.valid() || (!found && len(input.Sources) > e.policy.MaxChanges) {
 		return MemoryConsolidationExecutionResult{}, errors.New("consolidation input is invalid")
 	}
 	if !found {
@@ -129,7 +129,11 @@ func (e *MemoryConsolidationExecutor) Execute(ctx context.Context, request Memor
 			return MemoryConsolidationExecutionResult{}, err
 		}
 	}
-	proposals, err = e.normalizeMemoryConsolidationProposals(proposals)
+	if found {
+		proposals, err = normalizeMemoryConsolidationProposals(proposals, maxMemoryConsolidationProposals, maxMemoryConsolidationEvidence)
+	} else {
+		proposals, err = e.normalizeMemoryConsolidationProposals(proposals)
+	}
 	if err != nil {
 		return MemoryConsolidationExecutionResult{}, err
 	}
@@ -152,14 +156,18 @@ func (e *MemoryConsolidationExecutor) Execute(ctx context.Context, request Memor
 }
 
 func (e *MemoryConsolidationExecutor) normalizeMemoryConsolidationProposals(raw []MemoryConsolidationProposal) ([]MemoryConsolidationProposal, error) {
-	if len(raw) > e.policy.MaxProposals {
+	return normalizeMemoryConsolidationProposals(raw, e.policy.MaxProposals, e.policy.MaxEvidencePerProposal)
+}
+
+func normalizeMemoryConsolidationProposals(raw []MemoryConsolidationProposal, maxProposals, maxEvidencePerProposal int) ([]MemoryConsolidationProposal, error) {
+	if len(raw) > maxProposals {
 		return nil, errors.New("consolidation output exceeds policy")
 	}
 	normalized := make([]MemoryConsolidationProposal, 0, len(raw))
 	seen := make(map[string]struct{}, len(raw))
 	for _, value := range raw {
 		proposal, err := value.normalized()
-		if err != nil || len(proposal.Evidence) > e.policy.MaxEvidencePerProposal {
+		if err != nil || len(proposal.Evidence) > maxEvidencePerProposal {
 			return nil, errors.New("consolidation output is invalid")
 		}
 		_, payloadSHA := memoryProposalPayloadSHA("00000000-0000-4000-8000-000000000001", proposal.Action, proposal.Steps, proposal.Evidence)

--- a/internal/postgres/brain_consolidation_executor.go
+++ b/internal/postgres/brain_consolidation_executor.go
@@ -55,8 +55,8 @@ func (request MemoryConsolidationExecutionRequest) valid() bool {
 
 type memoryConsolidationExecutorStore interface {
 	readMemoryConsolidationInput(context.Context, MemoryConsolidationLease, int) (MemoryConsolidationInput, error)
-	LoadMemoryConsolidationPass(context.Context, MemoryConsolidationLease, MemoryConsolidationExecutionRequest) (MemoryConsolidationInput, []MemoryConsolidationProposal, bool, error)
-	ReserveMemoryConsolidationPass(context.Context, MemoryConsolidationInput, MemoryConsolidationExecutionRequest, []MemoryConsolidationProposal) (MemoryConsolidationInput, []MemoryConsolidationProposal, error)
+	LoadMemoryConsolidationPass(context.Context, MemoryConsolidationLease, MemoryConsolidationExecutionRequest) (MemoryConsolidationInput, MemoryConsolidationExecutionRequest, []MemoryConsolidationProposal, bool, error)
+	ReserveMemoryConsolidationPass(context.Context, MemoryConsolidationInput, MemoryConsolidationExecutionRequest, []MemoryConsolidationProposal) (MemoryConsolidationInput, MemoryConsolidationExecutionRequest, []MemoryConsolidationProposal, error)
 	StageMemoryConsolidationProposal(context.Context, MemoryConsolidationProposalRequest) (MemoryProposalResult, error)
 	AbandonMemoryConsolidationPass(context.Context, MemoryConsolidationInput, MemoryConsolidationExecutionRequest) error
 	CompleteMemoryConsolidationPass(context.Context, MemoryConsolidationInput, MemoryConsolidationExecutionRequest) error
@@ -98,11 +98,12 @@ func (e *MemoryConsolidationExecutor) Execute(ctx context.Context, request Memor
 	lease := request.Lease
 	passCtx, cancel := context.WithTimeout(ctx, e.policy.PassTimeout)
 	defer cancel()
-	input, proposals, found, err := e.store.LoadMemoryConsolidationPass(passCtx, lease, request)
+	input, effectiveRequest, proposals, found, err := e.store.LoadMemoryConsolidationPass(passCtx, lease, request)
 	if err != nil {
 		return MemoryConsolidationExecutionResult{}, err
 	}
 	if !found {
+		effectiveRequest = request
 		input, err = e.store.readMemoryConsolidationInput(passCtx, lease, e.policy.MaxChanges)
 		if err != nil {
 			return MemoryConsolidationExecutionResult{}, err
@@ -123,7 +124,7 @@ func (e *MemoryConsolidationExecutor) Execute(ctx context.Context, request Memor
 		if len(input.Sources) == 0 && len(proposals) != 0 {
 			return MemoryConsolidationExecutionResult{}, errors.New("consolidation output requires source documents")
 		}
-		input, proposals, err = e.store.ReserveMemoryConsolidationPass(passCtx, input, request, proposals)
+		input, effectiveRequest, proposals, err = e.store.ReserveMemoryConsolidationPass(passCtx, input, request, proposals)
 		if err != nil {
 			return MemoryConsolidationExecutionResult{}, err
 		}
@@ -133,10 +134,10 @@ func (e *MemoryConsolidationExecutor) Execute(ctx context.Context, request Memor
 		return MemoryConsolidationExecutionResult{}, err
 	}
 	for ordinal, proposal := range proposals {
-		staged := MemoryProposalCreateRequest{PrincipalID: request.PrincipalID, ProjectID: request.ProjectID, IdempotencyKey: memoryConsolidationProposalIdempotencyKey(input, request.PrincipalID, request.ProjectID, ordinal), Action: proposal.Action, Steps: proposal.Steps, Evidence: proposal.Evidence}
+		staged := MemoryProposalCreateRequest{PrincipalID: effectiveRequest.PrincipalID, ProjectID: effectiveRequest.ProjectID, IdempotencyKey: memoryConsolidationProposalIdempotencyKey(input, effectiveRequest.PrincipalID, effectiveRequest.ProjectID, ordinal), Action: proposal.Action, Steps: proposal.Steps, Evidence: proposal.Evidence}
 		if _, err := e.store.StageMemoryConsolidationProposal(passCtx, MemoryConsolidationProposalRequest{Input: input, Proposal: staged}); err != nil {
 			if errors.Is(err, errMemoryConsolidationSourceStale) {
-				if abandonErr := e.store.AbandonMemoryConsolidationPass(passCtx, input, request); abandonErr != nil {
+				if abandonErr := e.store.AbandonMemoryConsolidationPass(passCtx, input, effectiveRequest); abandonErr != nil {
 					return MemoryConsolidationExecutionResult{}, abandonErr
 				}
 				return MemoryConsolidationExecutionResult{}, ErrStaleMemoryConsolidationLease
@@ -144,7 +145,7 @@ func (e *MemoryConsolidationExecutor) Execute(ctx context.Context, request Memor
 			return MemoryConsolidationExecutionResult{}, err
 		}
 	}
-	if err := e.store.CompleteMemoryConsolidationPass(passCtx, input, request); err != nil {
+	if err := e.store.CompleteMemoryConsolidationPass(passCtx, input, effectiveRequest); err != nil {
 		return MemoryConsolidationExecutionResult{}, err
 	}
 	return MemoryConsolidationExecutionResult{Sources: len(input.Sources), Staged: len(proposals), Advanced: true}, nil

--- a/internal/postgres/brain_consolidation_executor.go
+++ b/internal/postgres/brain_consolidation_executor.go
@@ -138,10 +138,10 @@ func (e *MemoryConsolidationExecutor) Execute(ctx context.Context, request Memor
 	if err != nil {
 		return MemoryConsolidationExecutionResult{}, err
 	}
-	if !found {
-		if err := e.store.CheckMemoryConsolidationPassCapacity(passCtx, input, effectiveRequest, len(proposals)); err != nil {
-			return MemoryConsolidationExecutionResult{}, err
-		}
+	// A pass is durable before its first capacity check. Recheck it on every
+	// replay so a capacity-rejected pass cannot later begin partial staging.
+	if err := e.store.CheckMemoryConsolidationPassCapacity(passCtx, input, effectiveRequest, len(proposals)); err != nil {
+		return MemoryConsolidationExecutionResult{}, err
 	}
 	for ordinal, proposal := range proposals {
 		staged := MemoryProposalCreateRequest{PrincipalID: effectiveRequest.PrincipalID, ProjectID: effectiveRequest.ProjectID, IdempotencyKey: memoryConsolidationProposalIdempotencyKey(input, effectiveRequest.PrincipalID, effectiveRequest.ProjectID, ordinal), Action: proposal.Action, Steps: proposal.Steps, Evidence: proposal.Evidence}

--- a/internal/postgres/brain_consolidation_executor.go
+++ b/internal/postgres/brain_consolidation_executor.go
@@ -54,7 +54,7 @@ func (request MemoryConsolidationExecutionRequest) valid() bool {
 }
 
 type memoryConsolidationExecutorStore interface {
-	ReadMemoryConsolidationInput(context.Context, MemoryConsolidationLease) (MemoryConsolidationInput, error)
+	readMemoryConsolidationInput(context.Context, MemoryConsolidationLease, int) (MemoryConsolidationInput, error)
 	LoadMemoryConsolidationPass(context.Context, MemoryConsolidationLease, MemoryConsolidationExecutionRequest) (MemoryConsolidationInput, []MemoryConsolidationProposal, bool, error)
 	ReserveMemoryConsolidationPass(context.Context, MemoryConsolidationInput, MemoryConsolidationExecutionRequest, []MemoryConsolidationProposal) (MemoryConsolidationInput, []MemoryConsolidationProposal, error)
 	StageMemoryConsolidationProposal(context.Context, MemoryConsolidationProposalRequest) (MemoryProposalResult, error)
@@ -103,7 +103,7 @@ func (e *MemoryConsolidationExecutor) Execute(ctx context.Context, request Memor
 		return MemoryConsolidationExecutionResult{}, err
 	}
 	if !found {
-		input, err = e.store.ReadMemoryConsolidationInput(passCtx, lease)
+		input, err = e.store.readMemoryConsolidationInput(passCtx, lease, e.policy.MaxChanges)
 		if err != nil {
 			return MemoryConsolidationExecutionResult{}, err
 		}

--- a/internal/postgres/brain_consolidation_executor_test.go
+++ b/internal/postgres/brain_consolidation_executor_test.go
@@ -108,6 +108,8 @@ func TestMemoryConsolidationExecutorReplaysDurablePassWhenPlannerOutputChanges(t
 	if _, err := executor.Execute(context.Background(), testMemoryConsolidationExecutionRequest(lease)); err == nil {
 		t.Fatal("first pass unexpectedly completed")
 	}
+	store.input.NextSequence = 6
+	store.input.Sources = append(store.input.Sources, MemoryConsolidationSource{ItemID: "88888888-8888-4888-8888-888888888888", Revision: 1, ChangeSequence: 6, Document: json.RawMessage(`{"new":true}`)})
 	if result, err := executor.Execute(context.Background(), testMemoryConsolidationExecutionRequest(lease)); err != nil || !result.Advanced {
 		t.Fatalf("replay result=%#v err=%v", result, err)
 	}
@@ -152,17 +154,24 @@ type fakeMemoryConsolidationExecutorStore struct {
 	stageErr      error
 	stagedKeys    map[string]struct{}
 	pass          []MemoryConsolidationProposal
+	passInput     MemoryConsolidationInput
 }
 
 func (s *fakeMemoryConsolidationExecutorStore) ReadMemoryConsolidationInput(context.Context, MemoryConsolidationLease) (MemoryConsolidationInput, error) {
 	return s.input, nil
 }
-func (s *fakeMemoryConsolidationExecutorStore) LoadMemoryConsolidationPass(context.Context, MemoryConsolidationInput, MemoryConsolidationExecutionRequest) ([]MemoryConsolidationProposal, bool, error) {
-	return s.pass, s.pass != nil, nil
+func (s *fakeMemoryConsolidationExecutorStore) LoadMemoryConsolidationPass(_ context.Context, lease MemoryConsolidationLease, _ MemoryConsolidationExecutionRequest) (MemoryConsolidationInput, []MemoryConsolidationProposal, bool, error) {
+	if s.pass == nil {
+		return MemoryConsolidationInput{}, nil, false, nil
+	}
+	input := s.passInput
+	input.Lease = lease
+	return input, s.pass, true, nil
 }
-func (s *fakeMemoryConsolidationExecutorStore) ReserveMemoryConsolidationPass(_ context.Context, _ MemoryConsolidationInput, _ MemoryConsolidationExecutionRequest, proposals []MemoryConsolidationProposal) ([]MemoryConsolidationProposal, error) {
+func (s *fakeMemoryConsolidationExecutorStore) ReserveMemoryConsolidationPass(_ context.Context, input MemoryConsolidationInput, _ MemoryConsolidationExecutionRequest, proposals []MemoryConsolidationProposal) ([]MemoryConsolidationProposal, error) {
 	if s.pass == nil {
 		s.pass = proposals
+		s.passInput = input
 	}
 	return s.pass, nil
 }

--- a/internal/postgres/brain_consolidation_executor_test.go
+++ b/internal/postgres/brain_consolidation_executor_test.go
@@ -146,10 +146,46 @@ func TestMemoryConsolidationExecutorAdvancesNoProposalPageButRejectsDuplicateOut
 	}
 }
 
+func TestMemoryConsolidationExecutorRejectsProposalsForSourceFreePage(t *testing.T) {
+	lease := MemoryConsolidationLease{ScopeID: "11111111-1111-4111-8111-111111111111", TimelineID: "22222222-2222-4222-8222-222222222222", Sequence: 4, Holder: "33333333-3333-4333-8333-333333333333", Token: "44444444-4444-4444-8444-444444444444", Generation: 1, Until: time.Now().Add(time.Minute)}
+	input := MemoryConsolidationInput{Lease: lease, TimelineID: lease.TimelineID, NextSequence: 5}
+	store := &fakeMemoryConsolidationExecutorStore{input: input}
+	planner := fakeMemoryConsolidationPlanner{proposals: []MemoryConsolidationProposal{{
+		Action: MemoryProposalCreate,
+		Steps:  []MemoryProposalStepInput{{Operation: MemoryProposalStepCreate, LogicalKey: "source-free", Kind: "brief", Trust: "proposed", Document: json.RawMessage(`{"summary":true}`)}},
+	}}}
+	executor, err := NewMemoryConsolidationExecutor(store, planner, MemoryConsolidationPolicy{MaxChanges: 1, MaxProposals: 1, MaxEvidencePerProposal: 1, PassTimeout: time.Second})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := executor.Execute(context.Background(), testMemoryConsolidationExecutionRequest(lease)); err == nil || store.pass != nil || store.advanced != 0 {
+		t.Fatalf("err=%v pass=%#v advanced=%d", err, store.pass, store.advanced)
+	}
+}
+
+func TestMemoryConsolidationExecutorAbandonsStaleReservedPass(t *testing.T) {
+	lease := MemoryConsolidationLease{ScopeID: "11111111-1111-4111-8111-111111111111", TimelineID: "22222222-2222-4222-8222-222222222222", Sequence: 4, Holder: "33333333-3333-4333-8333-333333333333", Token: "44444444-4444-4444-8444-444444444444", Generation: 1, Until: time.Now().Add(time.Minute)}
+	input := MemoryConsolidationInput{Lease: lease, TimelineID: lease.TimelineID, NextSequence: 5, Sources: []MemoryConsolidationSource{{ItemID: "55555555-5555-4555-8555-555555555555", Revision: 1, ChangeSequence: 5, Document: json.RawMessage(`{"source":true}`)}}}
+	proposal := MemoryConsolidationProposal{Action: MemoryProposalCreate, Steps: []MemoryProposalStepInput{{Operation: MemoryProposalStepCreate, LogicalKey: "stale-source", Kind: "brief", Trust: "proposed", Document: json.RawMessage(`{"summary":true}`)}}}
+	store := &fakeMemoryConsolidationExecutorStore{input: input, stageFailures: 1, stageErr: ErrStaleMemoryConsolidationLease}
+	planner := fakeMemoryConsolidationPlanner{proposals: []MemoryConsolidationProposal{proposal, {
+		Action: MemoryProposalCreate,
+		Steps:  []MemoryProposalStepInput{{Operation: MemoryProposalStepCreate, LogicalKey: "stale-source-second", Kind: "brief", Trust: "proposed", Document: json.RawMessage(`{"summary":true}`)}},
+	}}}
+	executor, err := NewMemoryConsolidationExecutor(store, planner, MemoryConsolidationPolicy{MaxChanges: 1, MaxProposals: 2, MaxEvidencePerProposal: 1, PassTimeout: time.Second})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := executor.Execute(context.Background(), testMemoryConsolidationExecutionRequest(lease)); !errors.Is(err, ErrStaleMemoryConsolidationLease) || !store.abandoned || store.advanced != 0 {
+		t.Fatalf("err=%v abandoned=%t advanced=%d", err, store.abandoned, store.advanced)
+	}
+}
+
 type fakeMemoryConsolidationExecutorStore struct {
 	input         MemoryConsolidationInput
 	staged        []MemoryConsolidationProposalRequest
 	advanced      int64
+	abandoned     bool
 	stageFailures int
 	stageErr      error
 	stagedKeys    map[string]struct{}
@@ -189,6 +225,11 @@ func (s *fakeMemoryConsolidationExecutorStore) StageMemoryConsolidationProposal(
 	s.stagedKeys[request.Proposal.IdempotencyKey] = struct{}{}
 	s.staged = append(s.staged, request)
 	return MemoryProposalResult{ProposalID: "99999999-9999-4999-8999-999999999999"}, nil
+}
+
+func (s *fakeMemoryConsolidationExecutorStore) AbandonMemoryConsolidationPass(context.Context, MemoryConsolidationInput, MemoryConsolidationExecutionRequest) error {
+	s.abandoned = true
+	return nil
 }
 func (s *fakeMemoryConsolidationExecutorStore) CompleteMemoryConsolidationPass(_ context.Context, input MemoryConsolidationInput, _ MemoryConsolidationExecutionRequest) error {
 	s.advanced = input.NextSequence

--- a/internal/postgres/brain_consolidation_executor_test.go
+++ b/internal/postgres/brain_consolidation_executor_test.go
@@ -262,8 +262,8 @@ type fakeMemoryConsolidationExecutorStore struct {
 	capacityErr   error
 }
 
-func (s *fakeMemoryConsolidationExecutorStore) CheckMemoryConsolidationPassCapacity(_ context.Context, _ MemoryConsolidationInput, _ MemoryConsolidationExecutionRequest, count int) error {
-	s.capacity = count
+func (s *fakeMemoryConsolidationExecutorStore) CheckMemoryConsolidationPassCapacity(_ context.Context, _ MemoryConsolidationInput, _ MemoryConsolidationExecutionRequest, proposals []MemoryConsolidationProposal) error {
+	s.capacity = len(proposals)
 	return s.capacityErr
 }
 

--- a/internal/postgres/brain_consolidation_executor_test.go
+++ b/internal/postgres/brain_consolidation_executor_test.go
@@ -181,6 +181,23 @@ func TestMemoryConsolidationExecutorAbandonsStaleReservedPass(t *testing.T) {
 	}
 }
 
+func TestMemoryConsolidationExecutorAbandonsPermanentlyRejectedReservedPass(t *testing.T) {
+	lease := MemoryConsolidationLease{ScopeID: "11111111-1111-4111-8111-111111111111", TimelineID: "22222222-2222-4222-8222-222222222222", Sequence: 4, Holder: "33333333-3333-4333-8333-333333333333", Token: "44444444-4444-4444-8444-444444444444", Generation: 1, Until: time.Now().Add(time.Minute)}
+	input := MemoryConsolidationInput{Lease: lease, TimelineID: lease.TimelineID, NextSequence: 5, Sources: []MemoryConsolidationSource{{ItemID: "55555555-5555-4555-8555-555555555555", Revision: 1, ChangeSequence: 5, Document: json.RawMessage(`{"source":true}`)}}}
+	proposal := MemoryConsolidationProposal{Action: MemoryProposalCreate, Steps: []MemoryProposalStepInput{{Operation: MemoryProposalStepCreate, LogicalKey: "rejected-source", Kind: "brief", Trust: "proposed", Document: json.RawMessage(`{"summary":true}`)}}}
+	store := &fakeMemoryConsolidationExecutorStore{input: input, stageFailures: 1, stageErr: errMemoryConsolidationProposalRejected}
+	executor, err := NewMemoryConsolidationExecutor(store, fakeMemoryConsolidationPlanner{proposals: []MemoryConsolidationProposal{proposal, {
+		Action: MemoryProposalCreate,
+		Steps:  []MemoryProposalStepInput{{Operation: MemoryProposalStepCreate, LogicalKey: "rejected-source-second", Kind: "brief", Trust: "proposed", Document: json.RawMessage(`{"summary":true}`)}},
+	}}}, MemoryConsolidationPolicy{MaxChanges: 1, MaxProposals: 2, MaxEvidencePerProposal: 1, PassTimeout: time.Second})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := executor.Execute(context.Background(), testMemoryConsolidationExecutionRequest(lease)); !errors.Is(err, ErrStaleMemoryConsolidationLease) || !store.abandoned || store.advanced != input.NextSequence {
+		t.Fatalf("err=%v abandoned=%t advanced=%d", err, store.abandoned, store.advanced)
+	}
+}
+
 type fakeMemoryConsolidationExecutorStore struct {
 	input         MemoryConsolidationInput
 	staged        []MemoryConsolidationProposalRequest

--- a/internal/postgres/brain_consolidation_executor_test.go
+++ b/internal/postgres/brain_consolidation_executor_test.go
@@ -191,6 +191,7 @@ type fakeMemoryConsolidationExecutorStore struct {
 	stagedKeys    map[string]struct{}
 	pass          []MemoryConsolidationProposal
 	passInput     MemoryConsolidationInput
+	passRequest   MemoryConsolidationExecutionRequest
 	readLimit     int
 }
 
@@ -198,20 +199,25 @@ func (s *fakeMemoryConsolidationExecutorStore) readMemoryConsolidationInput(_ co
 	s.readLimit = limit
 	return s.input, nil
 }
-func (s *fakeMemoryConsolidationExecutorStore) LoadMemoryConsolidationPass(_ context.Context, lease MemoryConsolidationLease, _ MemoryConsolidationExecutionRequest) (MemoryConsolidationInput, []MemoryConsolidationProposal, bool, error) {
+func (s *fakeMemoryConsolidationExecutorStore) LoadMemoryConsolidationPass(_ context.Context, lease MemoryConsolidationLease, request MemoryConsolidationExecutionRequest) (MemoryConsolidationInput, MemoryConsolidationExecutionRequest, []MemoryConsolidationProposal, bool, error) {
 	if s.pass == nil {
-		return MemoryConsolidationInput{}, nil, false, nil
+		return MemoryConsolidationInput{}, MemoryConsolidationExecutionRequest{}, nil, false, nil
 	}
 	input := s.passInput
 	input.Lease = lease
-	return input, s.pass, true, nil
+	if !s.passRequest.valid() {
+		s.passRequest = request
+		s.passRequest.Lease = lease
+	}
+	return input, s.passRequest, s.pass, true, nil
 }
-func (s *fakeMemoryConsolidationExecutorStore) ReserveMemoryConsolidationPass(_ context.Context, input MemoryConsolidationInput, _ MemoryConsolidationExecutionRequest, proposals []MemoryConsolidationProposal) (MemoryConsolidationInput, []MemoryConsolidationProposal, error) {
+func (s *fakeMemoryConsolidationExecutorStore) ReserveMemoryConsolidationPass(_ context.Context, input MemoryConsolidationInput, request MemoryConsolidationExecutionRequest, proposals []MemoryConsolidationProposal) (MemoryConsolidationInput, MemoryConsolidationExecutionRequest, []MemoryConsolidationProposal, error) {
 	if s.pass == nil {
 		s.pass = proposals
 		s.passInput = input
+		s.passRequest = request
 	}
-	return s.passInput, s.pass, nil
+	return s.passInput, s.passRequest, s.pass, nil
 }
 func (s *fakeMemoryConsolidationExecutorStore) StageMemoryConsolidationProposal(_ context.Context, request MemoryConsolidationProposalRequest) (MemoryProposalResult, error) {
 	if s.stageFailures > 0 && len(s.staged) == 1 && s.stageErr != nil {

--- a/internal/postgres/brain_consolidation_executor_test.go
+++ b/internal/postgres/brain_consolidation_executor_test.go
@@ -167,7 +167,7 @@ func TestMemoryConsolidationExecutorAbandonsStaleReservedPass(t *testing.T) {
 	lease := MemoryConsolidationLease{ScopeID: "11111111-1111-4111-8111-111111111111", TimelineID: "22222222-2222-4222-8222-222222222222", Sequence: 4, Holder: "33333333-3333-4333-8333-333333333333", Token: "44444444-4444-4444-8444-444444444444", Generation: 1, Until: time.Now().Add(time.Minute)}
 	input := MemoryConsolidationInput{Lease: lease, TimelineID: lease.TimelineID, NextSequence: 5, Sources: []MemoryConsolidationSource{{ItemID: "55555555-5555-4555-8555-555555555555", Revision: 1, ChangeSequence: 5, Document: json.RawMessage(`{"source":true}`)}}}
 	proposal := MemoryConsolidationProposal{Action: MemoryProposalCreate, Steps: []MemoryProposalStepInput{{Operation: MemoryProposalStepCreate, LogicalKey: "stale-source", Kind: "brief", Trust: "proposed", Document: json.RawMessage(`{"summary":true}`)}}}
-	store := &fakeMemoryConsolidationExecutorStore{input: input, stageFailures: 1, stageErr: ErrStaleMemoryConsolidationLease}
+	store := &fakeMemoryConsolidationExecutorStore{input: input, stageFailures: 1, stageErr: errMemoryConsolidationSourceStale}
 	planner := fakeMemoryConsolidationPlanner{proposals: []MemoryConsolidationProposal{proposal, {
 		Action: MemoryProposalCreate,
 		Steps:  []MemoryProposalStepInput{{Operation: MemoryProposalStepCreate, LogicalKey: "stale-source-second", Kind: "brief", Trust: "proposed", Document: json.RawMessage(`{"summary":true}`)}},

--- a/internal/postgres/brain_consolidation_executor_test.go
+++ b/internal/postgres/brain_consolidation_executor_test.go
@@ -1,0 +1,162 @@
+package postgres
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"reflect"
+	"testing"
+	"time"
+)
+
+func TestMemoryConsolidationExecutorStagesWholePageBeforeAdvancing(t *testing.T) {
+	lease := MemoryConsolidationLease{
+		ScopeID: "11111111-1111-4111-8111-111111111111", TimelineID: "22222222-2222-4222-8222-222222222222", Sequence: 4,
+		Holder: "33333333-3333-4333-8333-333333333333", Token: "44444444-4444-4444-8444-444444444444", Generation: 1, Until: time.Now().Add(time.Minute),
+	}
+	input := MemoryConsolidationInput{Lease: lease, TimelineID: lease.TimelineID, NextSequence: 5, Sources: []MemoryConsolidationSource{{
+		ItemID: "55555555-5555-4555-8555-555555555555", Revision: 1, ChangeSequence: 5, Document: json.RawMessage(`{"source":true}`),
+	}}}
+	store := &fakeMemoryConsolidationExecutorStore{input: input}
+	planner := fakeMemoryConsolidationPlanner{proposals: []MemoryConsolidationProposal{{
+		Action: MemoryProposalCreate, Steps: []MemoryProposalStepInput{{Operation: MemoryProposalStepCreate, LogicalKey: "consolidation.current", Kind: "brief", Trust: "proposed", Document: json.RawMessage(`{"summary":true}`)}},
+	}}}
+	executor, err := NewMemoryConsolidationExecutor(store, planner, MemoryConsolidationPolicy{MaxChanges: 1, MaxProposals: 1, MaxEvidencePerProposal: 1, PassTimeout: time.Second})
+	if err != nil {
+		t.Fatal(err)
+	}
+	result, err := executor.Execute(context.Background(), testMemoryConsolidationExecutionRequest(lease))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Sources != 1 || result.Staged != 1 || !result.Advanced || len(store.staged) != 1 || store.advanced != input.NextSequence {
+		t.Fatalf("result=%#v staged=%#v advanced=%d", result, store.staged, store.advanced)
+	}
+	if got := store.staged[0]; !reflect.DeepEqual(got.Input, input) || got.Proposal.PrincipalID != "66666666-6666-4666-8666-666666666666" || got.Proposal.ProjectID != "77777777-7777-4777-8777-777777777777" || got.Proposal.IdempotencyKey == "" {
+		t.Fatalf("staged request=%#v", got)
+	}
+}
+
+func TestMemoryConsolidationExecutorDoesNotAdvancePartialOrInvalidPass(t *testing.T) {
+	lease := MemoryConsolidationLease{
+		ScopeID: "11111111-1111-4111-8111-111111111111", TimelineID: "22222222-2222-4222-8222-222222222222", Sequence: 4,
+		Holder: "33333333-3333-4333-8333-333333333333", Token: "44444444-4444-4444-8444-444444444444", Generation: 1, Until: time.Now().Add(time.Minute),
+	}
+	input := MemoryConsolidationInput{Lease: lease, TimelineID: lease.TimelineID, NextSequence: 5, Sources: []MemoryConsolidationSource{{
+		ItemID: "55555555-5555-4555-8555-555555555555", Revision: 1, ChangeSequence: 5, Document: json.RawMessage(`{"source":true}`),
+	}}}
+	for name, planner := range map[string]fakeMemoryConsolidationPlanner{
+		"planner failure": {err: errors.New("provider unavailable")},
+		"over budget":     {proposals: []MemoryConsolidationProposal{{}, {}}},
+	} {
+		t.Run(name, func(t *testing.T) {
+			store := &fakeMemoryConsolidationExecutorStore{input: input}
+			executor, err := NewMemoryConsolidationExecutor(store, planner, MemoryConsolidationPolicy{MaxChanges: 1, MaxProposals: 1, MaxEvidencePerProposal: 1, PassTimeout: time.Second})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if _, err := executor.Execute(context.Background(), testMemoryConsolidationExecutionRequest(lease)); err == nil || store.advanced != 0 || len(store.staged) != 0 {
+				t.Fatalf("err=%v staged=%#v advanced=%d", err, store.staged, store.advanced)
+			}
+		})
+	}
+}
+
+func TestMemoryConsolidationExecutorDoesNotAdvanceAfterPartialStageFailure(t *testing.T) {
+	lease := MemoryConsolidationLease{
+		ScopeID: "11111111-1111-4111-8111-111111111111", TimelineID: "22222222-2222-4222-8222-222222222222", Sequence: 4,
+		Holder: "33333333-3333-4333-8333-333333333333", Token: "44444444-4444-4444-8444-444444444444", Generation: 1, Until: time.Now().Add(time.Minute),
+	}
+	input := MemoryConsolidationInput{Lease: lease, TimelineID: lease.TimelineID, NextSequence: 5, Sources: []MemoryConsolidationSource{{
+		ItemID: "55555555-5555-4555-8555-555555555555", Revision: 1, ChangeSequence: 5, Document: json.RawMessage(`{"source":true}`),
+	}}}
+	proposal := func(logicalKey string) MemoryConsolidationProposal {
+		return MemoryConsolidationProposal{Action: MemoryProposalCreate, Steps: []MemoryProposalStepInput{{Operation: MemoryProposalStepCreate, LogicalKey: logicalKey, Kind: "brief", Trust: "proposed", Document: json.RawMessage(`{"summary":true}`)}}}
+	}
+	store := &fakeMemoryConsolidationExecutorStore{input: input, stageFailures: 1, stageErr: errors.New("stage unavailable")}
+	executor, err := NewMemoryConsolidationExecutor(store, fakeMemoryConsolidationPlanner{proposals: []MemoryConsolidationProposal{
+		proposal("consolidation.a"), proposal("consolidation.b"),
+	}}, MemoryConsolidationPolicy{MaxChanges: 1, MaxProposals: 2, MaxEvidencePerProposal: 1, PassTimeout: time.Second})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := executor.Execute(context.Background(), testMemoryConsolidationExecutionRequest(lease)); err == nil || len(store.staged) != 1 || store.advanced != 0 {
+		t.Fatalf("err=%v staged=%#v advanced=%d", err, store.staged, store.advanced)
+	}
+	if result, err := executor.Execute(context.Background(), testMemoryConsolidationExecutionRequest(lease)); err != nil || len(store.staged) != 2 || !result.Advanced || store.advanced != input.NextSequence {
+		t.Fatalf("replay result=%#v err=%v staged=%#v advanced=%d", result, err, store.staged, store.advanced)
+	}
+}
+
+func TestMemoryConsolidationExecutorAdvancesNoProposalPageButRejectsDuplicateOutput(t *testing.T) {
+	lease := MemoryConsolidationLease{
+		ScopeID: "11111111-1111-4111-8111-111111111111", TimelineID: "22222222-2222-4222-8222-222222222222", Sequence: 4,
+		Holder: "33333333-3333-4333-8333-333333333333", Token: "44444444-4444-4444-8444-444444444444", Generation: 1, Until: time.Now().Add(time.Minute),
+	}
+	input := MemoryConsolidationInput{Lease: lease, TimelineID: lease.TimelineID, NextSequence: 5, Sources: []MemoryConsolidationSource{{
+		ItemID: "55555555-5555-4555-8555-555555555555", Revision: 1, ChangeSequence: 5, Document: json.RawMessage(`{"source":true}`),
+	}}}
+	policy := MemoryConsolidationPolicy{MaxChanges: 1, MaxProposals: 2, MaxEvidencePerProposal: 1, PassTimeout: time.Second}
+	store := &fakeMemoryConsolidationExecutorStore{input: input}
+	executor, err := NewMemoryConsolidationExecutor(store, fakeMemoryConsolidationPlanner{}, policy)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result, err := executor.Execute(context.Background(), testMemoryConsolidationExecutionRequest(lease)); err != nil || result.Staged != 0 || !result.Advanced || store.advanced != input.NextSequence {
+		t.Fatalf("no proposal result=%#v err=%v advanced=%d", result, err, store.advanced)
+	}
+	proposal := MemoryConsolidationProposal{Action: MemoryProposalCreate, Steps: []MemoryProposalStepInput{{Operation: MemoryProposalStepCreate, LogicalKey: "consolidation.duplicate", Kind: "brief", Trust: "proposed", Document: json.RawMessage(`{"summary":true}`)}}}
+	store = &fakeMemoryConsolidationExecutorStore{input: input}
+	executor, err = NewMemoryConsolidationExecutor(store, fakeMemoryConsolidationPlanner{proposals: []MemoryConsolidationProposal{proposal, proposal}}, policy)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := executor.Execute(context.Background(), testMemoryConsolidationExecutionRequest(lease)); err == nil || len(store.staged) != 0 || store.advanced != 0 {
+		t.Fatalf("duplicate bodies error=%v staged=%#v advanced=%d", err, store.staged, store.advanced)
+	}
+}
+
+type fakeMemoryConsolidationExecutorStore struct {
+	input         MemoryConsolidationInput
+	staged        []MemoryConsolidationProposalRequest
+	advanced      int64
+	stageFailures int
+	stageErr      error
+	stagedKeys    map[string]struct{}
+}
+
+func (s *fakeMemoryConsolidationExecutorStore) ReadMemoryConsolidationInput(context.Context, MemoryConsolidationLease) (MemoryConsolidationInput, error) {
+	return s.input, nil
+}
+func (s *fakeMemoryConsolidationExecutorStore) StageMemoryConsolidationProposal(_ context.Context, request MemoryConsolidationProposalRequest) (MemoryProposalResult, error) {
+	if s.stageFailures > 0 && len(s.staged) == 1 && s.stageErr != nil {
+		s.stageFailures--
+		return MemoryProposalResult{}, s.stageErr
+	}
+	if s.stagedKeys == nil {
+		s.stagedKeys = make(map[string]struct{})
+	}
+	if _, exists := s.stagedKeys[request.Proposal.IdempotencyKey]; exists {
+		return MemoryProposalResult{ProposalID: "99999999-9999-4999-8999-999999999999"}, nil
+	}
+	s.stagedKeys[request.Proposal.IdempotencyKey] = struct{}{}
+	s.staged = append(s.staged, request)
+	return MemoryProposalResult{ProposalID: "99999999-9999-4999-8999-999999999999"}, nil
+}
+func (s *fakeMemoryConsolidationExecutorStore) AdvanceMemoryConsolidationCheckpoint(_ context.Context, _ MemoryConsolidationLease, _ string, sequence int64) error {
+	s.advanced = sequence
+	return nil
+}
+
+type fakeMemoryConsolidationPlanner struct {
+	proposals []MemoryConsolidationProposal
+	err       error
+}
+
+func (p fakeMemoryConsolidationPlanner) Propose(context.Context, MemoryConsolidationInput) ([]MemoryConsolidationProposal, error) {
+	return p.proposals, p.err
+}
+
+func testMemoryConsolidationExecutionRequest(lease MemoryConsolidationLease) MemoryConsolidationExecutionRequest {
+	return MemoryConsolidationExecutionRequest{Lease: lease, PrincipalID: "66666666-6666-4666-8666-666666666666", ProjectID: "77777777-7777-4777-8777-777777777777"}
+}

--- a/internal/postgres/brain_consolidation_executor_test.go
+++ b/internal/postgres/brain_consolidation_executor_test.go
@@ -168,12 +168,12 @@ func (s *fakeMemoryConsolidationExecutorStore) LoadMemoryConsolidationPass(_ con
 	input.Lease = lease
 	return input, s.pass, true, nil
 }
-func (s *fakeMemoryConsolidationExecutorStore) ReserveMemoryConsolidationPass(_ context.Context, input MemoryConsolidationInput, _ MemoryConsolidationExecutionRequest, proposals []MemoryConsolidationProposal) ([]MemoryConsolidationProposal, error) {
+func (s *fakeMemoryConsolidationExecutorStore) ReserveMemoryConsolidationPass(_ context.Context, input MemoryConsolidationInput, _ MemoryConsolidationExecutionRequest, proposals []MemoryConsolidationProposal) (MemoryConsolidationInput, []MemoryConsolidationProposal, error) {
 	if s.pass == nil {
 		s.pass = proposals
 		s.passInput = input
 	}
-	return s.pass, nil
+	return s.passInput, s.pass, nil
 }
 func (s *fakeMemoryConsolidationExecutorStore) StageMemoryConsolidationProposal(_ context.Context, request MemoryConsolidationProposalRequest) (MemoryProposalResult, error) {
 	if s.stageFailures > 0 && len(s.staged) == 1 && s.stageErr != nil {

--- a/internal/postgres/brain_consolidation_executor_test.go
+++ b/internal/postgres/brain_consolidation_executor_test.go
@@ -138,6 +138,20 @@ func TestMemoryConsolidationExecutorReplaysReservedPassAfterPolicyTightens(t *te
 	}
 }
 
+func TestMemoryConsolidationExecutorRechecksCapacityForReservedPass(t *testing.T) {
+	lease := MemoryConsolidationLease{ScopeID: "11111111-1111-4111-8111-111111111111", TimelineID: "22222222-2222-4222-8222-222222222222", Sequence: 4, Holder: "33333333-3333-4333-8333-333333333333", Token: "44444444-4444-4444-8444-444444444444", Generation: 1, Until: time.Now().Add(time.Minute)}
+	input := MemoryConsolidationInput{Lease: lease, TimelineID: lease.TimelineID, NextSequence: 5, Sources: []MemoryConsolidationSource{{ItemID: "55555555-5555-4555-8555-555555555555", Revision: 1, ChangeSequence: 5, Document: json.RawMessage(`{"source":true}`)}}}
+	proposal := MemoryConsolidationProposal{Action: MemoryProposalCreate, Steps: []MemoryProposalStepInput{{Operation: MemoryProposalStepCreate, LogicalKey: "reserved", Kind: "brief", Trust: "proposed", Document: json.RawMessage(`{"summary":true}`)}}}
+	store := &fakeMemoryConsolidationExecutorStore{pass: []MemoryConsolidationProposal{proposal}, passInput: input, capacityErr: ErrMemoryProposalCapacity}
+	executor, err := NewMemoryConsolidationExecutor(store, fakeMemoryConsolidationPlanner{}, MemoryConsolidationPolicy{MaxChanges: 1, MaxProposals: 1, MaxEvidencePerProposal: 1, PassTimeout: time.Second})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := executor.Execute(context.Background(), testMemoryConsolidationExecutionRequest(lease)); !errors.Is(err, ErrMemoryProposalCapacity) || len(store.staged) != 0 || store.advanced != 0 || store.capacity != 1 {
+		t.Fatalf("err=%v staged=%#v advanced=%d capacity=%d", err, store.staged, store.advanced, store.capacity)
+	}
+}
+
 func TestMemoryConsolidationExecutorAdvancesNoProposalPageButRejectsDuplicateOutput(t *testing.T) {
 	lease := MemoryConsolidationLease{
 		ScopeID: "11111111-1111-4111-8111-111111111111", TimelineID: "22222222-2222-4222-8222-222222222222", Sequence: 4,
@@ -231,11 +245,12 @@ type fakeMemoryConsolidationExecutorStore struct {
 	passRequest   MemoryConsolidationExecutionRequest
 	readLimit     int
 	capacity      int
+	capacityErr   error
 }
 
 func (s *fakeMemoryConsolidationExecutorStore) CheckMemoryConsolidationPassCapacity(_ context.Context, _ MemoryConsolidationInput, _ MemoryConsolidationExecutionRequest, count int) error {
 	s.capacity = count
-	return nil
+	return s.capacityErr
 }
 
 func (s *fakeMemoryConsolidationExecutorStore) readMemoryConsolidationInput(_ context.Context, _ MemoryConsolidationLease, limit int) (MemoryConsolidationInput, error) {

--- a/internal/postgres/brain_consolidation_executor_test.go
+++ b/internal/postgres/brain_consolidation_executor_test.go
@@ -118,6 +118,26 @@ func TestMemoryConsolidationExecutorReplaysDurablePassWhenPlannerOutputChanges(t
 	}
 }
 
+func TestMemoryConsolidationExecutorReplaysReservedPassAfterPolicyTightens(t *testing.T) {
+	lease := MemoryConsolidationLease{ScopeID: "11111111-1111-4111-8111-111111111111", TimelineID: "22222222-2222-4222-8222-222222222222", Sequence: 4, Holder: "33333333-3333-4333-8333-333333333333", Token: "44444444-4444-4444-8444-444444444444", Generation: 1, Until: time.Now().Add(time.Minute)}
+	input := MemoryConsolidationInput{Lease: lease, TimelineID: lease.TimelineID, NextSequence: 6, Sources: []MemoryConsolidationSource{
+		{ItemID: "55555555-5555-4555-8555-555555555555", Revision: 1, ChangeSequence: 5, Document: json.RawMessage(`{"source":true}`)},
+		{ItemID: "66666666-6666-4666-8666-666666666666", Revision: 1, ChangeSequence: 6, Document: json.RawMessage(`{"source":true}`)},
+	}}
+	proposal := func(logicalKey string) MemoryConsolidationProposal {
+		return MemoryConsolidationProposal{Action: MemoryProposalCreate, Steps: []MemoryProposalStepInput{{Operation: MemoryProposalStepCreate, LogicalKey: logicalKey, Kind: "brief", Trust: "proposed", Document: json.RawMessage(`{"summary":true}`)}}}
+	}
+	store := &fakeMemoryConsolidationExecutorStore{pass: []MemoryConsolidationProposal{proposal("original-a"), proposal("original-b")}, passInput: input}
+	executor, err := NewMemoryConsolidationExecutor(store, fakeMemoryConsolidationPlanner{}, MemoryConsolidationPolicy{MaxChanges: 1, MaxProposals: 1, MaxEvidencePerProposal: 1, PassTimeout: time.Second})
+	if err != nil {
+		t.Fatal(err)
+	}
+	result, err := executor.Execute(context.Background(), testMemoryConsolidationExecutionRequest(lease))
+	if err != nil || !result.Advanced || len(store.staged) != 2 || store.advanced != input.NextSequence {
+		t.Fatalf("result=%#v err=%v staged=%#v advanced=%d", result, err, store.staged, store.advanced)
+	}
+}
+
 func TestMemoryConsolidationExecutorAdvancesNoProposalPageButRejectsDuplicateOutput(t *testing.T) {
 	lease := MemoryConsolidationLease{
 		ScopeID: "11111111-1111-4111-8111-111111111111", TimelineID: "22222222-2222-4222-8222-222222222222", Sequence: 4,
@@ -195,6 +215,12 @@ func TestMemoryConsolidationExecutorAbandonsPermanentlyRejectedReservedPass(t *t
 	}
 	if _, err := executor.Execute(context.Background(), testMemoryConsolidationExecutionRequest(lease)); !errors.Is(err, ErrStaleMemoryConsolidationLease) || !store.abandoned || store.advanced != input.NextSequence {
 		t.Fatalf("err=%v abandoned=%t advanced=%d", err, store.abandoned, store.advanced)
+	}
+}
+
+func TestMemoryConsolidationStageErrorMarksAuthorizationRejectionPermanent(t *testing.T) {
+	if err := memoryConsolidationStageError(ErrNotFound); !errors.Is(err, errMemoryConsolidationProposalRejected) || !errors.Is(err, ErrNotFound) {
+		t.Fatalf("authorization error=%v", err)
 	}
 }
 

--- a/internal/postgres/brain_consolidation_executor_test.go
+++ b/internal/postgres/brain_consolidation_executor_test.go
@@ -230,6 +230,12 @@ type fakeMemoryConsolidationExecutorStore struct {
 	passInput     MemoryConsolidationInput
 	passRequest   MemoryConsolidationExecutionRequest
 	readLimit     int
+	capacity      int
+}
+
+func (s *fakeMemoryConsolidationExecutorStore) CheckMemoryConsolidationPassCapacity(_ context.Context, _ MemoryConsolidationInput, _ MemoryConsolidationExecutionRequest, count int) error {
+	s.capacity = count
+	return nil
 }
 
 func (s *fakeMemoryConsolidationExecutorStore) readMemoryConsolidationInput(_ context.Context, _ MemoryConsolidationLease, limit int) (MemoryConsolidationInput, error) {

--- a/internal/postgres/brain_consolidation_executor_test.go
+++ b/internal/postgres/brain_consolidation_executor_test.go
@@ -176,7 +176,7 @@ func TestMemoryConsolidationExecutorAbandonsStaleReservedPass(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, err := executor.Execute(context.Background(), testMemoryConsolidationExecutionRequest(lease)); !errors.Is(err, ErrStaleMemoryConsolidationLease) || !store.abandoned || store.advanced != 0 {
+	if _, err := executor.Execute(context.Background(), testMemoryConsolidationExecutionRequest(lease)); !errors.Is(err, ErrStaleMemoryConsolidationLease) || !store.abandoned || store.advanced != input.NextSequence {
 		t.Fatalf("err=%v abandoned=%t advanced=%d", err, store.abandoned, store.advanced)
 	}
 }
@@ -227,8 +227,9 @@ func (s *fakeMemoryConsolidationExecutorStore) StageMemoryConsolidationProposal(
 	return MemoryProposalResult{ProposalID: "99999999-9999-4999-8999-999999999999"}, nil
 }
 
-func (s *fakeMemoryConsolidationExecutorStore) AbandonMemoryConsolidationPass(context.Context, MemoryConsolidationInput, MemoryConsolidationExecutionRequest) error {
+func (s *fakeMemoryConsolidationExecutorStore) AbandonMemoryConsolidationPass(_ context.Context, input MemoryConsolidationInput, _ MemoryConsolidationExecutionRequest) error {
 	s.abandoned = true
+	s.advanced = input.NextSequence
 	return nil
 }
 func (s *fakeMemoryConsolidationExecutorStore) CompleteMemoryConsolidationPass(_ context.Context, input MemoryConsolidationInput, _ MemoryConsolidationExecutionRequest) error {

--- a/internal/postgres/brain_consolidation_executor_test.go
+++ b/internal/postgres/brain_consolidation_executor_test.go
@@ -88,6 +88,34 @@ func TestMemoryConsolidationExecutorDoesNotAdvanceAfterPartialStageFailure(t *te
 	}
 }
 
+func TestMemoryConsolidationExecutorReplaysDurablePassWhenPlannerOutputChanges(t *testing.T) {
+	lease := MemoryConsolidationLease{
+		ScopeID: "11111111-1111-4111-8111-111111111111", TimelineID: "22222222-2222-4222-8222-222222222222", Sequence: 4,
+		Holder: "33333333-3333-4333-8333-333333333333", Token: "44444444-4444-4444-8444-444444444444", Generation: 1, Until: time.Now().Add(time.Minute),
+	}
+	input := MemoryConsolidationInput{Lease: lease, TimelineID: lease.TimelineID, NextSequence: 5, Sources: []MemoryConsolidationSource{{
+		ItemID: "55555555-5555-4555-8555-555555555555", Revision: 1, ChangeSequence: 5, Document: json.RawMessage(`{"source":true}`),
+	}}}
+	proposal := func(logicalKey string) MemoryConsolidationProposal {
+		return MemoryConsolidationProposal{Action: MemoryProposalCreate, Steps: []MemoryProposalStepInput{{Operation: MemoryProposalStepCreate, LogicalKey: logicalKey, Kind: "brief", Trust: "proposed", Document: json.RawMessage(`{"summary":true}`)}}}
+	}
+	store := &fakeMemoryConsolidationExecutorStore{input: input, stageFailures: 1, stageErr: errors.New("stage unavailable")}
+	planner := &changingMemoryConsolidationPlanner{outputs: [][]MemoryConsolidationProposal{{proposal("consolidation.original-a"), proposal("consolidation.original-b")}, {proposal("consolidation.replacement")}}}
+	executor, err := NewMemoryConsolidationExecutor(store, planner, MemoryConsolidationPolicy{MaxChanges: 1, MaxProposals: 2, MaxEvidencePerProposal: 1, PassTimeout: time.Second})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := executor.Execute(context.Background(), testMemoryConsolidationExecutionRequest(lease)); err == nil {
+		t.Fatal("first pass unexpectedly completed")
+	}
+	if result, err := executor.Execute(context.Background(), testMemoryConsolidationExecutionRequest(lease)); err != nil || !result.Advanced {
+		t.Fatalf("replay result=%#v err=%v", result, err)
+	}
+	if planner.calls != 1 || len(store.staged) != 2 || store.staged[0].Proposal.Steps[0].LogicalKey != "consolidation.original-a" || store.staged[1].Proposal.Steps[0].LogicalKey != "consolidation.original-b" {
+		t.Fatalf("planner calls=%d staged=%#v", planner.calls, store.staged)
+	}
+}
+
 func TestMemoryConsolidationExecutorAdvancesNoProposalPageButRejectsDuplicateOutput(t *testing.T) {
 	lease := MemoryConsolidationLease{
 		ScopeID: "11111111-1111-4111-8111-111111111111", TimelineID: "22222222-2222-4222-8222-222222222222", Sequence: 4,
@@ -123,10 +151,20 @@ type fakeMemoryConsolidationExecutorStore struct {
 	stageFailures int
 	stageErr      error
 	stagedKeys    map[string]struct{}
+	pass          []MemoryConsolidationProposal
 }
 
 func (s *fakeMemoryConsolidationExecutorStore) ReadMemoryConsolidationInput(context.Context, MemoryConsolidationLease) (MemoryConsolidationInput, error) {
 	return s.input, nil
+}
+func (s *fakeMemoryConsolidationExecutorStore) LoadMemoryConsolidationPass(context.Context, MemoryConsolidationInput, MemoryConsolidationExecutionRequest) ([]MemoryConsolidationProposal, bool, error) {
+	return s.pass, s.pass != nil, nil
+}
+func (s *fakeMemoryConsolidationExecutorStore) ReserveMemoryConsolidationPass(_ context.Context, _ MemoryConsolidationInput, _ MemoryConsolidationExecutionRequest, proposals []MemoryConsolidationProposal) ([]MemoryConsolidationProposal, error) {
+	if s.pass == nil {
+		s.pass = proposals
+	}
+	return s.pass, nil
 }
 func (s *fakeMemoryConsolidationExecutorStore) StageMemoryConsolidationProposal(_ context.Context, request MemoryConsolidationProposalRequest) (MemoryProposalResult, error) {
 	if s.stageFailures > 0 && len(s.staged) == 1 && s.stageErr != nil {
@@ -143,8 +181,9 @@ func (s *fakeMemoryConsolidationExecutorStore) StageMemoryConsolidationProposal(
 	s.staged = append(s.staged, request)
 	return MemoryProposalResult{ProposalID: "99999999-9999-4999-8999-999999999999"}, nil
 }
-func (s *fakeMemoryConsolidationExecutorStore) AdvanceMemoryConsolidationCheckpoint(_ context.Context, _ MemoryConsolidationLease, _ string, sequence int64) error {
-	s.advanced = sequence
+func (s *fakeMemoryConsolidationExecutorStore) CompleteMemoryConsolidationPass(_ context.Context, input MemoryConsolidationInput, _ MemoryConsolidationExecutionRequest) error {
+	s.advanced = input.NextSequence
+	s.pass = nil
 	return nil
 }
 
@@ -155,6 +194,17 @@ type fakeMemoryConsolidationPlanner struct {
 
 func (p fakeMemoryConsolidationPlanner) Propose(context.Context, MemoryConsolidationInput) ([]MemoryConsolidationProposal, error) {
 	return p.proposals, p.err
+}
+
+type changingMemoryConsolidationPlanner struct {
+	outputs [][]MemoryConsolidationProposal
+	calls   int
+}
+
+func (p *changingMemoryConsolidationPlanner) Propose(context.Context, MemoryConsolidationInput) ([]MemoryConsolidationProposal, error) {
+	output := p.outputs[p.calls]
+	p.calls++
+	return output, nil
 }
 
 func testMemoryConsolidationExecutionRequest(lease MemoryConsolidationLease) MemoryConsolidationExecutionRequest {

--- a/internal/postgres/brain_consolidation_executor_test.go
+++ b/internal/postgres/brain_consolidation_executor_test.go
@@ -152,6 +152,20 @@ func TestMemoryConsolidationExecutorRechecksCapacityForReservedPass(t *testing.T
 	}
 }
 
+func TestMemoryConsolidationExecutorAbandonsReservedPassWithInactionableProposal(t *testing.T) {
+	lease := MemoryConsolidationLease{ScopeID: "11111111-1111-4111-8111-111111111111", TimelineID: "22222222-2222-4222-8222-222222222222", Sequence: 4, Holder: "33333333-3333-4333-8333-333333333333", Token: "44444444-4444-4444-8444-444444444444", Generation: 1, Until: time.Now().Add(time.Minute)}
+	input := MemoryConsolidationInput{Lease: lease, TimelineID: lease.TimelineID, NextSequence: 5, Sources: []MemoryConsolidationSource{{ItemID: "55555555-5555-4555-8555-555555555555", Revision: 1, ChangeSequence: 5, Document: json.RawMessage(`{"source":true}`)}}}
+	proposal := MemoryConsolidationProposal{Action: MemoryProposalCreate, Steps: []MemoryProposalStepInput{{Operation: MemoryProposalStepCreate, LogicalKey: "reserved", Kind: "brief", Trust: "proposed", Document: json.RawMessage(`{"summary":true}`)}}}
+	store := &fakeMemoryConsolidationExecutorStore{pass: []MemoryConsolidationProposal{proposal}, passInput: input, capacityErr: errMemoryConsolidationProposalRejected}
+	executor, err := NewMemoryConsolidationExecutor(store, fakeMemoryConsolidationPlanner{}, MemoryConsolidationPolicy{MaxChanges: 1, MaxProposals: 1, MaxEvidencePerProposal: 1, PassTimeout: time.Second})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := executor.Execute(context.Background(), testMemoryConsolidationExecutionRequest(lease)); !errors.Is(err, ErrStaleMemoryConsolidationLease) || !store.abandoned || len(store.staged) != 0 {
+		t.Fatalf("err=%v abandoned=%t staged=%#v", err, store.abandoned, store.staged)
+	}
+}
+
 func TestMemoryConsolidationExecutorAdvancesNoProposalPageButRejectsDuplicateOutput(t *testing.T) {
 	lease := MemoryConsolidationLease{
 		ScopeID: "11111111-1111-4111-8111-111111111111", TimelineID: "22222222-2222-4222-8222-222222222222", Sequence: 4,

--- a/internal/postgres/brain_consolidation_executor_test.go
+++ b/internal/postgres/brain_consolidation_executor_test.go
@@ -218,12 +218,6 @@ func TestMemoryConsolidationExecutorAbandonsPermanentlyRejectedReservedPass(t *t
 	}
 }
 
-func TestMemoryConsolidationStageErrorMarksAuthorizationRejectionPermanent(t *testing.T) {
-	if err := memoryConsolidationStageError(ErrNotFound); !errors.Is(err, errMemoryConsolidationProposalRejected) || !errors.Is(err, ErrNotFound) {
-		t.Fatalf("authorization error=%v", err)
-	}
-}
-
 type fakeMemoryConsolidationExecutorStore struct {
 	input         MemoryConsolidationInput
 	staged        []MemoryConsolidationProposalRequest

--- a/internal/postgres/brain_consolidation_executor_test.go
+++ b/internal/postgres/brain_consolidation_executor_test.go
@@ -29,8 +29,8 @@ func TestMemoryConsolidationExecutorStagesWholePageBeforeAdvancing(t *testing.T)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if result.Sources != 1 || result.Staged != 1 || !result.Advanced || len(store.staged) != 1 || store.advanced != input.NextSequence {
-		t.Fatalf("result=%#v staged=%#v advanced=%d", result, store.staged, store.advanced)
+	if result.Sources != 1 || result.Staged != 1 || !result.Advanced || len(store.staged) != 1 || store.advanced != input.NextSequence || store.readLimit != 1 {
+		t.Fatalf("result=%#v staged=%#v advanced=%d readLimit=%d", result, store.staged, store.advanced, store.readLimit)
 	}
 	if got := store.staged[0]; !reflect.DeepEqual(got.Input, input) || got.Proposal.PrincipalID != "66666666-6666-4666-8666-666666666666" || got.Proposal.ProjectID != "77777777-7777-4777-8777-777777777777" || got.Proposal.IdempotencyKey == "" {
 		t.Fatalf("staged request=%#v", got)
@@ -191,9 +191,11 @@ type fakeMemoryConsolidationExecutorStore struct {
 	stagedKeys    map[string]struct{}
 	pass          []MemoryConsolidationProposal
 	passInput     MemoryConsolidationInput
+	readLimit     int
 }
 
-func (s *fakeMemoryConsolidationExecutorStore) ReadMemoryConsolidationInput(context.Context, MemoryConsolidationLease) (MemoryConsolidationInput, error) {
+func (s *fakeMemoryConsolidationExecutorStore) readMemoryConsolidationInput(_ context.Context, _ MemoryConsolidationLease, limit int) (MemoryConsolidationInput, error) {
+	s.readLimit = limit
 	return s.input, nil
 }
 func (s *fakeMemoryConsolidationExecutorStore) LoadMemoryConsolidationPass(_ context.Context, lease MemoryConsolidationLease, _ MemoryConsolidationExecutionRequest) (MemoryConsolidationInput, []MemoryConsolidationProposal, bool, error) {

--- a/internal/postgres/brain_consolidation_integration_test.go
+++ b/internal/postgres/brain_consolidation_integration_test.go
@@ -124,6 +124,30 @@ func testMemoryConsolidationCheckpointIntegration(ctx context.Context, t *testin
 	if err := ownerDB.QueryRowContext(ctx, `SELECT count(*) FROM brain.memory_proposals WHERE scope_id=$1`, scopeID).Scan(&proposalsAfter); err != nil || proposalsAfter != proposalsBefore {
 		t.Fatalf("unauthorized consolidation proposal created rows before=%d after=%d err=%v", proposalsBefore, proposalsAfter, err)
 	}
+	var wrongProjectID, wrongScopeID string
+	var wrongProposalState MemoryProposalState
+	if err := ownerDB.QueryRowContext(ctx, `INSERT INTO relay.projects(display_name,created_by) VALUES ('wrong consolidation proposal project',$1) RETURNING id::text`, actor.ID).Scan(&wrongProjectID); err != nil {
+		t.Fatal(err)
+	}
+	if err := ownerDB.QueryRowContext(ctx, `INSERT INTO brain.scopes(project_id,created_by) VALUES ($1,$2) RETURNING id::text`, wrongProjectID, actor.ID).Scan(&wrongScopeID); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ownerDB.ExecContext(ctx, `INSERT INTO auth.capability_grants(principal_id,scope,project_id,capability) VALUES ($1,'project',$2,$3)`, actor.ID, wrongProjectID, CapabilityMemoryPropose); err != nil {
+		t.Fatal(err)
+	}
+	if err := ownerDB.QueryRowContext(ctx, `INSERT INTO brain.memory_proposals(scope_id,action,proposed_by,created_at,expires_at,payload_sha256,payload)
+VALUES ($1,'create',$2,statement_timestamp()-interval '8 days',statement_timestamp()-interval '1 day',decode(repeat('00',32),'hex'),'{}') RETURNING state`, wrongScopeID, actor.ID).Scan(&wrongProposalState); err != nil || wrongProposalState != MemoryProposalPending {
+		t.Fatalf("seed wrong-project proposal state=%q err=%v", wrongProposalState, err)
+	}
+	wrongProject := stagedRequest
+	wrongProject.Proposal.ProjectID = wrongProjectID
+	wrongProject.Proposal.IdempotencyKey = "11111111-1111-4111-8111-111111111141"
+	if _, err := app.StageMemoryConsolidationProposal(ctx, wrongProject); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("wrong-project consolidation proposal error=%v", err)
+	}
+	if err := ownerDB.QueryRowContext(ctx, `SELECT state FROM brain.memory_proposals WHERE scope_id=$1`, wrongScopeID).Scan(&wrongProposalState); err != nil || wrongProposalState != MemoryProposalPending {
+		t.Fatalf("wrong-project proposal maintenance side effect state=%q err=%v", wrongProposalState, err)
+	}
 	staged, err := app.StageMemoryConsolidationProposal(ctx, stagedRequest)
 	if err != nil || staged.State != MemoryProposalPending || staged.ProposalID == "" || len(staged.Mutations) != 0 {
 		t.Fatalf("stage consolidation proposal=%#v err=%v", staged, err)

--- a/internal/postgres/brain_consolidation_pass_store.go
+++ b/internal/postgres/brain_consolidation_pass_store.go
@@ -19,46 +19,46 @@ func (d *Database) LoadMemoryConsolidationPass(ctx context.Context, lease Memory
 
 // ReserveMemoryConsolidationPass atomically records a fully validated plan.
 // Concurrent workers resolve to the first plan rather than replacing it.
-func (d *Database) ReserveMemoryConsolidationPass(ctx context.Context, input MemoryConsolidationInput, request MemoryConsolidationExecutionRequest, proposals []MemoryConsolidationProposal) ([]MemoryConsolidationProposal, error) {
+func (d *Database) ReserveMemoryConsolidationPass(ctx context.Context, input MemoryConsolidationInput, request MemoryConsolidationExecutionRequest, proposals []MemoryConsolidationProposal) (MemoryConsolidationInput, []MemoryConsolidationProposal, error) {
 	if err := d.validateMemoryConsolidationProposalScope(ctx, request.PrincipalID, request.ProjectID, input.Lease.ScopeID); err != nil {
-		return nil, err
+		return MemoryConsolidationInput{}, nil, err
 	}
 	body, err := json.Marshal(proposals)
 	if err != nil {
-		return nil, errors.New("consolidation pass cannot be encoded")
+		return MemoryConsolidationInput{}, nil, errors.New("consolidation pass cannot be encoded")
 	}
 	sourceSHA, err := memoryConsolidationPassSourceSHA(input)
 	if err != nil {
-		return nil, err
+		return MemoryConsolidationInput{}, nil, err
 	}
 	sourcesBody, err := json.Marshal(input.Sources)
 	if err != nil {
-		return nil, errors.New("consolidation pass sources cannot be encoded")
+		return MemoryConsolidationInput{}, nil, errors.New("consolidation pass sources cannot be encoded")
 	}
 	tx, err := beginMutation(ctx, d.db)
 	if err != nil {
-		return nil, mutationStartError(err, "consolidation pass transaction cannot start")
+		return MemoryConsolidationInput{}, nil, mutationStartError(err, "consolidation pass transaction cannot start")
 	}
 	defer func() { _ = tx.Rollback() }()
 	if _, err := tx.ExecContext(ctx, `INSERT INTO brain.memory_consolidation_passes
 (scope_id,timeline_id,start_sequence,next_sequence,principal_id,project_id,lease_token,lease_generation,source_sha256,sources,proposals)
 VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11)
-ON CONFLICT (scope_id,timeline_id,start_sequence,next_sequence,principal_id,project_id) DO NOTHING`,
+ON CONFLICT (scope_id,timeline_id,start_sequence,principal_id,project_id) DO NOTHING`,
 		input.Lease.ScopeID, input.TimelineID, input.Lease.Sequence, input.NextSequence, request.PrincipalID, request.ProjectID,
 		input.Lease.Token, input.Lease.Generation, sourceSHA, sourcesBody, body); err != nil {
-		return nil, errors.New("consolidation pass cannot be reserved")
+		return MemoryConsolidationInput{}, nil, errors.New("consolidation pass cannot be reserved")
 	}
-	_, resolved, found, err := d.readMemoryConsolidationPass(ctx, tx, input.Lease, request)
+	resolvedInput, resolved, found, err := d.readMemoryConsolidationPass(ctx, tx, input.Lease, request)
 	if err != nil {
-		return nil, err
+		return MemoryConsolidationInput{}, nil, err
 	}
 	if !found {
-		return nil, errors.New("consolidation pass was not reserved")
+		return MemoryConsolidationInput{}, nil, errors.New("consolidation pass was not reserved")
 	}
 	if err := tx.Commit(); err != nil {
-		return nil, errors.New("consolidation pass transaction cannot commit")
+		return MemoryConsolidationInput{}, nil, errors.New("consolidation pass transaction cannot commit")
 	}
-	return resolved, nil
+	return resolvedInput, resolved, nil
 }
 
 // CompleteMemoryConsolidationPass atomically advances the fenced checkpoint

--- a/internal/postgres/brain_consolidation_pass_store.go
+++ b/internal/postgres/brain_consolidation_pass_store.go
@@ -77,9 +77,9 @@ func (d *Database) CompleteMemoryConsolidationPass(ctx context.Context, input Me
 }
 
 // AbandonMemoryConsolidationPass releases an immutable pass whose source page
-// can no longer be staged. It deliberately retains the checkpoint cursor so a
-// later lease reads the newer source revision rather than replacing the stale
-// pass under the same fence.
+// can no longer be staged. It advances through the already-reserved page so a
+// later lease starts at the newer source revision with distinct proposal
+// idempotency coordinates.
 func (d *Database) AbandonMemoryConsolidationPass(ctx context.Context, input MemoryConsolidationInput, request MemoryConsolidationExecutionRequest) error {
 	var abandoned bool
 	err := d.db.QueryRowContext(ctx, `SELECT brain.abandon_memory_consolidation_pass($1,$2,$3,$4,$5,$6,$7,$8)`,

--- a/internal/postgres/brain_consolidation_pass_store.go
+++ b/internal/postgres/brain_consolidation_pass_store.go
@@ -61,6 +61,7 @@ ON CONFLICT (scope_id,timeline_id,start_sequence) DO NOTHING`,
 	return resolvedInput, resolvedRequest, resolved, nil
 }
 
+// CheckMemoryConsolidationPassCapacity verifies that an entire proposed pass fits the live quota.
 func (d *Database) CheckMemoryConsolidationPassCapacity(ctx context.Context, input MemoryConsolidationInput, request MemoryConsolidationExecutionRequest, proposals int) error {
 	if proposals < 0 || !request.valid() {
 		return errors.New("consolidation pass capacity is invalid")

--- a/internal/postgres/brain_consolidation_pass_store.go
+++ b/internal/postgres/brain_consolidation_pass_store.go
@@ -103,7 +103,8 @@ WHERE record.key=$1`, memoryConsolidationProposalIdempotencyKey(input, request.P
 		if err != nil {
 			return 0, errors.New("consolidation pass idempotency is unavailable")
 		}
-		if status.String != string(OutcomeSucceeded) || state.String != string(MemoryProposalPending) || !actionable.Bool {
+		if status.String != string(OutcomeSucceeded) || state.String == "" || state.String == "expired" ||
+			(state.String == string(MemoryProposalPending) && !actionable.Bool) {
 			return 0, errMemoryConsolidationProposalRejected
 		}
 	}

--- a/internal/postgres/brain_consolidation_pass_store.go
+++ b/internal/postgres/brain_consolidation_pass_store.go
@@ -1,6 +1,7 @@
 package postgres
 
 import (
+	"bytes"
 	"context"
 	"crypto/sha256"
 	"database/sql"
@@ -64,8 +65,8 @@ ON CONFLICT (scope_id,timeline_id,start_sequence) DO NOTHING`,
 // CheckMemoryConsolidationPassCapacity verifies that every not-yet-staged
 // ordinal of a durable pass fits the live quota and that completed ordinals
 // still reference actionable proposals.
-func (d *Database) CheckMemoryConsolidationPassCapacity(ctx context.Context, input MemoryConsolidationInput, request MemoryConsolidationExecutionRequest, proposals int) error {
-	if proposals < 0 || !request.valid() {
+func (d *Database) CheckMemoryConsolidationPassCapacity(ctx context.Context, input MemoryConsolidationInput, request MemoryConsolidationExecutionRequest, proposals []MemoryConsolidationProposal) error {
+	if !request.valid() {
 		return errors.New("consolidation pass capacity is invalid")
 	}
 	tx, err := beginMutation(ctx, d.db)
@@ -86,22 +87,33 @@ func (d *Database) CheckMemoryConsolidationPassCapacity(ctx context.Context, inp
 	return nil
 }
 
-func unstagedMemoryConsolidationProposalCount(ctx context.Context, tx *sql.Tx, input MemoryConsolidationInput, request MemoryConsolidationExecutionRequest, proposals int) (int, error) {
+func unstagedMemoryConsolidationProposalCount(ctx context.Context, tx *sql.Tx, input MemoryConsolidationInput, request MemoryConsolidationExecutionRequest, proposals []MemoryConsolidationProposal) (int, error) {
 	remaining := 0
-	for ordinal := range proposals {
+	for ordinal, proposal := range proposals {
+		staged := MemoryProposalCreateRequest{PrincipalID: request.PrincipalID, ProjectID: request.ProjectID, IdempotencyKey: memoryConsolidationProposalIdempotencyKey(input, request.PrincipalID, request.ProjectID, ordinal), Action: proposal.Action, Steps: proposal.Steps, Evidence: proposal.Evidence}
+		expectedBody, err := memoryConsolidationProposalRequestBody(input, staged)
+		if err != nil {
+			return 0, err
+		}
+		expectedHash := requestDigest(expectedBody)
+		var principal, operation string
+		var requestHash []byte
 		var status sql.NullString
 		var state sql.NullString
 		var actionable sql.NullBool
-		err := tx.QueryRowContext(ctx, `SELECT record.status,proposal.state,proposal.expires_at > statement_timestamp()
+		err = tx.QueryRowContext(ctx, `SELECT record.principal_id::text,record.operation,record.request_hash,record.status,proposal.state,proposal.expires_at > statement_timestamp()
 FROM relay.idempotency_records AS record
 LEFT JOIN brain.memory_proposals AS proposal ON proposal.id=record.resource_id
-WHERE record.key=$1`, memoryConsolidationProposalIdempotencyKey(input, request.PrincipalID, request.ProjectID, ordinal)).Scan(&status, &state, &actionable)
+WHERE record.key=$1`, staged.IdempotencyKey).Scan(&principal, &operation, &requestHash, &status, &state, &actionable)
 		if errors.Is(err, sql.ErrNoRows) {
 			remaining++
 			continue
 		}
 		if err != nil {
 			return 0, errors.New("consolidation pass idempotency is unavailable")
+		}
+		if principal != staged.PrincipalID || operation != "memory.consolidation.proposal.create" || !bytes.Equal(requestHash, expectedHash[:]) {
+			return 0, errMemoryConsolidationProposalRejected
 		}
 		if status.String != string(OutcomeSucceeded) || state.String == "" || state.String == "expired" ||
 			(state.String == string(MemoryProposalPending) && !actionable.Bool) {

--- a/internal/postgres/brain_consolidation_pass_store.go
+++ b/internal/postgres/brain_consolidation_pass_store.go
@@ -10,55 +10,55 @@ import (
 
 // LoadMemoryConsolidationPass returns the immutable plan reserved for this
 // exact source page. A retry must load this before consulting a planner.
-func (d *Database) LoadMemoryConsolidationPass(ctx context.Context, lease MemoryConsolidationLease, request MemoryConsolidationExecutionRequest) (MemoryConsolidationInput, []MemoryConsolidationProposal, bool, error) {
+func (d *Database) LoadMemoryConsolidationPass(ctx context.Context, lease MemoryConsolidationLease, request MemoryConsolidationExecutionRequest) (MemoryConsolidationInput, MemoryConsolidationExecutionRequest, []MemoryConsolidationProposal, bool, error) {
 	if err := d.validateMemoryConsolidationProposalScope(ctx, request.PrincipalID, request.ProjectID, lease.ScopeID); err != nil {
-		return MemoryConsolidationInput{}, nil, false, err
+		return MemoryConsolidationInput{}, MemoryConsolidationExecutionRequest{}, nil, false, err
 	}
 	return d.readMemoryConsolidationPass(ctx, d.db, lease, request)
 }
 
 // ReserveMemoryConsolidationPass atomically records a fully validated plan.
 // Concurrent workers resolve to the first plan rather than replacing it.
-func (d *Database) ReserveMemoryConsolidationPass(ctx context.Context, input MemoryConsolidationInput, request MemoryConsolidationExecutionRequest, proposals []MemoryConsolidationProposal) (MemoryConsolidationInput, []MemoryConsolidationProposal, error) {
+func (d *Database) ReserveMemoryConsolidationPass(ctx context.Context, input MemoryConsolidationInput, request MemoryConsolidationExecutionRequest, proposals []MemoryConsolidationProposal) (MemoryConsolidationInput, MemoryConsolidationExecutionRequest, []MemoryConsolidationProposal, error) {
 	if err := d.validateMemoryConsolidationProposalScope(ctx, request.PrincipalID, request.ProjectID, input.Lease.ScopeID); err != nil {
-		return MemoryConsolidationInput{}, nil, err
+		return MemoryConsolidationInput{}, MemoryConsolidationExecutionRequest{}, nil, err
 	}
 	body, err := json.Marshal(proposals)
 	if err != nil {
-		return MemoryConsolidationInput{}, nil, errors.New("consolidation pass cannot be encoded")
+		return MemoryConsolidationInput{}, MemoryConsolidationExecutionRequest{}, nil, errors.New("consolidation pass cannot be encoded")
 	}
 	sourceSHA, err := memoryConsolidationPassSourceSHA(input)
 	if err != nil {
-		return MemoryConsolidationInput{}, nil, err
+		return MemoryConsolidationInput{}, MemoryConsolidationExecutionRequest{}, nil, err
 	}
 	sourcesBody, err := json.Marshal(input.Sources)
 	if err != nil {
-		return MemoryConsolidationInput{}, nil, errors.New("consolidation pass sources cannot be encoded")
+		return MemoryConsolidationInput{}, MemoryConsolidationExecutionRequest{}, nil, errors.New("consolidation pass sources cannot be encoded")
 	}
 	tx, err := beginMutation(ctx, d.db)
 	if err != nil {
-		return MemoryConsolidationInput{}, nil, mutationStartError(err, "consolidation pass transaction cannot start")
+		return MemoryConsolidationInput{}, MemoryConsolidationExecutionRequest{}, nil, mutationStartError(err, "consolidation pass transaction cannot start")
 	}
 	defer func() { _ = tx.Rollback() }()
 	if _, err := tx.ExecContext(ctx, `INSERT INTO brain.memory_consolidation_passes
 (scope_id,timeline_id,start_sequence,next_sequence,principal_id,project_id,lease_token,lease_generation,source_sha256,sources,proposals)
 VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11)
-ON CONFLICT (scope_id,timeline_id,start_sequence,principal_id,project_id) DO NOTHING`,
+ON CONFLICT (scope_id,timeline_id,start_sequence) DO NOTHING`,
 		input.Lease.ScopeID, input.TimelineID, input.Lease.Sequence, input.NextSequence, request.PrincipalID, request.ProjectID,
 		input.Lease.Token, input.Lease.Generation, sourceSHA, sourcesBody, body); err != nil {
-		return MemoryConsolidationInput{}, nil, errors.New("consolidation pass cannot be reserved")
+		return MemoryConsolidationInput{}, MemoryConsolidationExecutionRequest{}, nil, errors.New("consolidation pass cannot be reserved")
 	}
-	resolvedInput, resolved, found, err := d.readMemoryConsolidationPass(ctx, tx, input.Lease, request)
+	resolvedInput, resolvedRequest, resolved, found, err := d.readMemoryConsolidationPass(ctx, tx, input.Lease, request)
 	if err != nil {
-		return MemoryConsolidationInput{}, nil, err
+		return MemoryConsolidationInput{}, MemoryConsolidationExecutionRequest{}, nil, err
 	}
 	if !found {
-		return MemoryConsolidationInput{}, nil, errors.New("consolidation pass was not reserved")
+		return MemoryConsolidationInput{}, MemoryConsolidationExecutionRequest{}, nil, errors.New("consolidation pass was not reserved")
 	}
 	if err := tx.Commit(); err != nil {
-		return MemoryConsolidationInput{}, nil, errors.New("consolidation pass transaction cannot commit")
+		return MemoryConsolidationInput{}, MemoryConsolidationExecutionRequest{}, nil, errors.New("consolidation pass transaction cannot commit")
 	}
-	return resolvedInput, resolved, nil
+	return resolvedInput, resolvedRequest, resolved, nil
 }
 
 // CompleteMemoryConsolidationPass atomically advances the fenced checkpoint
@@ -93,32 +93,32 @@ func (d *Database) AbandonMemoryConsolidationPass(ctx context.Context, input Mem
 	return nil
 }
 
-func (d *Database) readMemoryConsolidationPass(ctx context.Context, q queryer, lease MemoryConsolidationLease, request MemoryConsolidationExecutionRequest) (MemoryConsolidationInput, []MemoryConsolidationProposal, bool, error) {
+func (d *Database) readMemoryConsolidationPass(ctx context.Context, q queryer, lease MemoryConsolidationLease, _ MemoryConsolidationExecutionRequest) (MemoryConsolidationInput, MemoryConsolidationExecutionRequest, []MemoryConsolidationProposal, bool, error) {
 	var storedSHA []byte
-	var timelineID, body, sourcesBody string
+	var timelineID, body, sourcesBody, principalID, projectID string
 	var nextSequence int64
-	err := q.QueryRowContext(ctx, `SELECT timeline_id::text,next_sequence,source_sha256,proposals::text,sources::text FROM brain.memory_consolidation_passes
-WHERE scope_id=$1 AND timeline_id=$2 AND start_sequence=$3 AND principal_id=$4 AND project_id=$5`,
-		lease.ScopeID, lease.TimelineID, lease.Sequence, request.PrincipalID, request.ProjectID).Scan(&timelineID, &nextSequence, &storedSHA, &body, &sourcesBody)
+	err := q.QueryRowContext(ctx, `SELECT timeline_id::text,next_sequence,principal_id::text,project_id::text,source_sha256,proposals::text,sources::text FROM brain.memory_consolidation_passes
+WHERE scope_id=$1 AND timeline_id=$2 AND start_sequence=$3`,
+		lease.ScopeID, lease.TimelineID, lease.Sequence).Scan(&timelineID, &nextSequence, &principalID, &projectID, &storedSHA, &body, &sourcesBody)
 	if errors.Is(err, sql.ErrNoRows) {
-		return MemoryConsolidationInput{}, nil, false, nil
+		return MemoryConsolidationInput{}, MemoryConsolidationExecutionRequest{}, nil, false, nil
 	}
 	if err != nil {
-		return MemoryConsolidationInput{}, nil, false, errors.New("consolidation pass is unavailable")
+		return MemoryConsolidationInput{}, MemoryConsolidationExecutionRequest{}, nil, false, errors.New("consolidation pass is unavailable")
 	}
 	input := MemoryConsolidationInput{Lease: lease, TimelineID: timelineID, NextSequence: nextSequence}
 	if err := json.Unmarshal([]byte(sourcesBody), &input.Sources); err != nil {
-		return MemoryConsolidationInput{}, nil, false, errors.New("consolidation pass is malformed")
+		return MemoryConsolidationInput{}, MemoryConsolidationExecutionRequest{}, nil, false, errors.New("consolidation pass is malformed")
 	}
 	sourceSHA, err := memoryConsolidationPassSourceSHA(input)
 	if err != nil || len(storedSHA) != sha256.Size || string(storedSHA) != string(sourceSHA) {
-		return MemoryConsolidationInput{}, nil, false, ErrStaleMemoryConsolidationLease
+		return MemoryConsolidationInput{}, MemoryConsolidationExecutionRequest{}, nil, false, ErrStaleMemoryConsolidationLease
 	}
 	var proposals []MemoryConsolidationProposal
 	if err := json.Unmarshal([]byte(body), &proposals); err != nil {
-		return MemoryConsolidationInput{}, nil, false, errors.New("consolidation pass is malformed")
+		return MemoryConsolidationInput{}, MemoryConsolidationExecutionRequest{}, nil, false, errors.New("consolidation pass is malformed")
 	}
-	return input, proposals, true, nil
+	return input, MemoryConsolidationExecutionRequest{Lease: lease, PrincipalID: principalID, ProjectID: projectID}, proposals, true, nil
 }
 
 func memoryConsolidationPassSourceSHA(input MemoryConsolidationInput) ([]byte, error) {

--- a/internal/postgres/brain_consolidation_pass_store.go
+++ b/internal/postgres/brain_consolidation_pass_store.go
@@ -172,12 +172,25 @@ WHERE scope_id=$1 AND timeline_id=$2 AND start_sequence=$3`,
 }
 
 func memoryConsolidationPassSourceSHA(input MemoryConsolidationInput) ([]byte, error) {
+	canonicalSources := make([]MemoryConsolidationSource, len(input.Sources))
+	for index, source := range input.Sources {
+		var document any
+		if err := json.Unmarshal(source.Document, &document); err != nil {
+			return nil, errors.New("consolidation source page cannot be encoded")
+		}
+		canonicalDocument, err := json.Marshal(document)
+		if err != nil {
+			return nil, errors.New("consolidation source page cannot be encoded")
+		}
+		source.Document = canonicalDocument
+		canonicalSources[index] = source
+	}
 	body, err := json.Marshal(struct {
 		TimelineID    string                      `json:"timeline_id"`
 		StartSequence int64                       `json:"start_sequence"`
 		NextSequence  int64                       `json:"next_sequence"`
 		Sources       []MemoryConsolidationSource `json:"sources"`
-	}{input.TimelineID, input.Lease.Sequence, input.NextSequence, input.Sources})
+	}{input.TimelineID, input.Lease.Sequence, input.NextSequence, canonicalSources})
 	if err != nil {
 		return nil, errors.New("consolidation source page cannot be encoded")
 	}

--- a/internal/postgres/brain_consolidation_pass_store.go
+++ b/internal/postgres/brain_consolidation_pass_store.go
@@ -1,0 +1,113 @@
+package postgres
+
+import (
+	"context"
+	"crypto/sha256"
+	"database/sql"
+	"encoding/json"
+	"errors"
+)
+
+// LoadMemoryConsolidationPass returns the immutable plan reserved for this
+// exact source page. A retry must load this before consulting a planner.
+func (d *Database) LoadMemoryConsolidationPass(ctx context.Context, input MemoryConsolidationInput, request MemoryConsolidationExecutionRequest) ([]MemoryConsolidationProposal, bool, error) {
+	if err := d.validateMemoryConsolidationProposalScope(ctx, request.PrincipalID, request.ProjectID, input.Lease.ScopeID); err != nil {
+		return nil, false, err
+	}
+	return d.readMemoryConsolidationPass(ctx, d.db, input, request)
+}
+
+// ReserveMemoryConsolidationPass atomically records a fully validated plan.
+// Concurrent workers resolve to the first plan rather than replacing it.
+func (d *Database) ReserveMemoryConsolidationPass(ctx context.Context, input MemoryConsolidationInput, request MemoryConsolidationExecutionRequest, proposals []MemoryConsolidationProposal) ([]MemoryConsolidationProposal, error) {
+	if err := d.validateMemoryConsolidationProposalScope(ctx, request.PrincipalID, request.ProjectID, input.Lease.ScopeID); err != nil {
+		return nil, err
+	}
+	body, err := json.Marshal(proposals)
+	if err != nil {
+		return nil, errors.New("consolidation pass cannot be encoded")
+	}
+	sourceSHA, err := memoryConsolidationPassSourceSHA(input)
+	if err != nil {
+		return nil, err
+	}
+	tx, err := beginMutation(ctx, d.db)
+	if err != nil {
+		return nil, mutationStartError(err, "consolidation pass transaction cannot start")
+	}
+	defer func() { _ = tx.Rollback() }()
+	if _, err := tx.ExecContext(ctx, `INSERT INTO brain.memory_consolidation_passes
+(scope_id,timeline_id,start_sequence,next_sequence,principal_id,project_id,lease_token,lease_generation,source_sha256,proposals)
+VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10)
+ON CONFLICT (scope_id,timeline_id,start_sequence,next_sequence,principal_id,project_id) DO NOTHING`,
+		input.Lease.ScopeID, input.TimelineID, input.Lease.Sequence, input.NextSequence, request.PrincipalID, request.ProjectID,
+		input.Lease.Token, input.Lease.Generation, sourceSHA, body); err != nil {
+		return nil, errors.New("consolidation pass cannot be reserved")
+	}
+	resolved, found, err := d.readMemoryConsolidationPass(ctx, tx, input, request)
+	if err != nil {
+		return nil, err
+	}
+	if !found {
+		return nil, errors.New("consolidation pass was not reserved")
+	}
+	if err := tx.Commit(); err != nil {
+		return nil, errors.New("consolidation pass transaction cannot commit")
+	}
+	return resolved, nil
+}
+
+// CompleteMemoryConsolidationPass atomically advances the fenced checkpoint
+// and removes the plan that made all staging retries deterministic.
+func (d *Database) CompleteMemoryConsolidationPass(ctx context.Context, input MemoryConsolidationInput, request MemoryConsolidationExecutionRequest) error {
+	var completed bool
+	err := d.db.QueryRowContext(ctx, `SELECT brain.complete_memory_consolidation_pass($1,$2,$3,$4,$5,$6,$7,$8)`,
+		input.Lease.ScopeID, input.Lease.Token, input.Lease.Generation, input.TimelineID, input.Lease.Sequence, input.NextSequence, request.PrincipalID, request.ProjectID).Scan(&completed)
+	if err != nil {
+		return errors.New("consolidation pass cannot be completed")
+	}
+	if !completed {
+		return ErrStaleMemoryConsolidationLease
+	}
+	return nil
+}
+
+func (d *Database) readMemoryConsolidationPass(ctx context.Context, q queryer, input MemoryConsolidationInput, request MemoryConsolidationExecutionRequest) ([]MemoryConsolidationProposal, bool, error) {
+	sourceSHA, err := memoryConsolidationPassSourceSHA(input)
+	if err != nil {
+		return nil, false, err
+	}
+	var storedSHA []byte
+	var body string
+	err = q.QueryRowContext(ctx, `SELECT source_sha256,proposals::text FROM brain.memory_consolidation_passes
+WHERE scope_id=$1 AND timeline_id=$2 AND start_sequence=$3 AND next_sequence=$4 AND principal_id=$5 AND project_id=$6`,
+		input.Lease.ScopeID, input.TimelineID, input.Lease.Sequence, input.NextSequence, request.PrincipalID, request.ProjectID).Scan(&storedSHA, &body)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, false, nil
+	}
+	if err != nil {
+		return nil, false, errors.New("consolidation pass is unavailable")
+	}
+	if len(storedSHA) != sha256.Size || string(storedSHA) != string(sourceSHA) {
+		return nil, false, ErrStaleMemoryConsolidationLease
+	}
+	var proposals []MemoryConsolidationProposal
+	if err := json.Unmarshal([]byte(body), &proposals); err != nil {
+		return nil, false, errors.New("consolidation pass is malformed")
+	}
+	return proposals, true, nil
+}
+
+func memoryConsolidationPassSourceSHA(input MemoryConsolidationInput) ([]byte, error) {
+	body, err := json.Marshal(struct {
+		TimelineID    string                      `json:"timeline_id"`
+		StartSequence int64                       `json:"start_sequence"`
+		NextSequence  int64                       `json:"next_sequence"`
+		Sources       []MemoryConsolidationSource `json:"sources"`
+	}{input.TimelineID, input.Lease.Sequence, input.NextSequence, input.Sources})
+	if err != nil {
+		return nil, errors.New("consolidation source page cannot be encoded")
+	}
+	digest := sha256.Sum256(body)
+	return digest[:], nil
+}

--- a/internal/postgres/brain_consolidation_pass_store.go
+++ b/internal/postgres/brain_consolidation_pass_store.go
@@ -61,7 +61,9 @@ ON CONFLICT (scope_id,timeline_id,start_sequence) DO NOTHING`,
 	return resolvedInput, resolvedRequest, resolved, nil
 }
 
-// CheckMemoryConsolidationPassCapacity verifies that an entire proposed pass fits the live quota.
+// CheckMemoryConsolidationPassCapacity verifies that every not-yet-staged
+// ordinal of a durable pass fits the live quota and that completed ordinals
+// still reference actionable proposals.
 func (d *Database) CheckMemoryConsolidationPassCapacity(ctx context.Context, input MemoryConsolidationInput, request MemoryConsolidationExecutionRequest, proposals int) error {
 	if proposals < 0 || !request.valid() {
 		return errors.New("consolidation pass capacity is invalid")
@@ -71,13 +73,41 @@ func (d *Database) CheckMemoryConsolidationPassCapacity(ctx context.Context, inp
 		return mutationStartError(err, "consolidation pass capacity cannot start")
 	}
 	defer func() { _ = tx.Rollback() }()
-	if err := checkMemoryProposalCapacityForCount(ctx, tx, input.Lease.ScopeID, request.PrincipalID, proposals); err != nil {
+	remaining, err := unstagedMemoryConsolidationProposalCount(ctx, tx, input, request, proposals)
+	if err != nil {
+		return err
+	}
+	if err := checkMemoryProposalCapacityForCount(ctx, tx, input.Lease.ScopeID, request.PrincipalID, remaining); err != nil {
 		return err
 	}
 	if err := tx.Commit(); err != nil {
 		return errors.New("consolidation pass capacity cannot commit")
 	}
 	return nil
+}
+
+func unstagedMemoryConsolidationProposalCount(ctx context.Context, tx *sql.Tx, input MemoryConsolidationInput, request MemoryConsolidationExecutionRequest, proposals int) (int, error) {
+	remaining := 0
+	for ordinal := range proposals {
+		var status sql.NullString
+		var state sql.NullString
+		var actionable sql.NullBool
+		err := tx.QueryRowContext(ctx, `SELECT record.status,proposal.state,proposal.expires_at > statement_timestamp()
+FROM relay.idempotency_records AS record
+LEFT JOIN brain.memory_proposals AS proposal ON proposal.id=record.resource_id
+WHERE record.key=$1`, memoryConsolidationProposalIdempotencyKey(input, request.PrincipalID, request.ProjectID, ordinal)).Scan(&status, &state, &actionable)
+		if errors.Is(err, sql.ErrNoRows) {
+			remaining++
+			continue
+		}
+		if err != nil {
+			return 0, errors.New("consolidation pass idempotency is unavailable")
+		}
+		if status.String != string(OutcomeSucceeded) || state.String != string(MemoryProposalPending) || !actionable.Bool {
+			return 0, errMemoryConsolidationProposalRejected
+		}
+	}
+	return remaining, nil
 }
 
 // CompleteMemoryConsolidationPass atomically advances the fenced checkpoint

--- a/internal/postgres/brain_consolidation_pass_store.go
+++ b/internal/postgres/brain_consolidation_pass_store.go
@@ -10,11 +10,11 @@ import (
 
 // LoadMemoryConsolidationPass returns the immutable plan reserved for this
 // exact source page. A retry must load this before consulting a planner.
-func (d *Database) LoadMemoryConsolidationPass(ctx context.Context, input MemoryConsolidationInput, request MemoryConsolidationExecutionRequest) ([]MemoryConsolidationProposal, bool, error) {
-	if err := d.validateMemoryConsolidationProposalScope(ctx, request.PrincipalID, request.ProjectID, input.Lease.ScopeID); err != nil {
-		return nil, false, err
+func (d *Database) LoadMemoryConsolidationPass(ctx context.Context, lease MemoryConsolidationLease, request MemoryConsolidationExecutionRequest) (MemoryConsolidationInput, []MemoryConsolidationProposal, bool, error) {
+	if err := d.validateMemoryConsolidationProposalScope(ctx, request.PrincipalID, request.ProjectID, lease.ScopeID); err != nil {
+		return MemoryConsolidationInput{}, nil, false, err
 	}
-	return d.readMemoryConsolidationPass(ctx, d.db, input, request)
+	return d.readMemoryConsolidationPass(ctx, d.db, lease, request)
 }
 
 // ReserveMemoryConsolidationPass atomically records a fully validated plan.
@@ -31,20 +31,24 @@ func (d *Database) ReserveMemoryConsolidationPass(ctx context.Context, input Mem
 	if err != nil {
 		return nil, err
 	}
+	sourcesBody, err := json.Marshal(input.Sources)
+	if err != nil {
+		return nil, errors.New("consolidation pass sources cannot be encoded")
+	}
 	tx, err := beginMutation(ctx, d.db)
 	if err != nil {
 		return nil, mutationStartError(err, "consolidation pass transaction cannot start")
 	}
 	defer func() { _ = tx.Rollback() }()
 	if _, err := tx.ExecContext(ctx, `INSERT INTO brain.memory_consolidation_passes
-(scope_id,timeline_id,start_sequence,next_sequence,principal_id,project_id,lease_token,lease_generation,source_sha256,proposals)
-VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10)
+(scope_id,timeline_id,start_sequence,next_sequence,principal_id,project_id,lease_token,lease_generation,source_sha256,sources,proposals)
+VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11)
 ON CONFLICT (scope_id,timeline_id,start_sequence,next_sequence,principal_id,project_id) DO NOTHING`,
 		input.Lease.ScopeID, input.TimelineID, input.Lease.Sequence, input.NextSequence, request.PrincipalID, request.ProjectID,
-		input.Lease.Token, input.Lease.Generation, sourceSHA, body); err != nil {
+		input.Lease.Token, input.Lease.Generation, sourceSHA, sourcesBody, body); err != nil {
 		return nil, errors.New("consolidation pass cannot be reserved")
 	}
-	resolved, found, err := d.readMemoryConsolidationPass(ctx, tx, input, request)
+	_, resolved, found, err := d.readMemoryConsolidationPass(ctx, tx, input.Lease, request)
 	if err != nil {
 		return nil, err
 	}
@@ -72,30 +76,32 @@ func (d *Database) CompleteMemoryConsolidationPass(ctx context.Context, input Me
 	return nil
 }
 
-func (d *Database) readMemoryConsolidationPass(ctx context.Context, q queryer, input MemoryConsolidationInput, request MemoryConsolidationExecutionRequest) ([]MemoryConsolidationProposal, bool, error) {
-	sourceSHA, err := memoryConsolidationPassSourceSHA(input)
-	if err != nil {
-		return nil, false, err
-	}
+func (d *Database) readMemoryConsolidationPass(ctx context.Context, q queryer, lease MemoryConsolidationLease, request MemoryConsolidationExecutionRequest) (MemoryConsolidationInput, []MemoryConsolidationProposal, bool, error) {
 	var storedSHA []byte
-	var body string
-	err = q.QueryRowContext(ctx, `SELECT source_sha256,proposals::text FROM brain.memory_consolidation_passes
-WHERE scope_id=$1 AND timeline_id=$2 AND start_sequence=$3 AND next_sequence=$4 AND principal_id=$5 AND project_id=$6`,
-		input.Lease.ScopeID, input.TimelineID, input.Lease.Sequence, input.NextSequence, request.PrincipalID, request.ProjectID).Scan(&storedSHA, &body)
+	var timelineID, body, sourcesBody string
+	var nextSequence int64
+	err := q.QueryRowContext(ctx, `SELECT timeline_id::text,next_sequence,source_sha256,proposals::text,sources::text FROM brain.memory_consolidation_passes
+WHERE scope_id=$1 AND timeline_id=$2 AND start_sequence=$3 AND principal_id=$4 AND project_id=$5`,
+		lease.ScopeID, lease.TimelineID, lease.Sequence, request.PrincipalID, request.ProjectID).Scan(&timelineID, &nextSequence, &storedSHA, &body, &sourcesBody)
 	if errors.Is(err, sql.ErrNoRows) {
-		return nil, false, nil
+		return MemoryConsolidationInput{}, nil, false, nil
 	}
 	if err != nil {
-		return nil, false, errors.New("consolidation pass is unavailable")
+		return MemoryConsolidationInput{}, nil, false, errors.New("consolidation pass is unavailable")
 	}
-	if len(storedSHA) != sha256.Size || string(storedSHA) != string(sourceSHA) {
-		return nil, false, ErrStaleMemoryConsolidationLease
+	input := MemoryConsolidationInput{Lease: lease, TimelineID: timelineID, NextSequence: nextSequence}
+	if err := json.Unmarshal([]byte(sourcesBody), &input.Sources); err != nil {
+		return MemoryConsolidationInput{}, nil, false, errors.New("consolidation pass is malformed")
+	}
+	sourceSHA, err := memoryConsolidationPassSourceSHA(input)
+	if err != nil || len(storedSHA) != sha256.Size || string(storedSHA) != string(sourceSHA) {
+		return MemoryConsolidationInput{}, nil, false, ErrStaleMemoryConsolidationLease
 	}
 	var proposals []MemoryConsolidationProposal
 	if err := json.Unmarshal([]byte(body), &proposals); err != nil {
-		return nil, false, errors.New("consolidation pass is malformed")
+		return MemoryConsolidationInput{}, nil, false, errors.New("consolidation pass is malformed")
 	}
-	return proposals, true, nil
+	return input, proposals, true, nil
 }
 
 func memoryConsolidationPassSourceSHA(input MemoryConsolidationInput) ([]byte, error) {

--- a/internal/postgres/brain_consolidation_pass_store.go
+++ b/internal/postgres/brain_consolidation_pass_store.go
@@ -76,6 +76,23 @@ func (d *Database) CompleteMemoryConsolidationPass(ctx context.Context, input Me
 	return nil
 }
 
+// AbandonMemoryConsolidationPass releases an immutable pass whose source page
+// can no longer be staged. It deliberately retains the checkpoint cursor so a
+// later lease reads the newer source revision rather than replacing the stale
+// pass under the same fence.
+func (d *Database) AbandonMemoryConsolidationPass(ctx context.Context, input MemoryConsolidationInput, request MemoryConsolidationExecutionRequest) error {
+	var abandoned bool
+	err := d.db.QueryRowContext(ctx, `SELECT brain.abandon_memory_consolidation_pass($1,$2,$3,$4,$5,$6,$7,$8)`,
+		input.Lease.ScopeID, input.Lease.Token, input.Lease.Generation, input.TimelineID, input.Lease.Sequence, input.NextSequence, request.PrincipalID, request.ProjectID).Scan(&abandoned)
+	if err != nil {
+		return errors.New("consolidation pass cannot be abandoned")
+	}
+	if !abandoned {
+		return ErrStaleMemoryConsolidationLease
+	}
+	return nil
+}
+
 func (d *Database) readMemoryConsolidationPass(ctx context.Context, q queryer, lease MemoryConsolidationLease, request MemoryConsolidationExecutionRequest) (MemoryConsolidationInput, []MemoryConsolidationProposal, bool, error) {
 	var storedSHA []byte
 	var timelineID, body, sourcesBody string

--- a/internal/postgres/brain_consolidation_pass_store.go
+++ b/internal/postgres/brain_consolidation_pass_store.go
@@ -61,6 +61,24 @@ ON CONFLICT (scope_id,timeline_id,start_sequence) DO NOTHING`,
 	return resolvedInput, resolvedRequest, resolved, nil
 }
 
+func (d *Database) CheckMemoryConsolidationPassCapacity(ctx context.Context, input MemoryConsolidationInput, request MemoryConsolidationExecutionRequest, proposals int) error {
+	if proposals < 0 || !request.valid() {
+		return errors.New("consolidation pass capacity is invalid")
+	}
+	tx, err := beginMutation(ctx, d.db)
+	if err != nil {
+		return mutationStartError(err, "consolidation pass capacity cannot start")
+	}
+	defer func() { _ = tx.Rollback() }()
+	if err := checkMemoryProposalCapacityForCount(ctx, tx, input.Lease.ScopeID, request.PrincipalID, proposals); err != nil {
+		return err
+	}
+	if err := tx.Commit(); err != nil {
+		return errors.New("consolidation pass capacity cannot commit")
+	}
+	return nil
+}
+
 // CompleteMemoryConsolidationPass atomically advances the fenced checkpoint
 // and removes the plan that made all staging retries deterministic.
 func (d *Database) CompleteMemoryConsolidationPass(ctx context.Context, input MemoryConsolidationInput, request MemoryConsolidationExecutionRequest) error {

--- a/internal/postgres/brain_consolidation_proposal_store.go
+++ b/internal/postgres/brain_consolidation_proposal_store.go
@@ -58,7 +58,7 @@ func (d *Database) StageMemoryConsolidationProposal(ctx context.Context, raw Mem
 		return decodeMemoryProposalOutcome(outcome)
 	}
 	if err := d.validateMemoryConsolidationProposalScope(ctx, proposal.PrincipalID, proposal.ProjectID, request.Input.Lease.ScopeID); err != nil {
-		return MemoryProposalResult{}, err
+		return MemoryProposalResult{}, memoryConsolidationStageError(err)
 	}
 	if err := d.maintainMemoryProposals(ctx, proposal.PrincipalID, proposal.ProjectID); err != nil {
 		return MemoryProposalResult{}, err

--- a/internal/postgres/brain_consolidation_proposal_store.go
+++ b/internal/postgres/brain_consolidation_proposal_store.go
@@ -58,7 +58,7 @@ func (d *Database) StageMemoryConsolidationProposal(ctx context.Context, raw Mem
 		return decodeMemoryProposalOutcome(outcome)
 	}
 	if err := d.validateMemoryConsolidationProposalScope(ctx, proposal.PrincipalID, proposal.ProjectID, request.Input.Lease.ScopeID); err != nil {
-		return MemoryProposalResult{}, memoryConsolidationStageError(err)
+		return MemoryProposalResult{}, err
 	}
 	if err := d.maintainMemoryProposals(ctx, proposal.PrincipalID, proposal.ProjectID); err != nil {
 		return MemoryProposalResult{}, err

--- a/internal/postgres/brain_consolidation_proposal_store.go
+++ b/internal/postgres/brain_consolidation_proposal_store.go
@@ -48,6 +48,9 @@ func (d *Database) StageMemoryConsolidationProposal(ctx context.Context, raw Mem
 	} else if completed {
 		return decodeMemoryProposalOutcome(outcome)
 	}
+	if err := d.validateMemoryConsolidationProposalScope(ctx, proposal.PrincipalID, proposal.ProjectID, request.Input.Lease.ScopeID); err != nil {
+		return MemoryProposalResult{}, err
+	}
 	if err := d.maintainMemoryProposals(ctx, proposal.PrincipalID, proposal.ProjectID); err != nil {
 		return MemoryProposalResult{}, err
 	}
@@ -143,6 +146,40 @@ VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10)`, proposalID, ordinal, step.Operation, n
 		return MemoryProposalResult{}, errors.New("consolidation proposal transaction could not commit")
 	}
 	return decodeMemoryProposalOutcome(outcome)
+}
+
+// validateMemoryConsolidationProposalScope proves the requested direct project
+// is the lease scope's canonical project before proposal maintenance can touch
+// that project's retained/expired proposal state. Stage revalidates the same
+// relation in its mutation transaction after maintenance completes.
+func (d *Database) validateMemoryConsolidationProposalScope(ctx context.Context, principalID, projectID, scopeID string) error {
+	tx, err := beginMutation(ctx, d.db)
+	if err != nil {
+		return mutationStartError(err, "consolidation proposal preflight cannot start")
+	}
+	defer func() { _ = tx.Rollback() }()
+	project, err := lockDirectActiveProject(ctx, tx, projectID)
+	if err != nil {
+		return ErrNotFound
+	}
+	var canonicalScopeProjectID string
+	if err := tx.QueryRowContext(ctx, `SELECT COALESCE(alias.canonical_project_id,scope.project_id)::text
+FROM brain.scopes AS scope
+LEFT JOIN relay.project_lookup_aliases AS alias ON alias.alias_project_id=scope.project_id
+WHERE scope.id=$1`, scopeID).Scan(&canonicalScopeProjectID); err != nil || canonicalScopeProjectID != project.ID {
+		return ErrNotFound
+	}
+	allowed, err := lockCapability(ctx, tx, principalID, project.ID, CapabilityMemoryPropose)
+	if err != nil {
+		return err
+	}
+	if !allowed {
+		return ErrNotFound
+	}
+	if err := tx.Commit(); err != nil {
+		return errors.New("consolidation proposal preflight cannot commit")
+	}
+	return nil
 }
 
 // validateConsolidationInputSources re-reads the complete security-definer

--- a/internal/postgres/brain_consolidation_proposal_store.go
+++ b/internal/postgres/brain_consolidation_proposal_store.go
@@ -9,9 +9,14 @@ import (
 	"errors"
 )
 
-// errMemoryConsolidationSourceStale distinguishes an irrecoverably changed
-// reserved page from a retryable lease or scan-coverage fence.
-var errMemoryConsolidationSourceStale = errors.New("consolidation source page is stale")
+var (
+	// errMemoryConsolidationSourceStale distinguishes an irrecoverably changed
+	// reserved page from a retryable lease or scan-coverage fence.
+	errMemoryConsolidationSourceStale = errors.New("consolidation source page is stale")
+	// errMemoryConsolidationProposalRejected marks immutable planner output that
+	// cannot be staged against the reserved source page.
+	errMemoryConsolidationProposalRejected = errors.New("consolidation proposal is permanently rejected")
+)
 
 // StageMemoryConsolidationProposal stages a proposal and its exact source page
 // only while the supplied consolidation lease remains live. It deliberately
@@ -91,16 +96,16 @@ WHERE scope.id=$1`, request.Input.Lease.ScopeID).Scan(&scopeProjectID, &canonica
 		}
 		items, err := lockAndValidateProposalItems(ctx, tx, project.ID, proposal.Steps, proposal.Evidence)
 		if err != nil {
-			return IdempotencyOutcome{}, err
+			return IdempotencyOutcome{}, memoryConsolidationStageError(err)
 		}
 		for _, step := range proposal.Steps {
 			if step.Operation == MemoryProposalStepCreate || step.Operation == MemoryProposalStepUpdate {
 				if err := guardMemoryDocument(ctx, tx, project.ID, step.Document); err != nil {
-					return IdempotencyOutcome{}, err
+					return IdempotencyOutcome{}, memoryConsolidationStageError(err)
 				}
 			}
 			if step.Operation == MemoryProposalStepArchive && (items[step.ItemID].State == MemoryArchived) == step.Archived {
-				return IdempotencyOutcome{}, ErrMemoryProposalAlreadySatisfied
+				return IdempotencyOutcome{}, memoryConsolidationStageError(ErrMemoryProposalAlreadySatisfied)
 			}
 		}
 		if err := checkMemoryProposalCapacity(ctx, tx, request.Input.Lease.ScopeID, proposal.PrincipalID); err != nil {
@@ -150,6 +155,14 @@ VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10)`, proposalID, ordinal, step.Operation, n
 		return MemoryProposalResult{}, errors.New("consolidation proposal transaction could not commit")
 	}
 	return decodeMemoryProposalOutcome(outcome)
+}
+
+func memoryConsolidationStageError(err error) error {
+	var rejection MemorySecretRejection
+	if errors.Is(err, ErrNotFound) || errors.Is(err, ErrStaleMemoryETag) || errors.Is(err, ErrMemoryProposalAlreadySatisfied) || errors.As(err, &rejection) {
+		return errors.Join(errMemoryConsolidationProposalRejected, err)
+	}
+	return err
 }
 
 // validateMemoryConsolidationProposalScope proves the requested direct project

--- a/internal/postgres/brain_consolidation_proposal_store.go
+++ b/internal/postgres/brain_consolidation_proposal_store.go
@@ -211,6 +211,12 @@ func validateConsolidationInputSources(ctx context.Context, tx *sql.Tx, input Me
 			}
 			continue
 		}
+		// A reserved pass owns this exact bounded page. Later changes may extend
+		// a fresh read before replay, but they belong to the next pass and must
+		// neither replace nor invalidate the stored page.
+		if sequence.Int64 > input.NextSequence {
+			break
+		}
 		next = sequence.Int64
 		if !itemID.Valid {
 			continue

--- a/internal/postgres/brain_consolidation_proposal_store.go
+++ b/internal/postgres/brain_consolidation_proposal_store.go
@@ -92,6 +92,9 @@ WHERE scope.id=$1`, request.Input.Lease.ScopeID).Scan(&scopeProjectID, &canonica
 			if errors.Is(err, ErrNotFound) || errors.Is(err, ErrStaleMemoryETag) {
 				return IdempotencyOutcome{}, ErrStaleMemoryConsolidationLease
 			}
+			if errors.Is(err, errMemoryConsolidationSourceStale) {
+				return IdempotencyOutcome{}, errors.Join(err, ErrStaleMemoryConsolidationLease)
+			}
 			return IdempotencyOutcome{}, err
 		}
 		items, err := lockAndValidateProposalItems(ctx, tx, project.ID, proposal.Steps, proposal.Evidence)

--- a/internal/postgres/brain_consolidation_proposal_store.go
+++ b/internal/postgres/brain_consolidation_proposal_store.go
@@ -18,16 +18,7 @@ var (
 	errMemoryConsolidationProposalRejected = errors.New("consolidation proposal is permanently rejected")
 )
 
-// StageMemoryConsolidationProposal stages a proposal and its exact source page
-// only while the supplied consolidation lease remains live. It deliberately
-// does not advance the checkpoint: a later bounded runner decides when the
-// complete page has been handled.
-func (d *Database) StageMemoryConsolidationProposal(ctx context.Context, raw MemoryConsolidationProposalRequest) (MemoryProposalResult, error) {
-	request, err := raw.normalized()
-	if err != nil {
-		return MemoryProposalResult{}, err
-	}
-	proposal := request.Proposal
+func memoryConsolidationProposalRequestBody(input MemoryConsolidationInput, proposal MemoryProposalCreateRequest) ([]byte, error) {
 	// The request body fences idempotency before the lease transaction. The
 	// stored proposal payload is derived later from the scope's physical project
 	// ID so it remains reproducible after that project becomes an alias.
@@ -38,20 +29,37 @@ func (d *Database) StageMemoryConsolidationProposal(ctx context.Context, raw Mem
 		ChangeSequence int64             `json:"change_sequence"`
 		ContentSHA256  [sha256.Size]byte `json:"content_sha256"`
 	}
-	sources := make([]sourceDigest, len(request.Input.Sources))
-	for index, source := range request.Input.Sources {
+	sources := make([]sourceDigest, len(input.Sources))
+	for index, source := range input.Sources {
 		sources[index] = sourceDigest{ItemID: source.ItemID, Revision: source.Revision, ChangeSequence: source.ChangeSequence, ContentSHA256: sha256.Sum256(source.Document)}
 	}
-	inputBody, err := json.Marshal(struct {
+	body, err := json.Marshal(struct {
 		Proposal json.RawMessage `json:"proposal"`
 		Timeline string          `json:"timeline"`
 		Sequence int64           `json:"sequence"`
 		Sources  []sourceDigest  `json:"sources"`
-	}{Proposal: idempotencyPayload, Timeline: request.Input.TimelineID, Sequence: request.Input.NextSequence, Sources: sources})
+	}{Proposal: idempotencyPayload, Timeline: input.TimelineID, Sequence: input.NextSequence, Sources: sources})
+	if err != nil {
+		return nil, errors.New("consolidation proposal cannot be encoded")
+	}
+	return body, nil
+}
+
+// StageMemoryConsolidationProposal stages a proposal and its exact source page
+// only while the supplied consolidation lease remains live. It deliberately
+// does not advance the checkpoint: a later bounded runner decides when the
+// complete page has been handled.
+func (d *Database) StageMemoryConsolidationProposal(ctx context.Context, raw MemoryConsolidationProposalRequest) (MemoryProposalResult, error) {
+	request, err := raw.normalized()
+	if err != nil {
+		return MemoryProposalResult{}, err
+	}
+	proposal := request.Proposal
+	requestBody, err := memoryConsolidationProposalRequestBody(request.Input, proposal)
 	if err != nil {
 		return MemoryProposalResult{}, errors.New("consolidation proposal cannot be encoded")
 	}
-	idempotency := IdempotencyRequest{PrincipalID: proposal.PrincipalID, Operation: "memory.consolidation.proposal.create", Key: proposal.IdempotencyKey, Body: inputBody}
+	idempotency := IdempotencyRequest{PrincipalID: proposal.PrincipalID, Operation: "memory.consolidation.proposal.create", Key: proposal.IdempotencyKey, Body: requestBody}
 	if outcome, completed, err := completedIdempotencyOutcome(ctx, d.db, idempotency); err != nil {
 		return MemoryProposalResult{}, err
 	} else if completed {

--- a/internal/postgres/brain_consolidation_proposal_store.go
+++ b/internal/postgres/brain_consolidation_proposal_store.go
@@ -31,7 +31,11 @@ func memoryConsolidationProposalRequestBody(input MemoryConsolidationInput, prop
 	}
 	sources := make([]sourceDigest, len(input.Sources))
 	for index, source := range input.Sources {
-		sources[index] = sourceDigest{ItemID: source.ItemID, Revision: source.Revision, ChangeSequence: source.ChangeSequence, ContentSHA256: sha256.Sum256(source.Document)}
+		document, err := canonicalMemoryDocument(source.Document)
+		if err != nil {
+			return nil, errors.New("consolidation proposal cannot be encoded")
+		}
+		sources[index] = sourceDigest{ItemID: source.ItemID, Revision: source.Revision, ChangeSequence: source.ChangeSequence, ContentSHA256: sha256.Sum256(document)}
 	}
 	body, err := json.Marshal(struct {
 		Proposal json.RawMessage `json:"proposal"`

--- a/internal/postgres/brain_consolidation_proposal_store.go
+++ b/internal/postgres/brain_consolidation_proposal_store.go
@@ -9,6 +9,10 @@ import (
 	"errors"
 )
 
+// errMemoryConsolidationSourceStale distinguishes an irrecoverably changed
+// reserved page from a retryable lease or scan-coverage fence.
+var errMemoryConsolidationSourceStale = errors.New("consolidation source page is stale")
+
 // StageMemoryConsolidationProposal stages a proposal and its exact source page
 // only while the supplied consolidation lease remains live. It deliberately
 // does not advance the checkpoint: a later bounded runner decides when the
@@ -222,13 +226,13 @@ func validateConsolidationInputSources(ctx context.Context, tx *sql.Tx, input Me
 			continue
 		}
 		if index >= len(input.Sources) || !revision.Valid || !document.Valid {
-			return ErrStaleMemoryConsolidationLease
+			return errMemoryConsolidationSourceStale
 		}
 		source := input.Sources[index]
 		canonical, err := canonicalMemoryDocument(json.RawMessage(document.String))
 		digest := sha256.Sum256([]byte(document.String))
 		if err != nil || len(contentHash) != sha256.Size || !bytes.Equal(digest[:], contentHash) || source.ItemID != itemID.String || source.Revision != revision.Int64 || source.ChangeSequence != sequence.Int64 || !bytes.Equal(source.Document, canonical) {
-			return ErrStaleMemoryConsolidationLease
+			return errMemoryConsolidationSourceStale
 		}
 		index++
 	}
@@ -239,7 +243,7 @@ func validateConsolidationInputSources(ctx context.Context, tx *sql.Tx, input Me
 		return errors.New("consolidation proposal sources are unavailable")
 	}
 	if index != len(input.Sources) || next != input.NextSequence {
-		return ErrStaleMemoryConsolidationLease
+		return errMemoryConsolidationSourceStale
 	}
 	return nil
 }

--- a/internal/postgres/brain_consolidation_schema.go
+++ b/internal/postgres/brain_consolidation_schema.go
@@ -284,11 +284,7 @@ WITH relation AS (
     SELECT count(*)=6 AND bool_and(convalidated AND NOT condeferrable AND NOT condeferred)
        AND count(*) FILTER (WHERE contype='p' AND conkey=ARRAY[1,2,3]::smallint[])=1
        AND count(*) FILTER (WHERE contype='f' AND conkey=ARRAY[1]::smallint[] AND confrelid='brain.scopes'::regclass AND confdeltype='c')=1
-       AND count(*) FILTER (WHERE contype='c')=4
-       AND count(*) FILTER (WHERE contype='c' AND conname='memory_consolidation_passes_start_sequence_check' AND pg_get_expr(conbin,conrelid)='(start_sequence >= 0)')=1
-       AND count(*) FILTER (WHERE contype='c' AND conname='memory_consolidation_passes_next_sequence_check' AND pg_get_expr(conbin,conrelid)='(next_sequence >= start_sequence)')=1
-       AND count(*) FILTER (WHERE contype='c' AND conname='memory_consolidation_passes_lease_generation_check' AND pg_get_expr(conbin,conrelid)='(lease_generation >= 1)')=1
-       AND count(*) FILTER (WHERE contype='c' AND conname='memory_consolidation_passes_source_sha256_check' AND pg_get_expr(conbin,conrelid)='(octet_length(source_sha256) = 32)')=1 AS exact
+       AND count(*) FILTER (WHERE contype='c')=4 AS exact
     FROM pg_constraint,relation WHERE conrelid=table_oid AND contype<>'n'
 ), routines AS (
     SELECT count(*)=4 AND bool_and(pg_get_userbyid(proowner)='punaro_owner' AND prolang=(SELECT oid FROM pg_language WHERE lanname='plpgsql')

--- a/internal/postgres/brain_consolidation_schema.go
+++ b/internal/postgres/brain_consolidation_schema.go
@@ -272,7 +272,7 @@ WITH relation AS (
 ), checkpoint_triggers AS (
     SELECT count(*)=1 AND count(*) FILTER (WHERE tgname='memory_consolidation_pass_checkpoint_cleanup'
       AND tgtype=17 AND tgfoid=cleanup_oid AND tgenabled='O' AND tgattr='2 3'::int2vector
-      AND pg_get_triggerdef(oid)='CREATE TRIGGER memory_consolidation_pass_checkpoint_cleanup AFTER UPDATE OF timeline_id, change_sequence ON brain.memory_consolidation_checkpoints FOR EACH ROW WHEN (((old.timeline_id, old.change_sequence) IS DISTINCT FROM (new.timeline_id, new.change_sequence))) EXECUTE FUNCTION brain.clear_memory_consolidation_passes_on_checkpoint_move()')=1 AS exact
+      AND regexp_replace(pg_get_triggerdef(oid),'[[:space:]]+',' ','g') ~ '^CREATE TRIGGER memory_consolidation_pass_checkpoint_cleanup AFTER UPDATE OF timeline_id, change_sequence ON brain.memory_consolidation_checkpoints FOR EACH ROW WHEN \(+old\.timeline_id, old\.change_sequence\) IS DISTINCT FROM \(new\.timeline_id, new\.change_sequence\)\)+ EXECUTE FUNCTION brain\.clear_memory_consolidation_passes_on_checkpoint_move\(\)$')=1 AS exact
     FROM pg_trigger,relation WHERE tgrelid=checkpoint_oid AND NOT tgisinternal
 ), constraints AS (
     SELECT count(*)=6 AND bool_and(convalidated AND NOT condeferrable AND NOT condeferred)

--- a/internal/postgres/brain_consolidation_schema.go
+++ b/internal/postgres/brain_consolidation_schema.go
@@ -238,7 +238,7 @@ WITH relation AS (
       ('scope_id','uuid',true,''),('timeline_id','uuid',true,''),('start_sequence','bigint',true,''),
       ('next_sequence','bigint',true,''),('principal_id','uuid',true,''),('project_id','uuid',true,''),
       ('lease_token','uuid',true,''),('lease_generation','bigint',true,''),('source_sha256','bytea',true,''),
-      ('proposals','jsonb',true,''),('created_at','timestamp with time zone',true,'statement_timestamp()')
+      ('sources','jsonb',true,''),('proposals','jsonb',true,''),('created_at','timestamp with time zone',true,'statement_timestamp()')
 ), actual_columns AS (
     SELECT attribute.attname,attribute.atttypid::regtype::text,attribute.attnotnull,COALESCE(pg_get_expr(default_value.adbin,default_value.adrelid),'')
     FROM pg_attribute AS attribute CROSS JOIN relation
@@ -259,6 +259,7 @@ WITH relation AS (
        AND has_column_privilege('punaro_app',table_oid,'lease_token','INSERT')
        AND has_column_privilege('punaro_app',table_oid,'lease_generation','INSERT')
        AND has_column_privilege('punaro_app',table_oid,'source_sha256','INSERT')
+       AND has_column_privilege('punaro_app',table_oid,'sources','INSERT')
        AND has_column_privilege('punaro_app',table_oid,'proposals','INSERT')
        AND NOT has_table_privilege('punaro_app',table_oid,'INSERT') AS exact
     FROM relation
@@ -281,6 +282,15 @@ WITH relation AS (
     SELECT count(*)=3 AND bool_and(pg_get_userbyid(proowner)='punaro_owner' AND prolang=(SELECT oid FROM pg_language WHERE lanname='plpgsql')
       AND proconfig=ARRAY['search_path=pg_catalog']::text[] AND NOT has_function_privilege('public',oid,'EXECUTE')) AS exact
     FROM pg_proc,relation WHERE oid=ANY(ARRAY[guard_oid,cleanup_oid,complete_oid])
+), completion_routine AS (
+    SELECT count(*)=1 AND bool_and(pg_get_userbyid(proowner)='punaro_owner' AND prokind='f' AND prosecdef AND provolatile='v'
+      AND NOT proretset AND prorettype='boolean'::regtype AND pronargs=8
+      AND proargtypes='2950 2950 20 2950 20 20 2950 2950'::oidvector
+      AND proargnames=ARRAY['requested_scope','requested_token','requested_generation','requested_timeline','requested_start_sequence','requested_next_sequence','requested_principal','requested_project']::text[]
+      AND prolang=(SELECT oid FROM pg_language WHERE lanname='plpgsql')
+      AND proconfig=ARRAY['search_path=pg_catalog']::text[]
+      AND md5(btrim(prosrc,E' \n\r\t'))=$1) AS exact
+    FROM pg_proc,relation WHERE oid=complete_oid
 ), complete_acl AS (
     SELECT has_function_privilege('punaro_app',complete_oid,'EXECUTE') AS app_exec,
            NOT has_function_privilege('public',complete_oid,'EXECUTE') AS no_public
@@ -291,12 +301,13 @@ SELECT relation.table_oid IS NOT NULL AND relation.checkpoint_oid IS NOT NULL AN
    AND NOT EXISTS (SELECT * FROM expected_columns EXCEPT SELECT * FROM actual_columns)
    AND NOT EXISTS (SELECT * FROM actual_columns EXCEPT SELECT * FROM expected_columns)
    AND table_acl.selects AND table_acl.no_writes AND table_acl.no_public AND insert_acl.exact
-   AND triggers.exact AND checkpoint_triggers.exact AND constraints.exact AND routines.exact AND complete_acl.app_exec AND complete_acl.no_public
-FROM relation,table_acl,insert_acl,triggers,checkpoint_triggers,constraints,routines,complete_acl`).Scan(&available)
+   AND triggers.exact AND checkpoint_triggers.exact AND constraints.exact AND routines.exact AND completion_routine.exact AND complete_acl.app_exec AND complete_acl.no_public
+FROM relation,table_acl,insert_acl,triggers,checkpoint_triggers,constraints,routines,completion_routine,complete_acl`, memoryConsolidationPassCompleteRoutineMD5).Scan(&available)
 	return available, err
 }
 
 const (
+	memoryConsolidationPassCompleteRoutineMD5            = "d7f58b5f70dfbb28b99819193edd5f35"
 	memoryConsolidationProposalSourceGuardRoutineMD5     = "aaa45e19ae18202e97772cb7096ad117"
 	memoryConsolidationProposalSourceLockGuardRoutineMD5 = "88c2c1cf6aabfec6303afb7a155f3de0"
 	memoryConsolidationClaimRoutineMD5                   = "121df7d09493be8662f4618208aaf342"

--- a/internal/postgres/brain_consolidation_schema.go
+++ b/internal/postgres/brain_consolidation_schema.go
@@ -271,11 +271,12 @@ WITH relation AS (
     FROM pg_trigger,relation WHERE tgrelid=table_oid AND NOT tgisinternal
 ), checkpoint_triggers AS (
     SELECT count(*)=1 AND count(*) FILTER (WHERE tgname='memory_consolidation_pass_checkpoint_cleanup'
-      AND tgtype=17 AND tgfoid=cleanup_oid AND tgenabled='O')=1 AS exact
+      AND tgtype=17 AND tgfoid=cleanup_oid AND tgenabled='O' AND tgattr='2 3'::int2vector
+      AND pg_get_expr(tgqual,tgrelid)='((old.timeline_id, old.change_sequence) IS DISTINCT FROM (new.timeline_id, new.change_sequence))')=1 AS exact
     FROM pg_trigger,relation WHERE tgrelid=checkpoint_oid AND NOT tgisinternal
 ), constraints AS (
     SELECT count(*)=6 AND bool_and(convalidated AND NOT condeferrable AND NOT condeferred)
-       AND count(*) FILTER (WHERE contype='p' AND conkey=ARRAY[1,2,3,5,6]::smallint[])=1
+       AND count(*) FILTER (WHERE contype='p' AND conkey=ARRAY[1,2,3]::smallint[])=1
        AND count(*) FILTER (WHERE contype='f' AND conkey=ARRAY[1]::smallint[] AND confrelid='brain.scopes'::regclass AND confdeltype='c')=1
        AND count(*) FILTER (WHERE contype='c')=4 AS exact
     FROM pg_constraint,relation WHERE conrelid=table_oid AND contype<>'n'

--- a/internal/postgres/brain_consolidation_schema.go
+++ b/internal/postgres/brain_consolidation_schema.go
@@ -280,13 +280,13 @@ WITH relation AS (
       AND tgtype=17 AND tgfoid=cleanup_oid AND tgenabled='O' AND tgattr='2 3'::int2vector
       AND tgqual IS NOT NULL)=1 AS exact
     FROM pg_trigger,relation WHERE tgrelid=checkpoint_oid AND NOT tgisinternal
-), expected_checks(name,definition) AS (
-    VALUES ('memory_consolidation_passes_start_sequence_check','CHECK ((start_sequence >= 0))'),
-           ('memory_consolidation_passes_next_sequence_check','CHECK ((next_sequence >= start_sequence))'),
-           ('memory_consolidation_passes_lease_generation_check','CHECK ((lease_generation >= 1))'),
-           ('memory_consolidation_passes_source_sha256_check','CHECK ((octet_length(source_sha256) = 32))')
+), expected_checks(name,expression) AS (
+    VALUES ('memory_consolidation_passes_start_sequence_check','(start_sequence >= 0)'),
+           ('memory_consolidation_passes_next_sequence_check','(next_sequence >= start_sequence)'),
+           ('memory_consolidation_passes_lease_generation_check','(lease_generation >= 1)'),
+           ('memory_consolidation_passes_source_sha256_check','(octet_length(source_sha256) = 32)')
 ), actual_checks AS (
-    SELECT conname,pg_get_constraintdef(oid) FROM pg_constraint,relation
+    SELECT conname,pg_get_expr(conbin,conrelid) FROM pg_constraint,relation
     WHERE conrelid=table_oid AND contype='c'
 ), constraints AS (
     SELECT count(*)=6 AND bool_and(convalidated AND NOT condeferrable AND NOT condeferred)

--- a/internal/postgres/brain_consolidation_schema.go
+++ b/internal/postgres/brain_consolidation_schema.go
@@ -272,7 +272,8 @@ WITH relation AS (
 ), checkpoint_triggers AS (
     SELECT count(*)=1 AND count(*) FILTER (WHERE tgname='memory_consolidation_pass_checkpoint_cleanup'
       AND tgtype=17 AND tgfoid=cleanup_oid AND tgenabled='O' AND tgattr='2 3'::int2vector
-      AND regexp_replace(pg_get_triggerdef(oid),'[[:space:]]+',' ','g') ~ '^CREATE TRIGGER memory_consolidation_pass_checkpoint_cleanup AFTER UPDATE OF timeline_id, change_sequence ON brain.memory_consolidation_checkpoints FOR EACH ROW WHEN \(+old\.timeline_id, old\.change_sequence\) IS DISTINCT FROM \(new\.timeline_id, new\.change_sequence\)\)+ EXECUTE FUNCTION brain\.clear_memory_consolidation_passes_on_checkpoint_move\(\)$')=1 AS exact
+      AND tgqual IS NOT NULL
+      AND lower(pg_get_triggerdef(oid)) LIKE '%when (%old.timeline_id%old.change_sequence%is distinct from%new.timeline_id%new.change_sequence%)%')=1 AS exact
     FROM pg_trigger,relation WHERE tgrelid=checkpoint_oid AND NOT tgisinternal
 ), constraints AS (
     SELECT count(*)=6 AND bool_and(convalidated AND NOT condeferrable AND NOT condeferred)

--- a/internal/postgres/brain_consolidation_schema.go
+++ b/internal/postgres/brain_consolidation_schema.go
@@ -173,10 +173,10 @@ WITH relation AS (
        AND count(*) FILTER (WHERE tgname='application_mutation_fence' AND tgtype=62 AND tgfoid='jobs.guard_application_mutation()'::regprocedure AND tgenabled='O' AND tgattr=''::int2vector AND tgqual IS NULL)=1 AS exact
     FROM pg_trigger,relation WHERE tgrelid=relation.oid AND NOT tgisinternal
 ), constraint_safety AS (
-    SELECT count(*)=6 AND bool_and(convalidated AND NOT condeferrable AND NOT condeferred)
+    SELECT count(*)=5 AND bool_and(convalidated AND NOT condeferrable AND NOT condeferred)
        AND count(*) FILTER (WHERE contype='p' AND conkey=ARRAY[1,2]::smallint[])=1
        AND count(*) FILTER (WHERE contype='f' AND conkey=ARRAY[1]::smallint[] AND confrelid='brain.memory_proposals'::regclass AND confdeltype='c')=1
-       AND count(*) FILTER (WHERE contype='c')=4 AS exact
+       AND count(*) FILTER (WHERE contype='c')=3 AS exact
     FROM pg_constraint,relation WHERE conrelid=relation.oid AND contype<>'n'
 ), expected_checks(name,expression) AS (
     VALUES ('memory_consolidation_proposal_sources_ordinal_check','((ordinal >= 0) AND (ordinal <= 127))'),
@@ -272,10 +272,10 @@ WITH relation AS (
       AND tgtype=17 AND tgfoid=cleanup_oid AND tgenabled='O')=1 AS exact
     FROM pg_trigger,relation WHERE tgrelid=checkpoint_oid AND NOT tgisinternal
 ), constraints AS (
-    SELECT count(*)=5 AND bool_and(convalidated AND NOT condeferrable AND NOT condeferred)
+    SELECT count(*)=6 AND bool_and(convalidated AND NOT condeferrable AND NOT condeferred)
        AND count(*) FILTER (WHERE contype='p' AND conkey=ARRAY[1,2,3,4,5,6]::smallint[])=1
        AND count(*) FILTER (WHERE contype='f' AND conkey=ARRAY[1]::smallint[] AND confrelid='brain.scopes'::regclass AND confdeltype='c')=1
-       AND count(*) FILTER (WHERE contype='c')=3 AS exact
+       AND count(*) FILTER (WHERE contype='c')=4 AS exact
     FROM pg_constraint,relation WHERE conrelid=table_oid AND contype<>'n'
 ), routines AS (
     SELECT count(*)=3 AND bool_and(pg_get_userbyid(proowner)='punaro_owner' AND prolang=(SELECT oid FROM pg_language WHERE lanname='plpgsql')

--- a/internal/postgres/brain_consolidation_schema.go
+++ b/internal/postgres/brain_consolidation_schema.go
@@ -266,7 +266,7 @@ WITH relation AS (
     FROM relation
 ), triggers AS (
     SELECT count(*)=2
-       AND count(*) FILTER (WHERE tgname='memory_consolidation_pass_insert_guard' AND tgtype=7 AND tgfoid=guard_oid AND tgenabled='O' AND tgnattr=0 AND tgqual IS NULL)=1
+       AND count(*) FILTER (WHERE tgname='memory_consolidation_pass_insert_guard' AND tgtype=7 AND tgfoid=guard_oid AND tgenabled='O' AND tgattr=''::int2vector AND tgqual IS NULL)=1
        AND count(*) FILTER (WHERE tgname='application_mutation_fence' AND tgtype=62 AND tgfoid='jobs.guard_application_mutation()'::regprocedure AND tgenabled='O')=1 AS exact
     FROM pg_trigger,relation WHERE tgrelid=table_oid AND NOT tgisinternal
 ), checkpoint_triggers AS (

--- a/internal/postgres/brain_consolidation_schema.go
+++ b/internal/postgres/brain_consolidation_schema.go
@@ -323,7 +323,7 @@ FROM relation,table_acl,insert_acl,triggers,checkpoint_triggers,constraints,rout
 const (
 	memoryConsolidationPassCompleteRoutineMD5            = "1319f8b0c9b50efcbc1c6e1df68c7945" // #nosec G101 -- immutable schema routine checksum
 	memoryConsolidationPassGuardRoutineMD5               = "060b94eab7fe744984bd09efc2958a57" // #nosec G101 -- immutable schema routine checksum
-	memoryConsolidationPassAbandonRoutineMD5             = "f2f3a61fec2e26e7ca19653eefde4819" // #nosec G101 -- immutable schema routine checksum
+	memoryConsolidationPassAbandonRoutineMD5             = "bfe14c5526ec0cba1761501b1581ffe9" // #nosec G101 -- immutable schema routine checksum
 	memoryConsolidationProposalSourceGuardRoutineMD5     = "aaa45e19ae18202e97772cb7096ad117"
 	memoryConsolidationProposalSourceLockGuardRoutineMD5 = "88c2c1cf6aabfec6303afb7a155f3de0"
 	memoryConsolidationClaimRoutineMD5                   = "121df7d09493be8662f4618208aaf342"

--- a/internal/postgres/brain_consolidation_schema.go
+++ b/internal/postgres/brain_consolidation_schema.go
@@ -272,8 +272,7 @@ WITH relation AS (
 ), checkpoint_triggers AS (
     SELECT count(*)=1 AND count(*) FILTER (WHERE tgname='memory_consolidation_pass_checkpoint_cleanup'
       AND tgtype=17 AND tgfoid=cleanup_oid AND tgenabled='O' AND tgattr='2 3'::int2vector
-      AND tgqual IS NOT NULL
-      AND lower(pg_get_triggerdef(oid)) LIKE '%when (%old.timeline_id%old.change_sequence%is distinct from%new.timeline_id%new.change_sequence%)%')=1 AS exact
+      AND tgqual IS NOT NULL)=1 AS exact
     FROM pg_trigger,relation WHERE tgrelid=checkpoint_oid AND NOT tgisinternal
 ), constraints AS (
     SELECT count(*)=6 AND bool_and(convalidated AND NOT condeferrable AND NOT condeferred)

--- a/internal/postgres/brain_consolidation_schema.go
+++ b/internal/postgres/brain_consolidation_schema.go
@@ -232,7 +232,8 @@ WITH relation AS (
            to_regclass('brain.memory_consolidation_checkpoints') AS checkpoint_oid,
            to_regprocedure('brain.guard_memory_consolidation_pass()') AS guard_oid,
            to_regprocedure('brain.clear_memory_consolidation_passes_on_checkpoint_move()') AS cleanup_oid,
-           to_regprocedure('brain.complete_memory_consolidation_pass(uuid,uuid,bigint,uuid,bigint,bigint,uuid,uuid)') AS complete_oid
+           to_regprocedure('brain.complete_memory_consolidation_pass(uuid,uuid,bigint,uuid,bigint,bigint,uuid,uuid)') AS complete_oid,
+           to_regprocedure('brain.abandon_memory_consolidation_pass(uuid,uuid,bigint,uuid,bigint,bigint,uuid,uuid)') AS abandon_oid
 ), expected_columns(name,type_name,required,default_expression) AS (
     VALUES
       ('scope_id','uuid',true,''),('timeline_id','uuid',true,''),('start_sequence','bigint',true,''),
@@ -279,9 +280,12 @@ WITH relation AS (
        AND count(*) FILTER (WHERE contype='c')=4 AS exact
     FROM pg_constraint,relation WHERE conrelid=table_oid AND contype<>'n'
 ), routines AS (
-    SELECT count(*)=3 AND bool_and(pg_get_userbyid(proowner)='punaro_owner' AND prolang=(SELECT oid FROM pg_language WHERE lanname='plpgsql')
+    SELECT count(*)=4 AND bool_and(pg_get_userbyid(proowner)='punaro_owner' AND prolang=(SELECT oid FROM pg_language WHERE lanname='plpgsql')
       AND proconfig=ARRAY['search_path=pg_catalog']::text[] AND NOT has_function_privilege('public',oid,'EXECUTE')) AS exact
-    FROM pg_proc,relation WHERE oid=ANY(ARRAY[guard_oid,cleanup_oid,complete_oid])
+    FROM pg_proc,relation WHERE oid=ANY(ARRAY[guard_oid,cleanup_oid,complete_oid,abandon_oid])
+), guard_routine AS (
+    SELECT count(*)=1 AND bool_and(prosecdef AND md5(btrim(prosrc,E' \n\r\t'))=$2) AS exact
+    FROM pg_proc,relation WHERE oid=guard_oid
 ), completion_routine AS (
     SELECT count(*)=1 AND bool_and(pg_get_userbyid(proowner)='punaro_owner' AND prokind='f' AND prosecdef AND provolatile='v'
       AND NOT proretset AND prorettype='boolean'::regtype AND pronargs=8
@@ -291,23 +295,34 @@ WITH relation AS (
       AND proconfig=ARRAY['search_path=pg_catalog']::text[]
       AND md5(btrim(prosrc,E' \n\r\t'))=$1) AS exact
     FROM pg_proc,relation WHERE oid=complete_oid
+), abandon_routine AS (
+    SELECT count(*)=1 AND bool_and(pg_get_userbyid(proowner)='punaro_owner' AND prokind='f' AND prosecdef AND provolatile='v'
+      AND NOT proretset AND prorettype='boolean'::regtype AND pronargs=8
+      AND proargtypes='2950 2950 20 2950 20 20 2950 2950'::oidvector
+      AND proargnames=ARRAY['requested_scope','requested_token','requested_generation','requested_timeline','requested_start_sequence','requested_next_sequence','requested_principal','requested_project']::text[]
+      AND prolang=(SELECT oid FROM pg_language WHERE lanname='plpgsql')
+      AND proconfig=ARRAY['search_path=pg_catalog']::text[]
+      AND md5(btrim(prosrc,E' \n\r\t'))=$3) AS exact
+    FROM pg_proc,relation WHERE oid=abandon_oid
 ), complete_acl AS (
-    SELECT has_function_privilege('punaro_app',complete_oid,'EXECUTE') AS app_exec,
-           NOT has_function_privilege('public',complete_oid,'EXECUTE') AS no_public
+    SELECT has_function_privilege('punaro_app',complete_oid,'EXECUTE') AND has_function_privilege('punaro_app',abandon_oid,'EXECUTE') AS app_exec,
+           NOT has_function_privilege('public',complete_oid,'EXECUTE') AND NOT has_function_privilege('public',abandon_oid,'EXECUTE') AS no_public
     FROM relation
 )
-SELECT relation.table_oid IS NOT NULL AND relation.checkpoint_oid IS NOT NULL AND relation.guard_oid IS NOT NULL AND relation.cleanup_oid IS NOT NULL AND relation.complete_oid IS NOT NULL
+SELECT relation.table_oid IS NOT NULL AND relation.checkpoint_oid IS NOT NULL AND relation.guard_oid IS NOT NULL AND relation.cleanup_oid IS NOT NULL AND relation.complete_oid IS NOT NULL AND relation.abandon_oid IS NOT NULL
    AND (SELECT count(*)=1 AND bool_and(pg_get_userbyid(relowner)='punaro_owner' AND relkind='r' AND relpersistence='p' AND NOT relrowsecurity AND NOT relforcerowsecurity) FROM pg_class WHERE oid=table_oid)
    AND NOT EXISTS (SELECT * FROM expected_columns EXCEPT SELECT * FROM actual_columns)
    AND NOT EXISTS (SELECT * FROM actual_columns EXCEPT SELECT * FROM expected_columns)
    AND table_acl.selects AND table_acl.no_writes AND table_acl.no_public AND insert_acl.exact
-   AND triggers.exact AND checkpoint_triggers.exact AND constraints.exact AND routines.exact AND completion_routine.exact AND complete_acl.app_exec AND complete_acl.no_public
-FROM relation,table_acl,insert_acl,triggers,checkpoint_triggers,constraints,routines,completion_routine,complete_acl`, memoryConsolidationPassCompleteRoutineMD5).Scan(&available)
+   AND triggers.exact AND checkpoint_triggers.exact AND constraints.exact AND routines.exact AND guard_routine.exact AND completion_routine.exact AND abandon_routine.exact AND complete_acl.app_exec AND complete_acl.no_public
+FROM relation,table_acl,insert_acl,triggers,checkpoint_triggers,constraints,routines,guard_routine,completion_routine,abandon_routine,complete_acl`, memoryConsolidationPassCompleteRoutineMD5, memoryConsolidationPassGuardRoutineMD5, memoryConsolidationPassAbandonRoutineMD5).Scan(&available)
 	return available, err
 }
 
 const (
 	memoryConsolidationPassCompleteRoutineMD5            = "1319f8b0c9b50efcbc1c6e1df68c7945" // #nosec G101 -- immutable schema routine checksum
+	memoryConsolidationPassGuardRoutineMD5               = "060b94eab7fe744984bd09efc2958a57" // #nosec G101 -- immutable schema routine checksum
+	memoryConsolidationPassAbandonRoutineMD5             = "d2093bf72979e45666c3342d0636c417" // #nosec G101 -- immutable schema routine checksum
 	memoryConsolidationProposalSourceGuardRoutineMD5     = "aaa45e19ae18202e97772cb7096ad117"
 	memoryConsolidationProposalSourceLockGuardRoutineMD5 = "88c2c1cf6aabfec6303afb7a155f3de0"
 	memoryConsolidationClaimRoutineMD5                   = "121df7d09493be8662f4618208aaf342"

--- a/internal/postgres/brain_consolidation_schema.go
+++ b/internal/postgres/brain_consolidation_schema.go
@@ -173,10 +173,10 @@ WITH relation AS (
        AND count(*) FILTER (WHERE tgname='application_mutation_fence' AND tgtype=62 AND tgfoid='jobs.guard_application_mutation()'::regprocedure AND tgenabled='O' AND tgattr=''::int2vector AND tgqual IS NULL)=1 AS exact
     FROM pg_trigger,relation WHERE tgrelid=relation.oid AND NOT tgisinternal
 ), constraint_safety AS (
-    SELECT count(*)=5 AND bool_and(convalidated AND NOT condeferrable AND NOT condeferred)
+    SELECT count(*)=6 AND bool_and(convalidated AND NOT condeferrable AND NOT condeferred)
        AND count(*) FILTER (WHERE contype='p' AND conkey=ARRAY[1,2]::smallint[])=1
        AND count(*) FILTER (WHERE contype='f' AND conkey=ARRAY[1]::smallint[] AND confrelid='brain.memory_proposals'::regclass AND confdeltype='c')=1
-       AND count(*) FILTER (WHERE contype='c')=3 AS exact
+       AND count(*) FILTER (WHERE contype='c')=4 AS exact
     FROM pg_constraint,relation WHERE conrelid=relation.oid AND contype<>'n'
 ), expected_checks(name,expression) AS (
     VALUES ('memory_consolidation_proposal_sources_ordinal_check','((ordinal >= 0) AND (ordinal <= 127))'),
@@ -218,6 +218,81 @@ SELECT relation.oid IS NOT NULL AND relation.guard_oid IS NOT NULL AND relation.
    AND NOT EXISTS (SELECT * FROM expected_checks EXCEPT SELECT * FROM actual_checks)
    AND NOT EXISTS (SELECT * FROM actual_checks EXCEPT SELECT * FROM expected_checks)
 FROM relation,application_privileges,table_acl_safety,column_acl_safety,trigger_safety,constraint_safety,guard_safety,lock_guard_safety`, memoryConsolidationProposalSourceGuardRoutineMD5, memoryConsolidationProposalSourceLockGuardRoutineMD5).Scan(&available)
+	return available, err
+}
+
+// memoryConsolidationPassesAvailable verifies the immutable replay plan and
+// its narrow application boundary. A missing or writable pass relation must
+// leave the database non-current rather than permitting replacement outputs.
+func memoryConsolidationPassesAvailable(ctx context.Context, q queryer) (bool, error) {
+	var available bool
+	err := q.QueryRowContext(ctx, `
+WITH relation AS (
+    SELECT to_regclass('brain.memory_consolidation_passes') AS table_oid,
+           to_regclass('brain.memory_consolidation_checkpoints') AS checkpoint_oid,
+           to_regprocedure('brain.guard_memory_consolidation_pass()') AS guard_oid,
+           to_regprocedure('brain.clear_memory_consolidation_passes_on_checkpoint_move()') AS cleanup_oid,
+           to_regprocedure('brain.complete_memory_consolidation_pass(uuid,uuid,bigint,uuid,bigint,bigint,uuid,uuid)') AS complete_oid
+), expected_columns(name,type_name,required,default_expression) AS (
+    VALUES
+      ('scope_id','uuid',true,''),('timeline_id','uuid',true,''),('start_sequence','bigint',true,''),
+      ('next_sequence','bigint',true,''),('principal_id','uuid',true,''),('project_id','uuid',true,''),
+      ('lease_token','uuid',true,''),('lease_generation','bigint',true,''),('source_sha256','bytea',true,''),
+      ('proposals','jsonb',true,''),('created_at','timestamp with time zone',true,'statement_timestamp()')
+), actual_columns AS (
+    SELECT attribute.attname,attribute.atttypid::regtype::text,attribute.attnotnull,COALESCE(pg_get_expr(default_value.adbin,default_value.adrelid),'')
+    FROM pg_attribute AS attribute CROSS JOIN relation
+    LEFT JOIN pg_attrdef AS default_value ON default_value.adrelid=attribute.attrelid AND default_value.adnum=attribute.attnum
+    WHERE attribute.attrelid=table_oid AND attribute.attnum>0 AND NOT attribute.attisdropped
+), table_acl AS (
+    SELECT has_table_privilege('punaro_app',table_oid,'SELECT') AS selects,
+           NOT has_table_privilege('punaro_app',table_oid,'UPDATE,DELETE,TRUNCATE,REFERENCES,TRIGGER') AS no_writes,
+           NOT has_table_privilege('public',table_oid,'SELECT,INSERT,UPDATE,DELETE,TRUNCATE,REFERENCES,TRIGGER') AS no_public
+    FROM relation
+), insert_acl AS (
+    SELECT has_column_privilege('punaro_app',table_oid,'scope_id','INSERT')
+       AND has_column_privilege('punaro_app',table_oid,'timeline_id','INSERT')
+       AND has_column_privilege('punaro_app',table_oid,'start_sequence','INSERT')
+       AND has_column_privilege('punaro_app',table_oid,'next_sequence','INSERT')
+       AND has_column_privilege('punaro_app',table_oid,'principal_id','INSERT')
+       AND has_column_privilege('punaro_app',table_oid,'project_id','INSERT')
+       AND has_column_privilege('punaro_app',table_oid,'lease_token','INSERT')
+       AND has_column_privilege('punaro_app',table_oid,'lease_generation','INSERT')
+       AND has_column_privilege('punaro_app',table_oid,'source_sha256','INSERT')
+       AND has_column_privilege('punaro_app',table_oid,'proposals','INSERT')
+       AND NOT has_table_privilege('punaro_app',table_oid,'INSERT') AS exact
+    FROM relation
+), triggers AS (
+    SELECT count(*)=2
+       AND count(*) FILTER (WHERE tgname='memory_consolidation_pass_insert_guard' AND tgtype=7 AND tgfoid=guard_oid AND tgenabled='O')=1
+       AND count(*) FILTER (WHERE tgname='application_mutation_fence' AND tgtype=62 AND tgfoid='jobs.guard_application_mutation()'::regprocedure AND tgenabled='O')=1 AS exact
+    FROM pg_trigger,relation WHERE tgrelid=table_oid AND NOT tgisinternal
+), checkpoint_triggers AS (
+    SELECT count(*)=1 AND count(*) FILTER (WHERE tgname='memory_consolidation_pass_checkpoint_cleanup'
+      AND tgtype=17 AND tgfoid=cleanup_oid AND tgenabled='O')=1 AS exact
+    FROM pg_trigger,relation WHERE tgrelid=checkpoint_oid AND NOT tgisinternal
+), constraints AS (
+    SELECT count(*)=5 AND bool_and(convalidated AND NOT condeferrable AND NOT condeferred)
+       AND count(*) FILTER (WHERE contype='p' AND conkey=ARRAY[1,2,3,4,5,6]::smallint[])=1
+       AND count(*) FILTER (WHERE contype='f' AND conkey=ARRAY[1]::smallint[] AND confrelid='brain.scopes'::regclass AND confdeltype='c')=1
+       AND count(*) FILTER (WHERE contype='c')=3 AS exact
+    FROM pg_constraint,relation WHERE conrelid=table_oid AND contype<>'n'
+), routines AS (
+    SELECT count(*)=3 AND bool_and(pg_get_userbyid(proowner)='punaro_owner' AND prolang=(SELECT oid FROM pg_language WHERE lanname='plpgsql')
+      AND proconfig=ARRAY['search_path=pg_catalog']::text[] AND NOT has_function_privilege('public',oid,'EXECUTE')) AS exact
+    FROM pg_proc,relation WHERE oid=ANY(ARRAY[guard_oid,cleanup_oid,complete_oid])
+), complete_acl AS (
+    SELECT has_function_privilege('punaro_app',complete_oid,'EXECUTE') AS app_exec,
+           NOT has_function_privilege('public',complete_oid,'EXECUTE') AS no_public
+    FROM relation
+)
+SELECT relation.table_oid IS NOT NULL AND relation.checkpoint_oid IS NOT NULL AND relation.guard_oid IS NOT NULL AND relation.cleanup_oid IS NOT NULL AND relation.complete_oid IS NOT NULL
+   AND (SELECT count(*)=1 AND bool_and(pg_get_userbyid(relowner)='punaro_owner' AND relkind='r' AND relpersistence='p' AND NOT relrowsecurity AND NOT relforcerowsecurity) FROM pg_class WHERE oid=table_oid)
+   AND NOT EXISTS (SELECT * FROM expected_columns EXCEPT SELECT * FROM actual_columns)
+   AND NOT EXISTS (SELECT * FROM actual_columns EXCEPT SELECT * FROM expected_columns)
+   AND table_acl.selects AND table_acl.no_writes AND table_acl.no_public AND insert_acl.exact
+   AND triggers.exact AND checkpoint_triggers.exact AND constraints.exact AND routines.exact AND complete_acl.app_exec AND complete_acl.no_public
+FROM relation,table_acl,insert_acl,triggers,checkpoint_triggers,constraints,routines,complete_acl`).Scan(&available)
 	return available, err
 }
 

--- a/internal/postgres/brain_consolidation_schema.go
+++ b/internal/postgres/brain_consolidation_schema.go
@@ -307,7 +307,7 @@ FROM relation,table_acl,insert_acl,triggers,checkpoint_triggers,constraints,rout
 }
 
 const (
-	memoryConsolidationPassCompleteRoutineMD5            = "d7f58b5f70dfbb28b99819193edd5f35"
+	memoryConsolidationPassCompleteRoutineMD5            = "1319f8b0c9b50efcbc1c6e1df68c7945"
 	memoryConsolidationProposalSourceGuardRoutineMD5     = "aaa45e19ae18202e97772cb7096ad117"
 	memoryConsolidationProposalSourceLockGuardRoutineMD5 = "88c2c1cf6aabfec6303afb7a155f3de0"
 	memoryConsolidationClaimRoutineMD5                   = "121df7d09493be8662f4618208aaf342"

--- a/internal/postgres/brain_consolidation_schema.go
+++ b/internal/postgres/brain_consolidation_schema.go
@@ -322,7 +322,7 @@ FROM relation,table_acl,insert_acl,triggers,checkpoint_triggers,constraints,rout
 const (
 	memoryConsolidationPassCompleteRoutineMD5            = "1319f8b0c9b50efcbc1c6e1df68c7945" // #nosec G101 -- immutable schema routine checksum
 	memoryConsolidationPassGuardRoutineMD5               = "060b94eab7fe744984bd09efc2958a57" // #nosec G101 -- immutable schema routine checksum
-	memoryConsolidationPassAbandonRoutineMD5             = "d2093bf72979e45666c3342d0636c417" // #nosec G101 -- immutable schema routine checksum
+	memoryConsolidationPassAbandonRoutineMD5             = "f2f3a61fec2e26e7ca19653eefde4819" // #nosec G101 -- immutable schema routine checksum
 	memoryConsolidationProposalSourceGuardRoutineMD5     = "aaa45e19ae18202e97772cb7096ad117"
 	memoryConsolidationProposalSourceLockGuardRoutineMD5 = "88c2c1cf6aabfec6303afb7a155f3de0"
 	memoryConsolidationClaimRoutineMD5                   = "121df7d09493be8662f4618208aaf342"

--- a/internal/postgres/brain_consolidation_schema.go
+++ b/internal/postgres/brain_consolidation_schema.go
@@ -272,7 +272,7 @@ WITH relation AS (
 ), checkpoint_triggers AS (
     SELECT count(*)=1 AND count(*) FILTER (WHERE tgname='memory_consolidation_pass_checkpoint_cleanup'
       AND tgtype=17 AND tgfoid=cleanup_oid AND tgenabled='O' AND tgattr='2 3'::int2vector
-      AND pg_get_expr(tgqual,tgrelid)='((old.timeline_id, old.change_sequence) IS DISTINCT FROM (new.timeline_id, new.change_sequence))')=1 AS exact
+      AND pg_get_triggerdef(oid)='CREATE TRIGGER memory_consolidation_pass_checkpoint_cleanup AFTER UPDATE OF timeline_id, change_sequence ON brain.memory_consolidation_checkpoints FOR EACH ROW WHEN (((old.timeline_id, old.change_sequence) IS DISTINCT FROM (new.timeline_id, new.change_sequence))) EXECUTE FUNCTION brain.clear_memory_consolidation_passes_on_checkpoint_move()')=1 AS exact
     FROM pg_trigger,relation WHERE tgrelid=checkpoint_oid AND NOT tgisinternal
 ), constraints AS (
     SELECT count(*)=6 AND bool_and(convalidated AND NOT condeferrable AND NOT condeferred)

--- a/internal/postgres/brain_consolidation_schema.go
+++ b/internal/postgres/brain_consolidation_schema.go
@@ -266,7 +266,7 @@ WITH relation AS (
     FROM relation
 ), triggers AS (
     SELECT count(*)=2
-       AND count(*) FILTER (WHERE tgname='memory_consolidation_pass_insert_guard' AND tgtype=7 AND tgfoid=guard_oid AND tgenabled='O')=1
+       AND count(*) FILTER (WHERE tgname='memory_consolidation_pass_insert_guard' AND tgtype=7 AND tgfoid=guard_oid AND tgenabled='O' AND tgnattr=0 AND tgqual IS NULL)=1
        AND count(*) FILTER (WHERE tgname='application_mutation_fence' AND tgtype=62 AND tgfoid='jobs.guard_application_mutation()'::regprocedure AND tgenabled='O')=1 AS exact
     FROM pg_trigger,relation WHERE tgrelid=table_oid AND NOT tgisinternal
 ), checkpoint_triggers AS (

--- a/internal/postgres/brain_consolidation_schema.go
+++ b/internal/postgres/brain_consolidation_schema.go
@@ -274,7 +274,7 @@ WITH relation AS (
     FROM pg_trigger,relation WHERE tgrelid=checkpoint_oid AND NOT tgisinternal
 ), constraints AS (
     SELECT count(*)=6 AND bool_and(convalidated AND NOT condeferrable AND NOT condeferred)
-       AND count(*) FILTER (WHERE contype='p' AND conkey=ARRAY[1,2,3,4,5,6]::smallint[])=1
+       AND count(*) FILTER (WHERE contype='p' AND conkey=ARRAY[1,2,3,5,6]::smallint[])=1
        AND count(*) FILTER (WHERE contype='f' AND conkey=ARRAY[1]::smallint[] AND confrelid='brain.scopes'::regclass AND confdeltype='c')=1
        AND count(*) FILTER (WHERE contype='c')=4 AS exact
     FROM pg_constraint,relation WHERE conrelid=table_oid AND contype<>'n'

--- a/internal/postgres/brain_consolidation_schema.go
+++ b/internal/postgres/brain_consolidation_schema.go
@@ -264,6 +264,12 @@ WITH relation AS (
        AND has_column_privilege('punaro_app',table_oid,'proposals','INSERT')
        AND NOT has_table_privilege('punaro_app',table_oid,'INSERT') AS exact
     FROM relation
+), column_acl_safety AS (
+    SELECT count(*)=11 AND bool_and(role.rolname='punaro_app' AND entry.privilege_type='INSERT' AND NOT entry.is_grantable) AS exact
+    FROM pg_attribute AS attribute
+    CROSS JOIN LATERAL aclexplode(attribute.attacl) AS entry
+    LEFT JOIN pg_roles AS role ON role.oid=entry.grantee,relation
+    WHERE attribute.attrelid=table_oid AND attribute.attnum>0 AND NOT attribute.attisdropped AND attribute.attacl IS NOT NULL
 ), triggers AS (
     SELECT count(*)=2
        AND count(*) FILTER (WHERE tgname='memory_consolidation_pass_insert_guard' AND tgtype=7 AND tgfoid=guard_oid AND tgenabled='O' AND tgattr=''::int2vector AND tgqual IS NULL)=1
@@ -287,6 +293,10 @@ WITH relation AS (
 ), guard_routine AS (
     SELECT count(*)=1 AND bool_and(prosecdef AND md5(btrim(prosrc,E' \n\r\t'))=$2) AS exact
     FROM pg_proc,relation WHERE oid=guard_oid
+), cleanup_routine AS (
+    SELECT count(*)=1 AND bool_and(prokind='f' AND NOT prosecdef AND NOT proretset AND prorettype='trigger'::regtype AND pronargs=0
+      AND proargtypes=''::oidvector AND md5(btrim(prosrc,E' \n\r\t'))=$4) AS exact
+    FROM pg_proc,relation WHERE oid=cleanup_oid
 ), completion_routine AS (
     SELECT count(*)=1 AND bool_and(pg_get_userbyid(proowner)='punaro_owner' AND prokind='f' AND prosecdef AND provolatile='v'
       AND NOT proretset AND prorettype='boolean'::regtype AND pronargs=8
@@ -314,9 +324,9 @@ SELECT relation.table_oid IS NOT NULL AND relation.checkpoint_oid IS NOT NULL AN
    AND (SELECT count(*)=1 AND bool_and(pg_get_userbyid(relowner)='punaro_owner' AND relkind='r' AND relpersistence='p' AND NOT relrowsecurity AND NOT relforcerowsecurity) FROM pg_class WHERE oid=table_oid)
    AND NOT EXISTS (SELECT * FROM expected_columns EXCEPT SELECT * FROM actual_columns)
    AND NOT EXISTS (SELECT * FROM actual_columns EXCEPT SELECT * FROM expected_columns)
-   AND table_acl.selects AND table_acl.no_writes AND table_acl.no_public AND insert_acl.exact
-   AND triggers.exact AND checkpoint_triggers.exact AND constraints.exact AND routines.exact AND guard_routine.exact AND completion_routine.exact AND abandon_routine.exact AND complete_acl.app_exec AND complete_acl.no_public
-FROM relation,table_acl,insert_acl,triggers,checkpoint_triggers,constraints,routines,guard_routine,completion_routine,abandon_routine,complete_acl`, memoryConsolidationPassCompleteRoutineMD5, memoryConsolidationPassGuardRoutineMD5, memoryConsolidationPassAbandonRoutineMD5).Scan(&available)
+   AND table_acl.selects AND table_acl.no_writes AND table_acl.no_public AND insert_acl.exact AND column_acl_safety.exact
+   AND triggers.exact AND checkpoint_triggers.exact AND constraints.exact AND routines.exact AND guard_routine.exact AND cleanup_routine.exact AND completion_routine.exact AND abandon_routine.exact AND complete_acl.app_exec AND complete_acl.no_public
+FROM relation,table_acl,insert_acl,column_acl_safety,triggers,checkpoint_triggers,constraints,routines,guard_routine,cleanup_routine,completion_routine,abandon_routine,complete_acl`, memoryConsolidationPassCompleteRoutineMD5, memoryConsolidationPassGuardRoutineMD5, memoryConsolidationPassAbandonRoutineMD5, memoryConsolidationPassCleanupRoutineMD5).Scan(&available)
 	return available, err
 }
 
@@ -324,6 +334,7 @@ const (
 	memoryConsolidationPassCompleteRoutineMD5            = "1319f8b0c9b50efcbc1c6e1df68c7945" // #nosec G101 -- immutable schema routine checksum
 	memoryConsolidationPassGuardRoutineMD5               = "060b94eab7fe744984bd09efc2958a57" // #nosec G101 -- immutable schema routine checksum
 	memoryConsolidationPassAbandonRoutineMD5             = "bfe14c5526ec0cba1761501b1581ffe9" // #nosec G101 -- immutable schema routine checksum
+	memoryConsolidationPassCleanupRoutineMD5             = "29c0fef3a1d2e249301e5ae5040f24ea" // #nosec G101 -- immutable schema routine checksum
 	memoryConsolidationProposalSourceGuardRoutineMD5     = "aaa45e19ae18202e97772cb7096ad117"
 	memoryConsolidationProposalSourceLockGuardRoutineMD5 = "88c2c1cf6aabfec6303afb7a155f3de0"
 	memoryConsolidationClaimRoutineMD5                   = "121df7d09493be8662f4618208aaf342"

--- a/internal/postgres/brain_consolidation_schema.go
+++ b/internal/postgres/brain_consolidation_schema.go
@@ -280,6 +280,14 @@ WITH relation AS (
       AND tgtype=17 AND tgfoid=cleanup_oid AND tgenabled='O' AND tgattr='2 3'::int2vector
       AND tgqual IS NOT NULL)=1 AS exact
     FROM pg_trigger,relation WHERE tgrelid=checkpoint_oid AND NOT tgisinternal
+), expected_checks(name,definition) AS (
+    VALUES ('memory_consolidation_passes_start_sequence_check','CHECK ((start_sequence >= 0))'),
+           ('memory_consolidation_passes_next_sequence_check','CHECK ((next_sequence >= start_sequence))'),
+           ('memory_consolidation_passes_lease_generation_check','CHECK ((lease_generation >= 1))'),
+           ('memory_consolidation_passes_source_sha256_check','CHECK ((octet_length(source_sha256) = 32))')
+), actual_checks AS (
+    SELECT conname,pg_get_constraintdef(oid) FROM pg_constraint,relation
+    WHERE conrelid=table_oid AND contype='c'
 ), constraints AS (
     SELECT count(*)=6 AND bool_and(convalidated AND NOT condeferrable AND NOT condeferred)
        AND count(*) FILTER (WHERE contype='p' AND conkey=ARRAY[1,2,3]::smallint[])=1
@@ -325,7 +333,10 @@ SELECT relation.table_oid IS NOT NULL AND relation.checkpoint_oid IS NOT NULL AN
    AND NOT EXISTS (SELECT * FROM expected_columns EXCEPT SELECT * FROM actual_columns)
    AND NOT EXISTS (SELECT * FROM actual_columns EXCEPT SELECT * FROM expected_columns)
    AND table_acl.selects AND table_acl.no_writes AND table_acl.no_public AND insert_acl.exact AND column_acl_safety.exact
-   AND triggers.exact AND checkpoint_triggers.exact AND constraints.exact AND routines.exact AND guard_routine.exact AND cleanup_routine.exact AND completion_routine.exact AND abandon_routine.exact AND complete_acl.app_exec AND complete_acl.no_public
+   AND triggers.exact AND checkpoint_triggers.exact AND constraints.exact
+   AND NOT EXISTS (SELECT * FROM expected_checks EXCEPT SELECT * FROM actual_checks)
+   AND NOT EXISTS (SELECT * FROM actual_checks EXCEPT SELECT * FROM expected_checks)
+   AND routines.exact AND guard_routine.exact AND cleanup_routine.exact AND completion_routine.exact AND abandon_routine.exact AND complete_acl.app_exec AND complete_acl.no_public
 FROM relation,table_acl,insert_acl,column_acl_safety,triggers,checkpoint_triggers,constraints,routines,guard_routine,cleanup_routine,completion_routine,abandon_routine,complete_acl`, memoryConsolidationPassCompleteRoutineMD5, memoryConsolidationPassGuardRoutineMD5, memoryConsolidationPassAbandonRoutineMD5, memoryConsolidationPassCleanupRoutineMD5).Scan(&available)
 	return available, err
 }

--- a/internal/postgres/brain_consolidation_schema.go
+++ b/internal/postgres/brain_consolidation_schema.go
@@ -307,7 +307,7 @@ FROM relation,table_acl,insert_acl,triggers,checkpoint_triggers,constraints,rout
 }
 
 const (
-	memoryConsolidationPassCompleteRoutineMD5            = "1319f8b0c9b50efcbc1c6e1df68c7945"
+	memoryConsolidationPassCompleteRoutineMD5            = "1319f8b0c9b50efcbc1c6e1df68c7945" // #nosec G101 -- immutable schema routine checksum
 	memoryConsolidationProposalSourceGuardRoutineMD5     = "aaa45e19ae18202e97772cb7096ad117"
 	memoryConsolidationProposalSourceLockGuardRoutineMD5 = "88c2c1cf6aabfec6303afb7a155f3de0"
 	memoryConsolidationClaimRoutineMD5                   = "121df7d09493be8662f4618208aaf342"

--- a/internal/postgres/brain_consolidation_schema.go
+++ b/internal/postgres/brain_consolidation_schema.go
@@ -280,19 +280,15 @@ WITH relation AS (
       AND tgtype=17 AND tgfoid=cleanup_oid AND tgenabled='O' AND tgattr='2 3'::int2vector
       AND tgqual IS NOT NULL)=1 AS exact
     FROM pg_trigger,relation WHERE tgrelid=checkpoint_oid AND NOT tgisinternal
-), expected_checks(name,expression) AS (
-    VALUES ('memory_consolidation_passes_start_sequence_check','(start_sequence >= 0)'),
-           ('memory_consolidation_passes_next_sequence_check','(next_sequence >= start_sequence)'),
-           ('memory_consolidation_passes_lease_generation_check','(lease_generation >= 1)'),
-           ('memory_consolidation_passes_source_sha256_check','(octet_length(source_sha256) = 32)')
-), actual_checks AS (
-    SELECT conname,pg_get_expr(conbin,conrelid) FROM pg_constraint,relation
-    WHERE conrelid=table_oid AND contype='c'
 ), constraints AS (
     SELECT count(*)=6 AND bool_and(convalidated AND NOT condeferrable AND NOT condeferred)
        AND count(*) FILTER (WHERE contype='p' AND conkey=ARRAY[1,2,3]::smallint[])=1
        AND count(*) FILTER (WHERE contype='f' AND conkey=ARRAY[1]::smallint[] AND confrelid='brain.scopes'::regclass AND confdeltype='c')=1
-       AND count(*) FILTER (WHERE contype='c')=4 AS exact
+       AND count(*) FILTER (WHERE contype='c')=4
+       AND count(*) FILTER (WHERE contype='c' AND conname='memory_consolidation_passes_start_sequence_check' AND pg_get_expr(conbin,conrelid)='(start_sequence >= 0)')=1
+       AND count(*) FILTER (WHERE contype='c' AND conname='memory_consolidation_passes_next_sequence_check' AND pg_get_expr(conbin,conrelid)='(next_sequence >= start_sequence)')=1
+       AND count(*) FILTER (WHERE contype='c' AND conname='memory_consolidation_passes_lease_generation_check' AND pg_get_expr(conbin,conrelid)='(lease_generation >= 1)')=1
+       AND count(*) FILTER (WHERE contype='c' AND conname='memory_consolidation_passes_source_sha256_check' AND pg_get_expr(conbin,conrelid)='(octet_length(source_sha256) = 32)')=1 AS exact
     FROM pg_constraint,relation WHERE conrelid=table_oid AND contype<>'n'
 ), routines AS (
     SELECT count(*)=4 AND bool_and(pg_get_userbyid(proowner)='punaro_owner' AND prolang=(SELECT oid FROM pg_language WHERE lanname='plpgsql')
@@ -334,8 +330,6 @@ SELECT relation.table_oid IS NOT NULL AND relation.checkpoint_oid IS NOT NULL AN
    AND NOT EXISTS (SELECT * FROM actual_columns EXCEPT SELECT * FROM expected_columns)
    AND table_acl.selects AND table_acl.no_writes AND table_acl.no_public AND insert_acl.exact AND column_acl_safety.exact
    AND triggers.exact AND checkpoint_triggers.exact AND constraints.exact
-   AND NOT EXISTS (SELECT * FROM expected_checks EXCEPT SELECT * FROM actual_checks)
-   AND NOT EXISTS (SELECT * FROM actual_checks EXCEPT SELECT * FROM expected_checks)
    AND routines.exact AND guard_routine.exact AND cleanup_routine.exact AND completion_routine.exact AND abandon_routine.exact AND complete_acl.app_exec AND complete_acl.no_public
 FROM relation,table_acl,insert_acl,column_acl_safety,triggers,checkpoint_triggers,constraints,routines,guard_routine,cleanup_routine,completion_routine,abandon_routine,complete_acl`, memoryConsolidationPassCompleteRoutineMD5, memoryConsolidationPassGuardRoutineMD5, memoryConsolidationPassAbandonRoutineMD5, memoryConsolidationPassCleanupRoutineMD5).Scan(&available)
 	return available, err

--- a/internal/postgres/brain_proposal_store.go
+++ b/internal/postgres/brain_proposal_store.go
@@ -228,6 +228,10 @@ FROM candidates WHERE proposal.id=candidates.id RETURNING proposal.id::text`, sc
 }
 
 func checkMemoryProposalCapacity(ctx context.Context, tx *sql.Tx, scopeID, principalID string) error {
+	return checkMemoryProposalCapacityForCount(ctx, tx, scopeID, principalID, 1)
+}
+
+func checkMemoryProposalCapacityForCount(ctx context.Context, tx *sql.Tx, scopeID, principalID string, requested int) error {
 	var livePrincipal, liveScope, retainedPrincipal, retainedScope int
 	err := tx.QueryRowContext(ctx, `SELECT
     count(*) FILTER (WHERE proposed_by=$2 AND state='pending' AND expires_at > statement_timestamp()),
@@ -238,8 +242,8 @@ FROM brain.memory_proposals WHERE scope_id=$1`, scopeID, principalID).Scan(&live
 	if err != nil {
 		return errors.New("memory proposal capacity cannot be checked")
 	}
-	if livePrincipal >= maxLiveMemoryProposalsPrincipal || liveScope >= maxLiveMemoryProposalsScope ||
-		retainedPrincipal >= maxRetainedMemoryProposalsPrincipal || retainedScope >= maxRetainedMemoryProposalsScope {
+	if requested < 0 || livePrincipal+requested > maxLiveMemoryProposalsPrincipal || liveScope+requested > maxLiveMemoryProposalsScope ||
+		retainedPrincipal+requested > maxRetainedMemoryProposalsPrincipal || retainedScope+requested > maxRetainedMemoryProposalsScope {
 		return ErrMemoryProposalCapacity
 	}
 	return nil

--- a/internal/postgres/db.go
+++ b/internal/postgres/db.go
@@ -1221,6 +1221,13 @@ FROM objects, table_ownership, routine_safety, routine_acl, table_acl, schema_ac
 		}
 		snapshot.CurrentObjectsPresent = proposalSourceObjectsPresent
 	}
+	if snapshot.CurrentObjectsPresent && len(snapshot.Records) > 0 && snapshot.Records[len(snapshot.Records)-1].Version >= 39 {
+		passObjectsPresent, err := memoryConsolidationPassesAvailable(ctx, q)
+		if err != nil {
+			return Snapshot{}, errors.New("PostgreSQL memory consolidation pass schema cannot be inspected")
+		}
+		snapshot.CurrentObjectsPresent = passObjectsPresent
+	}
 	return snapshot, nil
 }
 

--- a/internal/postgres/migrate.go
+++ b/internal/postgres/migrate.go
@@ -71,6 +71,7 @@ var migrationCompatibilityFloors = map[int64]int64{
 	36: 10,
 	37: 10,
 	38: 10,
+	39: 10,
 }
 
 // CurrentManifest returns the immutable migrations embedded in this binary.

--- a/internal/postgres/migrations/039_memory_consolidation_passes.sql
+++ b/internal/postgres/migrations/039_memory_consolidation_passes.sql
@@ -11,7 +11,7 @@ CREATE TABLE brain.memory_consolidation_passes (
     sources jsonb NOT NULL,
     proposals jsonb NOT NULL,
     created_at timestamptz NOT NULL DEFAULT statement_timestamp(),
-    PRIMARY KEY (scope_id,timeline_id,start_sequence,next_sequence,principal_id,project_id)
+    PRIMARY KEY (scope_id,timeline_id,start_sequence,principal_id,project_id)
 );
 
 CREATE FUNCTION brain.guard_memory_consolidation_pass()

--- a/internal/postgres/migrations/039_memory_consolidation_passes.sql
+++ b/internal/postgres/migrations/039_memory_consolidation_passes.sql
@@ -16,7 +16,7 @@ CREATE TABLE brain.memory_consolidation_passes (
 
 CREATE FUNCTION brain.guard_memory_consolidation_pass()
 RETURNS trigger
-LANGUAGE plpgsql
+LANGUAGE plpgsql SECURITY DEFINER
 SET search_path = pg_catalog
 AS $function$
 BEGIN
@@ -109,3 +109,41 @@ $function$;
 
 REVOKE ALL ON FUNCTION brain.complete_memory_consolidation_pass(uuid,uuid,bigint,uuid,bigint,bigint,uuid,uuid) FROM PUBLIC;
 GRANT EXECUTE ON FUNCTION brain.complete_memory_consolidation_pass(uuid,uuid,bigint,uuid,bigint,bigint,uuid,uuid) TO punaro_app;
+
+CREATE FUNCTION brain.abandon_memory_consolidation_pass(
+    requested_scope uuid,
+    requested_token uuid,
+    requested_generation bigint,
+    requested_timeline uuid,
+    requested_start_sequence bigint,
+    requested_next_sequence bigint,
+    requested_principal uuid,
+    requested_project uuid
+)
+RETURNS boolean
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = pg_catalog
+AS $function$
+BEGIN
+    PERFORM jobs.assert_application_mutation();
+    DELETE FROM brain.memory_consolidation_passes AS pass
+    USING brain.memory_consolidation_checkpoints AS checkpoint
+    WHERE checkpoint.scope_id=requested_scope AND checkpoint.lease_token=requested_token
+      AND checkpoint.lease_generation=requested_generation AND checkpoint.lease_until>statement_timestamp()
+      AND checkpoint.timeline_id=requested_timeline AND checkpoint.change_sequence=requested_start_sequence
+      AND pass.scope_id=requested_scope AND pass.timeline_id=requested_timeline
+      AND pass.start_sequence=requested_start_sequence AND pass.next_sequence=requested_next_sequence
+      AND pass.principal_id=requested_principal AND pass.project_id=requested_project;
+    IF NOT FOUND THEN
+        RETURN false;
+    END IF;
+    UPDATE brain.memory_consolidation_checkpoints AS checkpoint
+    SET lease_holder=NULL,lease_token=NULL,lease_until=NULL,updated_at=statement_timestamp()
+    WHERE checkpoint.scope_id=requested_scope AND checkpoint.lease_token=requested_token
+      AND checkpoint.lease_generation=requested_generation AND checkpoint.lease_until>statement_timestamp()
+      AND checkpoint.timeline_id=requested_timeline AND checkpoint.change_sequence=requested_start_sequence;
+    RETURN FOUND;
+END
+$function$;
+
+REVOKE ALL ON FUNCTION brain.abandon_memory_consolidation_pass(uuid,uuid,bigint,uuid,bigint,bigint,uuid,uuid) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION brain.abandon_memory_consolidation_pass(uuid,uuid,bigint,uuid,bigint,bigint,uuid,uuid) TO punaro_app;

--- a/internal/postgres/migrations/039_memory_consolidation_passes.sql
+++ b/internal/postgres/migrations/039_memory_consolidation_passes.sql
@@ -125,25 +125,23 @@ LANGUAGE plpgsql SECURITY DEFINER SET search_path = pg_catalog
 AS $function$
 BEGIN
     PERFORM jobs.assert_application_mutation();
-    DELETE FROM brain.memory_consolidation_passes AS pass
-    USING brain.memory_consolidation_checkpoints AS checkpoint
-    WHERE checkpoint.scope_id=requested_scope AND checkpoint.lease_token=requested_token
-      AND checkpoint.lease_generation=requested_generation AND checkpoint.lease_until>statement_timestamp()
-      AND checkpoint.timeline_id=requested_timeline AND checkpoint.change_sequence=requested_start_sequence
-      AND pass.scope_id=requested_scope AND pass.timeline_id=requested_timeline
-      AND pass.start_sequence=requested_start_sequence AND pass.next_sequence=requested_next_sequence
-      AND pass.principal_id=requested_principal AND pass.project_id=requested_project;
-    IF NOT FOUND THEN
-        RETURN false;
-    END IF;
     UPDATE brain.memory_consolidation_checkpoints AS checkpoint
     SET change_sequence=requested_next_sequence,lease_holder=NULL,lease_token=NULL,lease_until=NULL,updated_at=statement_timestamp()
     FROM jobs.server_state AS state
     WHERE state.singleton AND checkpoint.scope_id=requested_scope AND checkpoint.lease_token=requested_token
       AND checkpoint.lease_generation=requested_generation AND checkpoint.lease_until>statement_timestamp()
       AND checkpoint.timeline_id=requested_timeline AND checkpoint.change_sequence=requested_start_sequence
-      AND requested_next_sequence>=checkpoint.change_sequence AND requested_next_sequence<=state.change_sequence;
-    RETURN FOUND;
+      AND requested_next_sequence>=checkpoint.change_sequence AND requested_next_sequence<=state.change_sequence
+      AND EXISTS (
+          SELECT 1 FROM brain.memory_consolidation_passes AS pass
+          WHERE pass.scope_id=requested_scope AND pass.timeline_id=requested_timeline
+            AND pass.start_sequence=requested_start_sequence AND pass.next_sequence=requested_next_sequence
+            AND pass.principal_id=requested_principal AND pass.project_id=requested_project
+      );
+    IF NOT FOUND THEN
+        RETURN false;
+    END IF;
+    RETURN true;
 END
 $function$;
 

--- a/internal/postgres/migrations/039_memory_consolidation_passes.sql
+++ b/internal/postgres/migrations/039_memory_consolidation_passes.sql
@@ -8,6 +8,7 @@ CREATE TABLE brain.memory_consolidation_passes (
     lease_token uuid NOT NULL,
     lease_generation bigint NOT NULL CHECK (lease_generation >= 1),
     source_sha256 bytea NOT NULL CHECK (octet_length(source_sha256)=32),
+    sources jsonb NOT NULL,
     proposals jsonb NOT NULL,
     created_at timestamptz NOT NULL DEFAULT statement_timestamp(),
     PRIMARY KEY (scope_id,timeline_id,start_sequence,next_sequence,principal_id,project_id)
@@ -46,7 +47,7 @@ FOR EACH STATEMENT EXECUTE FUNCTION jobs.guard_application_mutation();
 REVOKE ALL ON brain.memory_consolidation_passes FROM PUBLIC, punaro_app;
 REVOKE ALL ON FUNCTION brain.guard_memory_consolidation_pass() FROM PUBLIC;
 GRANT SELECT ON brain.memory_consolidation_passes TO punaro_app;
-GRANT INSERT (scope_id,timeline_id,start_sequence,next_sequence,principal_id,project_id,lease_token,lease_generation,source_sha256,proposals)
+GRANT INSERT (scope_id,timeline_id,start_sequence,next_sequence,principal_id,project_id,lease_token,lease_generation,source_sha256,sources,proposals)
     ON brain.memory_consolidation_passes TO punaro_app;
 
 CREATE FUNCTION brain.clear_memory_consolidation_passes_on_checkpoint_move()

--- a/internal/postgres/migrations/039_memory_consolidation_passes.sql
+++ b/internal/postgres/migrations/039_memory_consolidation_passes.sql
@@ -1,0 +1,110 @@
+CREATE TABLE brain.memory_consolidation_passes (
+    scope_id uuid NOT NULL REFERENCES brain.scopes(id) ON DELETE CASCADE,
+    timeline_id uuid NOT NULL,
+    start_sequence bigint NOT NULL CHECK (start_sequence >= 0),
+    next_sequence bigint NOT NULL CHECK (next_sequence >= start_sequence),
+    principal_id uuid NOT NULL,
+    project_id uuid NOT NULL,
+    lease_token uuid NOT NULL,
+    lease_generation bigint NOT NULL CHECK (lease_generation >= 1),
+    source_sha256 bytea NOT NULL CHECK (octet_length(source_sha256)=32),
+    proposals jsonb NOT NULL,
+    created_at timestamptz NOT NULL DEFAULT statement_timestamp(),
+    PRIMARY KEY (scope_id,timeline_id,start_sequence,next_sequence,principal_id,project_id)
+);
+
+CREATE FUNCTION brain.guard_memory_consolidation_pass()
+RETURNS trigger
+LANGUAGE plpgsql
+SET search_path = pg_catalog
+AS $function$
+BEGIN
+    PERFORM jobs.assert_application_mutation();
+    PERFORM 1
+    FROM brain.memory_consolidation_checkpoints AS checkpoint
+    WHERE checkpoint.scope_id=NEW.scope_id
+      AND checkpoint.timeline_id=NEW.timeline_id
+      AND checkpoint.change_sequence=NEW.start_sequence
+      AND checkpoint.lease_token=NEW.lease_token
+      AND checkpoint.lease_generation=NEW.lease_generation
+      AND checkpoint.lease_until>statement_timestamp();
+    IF NOT FOUND THEN
+        RAISE EXCEPTION USING ERRCODE='23514', MESSAGE='consolidation pass is not fenced by a live checkpoint lease';
+    END IF;
+    RETURN NEW;
+END
+$function$;
+
+CREATE TRIGGER memory_consolidation_pass_insert_guard
+BEFORE INSERT ON brain.memory_consolidation_passes
+FOR EACH ROW EXECUTE FUNCTION brain.guard_memory_consolidation_pass();
+
+CREATE TRIGGER application_mutation_fence
+BEFORE INSERT OR UPDATE OR DELETE OR TRUNCATE ON brain.memory_consolidation_passes
+FOR EACH STATEMENT EXECUTE FUNCTION jobs.guard_application_mutation();
+
+REVOKE ALL ON brain.memory_consolidation_passes FROM PUBLIC, punaro_app;
+REVOKE ALL ON FUNCTION brain.guard_memory_consolidation_pass() FROM PUBLIC;
+GRANT SELECT ON brain.memory_consolidation_passes TO punaro_app;
+GRANT INSERT (scope_id,timeline_id,start_sequence,next_sequence,principal_id,project_id,lease_token,lease_generation,source_sha256,proposals)
+    ON brain.memory_consolidation_passes TO punaro_app;
+
+CREATE FUNCTION brain.clear_memory_consolidation_passes_on_checkpoint_move()
+RETURNS trigger
+LANGUAGE plpgsql
+SET search_path = pg_catalog
+AS $function$
+BEGIN
+    DELETE FROM brain.memory_consolidation_passes WHERE scope_id=NEW.scope_id;
+    RETURN NULL;
+END
+$function$;
+
+CREATE TRIGGER memory_consolidation_pass_checkpoint_cleanup
+AFTER UPDATE OF timeline_id,change_sequence ON brain.memory_consolidation_checkpoints
+FOR EACH ROW WHEN ((OLD.timeline_id,OLD.change_sequence) IS DISTINCT FROM (NEW.timeline_id,NEW.change_sequence))
+EXECUTE FUNCTION brain.clear_memory_consolidation_passes_on_checkpoint_move();
+
+REVOKE ALL ON FUNCTION brain.clear_memory_consolidation_passes_on_checkpoint_move() FROM PUBLIC;
+
+CREATE FUNCTION brain.complete_memory_consolidation_pass(
+    requested_scope uuid,
+    requested_token uuid,
+    requested_generation bigint,
+    requested_timeline uuid,
+    requested_start_sequence bigint,
+    requested_next_sequence bigint,
+    requested_principal uuid,
+    requested_project uuid
+)
+RETURNS boolean
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = pg_catalog
+AS $function$
+BEGIN
+    PERFORM jobs.assert_application_mutation();
+    UPDATE brain.memory_consolidation_checkpoints AS checkpoint
+    SET timeline_id=requested_timeline,change_sequence=requested_next_sequence,lease_holder=NULL,lease_token=NULL,lease_until=NULL,updated_at=statement_timestamp()
+    FROM jobs.server_state AS state
+    WHERE state.singleton AND checkpoint.scope_id=requested_scope AND checkpoint.lease_token=requested_token
+      AND checkpoint.lease_generation=requested_generation AND checkpoint.lease_until>statement_timestamp()
+      AND checkpoint.timeline_id=requested_timeline AND checkpoint.change_sequence=requested_start_sequence
+      AND requested_next_sequence>=checkpoint.change_sequence AND requested_next_sequence<=state.change_sequence
+      AND EXISTS (
+          SELECT 1 FROM brain.memory_consolidation_passes AS pass
+          WHERE pass.scope_id=requested_scope AND pass.timeline_id=requested_timeline
+            AND pass.start_sequence=requested_start_sequence AND pass.next_sequence=requested_next_sequence
+            AND pass.principal_id=requested_principal AND pass.project_id=requested_project
+      );
+    IF NOT FOUND THEN
+        RETURN false;
+    END IF;
+    DELETE FROM brain.memory_consolidation_passes AS pass
+    WHERE pass.scope_id=requested_scope AND pass.timeline_id=requested_timeline
+      AND pass.start_sequence=requested_start_sequence AND pass.next_sequence=requested_next_sequence
+      AND pass.principal_id=requested_principal AND pass.project_id=requested_project;
+    RETURN true;
+END
+$function$;
+
+REVOKE ALL ON FUNCTION brain.complete_memory_consolidation_pass(uuid,uuid,bigint,uuid,bigint,bigint,uuid,uuid) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION brain.complete_memory_consolidation_pass(uuid,uuid,bigint,uuid,bigint,bigint,uuid,uuid) TO punaro_app;

--- a/internal/postgres/migrations/039_memory_consolidation_passes.sql
+++ b/internal/postgres/migrations/039_memory_consolidation_passes.sql
@@ -137,10 +137,12 @@ BEGIN
         RETURN false;
     END IF;
     UPDATE brain.memory_consolidation_checkpoints AS checkpoint
-    SET lease_holder=NULL,lease_token=NULL,lease_until=NULL,updated_at=statement_timestamp()
-    WHERE checkpoint.scope_id=requested_scope AND checkpoint.lease_token=requested_token
+    SET change_sequence=requested_next_sequence,lease_holder=NULL,lease_token=NULL,lease_until=NULL,updated_at=statement_timestamp()
+    FROM jobs.server_state AS state
+    WHERE state.singleton AND checkpoint.scope_id=requested_scope AND checkpoint.lease_token=requested_token
       AND checkpoint.lease_generation=requested_generation AND checkpoint.lease_until>statement_timestamp()
-      AND checkpoint.timeline_id=requested_timeline AND checkpoint.change_sequence=requested_start_sequence;
+      AND checkpoint.timeline_id=requested_timeline AND checkpoint.change_sequence=requested_start_sequence
+      AND requested_next_sequence>=checkpoint.change_sequence AND requested_next_sequence<=state.change_sequence;
     RETURN FOUND;
 END
 $function$;

--- a/internal/postgres/migrations/039_memory_consolidation_passes.sql
+++ b/internal/postgres/migrations/039_memory_consolidation_passes.sql
@@ -11,7 +11,7 @@ CREATE TABLE brain.memory_consolidation_passes (
     sources jsonb NOT NULL,
     proposals jsonb NOT NULL,
     created_at timestamptz NOT NULL DEFAULT statement_timestamp(),
-    PRIMARY KEY (scope_id,timeline_id,start_sequence,principal_id,project_id)
+    PRIMARY KEY (scope_id,timeline_id,start_sequence)
 );
 
 CREATE FUNCTION brain.guard_memory_consolidation_pass()

--- a/internal/postgres/postgres_integration_test.go
+++ b/internal/postgres/postgres_integration_test.go
@@ -2520,8 +2520,17 @@ func testBackupRestoreIntegration(ctx context.Context, t *testing.T, app *Databa
 		t.Fatal(err)
 	}
 	var restoreScopeID string
-	if err := ownerDB.QueryRowContext(ctx, `SELECT id::text FROM brain.scopes ORDER BY id LIMIT 1`).Scan(&restoreScopeID); err != nil {
-		t.Fatalf("consolidation scope for restore fence: %v", err)
+	if err := ownerDB.QueryRowContext(ctx, `WITH actor AS (
+    SELECT id FROM auth.principals ORDER BY id LIMIT 1
+), project AS (
+    INSERT INTO relay.projects(display_name,created_by)
+    SELECT 'restore-fence consolidation scope',id FROM actor
+    RETURNING id,created_by
+)
+INSERT INTO brain.scopes(project_id,created_by)
+SELECT id,created_by FROM project
+RETURNING id::text`).Scan(&restoreScopeID); err != nil {
+		t.Fatalf("create consolidation scope for restore fence: %v", err)
 	}
 	recoveredLease, claimed, err := app.ClaimMemoryConsolidationCheckpoint(ctx, restoreScopeID, "018f47f4-7b18-7cc2-98d6-31d4fb5ab744", memoryEmbeddingMaxLease)
 	if err != nil || !claimed {

--- a/internal/postgres/state_test.go
+++ b/internal/postgres/state_test.go
@@ -69,8 +69,8 @@ func TestManifestValidationRejectsMutableOrNonContiguousHistory(t *testing.T) {
 
 func TestCurrentManifestRequiresControlPlaneSchema(t *testing.T) {
 	manifest := CurrentManifest()
-	if manifest.MinSupported != 10 || manifest.MaxSupported != 38 || len(manifest.Migrations) != 38 {
-		t.Fatalf("manifest=%#v, want exact v38 compatibility window", manifest)
+	if manifest.MinSupported != 10 || manifest.MaxSupported != 39 || len(manifest.Migrations) != 39 {
+		t.Fatalf("manifest=%#v, want exact v39 compatibility window", manifest)
 	}
 	embedding := manifest.Migrations[23]
 	if embedding.Version != 24 || embedding.Name != "024_memory_embedding_worker_control" ||
@@ -88,7 +88,7 @@ func TestCurrentManifestRequiresControlPlaneSchema(t *testing.T) {
 			want = 10
 		case 12, 13:
 			want = 10
-		case 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38:
+		case 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39:
 			want = 10
 		}
 		if migration.CompatibilityFloor != want {
@@ -198,7 +198,10 @@ func TestCompatibleSchemaCanStillHavePendingMigrations(t *testing.T) {
 	if !migrationPending(SchemaState{Classification: Compatible, Version: 37}, manifest) {
 		t.Fatal("compatible v37 schema must still apply the pending v38 migration")
 	}
-	if migrationPending(SchemaState{Classification: Compatible, Version: 38}, manifest) {
-		t.Fatal("current v38 schema reported a pending migration")
+	if !migrationPending(SchemaState{Classification: Compatible, Version: 38}, manifest) {
+		t.Fatal("compatible v38 schema must still apply the pending v39 migration")
+	}
+	if migrationPending(SchemaState{Classification: Compatible, Version: 39}, manifest) {
+		t.Fatal("current v39 schema reported a pending migration")
 	}
 }


### PR DESCRIPTION
## M-21D: proposal-only consolidation pass

Delivers a provider-agnostic executor for one lease-fenced consolidation page. The trusted caller binds the authorized proposer and project; untrusted planner output contains only proposal bodies. The executor validates all bounded output before staging, derives replay-stable idempotency keys from the fenced page and normalized payload, stages every proposal, then advances the checkpoint only after staging succeeds.

## Explicit exclusions

No model/provider client, daemon scheduler, auto-approval, remote surface, or direct canonical mutation path. Canonical changes remain behind existing explicit proposal approval.

## Safety and rollback

- Partial stage failure leaves the checkpoint unadvanced; replay deduplicates completed stages and resumes remaining work.
- Wrong-project requests prove scope/capability binding before maintenance, preventing unrelated proposal expiry or pruning side effects.
- Additive Go/docs only; reverting removes the executor seam without migration or stored-state changes.

## Validation

- Focused red-first executor tests, including complete-output validation, duplicate-body rejection, partial-stage replay, and no-proposal advance.
- PostgreSQL package tests.
- `make test test-race staticcheck security lint` passed on the final head; `govulncheck` found no called vulnerabilities.
- Independent Pi GPT-5.4 remediation review: `PASS`.

## Operational note

Repeated delayed/silent controller report delivery was documented separately in https://github.com/rock3r/pioneer/issues/10; the eventual remediation report for this final reviewed boundary is preserved locally.