### PR TITLE
feat: add server-authorized invoke capability

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -341,6 +341,33 @@ recipient       inject into local agent_mailbox
 recipient       POST /v1/deliveries/{id}/ack
 ```
 
+### Server-authorized invocation
+
+`notify` is still only the best-effort wake hint above: it can reach an
+already-attached adapter but cannot create an agent process. `invoke` is a
+separate, explicitly granted conversation capability. An attached member with
+`invoke` may submit `POST /v1/conversations/{id}/invocations` with only its
+endpoint, a receiving target endpoint, and an idempotency key. The server
+authorizes the caller's live ownership plus `invoke`, derives the target
+machine from the durable endpoint record, requires that target to have
+`receive`, verifies unacknowledged work exists, and creates a handoff only if
+the target is currently offline. An attached target produces the content-free
+`already_running` result instead; it never causes a second start.
+
+An invocation stores no message body. It has a durable ID, target machine,
+stable random fence, retry state, lease generation/token, and body-free audit
+events for request, lease, retry, acceptance, and terminal failure. The target
+machine's always-on adapter leases those records and hands the fixed local
+runtime command only `invocation_id`, conversation ID, target endpoint, and
+fence. The runtime must durably make a fence idempotent before it reports
+success and attaches the role; ordinary delivery then follows the existing
+lease/inject/ack flow. A failed handoff retries after 2, 4, then 8 seconds and
+becomes a visible terminal failure after three attempts. If the adapter crashes
+after local acceptance but before its server outcome, its private journal and
+the stable fence prevent a second start on the re-leased record. This is a
+fenced at-least-once handoff acknowledgement, not an unsupported claim of
+exactly-once process creation.
+
 The lease response is the source of truth. It contains bounded durable
 deliveries plus a map of conversation IDs to the recipient's highest contiguous
 acknowledged sequence. Every recipient has an independent
@@ -719,8 +746,11 @@ API client and reaches the relay using its own enrolled machine credential.
 | `POST` | `/v1/conversations` | Create a conversation with explicit members; idempotent per signed machine and key. |
 | `GET` | `/v1/conversations` | List conversations the caller may discover. |
 | `POST` | `/v1/conversations/{id}/messages` | Append an authorized message. |
+| `POST` | `/v1/conversations/{id}/invocations` | Request a server-authorized, body-free offline-role handoff. |
 | `POST` | `/v1/deliveries/lease` | Lease bounded durable deliveries for one endpoint. |
 | `POST` | `/v1/deliveries/{id}/ack` | Acknowledge after local injection. |
+| `POST` | `/v1/invocations/lease` | Lease content-free runtime handoffs for the authenticated machine. |
+| `POST` | `/v1/invocations/{id}/outcome` | Record one fenced local-runtime outcome. |
 | `GET` | `/v1/notifications` | Best-effort WebSocket wake-up stream. |
 
 Use opaque UUID/ULID identifiers. Endpoint names are labels, not URL

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -372,7 +372,9 @@ Terminal invocation records, their idempotency bindings, and their body-free
 audit trail are retained for 24 hours from their terminal transition to serve
 bounded client retries, then pruned atomically by later invoke traffic. Pending
 handoffs and the short accepted-attachment fence are never pruned by this
-retention path.
+retention path. A pending handoff that has neither been polled nor completed
+for 24 hours is terminally failed before a later invoke can create a fresh
+fence, bounding its coalesced idempotency and audit metadata.
 
 The lease response is the source of truth. It contains bounded durable
 deliveries plus a map of conversation IDs to the recipient's highest contiguous

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -369,9 +369,10 @@ fenced at-least-once handoff acknowledgement, not an unsupported claim of
 exactly-once process creation.
 
 Terminal invocation records, their idempotency bindings, and their body-free
-audit trail are retained for 24 hours to serve bounded client retries, then
-pruned atomically by later invoke traffic. Pending handoffs and the short
-accepted-attachment fence are never pruned by this retention path.
+audit trail are retained for 24 hours from their terminal transition to serve
+bounded client retries, then pruned atomically by later invoke traffic. Pending
+handoffs and the short accepted-attachment fence are never pruned by this
+retention path.
 
 The lease response is the source of truth. It contains bounded durable
 deliveries plus a map of conversation IDs to the recipient's highest contiguous

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -368,6 +368,11 @@ the stable fence prevent a second start on the re-leased record. This is a
 fenced at-least-once handoff acknowledgement, not an unsupported claim of
 exactly-once process creation.
 
+Terminal invocation records, their idempotency bindings, and their body-free
+audit trail are retained for 24 hours to serve bounded client retries, then
+pruned atomically by later invoke traffic. Pending handoffs and the short
+accepted-attachment fence are never pruned by this retention path.
+
 The lease response is the source of truth. It contains bounded durable
 deliveries plus a map of conversation IDs to the recipient's highest contiguous
 acknowledged sequence. Every recipient has an independent

--- a/cmd/punaro-adapter/main.go
+++ b/cmd/punaro-adapter/main.go
@@ -23,15 +23,16 @@ import (
 )
 
 type adapterConfig struct {
-	relayURL      string
-	machineID     string
-	privateKey    ed25519.PrivateKey
-	attachedGroup string
-	mailboxBinary string
-	mailboxState  string
-	dataDir       string
-	pollInterval  time.Duration
-	accessToken   adapter.AccessServiceToken
+	relayURL       string
+	machineID      string
+	privateKey     ed25519.PrivateKey
+	attachedGroup  string
+	mailboxBinary  string
+	mailboxState   string
+	dataDir        string
+	pollInterval   time.Duration
+	accessToken    adapter.AccessServiceToken
+	invokerCommand string
 }
 
 func main() {
@@ -43,10 +44,12 @@ func main() {
 		err = runSend(os.Args[2:])
 	case os.Args[1] == "create":
 		err = runCreate(os.Args[2:])
+	case os.Args[1] == "invoke":
+		err = runInvoke(os.Args[2:])
 	case os.Args[1] == "attachment-notify":
 		err = runAttachmentNotify(os.Args[2:])
 	default:
-		err = fmt.Errorf("unknown command %q (supported: send, create, attachment-notify)", os.Args[1])
+		err = fmt.Errorf("unknown command %q (supported: send, create, invoke, attachment-notify)", os.Args[1])
 	}
 	if err != nil {
 		log.Printf("punaro-adapter stopped: %v", err)
@@ -89,6 +92,8 @@ func parseCreateArgs(args []string) (createRequest, error) {
 				capability |= relay.CapReceive
 			case "admin":
 				capability |= relay.CapAdmin
+			case "invoke":
+				capability |= relay.CapInvoke
 			default:
 				return createRequest{}, fmt.Errorf("invalid member capability")
 			}
@@ -99,6 +104,48 @@ func parseCreateArgs(args []string) (createRequest, error) {
 		request.members = append(request.members, relay.Member{Endpoint: endpoint, Capabilities: capability})
 	}
 	return request, nil
+}
+
+type invokeRequest struct {
+	conversationID string
+	fromEndpoint   string
+	targetEndpoint string
+	idempotencyKey string
+}
+
+func parseInvokeArgs(args []string) (invokeRequest, error) {
+	flags := flag.NewFlagSet("punaro-adapter invoke", flag.ContinueOnError)
+	flags.SetOutput(io.Discard)
+	var request invokeRequest
+	flags.StringVar(&request.conversationID, "conversation", "", "conversation ID")
+	flags.StringVar(&request.fromEndpoint, "from", "", "attached invoking endpoint")
+	flags.StringVar(&request.targetEndpoint, "target", "", "offline receiving endpoint")
+	flags.StringVar(&request.idempotencyKey, "idempotency-key", "", "stable invocation retry key")
+	if err := flags.Parse(args); err != nil || flags.NArg() != 0 || strings.TrimSpace(request.conversationID) == "" || strings.TrimSpace(request.fromEndpoint) == "" || strings.TrimSpace(request.targetEndpoint) == "" || strings.TrimSpace(request.idempotencyKey) == "" {
+		return invokeRequest{}, fmt.Errorf("--conversation, --from, --target, and --idempotency-key are required")
+	}
+	return request, nil
+}
+
+func runInvoke(args []string) error {
+	request, err := parseInvokeArgs(args)
+	if err != nil {
+		return err
+	}
+	config, err := loadConfig()
+	if err != nil {
+		return fmt.Errorf("configuration: %w", err)
+	}
+	client, err := adapter.NewHTTPRelayClient(config.relayURL, config.machineID, config.privateKey, nil, config.accessToken)
+	if err != nil {
+		return err
+	}
+	invocation, err := client.Invoke(context.Background(), request.conversationID, request.fromEndpoint, request.targetEndpoint, request.idempotencyKey)
+	if err != nil {
+		return err
+	}
+	_, err = fmt.Fprintf(os.Stdout, "{\"id\":%q,\"status\":%q}\n", invocation.ID, invocation.Status)
+	return err
 }
 
 func runCreate(args []string) error {
@@ -271,7 +318,14 @@ func run() error {
 		return err
 	}
 	defer func() { _ = offerOutbox.Close() }()
-	syncer := adapter.Syncer{Mailbox: mailbox, Relay: relayClient, Journal: journal}
+	var invoker adapter.Invoker
+	if config.invokerCommand != "" {
+		invoker, err = adapter.NewCommandInvoker(config.invokerCommand)
+		if err != nil {
+			return fmt.Errorf("invocation runtime: %w", err)
+		}
+	}
+	syncer := adapter.Syncer{Mailbox: mailbox, Relay: relayClient, Journal: journal, Invoker: invoker}
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer stop()
 	wake := make(chan struct{}, 1)
@@ -364,7 +418,7 @@ func loadConfig() (adapterConfig, error) {
 	if (accessToken.ClientID == "") != (accessToken.ClientSecret == "") {
 		return adapterConfig{}, fmt.Errorf("both PUNARO_CF_ACCESS_CLIENT_ID and PUNARO_CF_ACCESS_CLIENT_SECRET are required together")
 	}
-	return adapterConfig{relayURL: relayURL, machineID: machineID, privateKey: key, attachedGroup: group, mailboxBinary: mailboxBinary, mailboxState: strings.TrimSpace(os.Getenv("PUNARO_MAILBOX_STATE_DIR")), dataDir: dataDir, pollInterval: pollInterval, accessToken: accessToken}, nil
+	return adapterConfig{relayURL: relayURL, machineID: machineID, privateKey: key, attachedGroup: group, mailboxBinary: mailboxBinary, mailboxState: strings.TrimSpace(os.Getenv("PUNARO_MAILBOX_STATE_DIR")), dataDir: dataDir, pollInterval: pollInterval, accessToken: accessToken, invokerCommand: strings.TrimSpace(os.Getenv("PUNARO_INVOKER_COMMAND"))}, nil
 }
 
 func loadPrivateKey(path string) (ed25519.PrivateKey, error) {

--- a/cmd/punaro-adapter/main_test.go
+++ b/cmd/punaro-adapter/main_test.go
@@ -39,6 +39,16 @@ func TestParseCreateArgsRequiresExplicitMembership(t *testing.T) {
 	}
 }
 
+func TestParseInvokeArgsRequiresExplicitContentFreeTargetAndRetryKey(t *testing.T) {
+	if _, err := parseInvokeArgs([]string{"--conversation", "conversation-1", "--from", "agent/a", "--target", "agent/b"}); err == nil {
+		t.Fatal("invoke without idempotency key was accepted")
+	}
+	request, err := parseInvokeArgs([]string{"--conversation", "conversation-1", "--from", "agent/a", "--target", "agent/b", "--idempotency-key", "invoke-1"})
+	if err != nil || request.conversationID != "conversation-1" || request.fromEndpoint != "agent/a" || request.targetEndpoint != "agent/b" || request.idempotencyKey != "invoke-1" {
+		t.Fatalf("invoke request did not parse: %#v err=%v", request, err)
+	}
+}
+
 func TestLoadConfigRequiresPrivateKeyAndAttachmentGroup(t *testing.T) {
 	t.Setenv("PUNARO_ADAPTER_RELAY_URL", "https://relay.example")
 	t.Setenv("PUNARO_MACHINE_ID", "machine-a")

--- a/docs/alpha-text-relay.md
+++ b/docs/alpha-text-relay.md
@@ -79,6 +79,20 @@ PUNARO_ADAPTER_DATA_DIR=/var/lib/punaro-adapter
 PUNARO_ADAPTER_POLL_INTERVAL=30s
 ```
 
+To enable offline-role invocation, additionally configure
+`PUNARO_INVOKER_COMMAND` with an absolute, protected executable owned by the
+local operator. Punaro invokes it only as:
+
+```text
+COMMAND invoke --invocation-id ID --conversation ID --endpoint ENDPOINT --fence FENCE
+```
+
+It receives no message body. It must persist the fence before starting or
+attaching the role, treat the same fence as an idempotent no-op after a crash,
+and return success only after that durable acceptance. Without this local
+runtime configuration the adapter continues normal mail delivery but does not
+lease invoke work.
+
 For an Access service-token policy, provision both
 `PUNARO_CF_ACCESS_CLIENT_ID` and `PUNARO_CF_ACCESS_CLIENT_SECRET` through the
 same private environment that starts the adapter. The adapter rejects a partial

--- a/internal/adapter/client.go
+++ b/internal/adapter/client.go
@@ -195,7 +195,9 @@ func (c *HTTPRelayClient) LeaseInvocations(ctx context.Context) ([]relay.Invocat
 	var response struct {
 		Invocations []relay.Invocation `json:"invocations"`
 	}
-	_, err := c.doJSON(ctx, http.MethodPost, "/v1/invocations/lease", map[string]any{"consumer_id": c.consumerID}, &response)
+	// A runtime handoff can take the full invocation timeout. Claim only one
+	// record per sync so queued work never burns leases while waiting locally.
+	_, err := c.doJSON(ctx, http.MethodPost, "/v1/invocations/lease", map[string]any{"consumer_id": c.consumerID, "limit": 1}, &response)
 	return response.Invocations, err
 }
 

--- a/internal/adapter/client.go
+++ b/internal/adapter/client.go
@@ -190,6 +190,25 @@ func (c *HTTPRelayClient) Lease(ctx context.Context, endpoint string) ([]relay.D
 	return response.Deliveries, err
 }
 
+// LeaseInvocations obtains content-free, server-authorized local runtime work.
+func (c *HTTPRelayClient) LeaseInvocations(ctx context.Context) ([]relay.Invocation, error) {
+	var response struct {
+		Invocations []relay.Invocation `json:"invocations"`
+	}
+	_, err := c.doJSON(ctx, http.MethodPost, "/v1/invocations/lease", map[string]any{"consumer_id": c.consumerID}, &response)
+	return response.Invocations, err
+}
+
+// ReportInvocation records the host-local runtime outcome using the relay
+// lease fence. A failed report leaves the durable handoff for retry.
+func (c *HTTPRelayClient) ReportInvocation(ctx context.Context, invocation relay.Invocation, accepted bool) error {
+	if strings.TrimSpace(invocation.ID) == "" || !relay.ValidRequestToken(invocation.LeaseToken) || invocation.LeaseGeneration < 1 {
+		return fmt.Errorf("invocation lease is required")
+	}
+	_, err := c.doJSON(ctx, http.MethodPost, "/v1/invocations/"+url.PathEscape(invocation.ID)+"/outcome", map[string]any{"lease_token": invocation.LeaseToken, "lease_generation": invocation.LeaseGeneration, "accepted": accepted}, nil)
+	return err
+}
+
 // CreateConversation bootstraps an explicit, membership-scoped room from an
 // attached local endpoint. The relay still verifies endpoint ownership.
 func (c *HTTPRelayClient) CreateConversation(ctx context.Context, creator string, members []relay.Member, idempotencyKey string) (relay.Conversation, error) {
@@ -216,6 +235,9 @@ func capabilityNames(capabilities relay.Capability) []string {
 	if capabilities&relay.CapAdmin != 0 {
 		result = append(result, "admin")
 	}
+	if capabilities&relay.CapInvoke != 0 {
+		result = append(result, "invoke")
+	}
 	return result
 }
 
@@ -232,6 +254,17 @@ func (c *HTTPRelayClient) Send(ctx context.Context, conversationID, fromEndpoint
 		return message, &relayHTTPStatusError{status: status, err: err}
 	}
 	return message, nil
+}
+
+// Invoke requests a body-free server-authorized handoff for an offline
+// receiving member. The target machine and pending work are derived server-side.
+func (c *HTTPRelayClient) Invoke(ctx context.Context, conversationID, fromEndpoint, targetEndpoint, idempotencyKey string) (relay.Invocation, error) {
+	if strings.TrimSpace(conversationID) == "" || strings.TrimSpace(fromEndpoint) == "" || strings.TrimSpace(targetEndpoint) == "" || strings.TrimSpace(idempotencyKey) == "" {
+		return relay.Invocation{}, fmt.Errorf("conversation, invoking endpoint, target endpoint, and idempotency key are required")
+	}
+	var invocation relay.Invocation
+	_, err := c.doJSONWithIdempotency(ctx, http.MethodPost, "/v1/conversations/"+url.PathEscape(conversationID)+"/invocations", map[string]any{"from_endpoint": fromEndpoint, "target_endpoint": targetEndpoint}, idempotencyKey, &invocation)
+	return invocation, err
 }
 
 // ValidateSender performs an authenticated, side-effect-free check that an

--- a/internal/adapter/client_test.go
+++ b/internal/adapter/client_test.go
@@ -119,6 +119,35 @@ func TestHTTPRelayClientValidatesSenderWithoutMessageMutation(t *testing.T) {
 	}
 }
 
+func TestHTTPRelayClientLeasesOneInvocationPerSync(t *testing.T) {
+	_, machinePrivate, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/v1/invocations/lease" {
+			t.Fatalf("unexpected route %s %s", r.Method, r.URL.Path)
+		}
+		var request struct {
+			ConsumerID string `json:"consumer_id"`
+			Limit      int    `json:"limit"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&request); err != nil || request.ConsumerID != "adapter-a" || request.Limit != 1 {
+			t.Fatalf("request=%#v err=%v", request, err)
+		}
+		_, _ = w.Write([]byte(`{"invocations":[]}`))
+	}))
+	defer server.Close()
+	client, err := NewHTTPRelayClient(server.URL, "machine-a", machinePrivate, server.Client(), AccessServiceToken{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	client.consumerID = "adapter-a"
+	if invocations, err := client.LeaseInvocations(context.Background()); err != nil || len(invocations) != 0 {
+		t.Fatalf("invocations=%#v err=%v", invocations, err)
+	}
+}
+
 func TestHTTPRelayClientClassifiesOnlyPreAppendRejectionsAsTerminalOfferFailures(t *testing.T) {
 	_, private, err := ed25519.GenerateKey(rand.Reader)
 	if err != nil {

--- a/internal/adapter/invocation_test.go
+++ b/internal/adapter/invocation_test.go
@@ -89,6 +89,29 @@ func TestSyncerReportsFailedRuntimeHandoffForBoundedRelayRetry(t *testing.T) {
 	}
 }
 
+func TestSyncerDoesNotInvokeRoleThatAttachedDuringCycle(t *testing.T) {
+	journal, err := OpenJournal(filepath.Join(t.TempDir(), "adapter.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = journal.Close() })
+	mailbox := &fakeMailbox{onAttached: func(call int) []string {
+		if call == 1 {
+			return nil
+		}
+		return []string{"agent/recipient"}
+	}}
+	relayClient := &fakeInvocationRelay{fakeRelay: fakeRelay{deliveries: map[string][]relay.Delivery{}}, invocations: []relay.Invocation{{ID: "invoke-1", ConversationID: "conversation-1", TargetEndpoint: "agent/recipient", TargetMachineID: "machine-a", Fence: "stable-fence", LeaseToken: "lease-1", LeaseGeneration: 1}}}
+	runtime := &fakeInvoker{}
+	syncer := Syncer{Mailbox: mailbox, Relay: relayClient, Journal: journal, Invoker: runtime}
+	if err := syncer.SyncOnce(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if runtime.calls != 0 || len(relayClient.reports) != 1 || relayClient.reports[0].accepted {
+		t.Fatalf("runtime calls=%d reports=%#v", runtime.calls, relayClient.reports)
+	}
+}
+
 type fakeInvoker struct {
 	calls  int
 	fences []string

--- a/internal/adapter/invocation_test.go
+++ b/internal/adapter/invocation_test.go
@@ -1,0 +1,87 @@
+package adapter
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/rock3r/punaro/internal/relay"
+)
+
+func TestSyncerFencesRuntimeInvokeAcrossLostOutcomeAcknowledgement(t *testing.T) {
+	journal, err := OpenJournal(filepath.Join(t.TempDir(), "adapter.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = journal.Close() })
+	invocation := relay.Invocation{ID: "invoke-1", ConversationID: "conversation-1", TargetEndpoint: "agent/offline", TargetMachineID: "machine-a", Fence: "stable-fence", LeaseToken: "lease-1", LeaseGeneration: 1}
+	relayClient := &fakeInvocationRelay{fakeRelay: fakeRelay{deliveries: map[string][]relay.Delivery{}}, invocations: []relay.Invocation{invocation}, reportErr: errors.New("lost response")}
+	runtime := &fakeInvoker{}
+	syncer := Syncer{Mailbox: &fakeMailbox{}, Relay: relayClient, Journal: journal, Invoker: runtime}
+	if err := syncer.SyncOnce(context.Background()); err == nil {
+		t.Fatal("lost outcome acknowledgement reported success")
+	}
+	if runtime.calls != 1 || runtime.fences[0] != "stable-fence" {
+		t.Fatalf("runtime calls=%d fences=%#v", runtime.calls, runtime.fences)
+	}
+	relayClient.reportErr = nil
+	invocation.LeaseToken, invocation.LeaseGeneration = "lease-2", 2
+	relayClient.invocations = []relay.Invocation{invocation}
+	if err := syncer.SyncOnce(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if runtime.calls != 1 || len(relayClient.reports) != 2 || !relayClient.reports[1].accepted {
+		t.Fatalf("runtime calls=%d reports=%#v", runtime.calls, relayClient.reports)
+	}
+}
+
+func TestSyncerReportsFailedRuntimeHandoffForBoundedRelayRetry(t *testing.T) {
+	journal, err := OpenJournal(filepath.Join(t.TempDir(), "adapter.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = journal.Close() })
+	relayClient := &fakeInvocationRelay{fakeRelay: fakeRelay{deliveries: map[string][]relay.Delivery{}}, invocations: []relay.Invocation{{ID: "invoke-1", ConversationID: "conversation-1", TargetEndpoint: "agent/offline", TargetMachineID: "machine-a", Fence: "stable-fence", LeaseToken: "lease-1", LeaseGeneration: 1}}}
+	syncer := Syncer{Mailbox: &fakeMailbox{}, Relay: relayClient, Journal: journal, Invoker: &fakeInvoker{err: errors.New("runtime unavailable")}, Now: func() time.Time { return time.Date(2026, time.August, 3, 12, 0, 0, 0, time.UTC) }}
+	if err := syncer.SyncOnce(context.Background()); err == nil {
+		t.Fatal("failed runtime handoff reported success")
+	}
+	if len(relayClient.reports) != 1 || relayClient.reports[0].accepted {
+		t.Fatalf("reports=%#v", relayClient.reports)
+	}
+}
+
+type fakeInvoker struct {
+	calls  int
+	fences []string
+	err    error
+}
+
+func (i *fakeInvoker) Invoke(_ context.Context, invocation relay.Invocation) error {
+	i.calls++
+	i.fences = append(i.fences, invocation.Fence)
+	return i.err
+}
+
+type invocationReport struct {
+	id       string
+	accepted bool
+}
+
+type fakeInvocationRelay struct {
+	fakeRelay
+	invocations []relay.Invocation
+	reports     []invocationReport
+	reportErr   error
+}
+
+func (r *fakeInvocationRelay) LeaseInvocations(context.Context) ([]relay.Invocation, error) {
+	return r.invocations, nil
+}
+
+func (r *fakeInvocationRelay) ReportInvocation(_ context.Context, invocation relay.Invocation, accepted bool) error {
+	r.reports = append(r.reports, invocationReport{id: invocation.ID, accepted: accepted})
+	return r.reportErr
+}

--- a/internal/adapter/invocation_test.go
+++ b/internal/adapter/invocation_test.go
@@ -28,7 +28,7 @@ func TestSyncerFencesRuntimeInvokeAcrossLostOutcomeAcknowledgement(t *testing.T)
 		t.Fatalf("runtime calls=%d fences=%#v", runtime.calls, runtime.fences)
 	}
 	relayClient.reportErr = nil
-	invocation.LeaseToken, invocation.LeaseGeneration = "lease-2", 2
+	invocation.LeaseToken, invocation.LeaseGeneration, invocation.RecoveryOnly = "lease-2", 2, true
 	relayClient.invocations = []relay.Invocation{invocation}
 	if err := syncer.SyncOnce(context.Background()); err != nil {
 		t.Fatal(err)
@@ -97,17 +97,20 @@ func TestSyncerReportsFailedRuntimeHandoffForBoundedRelayRetry(t *testing.T) {
 	}
 }
 
-func TestSyncerPrunesAcceptedJournalRowAfterTerminalReportCrashWindow(t *testing.T) {
+func TestSyncerPrunesTerminalJournalRowsAfterCrashRecoveryWindow(t *testing.T) {
 	journal, err := OpenJournal(filepath.Join(t.TempDir(), "adapter.db"))
 	if err != nil {
 		t.Fatal(err)
 	}
 	t.Cleanup(func() { _ = journal.Close() })
 	now := time.Date(2026, time.August, 3, 12, 0, 0, 0, time.UTC)
-	if _, err := journal.ensureInvocation("invoke-1", "stable-fence", now.Add(-invocationJournalRetention-time.Second)); err != nil {
+	if _, err := journal.ensureInvocation("accepted", "accepted-fence", now.Add(-invocationJournalRetention-time.Second)); err != nil {
 		t.Fatal(err)
 	}
-	if err := journal.markInvocationAccepted("invoke-1", "stable-fence", now.Add(-invocationJournalRetention-time.Second)); err != nil {
+	if err := journal.markInvocationAccepted("accepted", "accepted-fence", now.Add(-invocationJournalRetention-time.Second)); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := journal.ensureInvocation("failed", "failed-fence", now.Add(-invocationJournalRetention-time.Second)); err != nil {
 		t.Fatal(err)
 	}
 	syncer := Syncer{Journal: journal}
@@ -117,6 +120,24 @@ func TestSyncerPrunesAcceptedJournalRowAfterTerminalReportCrashWindow(t *testing
 	var retained int
 	if err := journal.db.QueryRowContext(context.Background(), `SELECT count(*) FROM inbound_invocations`).Scan(&retained); err != nil || retained != 0 {
 		t.Fatalf("retained invocation rows=%d err=%v", retained, err)
+	}
+}
+
+func TestSyncerFinalRecoveryNeverReinvokesWithoutAcceptedJournal(t *testing.T) {
+	journal, err := OpenJournal(filepath.Join(t.TempDir(), "adapter.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = journal.Close() })
+	invocation := relay.Invocation{ID: "invoke-1", ConversationID: "conversation-1", TargetEndpoint: "agent/offline", TargetMachineID: "machine-a", Fence: "stable-fence", LeaseToken: "lease-4", LeaseGeneration: 4, RecoveryOnly: true}
+	relayClient := &fakeInvocationRelay{fakeRelay: fakeRelay{deliveries: map[string][]relay.Delivery{}}, invocations: []relay.Invocation{invocation}}
+	runtime := &fakeInvoker{}
+	syncer := Syncer{Mailbox: &fakeMailbox{}, Relay: relayClient, Journal: journal, Invoker: runtime}
+	if err := syncer.SyncOnce(context.Background()); err == nil {
+		t.Fatal("unconfirmed final recovery reported success")
+	}
+	if runtime.calls != 0 || len(relayClient.reports) != 1 || relayClient.reports[0].accepted {
+		t.Fatalf("runtime calls=%d reports=%#v", runtime.calls, relayClient.reports)
 	}
 }
 

--- a/internal/adapter/invocation_test.go
+++ b/internal/adapter/invocation_test.go
@@ -39,7 +39,18 @@ func TestSyncerFencesRuntimeInvokeAcrossLostOutcomeAcknowledgement(t *testing.T)
 }
 
 func TestCommandInvokerRejectsSymlinkAndWritableAncestors(t *testing.T) {
-	directory := t.TempDir()
+	directory, err := os.MkdirTemp(".", ".invoke-runtime-test-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(directory) })
+	if err := os.Chmod(directory, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	directory, err = filepath.Abs(directory)
+	if err != nil {
+		t.Fatal(err)
+	}
 	command := filepath.Join(directory, "runtime")
 	if err := os.WriteFile(command, []byte("#!/bin/sh\nexit 0\n"), 0o700); err != nil { // #nosec G306 -- test executable must be executable by its owner.
 		t.Fatal(err)

--- a/internal/adapter/invocation_test.go
+++ b/internal/adapter/invocation_test.go
@@ -97,6 +97,29 @@ func TestSyncerReportsFailedRuntimeHandoffForBoundedRelayRetry(t *testing.T) {
 	}
 }
 
+func TestSyncerPrunesAcceptedJournalRowAfterTerminalReportCrashWindow(t *testing.T) {
+	journal, err := OpenJournal(filepath.Join(t.TempDir(), "adapter.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = journal.Close() })
+	now := time.Date(2026, time.August, 3, 12, 0, 0, 0, time.UTC)
+	if _, err := journal.ensureInvocation("invoke-1", "stable-fence", now.Add(-invocationJournalRetention-time.Second)); err != nil {
+		t.Fatal(err)
+	}
+	if err := journal.markInvocationAccepted("invoke-1", "stable-fence", now.Add(-invocationJournalRetention-time.Second)); err != nil {
+		t.Fatal(err)
+	}
+	syncer := Syncer{Journal: journal}
+	if err := syncer.syncInvocations(context.Background(), &fakeInvocationRelay{fakeRelay: fakeRelay{deliveries: map[string][]relay.Delivery{}}}, now); err != nil {
+		t.Fatal(err)
+	}
+	var retained int
+	if err := journal.db.QueryRowContext(context.Background(), `SELECT count(*) FROM inbound_invocations`).Scan(&retained); err != nil || retained != 0 {
+		t.Fatalf("retained invocation rows=%d err=%v", retained, err)
+	}
+}
+
 func TestSyncerDoesNotInvokeRoleThatAttachedDuringCycle(t *testing.T) {
 	journal, err := OpenJournal(filepath.Join(t.TempDir(), "adapter.db"))
 	if err != nil {

--- a/internal/adapter/invocation_test.go
+++ b/internal/adapter/invocation_test.go
@@ -37,7 +37,7 @@ func TestSyncerFencesRuntimeInvokeAcrossLostOutcomeAcknowledgement(t *testing.T)
 		t.Fatalf("runtime calls=%d reports=%#v", runtime.calls, relayClient.reports)
 	}
 	var retained int
-	if err := journal.db.QueryRow(`SELECT count(*) FROM inbound_invocations`).Scan(&retained); err != nil || retained != 0 {
+	if err := journal.db.QueryRowContext(context.Background(), `SELECT count(*) FROM inbound_invocations`).Scan(&retained); err != nil || retained != 0 {
 		t.Fatalf("retained invocation rows=%d err=%v", retained, err)
 	}
 }

--- a/internal/adapter/invocation_test.go
+++ b/internal/adapter/invocation_test.go
@@ -3,6 +3,7 @@ package adapter
 import (
 	"context"
 	"errors"
+	"os"
 	"path/filepath"
 	"testing"
 	"time"
@@ -34,6 +35,30 @@ func TestSyncerFencesRuntimeInvokeAcrossLostOutcomeAcknowledgement(t *testing.T)
 	}
 	if runtime.calls != 1 || len(relayClient.reports) != 2 || !relayClient.reports[1].accepted {
 		t.Fatalf("runtime calls=%d reports=%#v", runtime.calls, relayClient.reports)
+	}
+}
+
+func TestCommandInvokerRejectsSymlinkAndWritableAncestors(t *testing.T) {
+	directory := t.TempDir()
+	command := filepath.Join(directory, "runtime")
+	if err := os.WriteFile(command, []byte("#!/bin/sh\nexit 0\n"), 0o700); err != nil { // #nosec G306 -- test executable must be executable by its owner.
+		t.Fatal(err)
+	}
+	if _, err := NewCommandInvoker(command); err != nil {
+		t.Fatalf("protected command rejected: %v", err)
+	}
+	symlink := filepath.Join(directory, "runtime-link")
+	if err := os.Symlink(command, symlink); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := NewCommandInvoker(symlink); err == nil {
+		t.Fatal("symlinked command accepted")
+	}
+	if err := os.Chmod(directory, 0o777); err != nil { // #nosec G302 -- test constructs an intentionally unsafe ancestor.
+		t.Fatal(err)
+	}
+	if _, err := NewCommandInvoker(command); err == nil {
+		t.Fatal("command with writable ancestor accepted")
 	}
 }
 

--- a/internal/adapter/invocation_test.go
+++ b/internal/adapter/invocation_test.go
@@ -123,6 +123,29 @@ func TestSyncerPrunesTerminalJournalRowsAfterCrashRecoveryWindow(t *testing.T) {
 	}
 }
 
+func TestSyncerRetainsRecoveryJournalBeyondRelayWindow(t *testing.T) {
+	journal, err := OpenJournal(filepath.Join(t.TempDir(), "adapter.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = journal.Close() })
+	now := time.Date(2026, time.August, 3, 12, 0, 0, 0, time.UTC)
+	acceptedAt := now.Add(-25 * time.Hour) // Beyond the relay window, inside the local skew margin.
+	if _, err := journal.ensureInvocation("accepted", "accepted-fence", acceptedAt); err != nil {
+		t.Fatal(err)
+	}
+	if err := journal.markInvocationAccepted("accepted", "accepted-fence", acceptedAt); err != nil {
+		t.Fatal(err)
+	}
+	if err := journal.pruneInvocationRecoveryRows(now); err != nil {
+		t.Fatal(err)
+	}
+	var retained int
+	if err := journal.db.QueryRowContext(context.Background(), `SELECT count(*) FROM inbound_invocations`).Scan(&retained); err != nil || retained != 1 {
+		t.Fatalf("retained invocation rows=%d err=%v", retained, err)
+	}
+}
+
 func TestSyncerFinalRecoveryNeverReinvokesWithoutAcceptedJournal(t *testing.T) {
 	journal, err := OpenJournal(filepath.Join(t.TempDir(), "adapter.db"))
 	if err != nil {

--- a/internal/adapter/invocation_test.go
+++ b/internal/adapter/invocation_test.go
@@ -36,6 +36,10 @@ func TestSyncerFencesRuntimeInvokeAcrossLostOutcomeAcknowledgement(t *testing.T)
 	if runtime.calls != 1 || len(relayClient.reports) != 2 || !relayClient.reports[1].accepted {
 		t.Fatalf("runtime calls=%d reports=%#v", runtime.calls, relayClient.reports)
 	}
+	var retained int
+	if err := journal.db.QueryRow(`SELECT count(*) FROM inbound_invocations`).Scan(&retained); err != nil || retained != 0 {
+		t.Fatalf("retained invocation rows=%d err=%v", retained, err)
+	}
 }
 
 func TestCommandInvokerRejectsSymlinkAndWritableAncestors(t *testing.T) {

--- a/internal/adapter/invocation_test.go
+++ b/internal/adapter/invocation_test.go
@@ -44,7 +44,7 @@ func TestCommandInvokerRejectsSymlinkAndWritableAncestors(t *testing.T) {
 		t.Fatal(err)
 	}
 	t.Cleanup(func() { _ = os.RemoveAll(directory) })
-	if err := os.Chmod(directory, 0o700); err != nil {
+	if err := os.Chmod(directory, 0o700); err != nil { // #nosec G302 -- test fixture directory must be owner-traversable.
 		t.Fatal(err)
 	}
 	directory, err = filepath.Abs(directory)

--- a/internal/adapter/invocation_test.go
+++ b/internal/adapter/invocation_test.go
@@ -107,7 +107,7 @@ func TestSyncerDoesNotInvokeRoleThatAttachedDuringCycle(t *testing.T) {
 	if err := syncer.SyncOnce(context.Background()); err != nil {
 		t.Fatal(err)
 	}
-	if runtime.calls != 0 || len(relayClient.reports) != 1 || relayClient.reports[0].accepted {
+	if runtime.calls != 0 || len(relayClient.reports) != 1 || !relayClient.reports[0].accepted {
 		t.Fatalf("runtime calls=%d reports=%#v", runtime.calls, relayClient.reports)
 	}
 }

--- a/internal/adapter/invocation_test.go
+++ b/internal/adapter/invocation_test.go
@@ -91,6 +91,10 @@ func TestSyncerReportsFailedRuntimeHandoffForBoundedRelayRetry(t *testing.T) {
 	if len(relayClient.reports) != 1 || relayClient.reports[0].accepted {
 		t.Fatalf("reports=%#v", relayClient.reports)
 	}
+	var retained int
+	if err := journal.db.QueryRowContext(context.Background(), `SELECT count(*) FROM inbound_invocations`).Scan(&retained); err != nil || retained != 0 {
+		t.Fatalf("retained invocation rows=%d err=%v", retained, err)
+	}
 }
 
 func TestSyncerDoesNotInvokeRoleThatAttachedDuringCycle(t *testing.T) {

--- a/internal/adapter/invoker.go
+++ b/internal/adapter/invoker.go
@@ -1,0 +1,59 @@
+package adapter
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/rock3r/punaro/internal/relay"
+)
+
+const invocationRuntimeTimeout = 30 * time.Second
+
+// CommandInvoker invokes one operator-installed local runtime. The executable
+// and all argument names are fixed locally; the relay supplies only opaque
+// identifiers and the stable dedupe fence, never an executable or body.
+type CommandInvoker struct{ path string }
+
+// NewCommandInvoker validates an absolute, non-group/world-writable runtime
+// executable before the adapter enables remote invocation handoffs.
+func NewCommandInvoker(path string) (*CommandInvoker, error) {
+	if !filepath.IsAbs(path) || filepath.Clean(path) != path {
+		return nil, fmt.Errorf("invocation runtime command must be an absolute path")
+	}
+	info, err := os.Stat(path)
+	if err != nil || !info.Mode().IsRegular() || info.Mode().Perm()&0o022 != 0 {
+		return nil, fmt.Errorf("invocation runtime command must be a protected regular executable")
+	}
+	if info.Mode().Perm()&0o111 == 0 {
+		return nil, fmt.Errorf("invocation runtime command is not executable")
+	}
+	return &CommandInvoker{path: path}, nil
+}
+
+// Invoke starts one locally configured role under a stable fence. Exit zero
+// means the runtime durably accepted that fence, not merely that it spawned a
+// process. The runtime must make duplicate fences no-ops across its own crash
+// boundary before returning success.
+func (i *CommandInvoker) Invoke(ctx context.Context, invocation relay.Invocation) error {
+	if i == nil || i.path == "" || strings.TrimSpace(invocation.ID) == "" || strings.TrimSpace(invocation.ConversationID) == "" || strings.TrimSpace(invocation.TargetEndpoint) == "" || strings.TrimSpace(invocation.Fence) == "" {
+		return fmt.Errorf("invalid local invocation handoff")
+	}
+	deadline, cancel := context.WithTimeout(ctx, invocationRuntimeTimeout)
+	defer cancel()
+	// #nosec G204 -- path is validated operator configuration and arguments are
+	// fixed flags with opaque server identifiers; message bodies never appear.
+	command := exec.CommandContext(deadline, i.path, "invoke", "--invocation-id", invocation.ID, "--conversation", invocation.ConversationID, "--endpoint", invocation.TargetEndpoint, "--fence", invocation.Fence)
+	command.Stdout = nil
+	command.Stderr = nil
+	if err := command.Run(); err != nil {
+		return fmt.Errorf("local invocation runtime failed: %w", err)
+	}
+	return nil
+}
+
+var _ Invoker = (*CommandInvoker)(nil)

--- a/internal/adapter/invoker.go
+++ b/internal/adapter/invoker.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 	"time"
@@ -17,7 +16,7 @@ const invocationRuntimeTimeout = 30 * time.Second
 // CommandInvoker invokes one operator-installed local runtime. The executable
 // and all argument names are fixed locally; the relay supplies only opaque
 // identifiers and the stable dedupe fence, never an executable or body.
-type CommandInvoker struct{ path string }
+type CommandInvoker struct{ executable *os.File }
 
 // NewCommandInvoker validates an absolute, non-group/world-writable runtime
 // executable before the adapter enables remote invocation handoffs.
@@ -25,14 +24,11 @@ func NewCommandInvoker(path string) (*CommandInvoker, error) {
 	if !filepath.IsAbs(path) || filepath.Clean(path) != path {
 		return nil, fmt.Errorf("invocation runtime command must be an absolute path")
 	}
-	info, err := os.Stat(path)
-	if err != nil || !info.Mode().IsRegular() || info.Mode().Perm()&0o022 != 0 {
-		return nil, fmt.Errorf("invocation runtime command must be a protected regular executable")
+	executable, err := openPinnedInvocationExecutable(path)
+	if err != nil {
+		return nil, err
 	}
-	if info.Mode().Perm()&0o111 == 0 {
-		return nil, fmt.Errorf("invocation runtime command is not executable")
-	}
-	return &CommandInvoker{path: path}, nil
+	return &CommandInvoker{executable: executable}, nil
 }
 
 // Invoke starts one locally configured role under a stable fence. Exit zero
@@ -40,17 +36,12 @@ func NewCommandInvoker(path string) (*CommandInvoker, error) {
 // process. The runtime must make duplicate fences no-ops across its own crash
 // boundary before returning success.
 func (i *CommandInvoker) Invoke(ctx context.Context, invocation relay.Invocation) error {
-	if i == nil || i.path == "" || strings.TrimSpace(invocation.ID) == "" || strings.TrimSpace(invocation.ConversationID) == "" || strings.TrimSpace(invocation.TargetEndpoint) == "" || strings.TrimSpace(invocation.Fence) == "" {
+	if i == nil || i.executable == nil || strings.TrimSpace(invocation.ID) == "" || strings.TrimSpace(invocation.ConversationID) == "" || strings.TrimSpace(invocation.TargetEndpoint) == "" || strings.TrimSpace(invocation.Fence) == "" {
 		return fmt.Errorf("invalid local invocation handoff")
 	}
 	deadline, cancel := context.WithTimeout(ctx, invocationRuntimeTimeout)
 	defer cancel()
-	// #nosec G204 -- path is validated operator configuration and arguments are
-	// fixed flags with opaque server identifiers; message bodies never appear.
-	command := exec.CommandContext(deadline, i.path, "invoke", "--invocation-id", invocation.ID, "--conversation", invocation.ConversationID, "--endpoint", invocation.TargetEndpoint, "--fence", invocation.Fence)
-	command.Stdout = nil
-	command.Stderr = nil
-	if err := command.Run(); err != nil {
+	if err := runPinnedInvocationExecutable(deadline, i.executable, invocation); err != nil {
 		return fmt.Errorf("local invocation runtime failed: %w", err)
 	}
 	return nil

--- a/internal/adapter/invoker_unix.go
+++ b/internal/adapter/invoker_unix.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"syscall"
 
 	"github.com/rock3r/punaro/internal/relay"
 )
@@ -26,7 +27,7 @@ func openPinnedInvocationExecutable(path string) (*os.File, error) {
 	}
 	for current := canonicalPath; ; current = filepath.Dir(current) {
 		info, err := os.Lstat(current)
-		if err != nil || info.Mode()&os.ModeSymlink != 0 || info.Mode().Perm()&0o022 != 0 {
+		if err != nil || info.Mode()&os.ModeSymlink != 0 || info.Mode().Perm()&0o022 != 0 || !trustedInvocationPathOwner(info) {
 			return nil, fmt.Errorf("invocation runtime command must have protected non-symlink path components")
 		}
 		if current == string(filepath.Separator) {
@@ -34,7 +35,7 @@ func openPinnedInvocationExecutable(path string) (*os.File, error) {
 		}
 	}
 	info, err := os.Lstat(canonicalPath)
-	if err != nil || !info.Mode().IsRegular() {
+	if err != nil || !info.Mode().IsRegular() || !trustedInvocationPathOwner(info) {
 		return nil, fmt.Errorf("invocation runtime command must be a protected regular executable")
 	}
 	if info.Mode().Perm()&0o111 == 0 {
@@ -51,6 +52,11 @@ func openPinnedInvocationExecutable(path string) (*os.File, error) {
 		return nil, fmt.Errorf("invocation runtime command changed during validation")
 	}
 	return executable, nil
+}
+
+func trustedInvocationPathOwner(info os.FileInfo) bool {
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	return ok && (stat.Uid == uint32(os.Geteuid()) || stat.Uid == 0)
 }
 
 func runPinnedInvocationExecutable(ctx context.Context, executable *os.File, invocation relay.Invocation) error {

--- a/internal/adapter/invoker_unix.go
+++ b/internal/adapter/invoker_unix.go
@@ -56,7 +56,11 @@ func openPinnedInvocationExecutable(path string) (*os.File, error) {
 
 func trustedInvocationPathOwner(info os.FileInfo) bool {
 	stat, ok := info.Sys().(*syscall.Stat_t)
-	return ok && (stat.Uid == uint32(os.Geteuid()) || stat.Uid == 0)
+	if !ok {
+		return false
+	}
+	owner := int64(stat.Uid)
+	return owner == int64(os.Geteuid()) || owner == 0
 }
 
 func runPinnedInvocationExecutable(ctx context.Context, executable *os.File, invocation relay.Invocation) error {

--- a/internal/adapter/invoker_unix.go
+++ b/internal/adapter/invoker_unix.go
@@ -1,0 +1,64 @@
+//go:build !windows
+
+package adapter
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+
+	"github.com/rock3r/punaro/internal/relay"
+)
+
+// openPinnedInvocationExecutable rejects a symlink or writable ancestor, then
+// keeps the verified inode open. The later exec uses that descriptor rather
+// than resolving the configured pathname again.
+func openPinnedInvocationExecutable(path string) (*os.File, error) {
+	requestedInfo, err := os.Lstat(path)
+	if err != nil || requestedInfo.Mode()&os.ModeSymlink != 0 {
+		return nil, fmt.Errorf("invocation runtime command must be a protected regular executable")
+	}
+	canonicalPath, err := filepath.EvalSymlinks(path)
+	if err != nil {
+		return nil, fmt.Errorf("resolve invocation runtime command: %w", err)
+	}
+	for current := canonicalPath; ; current = filepath.Dir(current) {
+		info, err := os.Lstat(current)
+		if err != nil || info.Mode()&os.ModeSymlink != 0 || info.Mode().Perm()&0o022 != 0 {
+			return nil, fmt.Errorf("invocation runtime command must have protected non-symlink path components")
+		}
+		if current == string(filepath.Separator) {
+			break
+		}
+	}
+	info, err := os.Lstat(canonicalPath)
+	if err != nil || !info.Mode().IsRegular() {
+		return nil, fmt.Errorf("invocation runtime command must be a protected regular executable")
+	}
+	if info.Mode().Perm()&0o111 == 0 {
+		return nil, fmt.Errorf("invocation runtime command is not executable")
+	}
+	executable, err := os.Open(canonicalPath)
+	if err != nil {
+		return nil, fmt.Errorf("open invocation runtime command: %w", err)
+	}
+	openedInfo, err := executable.Stat()
+	currentInfo, currentErr := os.Lstat(canonicalPath)
+	if err != nil || currentErr != nil || currentInfo.Mode()&os.ModeSymlink != 0 || !os.SameFile(openedInfo, currentInfo) {
+		_ = executable.Close()
+		return nil, fmt.Errorf("invocation runtime command changed during validation")
+	}
+	return executable, nil
+}
+
+func runPinnedInvocationExecutable(ctx context.Context, executable *os.File, invocation relay.Invocation) error {
+	// #nosec G204 -- /dev/fd/3 is a verified, already-open operator executable;
+	// arguments are fixed flags with opaque server identifiers and no message body.
+	command := exec.CommandContext(ctx, "/dev/fd/3", "invoke", "--invocation-id", invocation.ID, "--conversation", invocation.ConversationID, "--endpoint", invocation.TargetEndpoint, "--fence", invocation.Fence)
+	command.ExtraFiles = []*os.File{executable}
+	command.Stdout = nil
+	command.Stderr = nil
+	return command.Run()
+}

--- a/internal/adapter/invoker_windows.go
+++ b/internal/adapter/invoker_windows.go
@@ -1,0 +1,19 @@
+//go:build windows
+
+package adapter
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/rock3r/punaro/internal/relay"
+)
+
+func openPinnedInvocationExecutable(string) (*os.File, error) {
+	return nil, fmt.Errorf("invocation runtime command is not supported on Windows")
+}
+
+func runPinnedInvocationExecutable(context.Context, *os.File, relay.Invocation) error {
+	return fmt.Errorf("invocation runtime command is not supported on Windows")
+}

--- a/internal/adapter/sync.go
+++ b/internal/adapter/sync.go
@@ -157,6 +157,14 @@ func (s *Syncer) syncInvocations(ctx context.Context, relayClient InvocationRela
 		if err := relayClient.ReportInvocation(ctx, invocation, accepted); err != nil {
 			return fmt.Errorf("report runtime invocation %q: %w", invocation.ID, err)
 		}
+		if accepted {
+			// A successful server outcome is the terminal acknowledgement for this
+			// handoff. The runtime owns the durable fence; retaining this adapter
+			// recovery row longer would grow local state without improving recovery.
+			if err := s.Journal.removeInvocation(invocation.ID, invocation.Fence); err != nil {
+				return fmt.Errorf("remove accepted invocation %q: %w", invocation.ID, err)
+			}
+		}
 	}
 	return nil
 }
@@ -348,6 +356,21 @@ func (j *Journal) markInvocationAccepted(invocationID, fence string, now time.Ti
 	}
 	if changed != 1 {
 		return errors.New("adapter invocation journal is missing")
+	}
+	return nil
+}
+
+func (j *Journal) removeInvocation(invocationID, fence string) error {
+	result, err := j.db.ExecContext(context.Background(), `DELETE FROM inbound_invocations WHERE invocation_id=? AND fence=?`, invocationID, fence)
+	if err != nil {
+		return err
+	}
+	changed, err := result.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if changed != 1 {
+		return errors.New("adapter journal invocation is missing")
 	}
 	return nil
 }

--- a/internal/adapter/sync.go
+++ b/internal/adapter/sync.go
@@ -114,8 +114,8 @@ func (s *Syncer) SyncOnce(ctx context.Context) error {
 }
 
 func (s *Syncer) syncInvocations(ctx context.Context, relayClient InvocationRelayClient, now time.Time) error {
-	if err := s.Journal.pruneAcceptedInvocations(now); err != nil {
-		return fmt.Errorf("prune accepted invocation recovery rows: %w", err)
+	if err := s.Journal.pruneInvocationRecoveryRows(now); err != nil {
+		return fmt.Errorf("prune invocation recovery rows: %w", err)
 	}
 	invocations, err := relayClient.LeaseInvocations(ctx)
 	if err != nil {
@@ -128,6 +128,18 @@ func (s *Syncer) syncInvocations(ctx context.Context, relayClient InvocationRela
 		}
 		accepted := state == invocationAccepted
 		if !accepted {
+			if invocation.RecoveryOnly {
+				// The relay has exhausted runtime-start attempts. A missing local
+				// acceptance record means we cannot safely cross the start boundary
+				// again; terminalize the handoff instead.
+				if err := relayClient.ReportInvocation(ctx, invocation, false); err != nil {
+					return fmt.Errorf("report unconfirmed recovery invocation %q: %w", invocation.ID, err)
+				}
+				if err := s.Journal.removeInvocation(invocation.ID, invocation.Fence); err != nil {
+					return fmt.Errorf("remove unconfirmed recovery invocation %q: %w", invocation.ID, err)
+				}
+				return fmt.Errorf("recovery-only invocation %q has no accepted local handoff", invocation.ID)
+			}
 			attached, err := s.Mailbox.Attached(ctx)
 			if err != nil {
 				return fmt.Errorf("recheck attached mailbox sessions: %w", err)
@@ -358,10 +370,11 @@ func (j *Journal) ensureInvocation(invocationID, fence string, now time.Time) (i
 	return state, nil
 }
 
-// pruneAcceptedInvocations bounds recovery rows left by a crash after the
-// relay commits an accepted outcome but before the adapter can remove it.
-func (j *Journal) pruneAcceptedInvocations(now time.Time) error {
-	_, err := j.db.ExecContext(context.Background(), `DELETE FROM inbound_invocations WHERE state=? AND updated_at<?`, invocationAccepted, now.Add(-invocationJournalRetention).UnixMilli())
+// pruneInvocationRecoveryRows bounds rows left by a crash after a terminal
+// relay outcome. The relay closes previously leased pending work before that
+// same recovery window can be leased again.
+func (j *Journal) pruneInvocationRecoveryRows(now time.Time) error {
+	_, err := j.db.ExecContext(context.Background(), `DELETE FROM inbound_invocations WHERE updated_at<?`, now.Add(-invocationJournalRetention).UnixMilli())
 	return err
 }
 

--- a/internal/adapter/sync.go
+++ b/internal/adapter/sync.go
@@ -138,8 +138,8 @@ func (s *Syncer) syncInvocations(ctx context.Context, relayClient InvocationRela
 				// beginning of this cycle. If it appeared meanwhile, release the
 				// handoff without crossing the process-start boundary; the next
 				// cycle advertises the live role and terminalizes the stale lease.
-				if err := relayClient.ReportInvocation(ctx, invocation, false); err != nil {
-					return fmt.Errorf("release locally attached invocation %q: %w", invocation.ID, err)
+				if err := relayClient.ReportInvocation(ctx, invocation, true); err != nil {
+					return fmt.Errorf("record locally attached invocation %q: %w", invocation.ID, err)
 				}
 				continue
 			}

--- a/internal/adapter/sync.go
+++ b/internal/adapter/sync.go
@@ -258,10 +258,11 @@ type invocationState string
 const (
 	invocationPending  invocationState = "pending"
 	invocationAccepted invocationState = "accepted"
-	// Keep an accepted local fence through the relay's pending crash-recovery
-	// window. After that, an unreported accepted outcome has expired remotely
-	// and can no longer be leased to cause a duplicate runtime start.
-	invocationJournalRetention = 24 * time.Hour
+	// Keep local recovery fences beyond the relay's 24-hour pending window. The
+	// adapter timestamps before a lease request while the relay timestamps its
+	// recovery window after it, so this margin covers ordinary latency and clock
+	// skew without letting a recovered accepted start lose its journal fence.
+	invocationJournalRetention = 48 * time.Hour
 )
 
 // Journal records the local side of the delivery transaction. It is deliberately

--- a/internal/adapter/sync.go
+++ b/internal/adapter/sync.go
@@ -150,6 +150,9 @@ func (s *Syncer) syncInvocations(ctx context.Context, relayClient InvocationRela
 				if reportErr := relayClient.ReportInvocation(ctx, invocation, false); reportErr != nil {
 					return fmt.Errorf("runtime invocation %q failed and retry report failed: %w", invocation.ID, reportErr)
 				}
+				if removeErr := s.Journal.removeInvocation(invocation.ID, invocation.Fence); removeErr != nil {
+					return fmt.Errorf("remove failed invocation %q: %w", invocation.ID, removeErr)
+				}
 				return fmt.Errorf("run runtime invocation %q: %w", invocation.ID, err)
 			}
 			if err := s.Journal.markInvocationAccepted(invocation.ID, invocation.Fence, now); err != nil {

--- a/internal/adapter/sync.go
+++ b/internal/adapter/sync.go
@@ -125,6 +125,24 @@ func (s *Syncer) syncInvocations(ctx context.Context, relayClient InvocationRela
 		}
 		accepted := state == invocationAccepted
 		if !accepted {
+			attached, err := s.Mailbox.Attached(ctx)
+			if err != nil {
+				return fmt.Errorf("recheck attached mailbox sessions: %w", err)
+			}
+			attached, err = uniqueEndpoints(attached)
+			if err != nil {
+				return err
+			}
+			if containsEndpoint(attached, invocation.TargetEndpoint) {
+				// The relay can only observe the attachment advertised at the
+				// beginning of this cycle. If it appeared meanwhile, release the
+				// handoff without crossing the process-start boundary; the next
+				// cycle advertises the live role and terminalizes the stale lease.
+				if err := relayClient.ReportInvocation(ctx, invocation, false); err != nil {
+					return fmt.Errorf("release locally attached invocation %q: %w", invocation.ID, err)
+				}
+				continue
+			}
 			if err := s.Invoker.Invoke(ctx, invocation); err != nil {
 				if reportErr := relayClient.ReportInvocation(ctx, invocation, false); reportErr != nil {
 					return fmt.Errorf("runtime invocation %q failed and retry report failed: %w", invocation.ID, reportErr)
@@ -141,6 +159,15 @@ func (s *Syncer) syncInvocations(ctx context.Context, relayClient InvocationRela
 		}
 	}
 	return nil
+}
+
+func containsEndpoint(endpoints []string, endpoint string) bool {
+	for _, candidate := range endpoints {
+		if candidate == endpoint {
+			return true
+		}
+	}
+	return false
 }
 
 func (s *Syncer) forwardAndAcknowledge(ctx context.Context, endpoint string, delivery relay.Delivery, now time.Time) error {

--- a/internal/adapter/sync.go
+++ b/internal/adapter/sync.go
@@ -141,6 +141,9 @@ func (s *Syncer) syncInvocations(ctx context.Context, relayClient InvocationRela
 				if err := relayClient.ReportInvocation(ctx, invocation, true); err != nil {
 					return fmt.Errorf("record locally attached invocation %q: %w", invocation.ID, err)
 				}
+				if err := s.Journal.removeInvocation(invocation.ID, invocation.Fence); err != nil {
+					return fmt.Errorf("remove locally attached invocation %q: %w", invocation.ID, err)
+				}
 				continue
 			}
 			if err := s.Invoker.Invoke(ctx, invocation); err != nil {

--- a/internal/adapter/sync.go
+++ b/internal/adapter/sync.go
@@ -114,6 +114,9 @@ func (s *Syncer) SyncOnce(ctx context.Context) error {
 }
 
 func (s *Syncer) syncInvocations(ctx context.Context, relayClient InvocationRelayClient, now time.Time) error {
+	if err := s.Journal.pruneAcceptedInvocations(now); err != nil {
+		return fmt.Errorf("prune accepted invocation recovery rows: %w", err)
+	}
 	invocations, err := relayClient.LeaseInvocations(ctx)
 	if err != nil {
 		return fmt.Errorf("lease runtime invocations: %w", err)
@@ -243,6 +246,10 @@ type invocationState string
 const (
 	invocationPending  invocationState = "pending"
 	invocationAccepted invocationState = "accepted"
+	// Keep an accepted local fence through the relay's pending crash-recovery
+	// window. After that, an unreported accepted outcome has expired remotely
+	// and can no longer be leased to cause a duplicate runtime start.
+	invocationJournalRetention = 24 * time.Hour
 )
 
 // Journal records the local side of the delivery transaction. It is deliberately
@@ -349,6 +356,13 @@ func (j *Journal) ensureInvocation(invocationID, fence string, now time.Time) (i
 		return "", fmt.Errorf("invocation ID was reused with another fence")
 	}
 	return state, nil
+}
+
+// pruneAcceptedInvocations bounds recovery rows left by a crash after the
+// relay commits an accepted outcome but before the adapter can remove it.
+func (j *Journal) pruneAcceptedInvocations(now time.Time) error {
+	_, err := j.db.ExecContext(context.Background(), `DELETE FROM inbound_invocations WHERE state=? AND updated_at<?`, invocationAccepted, now.Add(-invocationJournalRetention).UnixMilli())
+	return err
 }
 
 func (j *Journal) markInvocationAccepted(invocationID, fence string, now time.Time) error {

--- a/internal/adapter/sync.go
+++ b/internal/adapter/sync.go
@@ -32,6 +32,19 @@ type RelayClient interface {
 	Ack(ctx context.Context, delivery relay.Delivery) error
 }
 
+// InvocationRelayClient is the separate, body-free control-plane surface.
+type InvocationRelayClient interface {
+	LeaseInvocations(context.Context) ([]relay.Invocation, error)
+	ReportInvocation(context.Context, relay.Invocation, bool) error
+}
+
+// Invoker is a host-local, operator-configured process-start boundary. Its
+// implementation must deduplicate the stable invocation fence before starting
+// a role; no remote body reaches this interface.
+type Invoker interface {
+	Invoke(context.Context, relay.Invocation) error
+}
+
 // InboundMessage is an inert envelope injected into the local mailbox. The
 // original body remains data, while the stable relay IDs let downstream agents
 // identify duplicate at-least-once deliveries.
@@ -50,6 +63,7 @@ type Syncer struct {
 	Mailbox Mailbox
 	Relay   RelayClient
 	Journal *Journal
+	Invoker Invoker
 	Now     func() time.Time
 }
 
@@ -85,6 +99,45 @@ func (s *Syncer) SyncOnce(ctx context.Context) error {
 			if err := s.forwardAndAcknowledge(ctx, endpoint, delivery, now().UTC()); err != nil {
 				return err
 			}
+		}
+	}
+	if s.Invoker != nil {
+		invocationRelay, ok := s.Relay.(InvocationRelayClient)
+		if !ok {
+			return fmt.Errorf("adapter invocation relay is unavailable")
+		}
+		if err := s.syncInvocations(ctx, invocationRelay, now().UTC()); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (s *Syncer) syncInvocations(ctx context.Context, relayClient InvocationRelayClient, now time.Time) error {
+	invocations, err := relayClient.LeaseInvocations(ctx)
+	if err != nil {
+		return fmt.Errorf("lease runtime invocations: %w", err)
+	}
+	for _, invocation := range invocations {
+		state, err := s.Journal.ensureInvocation(invocation.ID, invocation.Fence, now)
+		if err != nil {
+			return fmt.Errorf("record invocation %q: %w", invocation.ID, err)
+		}
+		accepted := state == invocationAccepted
+		if !accepted {
+			if err := s.Invoker.Invoke(ctx, invocation); err != nil {
+				if reportErr := relayClient.ReportInvocation(ctx, invocation, false); reportErr != nil {
+					return fmt.Errorf("runtime invocation %q failed and retry report failed: %w", invocation.ID, reportErr)
+				}
+				return fmt.Errorf("run runtime invocation %q: %w", invocation.ID, err)
+			}
+			if err := s.Journal.markInvocationAccepted(invocation.ID, invocation.Fence, now); err != nil {
+				return fmt.Errorf("record accepted invocation %q: %w", invocation.ID, err)
+			}
+			accepted = true
+		}
+		if err := relayClient.ReportInvocation(ctx, invocation, accepted); err != nil {
+			return fmt.Errorf("report runtime invocation %q: %w", invocation.ID, err)
 		}
 	}
 	return nil
@@ -144,6 +197,13 @@ const (
 	deliveryAcknowledged deliveryState = "acknowledged"
 )
 
+type invocationState string
+
+const (
+	invocationPending  invocationState = "pending"
+	invocationAccepted invocationState = "accepted"
+)
+
 // Journal records the local side of the delivery transaction. It is deliberately
 // separate from agent-mailbox state so it remains available across mailbox CLI
 // process restarts.
@@ -168,6 +228,12 @@ func OpenJournal(database string) (*Journal, error) {
 			delivery_id TEXT PRIMARY KEY,
 			message_id TEXT NOT NULL,
 			state TEXT NOT NULL CHECK(state IN ('received', 'forwarded', 'acknowledged')),
+			updated_at INTEGER NOT NULL
+		)`,
+		`CREATE TABLE IF NOT EXISTS inbound_invocations (
+			invocation_id TEXT PRIMARY KEY,
+			fence TEXT NOT NULL,
+			state TEXT NOT NULL CHECK(state IN ('pending', 'accepted')),
 			updated_at INTEGER NOT NULL
 		)`,
 	} {
@@ -222,6 +288,39 @@ func (j *Journal) MarkAcknowledged(deliveryID string, now time.Time) error {
 	}
 	if changed != 1 {
 		return errors.New("adapter journal delivery is missing")
+	}
+	return nil
+}
+
+func (j *Journal) ensureInvocation(invocationID, fence string, now time.Time) (invocationState, error) {
+	if strings.TrimSpace(invocationID) == "" || strings.TrimSpace(fence) == "" {
+		return "", fmt.Errorf("invocation ID and fence are required")
+	}
+	if _, err := j.db.ExecContext(context.Background(), `INSERT INTO inbound_invocations(invocation_id,fence,state,updated_at) VALUES(?,?,?,?) ON CONFLICT(invocation_id) DO NOTHING`, invocationID, fence, invocationPending, now.UnixMilli()); err != nil {
+		return "", err
+	}
+	var storedFence string
+	var state invocationState
+	if err := j.db.QueryRowContext(context.Background(), `SELECT fence,state FROM inbound_invocations WHERE invocation_id=?`, invocationID).Scan(&storedFence, &state); err != nil {
+		return "", err
+	}
+	if storedFence != fence {
+		return "", fmt.Errorf("invocation ID was reused with another fence")
+	}
+	return state, nil
+}
+
+func (j *Journal) markInvocationAccepted(invocationID, fence string, now time.Time) error {
+	result, err := j.db.ExecContext(context.Background(), `UPDATE inbound_invocations SET state=?,updated_at=? WHERE invocation_id=? AND fence=?`, invocationAccepted, now.UnixMilli(), invocationID, fence)
+	if err != nil {
+		return err
+	}
+	changed, err := result.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if changed != 1 {
+		return errors.New("adapter invocation journal is missing")
 	}
 	return nil
 }

--- a/internal/adapter/sync_test.go
+++ b/internal/adapter/sync_test.go
@@ -77,12 +77,20 @@ func TestSyncOnceDoesNotAcknowledgeWhenMailboxInjectionFails(t *testing.T) {
 }
 
 type fakeMailbox struct {
-	attached []string
-	sent     []InboundMessage
-	sendErr  error
+	attached      []string
+	attachedCalls int
+	onAttached    func(int) []string
+	sent          []InboundMessage
+	sendErr       error
 }
 
-func (m *fakeMailbox) Attached(context.Context) ([]string, error) { return m.attached, nil }
+func (m *fakeMailbox) Attached(context.Context) ([]string, error) {
+	m.attachedCalls++
+	if m.onAttached != nil {
+		return m.onAttached(m.attachedCalls), nil
+	}
+	return m.attached, nil
+}
 func (m *fakeMailbox) Send(_ context.Context, _ string, message InboundMessage) error {
 	if m.sendErr != nil {
 		return m.sendErr

--- a/internal/relay/backend.go
+++ b/internal/relay/backend.go
@@ -66,6 +66,15 @@ type Backend interface {
 	ConversationsForMachine(machineID string, now time.Time) ([]Conversation, error)
 }
 
+// InvocationBackend is intentionally separate from Backend while PostgreSQL
+// mail cutover parity is staged. Selected backends without it fail closed
+// rather than treating a normal message or notification as process control.
+type InvocationBackend interface {
+	RequestInvocation(InvokeInput) (Invocation, bool, error)
+	LeaseInvocations(machineID, consumerID string, now time.Time, ttl time.Duration, limit int) ([]Invocation, error)
+	ReportInvocation(machineID, invocationID, token string, generation int64, accepted bool, now time.Time) error
+}
+
 // PrincipalEndpointBackend atomically binds advertised endpoint ownership to
 // the stable authenticated principal used by trusted attachment snapshots.
 // Legacy backends remain mail-only and need not implement it.

--- a/internal/relay/backend.go
+++ b/internal/relay/backend.go
@@ -73,6 +73,7 @@ type InvocationBackend interface {
 	RequestInvocation(InvokeInput) (Invocation, bool, error)
 	LeaseInvocations(machineID, consumerID string, now time.Time, ttl time.Duration, limit int) ([]Invocation, error)
 	ReportInvocation(machineID, invocationID, token string, generation int64, accepted bool, now time.Time) error
+	RejectInvocation(machineID, invocationID, token string, generation int64, now time.Time) error
 }
 
 // PrincipalEndpointBackend atomically binds advertised endpoint ownership to

--- a/internal/relay/http.go
+++ b/internal/relay/http.go
@@ -418,7 +418,21 @@ func (h *handler) leaseInvocations(w http.ResponseWriter, body []byte, machineID
 		writeStoreError(w, err)
 		return
 	}
-	writeJSON(w, http.StatusOK, map[string]any{"invocations": leased})
+	allowed := leased[:0]
+	for _, invocation := range leased {
+		if h.auth.AllowsEndpoint(machineID, invocation.TargetEndpoint) {
+			allowed = append(allowed, invocation)
+			continue
+		}
+		// An enrollment scope may narrow after the server queued work. Never
+		// return process-start authority for an endpoint that is no longer in
+		// scope; release the just-acquired lease without exposing it to the host.
+		if err := invocations.ReportInvocation(machineID, invocation.ID, invocation.LeaseToken, invocation.LeaseGeneration, false, now); err != nil {
+			writeStoreError(w, err)
+			return
+		}
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"invocations": allowed})
 }
 
 func (h *handler) reportInvocation(w http.ResponseWriter, body []byte, machineID, invocationID string, now time.Time) {

--- a/internal/relay/http.go
+++ b/internal/relay/http.go
@@ -141,7 +141,7 @@ func (h *handler) validateSender(w http.ResponseWriter, body []byte, machineID, 
 		FromEndpoint string `json:"from_endpoint"`
 	}
 	if err := decodeJSON(body, &request); err != nil {
-		writeError(w, http.StatusBadRequest, "invalid invocation request")
+		writeError(w, http.StatusBadRequest, "invalid sender validation request")
 		return
 	}
 	if !h.auth.AllowsEndpoint(machineID, request.FromEndpoint) {
@@ -370,7 +370,11 @@ func (h *handler) requestInvocation(w http.ResponseWriter, body []byte, machineI
 		FromEndpoint   string `json:"from_endpoint"`
 		TargetEndpoint string `json:"target_endpoint"`
 	}
-	if err := decodeJSON(body, &request); err != nil || !h.auth.AllowsEndpoint(machineID, request.FromEndpoint) {
+	if err := decodeJSON(body, &request); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid invocation request")
+		return
+	}
+	if !h.auth.AllowsEndpoint(machineID, request.FromEndpoint) {
 		writeError(w, http.StatusForbidden, "authorization denied")
 		return
 	}

--- a/internal/relay/http.go
+++ b/internal/relay/http.go
@@ -99,6 +99,13 @@ func (h *handler) serveHTTP(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		h.appendMessage(w, body, machineID, authority, conversationID, now, r.Header.Get("Idempotency-Key"))
+	case r.Method == http.MethodPost && strings.HasPrefix(r.URL.Path, "/v1/conversations/") && strings.HasSuffix(r.URL.Path, "/invocations"):
+		conversationID := strings.TrimSuffix(strings.TrimPrefix(r.URL.Path, "/v1/conversations/"), "/invocations")
+		if conversationID == "" || strings.Contains(conversationID, "/") {
+			writeError(w, http.StatusNotFound, "route not found")
+			return
+		}
+		h.requestInvocation(w, body, machineID, conversationID, now, r.Header.Get("Idempotency-Key"))
 	case r.Method == http.MethodPost && strings.HasPrefix(r.URL.Path, "/v1/conversations/") && strings.HasSuffix(r.URL.Path, "/sender-validation"):
 		conversationID := strings.TrimSuffix(strings.TrimPrefix(r.URL.Path, "/v1/conversations/"), "/sender-validation")
 		if conversationID == "" || strings.Contains(conversationID, "/") {
@@ -108,6 +115,15 @@ func (h *handler) serveHTTP(w http.ResponseWriter, r *http.Request) {
 		h.validateSender(w, body, machineID, conversationID, now)
 	case r.Method == http.MethodPost && r.URL.Path == "/v1/deliveries/lease":
 		h.leaseDeliveries(w, body, machineID, now)
+	case r.Method == http.MethodPost && r.URL.Path == "/v1/invocations/lease":
+		h.leaseInvocations(w, body, machineID, now)
+	case r.Method == http.MethodPost && strings.HasPrefix(r.URL.Path, "/v1/invocations/") && strings.HasSuffix(r.URL.Path, "/outcome"):
+		invocationID := strings.TrimSuffix(strings.TrimPrefix(r.URL.Path, "/v1/invocations/"), "/outcome")
+		if invocationID == "" || strings.Contains(invocationID, "/") {
+			writeError(w, http.StatusNotFound, "route not found")
+			return
+		}
+		h.reportInvocation(w, body, machineID, invocationID, now)
 	case r.Method == http.MethodPost && strings.HasPrefix(r.URL.Path, "/v1/deliveries/") && strings.HasSuffix(r.URL.Path, "/ack"):
 		deliveryID := strings.TrimSuffix(strings.TrimPrefix(r.URL.Path, "/v1/deliveries/"), "/ack")
 		if deliveryID == "" || strings.Contains(deliveryID, "/") {
@@ -124,7 +140,11 @@ func (h *handler) validateSender(w http.ResponseWriter, body []byte, machineID, 
 	var request struct {
 		FromEndpoint string `json:"from_endpoint"`
 	}
-	if err := decodeJSON(body, &request); err != nil || !h.auth.AllowsEndpoint(machineID, request.FromEndpoint) {
+	if err := decodeJSON(body, &request); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid invocation request")
+		return
+	}
+	if !h.auth.AllowsEndpoint(machineID, request.FromEndpoint) {
 		writeError(w, http.StatusForbidden, "authorization denied")
 		return
 	}
@@ -336,6 +356,89 @@ func (h *handler) appendMessage(w http.ResponseWriter, body []byte, machineID st
 	writeJSON(w, status, message)
 }
 
+func (h *handler) requestInvocation(w http.ResponseWriter, body []byte, machineID, conversationID string, now time.Time, idempotencyKey string) {
+	if !ValidRequestToken(idempotencyKey) {
+		writeError(w, http.StatusBadRequest, "Idempotency-Key is required")
+		return
+	}
+	invocations, ok := h.store.(InvocationBackend)
+	if !ok {
+		writeStoreError(w, ErrMaintenance)
+		return
+	}
+	var request struct {
+		FromEndpoint   string `json:"from_endpoint"`
+		TargetEndpoint string `json:"target_endpoint"`
+	}
+	if err := decodeJSON(body, &request); err != nil || !h.auth.AllowsEndpoint(machineID, request.FromEndpoint) {
+		writeError(w, http.StatusForbidden, "authorization denied")
+		return
+	}
+	invocation, duplicate, err := invocations.RequestInvocation(InvokeInput{ConversationID: conversationID, SenderMachineID: machineID, FromEndpoint: request.FromEndpoint, TargetEndpoint: request.TargetEndpoint, IdempotencyKey: idempotencyKey, Now: now})
+	if err != nil {
+		writeStoreError(w, err)
+		return
+	}
+	status := http.StatusCreated
+	if duplicate || invocation.Status == InvocationAlreadyRunning {
+		status = http.StatusOK
+	}
+	if !duplicate && invocation.Status == InvocationPending {
+		// This only accelerates the adapter's durable invocation lease. As with a
+		// message wake, loss or duplication of the hint cannot change the start
+		// decision and carries no control body.
+		h.notifier.Publish(invocation.TargetMachineID, invocation.ConversationID, 0)
+	}
+	writeJSON(w, status, invocation)
+}
+
+func (h *handler) leaseInvocations(w http.ResponseWriter, body []byte, machineID string, now time.Time) {
+	invocations, ok := h.store.(InvocationBackend)
+	if !ok {
+		writeStoreError(w, ErrMaintenance)
+		return
+	}
+	var request struct {
+		ConsumerID string `json:"consumer_id"`
+		Limit      int    `json:"limit"`
+	}
+	if err := decodeJSON(body, &request); err != nil || !ValidRequestToken(request.ConsumerID) {
+		writeError(w, http.StatusBadRequest, "invalid invocation lease request")
+		return
+	}
+	if request.Limit == 0 {
+		request.Limit = 50
+	}
+	leased, err := invocations.LeaseInvocations(machineID, request.ConsumerID, now, h.deliveryLeaseTTL, request.Limit)
+	if err != nil {
+		writeStoreError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"invocations": leased})
+}
+
+func (h *handler) reportInvocation(w http.ResponseWriter, body []byte, machineID, invocationID string, now time.Time) {
+	invocations, ok := h.store.(InvocationBackend)
+	if !ok {
+		writeStoreError(w, ErrMaintenance)
+		return
+	}
+	var request struct {
+		LeaseToken      string `json:"lease_token"`
+		LeaseGeneration int64  `json:"lease_generation"`
+		Accepted        bool   `json:"accepted"`
+	}
+	if err := decodeJSON(body, &request); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid invocation outcome")
+		return
+	}
+	if err := invocations.ReportInvocation(machineID, invocationID, request.LeaseToken, request.LeaseGeneration, request.Accepted, now); err != nil {
+		writeStoreError(w, err)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
 func (h *handler) leaseDeliveries(w http.ResponseWriter, body []byte, machineID string, now time.Time) {
 	var request struct {
 		Endpoint       string `json:"endpoint"`
@@ -421,6 +524,8 @@ func parseCapabilities(values []string) (Capability, error) {
 			capabilities |= CapReceive
 		case "admin":
 			capabilities |= CapAdmin
+		case "invoke":
+			capabilities |= CapInvoke
 		default:
 			return 0, fmt.Errorf("unknown capability")
 		}

--- a/internal/relay/http.go
+++ b/internal/relay/http.go
@@ -387,7 +387,7 @@ func (h *handler) requestInvocation(w http.ResponseWriter, body []byte, machineI
 	if duplicate || invocation.Status == InvocationAlreadyRunning {
 		status = http.StatusOK
 	}
-	if !duplicate && invocation.Status == InvocationPending {
+	if !duplicate && invocation.Status == InvocationPending && h.auth.AllowsEndpoint(invocation.TargetMachineID, invocation.TargetEndpoint) {
 		// This only accelerates the adapter's durable invocation lease. As with a
 		// message wake, loss or duplication of the hint cannot change the start
 		// decision and carries no control body.
@@ -426,8 +426,9 @@ func (h *handler) leaseInvocations(w http.ResponseWriter, body []byte, machineID
 		}
 		// An enrollment scope may narrow after the server queued work. Never
 		// return process-start authority for an endpoint that is no longer in
-		// scope; release the just-acquired lease without exposing it to the host.
-		if err := invocations.ReportInvocation(machineID, invocation.ID, invocation.LeaseToken, invocation.LeaseGeneration, false, now); err != nil {
+		// scope. This is terminal policy rejection, not a runtime failure, so it
+		// must not consume the bounded runtime retry budget.
+		if err := invocations.RejectInvocation(machineID, invocation.ID, invocation.LeaseToken, invocation.LeaseGeneration, now); err != nil {
 			writeStoreError(w, err)
 			return
 		}

--- a/internal/relay/http.go
+++ b/internal/relay/http.go
@@ -391,7 +391,7 @@ func (h *handler) requestInvocation(w http.ResponseWriter, body []byte, machineI
 		// This only accelerates the adapter's durable invocation lease. As with a
 		// message wake, loss or duplication of the hint cannot change the start
 		// decision and carries no control body.
-		h.notifier.Publish(invocation.TargetMachineID, invocation.ConversationID, 0)
+		h.notifier.Publish(invocation.TargetMachineID, invocation.ConversationID, 1)
 	}
 	writeJSON(w, status, invocation)
 }

--- a/internal/relay/http_test.go
+++ b/internal/relay/http_test.go
@@ -41,7 +41,10 @@ func TestHTTPDurableMessageFlowRequiresSignedMachineRequests(t *testing.T) {
 		t.Fatal(err)
 	}
 	clock := time.Date(2026, time.July, 13, 12, 0, 0, 0, time.UTC)
-	handler := NewHandler(store, auth, HandlerOptions{Now: func() time.Time { return clock }, EndpointLeaseTTL: time.Minute, DeliveryLeaseTTL: time.Minute})
+	notifier := NewNotifier()
+	targetNotifications := notifier.Register("machine-b")
+	t.Cleanup(targetNotifications.Close)
+	handler := NewHandler(store, auth, HandlerOptions{Now: func() time.Time { return clock }, EndpointLeaseTTL: time.Minute, DeliveryLeaseTTL: time.Minute, Notifier: notifier})
 
 	serveSigned(t, handler, privateA, "machine-a", http.MethodPut, "/v1/machines/me/endpoints", `{"endpoints":["agent/a/session"]}`, "advertise-a", "")
 	serveSigned(t, handler, privateB, "machine-b", http.MethodPut, "/v1/machines/me/endpoints", `{"endpoints":["agent/b/session"]}`, "advertise-b", "")
@@ -257,7 +260,10 @@ func TestHTTPInvokeIsAContentFreeOfflineRuntimeHandoff(t *testing.T) {
 		t.Fatal(err)
 	}
 	clock := time.Date(2026, time.July, 13, 12, 0, 0, 0, time.UTC)
-	handler := NewHandler(store, auth, HandlerOptions{Now: func() time.Time { return clock }, EndpointLeaseTTL: time.Minute, DeliveryLeaseTTL: time.Minute})
+	notifier := NewNotifier()
+	targetNotifications := notifier.Register("machine-b")
+	t.Cleanup(targetNotifications.Close)
+	handler := NewHandler(store, auth, HandlerOptions{Now: func() time.Time { return clock }, EndpointLeaseTTL: time.Minute, DeliveryLeaseTTL: time.Minute, Notifier: notifier})
 	serveSigned(t, handler, privateA, "machine-a", http.MethodPut, "/v1/machines/me/endpoints", `{"endpoints":["agent/a/session"]}`, "invoke-advertise-a", "")
 	serveSigned(t, handler, privateB, "machine-b", http.MethodPut, "/v1/machines/me/endpoints", `{"endpoints":["agent/b/session"]}`, "invoke-advertise-b", "")
 	created := serveSigned(t, handler, privateA, "machine-a", http.MethodPost, "/v1/conversations", `{"creator_endpoint":"agent/a/session","members":[{"endpoint":"agent/a/session","capabilities":["send","receive","admin","invoke"]},{"endpoint":"agent/b/session","capabilities":["receive"]}]}`, "invoke-create", "invoke-create")
@@ -277,6 +283,14 @@ func TestHTTPInvokeIsAContentFreeOfflineRuntimeHandoff(t *testing.T) {
 	requested := serveSigned(t, handler, privateA, "machine-a", http.MethodPost, "/v1/conversations/"+conversation.ID+"/invocations", `{"from_endpoint":"agent/a/session","target_endpoint":"agent/b/session"}`, "invoke-request", "invoke-request")
 	if requested.Code != http.StatusCreated || strings.Contains(requested.Body.String(), "opaque work") {
 		t.Fatalf("invoke status=%d body=%s", requested.Code, requested.Body.String())
+	}
+	select {
+	case wake := <-targetNotifications.Events():
+		if wake.Type != "wake" || wake.TopicID != conversation.ID || wake.Sequence != 1 {
+			t.Fatalf("invoke wake=%#v", wake)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("invoke request did not wake target adapter")
 	}
 	var invocation Invocation
 	if err := json.NewDecoder(requested.Body).Decode(&invocation); err != nil || invocation.ID == "" || invocation.Fence == "" || invocation.TargetMachineID != "machine-b" {

--- a/internal/relay/http_test.go
+++ b/internal/relay/http_test.go
@@ -315,6 +315,94 @@ func TestHTTPInvokeIsAContentFreeOfflineRuntimeHandoff(t *testing.T) {
 	}
 }
 
+func TestHTTPInvocationLeaseRejectsOutOfScopeTargetWithoutRetry(t *testing.T) {
+	publicA, privateA, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	publicB, privateB, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	store, err := Open(filepath.Join(t.TempDir(), "relay.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	auth, err := NewAuthenticator(store, []Machine{
+		{ID: "machine-a", PublicKey: publicA, EndpointPrefixes: []string{"agent/a/"}},
+		{ID: "machine-b", PublicKey: publicB, EndpointPrefixes: []string{"agent/b/allowed/"}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	clock := time.Date(2026, time.July, 13, 12, 0, 0, 0, time.UTC)
+	notifier := NewNotifier()
+	targetNotifications := notifier.Register("machine-b")
+	t.Cleanup(targetNotifications.Close)
+	handler := NewHandler(store, auth, HandlerOptions{Now: func() time.Time { return clock }, EndpointLeaseTTL: time.Minute, DeliveryLeaseTTL: time.Minute, Notifier: notifier})
+	serveSigned(t, handler, privateA, "machine-a", http.MethodPut, "/v1/machines/me/endpoints", `{"endpoints":["agent/a/session"]}`, "scope-advertise-a", "")
+	// Simulate a persisted role whose machine's enrollment was narrowed after it
+	// was recorded. The direct store setup deliberately bypasses HTTP's current
+	// scope check so the lease route has to contain the old work safely.
+	if err := store.AdvertiseEndpoints("machine-b", []string{"agent/b/out-of-scope"}, clock, time.Hour); err != nil {
+		t.Fatal(err)
+	}
+	created := serveSigned(t, handler, privateA, "machine-a", http.MethodPost, "/v1/conversations", `{"creator_endpoint":"agent/a/session","members":[{"endpoint":"agent/a/session","capabilities":["send","receive","admin","invoke"]},{"endpoint":"agent/b/out-of-scope","capabilities":["receive"]}]}`, "scope-create", "scope-create")
+	if created.Code != http.StatusCreated {
+		t.Fatalf("create status=%d body=%s", created.Code, created.Body.String())
+	}
+	var conversation Conversation
+	if err := json.NewDecoder(created.Body).Decode(&conversation); err != nil {
+		t.Fatal(err)
+	}
+	if response := serveSigned(t, handler, privateA, "machine-a", http.MethodPost, "/v1/conversations/"+conversation.ID+"/messages", `{"from_endpoint":"agent/a/session","body":"opaque work"}`, "scope-message", "scope-message"); response.Code != http.StatusCreated {
+		t.Fatalf("message status=%d body=%s", response.Code, response.Body.String())
+	}
+	select {
+	case <-targetNotifications.Events():
+		// The ordinary message notification is expected. The assertion below
+		// verifies that the invocation itself adds no out-of-scope wake hint.
+	case <-time.After(time.Second):
+		t.Fatal("message did not wake target machine")
+	}
+	if err := store.AdvertiseEndpoints("machine-b", nil, clock, time.Hour); err != nil {
+		t.Fatal(err)
+	}
+	requested := serveSigned(t, handler, privateA, "machine-a", http.MethodPost, "/v1/conversations/"+conversation.ID+"/invocations", `{"from_endpoint":"agent/a/session","target_endpoint":"agent/b/out-of-scope"}`, "scope-invoke", "scope-invoke")
+	if requested.Code != http.StatusCreated {
+		t.Fatalf("invoke status=%d body=%s", requested.Code, requested.Body.String())
+	}
+	var invocation Invocation
+	if err := json.NewDecoder(requested.Body).Decode(&invocation); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case wake := <-targetNotifications.Events():
+		t.Fatalf("out-of-scope target received wake=%#v", wake)
+	case <-time.After(20 * time.Millisecond):
+	}
+	lease := serveSigned(t, handler, privateB, "machine-b", http.MethodPost, "/v1/invocations/lease", `{"consumer_id":"adapter-b"}`, "scope-lease", "")
+	if lease.Code != http.StatusOK || lease.Body.String() != `{"invocations":[]}`+"\n" {
+		t.Fatalf("lease status=%d body=%s", lease.Code, lease.Body.String())
+	}
+	var status InvocationStatus
+	var attempts int
+	if err := store.db.QueryRowContext(context.Background(), `SELECT status,attempts FROM invocations WHERE id=?`, invocation.ID).Scan(&status, &attempts); err != nil {
+		t.Fatal(err)
+	}
+	if status != InvocationFailed || attempts != 1 {
+		t.Fatalf("status=%q attempts=%d", status, attempts)
+	}
+	if leased, err := store.LeaseInvocations("machine-b", "adapter-b", clock.Add(time.Hour), time.Minute, 1); err != nil || len(leased) != 0 {
+		t.Fatalf("terminalized invocation leased=%#v err=%v", leased, err)
+	}
+	audit, err := store.InvocationAudit(invocation.ID)
+	if err != nil || len(audit) != 3 || audit[0].Action != "requested" || audit[1].Action != "leased" || audit[2].Action != "failed" {
+		t.Fatalf("audit=%#v err=%v", audit, err)
+	}
+}
+
 func TestHTTPRejectsUnsignedEndpointClaimsAndUnknownJSON(t *testing.T) {
 	t.Parallel()
 	public, private, err := ed25519.GenerateKey(rand.Reader)

--- a/internal/relay/http_test.go
+++ b/internal/relay/http_test.go
@@ -238,6 +238,69 @@ func TestHTTPCreateConversationDeduplicatesSameMachineIdempotencyKey(t *testing.
 	}
 }
 
+func TestHTTPInvokeIsAContentFreeOfflineRuntimeHandoff(t *testing.T) {
+	publicA, privateA, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	publicB, privateB, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	store, err := Open(filepath.Join(t.TempDir(), "relay.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	auth, err := NewAuthenticator(store, []Machine{{ID: "machine-a", PublicKey: publicA, EndpointPrefixes: []string{"agent/a/"}}, {ID: "machine-b", PublicKey: publicB, EndpointPrefixes: []string{"agent/b/"}}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	clock := time.Date(2026, time.July, 13, 12, 0, 0, 0, time.UTC)
+	handler := NewHandler(store, auth, HandlerOptions{Now: func() time.Time { return clock }, EndpointLeaseTTL: time.Minute, DeliveryLeaseTTL: time.Minute})
+	serveSigned(t, handler, privateA, "machine-a", http.MethodPut, "/v1/machines/me/endpoints", `{"endpoints":["agent/a/session"]}`, "invoke-advertise-a", "")
+	serveSigned(t, handler, privateB, "machine-b", http.MethodPut, "/v1/machines/me/endpoints", `{"endpoints":["agent/b/session"]}`, "invoke-advertise-b", "")
+	created := serveSigned(t, handler, privateA, "machine-a", http.MethodPost, "/v1/conversations", `{"creator_endpoint":"agent/a/session","members":[{"endpoint":"agent/a/session","capabilities":["send","receive","admin","invoke"]},{"endpoint":"agent/b/session","capabilities":["receive"]}]}`, "invoke-create", "invoke-create")
+	if created.Code != http.StatusCreated {
+		t.Fatalf("create status=%d body=%s", created.Code, created.Body.String())
+	}
+	var conversation Conversation
+	if err := json.NewDecoder(created.Body).Decode(&conversation); err != nil {
+		t.Fatal(err)
+	}
+	if response := serveSigned(t, handler, privateA, "machine-a", http.MethodPost, "/v1/conversations/"+conversation.ID+"/messages", `{"from_endpoint":"agent/a/session","body":"opaque work"}`, "invoke-message", "invoke-message"); response.Code != http.StatusCreated {
+		t.Fatalf("message status=%d body=%s", response.Code, response.Body.String())
+	}
+	if response := serveSigned(t, handler, privateB, "machine-b", http.MethodPut, "/v1/machines/me/endpoints", `{"endpoints":[]}`, "invoke-detach-b", ""); response.Code != http.StatusOK {
+		t.Fatalf("detach status=%d body=%s", response.Code, response.Body.String())
+	}
+	requested := serveSigned(t, handler, privateA, "machine-a", http.MethodPost, "/v1/conversations/"+conversation.ID+"/invocations", `{"from_endpoint":"agent/a/session","target_endpoint":"agent/b/session"}`, "invoke-request", "invoke-request")
+	if requested.Code != http.StatusCreated || strings.Contains(requested.Body.String(), "opaque work") {
+		t.Fatalf("invoke status=%d body=%s", requested.Code, requested.Body.String())
+	}
+	var invocation Invocation
+	if err := json.NewDecoder(requested.Body).Decode(&invocation); err != nil || invocation.ID == "" || invocation.Fence == "" || invocation.TargetMachineID != "machine-b" {
+		t.Fatalf("invocation=%#v err=%v", invocation, err)
+	}
+	lease := serveSigned(t, handler, privateB, "machine-b", http.MethodPost, "/v1/invocations/lease", `{"consumer_id":"adapter-b"}`, "invoke-lease", "")
+	if lease.Code != http.StatusOK || strings.Contains(lease.Body.String(), "opaque work") {
+		t.Fatalf("lease status=%d body=%s", lease.Code, lease.Body.String())
+	}
+	var leased struct {
+		Invocations []Invocation `json:"invocations"`
+	}
+	if err := json.NewDecoder(lease.Body).Decode(&leased); err != nil || len(leased.Invocations) != 1 || leased.Invocations[0].ID != invocation.ID {
+		t.Fatalf("leased=%#v err=%v", leased, err)
+	}
+	outcomeBody, err := json.Marshal(map[string]any{"lease_token": leased.Invocations[0].LeaseToken, "lease_generation": leased.Invocations[0].LeaseGeneration, "accepted": true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if response := serveSigned(t, handler, privateB, "machine-b", http.MethodPost, "/v1/invocations/"+invocation.ID+"/outcome", string(outcomeBody), "invoke-outcome", ""); response.Code != http.StatusNoContent {
+		t.Fatalf("outcome status=%d body=%s", response.Code, response.Body.String())
+	}
+}
+
 func TestHTTPRejectsUnsignedEndpointClaimsAndUnknownJSON(t *testing.T) {
 	t.Parallel()
 	public, private, err := ed25519.GenerateKey(rand.Reader)

--- a/internal/relay/invocation.go
+++ b/internal/relay/invocation.go
@@ -110,7 +110,7 @@ func (s *Store) RequestInvocation(input InvokeInput) (Invocation, bool, error) {
 	// offline role. They must converge on one durable fence, rather than start
 	// separate runtime processes merely because their idempotency domains differ.
 	var pendingID string
-	err = tx.QueryRowContext(context.Background(), `SELECT id FROM invocations WHERE conversation_id=? AND target_endpoint=? AND status=? ORDER BY created_at,id LIMIT 1`, input.ConversationID, input.TargetEndpoint, InvocationPending).Scan(&pendingID)
+	err = tx.QueryRowContext(context.Background(), `SELECT id FROM invocations WHERE conversation_id=? AND target_endpoint=? AND target_machine_id=? AND target_ownership_generation=? AND (status=? OR (status=? AND not_before>?)) ORDER BY created_at,id LIMIT 1`, input.ConversationID, input.TargetEndpoint, targetMachine, targetOwnershipGeneration, InvocationPending, InvocationSucceeded, input.Now.UnixMilli()).Scan(&pendingID)
 	if err == nil {
 		invocation, err := invocationByID(tx, pendingID)
 		if err != nil {
@@ -165,8 +165,8 @@ func (s *Store) LeaseInvocations(machineID, consumerID string, now time.Time, tt
 	// machine a process-start lease, even if the endpoint is offline again.
 	staleOwnerRows, err := tx.QueryContext(context.Background(), `SELECT invocation.id FROM invocations AS invocation
 		LEFT JOIN endpoints AS endpoint ON endpoint.endpoint=invocation.target_endpoint
-		WHERE invocation.target_machine_id=? AND invocation.status=?
-		AND (endpoint.endpoint IS NULL OR endpoint.machine_id<>invocation.target_machine_id OR endpoint.ownership_generation<>invocation.target_ownership_generation)`, machineID, InvocationPending)
+		WHERE invocation.target_machine_id=? AND invocation.status=? AND (invocation.lease_machine_id IS NULL OR invocation.lease_until<=?)
+		AND (endpoint.endpoint IS NULL OR endpoint.machine_id<>invocation.target_machine_id OR endpoint.ownership_generation<>invocation.target_ownership_generation)`, machineID, InvocationPending, now.UnixMilli())
 	if err != nil {
 		return nil, fmt.Errorf("find invocation ownership changes: %w", err)
 	}
@@ -191,8 +191,8 @@ func (s *Store) LeaseInvocations(machineID, consumerID string, now time.Time, tt
 		}
 	}
 	staleRows, err := tx.QueryContext(context.Background(), `SELECT invocation.id FROM invocations AS invocation
-		WHERE invocation.target_machine_id=? AND invocation.status=? AND invocation.lease_machine_id IS NULL
-		AND NOT EXISTS (SELECT 1 FROM deliveries AS delivery JOIN messages AS message ON message.id=delivery.message_id WHERE delivery.recipient_endpoint=invocation.target_endpoint AND delivery.acked_at IS NULL AND message.conversation_id=invocation.conversation_id)`, machineID, InvocationPending)
+		WHERE invocation.target_machine_id=? AND invocation.status=? AND (invocation.lease_machine_id IS NULL OR invocation.lease_until<=?)
+		AND NOT EXISTS (SELECT 1 FROM deliveries AS delivery JOIN messages AS message ON message.id=delivery.message_id WHERE delivery.recipient_endpoint=invocation.target_endpoint AND delivery.acked_at IS NULL AND message.conversation_id=invocation.conversation_id)`, machineID, InvocationPending, now.UnixMilli())
 	if err != nil {
 		return nil, fmt.Errorf("find stale invocations: %w", err)
 	}
@@ -221,8 +221,8 @@ func (s *Store) LeaseInvocations(machineID, consumerID string, now time.Time, tt
 	// authoritative proof that starting another copy is no longer allowed.
 	onlineRows, err := tx.QueryContext(context.Background(), `SELECT invocation.id FROM invocations AS invocation
 		JOIN endpoints AS endpoint ON endpoint.endpoint=invocation.target_endpoint
-		WHERE invocation.target_machine_id=? AND invocation.status=? AND invocation.lease_machine_id IS NULL
-		AND endpoint.machine_id=invocation.target_machine_id AND endpoint.ownership_generation=invocation.target_ownership_generation AND endpoint.lease_until>?`, machineID, InvocationPending, now.UnixMilli())
+		WHERE invocation.target_machine_id=? AND invocation.status=? AND (invocation.lease_machine_id IS NULL OR invocation.lease_until<=?)
+		AND endpoint.machine_id=invocation.target_machine_id AND endpoint.ownership_generation=invocation.target_ownership_generation AND endpoint.lease_until>?`, machineID, InvocationPending, now.UnixMilli(), now.UnixMilli())
 	if err != nil {
 		return nil, fmt.Errorf("find online invocation targets: %w", err)
 	}
@@ -250,9 +250,10 @@ func (s *Store) LeaseInvocations(machineID, consumerID string, now time.Time, tt
 		}
 	}
 	rows, err := tx.QueryContext(context.Background(), `SELECT invocation.id,invocation.conversation_id,invocation.target_endpoint,invocation.target_machine_id,invocation.fence,invocation.lease_generation,invocation.attempts,invocation.lease_until FROM invocations AS invocation
-		JOIN endpoints AS endpoint ON endpoint.endpoint=invocation.target_endpoint AND endpoint.machine_id=invocation.target_machine_id AND endpoint.ownership_generation=invocation.target_ownership_generation
+		JOIN endpoints AS endpoint ON endpoint.endpoint=invocation.target_endpoint AND endpoint.machine_id=invocation.target_machine_id
 		WHERE invocation.target_machine_id=? AND invocation.status=? AND invocation.not_before<=? AND (invocation.lease_until IS NULL OR invocation.lease_until<=? OR (invocation.lease_machine_id=? AND invocation.lease_consumer_id=?))
-		ORDER BY created_at,id LIMIT ?`, machineID, InvocationPending, now.UnixMilli(), now.UnixMilli(), machineID, consumerID, limit)
+		AND (endpoint.ownership_generation=invocation.target_ownership_generation OR (invocation.lease_machine_id=? AND invocation.lease_consumer_id=? AND invocation.lease_until>?))
+		ORDER BY created_at,id LIMIT ?`, machineID, InvocationPending, now.UnixMilli(), now.UnixMilli(), machineID, consumerID, machineID, consumerID, now.UnixMilli(), limit)
 	if err != nil {
 		return nil, fmt.Errorf("find invocations: %w", err)
 	}
@@ -332,7 +333,7 @@ func (s *Store) ReportInvocation(machineID, invocationID, token string, generati
 		return fmt.Errorf("read invocation lease: %w", err)
 	}
 	if accepted {
-		if _, err := tx.ExecContext(context.Background(), `UPDATE invocations SET status=?,lease_machine_id=NULL,lease_consumer_id=NULL,lease_token=NULL,lease_until=NULL WHERE id=?`, InvocationSucceeded, invocationID); err != nil {
+		if _, err := tx.ExecContext(context.Background(), `UPDATE invocations SET status=?,not_before=?,lease_machine_id=NULL,lease_consumer_id=NULL,lease_token=NULL,lease_until=NULL WHERE id=?`, InvocationSucceeded, now.Add(maxInvocationBackoff).UnixMilli(), invocationID); err != nil {
 			return fmt.Errorf("accept invocation: %w", err)
 		}
 		if err := recordInvocationAudit(tx, invocationID, "accepted", now); err != nil {

--- a/internal/relay/invocation.go
+++ b/internal/relay/invocation.go
@@ -261,9 +261,6 @@ func (s *Store) LeaseInvocations(machineID, consumerID string, now time.Time, tt
 	if err := s.ensureInvocationSchema(); err != nil {
 		return nil, err
 	}
-	if err := s.ensureInvocationSchema(); err != nil {
-		return nil, err
-	}
 	if !ValidMachineID(machineID) || !ValidRequestToken(consumerID) || ttl <= 0 || limit < 1 || limit > 100 {
 		return nil, fmt.Errorf("invalid invocation lease request")
 	}

--- a/internal/relay/invocation.go
+++ b/internal/relay/invocation.go
@@ -145,7 +145,7 @@ func (s *Store) requestInvocationWithSchema(input InvokeInput, requestHash strin
 		// retrying the same key after the endpoint detached could unexpectedly
 		// become a new start request.
 		invocation := Invocation{ID: uuid.NewString(), ConversationID: input.ConversationID, TargetEndpoint: input.TargetEndpoint, TargetMachineID: targetMachine, Fence: uuid.NewString(), Status: InvocationAlreadyRunning}
-		if _, err := tx.ExecContext(context.Background(), `INSERT INTO invocations(id,conversation_id,from_endpoint,target_endpoint,target_machine_id,target_ownership_generation,fence,status,not_before,created_at,terminal_at) VALUES(?,?,?,?,?,?,?,?,?,?,?)`, invocation.ID, invocation.ConversationID, input.FromEndpoint, invocation.TargetEndpoint, invocation.TargetMachineID, targetOwnershipGeneration, invocation.Fence, invocation.Status, input.Now.UnixMilli(), input.Now.UnixMilli(), input.Now.UnixMilli()); err != nil {
+		if _, err := tx.ExecContext(context.Background(), `INSERT INTO invocations(id,conversation_id,from_endpoint,target_endpoint,target_machine_id,target_ownership_generation,fence,status,not_before,created_at,last_activity_at,terminal_at) VALUES(?,?,?,?,?,?,?,?,?,?,?,?)`, invocation.ID, invocation.ConversationID, input.FromEndpoint, invocation.TargetEndpoint, invocation.TargetMachineID, targetOwnershipGeneration, invocation.Fence, invocation.Status, input.Now.UnixMilli(), input.Now.UnixMilli(), input.Now.UnixMilli(), input.Now.UnixMilli()); err != nil {
 			return Invocation{}, false, fmt.Errorf("record already-running invocation: %w", err)
 		}
 		if _, err := tx.ExecContext(context.Background(), `INSERT INTO invocation_idempotency(machine_id,key,request_hash,invocation_id) VALUES(?,?,?,?)`, input.SenderMachineID, input.IdempotencyKey, requestHash, invocation.ID); err != nil {
@@ -184,7 +184,7 @@ func (s *Store) requestInvocationWithSchema(input InvokeInput, requestHash strin
 		return Invocation{}, false, fmt.Errorf("find pending invocation: %w", err)
 	}
 	invocation := Invocation{ID: uuid.NewString(), ConversationID: input.ConversationID, TargetEndpoint: input.TargetEndpoint, TargetMachineID: targetMachine, Fence: uuid.NewString(), Status: InvocationPending}
-	if _, err := tx.ExecContext(context.Background(), `INSERT INTO invocations(id,conversation_id,from_endpoint,target_endpoint,target_machine_id,target_ownership_generation,fence,status,not_before,created_at) VALUES(?,?,?,?,?,?,?,?,?,?)`, invocation.ID, invocation.ConversationID, input.FromEndpoint, invocation.TargetEndpoint, invocation.TargetMachineID, targetOwnershipGeneration, invocation.Fence, invocation.Status, input.Now.UnixMilli(), input.Now.UnixMilli()); err != nil {
+	if _, err := tx.ExecContext(context.Background(), `INSERT INTO invocations(id,conversation_id,from_endpoint,target_endpoint,target_machine_id,target_ownership_generation,fence,status,not_before,created_at,last_activity_at) VALUES(?,?,?,?,?,?,?,?,?,?,?)`, invocation.ID, invocation.ConversationID, input.FromEndpoint, invocation.TargetEndpoint, invocation.TargetMachineID, targetOwnershipGeneration, invocation.Fence, invocation.Status, input.Now.UnixMilli(), input.Now.UnixMilli(), input.Now.UnixMilli()); err != nil {
 		return Invocation{}, false, fmt.Errorf("queue invocation: %w", err)
 	}
 	if _, err := tx.ExecContext(context.Background(), `INSERT INTO invocation_idempotency(machine_id,key,request_hash,invocation_id) VALUES(?,?,?,?)`, input.SenderMachineID, input.IdempotencyKey, requestHash, invocation.ID); err != nil {
@@ -208,7 +208,7 @@ func pruneExpiredTerminalInvocations(tx *sql.Tx, now time.Time) error {
 }
 
 func expireAbandonedInvocations(tx *sql.Tx, targetEndpoint string, now time.Time) error {
-	rows, err := tx.QueryContext(context.Background(), `SELECT id FROM invocations WHERE target_endpoint=? AND status=? AND created_at<? AND (lease_until IS NULL OR lease_until<=?)`, targetEndpoint, InvocationPending, now.Add(-invocationPendingRetention).UnixMilli(), now.UnixMilli())
+	rows, err := tx.QueryContext(context.Background(), `SELECT id FROM invocations WHERE target_endpoint=? AND status=? AND (CASE WHEN last_activity_at>0 THEN last_activity_at ELSE created_at END)<? AND (lease_until IS NULL OR lease_until<=?)`, targetEndpoint, InvocationPending, now.Add(-invocationPendingRetention).UnixMilli(), now.UnixMilli())
 	if err != nil {
 		return fmt.Errorf("find abandoned invocations: %w", err)
 	}
@@ -398,7 +398,7 @@ func (s *Store) LeaseInvocations(machineID, consumerID string, now time.Time, tt
 		invocation.LeaseGeneration++
 		invocation.LeaseToken = token
 		invocation.LeaseUntil = now.Add(ttl).UTC()
-		if _, err := tx.ExecContext(context.Background(), `UPDATE invocations SET attempts=?,lease_machine_id=?,lease_consumer_id=?,lease_token=?,lease_generation=?,lease_until=? WHERE id=?`, attempts, machineID, consumerID, token, invocation.LeaseGeneration, invocation.LeaseUntil.UnixMilli(), invocation.ID); err != nil {
+		if _, err := tx.ExecContext(context.Background(), `UPDATE invocations SET attempts=?,last_activity_at=?,lease_machine_id=?,lease_consumer_id=?,lease_token=?,lease_generation=?,lease_until=? WHERE id=?`, attempts, now.UnixMilli(), machineID, consumerID, token, invocation.LeaseGeneration, invocation.LeaseUntil.UnixMilli(), invocation.ID); err != nil {
 			return nil, fmt.Errorf("lease invocation: %w", err)
 		}
 		if err := recordInvocationAudit(tx, invocation.ID, "leased", now); err != nil {
@@ -555,6 +555,7 @@ func (s *Store) ensureInvocationSchema() error {
 			lease_generation INTEGER NOT NULL DEFAULT 0,
 			target_ownership_generation INTEGER NOT NULL DEFAULT 0,
 			lease_until INTEGER,
+			last_activity_at INTEGER NOT NULL DEFAULT 0,
 			terminal_at INTEGER,
 			created_at INTEGER NOT NULL
 		)`,
@@ -583,6 +584,9 @@ func (s *Store) ensureInvocationSchema() error {
 		return err
 	}
 	if err := ensureSQLiteColumn(context.Background(), s.db, "invocations", "terminal_at", "INTEGER"); err != nil {
+		return err
+	}
+	if err := ensureSQLiteColumn(context.Background(), s.db, "invocations", "last_activity_at", "INTEGER NOT NULL DEFAULT 0"); err != nil {
 		return err
 	}
 	return nil

--- a/internal/relay/invocation.go
+++ b/internal/relay/invocation.go
@@ -191,7 +191,8 @@ func (s *Store) requestInvocationWithSchema(input InvokeInput, requestHash strin
 }
 
 func pruneExpiredTerminalInvocations(tx *sql.Tx, now time.Time) error {
-	if _, err := tx.ExecContext(context.Background(), `DELETE FROM invocations WHERE status IN (?,?,?) AND created_at<?`, InvocationAlreadyRunning, InvocationSucceeded, InvocationFailed, now.Add(-invocationTerminalRetention).UnixMilli()); err != nil {
+	cutoff := now.Add(-invocationTerminalRetention).UnixMilli()
+	if _, err := tx.ExecContext(context.Background(), `DELETE FROM invocations WHERE created_at<? AND (status IN (?,?) OR (status=? AND not_before<?))`, cutoff, InvocationAlreadyRunning, InvocationFailed, InvocationSucceeded, now.UnixMilli()); err != nil {
 		return fmt.Errorf("prune terminal invocations: %w", err)
 	}
 	return nil

--- a/internal/relay/invocation.go
+++ b/internal/relay/invocation.go
@@ -396,7 +396,7 @@ func (s *Store) LeaseInvocations(machineID, consumerID string, now time.Time, tt
 			return nil, err
 		}
 	}
-	rows, err := tx.QueryContext(context.Background(), `SELECT invocation.id,invocation.conversation_id,invocation.target_endpoint,invocation.target_machine_id,invocation.fence,invocation.lease_generation,invocation.attempts,invocation.lease_until FROM invocations AS invocation
+	rows, err := tx.QueryContext(context.Background(), `SELECT invocation.id,invocation.conversation_id,invocation.target_endpoint,invocation.target_machine_id,invocation.fence,invocation.lease_generation,invocation.attempts,invocation.recovery_only,invocation.lease_until FROM invocations AS invocation
 		JOIN endpoints AS endpoint ON endpoint.endpoint=invocation.target_endpoint AND endpoint.machine_id=invocation.target_machine_id
 		WHERE invocation.target_machine_id=? AND invocation.status=? AND invocation.not_before<=? AND (invocation.lease_until IS NULL OR invocation.lease_until<=? OR (invocation.lease_machine_id=? AND invocation.lease_consumer_id=?))
 		AND (endpoint.ownership_generation=invocation.target_ownership_generation OR (invocation.lease_machine_id=? AND invocation.lease_consumer_id=? AND invocation.lease_until>?))
@@ -409,11 +409,13 @@ func (s *Store) LeaseInvocations(machineID, consumerID string, now time.Time, tt
 	for rows.Next() {
 		var invocation Invocation
 		var attempts int
+		var recoveryOnly bool
 		var priorLeaseUntil sql.NullInt64
-		if err := rows.Scan(&invocation.ID, &invocation.ConversationID, &invocation.TargetEndpoint, &invocation.TargetMachineID, &invocation.Fence, &invocation.LeaseGeneration, &attempts, &priorLeaseUntil); err != nil {
+		if err := rows.Scan(&invocation.ID, &invocation.ConversationID, &invocation.TargetEndpoint, &invocation.TargetMachineID, &invocation.Fence, &invocation.LeaseGeneration, &attempts, &recoveryOnly, &priorLeaseUntil); err != nil {
 			return nil, fmt.Errorf("read invocation: %w", err)
 		}
-		if !priorLeaseUntil.Valid || priorLeaseUntil.Int64 <= now.UnixMilli() {
+		freshLease := !priorLeaseUntil.Valid || priorLeaseUntil.Int64 <= now.UnixMilli()
+		if freshLease {
 			// A fresh lease, and a lease recovered after an adapter crash, each
 			// consume one bounded runtime-start attempt. Releasing a still-live
 			// lease to the same adapter does not.
@@ -422,11 +424,12 @@ func (s *Store) LeaseInvocations(machineID, consumerID string, now time.Time, tt
 				// boundary before its adapter crashed. Reissue its stable fence only
 				// for journal/outcome recovery; the adapter must never start work
 				// from this lease when it lacks a durable accepted record.
-				invocation.RecoveryOnly = true
+				recoveryOnly = true
 			} else {
 				attempts++
 			}
 		}
+		invocation.RecoveryOnly = recoveryOnly
 		token, err := randomToken()
 		if err != nil {
 			return nil, err
@@ -435,11 +438,17 @@ func (s *Store) LeaseInvocations(machineID, consumerID string, now time.Time, tt
 		invocation.LeaseGeneration++
 		invocation.LeaseToken = token
 		invocation.LeaseUntil = now.Add(ttl).UTC()
-		if _, err := tx.ExecContext(context.Background(), `UPDATE invocations SET attempts=?,last_activity_at=?,lease_machine_id=?,lease_consumer_id=?,lease_token=?,lease_generation=?,lease_until=? WHERE id=?`, attempts, now.UnixMilli(), machineID, consumerID, token, invocation.LeaseGeneration, invocation.LeaseUntil.UnixMilli(), invocation.ID); err != nil {
+		if freshLease {
+			if _, err := tx.ExecContext(context.Background(), `UPDATE invocations SET attempts=?,last_activity_at=?,recovery_only=?,lease_machine_id=?,lease_consumer_id=?,lease_token=?,lease_generation=?,lease_until=? WHERE id=?`, attempts, now.UnixMilli(), recoveryOnly, machineID, consumerID, token, invocation.LeaseGeneration, invocation.LeaseUntil.UnixMilli(), invocation.ID); err != nil {
+				return nil, fmt.Errorf("lease invocation: %w", err)
+			}
+		} else if _, err := tx.ExecContext(context.Background(), `UPDATE invocations SET lease_machine_id=?,lease_consumer_id=?,lease_token=?,lease_generation=?,lease_until=? WHERE id=?`, machineID, consumerID, token, invocation.LeaseGeneration, invocation.LeaseUntil.UnixMilli(), invocation.ID); err != nil {
 			return nil, fmt.Errorf("lease invocation: %w", err)
 		}
-		if err := recordInvocationAudit(tx, invocation.ID, "leased", now); err != nil {
-			return nil, err
+		if freshLease {
+			if err := recordInvocationAudit(tx, invocation.ID, "leased", now); err != nil {
+				return nil, err
+			}
 		}
 		invocations = append(invocations, invocation)
 	}
@@ -640,6 +649,7 @@ func (s *Store) ensureInvocationSchema() error {
 			lease_consumer_id TEXT,
 			lease_token TEXT,
 			lease_generation INTEGER NOT NULL DEFAULT 0,
+			recovery_only INTEGER NOT NULL DEFAULT 0,
 			target_ownership_generation INTEGER NOT NULL DEFAULT 0,
 			lease_until INTEGER,
 			last_activity_at INTEGER NOT NULL DEFAULT 0,
@@ -674,6 +684,9 @@ func (s *Store) ensureInvocationSchema() error {
 		return err
 	}
 	if err := ensureSQLiteColumn(context.Background(), s.db, "invocations", "last_activity_at", "INTEGER NOT NULL DEFAULT 0"); err != nil {
+		return err
+	}
+	if err := ensureSQLiteColumn(context.Background(), s.db, "invocations", "recovery_only", "INTEGER NOT NULL DEFAULT 0"); err != nil {
 		return err
 	}
 	return nil

--- a/internal/relay/invocation.go
+++ b/internal/relay/invocation.go
@@ -21,11 +21,35 @@ var _ InvocationBackend = (*Store)(nil)
 // RequestInvocation authorizes a distinct invoke capability and queues one
 // content-free handoff only when the target has pending work and is offline.
 func (s *Store) RequestInvocation(input InvokeInput) (Invocation, bool, error) {
-	if err := s.ensureInvocationSchema(); err != nil {
-		return Invocation{}, false, err
-	}
 	if strings.TrimSpace(input.ConversationID) == "" || !ValidMachineID(input.SenderMachineID) || !ValidEndpoint(input.FromEndpoint) || !ValidEndpoint(input.TargetEndpoint) || !ValidRequestToken(input.IdempotencyKey) {
 		return Invocation{}, false, fmt.Errorf("invalid invocation request")
+	}
+	// Do the inexpensive authority and pending-work checks before creating the
+	// optional control-plane tables. An unauthorized request must remain a
+	// read-only rejection, including for cutover-compatible stores.
+	if err := s.AssertEndpointOwnership(input.SenderMachineID, input.FromEndpoint, input.Now); err != nil {
+		return Invocation{}, false, err
+	}
+	var sourceCapabilities, targetCapabilities Capability
+	if err := s.db.QueryRowContext(context.Background(), `SELECT capabilities FROM memberships WHERE conversation_id=? AND endpoint=?`, input.ConversationID, input.FromEndpoint).Scan(&sourceCapabilities); errors.Is(err, sql.ErrNoRows) || sourceCapabilities&CapInvoke == 0 {
+		return Invocation{}, false, ErrForbidden
+	} else if err != nil {
+		return Invocation{}, false, fmt.Errorf("authorize invocation sender: %w", err)
+	}
+	if err := s.db.QueryRowContext(context.Background(), `SELECT capabilities FROM memberships WHERE conversation_id=? AND endpoint=?`, input.ConversationID, input.TargetEndpoint).Scan(&targetCapabilities); errors.Is(err, sql.ErrNoRows) || targetCapabilities&CapReceive == 0 {
+		return Invocation{}, false, ErrForbidden
+	} else if err != nil {
+		return Invocation{}, false, fmt.Errorf("authorize invocation target: %w", err)
+	}
+	var pending bool
+	if err := s.db.QueryRowContext(context.Background(), `SELECT EXISTS(SELECT 1 FROM deliveries AS delivery JOIN messages AS message ON message.id=delivery.message_id WHERE delivery.recipient_endpoint=? AND delivery.acked_at IS NULL AND message.conversation_id=?)`, input.TargetEndpoint, input.ConversationID).Scan(&pending); err != nil {
+		return Invocation{}, false, fmt.Errorf("inspect pending invocation work: %w", err)
+	}
+	if !pending {
+		return Invocation{}, false, ErrConflict
+	}
+	if err := s.ensureInvocationSchema(); err != nil {
+		return Invocation{}, false, err
 	}
 	requestHash := stableHash(input.ConversationID, input.FromEndpoint, input.TargetEndpoint)
 	tx, err := s.db.BeginTx(context.Background(), nil)
@@ -36,7 +60,6 @@ func (s *Store) RequestInvocation(input InvokeInput) (Invocation, bool, error) {
 	if err := endpointOwnedBy(tx, input.FromEndpoint, input.SenderMachineID, input.Now); err != nil {
 		return Invocation{}, false, err
 	}
-	var sourceCapabilities Capability
 	err = tx.QueryRowContext(context.Background(), `SELECT capabilities FROM memberships WHERE conversation_id=? AND endpoint=?`, input.ConversationID, input.FromEndpoint).Scan(&sourceCapabilities)
 	if errors.Is(err, sql.ErrNoRows) || sourceCapabilities&CapInvoke == 0 {
 		return Invocation{}, false, ErrForbidden
@@ -62,7 +85,6 @@ func (s *Store) RequestInvocation(input InvokeInput) (Invocation, bool, error) {
 	if !errors.Is(err, sql.ErrNoRows) {
 		return Invocation{}, false, fmt.Errorf("read invocation idempotency: %w", err)
 	}
-	var targetCapabilities Capability
 	err = tx.QueryRowContext(context.Background(), `SELECT capabilities FROM memberships WHERE conversation_id=? AND endpoint=?`, input.ConversationID, input.TargetEndpoint).Scan(&targetCapabilities)
 	if errors.Is(err, sql.ErrNoRows) || targetCapabilities&CapReceive == 0 {
 		return Invocation{}, false, ErrForbidden
@@ -80,7 +102,6 @@ func (s *Store) RequestInvocation(input InvokeInput) (Invocation, bool, error) {
 	if err != nil {
 		return Invocation{}, false, fmt.Errorf("resolve invocation target: %w", err)
 	}
-	var pending bool
 	if err := tx.QueryRowContext(context.Background(), `SELECT EXISTS(SELECT 1 FROM deliveries AS delivery JOIN messages AS message ON message.id=delivery.message_id WHERE delivery.recipient_endpoint=? AND delivery.acked_at IS NULL AND message.conversation_id=?)`, input.TargetEndpoint, input.ConversationID).Scan(&pending); err != nil {
 		return Invocation{}, false, fmt.Errorf("inspect pending invocation work: %w", err)
 	}
@@ -110,7 +131,7 @@ func (s *Store) RequestInvocation(input InvokeInput) (Invocation, bool, error) {
 	// offline role. They must converge on one durable fence, rather than start
 	// separate runtime processes merely because their idempotency domains differ.
 	var pendingID string
-	err = tx.QueryRowContext(context.Background(), `SELECT id FROM invocations WHERE conversation_id=? AND target_endpoint=? AND target_machine_id=? AND target_ownership_generation=? AND (status=? OR (status=? AND not_before>?)) ORDER BY created_at,id LIMIT 1`, input.ConversationID, input.TargetEndpoint, targetMachine, targetOwnershipGeneration, InvocationPending, InvocationSucceeded, input.Now.UnixMilli()).Scan(&pendingID)
+	err = tx.QueryRowContext(context.Background(), `SELECT id FROM invocations WHERE target_endpoint=? AND target_machine_id=? AND target_ownership_generation=? AND (status=? OR (status=? AND not_before>?)) ORDER BY created_at,id LIMIT 1`, input.TargetEndpoint, targetMachine, targetOwnershipGeneration, InvocationPending, InvocationSucceeded, input.Now.UnixMilli()).Scan(&pendingID)
 	if err == nil {
 		invocation, err := invocationByID(tx, pendingID)
 		if err != nil {
@@ -199,7 +220,7 @@ func (s *Store) LeaseInvocations(machineID, consumerID string, now time.Time, tt
 	}
 	staleRows, err := tx.QueryContext(context.Background(), `SELECT invocation.id FROM invocations AS invocation
 		WHERE invocation.target_machine_id=? AND invocation.status=? AND (invocation.lease_machine_id IS NULL OR invocation.lease_until<=?)
-		AND NOT EXISTS (SELECT 1 FROM deliveries AS delivery JOIN messages AS message ON message.id=delivery.message_id WHERE delivery.recipient_endpoint=invocation.target_endpoint AND delivery.acked_at IS NULL AND message.conversation_id=invocation.conversation_id)`, machineID, InvocationPending, now.UnixMilli())
+		AND NOT EXISTS (SELECT 1 FROM deliveries WHERE recipient_endpoint=invocation.target_endpoint AND acked_at IS NULL)`, machineID, InvocationPending, now.UnixMilli())
 	if err != nil {
 		return nil, fmt.Errorf("find stale invocations: %w", err)
 	}

--- a/internal/relay/invocation.go
+++ b/internal/relay/invocation.go
@@ -238,6 +238,41 @@ func expireAbandonedInvocations(tx *sql.Tx, targetEndpoint string, now time.Time
 	return nil
 }
 
+// expireAbandonedLeasedInvocations closes the crash-recovery window before an
+// adapter can obtain another lease. A never-leased request remains eligible for
+// its first start even if it is old; only a prior runtime handoff needs this
+// fence-preserving terminal transition.
+func expireAbandonedLeasedInvocations(tx *sql.Tx, machineID string, now time.Time) error {
+	rows, err := tx.QueryContext(context.Background(), `SELECT id FROM invocations WHERE target_machine_id=? AND status=? AND lease_generation>0 AND last_activity_at<? AND (lease_until IS NULL OR lease_until<=?)`, machineID, InvocationPending, now.Add(-invocationPendingRetention).UnixMilli(), now.UnixMilli())
+	if err != nil {
+		return fmt.Errorf("find abandoned leased invocations: %w", err)
+	}
+	var ids []string
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			_ = rows.Close()
+			return fmt.Errorf("read abandoned leased invocation: %w", err)
+		}
+		ids = append(ids, id)
+	}
+	if err := rows.Close(); err != nil {
+		return fmt.Errorf("find abandoned leased invocations: %w", err)
+	}
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("find abandoned leased invocations: %w", err)
+	}
+	for _, id := range ids {
+		if _, err := tx.ExecContext(context.Background(), `UPDATE invocations SET status=?,terminal_at=?,lease_machine_id=NULL,lease_consumer_id=NULL,lease_token=NULL,lease_until=NULL WHERE id=?`, InvocationFailed, now.UnixMilli(), id); err != nil {
+			return fmt.Errorf("expire abandoned leased invocation: %w", err)
+		}
+		if err := recordInvocationAudit(tx, id, "failed", now); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func invocationForCaller(invocation Invocation, input InvokeInput) Invocation {
 	if invocation.ConversationID == input.ConversationID {
 		return invocation
@@ -269,6 +304,9 @@ func (s *Store) LeaseInvocations(machineID, consumerID string, now time.Time, tt
 		return nil, err
 	}
 	defer rollback(tx)
+	if err := expireAbandonedLeasedInvocations(tx, machineID, now); err != nil {
+		return nil, err
+	}
 	// An invocation carries the endpoint ownership generation observed at
 	// authorization. A later detach or reassignment must not grant its old
 	// machine a process-start lease, even if the endpoint is offline again.

--- a/internal/relay/invocation.go
+++ b/internal/relay/invocation.go
@@ -72,7 +72,8 @@ func (s *Store) RequestInvocation(input InvokeInput) (Invocation, bool, error) {
 	}
 	var targetMachine string
 	var targetLeaseUntil int64
-	err = tx.QueryRowContext(context.Background(), `SELECT machine_id,lease_until FROM endpoints WHERE endpoint=?`, input.TargetEndpoint).Scan(&targetMachine, &targetLeaseUntil)
+	var targetOwnershipGeneration int64
+	err = tx.QueryRowContext(context.Background(), `SELECT machine_id,lease_until,ownership_generation FROM endpoints WHERE endpoint=?`, input.TargetEndpoint).Scan(&targetMachine, &targetLeaseUntil, &targetOwnershipGeneration)
 	if errors.Is(err, sql.ErrNoRows) {
 		return Invocation{}, false, ErrForbidden
 	}
@@ -91,7 +92,7 @@ func (s *Store) RequestInvocation(input InvokeInput) (Invocation, bool, error) {
 		// retrying the same key after the endpoint detached could unexpectedly
 		// become a new start request.
 		invocation := Invocation{ID: uuid.NewString(), ConversationID: input.ConversationID, TargetEndpoint: input.TargetEndpoint, TargetMachineID: targetMachine, Fence: uuid.NewString(), Status: InvocationAlreadyRunning}
-		if _, err := tx.ExecContext(context.Background(), `INSERT INTO invocations(id,conversation_id,from_endpoint,target_endpoint,target_machine_id,fence,status,not_before,created_at) VALUES(?,?,?,?,?,?,?,?,?)`, invocation.ID, invocation.ConversationID, input.FromEndpoint, invocation.TargetEndpoint, invocation.TargetMachineID, invocation.Fence, invocation.Status, input.Now.UnixMilli(), input.Now.UnixMilli()); err != nil {
+		if _, err := tx.ExecContext(context.Background(), `INSERT INTO invocations(id,conversation_id,from_endpoint,target_endpoint,target_machine_id,target_ownership_generation,fence,status,not_before,created_at) VALUES(?,?,?,?,?,?,?,?,?,?)`, invocation.ID, invocation.ConversationID, input.FromEndpoint, invocation.TargetEndpoint, invocation.TargetMachineID, targetOwnershipGeneration, invocation.Fence, invocation.Status, input.Now.UnixMilli(), input.Now.UnixMilli()); err != nil {
 			return Invocation{}, false, fmt.Errorf("record already-running invocation: %w", err)
 		}
 		if _, err := tx.ExecContext(context.Background(), `INSERT INTO invocation_idempotency(machine_id,key,request_hash,invocation_id) VALUES(?,?,?,?)`, input.SenderMachineID, input.IdempotencyKey, requestHash, invocation.ID); err != nil {
@@ -109,7 +110,7 @@ func (s *Store) RequestInvocation(input InvokeInput) (Invocation, bool, error) {
 	// offline role. They must converge on one durable fence, rather than start
 	// separate runtime processes merely because their idempotency domains differ.
 	var pendingID string
-	err = tx.QueryRowContext(context.Background(), `SELECT id FROM invocations WHERE target_endpoint=? AND status=? ORDER BY created_at,id LIMIT 1`, input.TargetEndpoint, InvocationPending).Scan(&pendingID)
+	err = tx.QueryRowContext(context.Background(), `SELECT id FROM invocations WHERE conversation_id=? AND target_endpoint=? AND status=? ORDER BY created_at,id LIMIT 1`, input.ConversationID, input.TargetEndpoint, InvocationPending).Scan(&pendingID)
 	if err == nil {
 		invocation, err := invocationByID(tx, pendingID)
 		if err != nil {
@@ -130,7 +131,7 @@ func (s *Store) RequestInvocation(input InvokeInput) (Invocation, bool, error) {
 		return Invocation{}, false, fmt.Errorf("find pending invocation: %w", err)
 	}
 	invocation := Invocation{ID: uuid.NewString(), ConversationID: input.ConversationID, TargetEndpoint: input.TargetEndpoint, TargetMachineID: targetMachine, Fence: uuid.NewString(), Status: InvocationPending}
-	if _, err := tx.ExecContext(context.Background(), `INSERT INTO invocations(id,conversation_id,from_endpoint,target_endpoint,target_machine_id,fence,status,not_before,created_at) VALUES(?,?,?,?,?,?,?,?,?)`, invocation.ID, invocation.ConversationID, input.FromEndpoint, invocation.TargetEndpoint, invocation.TargetMachineID, invocation.Fence, invocation.Status, input.Now.UnixMilli(), input.Now.UnixMilli()); err != nil {
+	if _, err := tx.ExecContext(context.Background(), `INSERT INTO invocations(id,conversation_id,from_endpoint,target_endpoint,target_machine_id,target_ownership_generation,fence,status,not_before,created_at) VALUES(?,?,?,?,?,?,?,?,?,?)`, invocation.ID, invocation.ConversationID, input.FromEndpoint, invocation.TargetEndpoint, invocation.TargetMachineID, targetOwnershipGeneration, invocation.Fence, invocation.Status, input.Now.UnixMilli(), input.Now.UnixMilli()); err != nil {
 		return Invocation{}, false, fmt.Errorf("queue invocation: %w", err)
 	}
 	if _, err := tx.ExecContext(context.Background(), `INSERT INTO invocation_idempotency(machine_id,key,request_hash,invocation_id) VALUES(?,?,?,?)`, input.SenderMachineID, input.IdempotencyKey, requestHash, invocation.ID); err != nil {
@@ -159,6 +160,36 @@ func (s *Store) LeaseInvocations(machineID, consumerID string, now time.Time, tt
 		return nil, err
 	}
 	defer rollback(tx)
+	// An invocation carries the endpoint ownership generation observed at
+	// authorization. A later detach or reassignment must not grant its old
+	// machine a process-start lease, even if the endpoint is offline again.
+	staleOwnerRows, err := tx.QueryContext(context.Background(), `SELECT invocation.id FROM invocations AS invocation
+		LEFT JOIN endpoints AS endpoint ON endpoint.endpoint=invocation.target_endpoint
+		WHERE invocation.target_machine_id=? AND invocation.status=?
+		AND (endpoint.endpoint IS NULL OR endpoint.machine_id<>invocation.target_machine_id OR endpoint.ownership_generation<>invocation.target_ownership_generation)`, machineID, InvocationPending)
+	if err != nil {
+		return nil, fmt.Errorf("find invocation ownership changes: %w", err)
+	}
+	var staleOwnerIDs []string
+	for staleOwnerRows.Next() {
+		var invocationID string
+		if err := staleOwnerRows.Scan(&invocationID); err != nil {
+			_ = staleOwnerRows.Close()
+			return nil, fmt.Errorf("read invocation ownership change: %w", err)
+		}
+		staleOwnerIDs = append(staleOwnerIDs, invocationID)
+	}
+	if err := staleOwnerRows.Close(); err != nil || staleOwnerRows.Err() != nil {
+		return nil, fmt.Errorf("find invocation ownership changes: %w", err)
+	}
+	for _, invocationID := range staleOwnerIDs {
+		if _, err := tx.ExecContext(context.Background(), `UPDATE invocations SET status=?,lease_machine_id=NULL,lease_consumer_id=NULL,lease_token=NULL,lease_until=NULL WHERE id=?`, InvocationFailed, invocationID); err != nil {
+			return nil, fmt.Errorf("fail stale invocation owner: %w", err)
+		}
+		if err := recordInvocationAudit(tx, invocationID, "failed", now); err != nil {
+			return nil, err
+		}
+	}
 	staleRows, err := tx.QueryContext(context.Background(), `SELECT invocation.id FROM invocations AS invocation
 		WHERE invocation.target_machine_id=? AND invocation.status=? AND invocation.lease_machine_id IS NULL
 		AND NOT EXISTS (SELECT 1 FROM deliveries AS delivery JOIN messages AS message ON message.id=delivery.message_id WHERE delivery.recipient_endpoint=invocation.target_endpoint AND delivery.acked_at IS NULL AND message.conversation_id=invocation.conversation_id)`, machineID, InvocationPending)
@@ -190,7 +221,8 @@ func (s *Store) LeaseInvocations(machineID, consumerID string, now time.Time, tt
 	// authoritative proof that starting another copy is no longer allowed.
 	onlineRows, err := tx.QueryContext(context.Background(), `SELECT invocation.id FROM invocations AS invocation
 		JOIN endpoints AS endpoint ON endpoint.endpoint=invocation.target_endpoint
-		WHERE invocation.target_machine_id=? AND invocation.status=? AND invocation.lease_machine_id IS NULL AND endpoint.lease_until>?`, machineID, InvocationPending, now.UnixMilli())
+		WHERE invocation.target_machine_id=? AND invocation.status=? AND invocation.lease_machine_id IS NULL
+		AND endpoint.machine_id=invocation.target_machine_id AND endpoint.ownership_generation=invocation.target_ownership_generation AND endpoint.lease_until>?`, machineID, InvocationPending, now.UnixMilli())
 	if err != nil {
 		return nil, fmt.Errorf("find online invocation targets: %w", err)
 	}
@@ -217,8 +249,9 @@ func (s *Store) LeaseInvocations(machineID, consumerID string, now time.Time, tt
 			return nil, err
 		}
 	}
-	rows, err := tx.QueryContext(context.Background(), `SELECT id,conversation_id,target_endpoint,target_machine_id,fence,lease_generation,attempts,lease_until FROM invocations
-		WHERE target_machine_id=? AND status=? AND not_before<=? AND (lease_until IS NULL OR lease_until<=? OR (lease_machine_id=? AND lease_consumer_id=?))
+	rows, err := tx.QueryContext(context.Background(), `SELECT invocation.id,invocation.conversation_id,invocation.target_endpoint,invocation.target_machine_id,invocation.fence,invocation.lease_generation,invocation.attempts,invocation.lease_until FROM invocations AS invocation
+		JOIN endpoints AS endpoint ON endpoint.endpoint=invocation.target_endpoint AND endpoint.machine_id=invocation.target_machine_id AND endpoint.ownership_generation=invocation.target_ownership_generation
+		WHERE invocation.target_machine_id=? AND invocation.status=? AND invocation.not_before<=? AND (invocation.lease_until IS NULL OR invocation.lease_until<=? OR (invocation.lease_machine_id=? AND invocation.lease_consumer_id=?))
 		ORDER BY created_at,id LIMIT ?`, machineID, InvocationPending, now.UnixMilli(), now.UnixMilli(), machineID, consumerID, limit)
 	if err != nil {
 		return nil, fmt.Errorf("find invocations: %w", err)
@@ -402,6 +435,7 @@ func (s *Store) ensureInvocationSchema() error {
 			lease_consumer_id TEXT,
 			lease_token TEXT,
 			lease_generation INTEGER NOT NULL DEFAULT 0,
+			target_ownership_generation INTEGER NOT NULL DEFAULT 0,
 			lease_until INTEGER,
 			created_at INTEGER NOT NULL
 		)`,
@@ -424,6 +458,9 @@ func (s *Store) ensureInvocationSchema() error {
 		if _, err := s.db.ExecContext(context.Background(), statement); err != nil {
 			return fmt.Errorf("initialize invocation state: %w", err)
 		}
+	}
+	if err := ensureSQLiteColumn(context.Background(), s.db, "invocations", "target_ownership_generation", "INTEGER NOT NULL DEFAULT 0"); err != nil {
+		return err
 	}
 	return nil
 }

--- a/internal/relay/invocation.go
+++ b/internal/relay/invocation.go
@@ -1,0 +1,331 @@
+package relay
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+const (
+	maxInvocationAttempts = 3
+	maxInvocationBackoff  = time.Minute
+)
+
+var _ InvocationBackend = (*Store)(nil)
+
+// RequestInvocation authorizes a distinct invoke capability and queues one
+// content-free handoff only when the target has pending work and is offline.
+func (s *Store) RequestInvocation(input InvokeInput) (Invocation, bool, error) {
+	if err := s.ensureInvocationSchema(); err != nil {
+		return Invocation{}, false, err
+	}
+	if strings.TrimSpace(input.ConversationID) == "" || !ValidMachineID(input.SenderMachineID) || !ValidEndpoint(input.FromEndpoint) || !ValidEndpoint(input.TargetEndpoint) || !ValidRequestToken(input.IdempotencyKey) {
+		return Invocation{}, false, fmt.Errorf("invalid invocation request")
+	}
+	requestHash := stableHash(input.ConversationID, input.FromEndpoint, input.TargetEndpoint)
+	tx, err := s.db.BeginTx(context.Background(), nil)
+	if err != nil {
+		return Invocation{}, false, err
+	}
+	defer rollback(tx)
+	if err := endpointOwnedBy(tx, input.FromEndpoint, input.SenderMachineID, input.Now); err != nil {
+		return Invocation{}, false, err
+	}
+	var sourceCapabilities Capability
+	err = tx.QueryRowContext(context.Background(), `SELECT capabilities FROM memberships WHERE conversation_id=? AND endpoint=?`, input.ConversationID, input.FromEndpoint).Scan(&sourceCapabilities)
+	if errors.Is(err, sql.ErrNoRows) || sourceCapabilities&CapInvoke == 0 {
+		return Invocation{}, false, ErrForbidden
+	}
+	if err != nil {
+		return Invocation{}, false, fmt.Errorf("authorize invocation sender: %w", err)
+	}
+	var existingID, existingHash string
+	err = tx.QueryRowContext(context.Background(), `SELECT invocation_id,request_hash FROM invocation_idempotency WHERE machine_id=? AND key=?`, input.SenderMachineID, input.IdempotencyKey).Scan(&existingID, &existingHash)
+	if err == nil {
+		if existingHash != requestHash {
+			return Invocation{}, false, ErrConflict
+		}
+		invocation, err := invocationByID(tx, existingID)
+		if err != nil {
+			return Invocation{}, false, err
+		}
+		if err := tx.Commit(); err != nil {
+			return Invocation{}, false, err
+		}
+		return invocation, true, nil
+	}
+	if !errors.Is(err, sql.ErrNoRows) {
+		return Invocation{}, false, fmt.Errorf("read invocation idempotency: %w", err)
+	}
+	var targetCapabilities Capability
+	err = tx.QueryRowContext(context.Background(), `SELECT capabilities FROM memberships WHERE conversation_id=? AND endpoint=?`, input.ConversationID, input.TargetEndpoint).Scan(&targetCapabilities)
+	if errors.Is(err, sql.ErrNoRows) || targetCapabilities&CapReceive == 0 {
+		return Invocation{}, false, ErrForbidden
+	}
+	if err != nil {
+		return Invocation{}, false, fmt.Errorf("authorize invocation target: %w", err)
+	}
+	var targetMachine string
+	var targetLeaseUntil int64
+	err = tx.QueryRowContext(context.Background(), `SELECT machine_id,lease_until FROM endpoints WHERE endpoint=?`, input.TargetEndpoint).Scan(&targetMachine, &targetLeaseUntil)
+	if errors.Is(err, sql.ErrNoRows) {
+		return Invocation{}, false, ErrForbidden
+	}
+	if err != nil {
+		return Invocation{}, false, fmt.Errorf("resolve invocation target: %w", err)
+	}
+	var pending bool
+	if err := tx.QueryRowContext(context.Background(), `SELECT EXISTS(SELECT 1 FROM deliveries AS delivery JOIN messages AS message ON message.id=delivery.message_id WHERE delivery.recipient_endpoint=? AND delivery.acked_at IS NULL AND message.conversation_id=?)`, input.TargetEndpoint, input.ConversationID).Scan(&pending); err != nil {
+		return Invocation{}, false, fmt.Errorf("inspect pending invocation work: %w", err)
+	}
+	if !pending {
+		return Invocation{}, false, ErrConflict
+	}
+	if targetLeaseUntil > input.Now.UnixMilli() {
+		// Persist this no-op result in the caller's idempotency domain. Otherwise
+		// retrying the same key after the endpoint detached could unexpectedly
+		// become a new start request.
+		invocation := Invocation{ID: uuid.NewString(), ConversationID: input.ConversationID, TargetEndpoint: input.TargetEndpoint, TargetMachineID: targetMachine, Fence: uuid.NewString(), Status: InvocationAlreadyRunning}
+		if _, err := tx.ExecContext(context.Background(), `INSERT INTO invocations(id,conversation_id,from_endpoint,target_endpoint,target_machine_id,fence,status,not_before,created_at) VALUES(?,?,?,?,?,?,?,?,?)`, invocation.ID, invocation.ConversationID, input.FromEndpoint, invocation.TargetEndpoint, invocation.TargetMachineID, invocation.Fence, invocation.Status, input.Now.UnixMilli(), input.Now.UnixMilli()); err != nil {
+			return Invocation{}, false, fmt.Errorf("record already-running invocation: %w", err)
+		}
+		if _, err := tx.ExecContext(context.Background(), `INSERT INTO invocation_idempotency(machine_id,key,request_hash,invocation_id) VALUES(?,?,?,?)`, input.SenderMachineID, input.IdempotencyKey, requestHash, invocation.ID); err != nil {
+			return Invocation{}, false, fmt.Errorf("record invocation idempotency: %w", err)
+		}
+		if err := recordInvocationAudit(tx, invocation.ID, "already_running", input.Now); err != nil {
+			return Invocation{}, false, err
+		}
+		if err := tx.Commit(); err != nil {
+			return Invocation{}, false, err
+		}
+		return invocation, false, nil
+	}
+	invocation := Invocation{ID: uuid.NewString(), ConversationID: input.ConversationID, TargetEndpoint: input.TargetEndpoint, TargetMachineID: targetMachine, Fence: uuid.NewString(), Status: InvocationPending}
+	if _, err := tx.ExecContext(context.Background(), `INSERT INTO invocations(id,conversation_id,from_endpoint,target_endpoint,target_machine_id,fence,status,not_before,created_at) VALUES(?,?,?,?,?,?,?,?,?)`, invocation.ID, invocation.ConversationID, input.FromEndpoint, invocation.TargetEndpoint, invocation.TargetMachineID, invocation.Fence, invocation.Status, input.Now.UnixMilli(), input.Now.UnixMilli()); err != nil {
+		return Invocation{}, false, fmt.Errorf("queue invocation: %w", err)
+	}
+	if _, err := tx.ExecContext(context.Background(), `INSERT INTO invocation_idempotency(machine_id,key,request_hash,invocation_id) VALUES(?,?,?,?)`, input.SenderMachineID, input.IdempotencyKey, requestHash, invocation.ID); err != nil {
+		return Invocation{}, false, fmt.Errorf("record invocation idempotency: %w", err)
+	}
+	if err := recordInvocationAudit(tx, invocation.ID, "requested", input.Now); err != nil {
+		return Invocation{}, false, err
+	}
+	if err := tx.Commit(); err != nil {
+		return Invocation{}, false, err
+	}
+	return invocation, false, nil
+}
+
+// LeaseInvocations gives an enrolled adapter bounded content-free start work.
+// The stable fence survives a lost response and every later lease generation.
+func (s *Store) LeaseInvocations(machineID, consumerID string, now time.Time, ttl time.Duration, limit int) ([]Invocation, error) {
+	if err := s.ensureInvocationSchema(); err != nil {
+		return nil, err
+	}
+	if !ValidMachineID(machineID) || !ValidRequestToken(consumerID) || ttl <= 0 || limit < 1 || limit > 100 {
+		return nil, fmt.Errorf("invalid invocation lease request")
+	}
+	tx, err := s.db.BeginTx(context.Background(), nil)
+	if err != nil {
+		return nil, err
+	}
+	defer rollback(tx)
+	rows, err := tx.QueryContext(context.Background(), `SELECT id,conversation_id,target_endpoint,target_machine_id,fence,lease_generation FROM invocations
+		WHERE target_machine_id=? AND status=? AND not_before<=? AND (lease_until IS NULL OR lease_until<=? OR (lease_machine_id=? AND lease_consumer_id=?))
+		ORDER BY created_at,id LIMIT ?`, machineID, InvocationPending, now.UnixMilli(), now.UnixMilli(), machineID, consumerID, limit)
+	if err != nil {
+		return nil, fmt.Errorf("find invocations: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	var invocations []Invocation
+	for rows.Next() {
+		var invocation Invocation
+		if err := rows.Scan(&invocation.ID, &invocation.ConversationID, &invocation.TargetEndpoint, &invocation.TargetMachineID, &invocation.Fence, &invocation.LeaseGeneration); err != nil {
+			return nil, fmt.Errorf("read invocation: %w", err)
+		}
+		token, err := randomToken()
+		if err != nil {
+			return nil, err
+		}
+		invocation.Status = InvocationPending
+		invocation.LeaseGeneration++
+		invocation.LeaseToken = token
+		invocation.LeaseUntil = now.Add(ttl).UTC()
+		if _, err := tx.ExecContext(context.Background(), `UPDATE invocations SET lease_machine_id=?,lease_consumer_id=?,lease_token=?,lease_generation=?,lease_until=? WHERE id=?`, machineID, consumerID, token, invocation.LeaseGeneration, invocation.LeaseUntil.UnixMilli(), invocation.ID); err != nil {
+			return nil, fmt.Errorf("lease invocation: %w", err)
+		}
+		if err := recordInvocationAudit(tx, invocation.ID, "leased", now); err != nil {
+			return nil, err
+		}
+		invocations = append(invocations, invocation)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	if err := tx.Commit(); err != nil {
+		return nil, err
+	}
+	return invocations, nil
+}
+
+// ReportInvocation accepts a durable local handoff or returns it to the queue
+// with bounded retry. A stale or foreign lease cannot change the result.
+func (s *Store) ReportInvocation(machineID, invocationID, token string, generation int64, accepted bool, now time.Time) error {
+	if err := s.ensureInvocationSchema(); err != nil {
+		return err
+	}
+	if !ValidMachineID(machineID) || strings.TrimSpace(invocationID) == "" || !ValidRequestToken(token) || generation < 1 {
+		return ErrForbidden
+	}
+	tx, err := s.db.BeginTx(context.Background(), nil)
+	if err != nil {
+		return err
+	}
+	defer rollback(tx)
+	var status InvocationStatus
+	var leaseMachine, leaseToken sql.NullString
+	var leaseGeneration int64
+	var leaseUntil sql.NullInt64
+	var attempts int
+	err = tx.QueryRowContext(context.Background(), `SELECT status,lease_machine_id,lease_token,lease_generation,lease_until,attempts FROM invocations WHERE id=?`, invocationID).Scan(&status, &leaseMachine, &leaseToken, &leaseGeneration, &leaseUntil, &attempts)
+	if errors.Is(err, sql.ErrNoRows) || status != InvocationPending || !leaseMachine.Valid || leaseMachine.String != machineID || !leaseToken.Valid || leaseToken.String != token || leaseGeneration != generation || !leaseUntil.Valid || leaseUntil.Int64 <= now.UnixMilli() {
+		return ErrForbidden
+	}
+	if err != nil {
+		return fmt.Errorf("read invocation lease: %w", err)
+	}
+	if accepted {
+		if _, err := tx.ExecContext(context.Background(), `UPDATE invocations SET status=?,lease_machine_id=NULL,lease_consumer_id=NULL,lease_token=NULL,lease_until=NULL WHERE id=?`, InvocationSucceeded, invocationID); err != nil {
+			return fmt.Errorf("accept invocation: %w", err)
+		}
+		if err := recordInvocationAudit(tx, invocationID, "accepted", now); err != nil {
+			return err
+		}
+	} else {
+		attempts++
+		status := InvocationPending
+		action := "retry"
+		if attempts >= maxInvocationAttempts {
+			status, action = InvocationFailed, "failed"
+		}
+		notBefore := now
+		if status == InvocationPending {
+			notBefore = now.Add(invocationBackoff(attempts))
+		}
+		if _, err := tx.ExecContext(context.Background(), `UPDATE invocations SET status=?,attempts=?,not_before=?,lease_machine_id=NULL,lease_consumer_id=NULL,lease_token=NULL,lease_until=NULL WHERE id=?`, status, attempts, notBefore.UnixMilli(), invocationID); err != nil {
+			return fmt.Errorf("retry invocation: %w", err)
+		}
+		if err := recordInvocationAudit(tx, invocationID, action, now); err != nil {
+			return err
+		}
+	}
+	return tx.Commit()
+}
+
+func invocationBackoff(attempt int) time.Duration {
+	// Leave a full poll interval for a transient local runtime failure before
+	// a second start attempt. The final terminal failure occurs after three
+	// leases, not by silently dropping the durable request.
+	backoff := 2 * time.Second << (attempt - 1)
+	if backoff > maxInvocationBackoff {
+		return maxInvocationBackoff
+	}
+	return backoff
+}
+
+// InvocationAudit returns body-free audit history for operational inspection.
+func (s *Store) InvocationAudit(invocationID string) ([]InvocationAuditEvent, error) {
+	if err := s.ensureInvocationSchema(); err != nil {
+		return nil, err
+	}
+	rows, err := s.db.QueryContext(context.Background(), `SELECT action,created_at FROM invocation_audit WHERE invocation_id=? ORDER BY ordinal`, invocationID)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+	var events []InvocationAuditEvent
+	for rows.Next() {
+		var event InvocationAuditEvent
+		var createdAt int64
+		if err := rows.Scan(&event.Action, &createdAt); err != nil {
+			return nil, err
+		}
+		event.CreatedAt = fromMillis(createdAt)
+		events = append(events, event)
+	}
+	return events, rows.Err()
+}
+
+func invocationByID(tx *sql.Tx, id string) (Invocation, error) {
+	var invocation Invocation
+	err := tx.QueryRowContext(context.Background(), `SELECT id,conversation_id,target_endpoint,target_machine_id,fence,status FROM invocations WHERE id=?`, id).Scan(&invocation.ID, &invocation.ConversationID, &invocation.TargetEndpoint, &invocation.TargetMachineID, &invocation.Fence, &invocation.Status)
+	if errors.Is(err, sql.ErrNoRows) {
+		return Invocation{}, ErrForbidden
+	}
+	if err != nil {
+		return Invocation{}, fmt.Errorf("read invocation: %w", err)
+	}
+	return invocation, nil
+}
+
+func recordInvocationAudit(tx *sql.Tx, invocationID, action string, now time.Time) error {
+	var ordinal int
+	if err := tx.QueryRowContext(context.Background(), `SELECT COALESCE(MAX(ordinal),0)+1 FROM invocation_audit WHERE invocation_id=?`, invocationID).Scan(&ordinal); err != nil {
+		return fmt.Errorf("allocate invocation audit ordinal: %w", err)
+	}
+	if _, err := tx.ExecContext(context.Background(), `INSERT INTO invocation_audit(invocation_id,ordinal,action,created_at) VALUES(?,?,?,?)`, invocationID, ordinal, action, now.UnixMilli()); err != nil {
+		return fmt.Errorf("record invocation audit: %w", err)
+	}
+	return nil
+}
+
+// ensureInvocationSchema is lazy because the published SQLite-to-PostgreSQL
+// cutover snapshot has not yet gained invocation parity. Once invoke is used,
+// that cutover intentionally refuses the unknown tables rather than silently
+// dropping control-plane state; a future paired migration must carry it.
+func (s *Store) ensureInvocationSchema() error {
+	for _, statement := range []string{
+		`CREATE TABLE IF NOT EXISTS invocations (
+			id TEXT PRIMARY KEY,
+			conversation_id TEXT NOT NULL REFERENCES conversations(id) ON DELETE CASCADE,
+			from_endpoint TEXT NOT NULL,
+			target_endpoint TEXT NOT NULL,
+			target_machine_id TEXT NOT NULL,
+			fence TEXT NOT NULL UNIQUE,
+			status TEXT NOT NULL CHECK(status IN ('pending', 'already_running', 'succeeded', 'failed')),
+			attempts INTEGER NOT NULL DEFAULT 0 CHECK(attempts >= 0),
+			not_before INTEGER NOT NULL,
+			lease_machine_id TEXT,
+			lease_consumer_id TEXT,
+			lease_token TEXT,
+			lease_generation INTEGER NOT NULL DEFAULT 0,
+			lease_until INTEGER,
+			created_at INTEGER NOT NULL
+		)`,
+		`CREATE TABLE IF NOT EXISTS invocation_idempotency (
+			machine_id TEXT NOT NULL,
+			key TEXT NOT NULL,
+			request_hash TEXT NOT NULL,
+			invocation_id TEXT NOT NULL REFERENCES invocations(id) ON DELETE CASCADE,
+			PRIMARY KEY(machine_id, key)
+		)`,
+		`CREATE TABLE IF NOT EXISTS invocation_audit (
+			invocation_id TEXT NOT NULL REFERENCES invocations(id) ON DELETE CASCADE,
+			ordinal INTEGER NOT NULL,
+			action TEXT NOT NULL CHECK(action IN ('requested', 'already_running', 'leased', 'retry', 'accepted', 'failed')),
+			created_at INTEGER NOT NULL,
+			PRIMARY KEY(invocation_id, ordinal)
+		)`,
+		`CREATE INDEX IF NOT EXISTS invocations_machine_pending ON invocations(target_machine_id, status, not_before, lease_until)`,
+	} {
+		if _, err := s.db.ExecContext(context.Background(), statement); err != nil {
+			return fmt.Errorf("initialize invocation state: %w", err)
+		}
+	}
+	return nil
+}

--- a/internal/relay/invocation.go
+++ b/internal/relay/invocation.go
@@ -41,6 +41,27 @@ func (s *Store) RequestInvocation(input InvokeInput) (Invocation, bool, error) {
 	} else if err != nil {
 		return Invocation{}, false, fmt.Errorf("authorize invocation target: %w", err)
 	}
+	requestHash := stableHash(input.ConversationID, input.FromEndpoint, input.TargetEndpoint)
+	invocationSchemaExists, err := s.invocationSchemaExists()
+	if err != nil {
+		return Invocation{}, false, err
+	}
+	if invocationSchemaExists {
+		var existingHash string
+		err := s.db.QueryRowContext(context.Background(), `SELECT request_hash FROM invocation_idempotency WHERE machine_id=? AND key=?`, input.SenderMachineID, input.IdempotencyKey).Scan(&existingHash)
+		if err == nil {
+			if existingHash != requestHash {
+				return Invocation{}, false, ErrConflict
+			}
+			if err := s.ensureInvocationSchema(); err != nil {
+				return Invocation{}, false, err
+			}
+			return s.requestInvocationWithSchema(input, requestHash)
+		}
+		if !errors.Is(err, sql.ErrNoRows) {
+			return Invocation{}, false, fmt.Errorf("read invocation idempotency: %w", err)
+		}
+	}
 	var pending bool
 	if err := s.db.QueryRowContext(context.Background(), `SELECT EXISTS(SELECT 1 FROM deliveries AS delivery JOIN messages AS message ON message.id=delivery.message_id WHERE delivery.recipient_endpoint=? AND delivery.acked_at IS NULL AND message.conversation_id=?)`, input.TargetEndpoint, input.ConversationID).Scan(&pending); err != nil {
 		return Invocation{}, false, fmt.Errorf("inspect pending invocation work: %w", err)
@@ -51,12 +72,17 @@ func (s *Store) RequestInvocation(input InvokeInput) (Invocation, bool, error) {
 	if err := s.ensureInvocationSchema(); err != nil {
 		return Invocation{}, false, err
 	}
-	requestHash := stableHash(input.ConversationID, input.FromEndpoint, input.TargetEndpoint)
+	return s.requestInvocationWithSchema(input, requestHash)
+}
+
+func (s *Store) requestInvocationWithSchema(input InvokeInput, requestHash string) (Invocation, bool, error) {
 	tx, err := s.db.BeginTx(context.Background(), nil)
 	if err != nil {
 		return Invocation{}, false, err
 	}
 	defer rollback(tx)
+	var sourceCapabilities, targetCapabilities Capability
+	var pending bool
 	if err := endpointOwnedBy(tx, input.FromEndpoint, input.SenderMachineID, input.Now); err != nil {
 		return Invocation{}, false, err
 	}

--- a/internal/relay/invocation.go
+++ b/internal/relay/invocation.go
@@ -159,12 +159,38 @@ func (s *Store) LeaseInvocations(machineID, consumerID string, now time.Time, tt
 		return nil, err
 	}
 	defer rollback(tx)
+	staleRows, err := tx.QueryContext(context.Background(), `SELECT invocation.id FROM invocations AS invocation
+		WHERE invocation.target_machine_id=? AND invocation.status=? AND invocation.lease_machine_id IS NULL
+		AND NOT EXISTS (SELECT 1 FROM deliveries AS delivery JOIN messages AS message ON message.id=delivery.message_id WHERE delivery.recipient_endpoint=invocation.target_endpoint AND delivery.acked_at IS NULL AND message.conversation_id=invocation.conversation_id)`, machineID, InvocationPending)
+	if err != nil {
+		return nil, fmt.Errorf("find stale invocations: %w", err)
+	}
+	var staleIDs []string
+	for staleRows.Next() {
+		var invocationID string
+		if err := staleRows.Scan(&invocationID); err != nil {
+			_ = staleRows.Close()
+			return nil, fmt.Errorf("read stale invocation: %w", err)
+		}
+		staleIDs = append(staleIDs, invocationID)
+	}
+	if err := staleRows.Close(); err != nil || staleRows.Err() != nil {
+		return nil, fmt.Errorf("find stale invocations: %w", err)
+	}
+	for _, invocationID := range staleIDs {
+		if _, err := tx.ExecContext(context.Background(), `UPDATE invocations SET status=? WHERE id=?`, InvocationFailed, invocationID); err != nil {
+			return nil, fmt.Errorf("fail stale invocation: %w", err)
+		}
+		if err := recordInvocationAudit(tx, invocationID, "failed", now); err != nil {
+			return nil, err
+		}
+	}
 	// A role may have attached after its caller observed it offline. Terminally
 	// consume that old request before leasing anything: attachment is the
 	// authoritative proof that starting another copy is no longer allowed.
 	onlineRows, err := tx.QueryContext(context.Background(), `SELECT invocation.id FROM invocations AS invocation
 		JOIN endpoints AS endpoint ON endpoint.endpoint=invocation.target_endpoint
-		WHERE invocation.target_machine_id=? AND invocation.status=? AND endpoint.lease_until>?`, machineID, InvocationPending, now.UnixMilli())
+		WHERE invocation.target_machine_id=? AND invocation.status=? AND invocation.lease_machine_id IS NULL AND endpoint.lease_until>?`, machineID, InvocationPending, now.UnixMilli())
 	if err != nil {
 		return nil, fmt.Errorf("find online invocation targets: %w", err)
 	}

--- a/internal/relay/invocation.go
+++ b/internal/relay/invocation.go
@@ -18,6 +18,9 @@ const (
 	// Retain terminal records long enough for a client retry, then reclaim them
 	// with the same transaction that accepts later invoke traffic.
 	invocationTerminalRetention = 24 * time.Hour
+	// A pending handoff without a poll or outcome must not retain unbounded
+	// coalesced idempotency and audit metadata forever.
+	invocationPendingRetention = 24 * time.Hour
 )
 
 var _ InvocationBackend = (*Store)(nil)
@@ -54,6 +57,9 @@ func (s *Store) RequestInvocation(input InvokeInput) (Invocation, bool, error) {
 		// The transaction rechecks authority, prunes expired terminal records,
 		// then resolves idempotency. This lets an expired key be reclaimed before
 		// it can reject a later valid request as a stale hash conflict.
+		if err := s.ensureInvocationSchema(); err != nil {
+			return Invocation{}, false, err
+		}
 		return s.requestInvocationWithSchema(input, requestHash)
 	}
 	var pending bool
@@ -125,6 +131,9 @@ func (s *Store) requestInvocationWithSchema(input InvokeInput, requestHash strin
 	if err != nil {
 		return Invocation{}, false, fmt.Errorf("resolve invocation target: %w", err)
 	}
+	if err := expireAbandonedInvocations(tx, input.TargetEndpoint, input.Now); err != nil {
+		return Invocation{}, false, err
+	}
 	if err := tx.QueryRowContext(context.Background(), `SELECT EXISTS(SELECT 1 FROM deliveries AS delivery JOIN messages AS message ON message.id=delivery.message_id WHERE delivery.recipient_endpoint=? AND delivery.acked_at IS NULL AND message.conversation_id=?)`, input.TargetEndpoint, input.ConversationID).Scan(&pending); err != nil {
 		return Invocation{}, false, fmt.Errorf("inspect pending invocation work: %w", err)
 	}
@@ -194,6 +203,37 @@ func pruneExpiredTerminalInvocations(tx *sql.Tx, now time.Time) error {
 	cutoff := now.Add(-invocationTerminalRetention).UnixMilli()
 	if _, err := tx.ExecContext(context.Background(), `DELETE FROM invocations WHERE terminal_at IS NOT NULL AND terminal_at<?`, cutoff); err != nil {
 		return fmt.Errorf("prune terminal invocations: %w", err)
+	}
+	return nil
+}
+
+func expireAbandonedInvocations(tx *sql.Tx, targetEndpoint string, now time.Time) error {
+	rows, err := tx.QueryContext(context.Background(), `SELECT id FROM invocations WHERE target_endpoint=? AND status=? AND created_at<?`, targetEndpoint, InvocationPending, now.Add(-invocationPendingRetention).UnixMilli())
+	if err != nil {
+		return fmt.Errorf("find abandoned invocations: %w", err)
+	}
+	var ids []string
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			_ = rows.Close()
+			return fmt.Errorf("read abandoned invocation: %w", err)
+		}
+		ids = append(ids, id)
+	}
+	if err := rows.Close(); err != nil {
+		return fmt.Errorf("find abandoned invocations: %w", err)
+	}
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("find abandoned invocations: %w", err)
+	}
+	for _, id := range ids {
+		if _, err := tx.ExecContext(context.Background(), `UPDATE invocations SET status=?,terminal_at=?,lease_machine_id=NULL,lease_consumer_id=NULL,lease_token=NULL,lease_until=NULL WHERE id=?`, InvocationFailed, now.UnixMilli(), id); err != nil {
+			return fmt.Errorf("expire abandoned invocation: %w", err)
+		}
+		if err := recordInvocationAudit(tx, id, "failed", now); err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/internal/relay/invocation.go
+++ b/internal/relay/invocation.go
@@ -14,6 +14,10 @@ import (
 const (
 	maxInvocationAttempts = 3
 	maxInvocationBackoff  = time.Minute
+	// Invocation records include their idempotency and body-free audit trail.
+	// Retain terminal records long enough for a client retry, then reclaim them
+	// with the same transaction that accepts later invoke traffic.
+	invocationTerminalRetention = 24 * time.Hour
 )
 
 var _ InvocationBackend = (*Store)(nil)
@@ -47,20 +51,10 @@ func (s *Store) RequestInvocation(input InvokeInput) (Invocation, bool, error) {
 		return Invocation{}, false, err
 	}
 	if invocationSchemaExists {
-		var existingHash string
-		err := s.db.QueryRowContext(context.Background(), `SELECT request_hash FROM invocation_idempotency WHERE machine_id=? AND key=?`, input.SenderMachineID, input.IdempotencyKey).Scan(&existingHash)
-		if err == nil {
-			if existingHash != requestHash {
-				return Invocation{}, false, ErrConflict
-			}
-			if err := s.ensureInvocationSchema(); err != nil {
-				return Invocation{}, false, err
-			}
-			return s.requestInvocationWithSchema(input, requestHash)
-		}
-		if !errors.Is(err, sql.ErrNoRows) {
-			return Invocation{}, false, fmt.Errorf("read invocation idempotency: %w", err)
-		}
+		// The transaction rechecks authority, prunes expired terminal records,
+		// then resolves idempotency. This lets an expired key be reclaimed before
+		// it can reject a later valid request as a stale hash conflict.
+		return s.requestInvocationWithSchema(input, requestHash)
 	}
 	var pending bool
 	if err := s.db.QueryRowContext(context.Background(), `SELECT EXISTS(SELECT 1 FROM deliveries AS delivery JOIN messages AS message ON message.id=delivery.message_id WHERE delivery.recipient_endpoint=? AND delivery.acked_at IS NULL AND message.conversation_id=?)`, input.TargetEndpoint, input.ConversationID).Scan(&pending); err != nil {
@@ -92,6 +86,9 @@ func (s *Store) requestInvocationWithSchema(input InvokeInput, requestHash strin
 	}
 	if err != nil {
 		return Invocation{}, false, fmt.Errorf("authorize invocation sender: %w", err)
+	}
+	if err := pruneExpiredTerminalInvocations(tx, input.Now); err != nil {
+		return Invocation{}, false, err
 	}
 	var existingID, existingHash string
 	err = tx.QueryRowContext(context.Background(), `SELECT invocation_id,request_hash FROM invocation_idempotency WHERE machine_id=? AND key=?`, input.SenderMachineID, input.IdempotencyKey).Scan(&existingID, &existingHash)
@@ -191,6 +188,13 @@ func (s *Store) requestInvocationWithSchema(input InvokeInput, requestHash strin
 		return Invocation{}, false, err
 	}
 	return invocation, false, nil
+}
+
+func pruneExpiredTerminalInvocations(tx *sql.Tx, now time.Time) error {
+	if _, err := tx.ExecContext(context.Background(), `DELETE FROM invocations WHERE status IN (?,?,?) AND created_at<?`, InvocationAlreadyRunning, InvocationSucceeded, InvocationFailed, now.Add(-invocationTerminalRetention).UnixMilli()); err != nil {
+		return fmt.Errorf("prune terminal invocations: %w", err)
+	}
+	return nil
 }
 
 func invocationForCaller(invocation Invocation, input InvokeInput) Invocation {
@@ -523,6 +527,7 @@ func (s *Store) ensureInvocationSchema() error {
 			PRIMARY KEY(invocation_id, ordinal)
 		)`,
 		`CREATE INDEX IF NOT EXISTS invocations_machine_pending ON invocations(target_machine_id, status, not_before, lease_until)`,
+		`CREATE INDEX IF NOT EXISTS invocations_terminal_retention ON invocations(status, created_at)`,
 	} {
 		if _, err := s.db.ExecContext(context.Background(), statement); err != nil {
 			return fmt.Errorf("initialize invocation state: %w", err)

--- a/internal/relay/invocation.go
+++ b/internal/relay/invocation.go
@@ -476,6 +476,49 @@ func (s *Store) ReportInvocation(machineID, invocationID, token string, generati
 	return tx.Commit()
 }
 
+// RejectInvocation terminally consumes a leased invocation which the relay can
+// no longer authorize for the enrolled machine. It deliberately does not use
+// ReportInvocation's runtime-failure path, so a narrowed enrollment cannot
+// turn policy denial into retry exhaustion.
+func (s *Store) RejectInvocation(machineID, invocationID, token string, generation int64, now time.Time) error {
+	if !ValidMachineID(machineID) || strings.TrimSpace(invocationID) == "" || !ValidRequestToken(token) || generation < 1 {
+		return ErrForbidden
+	}
+	exists, err := s.invocationSchemaExists()
+	if err != nil {
+		return err
+	}
+	if !exists {
+		return ErrForbidden
+	}
+	if err := s.ensureInvocationSchema(); err != nil {
+		return err
+	}
+	tx, err := s.db.BeginTx(context.Background(), nil)
+	if err != nil {
+		return err
+	}
+	defer rollback(tx)
+	var status InvocationStatus
+	var leaseMachine, leaseToken sql.NullString
+	var leaseGeneration int64
+	var leaseUntil sql.NullInt64
+	err = tx.QueryRowContext(context.Background(), `SELECT status,lease_machine_id,lease_token,lease_generation,lease_until FROM invocations WHERE id=?`, invocationID).Scan(&status, &leaseMachine, &leaseToken, &leaseGeneration, &leaseUntil)
+	if errors.Is(err, sql.ErrNoRows) || status != InvocationPending || !leaseMachine.Valid || leaseMachine.String != machineID || !leaseToken.Valid || leaseToken.String != token || leaseGeneration != generation || !leaseUntil.Valid || leaseUntil.Int64 <= now.UnixMilli() {
+		return ErrForbidden
+	}
+	if err != nil {
+		return fmt.Errorf("read invocation lease: %w", err)
+	}
+	if _, err := tx.ExecContext(context.Background(), `UPDATE invocations SET status=?,terminal_at=?,lease_machine_id=NULL,lease_consumer_id=NULL,lease_token=NULL,lease_until=NULL WHERE id=?`, InvocationFailed, now.UnixMilli(), invocationID); err != nil {
+		return fmt.Errorf("reject invocation: %w", err)
+	}
+	if err := recordInvocationAudit(tx, invocationID, "failed", now); err != nil {
+		return err
+	}
+	return tx.Commit()
+}
+
 func invocationBackoff(attempt int) time.Duration {
 	// Leave a full poll interval for a transient local runtime failure before
 	// a second start attempt. The final terminal failure occurs after three
@@ -495,6 +538,9 @@ func (s *Store) InvocationAudit(invocationID string) ([]InvocationAuditEvent, er
 	}
 	if !exists {
 		return nil, nil
+	}
+	if err := s.ensureInvocationSchema(); err != nil {
+		return nil, err
 	}
 	rows, err := s.db.QueryContext(context.Background(), `SELECT action,created_at FROM invocation_audit WHERE invocation_id=? ORDER BY ordinal`, invocationID)
 	if err != nil {

--- a/internal/relay/invocation.go
+++ b/internal/relay/invocation.go
@@ -136,7 +136,7 @@ func (s *Store) requestInvocationWithSchema(input InvokeInput, requestHash strin
 		// retrying the same key after the endpoint detached could unexpectedly
 		// become a new start request.
 		invocation := Invocation{ID: uuid.NewString(), ConversationID: input.ConversationID, TargetEndpoint: input.TargetEndpoint, TargetMachineID: targetMachine, Fence: uuid.NewString(), Status: InvocationAlreadyRunning}
-		if _, err := tx.ExecContext(context.Background(), `INSERT INTO invocations(id,conversation_id,from_endpoint,target_endpoint,target_machine_id,target_ownership_generation,fence,status,not_before,created_at) VALUES(?,?,?,?,?,?,?,?,?,?)`, invocation.ID, invocation.ConversationID, input.FromEndpoint, invocation.TargetEndpoint, invocation.TargetMachineID, targetOwnershipGeneration, invocation.Fence, invocation.Status, input.Now.UnixMilli(), input.Now.UnixMilli()); err != nil {
+		if _, err := tx.ExecContext(context.Background(), `INSERT INTO invocations(id,conversation_id,from_endpoint,target_endpoint,target_machine_id,target_ownership_generation,fence,status,not_before,created_at,terminal_at) VALUES(?,?,?,?,?,?,?,?,?,?,?)`, invocation.ID, invocation.ConversationID, input.FromEndpoint, invocation.TargetEndpoint, invocation.TargetMachineID, targetOwnershipGeneration, invocation.Fence, invocation.Status, input.Now.UnixMilli(), input.Now.UnixMilli(), input.Now.UnixMilli()); err != nil {
 			return Invocation{}, false, fmt.Errorf("record already-running invocation: %w", err)
 		}
 		if _, err := tx.ExecContext(context.Background(), `INSERT INTO invocation_idempotency(machine_id,key,request_hash,invocation_id) VALUES(?,?,?,?)`, input.SenderMachineID, input.IdempotencyKey, requestHash, invocation.ID); err != nil {
@@ -192,7 +192,7 @@ func (s *Store) requestInvocationWithSchema(input InvokeInput, requestHash strin
 
 func pruneExpiredTerminalInvocations(tx *sql.Tx, now time.Time) error {
 	cutoff := now.Add(-invocationTerminalRetention).UnixMilli()
-	if _, err := tx.ExecContext(context.Background(), `DELETE FROM invocations WHERE created_at<? AND (status IN (?,?) OR (status=? AND not_before<?))`, cutoff, InvocationAlreadyRunning, InvocationFailed, InvocationSucceeded, now.UnixMilli()); err != nil {
+	if _, err := tx.ExecContext(context.Background(), `DELETE FROM invocations WHERE terminal_at IS NOT NULL AND terminal_at<?`, cutoff); err != nil {
 		return fmt.Errorf("prune terminal invocations: %w", err)
 	}
 	return nil
@@ -252,7 +252,7 @@ func (s *Store) LeaseInvocations(machineID, consumerID string, now time.Time, tt
 		return nil, fmt.Errorf("find invocation ownership changes: %w", err)
 	}
 	for _, invocationID := range staleOwnerIDs {
-		if _, err := tx.ExecContext(context.Background(), `UPDATE invocations SET status=?,lease_machine_id=NULL,lease_consumer_id=NULL,lease_token=NULL,lease_until=NULL WHERE id=?`, InvocationFailed, invocationID); err != nil {
+		if _, err := tx.ExecContext(context.Background(), `UPDATE invocations SET status=?,terminal_at=?,lease_machine_id=NULL,lease_consumer_id=NULL,lease_token=NULL,lease_until=NULL WHERE id=?`, InvocationFailed, now.UnixMilli(), invocationID); err != nil {
 			return nil, fmt.Errorf("fail stale invocation owner: %w", err)
 		}
 		if err := recordInvocationAudit(tx, invocationID, "failed", now); err != nil {
@@ -278,7 +278,7 @@ func (s *Store) LeaseInvocations(machineID, consumerID string, now time.Time, tt
 		return nil, fmt.Errorf("find stale invocations: %w", err)
 	}
 	for _, invocationID := range staleIDs {
-		if _, err := tx.ExecContext(context.Background(), `UPDATE invocations SET status=? WHERE id=?`, InvocationFailed, invocationID); err != nil {
+		if _, err := tx.ExecContext(context.Background(), `UPDATE invocations SET status=?,terminal_at=? WHERE id=?`, InvocationFailed, now.UnixMilli(), invocationID); err != nil {
 			return nil, fmt.Errorf("fail stale invocation: %w", err)
 		}
 		if err := recordInvocationAudit(tx, invocationID, "failed", now); err != nil {
@@ -311,7 +311,7 @@ func (s *Store) LeaseInvocations(machineID, consumerID string, now time.Time, tt
 		return nil, fmt.Errorf("find online invocation targets: %w", err)
 	}
 	for _, invocationID := range onlineIDs {
-		if _, err := tx.ExecContext(context.Background(), `UPDATE invocations SET status=?,lease_machine_id=NULL,lease_consumer_id=NULL,lease_token=NULL,lease_until=NULL WHERE id=?`, InvocationAlreadyRunning, invocationID); err != nil {
+		if _, err := tx.ExecContext(context.Background(), `UPDATE invocations SET status=?,terminal_at=?,lease_machine_id=NULL,lease_consumer_id=NULL,lease_token=NULL,lease_until=NULL WHERE id=?`, InvocationAlreadyRunning, now.UnixMilli(), invocationID); err != nil {
 			return nil, fmt.Errorf("record online invocation target: %w", err)
 		}
 		if err := recordInvocationAudit(tx, invocationID, "already_running", now); err != nil {
@@ -340,7 +340,7 @@ func (s *Store) LeaseInvocations(machineID, consumerID string, now time.Time, tt
 			// consume one bounded runtime-start attempt. Releasing a still-live
 			// lease to the same adapter does not.
 			if attempts >= maxInvocationAttempts {
-				if _, err := tx.ExecContext(context.Background(), `UPDATE invocations SET status=?,lease_machine_id=NULL,lease_consumer_id=NULL,lease_token=NULL,lease_until=NULL WHERE id=?`, InvocationFailed, invocation.ID); err != nil {
+				if _, err := tx.ExecContext(context.Background(), `UPDATE invocations SET status=?,terminal_at=?,lease_machine_id=NULL,lease_consumer_id=NULL,lease_token=NULL,lease_until=NULL WHERE id=?`, InvocationFailed, now.UnixMilli(), invocation.ID); err != nil {
 					return nil, fmt.Errorf("fail exhausted invocation: %w", err)
 				}
 				if err := recordInvocationAudit(tx, invocation.ID, "failed", now); err != nil {
@@ -406,7 +406,7 @@ func (s *Store) ReportInvocation(machineID, invocationID, token string, generati
 		return fmt.Errorf("read invocation lease: %w", err)
 	}
 	if accepted {
-		if _, err := tx.ExecContext(context.Background(), `UPDATE invocations SET status=?,not_before=?,lease_machine_id=NULL,lease_consumer_id=NULL,lease_token=NULL,lease_until=NULL WHERE id=?`, InvocationSucceeded, now.Add(maxInvocationBackoff).UnixMilli(), invocationID); err != nil {
+		if _, err := tx.ExecContext(context.Background(), `UPDATE invocations SET status=?,not_before=?,terminal_at=?,lease_machine_id=NULL,lease_consumer_id=NULL,lease_token=NULL,lease_until=NULL WHERE id=?`, InvocationSucceeded, now.Add(maxInvocationBackoff).UnixMilli(), now.UnixMilli(), invocationID); err != nil {
 			return fmt.Errorf("accept invocation: %w", err)
 		}
 		if err := recordInvocationAudit(tx, invocationID, "accepted", now); err != nil {
@@ -422,7 +422,11 @@ func (s *Store) ReportInvocation(machineID, invocationID, token string, generati
 		if status == InvocationPending {
 			notBefore = now.Add(invocationBackoff(attempts))
 		}
-		if _, err := tx.ExecContext(context.Background(), `UPDATE invocations SET status=?,attempts=?,not_before=?,lease_machine_id=NULL,lease_consumer_id=NULL,lease_token=NULL,lease_until=NULL WHERE id=?`, status, attempts, notBefore.UnixMilli(), invocationID); err != nil {
+		var terminalAt any
+		if status != InvocationPending {
+			terminalAt = now.UnixMilli()
+		}
+		if _, err := tx.ExecContext(context.Background(), `UPDATE invocations SET status=?,attempts=?,not_before=?,terminal_at=?,lease_machine_id=NULL,lease_consumer_id=NULL,lease_token=NULL,lease_until=NULL WHERE id=?`, status, attempts, notBefore.UnixMilli(), terminalAt, invocationID); err != nil {
 			return fmt.Errorf("retry invocation: %w", err)
 		}
 		if err := recordInvocationAudit(tx, invocationID, action, now); err != nil {
@@ -511,6 +515,7 @@ func (s *Store) ensureInvocationSchema() error {
 			lease_generation INTEGER NOT NULL DEFAULT 0,
 			target_ownership_generation INTEGER NOT NULL DEFAULT 0,
 			lease_until INTEGER,
+			terminal_at INTEGER,
 			created_at INTEGER NOT NULL
 		)`,
 		`CREATE TABLE IF NOT EXISTS invocation_idempotency (
@@ -528,13 +533,16 @@ func (s *Store) ensureInvocationSchema() error {
 			PRIMARY KEY(invocation_id, ordinal)
 		)`,
 		`CREATE INDEX IF NOT EXISTS invocations_machine_pending ON invocations(target_machine_id, status, not_before, lease_until)`,
-		`CREATE INDEX IF NOT EXISTS invocations_terminal_retention ON invocations(status, created_at)`,
+		`CREATE INDEX IF NOT EXISTS invocations_terminal_at ON invocations(terminal_at)`,
 	} {
 		if _, err := s.db.ExecContext(context.Background(), statement); err != nil {
 			return fmt.Errorf("initialize invocation state: %w", err)
 		}
 	}
 	if err := ensureSQLiteColumn(context.Background(), s.db, "invocations", "target_ownership_generation", "INTEGER NOT NULL DEFAULT 0"); err != nil {
+		return err
+	}
+	if err := ensureSQLiteColumn(context.Background(), s.db, "invocations", "terminal_at", "INTEGER"); err != nil {
 		return err
 	}
 	return nil

--- a/internal/relay/invocation.go
+++ b/internal/relay/invocation.go
@@ -418,15 +418,14 @@ func (s *Store) LeaseInvocations(machineID, consumerID string, now time.Time, tt
 			// consume one bounded runtime-start attempt. Releasing a still-live
 			// lease to the same adapter does not.
 			if attempts >= maxInvocationAttempts {
-				if _, err := tx.ExecContext(context.Background(), `UPDATE invocations SET status=?,terminal_at=?,lease_machine_id=NULL,lease_consumer_id=NULL,lease_token=NULL,lease_until=NULL WHERE id=?`, InvocationFailed, now.UnixMilli(), invocation.ID); err != nil {
-					return nil, fmt.Errorf("fail exhausted invocation: %w", err)
-				}
-				if err := recordInvocationAudit(tx, invocation.ID, "failed", now); err != nil {
-					return nil, err
-				}
-				continue
+				// The final leased attempt may have crossed the runtime start
+				// boundary before its adapter crashed. Reissue its stable fence only
+				// for journal/outcome recovery; the adapter must never start work
+				// from this lease when it lacks a durable accepted record.
+				invocation.RecoveryOnly = true
+			} else {
+				attempts++
 			}
-			attempts++
 		}
 		token, err := randomToken()
 		if err != nil {

--- a/internal/relay/invocation.go
+++ b/internal/relay/invocation.go
@@ -208,7 +208,7 @@ func pruneExpiredTerminalInvocations(tx *sql.Tx, now time.Time) error {
 }
 
 func expireAbandonedInvocations(tx *sql.Tx, targetEndpoint string, now time.Time) error {
-	rows, err := tx.QueryContext(context.Background(), `SELECT id FROM invocations WHERE target_endpoint=? AND status=? AND created_at<?`, targetEndpoint, InvocationPending, now.Add(-invocationPendingRetention).UnixMilli())
+	rows, err := tx.QueryContext(context.Background(), `SELECT id FROM invocations WHERE target_endpoint=? AND status=? AND created_at<? AND (lease_until IS NULL OR lease_until<=?)`, targetEndpoint, InvocationPending, now.Add(-invocationPendingRetention).UnixMilli(), now.UnixMilli())
 	if err != nil {
 		return fmt.Errorf("find abandoned invocations: %w", err)
 	}

--- a/internal/relay/invocation.go
+++ b/internal/relay/invocation.go
@@ -555,3 +555,11 @@ func (s *Store) invocationSchemaExists() (bool, error) {
 	}
 	return exists, nil
 }
+
+func invocationSchemaExistsTx(tx *sql.Tx) (bool, error) {
+	var exists bool
+	if err := tx.QueryRowContext(context.Background(), `SELECT EXISTS(SELECT 1 FROM sqlite_master WHERE type='table' AND name='invocations')`).Scan(&exists); err != nil {
+		return false, fmt.Errorf("inspect invocation state: %w", err)
+	}
+	return exists, nil
+}

--- a/internal/relay/invocation.go
+++ b/internal/relay/invocation.go
@@ -135,6 +135,38 @@ func (s *Store) LeaseInvocations(machineID, consumerID string, now time.Time, tt
 		return nil, err
 	}
 	defer rollback(tx)
+	// A role may have attached after its caller observed it offline. Terminally
+	// consume that old request before leasing anything: attachment is the
+	// authoritative proof that starting another copy is no longer allowed.
+	onlineRows, err := tx.QueryContext(context.Background(), `SELECT invocation.id FROM invocations AS invocation
+		JOIN endpoints AS endpoint ON endpoint.endpoint=invocation.target_endpoint
+		WHERE invocation.target_machine_id=? AND invocation.status=? AND endpoint.lease_until>?`, machineID, InvocationPending, now.UnixMilli())
+	if err != nil {
+		return nil, fmt.Errorf("find online invocation targets: %w", err)
+	}
+	var onlineIDs []string
+	for onlineRows.Next() {
+		var invocationID string
+		if err := onlineRows.Scan(&invocationID); err != nil {
+			_ = onlineRows.Close()
+			return nil, fmt.Errorf("read online invocation target: %w", err)
+		}
+		onlineIDs = append(onlineIDs, invocationID)
+	}
+	if err := onlineRows.Close(); err != nil {
+		return nil, fmt.Errorf("close online invocation targets: %w", err)
+	}
+	if err := onlineRows.Err(); err != nil {
+		return nil, fmt.Errorf("find online invocation targets: %w", err)
+	}
+	for _, invocationID := range onlineIDs {
+		if _, err := tx.ExecContext(context.Background(), `UPDATE invocations SET status=?,lease_machine_id=NULL,lease_consumer_id=NULL,lease_token=NULL,lease_until=NULL WHERE id=?`, InvocationAlreadyRunning, invocationID); err != nil {
+			return nil, fmt.Errorf("record online invocation target: %w", err)
+		}
+		if err := recordInvocationAudit(tx, invocationID, "already_running", now); err != nil {
+			return nil, err
+		}
+	}
 	rows, err := tx.QueryContext(context.Background(), `SELECT id,conversation_id,target_endpoint,target_machine_id,fence,lease_generation FROM invocations
 		WHERE target_machine_id=? AND status=? AND not_before<=? AND (lease_until IS NULL OR lease_until<=? OR (lease_machine_id=? AND lease_consumer_id=?))
 		ORDER BY created_at,id LIMIT ?`, machineID, InvocationPending, now.UnixMilli(), now.UnixMilli(), machineID, consumerID, limit)

--- a/internal/relay/invocation.go
+++ b/internal/relay/invocation.go
@@ -106,7 +106,7 @@ func (s *Store) requestInvocationWithSchema(input InvokeInput, requestHash strin
 		if err := tx.Commit(); err != nil {
 			return Invocation{}, false, err
 		}
-		return invocation, true, nil
+		return invocationForCaller(invocation, input), true, nil
 	}
 	if !errors.Is(err, sql.ErrNoRows) {
 		return Invocation{}, false, fmt.Errorf("read invocation idempotency: %w", err)
@@ -172,7 +172,7 @@ func (s *Store) requestInvocationWithSchema(input InvokeInput, requestHash strin
 		if err := tx.Commit(); err != nil {
 			return Invocation{}, false, err
 		}
-		return invocation, true, nil
+		return invocationForCaller(invocation, input), true, nil
 	}
 	if !errors.Is(err, sql.ErrNoRows) {
 		return Invocation{}, false, fmt.Errorf("find pending invocation: %w", err)
@@ -191,6 +191,16 @@ func (s *Store) requestInvocationWithSchema(input InvokeInput, requestHash strin
 		return Invocation{}, false, err
 	}
 	return invocation, false, nil
+}
+
+func invocationForCaller(invocation Invocation, input InvokeInput) Invocation {
+	if invocation.ConversationID == input.ConversationID {
+		return invocation
+	}
+	// A shared endpoint-level start fence is deliberately opaque to callers in
+	// other conversations. They learn only that their request converged on a
+	// pending start, not the original conversation, machine, ID, or fence.
+	return Invocation{ConversationID: input.ConversationID, TargetEndpoint: input.TargetEndpoint, Status: invocation.Status}
 }
 
 // LeaseInvocations gives an enrolled adapter bounded content-free start work.

--- a/internal/relay/invocation.go
+++ b/internal/relay/invocation.go
@@ -149,6 +149,13 @@ func (s *Store) RequestInvocation(input InvokeInput) (Invocation, bool, error) {
 // LeaseInvocations gives an enrolled adapter bounded content-free start work.
 // The stable fence survives a lost response and every later lease generation.
 func (s *Store) LeaseInvocations(machineID, consumerID string, now time.Time, ttl time.Duration, limit int) ([]Invocation, error) {
+	exists, err := s.invocationSchemaExists()
+	if err != nil {
+		return nil, err
+	}
+	if !exists {
+		return nil, nil
+	}
 	if err := s.ensureInvocationSchema(); err != nil {
 		return nil, err
 	}
@@ -166,7 +173,7 @@ func (s *Store) LeaseInvocations(machineID, consumerID string, now time.Time, tt
 	staleOwnerRows, err := tx.QueryContext(context.Background(), `SELECT invocation.id FROM invocations AS invocation
 		LEFT JOIN endpoints AS endpoint ON endpoint.endpoint=invocation.target_endpoint
 		WHERE invocation.target_machine_id=? AND invocation.status=? AND (invocation.lease_machine_id IS NULL OR invocation.lease_until<=?)
-		AND (endpoint.endpoint IS NULL OR endpoint.machine_id<>invocation.target_machine_id OR endpoint.ownership_generation<>invocation.target_ownership_generation)`, machineID, InvocationPending, now.UnixMilli())
+		AND (endpoint.endpoint IS NULL OR endpoint.machine_id<>invocation.target_machine_id OR (endpoint.ownership_generation<>invocation.target_ownership_generation AND endpoint.lease_until<=?))`, machineID, InvocationPending, now.UnixMilli(), now.UnixMilli())
 	if err != nil {
 		return nil, fmt.Errorf("find invocation ownership changes: %w", err)
 	}
@@ -222,7 +229,7 @@ func (s *Store) LeaseInvocations(machineID, consumerID string, now time.Time, tt
 	onlineRows, err := tx.QueryContext(context.Background(), `SELECT invocation.id FROM invocations AS invocation
 		JOIN endpoints AS endpoint ON endpoint.endpoint=invocation.target_endpoint
 		WHERE invocation.target_machine_id=? AND invocation.status=? AND (invocation.lease_machine_id IS NULL OR invocation.lease_until<=?)
-		AND endpoint.machine_id=invocation.target_machine_id AND endpoint.ownership_generation=invocation.target_ownership_generation AND endpoint.lease_until>?`, machineID, InvocationPending, now.UnixMilli(), now.UnixMilli())
+		AND endpoint.machine_id=invocation.target_machine_id AND endpoint.lease_until>?`, machineID, InvocationPending, now.UnixMilli(), now.UnixMilli())
 	if err != nil {
 		return nil, fmt.Errorf("find online invocation targets: %w", err)
 	}
@@ -464,4 +471,12 @@ func (s *Store) ensureInvocationSchema() error {
 		return err
 	}
 	return nil
+}
+
+func (s *Store) invocationSchemaExists() (bool, error) {
+	var exists bool
+	if err := s.db.QueryRowContext(context.Background(), `SELECT EXISTS(SELECT 1 FROM sqlite_master WHERE type='table' AND name='invocations')`).Scan(&exists); err != nil {
+		return false, fmt.Errorf("inspect invocation state: %w", err)
+	}
+	return exists, nil
 }

--- a/internal/relay/invocation.go
+++ b/internal/relay/invocation.go
@@ -489,8 +489,12 @@ func invocationBackoff(attempt int) time.Duration {
 
 // InvocationAudit returns body-free audit history for operational inspection.
 func (s *Store) InvocationAudit(invocationID string) ([]InvocationAuditEvent, error) {
-	if err := s.ensureInvocationSchema(); err != nil {
+	exists, err := s.invocationSchemaExists()
+	if err != nil {
 		return nil, err
+	}
+	if !exists {
+		return nil, nil
 	}
 	rows, err := s.db.QueryContext(context.Background(), `SELECT action,created_at FROM invocation_audit WHERE invocation_id=? ORDER BY ordinal`, invocationID)
 	if err != nil {

--- a/internal/relay/invocation.go
+++ b/internal/relay/invocation.go
@@ -261,6 +261,9 @@ func (s *Store) LeaseInvocations(machineID, consumerID string, now time.Time, tt
 	if err := s.ensureInvocationSchema(); err != nil {
 		return nil, err
 	}
+	if err := s.ensureInvocationSchema(); err != nil {
+		return nil, err
+	}
 	if !ValidMachineID(machineID) || !ValidRequestToken(consumerID) || ttl <= 0 || limit < 1 || limit > 100 {
 		return nil, fmt.Errorf("invalid invocation lease request")
 	}

--- a/internal/relay/invocation.go
+++ b/internal/relay/invocation.go
@@ -105,6 +105,30 @@ func (s *Store) RequestInvocation(input InvokeInput) (Invocation, bool, error) {
 		}
 		return invocation, false, nil
 	}
+	// Different authorized callers can legitimately race to wake the same
+	// offline role. They must converge on one durable fence, rather than start
+	// separate runtime processes merely because their idempotency domains differ.
+	var pendingID string
+	err = tx.QueryRowContext(context.Background(), `SELECT id FROM invocations WHERE target_endpoint=? AND status=? ORDER BY created_at,id LIMIT 1`, input.TargetEndpoint, InvocationPending).Scan(&pendingID)
+	if err == nil {
+		invocation, err := invocationByID(tx, pendingID)
+		if err != nil {
+			return Invocation{}, false, err
+		}
+		if _, err := tx.ExecContext(context.Background(), `INSERT INTO invocation_idempotency(machine_id,key,request_hash,invocation_id) VALUES(?,?,?,?)`, input.SenderMachineID, input.IdempotencyKey, requestHash, invocation.ID); err != nil {
+			return Invocation{}, false, fmt.Errorf("record coalesced invocation idempotency: %w", err)
+		}
+		if err := recordInvocationAudit(tx, invocation.ID, "coalesced", input.Now); err != nil {
+			return Invocation{}, false, err
+		}
+		if err := tx.Commit(); err != nil {
+			return Invocation{}, false, err
+		}
+		return invocation, true, nil
+	}
+	if !errors.Is(err, sql.ErrNoRows) {
+		return Invocation{}, false, fmt.Errorf("find pending invocation: %w", err)
+	}
 	invocation := Invocation{ID: uuid.NewString(), ConversationID: input.ConversationID, TargetEndpoint: input.TargetEndpoint, TargetMachineID: targetMachine, Fence: uuid.NewString(), Status: InvocationPending}
 	if _, err := tx.ExecContext(context.Background(), `INSERT INTO invocations(id,conversation_id,from_endpoint,target_endpoint,target_machine_id,fence,status,not_before,created_at) VALUES(?,?,?,?,?,?,?,?,?)`, invocation.ID, invocation.ConversationID, input.FromEndpoint, invocation.TargetEndpoint, invocation.TargetMachineID, invocation.Fence, invocation.Status, input.Now.UnixMilli(), input.Now.UnixMilli()); err != nil {
 		return Invocation{}, false, fmt.Errorf("queue invocation: %w", err)
@@ -167,7 +191,7 @@ func (s *Store) LeaseInvocations(machineID, consumerID string, now time.Time, tt
 			return nil, err
 		}
 	}
-	rows, err := tx.QueryContext(context.Background(), `SELECT id,conversation_id,target_endpoint,target_machine_id,fence,lease_generation FROM invocations
+	rows, err := tx.QueryContext(context.Background(), `SELECT id,conversation_id,target_endpoint,target_machine_id,fence,lease_generation,attempts,lease_until FROM invocations
 		WHERE target_machine_id=? AND status=? AND not_before<=? AND (lease_until IS NULL OR lease_until<=? OR (lease_machine_id=? AND lease_consumer_id=?))
 		ORDER BY created_at,id LIMIT ?`, machineID, InvocationPending, now.UnixMilli(), now.UnixMilli(), machineID, consumerID, limit)
 	if err != nil {
@@ -177,8 +201,25 @@ func (s *Store) LeaseInvocations(machineID, consumerID string, now time.Time, tt
 	var invocations []Invocation
 	for rows.Next() {
 		var invocation Invocation
-		if err := rows.Scan(&invocation.ID, &invocation.ConversationID, &invocation.TargetEndpoint, &invocation.TargetMachineID, &invocation.Fence, &invocation.LeaseGeneration); err != nil {
+		var attempts int
+		var priorLeaseUntil sql.NullInt64
+		if err := rows.Scan(&invocation.ID, &invocation.ConversationID, &invocation.TargetEndpoint, &invocation.TargetMachineID, &invocation.Fence, &invocation.LeaseGeneration, &attempts, &priorLeaseUntil); err != nil {
 			return nil, fmt.Errorf("read invocation: %w", err)
+		}
+		if !priorLeaseUntil.Valid || priorLeaseUntil.Int64 <= now.UnixMilli() {
+			// A fresh lease, and a lease recovered after an adapter crash, each
+			// consume one bounded runtime-start attempt. Releasing a still-live
+			// lease to the same adapter does not.
+			if attempts >= maxInvocationAttempts {
+				if _, err := tx.ExecContext(context.Background(), `UPDATE invocations SET status=?,lease_machine_id=NULL,lease_consumer_id=NULL,lease_token=NULL,lease_until=NULL WHERE id=?`, InvocationFailed, invocation.ID); err != nil {
+					return nil, fmt.Errorf("fail exhausted invocation: %w", err)
+				}
+				if err := recordInvocationAudit(tx, invocation.ID, "failed", now); err != nil {
+					return nil, err
+				}
+				continue
+			}
+			attempts++
 		}
 		token, err := randomToken()
 		if err != nil {
@@ -188,7 +229,7 @@ func (s *Store) LeaseInvocations(machineID, consumerID string, now time.Time, tt
 		invocation.LeaseGeneration++
 		invocation.LeaseToken = token
 		invocation.LeaseUntil = now.Add(ttl).UTC()
-		if _, err := tx.ExecContext(context.Background(), `UPDATE invocations SET lease_machine_id=?,lease_consumer_id=?,lease_token=?,lease_generation=?,lease_until=? WHERE id=?`, machineID, consumerID, token, invocation.LeaseGeneration, invocation.LeaseUntil.UnixMilli(), invocation.ID); err != nil {
+		if _, err := tx.ExecContext(context.Background(), `UPDATE invocations SET attempts=?,lease_machine_id=?,lease_consumer_id=?,lease_token=?,lease_generation=?,lease_until=? WHERE id=?`, attempts, machineID, consumerID, token, invocation.LeaseGeneration, invocation.LeaseUntil.UnixMilli(), invocation.ID); err != nil {
 			return nil, fmt.Errorf("lease invocation: %w", err)
 		}
 		if err := recordInvocationAudit(tx, invocation.ID, "leased", now); err != nil {
@@ -239,7 +280,6 @@ func (s *Store) ReportInvocation(machineID, invocationID, token string, generati
 			return err
 		}
 	} else {
-		attempts++
 		status := InvocationPending
 		action := "retry"
 		if attempts >= maxInvocationAttempts {
@@ -349,7 +389,7 @@ func (s *Store) ensureInvocationSchema() error {
 		`CREATE TABLE IF NOT EXISTS invocation_audit (
 			invocation_id TEXT NOT NULL REFERENCES invocations(id) ON DELETE CASCADE,
 			ordinal INTEGER NOT NULL,
-			action TEXT NOT NULL CHECK(action IN ('requested', 'already_running', 'leased', 'retry', 'accepted', 'failed')),
+			action TEXT NOT NULL CHECK(action IN ('requested', 'coalesced', 'already_running', 'leased', 'retry', 'accepted', 'failed')),
 			created_at INTEGER NOT NULL,
 			PRIMARY KEY(invocation_id, ordinal)
 		)`,

--- a/internal/relay/invocation.go
+++ b/internal/relay/invocation.go
@@ -363,10 +363,14 @@ func (s *Store) LeaseInvocations(machineID, consumerID string, now time.Time, tt
 // ReportInvocation accepts a durable local handoff or returns it to the queue
 // with bounded retry. A stale or foreign lease cannot change the result.
 func (s *Store) ReportInvocation(machineID, invocationID, token string, generation int64, accepted bool, now time.Time) error {
-	if err := s.ensureInvocationSchema(); err != nil {
+	if !ValidMachineID(machineID) || strings.TrimSpace(invocationID) == "" || !ValidRequestToken(token) || generation < 1 {
+		return ErrForbidden
+	}
+	exists, err := s.invocationSchemaExists()
+	if err != nil {
 		return err
 	}
-	if !ValidMachineID(machineID) || strings.TrimSpace(invocationID) == "" || !ValidRequestToken(token) || generation < 1 {
+	if !exists {
 		return ErrForbidden
 	}
 	tx, err := s.db.BeginTx(context.Background(), nil)

--- a/internal/relay/invocation_test.go
+++ b/internal/relay/invocation_test.go
@@ -167,7 +167,11 @@ func TestInvokeCrashLeasesAreBounded(t *testing.T) {
 	if err != nil || len(recovery) != 1 || recovery[0].Fence != invocation.Fence || !recovery[0].RecoveryOnly {
 		t.Fatalf("recovery=%#v err=%v", recovery, err)
 	}
-	if err := store.ReportInvocation("recipient-machine", recovery[0].ID, recovery[0].LeaseToken, recovery[0].LeaseGeneration, false, now.Add(8*time.Second)); err != nil {
+	replay, err := store.LeaseInvocations("recipient-machine", "adapter", now.Add(8500*time.Millisecond), time.Second, 10)
+	if err != nil || len(replay) != 1 || !replay[0].RecoveryOnly {
+		t.Fatalf("replay=%#v err=%v", replay, err)
+	}
+	if err := store.ReportInvocation("recipient-machine", replay[0].ID, replay[0].LeaseToken, replay[0].LeaseGeneration, false, now.Add(8500*time.Millisecond)); err != nil {
 		t.Fatal(err)
 	}
 	if leased, err := store.LeaseInvocations("recipient-machine", "adapter", now.Add(9*time.Second), time.Second, 10); err != nil || len(leased) != 0 {

--- a/internal/relay/invocation_test.go
+++ b/internal/relay/invocation_test.go
@@ -321,7 +321,7 @@ func TestInvokeCoalescesPendingWorkAcrossConversationsForOneTarget(t *testing.T)
 	}
 	invocationA := request(conversationA, "invoke-a", false)
 	invocationB := request(conversationB, "invoke-b", true)
-	if invocationA.ID != invocationB.ID || invocationA.Fence != invocationB.Fence {
-		t.Fatalf("cross-conversation invocation was not coalesced: A=%#v B=%#v", invocationA, invocationB)
+	if invocationA.ID == "" || invocationA.Fence == "" || invocationB.ID != "" || invocationB.Fence != "" || invocationB.ConversationID != conversationB.ID || invocationB.TargetEndpoint != "agent/recipient" || invocationB.Status != InvocationPending {
+		t.Fatalf("cross-conversation invocation response leaked or did not coalesce: A=%#v B=%#v", invocationA, invocationB)
 	}
 }

--- a/internal/relay/invocation_test.go
+++ b/internal/relay/invocation_test.go
@@ -1,6 +1,7 @@
 package relay
 
 import (
+	"context"
 	"errors"
 	"path/filepath"
 	"testing"
@@ -174,7 +175,7 @@ func TestInvokeRejectsUnauthorizedAndDoesNotQueueAlreadyRunningTarget(t *testing
 	}
 }
 
-func TestInvokeDoesNotStartTargetThatAttachedAfterRequest(t *testing.T) {
+func TestInvokeFailsWhenTargetAttachmentChangesAfterRequest(t *testing.T) {
 	t.Parallel()
 	store, err := Open(filepath.Join(t.TempDir(), "relay.db"))
 	if err != nil {
@@ -209,7 +210,93 @@ func TestInvokeDoesNotStartTargetThatAttachedAfterRequest(t *testing.T) {
 		t.Fatalf("leased=%#v err=%v", leased, err)
 	}
 	audit, err := store.InvocationAudit(invocation.ID)
-	if err != nil || len(audit) != 2 || audit[1].Action != "already_running" {
+	if err != nil || len(audit) != 2 || audit[1].Action != "failed" {
 		t.Fatalf("audit=%#v err=%v", audit, err)
+	}
+}
+
+func TestInvokeDoesNotLeaseAcrossTargetOwnershipChange(t *testing.T) {
+	t.Parallel()
+	store, err := Open(filepath.Join(t.TempDir(), "relay.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	now := time.Date(2026, time.August, 3, 12, 0, 0, 0, time.UTC)
+	if err := store.AdvertiseEndpoints("sender-machine", []string{"agent/sender"}, now, time.Hour); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.AdvertiseEndpoints("owner-a", []string{"agent/recipient"}, now, time.Hour); err != nil {
+		t.Fatal(err)
+	}
+	conversation, err := store.CreateConversationIdempotent(CreateConversationInput{MachineID: "sender-machine", IdempotencyKey: "create", CreatorEndpoint: "agent/sender", Now: now, Members: []Member{{Endpoint: "agent/sender", Capabilities: CapSend | CapReceive | CapAdmin | CapInvoke}, {Endpoint: "agent/recipient", Capabilities: CapReceive}}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := store.AppendMessage(AppendInput{ConversationID: conversation.ID, SenderMachineID: "sender-machine", FromEndpoint: "agent/sender", Body: "opaque work", IdempotencyKey: "message", Now: now}); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.AdvertiseEndpoints("owner-a", nil, now.Add(time.Second), time.Hour); err != nil {
+		t.Fatal(err)
+	}
+	invocation, _, err := store.RequestInvocation(InvokeInput{ConversationID: conversation.ID, SenderMachineID: "sender-machine", FromEndpoint: "agent/sender", TargetEndpoint: "agent/recipient", IdempotencyKey: "invoke", Now: now.Add(2 * time.Second)})
+	if err != nil || invocation.Status != InvocationPending {
+		t.Fatalf("invocation=%#v err=%v", invocation, err)
+	}
+	if err := store.AdvertiseEndpoints("owner-b", []string{"agent/recipient"}, now.Add(3*time.Second), time.Hour); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.AdvertiseEndpoints("owner-b", nil, now.Add(4*time.Second), time.Hour); err != nil {
+		t.Fatal(err)
+	}
+	if leased, err := store.LeaseInvocations("owner-a", "adapter-a", now.Add(5*time.Second), time.Minute, 1); err != nil || len(leased) != 0 {
+		t.Fatalf("leased=%#v err=%v", leased, err)
+	}
+	var status InvocationStatus
+	if err := store.db.QueryRowContext(context.Background(), `SELECT status FROM invocations WHERE id=?`, invocation.ID).Scan(&status); err != nil || status != InvocationFailed {
+		t.Fatalf("status=%q err=%v", status, err)
+	}
+}
+
+func TestInvokeCoalescesOnlyWithinPendingWorkConversation(t *testing.T) {
+	t.Parallel()
+	store, err := Open(filepath.Join(t.TempDir(), "relay.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	now := time.Date(2026, time.August, 3, 12, 0, 0, 0, time.UTC)
+	if err := store.AdvertiseEndpoints("sender-machine", []string{"agent/sender"}, now, time.Hour); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.AdvertiseEndpoints("recipient-machine", []string{"agent/recipient"}, now, time.Hour); err != nil {
+		t.Fatal(err)
+	}
+	create := func(key string) Conversation {
+		conversation, err := store.CreateConversationIdempotent(CreateConversationInput{MachineID: "sender-machine", IdempotencyKey: key, CreatorEndpoint: "agent/sender", Now: now, Members: []Member{{Endpoint: "agent/sender", Capabilities: CapSend | CapReceive | CapAdmin | CapInvoke}, {Endpoint: "agent/recipient", Capabilities: CapReceive}}})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, _, err := store.AppendMessage(AppendInput{ConversationID: conversation.ID, SenderMachineID: "sender-machine", FromEndpoint: "agent/sender", Body: "opaque work", IdempotencyKey: "message-" + key, Now: now}); err != nil {
+			t.Fatal(err)
+		}
+		return conversation
+	}
+	conversationA := create("create-a")
+	conversationB := create("create-b")
+	if err := store.AdvertiseEndpoints("recipient-machine", nil, now.Add(time.Second), time.Hour); err != nil {
+		t.Fatal(err)
+	}
+	request := func(conversation Conversation, key string) Invocation {
+		invocation, duplicate, err := store.RequestInvocation(InvokeInput{ConversationID: conversation.ID, SenderMachineID: "sender-machine", FromEndpoint: "agent/sender", TargetEndpoint: "agent/recipient", IdempotencyKey: key, Now: now.Add(2 * time.Second)})
+		if err != nil || duplicate {
+			t.Fatalf("invocation=%#v duplicate=%t err=%v", invocation, duplicate, err)
+		}
+		return invocation
+	}
+	invocationA := request(conversationA, "invoke-a")
+	invocationB := request(conversationB, "invoke-b")
+	if invocationA.ID == invocationB.ID || invocationA.Fence == invocationB.Fence {
+		t.Fatalf("cross-conversation invocation was coalesced: A=%#v B=%#v", invocationA, invocationB)
 	}
 }

--- a/internal/relay/invocation_test.go
+++ b/internal/relay/invocation_test.go
@@ -280,7 +280,7 @@ func TestInvokeDoesNotLeaseAcrossTargetOwnershipChange(t *testing.T) {
 	}
 }
 
-func TestInvokeCoalescesOnlyWithinPendingWorkConversation(t *testing.T) {
+func TestInvokeCoalescesPendingWorkAcrossConversationsForOneTarget(t *testing.T) {
 	t.Parallel()
 	store, err := Open(filepath.Join(t.TempDir(), "relay.db"))
 	if err != nil {
@@ -309,16 +309,16 @@ func TestInvokeCoalescesOnlyWithinPendingWorkConversation(t *testing.T) {
 	if err := store.AdvertiseEndpoints("recipient-machine", nil, now.Add(time.Second), time.Hour); err != nil {
 		t.Fatal(err)
 	}
-	request := func(conversation Conversation, key string) Invocation {
+	request := func(conversation Conversation, key string, wantDuplicate bool) Invocation {
 		invocation, duplicate, err := store.RequestInvocation(InvokeInput{ConversationID: conversation.ID, SenderMachineID: "sender-machine", FromEndpoint: "agent/sender", TargetEndpoint: "agent/recipient", IdempotencyKey: key, Now: now.Add(2 * time.Second)})
-		if err != nil || duplicate {
+		if err != nil || duplicate != wantDuplicate {
 			t.Fatalf("invocation=%#v duplicate=%t err=%v", invocation, duplicate, err)
 		}
 		return invocation
 	}
-	invocationA := request(conversationA, "invoke-a")
-	invocationB := request(conversationB, "invoke-b")
-	if invocationA.ID == invocationB.ID || invocationA.Fence == invocationB.Fence {
-		t.Fatalf("cross-conversation invocation was coalesced: A=%#v B=%#v", invocationA, invocationB)
+	invocationA := request(conversationA, "invoke-a", false)
+	invocationB := request(conversationB, "invoke-b", true)
+	if invocationA.ID != invocationB.ID || invocationA.Fence != invocationB.Fence {
+		t.Fatalf("cross-conversation invocation was not coalesced: A=%#v B=%#v", invocationA, invocationB)
 	}
 }

--- a/internal/relay/invocation_test.go
+++ b/internal/relay/invocation_test.go
@@ -84,6 +84,14 @@ func TestInvokeQueuesOnlyOfflineAuthorizedRecipientAndFencesRetries(t *testing.T
 	if coalesced, duplicate, err := store.RequestInvocation(afterAccept); err != nil || !duplicate || coalesced.ID != invocation.ID || coalesced.Fence != invocation.Fence || coalesced.Status != InvocationSucceeded {
 		t.Fatalf("accepted coalescing invocation=%#v duplicate=%t err=%v", coalesced, duplicate, err)
 	}
+	// A successful local start is still fenced until the role can reattach, so
+	// another machine cannot overtake it in the handoff gap.
+	if err := store.AdvertiseEndpoints("replacement-machine", []string{"agent/recipient"}, retryAt.Add(time.Second), time.Hour); !errors.Is(err, ErrConflict) {
+		t.Fatalf("replacement attached during accepted handoff: %v", err)
+	}
+	if err := store.AdvertiseEndpoints("replacement-machine", []string{"agent/recipient"}, retryAt.Add(maxInvocationBackoff+time.Second), time.Hour); err != nil {
+		t.Fatalf("replacement did not attach after bounded handoff: %v", err)
+	}
 	if final, err := store.LeaseInvocations("recipient-machine", "adapter-a", retryAt.Add(time.Hour), time.Second, 10); err != nil || len(final) != 0 {
 		t.Fatalf("final=%#v err=%v", final, err)
 	}

--- a/internal/relay/invocation_test.go
+++ b/internal/relay/invocation_test.go
@@ -124,3 +124,43 @@ func TestInvokeRejectsUnauthorizedAndDoesNotQueueAlreadyRunningTarget(t *testing
 		t.Fatalf("already-running target leased=%#v err=%v", leased, err)
 	}
 }
+
+func TestInvokeDoesNotStartTargetThatAttachedAfterRequest(t *testing.T) {
+	t.Parallel()
+	store, err := Open(filepath.Join(t.TempDir(), "relay.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	now := time.Date(2026, time.August, 3, 12, 0, 0, 0, time.UTC)
+	if err := store.AdvertiseEndpoints("sender-machine", []string{"agent/sender"}, now, time.Hour); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.AdvertiseEndpoints("recipient-machine", []string{"agent/recipient"}, now, time.Hour); err != nil {
+		t.Fatal(err)
+	}
+	conversation, err := store.CreateConversationIdempotent(CreateConversationInput{MachineID: "sender-machine", IdempotencyKey: "create", CreatorEndpoint: "agent/sender", Now: now, Members: []Member{{Endpoint: "agent/sender", Capabilities: CapSend | CapReceive | CapAdmin | CapInvoke}, {Endpoint: "agent/recipient", Capabilities: CapReceive}}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := store.AppendMessage(AppendInput{ConversationID: conversation.ID, SenderMachineID: "sender-machine", FromEndpoint: "agent/sender", Body: "opaque work", IdempotencyKey: "message", Now: now}); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.AdvertiseEndpoints("recipient-machine", nil, now.Add(time.Second), time.Hour); err != nil {
+		t.Fatal(err)
+	}
+	invocation, _, err := store.RequestInvocation(InvokeInput{ConversationID: conversation.ID, SenderMachineID: "sender-machine", FromEndpoint: "agent/sender", TargetEndpoint: "agent/recipient", IdempotencyKey: "invoke", Now: now.Add(2 * time.Second)})
+	if err != nil || invocation.Status != InvocationPending {
+		t.Fatalf("invocation=%#v err=%v", invocation, err)
+	}
+	if err := store.AdvertiseEndpoints("recipient-machine", []string{"agent/recipient"}, now.Add(3*time.Second), time.Hour); err != nil {
+		t.Fatal(err)
+	}
+	if leased, err := store.LeaseInvocations("recipient-machine", "adapter", now.Add(3*time.Second), time.Minute, 10); err != nil || len(leased) != 0 {
+		t.Fatalf("leased=%#v err=%v", leased, err)
+	}
+	audit, err := store.InvocationAudit(invocation.ID)
+	if err != nil || len(audit) != 2 || audit[1].Action != "already_running" {
+		t.Fatalf("audit=%#v err=%v", audit, err)
+	}
+}

--- a/internal/relay/invocation_test.go
+++ b/internal/relay/invocation_test.go
@@ -43,6 +43,12 @@ func TestInvokeQueuesOnlyOfflineAuthorizedRecipientAndFencesRetries(t *testing.T
 	if err != nil || duplicate || invocation.Status != InvocationPending || invocation.TargetMachineID != "recipient-machine" || invocation.Fence == "" {
 		t.Fatalf("invocation=%#v duplicate=%t err=%v", invocation, duplicate, err)
 	}
+	coalescedRequest := request
+	coalescedRequest.IdempotencyKey = "invoke-another-caller"
+	coalesced, duplicate, err := store.RequestInvocation(coalescedRequest)
+	if err != nil || !duplicate || coalesced != invocation {
+		t.Fatalf("coalesced=%#v duplicate=%t err=%v", coalesced, duplicate, err)
+	}
 	repeated, duplicate, err := store.RequestInvocation(request)
 	if err != nil || !duplicate || repeated != invocation {
 		t.Fatalf("repeated=%#v duplicate=%t err=%v", repeated, duplicate, err)
@@ -75,7 +81,50 @@ func TestInvokeQueuesOnlyOfflineAuthorizedRecipientAndFencesRetries(t *testing.T
 		t.Fatalf("final=%#v err=%v", final, err)
 	}
 	audit, err := store.InvocationAudit(invocation.ID)
-	if err != nil || len(audit) != 5 || audit[0].Action != "requested" || audit[1].Action != "leased" || audit[2].Action != "retry" || audit[3].Action != "leased" || audit[4].Action != "accepted" {
+	if err != nil || len(audit) != 6 || audit[0].Action != "requested" || audit[1].Action != "coalesced" || audit[2].Action != "leased" || audit[3].Action != "retry" || audit[4].Action != "leased" || audit[5].Action != "accepted" {
+		t.Fatalf("audit=%#v err=%v", audit, err)
+	}
+}
+
+func TestInvokeCrashLeasesAreBounded(t *testing.T) {
+	t.Parallel()
+	store, err := Open(filepath.Join(t.TempDir(), "relay.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	now := time.Date(2026, time.August, 3, 12, 0, 0, 0, time.UTC)
+	if err := store.AdvertiseEndpoints("sender-machine", []string{"agent/sender"}, now, time.Hour); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.AdvertiseEndpoints("recipient-machine", []string{"agent/recipient"}, now, time.Hour); err != nil {
+		t.Fatal(err)
+	}
+	conversation, err := store.CreateConversationIdempotent(CreateConversationInput{MachineID: "sender-machine", IdempotencyKey: "create", CreatorEndpoint: "agent/sender", Now: now, Members: []Member{{Endpoint: "agent/sender", Capabilities: CapSend | CapReceive | CapAdmin | CapInvoke}, {Endpoint: "agent/recipient", Capabilities: CapReceive}}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := store.AppendMessage(AppendInput{ConversationID: conversation.ID, SenderMachineID: "sender-machine", FromEndpoint: "agent/sender", Body: "opaque work", IdempotencyKey: "message", Now: now}); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.AdvertiseEndpoints("recipient-machine", nil, now.Add(time.Second), time.Hour); err != nil {
+		t.Fatal(err)
+	}
+	invocation, _, err := store.RequestInvocation(InvokeInput{ConversationID: conversation.ID, SenderMachineID: "sender-machine", FromEndpoint: "agent/sender", TargetEndpoint: "agent/recipient", IdempotencyKey: "invoke", Now: now.Add(2 * time.Second)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for attempt := 0; attempt < maxInvocationAttempts; attempt++ {
+		leased, err := store.LeaseInvocations("recipient-machine", "adapter", now.Add(time.Duration(2+attempt*2)*time.Second), time.Second, 10)
+		if err != nil || len(leased) != 1 || leased[0].Fence != invocation.Fence {
+			t.Fatalf("attempt=%d leased=%#v err=%v", attempt, leased, err)
+		}
+	}
+	if leased, err := store.LeaseInvocations("recipient-machine", "adapter", now.Add(8*time.Second), time.Second, 10); err != nil || len(leased) != 0 {
+		t.Fatalf("exhausted leased=%#v err=%v", leased, err)
+	}
+	audit, err := store.InvocationAudit(invocation.ID)
+	if err != nil || len(audit) != 5 || audit[4].Action != "failed" {
 		t.Fatalf("audit=%#v err=%v", audit, err)
 	}
 }

--- a/internal/relay/invocation_test.go
+++ b/internal/relay/invocation_test.go
@@ -103,6 +103,9 @@ func TestEmptyInvocationLeaseDoesNotMaterializeControlState(t *testing.T) {
 	if leased, err := store.LeaseInvocations("machine-a", "adapter-a", time.Now().UTC(), time.Minute, 1); err != nil || len(leased) != 0 {
 		t.Fatalf("leased=%#v err=%v", leased, err)
 	}
+	if err := store.ReportInvocation("machine-a", "fabricated", "token", 1, true, time.Now().UTC()); !errors.Is(err, ErrForbidden) {
+		t.Fatalf("fabricated outcome err=%v", err)
+	}
 	var exists bool
 	if err := store.db.QueryRowContext(context.Background(), `SELECT EXISTS(SELECT 1 FROM sqlite_master WHERE type='table' AND name='invocations')`).Scan(&exists); err != nil || exists {
 		t.Fatalf("invocation state exists=%t err=%v", exists, err)

--- a/internal/relay/invocation_test.go
+++ b/internal/relay/invocation_test.go
@@ -64,6 +64,12 @@ func TestInvokeQueuesOnlyOfflineAuthorizedRecipientAndFencesRetries(t *testing.T
 	if err != nil || len(first) != 1 || first[0].Fence != invocation.Fence || first[0].LeaseGeneration != 1 {
 		t.Fatalf("first=%#v err=%v", first, err)
 	}
+	// A runtime may have durably accepted this start before its adapter crashes
+	// and the lease expires. Keep its endpoint reserved through the recovery
+	// window so another machine cannot mint a second process-start fence.
+	if err := store.AdvertiseEndpoints("replacement-machine", []string{"agent/recipient"}, now.Add(3*time.Second), time.Hour); !errors.Is(err, ErrConflict) {
+		t.Fatalf("replacement claimed expired pending handoff: %v", err)
+	}
 	if err := store.ReportInvocation("recipient-machine", first[0].ID, first[0].LeaseToken, first[0].LeaseGeneration, false, now.Add(2*time.Second)); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/relay/invocation_test.go
+++ b/internal/relay/invocation_test.go
@@ -299,6 +299,86 @@ func TestInvokeRetentionPreservesAnAcceptedAttachmentFence(t *testing.T) {
 	}
 }
 
+func TestInvokeExpiresAbandonedPendingHandoffBeforeCreatingFreshFence(t *testing.T) {
+	t.Parallel()
+	store, err := Open(filepath.Join(t.TempDir(), "relay.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	now := time.Date(2026, time.August, 3, 12, 0, 0, 0, time.UTC)
+	if err := store.AdvertiseEndpoints("sender-machine", []string{"agent/sender"}, now, 2*invocationPendingRetention); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.AdvertiseEndpoints("recipient-machine", []string{"agent/recipient"}, now, time.Hour); err != nil {
+		t.Fatal(err)
+	}
+	conversation, err := store.CreateConversationIdempotent(CreateConversationInput{MachineID: "sender-machine", IdempotencyKey: "create", CreatorEndpoint: "agent/sender", Now: now, Members: []Member{{Endpoint: "agent/sender", Capabilities: CapSend | CapReceive | CapAdmin | CapInvoke}, {Endpoint: "agent/recipient", Capabilities: CapReceive}}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := store.AppendMessage(AppendInput{ConversationID: conversation.ID, SenderMachineID: "sender-machine", FromEndpoint: "agent/sender", Body: "opaque work", IdempotencyKey: "message", Now: now}); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.AdvertiseEndpoints("recipient-machine", nil, now.Add(time.Second), time.Hour); err != nil {
+		t.Fatal(err)
+	}
+	request := InvokeInput{ConversationID: conversation.ID, SenderMachineID: "sender-machine", FromEndpoint: "agent/sender", TargetEndpoint: "agent/recipient", IdempotencyKey: "invoke", Now: now.Add(2 * time.Second)}
+	abandoned, duplicate, err := store.RequestInvocation(request)
+	if err != nil || duplicate || abandoned.Status != InvocationPending {
+		t.Fatalf("abandoned=%#v duplicate=%t err=%v", abandoned, duplicate, err)
+	}
+	request.IdempotencyKey = "invoke-fresh"
+	request.Now = now.Add(invocationPendingRetention + 3*time.Second)
+	fresh, duplicate, err := store.RequestInvocation(request)
+	if err != nil || duplicate || fresh.ID == abandoned.ID || fresh.Status != InvocationPending {
+		t.Fatalf("fresh=%#v duplicate=%t err=%v", fresh, duplicate, err)
+	}
+	audit, err := store.InvocationAudit(abandoned.ID)
+	if err != nil || len(audit) != 2 || audit[1].Action != "failed" {
+		t.Fatalf("audit=%#v err=%v", audit, err)
+	}
+}
+
+func TestInvokeRepairsPartialOptionalSchema(t *testing.T) {
+	t.Parallel()
+	store, err := Open(filepath.Join(t.TempDir(), "relay.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	now := time.Date(2026, time.August, 3, 12, 0, 0, 0, time.UTC)
+	if err := store.AdvertiseEndpoints("machine-a", []string{"agent/a", "agent/b"}, now, time.Hour); err != nil {
+		t.Fatal(err)
+	}
+	conversation, err := store.CreateConversationIdempotent(CreateConversationInput{MachineID: "machine-a", IdempotencyKey: "create", CreatorEndpoint: "agent/a", Now: now, Members: []Member{{Endpoint: "agent/a", Capabilities: CapSend | CapReceive | CapAdmin | CapInvoke}, {Endpoint: "agent/b", Capabilities: CapReceive}}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := store.AppendMessage(AppendInput{ConversationID: conversation.ID, SenderMachineID: "machine-a", FromEndpoint: "agent/a", Body: "opaque work", IdempotencyKey: "message", Now: now}); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.ensureInvocationSchema(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.db.ExecContext(context.Background(), `DROP TABLE invocation_idempotency`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.db.ExecContext(context.Background(), `DROP TABLE invocation_audit`); err != nil {
+		t.Fatal(err)
+	}
+	invocation, duplicate, err := store.RequestInvocation(InvokeInput{ConversationID: conversation.ID, SenderMachineID: "machine-a", FromEndpoint: "agent/a", TargetEndpoint: "agent/b", IdempotencyKey: "invoke", Now: now})
+	if err != nil || duplicate || invocation.Status != InvocationAlreadyRunning {
+		t.Fatalf("invocation=%#v duplicate=%t err=%v", invocation, duplicate, err)
+	}
+	for _, table := range []string{"invocation_idempotency", "invocation_audit"} {
+		var exists bool
+		if err := store.db.QueryRowContext(context.Background(), `SELECT EXISTS(SELECT 1 FROM sqlite_master WHERE type='table' AND name=?)`, table).Scan(&exists); err != nil || !exists {
+			t.Fatalf("table=%s exists=%t err=%v", table, exists, err)
+		}
+	}
+}
+
 func TestInvokeDoesNotStartTargetThatAttachedAfterRequest(t *testing.T) {
 	t.Parallel()
 	store, err := Open(filepath.Join(t.TempDir(), "relay.db"))

--- a/internal/relay/invocation_test.go
+++ b/internal/relay/invocation_test.go
@@ -1,0 +1,126 @@
+package relay
+
+import (
+	"errors"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestInvokeQueuesOnlyOfflineAuthorizedRecipientAndFencesRetries(t *testing.T) {
+	t.Parallel()
+	store, err := Open(filepath.Join(t.TempDir(), "relay.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	now := time.Date(2026, time.August, 3, 12, 0, 0, 0, time.UTC)
+	if err := store.AdvertiseEndpoints("sender-machine", []string{"agent/sender"}, now, time.Hour); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.AdvertiseEndpoints("recipient-machine", []string{"agent/recipient"}, now, time.Hour); err != nil {
+		t.Fatal(err)
+	}
+	conversation, err := store.CreateConversationIdempotent(CreateConversationInput{
+		MachineID: "sender-machine", IdempotencyKey: "create", CreatorEndpoint: "agent/sender", Now: now,
+		Members: []Member{
+			{Endpoint: "agent/sender", Capabilities: CapSend | CapReceive | CapAdmin | CapInvoke},
+			{Endpoint: "agent/recipient", Capabilities: CapReceive},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := store.AppendMessage(AppendInput{ConversationID: conversation.ID, SenderMachineID: "sender-machine", FromEndpoint: "agent/sender", Body: "opaque work", IdempotencyKey: "message", Now: now}); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.AdvertiseEndpoints("recipient-machine", nil, now.Add(time.Second), time.Hour); err != nil {
+		t.Fatal(err)
+	}
+
+	request := InvokeInput{ConversationID: conversation.ID, SenderMachineID: "sender-machine", FromEndpoint: "agent/sender", TargetEndpoint: "agent/recipient", IdempotencyKey: "invoke", Now: now.Add(2 * time.Second)}
+	invocation, duplicate, err := store.RequestInvocation(request)
+	if err != nil || duplicate || invocation.Status != InvocationPending || invocation.TargetMachineID != "recipient-machine" || invocation.Fence == "" {
+		t.Fatalf("invocation=%#v duplicate=%t err=%v", invocation, duplicate, err)
+	}
+	repeated, duplicate, err := store.RequestInvocation(request)
+	if err != nil || !duplicate || repeated != invocation {
+		t.Fatalf("repeated=%#v duplicate=%t err=%v", repeated, duplicate, err)
+	}
+	changed := request
+	changed.TargetEndpoint = "agent/sender"
+	if _, _, err := store.RequestInvocation(changed); !errors.Is(err, ErrConflict) {
+		t.Fatalf("changed idempotency request err=%v", err)
+	}
+
+	first, err := store.LeaseInvocations("recipient-machine", "adapter-a", now.Add(2*time.Second), time.Second, 10)
+	if err != nil || len(first) != 1 || first[0].Fence != invocation.Fence || first[0].LeaseGeneration != 1 {
+		t.Fatalf("first=%#v err=%v", first, err)
+	}
+	if err := store.ReportInvocation("recipient-machine", first[0].ID, first[0].LeaseToken, first[0].LeaseGeneration, false, now.Add(2*time.Second)); err != nil {
+		t.Fatal(err)
+	}
+	if retry, err := store.LeaseInvocations("recipient-machine", "adapter-a", now.Add(3*time.Second), time.Second, 10); err != nil || len(retry) != 0 {
+		t.Fatalf("early retry=%#v err=%v", retry, err)
+	}
+	retryAt := now.Add(4 * time.Second)
+	second, err := store.LeaseInvocations("recipient-machine", "adapter-a", retryAt, time.Second, 10)
+	if err != nil || len(second) != 1 || second[0].Fence != invocation.Fence || second[0].LeaseGeneration != 2 {
+		t.Fatalf("second=%#v err=%v", second, err)
+	}
+	if err := store.ReportInvocation("recipient-machine", second[0].ID, second[0].LeaseToken, second[0].LeaseGeneration, true, retryAt); err != nil {
+		t.Fatal(err)
+	}
+	if final, err := store.LeaseInvocations("recipient-machine", "adapter-a", retryAt.Add(time.Hour), time.Second, 10); err != nil || len(final) != 0 {
+		t.Fatalf("final=%#v err=%v", final, err)
+	}
+	audit, err := store.InvocationAudit(invocation.ID)
+	if err != nil || len(audit) != 5 || audit[0].Action != "requested" || audit[1].Action != "leased" || audit[2].Action != "retry" || audit[3].Action != "leased" || audit[4].Action != "accepted" {
+		t.Fatalf("audit=%#v err=%v", audit, err)
+	}
+}
+
+func TestInvokeRejectsUnauthorizedAndDoesNotQueueAlreadyRunningTarget(t *testing.T) {
+	t.Parallel()
+	store, err := Open(filepath.Join(t.TempDir(), "relay.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	now := time.Date(2026, time.August, 3, 12, 0, 0, 0, time.UTC)
+	if err := store.AdvertiseEndpoints("machine-a", []string{"agent/a", "agent/b"}, now, time.Hour); err != nil {
+		t.Fatal(err)
+	}
+	conversation, err := store.CreateConversationIdempotent(CreateConversationInput{MachineID: "machine-a", IdempotencyKey: "create", CreatorEndpoint: "agent/a", Now: now, Members: []Member{{Endpoint: "agent/a", Capabilities: CapSend | CapReceive | CapAdmin}, {Endpoint: "agent/b", Capabilities: CapReceive}}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := store.AppendMessage(AppendInput{ConversationID: conversation.ID, SenderMachineID: "machine-a", FromEndpoint: "agent/a", Body: "opaque work", IdempotencyKey: "message", Now: now}); err != nil {
+		t.Fatal(err)
+	}
+	request := InvokeInput{ConversationID: conversation.ID, SenderMachineID: "machine-a", FromEndpoint: "agent/a", TargetEndpoint: "agent/b", IdempotencyKey: "invoke", Now: now}
+	if _, _, err := store.RequestInvocation(request); !errors.Is(err, ErrForbidden) {
+		t.Fatalf("unauthorized invoke err=%v", err)
+	}
+	// Grant invoke in a distinct conversation, then prove that an attached target
+	// does not create a second start request.
+	conversation, err = store.CreateConversationIdempotent(CreateConversationInput{MachineID: "machine-a", IdempotencyKey: "create-invoke", CreatorEndpoint: "agent/a", Now: now, Members: []Member{{Endpoint: "agent/a", Capabilities: CapSend | CapReceive | CapAdmin | CapInvoke}, {Endpoint: "agent/b", Capabilities: CapReceive}}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := store.AppendMessage(AppendInput{ConversationID: conversation.ID, SenderMachineID: "machine-a", FromEndpoint: "agent/a", Body: "opaque work", IdempotencyKey: "message-invoke", Now: now}); err != nil {
+		t.Fatal(err)
+	}
+	request.ConversationID = conversation.ID
+	request.IdempotencyKey = "invoke-running"
+	invocation, duplicate, err := store.RequestInvocation(request)
+	if err != nil || duplicate || invocation.Status != InvocationAlreadyRunning {
+		t.Fatalf("already running invocation=%#v duplicate=%t err=%v", invocation, duplicate, err)
+	}
+	if repeated, duplicate, err := store.RequestInvocation(request); err != nil || !duplicate || repeated != invocation {
+		t.Fatalf("already-running retry=%#v duplicate=%t err=%v", repeated, duplicate, err)
+	}
+	if leased, err := store.LeaseInvocations("machine-a", "adapter", now, time.Second, 10); err != nil || len(leased) != 0 {
+		t.Fatalf("already-running target leased=%#v err=%v", leased, err)
+	}
+}

--- a/internal/relay/invocation_test.go
+++ b/internal/relay/invocation_test.go
@@ -375,7 +375,7 @@ func TestInvokeDoesNotExpireAbandonedHandoffWithLiveLease(t *testing.T) {
 		t.Fatalf("leased=%#v err=%v", leased, err)
 	}
 	request.IdempotencyKey = "invoke-during-lease"
-	request.Now = leasedAt.Add(time.Second)
+	request.Now = leasedAt.Add(time.Minute + time.Second)
 	if coalesced, duplicate, err := store.RequestInvocation(request); err != nil || !duplicate || coalesced.ID != invocation.ID || coalesced.Status != InvocationPending {
 		t.Fatalf("coalesced=%#v duplicate=%t err=%v", coalesced, duplicate, err)
 	}

--- a/internal/relay/invocation_test.go
+++ b/internal/relay/invocation_test.go
@@ -114,6 +114,9 @@ func TestEmptyInvocationLeaseDoesNotMaterializeControlState(t *testing.T) {
 	if err := store.ReportInvocation("machine-a", "fabricated", "token", 1, true, time.Now().UTC()); !errors.Is(err, ErrForbidden) {
 		t.Fatalf("fabricated outcome err=%v", err)
 	}
+	if audit, err := store.InvocationAudit("unknown"); err != nil || len(audit) != 0 {
+		t.Fatalf("empty audit=%#v err=%v", audit, err)
+	}
 	var exists bool
 	if err := store.db.QueryRowContext(context.Background(), `SELECT EXISTS(SELECT 1 FROM sqlite_master WHERE type='table' AND name='invocations')`).Scan(&exists); err != nil || exists {
 		t.Fatalf("invocation state exists=%t err=%v", exists, err)

--- a/internal/relay/invocation_test.go
+++ b/internal/relay/invocation_test.go
@@ -246,6 +246,54 @@ func TestInvokePrunesTerminalIdempotencyAndAuditAfterRetention(t *testing.T) {
 	}
 }
 
+func TestInvokeRetentionPreservesAnAcceptedAttachmentFence(t *testing.T) {
+	t.Parallel()
+	store, err := Open(filepath.Join(t.TempDir(), "relay.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	now := time.Date(2026, time.August, 3, 12, 0, 0, 0, time.UTC)
+	if err := store.AdvertiseEndpoints("sender-machine", []string{"agent/sender"}, now, 2*invocationTerminalRetention); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.AdvertiseEndpoints("recipient-machine", []string{"agent/recipient"}, now, 2*invocationTerminalRetention); err != nil {
+		t.Fatal(err)
+	}
+	conversation, err := store.CreateConversationIdempotent(CreateConversationInput{MachineID: "sender-machine", IdempotencyKey: "create", CreatorEndpoint: "agent/sender", Now: now, Members: []Member{{Endpoint: "agent/sender", Capabilities: CapSend | CapReceive | CapAdmin | CapInvoke}, {Endpoint: "agent/recipient", Capabilities: CapReceive}}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := store.AppendMessage(AppendInput{ConversationID: conversation.ID, SenderMachineID: "sender-machine", FromEndpoint: "agent/sender", Body: "opaque work", IdempotencyKey: "message", Now: now}); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.AdvertiseEndpoints("recipient-machine", nil, now.Add(time.Second), 2*invocationTerminalRetention); err != nil {
+		t.Fatal(err)
+	}
+	request := InvokeInput{ConversationID: conversation.ID, SenderMachineID: "sender-machine", FromEndpoint: "agent/sender", TargetEndpoint: "agent/recipient", IdempotencyKey: "invoke", Now: now.Add(2 * time.Second)}
+	invocation, _, err := store.RequestInvocation(request)
+	if err != nil || invocation.Status != InvocationPending {
+		t.Fatalf("invocation=%#v err=%v", invocation, err)
+	}
+	acceptedAt := now.Add(invocationTerminalRetention + 3*time.Second)
+	leased, err := store.LeaseInvocations("recipient-machine", "adapter", acceptedAt, time.Minute, 1)
+	if err != nil || len(leased) != 1 {
+		t.Fatalf("leased=%#v err=%v", leased, err)
+	}
+	if err := store.ReportInvocation("recipient-machine", leased[0].ID, leased[0].LeaseToken, leased[0].LeaseGeneration, true, acceptedAt); err != nil {
+		t.Fatal(err)
+	}
+	request.IdempotencyKey = "invoke-after-accept"
+	request.Now = acceptedAt.Add(time.Second)
+	if coalesced, duplicate, err := store.RequestInvocation(request); err != nil || !duplicate || coalesced.ID != invocation.ID || coalesced.Status != InvocationSucceeded {
+		t.Fatalf("coalesced=%#v duplicate=%t err=%v", coalesced, duplicate, err)
+	}
+	var remaining int
+	if err := store.db.QueryRowContext(context.Background(), `SELECT count(*) FROM invocations WHERE id=?`, invocation.ID).Scan(&remaining); err != nil || remaining != 1 {
+		t.Fatalf("accepted fence rows=%d err=%v", remaining, err)
+	}
+}
+
 func TestInvokeDoesNotStartTargetThatAttachedAfterRequest(t *testing.T) {
 	t.Parallel()
 	store, err := Open(filepath.Join(t.TempDir(), "relay.db"))

--- a/internal/relay/invocation_test.go
+++ b/internal/relay/invocation_test.go
@@ -340,6 +340,47 @@ func TestInvokeExpiresAbandonedPendingHandoffBeforeCreatingFreshFence(t *testing
 	}
 }
 
+func TestInvokeDoesNotExpireAbandonedHandoffWithLiveLease(t *testing.T) {
+	t.Parallel()
+	store, err := Open(filepath.Join(t.TempDir(), "relay.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	now := time.Date(2026, time.August, 3, 12, 0, 0, 0, time.UTC)
+	if err := store.AdvertiseEndpoints("sender-machine", []string{"agent/sender"}, now, 2*invocationPendingRetention); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.AdvertiseEndpoints("recipient-machine", []string{"agent/recipient"}, now, time.Hour); err != nil {
+		t.Fatal(err)
+	}
+	conversation, err := store.CreateConversationIdempotent(CreateConversationInput{MachineID: "sender-machine", IdempotencyKey: "create", CreatorEndpoint: "agent/sender", Now: now, Members: []Member{{Endpoint: "agent/sender", Capabilities: CapSend | CapReceive | CapAdmin | CapInvoke}, {Endpoint: "agent/recipient", Capabilities: CapReceive}}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := store.AppendMessage(AppendInput{ConversationID: conversation.ID, SenderMachineID: "sender-machine", FromEndpoint: "agent/sender", Body: "opaque work", IdempotencyKey: "message", Now: now}); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.AdvertiseEndpoints("recipient-machine", nil, now.Add(time.Second), time.Hour); err != nil {
+		t.Fatal(err)
+	}
+	request := InvokeInput{ConversationID: conversation.ID, SenderMachineID: "sender-machine", FromEndpoint: "agent/sender", TargetEndpoint: "agent/recipient", IdempotencyKey: "invoke", Now: now.Add(2 * time.Second)}
+	invocation, _, err := store.RequestInvocation(request)
+	if err != nil || invocation.Status != InvocationPending {
+		t.Fatalf("invocation=%#v err=%v", invocation, err)
+	}
+	leasedAt := now.Add(invocationPendingRetention + 3*time.Second)
+	leased, err := store.LeaseInvocations("recipient-machine", "adapter", leasedAt, time.Minute, 1)
+	if err != nil || len(leased) != 1 || leased[0].ID != invocation.ID {
+		t.Fatalf("leased=%#v err=%v", leased, err)
+	}
+	request.IdempotencyKey = "invoke-during-lease"
+	request.Now = leasedAt.Add(time.Second)
+	if coalesced, duplicate, err := store.RequestInvocation(request); err != nil || !duplicate || coalesced.ID != invocation.ID || coalesced.Status != InvocationPending {
+		t.Fatalf("coalesced=%#v duplicate=%t err=%v", coalesced, duplicate, err)
+	}
+}
+
 func TestInvokeRepairsPartialOptionalSchema(t *testing.T) {
 	t.Parallel()
 	store, err := Open(filepath.Join(t.TempDir(), "relay.db"))

--- a/internal/relay/invocation_test.go
+++ b/internal/relay/invocation_test.go
@@ -388,6 +388,13 @@ func TestInvokeDoesNotExpireAbandonedHandoffWithLiveLease(t *testing.T) {
 	if coalesced, duplicate, err := store.RequestInvocation(request); err != nil || !duplicate || coalesced.ID != invocation.ID || coalesced.Status != InvocationPending {
 		t.Fatalf("coalesced=%#v duplicate=%t err=%v", coalesced, duplicate, err)
 	}
+	if leased, err := store.LeaseInvocations("recipient-machine", "adapter", leasedAt.Add(invocationPendingRetention+time.Second), time.Minute, 1); err != nil || len(leased) != 0 {
+		t.Fatalf("abandoned leased invocation=%#v err=%v", leased, err)
+	}
+	var status InvocationStatus
+	if err := store.db.QueryRowContext(context.Background(), `SELECT status FROM invocations WHERE id=?`, invocation.ID).Scan(&status); err != nil || status != InvocationFailed {
+		t.Fatalf("status=%q err=%v", status, err)
+	}
 }
 
 func TestInvokeRepairsPartialOptionalSchema(t *testing.T) {

--- a/internal/relay/invocation_test.go
+++ b/internal/relay/invocation_test.go
@@ -163,11 +163,18 @@ func TestInvokeCrashLeasesAreBounded(t *testing.T) {
 			t.Fatalf("attempt=%d leased=%#v err=%v", attempt, leased, err)
 		}
 	}
-	if leased, err := store.LeaseInvocations("recipient-machine", "adapter", now.Add(8*time.Second), time.Second, 10); err != nil || len(leased) != 0 {
-		t.Fatalf("exhausted leased=%#v err=%v", leased, err)
+	recovery, err := store.LeaseInvocations("recipient-machine", "adapter", now.Add(8*time.Second), time.Second, 10)
+	if err != nil || len(recovery) != 1 || recovery[0].Fence != invocation.Fence || !recovery[0].RecoveryOnly {
+		t.Fatalf("recovery=%#v err=%v", recovery, err)
+	}
+	if err := store.ReportInvocation("recipient-machine", recovery[0].ID, recovery[0].LeaseToken, recovery[0].LeaseGeneration, false, now.Add(8*time.Second)); err != nil {
+		t.Fatal(err)
+	}
+	if leased, err := store.LeaseInvocations("recipient-machine", "adapter", now.Add(9*time.Second), time.Second, 10); err != nil || len(leased) != 0 {
+		t.Fatalf("terminal leased=%#v err=%v", leased, err)
 	}
 	audit, err := store.InvocationAudit(invocation.ID)
-	if err != nil || len(audit) != 5 || audit[4].Action != "failed" {
+	if err != nil || len(audit) != 6 || audit[5].Action != "failed" {
 		t.Fatalf("audit=%#v err=%v", audit, err)
 	}
 }

--- a/internal/relay/invocation_test.go
+++ b/internal/relay/invocation_test.go
@@ -93,6 +93,22 @@ func TestInvokeQueuesOnlyOfflineAuthorizedRecipientAndFencesRetries(t *testing.T
 	}
 }
 
+func TestEmptyInvocationLeaseDoesNotMaterializeControlState(t *testing.T) {
+	t.Parallel()
+	store, err := Open(filepath.Join(t.TempDir(), "relay.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	if leased, err := store.LeaseInvocations("machine-a", "adapter-a", time.Now().UTC(), time.Minute, 1); err != nil || len(leased) != 0 {
+		t.Fatalf("leased=%#v err=%v", leased, err)
+	}
+	var exists bool
+	if err := store.db.QueryRowContext(context.Background(), `SELECT EXISTS(SELECT 1 FROM sqlite_master WHERE type='table' AND name='invocations')`).Scan(&exists); err != nil || exists {
+		t.Fatalf("invocation state exists=%t err=%v", exists, err)
+	}
+}
+
 func TestInvokeCrashLeasesAreBounded(t *testing.T) {
 	t.Parallel()
 	store, err := Open(filepath.Join(t.TempDir(), "relay.db"))
@@ -181,7 +197,7 @@ func TestInvokeRejectsUnauthorizedAndDoesNotQueueAlreadyRunningTarget(t *testing
 	}
 }
 
-func TestInvokeFailsWhenTargetAttachmentChangesAfterRequest(t *testing.T) {
+func TestInvokeDoesNotStartTargetThatAttachedAfterRequest(t *testing.T) {
 	t.Parallel()
 	store, err := Open(filepath.Join(t.TempDir(), "relay.db"))
 	if err != nil {
@@ -216,7 +232,7 @@ func TestInvokeFailsWhenTargetAttachmentChangesAfterRequest(t *testing.T) {
 		t.Fatalf("leased=%#v err=%v", leased, err)
 	}
 	audit, err := store.InvocationAudit(invocation.ID)
-	if err != nil || len(audit) != 2 || audit[1].Action != "failed" {
+	if err != nil || len(audit) != 2 || audit[1].Action != "already_running" {
 		t.Fatalf("audit=%#v err=%v", audit, err)
 	}
 }

--- a/internal/relay/invocation_test.go
+++ b/internal/relay/invocation_test.go
@@ -208,6 +208,44 @@ func TestInvokeRejectsUnauthorizedAndDoesNotQueueAlreadyRunningTarget(t *testing
 	}
 }
 
+func TestInvokePrunesTerminalIdempotencyAndAuditAfterRetention(t *testing.T) {
+	t.Parallel()
+	store, err := Open(filepath.Join(t.TempDir(), "relay.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	now := time.Date(2026, time.August, 3, 12, 0, 0, 0, time.UTC)
+	if err := store.AdvertiseEndpoints("machine-a", []string{"agent/a", "agent/b"}, now, 2*invocationTerminalRetention); err != nil {
+		t.Fatal(err)
+	}
+	conversation, err := store.CreateConversationIdempotent(CreateConversationInput{MachineID: "machine-a", IdempotencyKey: "create", CreatorEndpoint: "agent/a", Now: now, Members: []Member{{Endpoint: "agent/a", Capabilities: CapSend | CapReceive | CapAdmin | CapInvoke}, {Endpoint: "agent/b", Capabilities: CapReceive}}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := store.AppendMessage(AppendInput{ConversationID: conversation.ID, SenderMachineID: "machine-a", FromEndpoint: "agent/a", Body: "opaque work", IdempotencyKey: "message", Now: now}); err != nil {
+		t.Fatal(err)
+	}
+	request := InvokeInput{ConversationID: conversation.ID, SenderMachineID: "machine-a", FromEndpoint: "agent/a", TargetEndpoint: "agent/b", IdempotencyKey: "invoke", Now: now}
+	first, duplicate, err := store.RequestInvocation(request)
+	if err != nil || duplicate || first.Status != InvocationAlreadyRunning {
+		t.Fatalf("first=%#v duplicate=%t err=%v", first, duplicate, err)
+	}
+	request.Now = now.Add(invocationTerminalRetention - time.Millisecond)
+	if repeated, duplicate, err := store.RequestInvocation(request); err != nil || !duplicate || repeated.ID != first.ID {
+		t.Fatalf("retained retry=%#v duplicate=%t err=%v", repeated, duplicate, err)
+	}
+	request.Now = now.Add(invocationTerminalRetention + time.Millisecond)
+	second, duplicate, err := store.RequestInvocation(request)
+	if err != nil || duplicate || second.ID == first.ID || second.Status != InvocationAlreadyRunning {
+		t.Fatalf("pruned retry=%#v duplicate=%t err=%v", second, duplicate, err)
+	}
+	var invocations, idempotency, audit int
+	if err := store.db.QueryRowContext(context.Background(), `SELECT (SELECT count(*) FROM invocations), (SELECT count(*) FROM invocation_idempotency), (SELECT count(*) FROM invocation_audit)`).Scan(&invocations, &idempotency, &audit); err != nil || invocations != 1 || idempotency != 1 || audit != 1 {
+		t.Fatalf("invocations=%d idempotency=%d audit=%d err=%v", invocations, idempotency, audit, err)
+	}
+}
+
 func TestInvokeDoesNotStartTargetThatAttachedAfterRequest(t *testing.T) {
 	t.Parallel()
 	store, err := Open(filepath.Join(t.TempDir(), "relay.db"))

--- a/internal/relay/invocation_test.go
+++ b/internal/relay/invocation_test.go
@@ -254,10 +254,10 @@ func TestInvokeRetentionPreservesAnAcceptedAttachmentFence(t *testing.T) {
 	}
 	t.Cleanup(func() { _ = store.Close() })
 	now := time.Date(2026, time.August, 3, 12, 0, 0, 0, time.UTC)
-	if err := store.AdvertiseEndpoints("sender-machine", []string{"agent/sender"}, now, 2*invocationTerminalRetention); err != nil {
+	if err := store.AdvertiseEndpoints("sender-machine", []string{"agent/sender"}, now, 3*invocationTerminalRetention); err != nil {
 		t.Fatal(err)
 	}
-	if err := store.AdvertiseEndpoints("recipient-machine", []string{"agent/recipient"}, now, 2*invocationTerminalRetention); err != nil {
+	if err := store.AdvertiseEndpoints("recipient-machine", []string{"agent/recipient"}, now, 3*invocationTerminalRetention); err != nil {
 		t.Fatal(err)
 	}
 	conversation, err := store.CreateConversationIdempotent(CreateConversationInput{MachineID: "sender-machine", IdempotencyKey: "create", CreatorEndpoint: "agent/sender", Now: now, Members: []Member{{Endpoint: "agent/sender", Capabilities: CapSend | CapReceive | CapAdmin | CapInvoke}, {Endpoint: "agent/recipient", Capabilities: CapReceive}}})
@@ -267,7 +267,7 @@ func TestInvokeRetentionPreservesAnAcceptedAttachmentFence(t *testing.T) {
 	if _, _, err := store.AppendMessage(AppendInput{ConversationID: conversation.ID, SenderMachineID: "sender-machine", FromEndpoint: "agent/sender", Body: "opaque work", IdempotencyKey: "message", Now: now}); err != nil {
 		t.Fatal(err)
 	}
-	if err := store.AdvertiseEndpoints("recipient-machine", nil, now.Add(time.Second), 2*invocationTerminalRetention); err != nil {
+	if err := store.AdvertiseEndpoints("recipient-machine", nil, now.Add(time.Second), 3*invocationTerminalRetention); err != nil {
 		t.Fatal(err)
 	}
 	request := InvokeInput{ConversationID: conversation.ID, SenderMachineID: "sender-machine", FromEndpoint: "agent/sender", TargetEndpoint: "agent/recipient", IdempotencyKey: "invoke", Now: now.Add(2 * time.Second)}
@@ -291,6 +291,11 @@ func TestInvokeRetentionPreservesAnAcceptedAttachmentFence(t *testing.T) {
 	var remaining int
 	if err := store.db.QueryRowContext(context.Background(), `SELECT count(*) FROM invocations WHERE id=?`, invocation.ID).Scan(&remaining); err != nil || remaining != 1 {
 		t.Fatalf("accepted fence rows=%d err=%v", remaining, err)
+	}
+	request.IdempotencyKey = "invoke-after-retention"
+	request.Now = acceptedAt.Add(invocationTerminalRetention + time.Millisecond)
+	if replacement, duplicate, err := store.RequestInvocation(request); err != nil || duplicate || replacement.ID == invocation.ID || replacement.Status != InvocationPending {
+		t.Fatalf("expired terminal=%#v duplicate=%t err=%v", replacement, duplicate, err)
 	}
 }
 

--- a/internal/relay/invocation_test.go
+++ b/internal/relay/invocation_test.go
@@ -78,11 +78,17 @@ func TestInvokeQueuesOnlyOfflineAuthorizedRecipientAndFencesRetries(t *testing.T
 	if err := store.ReportInvocation("recipient-machine", second[0].ID, second[0].LeaseToken, second[0].LeaseGeneration, true, retryAt); err != nil {
 		t.Fatal(err)
 	}
+	afterAccept := request
+	afterAccept.IdempotencyKey = "invoke-after-accept"
+	afterAccept.Now = retryAt
+	if coalesced, duplicate, err := store.RequestInvocation(afterAccept); err != nil || !duplicate || coalesced.ID != invocation.ID || coalesced.Fence != invocation.Fence || coalesced.Status != InvocationSucceeded {
+		t.Fatalf("accepted coalescing invocation=%#v duplicate=%t err=%v", coalesced, duplicate, err)
+	}
 	if final, err := store.LeaseInvocations("recipient-machine", "adapter-a", retryAt.Add(time.Hour), time.Second, 10); err != nil || len(final) != 0 {
 		t.Fatalf("final=%#v err=%v", final, err)
 	}
 	audit, err := store.InvocationAudit(invocation.ID)
-	if err != nil || len(audit) != 6 || audit[0].Action != "requested" || audit[1].Action != "coalesced" || audit[2].Action != "leased" || audit[3].Action != "retry" || audit[4].Action != "leased" || audit[5].Action != "accepted" {
+	if err != nil || len(audit) != 7 || audit[0].Action != "requested" || audit[1].Action != "coalesced" || audit[2].Action != "leased" || audit[3].Action != "retry" || audit[4].Action != "leased" || audit[5].Action != "accepted" || audit[6].Action != "coalesced" {
 		t.Fatalf("audit=%#v err=%v", audit, err)
 	}
 }

--- a/internal/relay/migration_source_test.go
+++ b/internal/relay/migration_source_test.go
@@ -215,6 +215,30 @@ func TestMigrationSourceManifestAndBarrier(t *testing.T) {
 	}
 }
 
+func TestMigrationSourceRejectsInvokeCapabilityBeforePreparation(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	now := time.Date(2026, time.August, 3, 12, 0, 0, 0, time.UTC)
+	path := filepath.Join(t.TempDir(), "relay.db")
+	store, err := Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	if err := store.AdvertiseEndpoints("machine-a", []string{"agent/a"}, now, time.Hour); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.CreateConversationIdempotent(CreateConversationInput{MachineID: "machine-a", IdempotencyKey: "create", CreatorEndpoint: "agent/a", Now: now, Members: []Member{{Endpoint: "agent/a", Capabilities: CapSend | CapReceive | CapAdmin | CapInvoke}}}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := InspectMigrationSource(ctx, path); err == nil {
+		t.Fatal("invoke-capability source was accepted for incompatible PostgreSQL cutover")
+	}
+	if got := migrationSourcePhase(t, store); got != MigrationSourceActive {
+		t.Fatalf("rejected source inspection changed phase to %q", got)
+	}
+}
+
 func TestCheckMigrationSourceEnrollmentCoverage(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()

--- a/internal/relay/store.go
+++ b/internal/relay/store.go
@@ -440,11 +440,27 @@ func (s *Store) AdvertiseEndpoints(machineID string, endpoints []string, now tim
 		}
 		seen[endpoint] = struct{}{}
 	}
+	invocationSchemaExists, err := s.invocationSchemaExists()
+	if err != nil {
+		return err
+	}
 	tx, err := s.db.BeginTx(context.Background(), nil)
 	if err != nil {
 		return err
 	}
 	defer rollback(tx)
+	if invocationSchemaExists {
+		for endpoint := range seen {
+			var liveStartLease bool
+			err := tx.QueryRowContext(context.Background(), `SELECT EXISTS(SELECT 1 FROM invocations WHERE target_endpoint=? AND target_machine_id<>? AND status=? AND lease_machine_id IS NOT NULL AND lease_until>?)`, endpoint, machineID, InvocationPending, now.UnixMilli()).Scan(&liveStartLease)
+			if err != nil {
+				return fmt.Errorf("inspect live invocation lease: %w", err)
+			}
+			if liveStartLease {
+				return ErrConflict
+			}
+		}
+	}
 	rows, err := tx.QueryContext(context.Background(), `SELECT endpoint FROM endpoints WHERE machine_id = ? AND lease_until > ?`, machineID, now.UnixMilli())
 	if err != nil {
 		return fmt.Errorf("find attached endpoints: %w", err)

--- a/internal/relay/store.go
+++ b/internal/relay/store.go
@@ -166,6 +166,7 @@ type Invocation struct {
 	LeaseToken      string           `json:"lease_token,omitempty"`
 	LeaseGeneration int64            `json:"lease_generation,omitempty"`
 	LeaseUntil      time.Time        `json:"lease_until,omitempty"`
+	RecoveryOnly    bool             `json:"recovery_only,omitempty"`
 }
 
 // InvocationAuditEvent is body-free durable evidence of authorization,

--- a/internal/relay/store.go
+++ b/internal/relay/store.go
@@ -440,15 +440,18 @@ func (s *Store) AdvertiseEndpoints(machineID string, endpoints []string, now tim
 		}
 		seen[endpoint] = struct{}{}
 	}
-	invocationSchemaExists, err := s.invocationSchemaExists()
-	if err != nil {
-		return err
-	}
 	tx, err := s.db.BeginTx(context.Background(), nil)
 	if err != nil {
 		return err
 	}
 	defer rollback(tx)
+	// Read optional invocation state under the same SQLite transaction that
+	// changes endpoint ownership. A pre-transaction snapshot could miss a
+	// concurrently committed start lease and permit its owner to be replaced.
+	invocationSchemaExists, err := invocationSchemaExistsTx(tx)
+	if err != nil {
+		return err
+	}
 	if invocationSchemaExists {
 		for endpoint := range seen {
 			var handoffReserved bool

--- a/internal/relay/store.go
+++ b/internal/relay/store.go
@@ -392,7 +392,7 @@ func (s *Store) migrate(ctx context.Context) error {
 }
 
 func ensureSQLiteColumn(ctx context.Context, db *sql.DB, table, name, definition string) error {
-	if table != "endpoints" && table != "deliveries" && table != "relay_migration_control" {
+	if table != "endpoints" && table != "deliveries" && table != "invocations" && table != "relay_migration_control" {
 		return errors.New("invalid relay migration table")
 	}
 	rows, err := db.QueryContext(ctx, "PRAGMA table_info("+table+")") // #nosec G202 -- table is restricted above to fixed internal names.

--- a/internal/relay/store.go
+++ b/internal/relay/store.go
@@ -54,6 +54,9 @@ const (
 	CapReceive
 	// CapAdmin reserves room-administration authority for a live endpoint.
 	CapAdmin
+	// CapInvoke permits a content-free, server-authorized start handoff for an
+	// offline receiving member. Existing send/admin grants never imply it.
+	CapInvoke
 )
 
 // Member is an explicitly authorized conversation endpoint.
@@ -122,6 +125,54 @@ type CreateConversationInput struct {
 	CreatorEndpoint      string
 	Members              []Member
 	Now                  time.Time
+}
+
+// InvocationStatus is the durable state of a server-authorized runtime
+// handoff. A runtime receives no message body: it attaches the endpoint and
+// then obtains pending delivery through the normal path.
+type InvocationStatus string
+
+const (
+	// InvocationPending is queued or eligible for a retry lease.
+	InvocationPending InvocationStatus = "pending"
+	// InvocationAlreadyRunning records the idempotent no-op for an attached target.
+	InvocationAlreadyRunning InvocationStatus = "already_running"
+	// InvocationSucceeded records a host-local runtime acceptance.
+	InvocationSucceeded InvocationStatus = "succeeded"
+	// InvocationFailed records a terminal failure after bounded retry exhaustion.
+	InvocationFailed InvocationStatus = "failed"
+)
+
+// InvokeInput binds one caller retry domain to a receiving conversation member.
+// The target machine is derived from durable server state, never request JSON.
+type InvokeInput struct {
+	ConversationID  string
+	SenderMachineID string
+	FromEndpoint    string
+	TargetEndpoint  string
+	IdempotencyKey  string
+	Now             time.Time
+}
+
+// Invocation is content-free runtime work. Fence remains stable for every
+// retry so a host-local runtime can reject duplicate process starts.
+type Invocation struct {
+	ID              string           `json:"id"`
+	ConversationID  string           `json:"conversation_id"`
+	TargetEndpoint  string           `json:"target_endpoint"`
+	TargetMachineID string           `json:"target_machine_id"`
+	Fence           string           `json:"fence"`
+	Status          InvocationStatus `json:"status"`
+	LeaseToken      string           `json:"lease_token,omitempty"`
+	LeaseGeneration int64            `json:"lease_generation,omitempty"`
+	LeaseUntil      time.Time        `json:"lease_until,omitempty"`
+}
+
+// InvocationAuditEvent is body-free durable evidence of authorization,
+// leasing, retry, and terminal handoff outcomes.
+type InvocationAuditEvent struct {
+	Action    string    `json:"action"`
+	CreatedAt time.Time `json:"created_at"`
 }
 
 // Store owns SQLite-backed relay state.
@@ -475,7 +526,7 @@ func (s *Store) createConversation(input CreateConversationInput) (Conversation,
 	seen := make(map[string]struct{}, len(members))
 	creatorAdmin := false
 	for _, member := range members {
-		if !ValidEndpoint(member.Endpoint) || member.Capabilities == 0 || member.Capabilities & ^(CapSend|CapReceive|CapAdmin) != 0 {
+		if !ValidEndpoint(member.Endpoint) || member.Capabilities == 0 || member.Capabilities & ^(CapSend|CapReceive|CapAdmin|CapInvoke) != 0 {
 			return Conversation{}, fmt.Errorf("invalid conversation member")
 		}
 		if _, duplicate := seen[member.Endpoint]; duplicate {

--- a/internal/relay/store.go
+++ b/internal/relay/store.go
@@ -455,7 +455,7 @@ func (s *Store) AdvertiseEndpoints(machineID string, endpoints []string, now tim
 	if invocationSchemaExists {
 		for endpoint := range seen {
 			var handoffReserved bool
-			err := tx.QueryRowContext(context.Background(), `SELECT EXISTS(SELECT 1 FROM invocations WHERE target_endpoint=? AND target_machine_id<>? AND ((status=? AND lease_machine_id IS NOT NULL AND lease_until>?) OR (status=? AND not_before>?)))`, endpoint, machineID, InvocationPending, now.UnixMilli(), InvocationSucceeded, now.UnixMilli()).Scan(&handoffReserved)
+			err := tx.QueryRowContext(context.Background(), `SELECT EXISTS(SELECT 1 FROM invocations WHERE target_endpoint=? AND target_machine_id<>? AND ((status=? AND (lease_machine_id IS NOT NULL AND lease_until>? OR (lease_generation>0 AND last_activity_at>?))) OR (status=? AND not_before>?)))`, endpoint, machineID, InvocationPending, now.UnixMilli(), now.Add(-invocationPendingRetention).UnixMilli(), InvocationSucceeded, now.UnixMilli()).Scan(&handoffReserved)
 			if err != nil {
 				return fmt.Errorf("inspect live invocation lease: %w", err)
 			}

--- a/internal/relay/store.go
+++ b/internal/relay/store.go
@@ -451,12 +451,12 @@ func (s *Store) AdvertiseEndpoints(machineID string, endpoints []string, now tim
 	defer rollback(tx)
 	if invocationSchemaExists {
 		for endpoint := range seen {
-			var liveStartLease bool
-			err := tx.QueryRowContext(context.Background(), `SELECT EXISTS(SELECT 1 FROM invocations WHERE target_endpoint=? AND target_machine_id<>? AND status=? AND lease_machine_id IS NOT NULL AND lease_until>?)`, endpoint, machineID, InvocationPending, now.UnixMilli()).Scan(&liveStartLease)
+			var handoffReserved bool
+			err := tx.QueryRowContext(context.Background(), `SELECT EXISTS(SELECT 1 FROM invocations WHERE target_endpoint=? AND target_machine_id<>? AND ((status=? AND lease_machine_id IS NOT NULL AND lease_until>?) OR (status=? AND not_before>?)))`, endpoint, machineID, InvocationPending, now.UnixMilli(), InvocationSucceeded, now.UnixMilli()).Scan(&handoffReserved)
 			if err != nil {
 				return fmt.Errorf("inspect live invocation lease: %w", err)
 			}
-			if liveStartLease {
+			if handoffReserved {
 				return ErrConflict
 			}
 		}


### PR DESCRIPTION
Closes #56.

Adds a body-free, server-authorized `invoke` capability for an offline receiving conversation member.

- Separate `invoke` capability and signed HTTP request/lease/outcome flow.
- Durable authorization, audit history, bounded retries, idempotency, lease generations, and a stable fence.
- Adapter-side protected fixed command plus private journal deduplication across a lost outcome/crash boundary.
- Covers idle/offline, already-running, unauthorized, retry, and crash/re-lease behavior.

Validated locally:

- `make test`
- `make test-race`
- `make staticcheck`
- `make security`
- `make lint`