### PR TITLE
feat: add strict remote MCP JSON-RPC boundary

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -98,6 +98,13 @@ those scopes receives an OAuth insufficient-scope response. A later slice must
 still check the operation-specific verified scope and Punaro's authoritative
 project capability grant for that bound principal before exposing transport or
 tools.
+The next transport-dark foundation defines a bounded, strict JSON-RPC 2.0
+single-request parser. It rejects batches, ambiguous duplicate object members,
+unknown envelope members, invalid request IDs, non-object params, excessive
+nesting, and trailing data. It is intentionally not mounted on `/mcp` and
+cannot dispatch a method; a later adapter must apply operation-specific OAuth
+scope and authoritative project capability checks before using the parsed
+request.
 The mutation slice is separately dark behind
 `PUNARO_MEMORY_MUTATIONS_ENABLED`, which requires the read API opt-in. It adds
 strict canonical create/update/archive/restore/purge and staged-proposal

--- a/internal/mcphttp/jsonrpc.go
+++ b/internal/mcphttp/jsonrpc.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"io"
 	"strings"
+	"unicode/utf8"
 )
 
 const maxJSONRPCRequestBytes = 64 << 10
@@ -21,7 +22,7 @@ type jsonRPCRequest struct {
 }
 
 func parseJSONRPCRequest(raw []byte) (jsonRPCRequest, bool) {
-	if len(raw) == 0 || len(raw) > maxJSONRPCRequestBytes {
+	if len(raw) == 0 || len(raw) > maxJSONRPCRequestBytes || !utf8.Valid(raw) {
 		return jsonRPCRequest{}, false
 	}
 	decoder := json.NewDecoder(bytes.NewReader(raw))

--- a/internal/mcphttp/jsonrpc.go
+++ b/internal/mcphttp/jsonrpc.go
@@ -154,6 +154,7 @@ func validJSONRPCID(raw json.RawMessage) bool {
 
 func validJSONObject(raw json.RawMessage, maxDepth int) bool {
 	decoder := json.NewDecoder(bytes.NewReader(raw))
+	decoder.UseNumber()
 	start, err := decoder.Token()
 	if err != nil || start != json.Delim('{') || !consumeJSONRPCValue(decoder, start, 1, maxDepth) {
 		return false
@@ -164,6 +165,7 @@ func validJSONObject(raw json.RawMessage, maxDepth int) bool {
 
 func validJSONRPCValue(raw json.RawMessage, maxDepth int) bool {
 	decoder := json.NewDecoder(bytes.NewReader(raw))
+	decoder.UseNumber()
 	start, err := decoder.Token()
 	if err != nil || !consumeJSONRPCValue(decoder, start, 1, maxDepth) {
 		return false

--- a/internal/mcphttp/jsonrpc.go
+++ b/internal/mcphttp/jsonrpc.go
@@ -1,0 +1,137 @@
+package mcphttp
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"strings"
+)
+
+const maxJSONRPCRequestBytes = 64 << 10
+const maxJSONRPCDepth = 32
+
+// jsonRPCRequest is a strictly parsed single JSON-RPC request. It is not
+// mounted by the remote MCP handler yet; a later transport adapter consumes it
+// only after OAuth and Punaro capability authorization.
+type jsonRPCRequest struct {
+	ID           json.RawMessage
+	Method       string
+	Params       json.RawMessage
+	Notification bool
+}
+
+func parseJSONRPCRequest(raw []byte) (jsonRPCRequest, bool) {
+	if len(raw) == 0 || len(raw) > maxJSONRPCRequestBytes {
+		return jsonRPCRequest{}, false
+	}
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	decoder.UseNumber()
+	start, err := decoder.Token()
+	if err != nil || start != json.Delim('{') {
+		return jsonRPCRequest{}, false
+	}
+	fields := make(map[string]json.RawMessage, 4)
+	for decoder.More() {
+		name, err := decoder.Token()
+		key, ok := name.(string)
+		if err != nil || !ok || (key != "jsonrpc" && key != "id" && key != "method" && key != "params") || fields[key] != nil {
+			return jsonRPCRequest{}, false
+		}
+		var value json.RawMessage
+		if decoder.Decode(&value) != nil || !validJSONRPCValue(value, maxJSONRPCDepth) {
+			return jsonRPCRequest{}, false
+		}
+		fields[key] = value
+	}
+	end, err := decoder.Token()
+	if err != nil || end != json.Delim('}') || decoder.Decode(&struct{}{}) != io.EOF {
+		return jsonRPCRequest{}, false
+	}
+	var version, method string
+	if len(fields) < 2 || json.Unmarshal(fields["jsonrpc"], &version) != nil || version != "2.0" || json.Unmarshal(fields["method"], &method) != nil || !validJSONRPCMethod(method) {
+		return jsonRPCRequest{}, false
+	}
+	request := jsonRPCRequest{Method: method, Params: append(json.RawMessage(nil), fields["params"]...)}
+	if id, present := fields["id"]; present {
+		if !validJSONRPCID(id) {
+			return jsonRPCRequest{}, false
+		}
+		request.ID = append(json.RawMessage(nil), id...)
+	} else {
+		request.Notification = true
+	}
+	if len(request.Params) > 0 && !validJSONObject(request.Params, maxJSONRPCDepth) {
+		return jsonRPCRequest{}, false
+	}
+	return request, true
+}
+
+func validJSONRPCMethod(method string) bool {
+	return method != "" && len(method) <= 128 && strings.TrimSpace(method) == method && !strings.ContainsAny(method, "\x00\r\n")
+}
+
+func validJSONRPCID(raw json.RawMessage) bool {
+	trimmed := bytes.TrimSpace(raw)
+	if bytes.Equal(trimmed, []byte("null")) {
+		return true
+	}
+	var stringID string
+	if json.Unmarshal(trimmed, &stringID) == nil {
+		return stringID != "" && len(stringID) <= 128 && strings.TrimSpace(stringID) == stringID && !strings.ContainsAny(stringID, "\x00\r\n")
+	}
+	var number json.Number
+	return json.Unmarshal(trimmed, &number) == nil && len(number.String()) <= 64
+}
+
+func validJSONObject(raw json.RawMessage, maxDepth int) bool {
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	start, err := decoder.Token()
+	if err != nil || start != json.Delim('{') || !consumeJSONRPCValue(decoder, start, 1, maxDepth) {
+		return false
+	}
+	_, err = decoder.Token()
+	return err == io.EOF
+}
+
+func validJSONRPCValue(raw json.RawMessage, maxDepth int) bool {
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	start, err := decoder.Token()
+	if err != nil || !consumeJSONRPCValue(decoder, start, 1, maxDepth) {
+		return false
+	}
+	_, err = decoder.Token()
+	return err == io.EOF
+}
+
+func consumeJSONRPCValue(decoder *json.Decoder, token json.Token, depth, maxDepth int) bool {
+	if depth > maxDepth {
+		return false
+	}
+	delim, container := token.(json.Delim)
+	if !container {
+		return true
+	}
+	if delim != '{' && delim != '[' {
+		return false
+	}
+	seen := map[string]struct{}{}
+	for decoder.More() {
+		if delim == '{' {
+			key, err := decoder.Token()
+			name, ok := key.(string)
+			if err != nil || !ok {
+				return false
+			}
+			if _, duplicate := seen[name]; duplicate {
+				return false
+			}
+			seen[name] = struct{}{}
+		}
+		next, err := decoder.Token()
+		if err != nil || !consumeJSONRPCValue(decoder, next, depth+1, maxDepth) {
+			return false
+		}
+	}
+	end, err := decoder.Token()
+	return err == nil && ((delim == '{' && end == json.Delim('}')) || (delim == '[' && end == json.Delim(']')))
+}

--- a/internal/mcphttp/jsonrpc.go
+++ b/internal/mcphttp/jsonrpc.go
@@ -22,7 +22,7 @@ type jsonRPCRequest struct {
 }
 
 func parseJSONRPCRequest(raw []byte) (jsonRPCRequest, bool) {
-	if len(raw) == 0 || len(raw) > maxJSONRPCRequestBytes || !utf8.Valid(raw) {
+	if len(raw) == 0 || len(raw) > maxJSONRPCRequestBytes || !utf8.Valid(raw) || !validJSONUnicodeEscapes(raw) {
 		return jsonRPCRequest{}, false
 	}
 	decoder := json.NewDecoder(bytes.NewReader(raw))
@@ -65,6 +65,74 @@ func parseJSONRPCRequest(raw []byte) (jsonRPCRequest, bool) {
 		return jsonRPCRequest{}, false
 	}
 	return request, true
+}
+
+func validJSONUnicodeEscapes(raw []byte) bool {
+	inString := false
+	for index := 0; index < len(raw); index++ {
+		if !inString {
+			if raw[index] == '"' {
+				inString = true
+			}
+			continue
+		}
+		if raw[index] == '"' {
+			inString = false
+			continue
+		}
+		if raw[index] != '\\' {
+			continue
+		}
+		index++
+		if index >= len(raw) {
+			return false
+		}
+		if raw[index] != 'u' {
+			continue
+		}
+		if index+4 >= len(raw) {
+			return false
+		}
+		unit, ok := jsonUTF16Unit(raw[index+1 : index+5])
+		if !ok {
+			return false
+		}
+		index += 4
+		if unit >= 0xd800 && unit <= 0xdbff {
+			if index+6 >= len(raw) || raw[index+1] != '\\' || raw[index+2] != 'u' {
+				return false
+			}
+			low, ok := jsonUTF16Unit(raw[index+3 : index+7])
+			if !ok || low < 0xdc00 || low > 0xdfff {
+				return false
+			}
+			index += 6
+		} else if unit >= 0xdc00 && unit <= 0xdfff {
+			return false
+		}
+	}
+	return !inString
+}
+
+func jsonUTF16Unit(raw []byte) (uint16, bool) {
+	if len(raw) != 4 {
+		return 0, false
+	}
+	var result uint16
+	for _, value := range raw {
+		result <<= 4
+		switch {
+		case value >= '0' && value <= '9':
+			result |= uint16(value - '0')
+		case value >= 'a' && value <= 'f':
+			result |= uint16(value-'a') + 10
+		case value >= 'A' && value <= 'F':
+			result |= uint16(value-'A') + 10
+		default:
+			return 0, false
+		}
+	}
+	return result, true
 }
 
 func validJSONRPCMethod(method string) bool {

--- a/internal/mcphttp/jsonrpc_test.go
+++ b/internal/mcphttp/jsonrpc_test.go
@@ -41,8 +41,8 @@ func TestParseJSONRPCRequestEnforcesSizeBoundary(t *testing.T) {
 
 func TestParseJSONRPCRequestEnforcesDepthBoundary(t *testing.T) {
 	for _, test := range []struct {
-		name    string
-		arrays  int
+		name     string
+		arrays   int
 		accepted bool
 	}{
 		{name: "at limit", arrays: maxJSONRPCDepth - 2, accepted: true},

--- a/internal/mcphttp/jsonrpc_test.go
+++ b/internal/mcphttp/jsonrpc_test.go
@@ -33,3 +33,14 @@ func TestParseJSONRPCRequestRejectsMalformedUTF8(t *testing.T) {
 		t.Fatal("accepted malformed UTF-8")
 	}
 }
+
+func TestParseJSONRPCRequestRejectsUnpairedSurrogateEscape(t *testing.T) {
+	for _, raw := range []string{
+		`{"jsonrpc":"2.0","id":1,"method":"tools/\ud800list"}`,
+		`{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{"query":"\udc00"}}`,
+	} {
+		if _, ok := parseJSONRPCRequest([]byte(raw)); ok {
+			t.Fatalf("accepted unpaired surrogate: %s", raw)
+		}
+	}
+}

--- a/internal/mcphttp/jsonrpc_test.go
+++ b/internal/mcphttp/jsonrpc_test.go
@@ -2,6 +2,7 @@ package mcphttp
 
 import (
 	"bytes"
+	"strings"
 	"testing"
 )
 
@@ -20,6 +21,39 @@ func TestParseJSONRPCRequestPreservesValidLargeNumbers(t *testing.T) {
 		if _, ok := parseJSONRPCRequest([]byte(raw)); !ok {
 			t.Fatalf("rejected valid large number: %s", raw)
 		}
+	}
+}
+
+func TestParseJSONRPCRequestEnforcesSizeBoundary(t *testing.T) {
+	prefix := `{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{"query":"`
+	suffix := `"}}`
+	accepted := []byte(prefix + strings.Repeat("x", maxJSONRPCRequestBytes-len(prefix)-len(suffix)) + suffix)
+	if len(accepted) != maxJSONRPCRequestBytes {
+		t.Fatalf("accepted length=%d", len(accepted))
+	}
+	if _, ok := parseJSONRPCRequest(accepted); !ok {
+		t.Fatal("rejected request at size limit")
+	}
+	if _, ok := parseJSONRPCRequest(append(accepted[:len(accepted)-len(suffix)], append([]byte("x"), []byte(suffix)...)...)); ok {
+		t.Fatal("accepted request over size limit")
+	}
+}
+
+func TestParseJSONRPCRequestEnforcesDepthBoundary(t *testing.T) {
+	for _, test := range []struct {
+		name    string
+		arrays  int
+		accepted bool
+	}{
+		{name: "at limit", arrays: maxJSONRPCDepth - 2, accepted: true},
+		{name: "over limit", arrays: maxJSONRPCDepth - 1, accepted: false},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			raw := `{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{"value":` + strings.Repeat("[", test.arrays) + "0" + strings.Repeat("]", test.arrays) + "}}"
+			if _, ok := parseJSONRPCRequest([]byte(raw)); ok != test.accepted {
+				t.Fatalf("accepted=%t want %t", ok, test.accepted)
+			}
+		})
 	}
 }
 

--- a/internal/mcphttp/jsonrpc_test.go
+++ b/internal/mcphttp/jsonrpc_test.go
@@ -1,6 +1,9 @@
 package mcphttp
 
-import "testing"
+import (
+	"bytes"
+	"testing"
+)
 
 func TestParseJSONRPCRequestAcceptsBoundedSingleRequest(t *testing.T) {
 	request, ok := parseJSONRPCRequest([]byte(`{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}`))
@@ -21,5 +24,12 @@ func TestParseJSONRPCRequestRejectsAmbiguousOrInvalidEnvelope(t *testing.T) {
 		if _, ok := parseJSONRPCRequest([]byte(raw)); ok {
 			t.Fatalf("accepted %s", raw)
 		}
+	}
+}
+
+func TestParseJSONRPCRequestRejectsMalformedUTF8(t *testing.T) {
+	raw := bytes.ReplaceAll([]byte(`{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{"query":"x"}}`), []byte("x"), []byte{0xff})
+	if _, ok := parseJSONRPCRequest(raw); ok {
+		t.Fatal("accepted malformed UTF-8")
 	}
 }

--- a/internal/mcphttp/jsonrpc_test.go
+++ b/internal/mcphttp/jsonrpc_test.go
@@ -1,0 +1,25 @@
+package mcphttp
+
+import "testing"
+
+func TestParseJSONRPCRequestAcceptsBoundedSingleRequest(t *testing.T) {
+	request, ok := parseJSONRPCRequest([]byte(`{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}`))
+	if !ok || string(request.ID) != "1" || request.Method != "tools/list" || string(request.Params) != "{}" || request.Notification {
+		t.Fatalf("request=%#v ok=%t", request, ok)
+	}
+}
+
+func TestParseJSONRPCRequestRejectsAmbiguousOrInvalidEnvelope(t *testing.T) {
+	for _, raw := range []string{
+		`[{"jsonrpc":"2.0","id":1,"method":"tools/list"}]`,
+		`{"jsonrpc":"2.0","id":1,"method":"tools/list","method":"tools/call"}`,
+		`{"jsonrpc":"2.0","id":{},"method":"tools/list"}`,
+		`{"jsonrpc":"2.0","id":1,"method":"tools/list","params":[]}`,
+		`{"jsonrpc":"2.0","id":1,"method":"tools/list","extra":true}`,
+		`{"jsonrpc":"1.0","id":1,"method":"tools/list"}`,
+	} {
+		if _, ok := parseJSONRPCRequest([]byte(raw)); ok {
+			t.Fatalf("accepted %s", raw)
+		}
+	}
+}

--- a/internal/mcphttp/jsonrpc_test.go
+++ b/internal/mcphttp/jsonrpc_test.go
@@ -12,6 +12,17 @@ func TestParseJSONRPCRequestAcceptsBoundedSingleRequest(t *testing.T) {
 	}
 }
 
+func TestParseJSONRPCRequestPreservesValidLargeNumbers(t *testing.T) {
+	for _, raw := range []string{
+		`{"jsonrpc":"2.0","id":1e400,"method":"tools/list","params":{}}`,
+		`{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{"n":1e400}}`,
+	} {
+		if _, ok := parseJSONRPCRequest([]byte(raw)); !ok {
+			t.Fatalf("rejected valid large number: %s", raw)
+		}
+	}
+}
+
 func TestParseJSONRPCRequestRejectsAmbiguousOrInvalidEnvelope(t *testing.T) {
 	for _, raw := range []string{
 		`[{"jsonrpc":"2.0","id":1,"method":"tools/list"}]`,


### PR DESCRIPTION
Summary: add a bounded strict JSON-RPC 2.0 single-request parser for the future remote MCP transport; reject batches, duplicate/unknown envelope fields, invalid IDs, non-object params, excessive nesting, and trailing data; keep it unmounted with no tools or request dispatch.

Validation: full Punaro test, race, static analysis, security, and lint gates completed. Independent Pioneer GPT-5.4 review again produced no stdout, stderr, or report artifact; evidence was appended to rock3r/pioneer issue 10.