### PR TITLE
feat: add role-addressed conversation routing

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -279,7 +279,8 @@ be enrolled for a named exact legacy endpoint; exact enrollment is equality
 only, never an implicit client-wide namespace.
 
 Each conversation has an explicit membership table with `send`, `receive`,
-and `admin` capabilities. The Telegram gateway is a distinct principal; only
+and `admin` capabilities plus an optional validated durable role label. The
+Telegram gateway is a distinct principal; only
 the configured Telegram user ID may control it. Neither a friendly endpoint
 name nor a client-provided `from` field is proof of identity.
 
@@ -384,6 +385,17 @@ and lease token. A lease that expires without an acknowledgement becomes
 available again. The recipient must tolerate duplicate delivery by durably
 recording the Punaro message UUID before local injection, or by using it as the
 local mailbox idempotency key.
+
+A message may name one membership `target_role`. The relay validates the role
+and the sender's current `send` authority in the append transaction, then
+creates deliveries only for other currently attached `receive` members holding
+that role. If none is eligible, it returns a stable no-recipient error before
+allocating a sequence, message, or idempotency record. Omitting `target_role`
+preserves existing broadcast behavior, including durable delivery to detached
+receivers. Only a current `admin` member may replace a membership role/binding;
+the new endpoint must be live and the operation atomically moves the role's
+unacknowledged deliveries and cursor, preserving at-least-once delivery across
+restart and rebinding.
 
 `ack` is idempotent. It is conditional on the current recipient, lease token,
 and lease generation. Acks from the wrong machine, stale lease holders, expired
@@ -755,6 +767,7 @@ API client and reaches the relay using its own enrolled machine credential.
 | `GET` | `/v1/conversations` | List conversations the caller may discover. |
 | `POST` | `/v1/conversations/{id}/messages` | Append an authorized message. |
 | `POST` | `/v1/conversations/{id}/invocations` | Request a server-authorized, body-free offline-role handoff. |
+| `PUT` | `/v1/conversations/{id}/memberships` | Admin-authorized role/binding replacement. |
 | `POST` | `/v1/deliveries/lease` | Lease bounded durable deliveries for one endpoint. |
 | `POST` | `/v1/deliveries/{id}/ack` | Acknowledge after local injection. |
 | `POST` | `/v1/invocations/lease` | Lease content-free runtime handoffs for the authenticated machine. |

--- a/internal/adapter/client.go
+++ b/internal/adapter/client.go
@@ -219,7 +219,7 @@ func (c *HTTPRelayClient) CreateConversation(ctx context.Context, creator string
 	}
 	encoded := make([]map[string]any, 0, len(members))
 	for _, member := range members {
-		encoded = append(encoded, map[string]any{"endpoint": member.Endpoint, "capabilities": capabilityNames(member.Capabilities)})
+		encoded = append(encoded, map[string]any{"endpoint": member.Endpoint, "capabilities": capabilityNames(member.Capabilities), "role": member.Role})
 	}
 	var conversation relay.Conversation
 	_, err := c.doJSONWithIdempotency(ctx, http.MethodPost, "/v1/conversations", map[string]any{"creator_endpoint": creator, "members": encoded}, idempotencyKey, &conversation)
@@ -247,11 +247,24 @@ func capabilityNames(capabilities relay.Capability) []string {
 // idempotency key belongs to the caller's retry domain and is never derived
 // from the body or a machine credential.
 func (c *HTTPRelayClient) Send(ctx context.Context, conversationID, fromEndpoint, body, idempotencyKey string) (relay.Message, error) {
+	return c.send(ctx, conversationID, fromEndpoint, "", body, idempotencyKey)
+}
+
+// SendToRole appends a message addressed to one validated membership role. The
+// relay accepts it only when that role has an active receiving member.
+func (c *HTTPRelayClient) SendToRole(ctx context.Context, conversationID, fromEndpoint, targetRole, body, idempotencyKey string) (relay.Message, error) {
+	if strings.TrimSpace(targetRole) == "" {
+		return relay.Message{}, fmt.Errorf("target role is required")
+	}
+	return c.send(ctx, conversationID, fromEndpoint, targetRole, body, idempotencyKey)
+}
+
+func (c *HTTPRelayClient) send(ctx context.Context, conversationID, fromEndpoint, targetRole, body, idempotencyKey string) (relay.Message, error) {
 	if strings.TrimSpace(conversationID) == "" || strings.TrimSpace(fromEndpoint) == "" || strings.TrimSpace(idempotencyKey) == "" {
 		return relay.Message{}, fmt.Errorf("conversation, sender endpoint, and idempotency key are required")
 	}
 	var message relay.Message
-	status, err := c.doJSONWithIdempotency(ctx, http.MethodPost, "/v1/conversations/"+url.PathEscape(conversationID)+"/messages", map[string]any{"from_endpoint": fromEndpoint, "body": body}, idempotencyKey, &message)
+	status, err := c.doJSONWithIdempotency(ctx, http.MethodPost, "/v1/conversations/"+url.PathEscape(conversationID)+"/messages", map[string]any{"from_endpoint": fromEndpoint, "target_role": targetRole, "body": body}, idempotencyKey, &message)
 	if err != nil {
 		return message, &relayHTTPStatusError{status: status, err: err}
 	}

--- a/internal/adapter/client.go
+++ b/internal/adapter/client.go
@@ -219,7 +219,11 @@ func (c *HTTPRelayClient) CreateConversation(ctx context.Context, creator string
 	}
 	encoded := make([]map[string]any, 0, len(members))
 	for _, member := range members {
-		encoded = append(encoded, map[string]any{"endpoint": member.Endpoint, "capabilities": capabilityNames(member.Capabilities), "role": member.Role})
+		item := map[string]any{"endpoint": member.Endpoint, "capabilities": capabilityNames(member.Capabilities)}
+		if member.Role != "" {
+			item["role"] = member.Role
+		}
+		encoded = append(encoded, item)
 	}
 	var conversation relay.Conversation
 	_, err := c.doJSONWithIdempotency(ctx, http.MethodPost, "/v1/conversations", map[string]any{"creator_endpoint": creator, "members": encoded}, idempotencyKey, &conversation)
@@ -264,7 +268,11 @@ func (c *HTTPRelayClient) send(ctx context.Context, conversationID, fromEndpoint
 		return relay.Message{}, fmt.Errorf("conversation, sender endpoint, and idempotency key are required")
 	}
 	var message relay.Message
-	status, err := c.doJSONWithIdempotency(ctx, http.MethodPost, "/v1/conversations/"+url.PathEscape(conversationID)+"/messages", map[string]any{"from_endpoint": fromEndpoint, "target_role": targetRole, "body": body}, idempotencyKey, &message)
+	request := map[string]any{"from_endpoint": fromEndpoint, "body": body}
+	if targetRole != "" {
+		request["target_role"] = targetRole
+	}
+	status, err := c.doJSONWithIdempotency(ctx, http.MethodPost, "/v1/conversations/"+url.PathEscape(conversationID)+"/messages", request, idempotencyKey, &message)
 	if err != nil {
 		return message, &relayHTTPStatusError{status: status, err: err}
 	}

--- a/internal/adapter/client_test.go
+++ b/internal/adapter/client_test.go
@@ -600,11 +600,30 @@ func TestHTTPRelayClientSignsBoundedProtocolRequests(t *testing.T) {
 			if r.Header.Get("Idempotency-Key") != "send-1" {
 				t.Fatal("missing idempotency key")
 			}
+			var messageRequest map[string]json.RawMessage
+			if err := json.Unmarshal(body, &messageRequest); err != nil {
+				t.Fatal(err)
+			}
+			if _, hasTargetRole := messageRequest["target_role"]; hasTargetRole {
+				t.Fatal("ordinary send exposed target_role to a legacy relay")
+			}
 			w.Header().Set("Content-Type", "application/json")
 			_, _ = w.Write([]byte(`{"id":"message-1","conversation_id":"conversation-1","sequence":1,"from_endpoint":"agent/a","body":"reply","created_at":"2026-07-13T12:00:00Z"}`))
 		case "/v1/conversations":
 			if r.Header.Get("Idempotency-Key") != "create-1" {
 				t.Fatal("missing create idempotency key")
+			}
+			var conversationRequest struct {
+				Members []map[string]json.RawMessage `json:"members"`
+			}
+			if err := json.Unmarshal(body, &conversationRequest); err != nil {
+				t.Fatal(err)
+			}
+			if len(conversationRequest.Members) != 1 {
+				t.Fatalf("members=%#v", conversationRequest.Members)
+			}
+			if _, hasRole := conversationRequest.Members[0]["role"]; hasRole {
+				t.Fatal("ordinary create exposed role to a legacy relay")
 			}
 			w.Header().Set("Content-Type", "application/json")
 			_, _ = w.Write([]byte(`{"id":"conversation-created"}`))

--- a/internal/postgres/attachment_integration_test.go
+++ b/internal/postgres/attachment_integration_test.go
@@ -179,8 +179,8 @@ func testTrustedAttachmentIntegration(ctx context.Context, t *testing.T, app *Da
 		ProjectID: project.ProjectID, IdempotencyKey: "attachment-conversation-create",
 		CreatorEndpoint: "agent/attachment/uploader", Now: now,
 		Members: []relay.Member{
-			{Endpoint: "agent/attachment/uploader", Capabilities: relay.CapSend | relay.CapReceive | relay.CapAdmin},
-			{Endpoint: "agent/attachment/recipient", Capabilities: relay.CapReceive},
+			{Endpoint: "agent/attachment/uploader", Capabilities: relay.CapSend | relay.CapReceive | relay.CapAdmin, Role: "coordinator"},
+			{Endpoint: "agent/attachment/recipient", Capabilities: relay.CapReceive, Role: "reviewer"},
 		},
 	})
 	if err != nil {
@@ -189,7 +189,7 @@ func testTrustedAttachmentIntegration(ctx context.Context, t *testing.T, app *Da
 	message, duplicateMessage, err := app.AppendMessage(relay.AppendInput{
 		ConversationID: conversation.ID, SenderMachineID: "attachment-uploader-machine",
 		PrincipalID: uploader.ID, CredentialLookupID: uploaderLookup, CredentialGeneration: 1,
-		FromEndpoint: "agent/attachment/uploader", Body: "trusted attachment reference",
+		FromEndpoint: "agent/attachment/uploader", TargetRole: "reviewer", Body: "trusted attachment reference",
 		ArtifactIDs: []string{reservation.ArtifactID}, IdempotencyKey: "attachment-message-append", Now: now,
 	})
 	if err != nil || duplicateMessage {
@@ -198,7 +198,7 @@ func testTrustedAttachmentIntegration(ctx context.Context, t *testing.T, app *Da
 	if retried, duplicate, err := app.AppendMessage(relay.AppendInput{
 		ConversationID: conversation.ID, SenderMachineID: "attachment-uploader-machine",
 		PrincipalID: uploader.ID, CredentialLookupID: uploaderLookup, CredentialGeneration: 1,
-		FromEndpoint: "agent/attachment/uploader", Body: "trusted attachment reference",
+		FromEndpoint: "agent/attachment/uploader", TargetRole: "reviewer", Body: "trusted attachment reference",
 		ArtifactIDs: []string{reservation.ArtifactID}, IdempotencyKey: "attachment-message-append", Now: now,
 	}); err != nil || !duplicate || retried.ID != message.ID {
 		t.Fatalf("attachment message retry=%#v duplicate=%t err=%v", retried, duplicate, err)
@@ -216,7 +216,7 @@ func testTrustedAttachmentIntegration(ctx context.Context, t *testing.T, app *Da
 		_, _, retryErr := app.AppendMessage(relay.AppendInput{
 			ConversationID: conversation.ID, SenderMachineID: "attachment-uploader-machine",
 			PrincipalID: uploader.ID, CredentialLookupID: uploaderLookup, CredentialGeneration: 1,
-			FromEndpoint: "agent/attachment/uploader", Body: "trusted attachment reference",
+			FromEndpoint: "agent/attachment/uploader", TargetRole: "reviewer", Body: "trusted attachment reference",
 			ArtifactIDs: []string{reservation.ArtifactID}, IdempotencyKey: "attachment-message-append", Now: now,
 		})
 		retryResult <- retryErr

--- a/internal/postgres/attachment_recipient_schema.go
+++ b/internal/postgres/attachment_recipient_schema.go
@@ -22,7 +22,8 @@ WITH objects AS (
            to_regprocedure('attachment.bind_conversation_project(uuid,uuid,bigint,uuid,text,uuid)') AS conversation_bind_oid,
            to_regprocedure('attachment.bind_message_artifacts(uuid,uuid,bigint,uuid,jsonb)') AS message_bind_oid,
            to_regprocedure('attachment.project_has_recipient_records(uuid,uuid)') AS project_records_oid,
-           to_regprocedure('attachment.authorize_download(uuid,uuid,bigint,uuid)') AS download_oid
+           to_regprocedure('attachment.authorize_download(uuid,uuid,bigint,uuid)') AS download_oid,
+           to_regprocedure('attachment.recipient_rebind_allowed(text,text,uuid)') AS rebind_oid
 ), expected_columns(relation_name, column_name, type_name, type_modifier, required) AS (
     VALUES
       ('attachment.endpoint_principals','endpoint','text',-1,true),
@@ -67,8 +68,9 @@ WITH objects AS (
       (project_records_oid,'4fe60fc8c8ddcb2d9f2abe97cf8c195c','v'::"char",true,'boolean',false),
       (download_oid,'11c4af626ef77090e6957b96f6f11b72','s'::"char",true,'record',true)
     ) AS expected(oid,body_hash,volatility,application_execute,result_type,returns_set)
+    UNION ALL SELECT rebind_oid,'b6546919e05918d373ac2dd9f46b0c16','s'::"char",true,'boolean',false FROM objects WHERE $1 >= 40
 ), routine_safety AS (
-    SELECT count(*) = 6
+    SELECT count(*) = CASE WHEN $1 >= 40 THEN 7 ELSE 6 END
        AND bool_and(pg_get_userbyid(proc.proowner) = 'punaro_owner')
        AND bool_and(language.lanname IN ('sql','plpgsql'))
        AND bool_and(proc.prokind = 'f' AND proc.prosecdef AND proc.provolatile = expected.volatility)
@@ -79,10 +81,10 @@ WITH objects AS (
     JOIN pg_proc AS proc ON proc.oid = expected.oid
     JOIN pg_language AS language ON language.oid = proc.prolang
 ), routine_acl AS (
-    SELECT count(*) = 11
+    SELECT count(*) = CASE WHEN $1 >= 40 THEN 13 ELSE 11 END
        AND bool_and(acl.privilege_type = 'EXECUTE' AND NOT acl.is_grantable)
        AND bool_and(grantee.rolname IN ('punaro_owner','punaro_app'))
-       AND count(*) FILTER (WHERE grantee.rolname = 'punaro_app') = 5 AS exact
+       AND count(*) FILTER (WHERE grantee.rolname = 'punaro_app') = CASE WHEN $1 >= 40 THEN 6 ELSE 5 END AS exact
     FROM expected_routines AS expected
     JOIN pg_proc AS proc ON proc.oid = expected.oid
     CROSS JOIN LATERAL aclexplode(COALESCE(proc.proacl,acldefault('f',proc.proowner))) AS acl
@@ -188,6 +190,7 @@ SELECT endpoint_oid IS NOT NULL AND conversation_oid IS NOT NULL AND message_oid
    AND endpoint_index_oid IS NOT NULL AND conversation_index_oid IS NOT NULL AND grant_index_oid IS NOT NULL
    AND authority_oid IS NOT NULL AND endpoint_bind_oid IS NOT NULL AND conversation_bind_oid IS NOT NULL
    AND message_bind_oid IS NOT NULL AND project_records_oid IS NOT NULL AND download_oid IS NOT NULL
+   AND ($1 < 40 OR rebind_oid IS NOT NULL)
    AND pg_get_function_result(download_oid) = 'TABLE(artifact_id uuid, project_id uuid, storage_path text, size_bytes bigint, sha256 text, display_name text, media_type text, ready_at timestamp with time zone)'
    AND table_safety.exact AND table_acl.exact AND routine_safety.exact AND routine_acl.exact
    AND constraint_safety.exact AND check_safety.exact AND index_safety.exact
@@ -207,6 +210,7 @@ SELECT endpoint_oid IS NOT NULL AND conversation_oid IS NOT NULL AND message_oid
    AND has_function_privilege('punaro_app',message_bind_oid,'EXECUTE')
    AND has_function_privilege('punaro_app',project_records_oid,'EXECUTE')
    AND has_function_privilege('punaro_app',download_oid,'EXECUTE')
+   AND ($1 < 40 OR has_function_privilege('punaro_app',rebind_oid,'EXECUTE'))
 FROM objects, table_safety, table_acl, routine_safety, routine_acl, constraint_safety, check_safety, index_safety`, version).Scan(&available)
 	return available, err
 }

--- a/internal/postgres/attachment_recipient_schema.go
+++ b/internal/postgres/attachment_recipient_schema.go
@@ -100,7 +100,8 @@ WITH objects AS (
     WHERE relation.oid = ANY(ARRAY[endpoint_oid,conversation_oid,message_oid,grant_oid,evidence_oid])
 ), constraint_safety AS (
     SELECT count(*) = 27 AND bool_and(convalidated AND NOT condeferrable AND NOT condeferred)
-       AND count(*) FILTER (WHERE contype = 'f' AND confupdtype = 'a' AND confdeltype = 'a' AND confmatchtype = 's') = 13 AS exact
+       AND count(*) FILTER (WHERE contype = 'f' AND confupdtype = 'a' AND confdeltype = 'a' AND confmatchtype = 's') = 12
+       AND count(*) FILTER (WHERE conname = 'recipient_grant_endpoints_delivery_fkey' AND contype = 'f' AND confupdtype = 'c' AND confdeltype = 'a' AND confmatchtype = 's') = 1 AS exact
     FROM pg_constraint, objects
     WHERE conrelid = ANY(ARRAY[endpoint_oid,conversation_oid,message_oid,grant_oid,evidence_oid])
       AND contype <> 'n'

--- a/internal/postgres/attachment_recipient_schema.go
+++ b/internal/postgres/attachment_recipient_schema.go
@@ -5,7 +5,7 @@ import "context"
 // attachmentRecipientControlsAvailable verifies the exact schema-v11 stable
 // principal snapshot and download authority. Application code receives only
 // narrow routine execution, never direct lifecycle-table authority.
-func attachmentRecipientControlsAvailable(ctx context.Context, q queryer) (bool, error) {
+func attachmentRecipientControlsAvailable(ctx context.Context, q queryer, version int64) (bool, error) {
 	var available bool
 	err := q.QueryRowContext(ctx, `
 WITH objects AS (
@@ -100,8 +100,8 @@ WITH objects AS (
     WHERE relation.oid = ANY(ARRAY[endpoint_oid,conversation_oid,message_oid,grant_oid,evidence_oid])
 ), constraint_safety AS (
     SELECT count(*) = 27 AND bool_and(convalidated AND NOT condeferrable AND NOT condeferred)
-       AND count(*) FILTER (WHERE contype = 'f' AND confupdtype = 'a' AND confdeltype = 'a' AND confmatchtype = 's') = 12
-       AND count(*) FILTER (WHERE conname = 'recipient_grant_endpoints_delivery_fkey' AND contype = 'f' AND confupdtype = 'c' AND confdeltype = 'a' AND confmatchtype = 's') = 1 AS exact
+       AND count(*) FILTER (WHERE contype = 'f' AND confupdtype = 'a' AND confdeltype = 'a' AND confmatchtype = 's') = CASE WHEN $1 >= 40 THEN 12 ELSE 13 END
+       AND ($1 < 40 OR count(*) FILTER (WHERE conname = 'recipient_grant_endpoints_delivery_fkey' AND contype = 'f' AND confupdtype = 'c' AND confdeltype = 'a' AND confmatchtype = 's') = 1) AS exact
     FROM pg_constraint, objects
     WHERE conrelid = ANY(ARRAY[endpoint_oid,conversation_oid,message_oid,grant_oid,evidence_oid])
       AND contype <> 'n'
@@ -207,6 +207,6 @@ SELECT endpoint_oid IS NOT NULL AND conversation_oid IS NOT NULL AND message_oid
    AND has_function_privilege('punaro_app',message_bind_oid,'EXECUTE')
    AND has_function_privilege('punaro_app',project_records_oid,'EXECUTE')
    AND has_function_privilege('punaro_app',download_oid,'EXECUTE')
-FROM objects, table_safety, table_acl, routine_safety, routine_acl, constraint_safety, check_safety, index_safety`).Scan(&available)
+FROM objects, table_safety, table_acl, routine_safety, routine_acl, constraint_safety, check_safety, index_safety`, version).Scan(&available)
 	return available, err
 }

--- a/internal/postgres/db.go
+++ b/internal/postgres/db.go
@@ -1054,7 +1054,7 @@ FROM objects, table_ownership, routine_safety, routine_acl, table_acl, schema_ac
 		snapshot.CurrentObjectsPresent = updateObjectsPresent
 	}
 	if snapshot.CurrentObjectsPresent && len(snapshot.Records) > 0 && snapshot.Records[len(snapshot.Records)-1].Version >= 7 {
-		relayObjectsPresent, err := relayControlsAvailable(ctx, q)
+		relayObjectsPresent, err := relayControlsAvailable(ctx, q, snapshot.Records[len(snapshot.Records)-1].Version)
 		if err != nil {
 			return Snapshot{}, errors.New("PostgreSQL relay schema cannot be inspected")
 		}
@@ -1075,7 +1075,7 @@ FROM objects, table_ownership, routine_safety, routine_acl, table_acl, schema_ac
 		snapshot.CurrentObjectsPresent = attachmentObjectsPresent
 	}
 	if snapshot.CurrentObjectsPresent && len(snapshot.Records) > 0 && snapshot.Records[len(snapshot.Records)-1].Version >= 11 {
-		recipientObjectsPresent, err := attachmentRecipientControlsAvailable(ctx, q)
+		recipientObjectsPresent, err := attachmentRecipientControlsAvailable(ctx, q, snapshot.Records[len(snapshot.Records)-1].Version)
 		if err != nil {
 			return Snapshot{}, errors.New("PostgreSQL attachment-recipient schema cannot be inspected")
 		}

--- a/internal/postgres/mail_cutover.go
+++ b/internal/postgres/mail_cutover.go
@@ -67,7 +67,7 @@ func canonicalMailCutoverManifest(request MailCutoverRequest) ([]byte, error) {
 	}
 	counts := []int64{manifest.Counts.Endpoints, manifest.Counts.Conversations, manifest.Counts.Memberships, manifest.Counts.Messages, manifest.Counts.Deliveries, manifest.Counts.RecipientCursors, manifest.Counts.MessageIdempotency, manifest.Counts.ConversationIdempotency, manifest.Counts.RequestNonces}
 	hashes := []string{manifest.TableSHA256.Endpoints, manifest.TableSHA256.Conversations, manifest.TableSHA256.Memberships, manifest.TableSHA256.Messages, manifest.TableSHA256.Deliveries, manifest.TableSHA256.RecipientCursors, manifest.TableSHA256.MessageIdempotency, manifest.TableSHA256.ConversationIdempotency, manifest.TableSHA256.RequestNonces}
-	if manifest.Version != 1 || manifest.SourceID != request.SourceID || manifest.Phase != relay.MigrationSourcePrepared || manifest.EpochID != request.EpochID || manifest.TargetIdentity != request.TargetIdentity || manifest.Fingerprint != request.SourceFingerprint {
+	if manifest.Version != 2 || manifest.SourceID != request.SourceID || manifest.Phase != relay.MigrationSourcePrepared || manifest.EpochID != request.EpochID || manifest.TargetIdentity != request.TargetIdentity || manifest.Fingerprint != request.SourceFingerprint {
 		return nil, errors.New("mail cutover manifest binding does not match")
 	}
 	for _, count := range counts {

--- a/internal/postgres/mail_cutover_import.go
+++ b/internal/postgres/mail_cutover_import.go
@@ -359,11 +359,11 @@ var mailCutoverMaterializationStatements = []string{
 	`INSERT INTO relay.mail_conversations(id,next_sequence,created_at)
 	 SELECT (payload->>'id')::uuid,(payload->>'next_sequence')::bigint,TIMESTAMPTZ 'epoch'+(payload->>'created_at')::bigint*INTERVAL '1 millisecond'
 	 FROM relay.mail_cutover_staging WHERE epoch_id=$1 AND table_name='mail_conversations' ORDER BY row_key COLLATE "C"`,
-	`INSERT INTO relay.mail_memberships(conversation_id,endpoint,capabilities)
-	 SELECT (payload->>'conversation_id')::uuid,payload->>'endpoint',(payload->>'capabilities')::smallint
+	`INSERT INTO relay.mail_memberships(conversation_id,endpoint,capabilities,role)
+	 SELECT (payload->>'conversation_id')::uuid,payload->>'endpoint',(payload->>'capabilities')::smallint,payload->>'role'
 	 FROM relay.mail_cutover_staging WHERE epoch_id=$1 AND table_name='mail_memberships' ORDER BY row_key COLLATE "C"`,
-	`INSERT INTO relay.mail_messages(id,conversation_id,sequence,from_endpoint,body,created_at)
-	 SELECT (payload->>'id')::uuid,(payload->>'conversation_id')::uuid,(payload->>'sequence')::bigint,payload->>'from_endpoint',payload->>'body',TIMESTAMPTZ 'epoch'+(payload->>'created_at')::bigint*INTERVAL '1 millisecond'
+	`INSERT INTO relay.mail_messages(id,conversation_id,sequence,from_endpoint,target_role,body,created_at)
+	 SELECT (payload->>'id')::uuid,(payload->>'conversation_id')::uuid,(payload->>'sequence')::bigint,payload->>'from_endpoint',payload->>'target_role',payload->>'body',TIMESTAMPTZ 'epoch'+(payload->>'created_at')::bigint*INTERVAL '1 millisecond'
 	 FROM relay.mail_cutover_staging WHERE epoch_id=$1 AND table_name='mail_messages' ORDER BY row_key COLLATE "C"`,
 	`INSERT INTO relay.mail_deliveries(id,message_id,recipient_endpoint,lease_machine_id,lease_token,lease_generation,ownership_generation,consumer_generation,lease_until,acked_at)
 	 SELECT (payload->>'id')::uuid,(payload->>'message_id')::uuid,payload->>'recipient_endpoint',payload->>'lease_machine_id',(payload->>'lease_token')::uuid,(payload->>'lease_generation')::bigint,(payload->>'ownership_generation')::bigint,(payload->>'consumer_generation')::bigint,

--- a/internal/postgres/mail_cutover_test.go
+++ b/internal/postgres/mail_cutover_test.go
@@ -43,7 +43,7 @@ func TestMailCutoverRequestValidation(t *testing.T) {
 		SourceFingerprint: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
 	}
 	manifest := relay.MigrationSourceManifest{
-		Version: 1, SourceID: valid.SourceID, Phase: relay.MigrationSourcePrepared, EpochID: valid.EpochID,
+		Version: 2, SourceID: valid.SourceID, Phase: relay.MigrationSourcePrepared, EpochID: valid.EpochID,
 		TargetIdentity: valid.TargetIdentity, Fingerprint: valid.SourceFingerprint,
 		TableSHA256: relay.MigrationSourceHashes{
 			Endpoints: strings.Repeat("c", 64), Conversations: strings.Repeat("c", 64), Memberships: strings.Repeat("c", 64),

--- a/internal/postgres/migrate.go
+++ b/internal/postgres/migrate.go
@@ -72,6 +72,7 @@ var migrationCompatibilityFloors = map[int64]int64{
 	37: 10,
 	38: 10,
 	39: 10,
+	40: 10,
 }
 
 // CurrentManifest returns the immutable migrations embedded in this binary.

--- a/internal/postgres/migrations/040_conversation_roles.sql
+++ b/internal/postgres/migrations/040_conversation_roles.sql
@@ -21,8 +21,9 @@ ON relay.mail_memberships (conversation_id, role, endpoint)
 WHERE (capabilities & 2) <> 0;
 
 -- Rebinding an unacknowledged delivery must retain the endpoint evidence for
--- attachments already bound to that delivery. The recipient principal remains
--- unchanged, so this carries no attachment authorization to a new principal.
+-- attachments already bound to that delivery. The application checks this
+-- function before a rebind; an attachment recipient can move only within the
+-- same stable principal.
 ALTER TABLE attachment.recipient_grant_endpoints
     DROP CONSTRAINT recipient_grant_endpoints_delivery_fkey,
     ADD CONSTRAINT recipient_grant_endpoints_delivery_fkey
@@ -30,6 +31,34 @@ ALTER TABLE attachment.recipient_grant_endpoints
         REFERENCES relay.mail_deliveries(message_id, recipient_endpoint)
         ON UPDATE CASCADE;
 
+CREATE FUNCTION attachment.recipient_rebind_allowed(
+    previous_endpoint text,
+    replacement_endpoint text,
+    requested_conversation uuid
+)
+RETURNS boolean
+LANGUAGE sql
+SECURITY DEFINER
+STABLE
+SET search_path = pg_catalog
+AS $function$
+    SELECT COALESCE(bool_and(
+        previous_binding.principal_id IS NOT NULL
+        AND replacement_binding.principal_id IS NOT NULL
+        AND previous_binding.principal_id = replacement_binding.principal_id
+    ), true)
+    FROM relay.mail_deliveries AS delivery
+    JOIN relay.mail_messages AS message ON message.id = delivery.message_id
+    JOIN attachment.message_artifacts AS artifact ON artifact.message_id = message.id
+    LEFT JOIN attachment.endpoint_principals AS previous_binding ON previous_binding.endpoint = previous_endpoint
+    LEFT JOIN attachment.endpoint_principals AS replacement_binding ON replacement_binding.endpoint = replacement_endpoint
+    WHERE delivery.recipient_endpoint = previous_endpoint
+      AND delivery.acked_at IS NULL
+      AND message.conversation_id = requested_conversation
+$function$;
+
 GRANT UPDATE (endpoint, capabilities, role) ON relay.mail_memberships TO punaro_app;
 GRANT UPDATE (recipient_endpoint) ON relay.mail_deliveries TO punaro_app;
 GRANT DELETE ON relay.mail_recipient_cursors TO punaro_app;
+REVOKE ALL ON FUNCTION attachment.recipient_rebind_allowed(text,text,uuid) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION attachment.recipient_rebind_allowed(text,text,uuid) TO punaro_app;

--- a/internal/postgres/migrations/040_conversation_roles.sql
+++ b/internal/postgres/migrations/040_conversation_roles.sql
@@ -20,4 +20,16 @@ CREATE INDEX mail_memberships_role_active
 ON relay.mail_memberships (conversation_id, role, endpoint)
 WHERE (capabilities & 2) <> 0;
 
+-- Rebinding an unacknowledged delivery must retain the endpoint evidence for
+-- attachments already bound to that delivery. The recipient principal remains
+-- unchanged, so this carries no attachment authorization to a new principal.
+ALTER TABLE attachment.recipient_grant_endpoints
+    DROP CONSTRAINT recipient_grant_endpoints_delivery_fkey,
+    ADD CONSTRAINT recipient_grant_endpoints_delivery_fkey
+        FOREIGN KEY (message_id, recipient_endpoint)
+        REFERENCES relay.mail_deliveries(message_id, recipient_endpoint)
+        ON UPDATE CASCADE;
+
 GRANT UPDATE (endpoint, capabilities, role) ON relay.mail_memberships TO punaro_app;
+GRANT UPDATE (recipient_endpoint) ON relay.mail_deliveries TO punaro_app;
+GRANT DELETE ON relay.mail_recipient_cursors TO punaro_app;

--- a/internal/postgres/migrations/040_conversation_roles.sql
+++ b/internal/postgres/migrations/040_conversation_roles.sql
@@ -1,0 +1,23 @@
+ALTER TABLE relay.mail_memberships
+    ADD COLUMN role text NOT NULL DEFAULT '' CHECK (
+        (role = '') OR (
+            char_length(role) >= 1 AND char_length(role) <= 64
+            AND octet_length(role) <= 256 AND btrim(role) = role
+            AND role !~ '[[:cntrl:]]'
+        )
+    );
+
+ALTER TABLE relay.mail_messages
+    ADD COLUMN target_role text NOT NULL DEFAULT '' CHECK (
+        (target_role = '') OR (
+            char_length(target_role) >= 1 AND char_length(target_role) <= 64
+            AND octet_length(target_role) <= 256 AND btrim(target_role) = target_role
+            AND target_role !~ '[[:cntrl:]]'
+        )
+    );
+
+CREATE INDEX mail_memberships_role_active
+ON relay.mail_memberships (conversation_id, role, endpoint)
+WHERE (capabilities & 2) <> 0;
+
+GRANT UPDATE (endpoint, capabilities, role) ON relay.mail_memberships TO punaro_app;

--- a/internal/postgres/migrations/040_conversation_roles.sql
+++ b/internal/postgres/migrations/040_conversation_roles.sql
@@ -43,14 +43,17 @@ STABLE
 SET search_path = pg_catalog
 AS $function$
     SELECT COALESCE(bool_and(
-        previous_binding.principal_id IS NOT NULL
+        evidence.recipient_principal_id IS NOT NULL
         AND replacement_binding.principal_id IS NOT NULL
-        AND previous_binding.principal_id = replacement_binding.principal_id
+        AND replacement_binding.principal_id = evidence.recipient_principal_id
     ), true)
     FROM relay.mail_deliveries AS delivery
     JOIN relay.mail_messages AS message ON message.id = delivery.message_id
     JOIN attachment.message_artifacts AS artifact ON artifact.message_id = message.id
-    LEFT JOIN attachment.endpoint_principals AS previous_binding ON previous_binding.endpoint = previous_endpoint
+    LEFT JOIN attachment.recipient_grant_endpoints AS evidence
+      ON evidence.message_id = delivery.message_id
+     AND evidence.recipient_endpoint = delivery.recipient_endpoint
+     AND evidence.artifact_id = artifact.artifact_id
     LEFT JOIN attachment.endpoint_principals AS replacement_binding ON replacement_binding.endpoint = replacement_endpoint
     WHERE delivery.recipient_endpoint = previous_endpoint
       AND delivery.acked_at IS NULL

--- a/internal/postgres/postgres_integration_test.go
+++ b/internal/postgres/postgres_integration_test.go
@@ -983,7 +983,7 @@ func testMailCutoverSubstrate(ctx context.Context, t *testing.T, app *Database, 
 		SourceFingerprint: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
 	}
 	manifest := relay.MigrationSourceManifest{
-		Version: 1, SourceID: request.SourceID, Phase: relay.MigrationSourcePrepared, EpochID: request.EpochID,
+		Version: 2, SourceID: request.SourceID, Phase: relay.MigrationSourcePrepared, EpochID: request.EpochID,
 		TargetIdentity: request.TargetIdentity, Fingerprint: request.SourceFingerprint,
 		TableSHA256: relay.MigrationSourceHashes{
 			Endpoints: emptyMailCutoverDigest, Conversations: emptyMailCutoverDigest, Memberships: emptyMailCutoverDigest,

--- a/internal/postgres/relay_store.go
+++ b/internal/postgres/relay_store.go
@@ -924,7 +924,7 @@ func (d *Database) relayPool() *sql.DB {
 	return d.db
 }
 
-func relayControlsAvailable(ctx context.Context, q queryer) (bool, error) {
+func relayControlsAvailable(ctx context.Context, q queryer, version int64) (bool, error) {
 	var available bool
 	err := q.QueryRowContext(ctx, `
 WITH objects AS (
@@ -940,6 +940,7 @@ WITH objects AS (
            to_regclass('relay.mail_endpoints_machine') AS endpoints_index_oid,
            to_regclass('relay.mail_deliveries_pending') AS deliveries_index_oid,
            to_regclass('relay.mail_request_nonces_expiry') AS nonces_index_oid,
+           to_regclass('relay.mail_memberships_role_active') AS roles_index_oid,
            to_regprocedure('relay.consume_mail_request_nonce(text,text,timestamp with time zone,timestamp with time zone)') AS consume_oid,
            to_regprocedure('jobs.guard_application_mutation()') AS legacy_guard_oid,
            to_regprocedure('relay.guard_mail_mutation()') AS cutover_guard_oid
@@ -953,9 +954,9 @@ WITH objects AS (
         (endpoints_oid,'consumer_id','text'::regtype,false),(endpoints_oid,'consumer_generation','bigint'::regtype,true),
         (endpoints_oid,'consumer_lease_until','timestamptz'::regtype,false),
         (conversations_oid,'id','uuid'::regtype,true),(conversations_oid,'next_sequence','bigint'::regtype,true),(conversations_oid,'created_at','timestamptz'::regtype,true),
-        (memberships_oid,'conversation_id','uuid'::regtype,true),(memberships_oid,'endpoint','text'::regtype,true),(memberships_oid,'capabilities','smallint'::regtype,true),(memberships_oid,'role','text'::regtype,true),
+        (memberships_oid,'conversation_id','uuid'::regtype,true),(memberships_oid,'endpoint','text'::regtype,true),(memberships_oid,'capabilities','smallint'::regtype,true),
         (messages_oid,'id','uuid'::regtype,true),(messages_oid,'conversation_id','uuid'::regtype,true),(messages_oid,'sequence','bigint'::regtype,true),
-        (messages_oid,'from_endpoint','text'::regtype,true),(messages_oid,'body','text'::regtype,true),(messages_oid,'created_at','timestamptz'::regtype,true),(messages_oid,'target_role','text'::regtype,true),
+        (messages_oid,'from_endpoint','text'::regtype,true),(messages_oid,'body','text'::regtype,true),(messages_oid,'created_at','timestamptz'::regtype,true),
         (deliveries_oid,'id','uuid'::regtype,true),(deliveries_oid,'message_id','uuid'::regtype,true),(deliveries_oid,'recipient_endpoint','text'::regtype,true),
         (deliveries_oid,'lease_machine_id','text'::regtype,false),(deliveries_oid,'lease_token','uuid'::regtype,false),(deliveries_oid,'lease_generation','bigint'::regtype,true),
         (deliveries_oid,'ownership_generation','bigint'::regtype,false),(deliveries_oid,'consumer_generation','bigint'::regtype,false),
@@ -967,6 +968,8 @@ WITH objects AS (
         (conversation_idempotency_oid,'conversation_id','uuid'::regtype,true),(conversation_idempotency_oid,'created_at','timestamptz'::regtype,true),
         (nonces_oid,'machine_id','text'::regtype,true),(nonces_oid,'nonce','text'::regtype,true),(nonces_oid,'expires_at','timestamptz'::regtype,true)
     ) AS expected(table_oid,column_name,type_oid,required)
+    UNION ALL SELECT memberships_oid,'role','text'::regtype,true FROM objects WHERE $1 >= 40
+    UNION ALL SELECT messages_oid,'target_role','text'::regtype,true FROM objects WHERE $1 >= 40
 ), actual_columns AS (
     SELECT attribute.attrelid,attribute.attname,attribute.atttypid,attribute.attnotnull
     FROM objects JOIN pg_attribute AS attribute
@@ -982,10 +985,11 @@ WITH objects AS (
     SELECT expected.* FROM objects, LATERAL (VALUES
         (endpoints_oid,'ownership_generation','1'),(endpoints_oid,'consumer_generation','0'),
         (conversations_oid,'id','gen_random_uuid()'),(conversations_oid,'next_sequence','0'),(conversations_oid,'created_at','statement_timestamp()'),
-        (memberships_oid,'role',quote_literal('') || '::text'),
-        (messages_oid,'id','gen_random_uuid()'),(messages_oid,'target_role',quote_literal('') || '::text'),(deliveries_oid,'id','gen_random_uuid()'),(deliveries_oid,'lease_generation','0'),
+        (messages_oid,'id','gen_random_uuid()'),(deliveries_oid,'id','gen_random_uuid()'),(deliveries_oid,'lease_generation','0'),
         (cursors_oid,'sequence','0')
     ) AS expected(table_oid,column_name,expression)
+    UNION ALL SELECT memberships_oid,'role',quote_literal('') || '::text' FROM objects WHERE $1 >= 40
+    UNION ALL SELECT messages_oid,'target_role',quote_literal('') || '::text' FROM objects WHERE $1 >= 40
 ), actual_defaults AS (
     SELECT default_value.adrelid,attribute.attname,pg_get_expr(default_value.adbin,default_value.adrelid)
     FROM objects JOIN pg_attrdef AS default_value
@@ -1027,12 +1031,14 @@ WITH objects AS (
     SELECT expected.* FROM objects, LATERAL (VALUES
         (endpoints_oid,ARRAY[1]::smallint[]),(endpoints_oid,ARRAY[2]::smallint[]),(endpoints_oid,ARRAY[4]::smallint[]),
         (endpoints_oid,ARRAY[5]::smallint[]),(endpoints_oid,ARRAY[6]::smallint[]),(endpoints_oid,ARRAY[5,7]::smallint[]),
-        (conversations_oid,ARRAY[2]::smallint[]),(memberships_oid,ARRAY[3]::smallint[]),(memberships_oid,ARRAY[4]::smallint[]),
-        (messages_oid,ARRAY[3]::smallint[]),(messages_oid,ARRAY[5]::smallint[]),(messages_oid,ARRAY[7]::smallint[]),
+        (conversations_oid,ARRAY[2]::smallint[]),(memberships_oid,ARRAY[3]::smallint[]),
+        (messages_oid,ARRAY[3]::smallint[]),(messages_oid,ARRAY[5]::smallint[]),
         (deliveries_oid,ARRAY[6]::smallint[]),(deliveries_oid,ARRAY[4,5,7,8,9]::smallint[]),
         (cursors_oid,ARRAY[3]::smallint[]),(message_idempotency_oid,ARRAY[2]::smallint[]),(message_idempotency_oid,ARRAY[3]::smallint[]),
         (conversation_idempotency_oid,ARRAY[2]::smallint[]),(conversation_idempotency_oid,ARRAY[3]::smallint[]),(nonces_oid,ARRAY[2]::smallint[])
     ) AS expected(table_oid,column_keys)
+    UNION ALL SELECT memberships_oid,ARRAY[4]::smallint[] FROM objects WHERE $1 >= 40
+    UNION ALL SELECT messages_oid,ARRAY[7]::smallint[] FROM objects WHERE $1 >= 40
 ), actual_check_keys AS (
     SELECT con.conrelid,con.conkey
     FROM objects JOIN pg_constraint AS con
@@ -1050,10 +1056,10 @@ WITH objects AS (
        AND EXISTS (SELECT 1 FROM pg_constraint WHERE conrelid=endpoints_oid AND contype='c' AND conkey @> ARRAY[5,7]::smallint[] AND conkey <@ ARRAY[5,7]::smallint[] AND pg_get_expr(conbin,conrelid)='((consumer_id IS NULL) = (consumer_lease_until IS NULL))')
        AND EXISTS (SELECT 1 FROM pg_constraint WHERE conrelid=conversations_oid AND contype='c' AND conkey=ARRAY[2]::smallint[] AND pg_get_expr(conbin,conrelid)='(next_sequence >= 0)')
        AND EXISTS (SELECT 1 FROM pg_constraint WHERE conrelid=memberships_oid AND contype='c' AND conkey=ARRAY[3]::smallint[] AND pg_get_expr(conbin,conrelid)='((capabilities >= 1) AND (capabilities <= 7))')
-       AND EXISTS (SELECT 1 FROM pg_constraint WHERE conrelid=memberships_oid AND contype='c' AND conkey=ARRAY[4]::smallint[] AND pg_get_expr(conbin,conrelid)='((role = ''''::text) OR ((char_length(role) >= 1) AND (char_length(role) <= 64) AND (octet_length(role) <= 256) AND (btrim(role) = role) AND (role !~ ''[[:cntrl:]]''::text)))')
+       AND ($1 < 40 OR EXISTS (SELECT 1 FROM pg_constraint WHERE conrelid=memberships_oid AND contype='c' AND conkey=ARRAY[4]::smallint[] AND pg_get_expr(conbin,conrelid)='((role = ''''::text) OR ((char_length(role) >= 1) AND (char_length(role) <= 64) AND (octet_length(role) <= 256) AND (btrim(role) = role) AND (role !~ ''[[:cntrl:]]''::text)))'))
        AND EXISTS (SELECT 1 FROM pg_constraint WHERE conrelid=messages_oid AND contype='c' AND conkey=ARRAY[3]::smallint[] AND pg_get_expr(conbin,conrelid)='(sequence > 0)')
        AND EXISTS (SELECT 1 FROM pg_constraint WHERE conrelid=messages_oid AND contype='c' AND conkey=ARRAY[5]::smallint[] AND pg_get_expr(conbin,conrelid)='(octet_length(body) <= 32768)')
-       AND EXISTS (SELECT 1 FROM pg_constraint WHERE conrelid=messages_oid AND contype='c' AND conkey=ARRAY[7]::smallint[] AND pg_get_expr(conbin,conrelid)='((target_role = ''''::text) OR ((char_length(target_role) >= 1) AND (char_length(target_role) <= 64) AND (octet_length(target_role) <= 256) AND (btrim(target_role) = target_role) AND (target_role !~ ''[[:cntrl:]]''::text)))')
+       AND ($1 < 40 OR EXISTS (SELECT 1 FROM pg_constraint WHERE conrelid=messages_oid AND contype='c' AND conkey=ARRAY[7]::smallint[] AND pg_get_expr(conbin,conrelid)='((target_role = ''''::text) OR ((char_length(target_role) >= 1) AND (char_length(target_role) <= 64) AND (octet_length(target_role) <= 256) AND (btrim(target_role) = target_role) AND (target_role !~ ''[[:cntrl:]]''::text)))'))
        AND EXISTS (SELECT 1 FROM pg_constraint WHERE conrelid=deliveries_oid AND contype='c' AND conkey=ARRAY[6]::smallint[] AND pg_get_expr(conbin,conrelid)='(lease_generation >= 0)')
        AND EXISTS (SELECT 1 FROM pg_constraint WHERE conrelid=deliveries_oid AND contype='c' AND conkey @> ARRAY[4,5,7,8,9]::smallint[] AND conkey <@ ARRAY[4,5,7,8,9]::smallint[] AND pg_get_expr(conbin,conrelid)='(((lease_machine_id IS NULL) AND (lease_token IS NULL) AND (ownership_generation IS NULL) AND (consumer_generation IS NULL) AND (lease_until IS NULL)) OR ((lease_machine_id IS NOT NULL) AND (lease_token IS NOT NULL) AND (ownership_generation IS NOT NULL) AND (consumer_generation IS NOT NULL) AND (lease_until IS NOT NULL)))')
        AND EXISTS (SELECT 1 FROM pg_constraint WHERE conrelid=cursors_oid AND contype='c' AND conkey=ARRAY[3]::smallint[] AND pg_get_expr(conbin,conrelid)='(sequence >= 0)')
@@ -1067,7 +1073,7 @@ WITH objects AS (
     SELECT count(*) FILTER (WHERE con.contype='p')=9
        AND count(*) FILTER (WHERE con.contype='u')=4
 	       AND count(*) FILTER (WHERE con.contype='f')=10
-	       AND count(*) FILTER (WHERE con.contype='c')=20
+	       AND count(*) FILTER (WHERE con.contype='c')=CASE WHEN $1 >= 40 THEN 20 ELSE 18 END
 	       AND NOT EXISTS (SELECT * FROM expected_keys EXCEPT SELECT * FROM actual_keys)
 	       AND NOT EXISTS (SELECT * FROM actual_keys EXCEPT SELECT * FROM expected_keys)
 	       AND NOT EXISTS (SELECT * FROM expected_foreign_keys EXCEPT SELECT * FROM actual_foreign_keys)
@@ -1106,25 +1112,27 @@ WITH objects AS (
        AND md5(regexp_replace(proc.prosrc,'^\s+|\s+$','','g'))='4c348d98b79375c10c6c53728b7368fb') AS exact
     FROM objects JOIN pg_proc AS proc ON proc.oid=consume_oid
 ), index_safety AS (
-    SELECT count(*)=3 AND bool_and(index.indisvalid AND index.indisready AND index.indislive AND NOT index.indisunique
+    SELECT count(*)=CASE WHEN $1 >= 40 THEN 4 ELSE 3 END AND bool_and(index.indisvalid AND index.indisready AND index.indislive AND NOT index.indisunique
        AND index.indnkeyatts=index.indnatts AND access_method.amname='btree'
        AND pg_get_userbyid(relation.relowner)='punaro_owner'
        AND CASE index.indexrelid
            WHEN objects.endpoints_index_oid THEN index.indrelid=objects.endpoints_oid AND index.indkey::text='2 3 1'
            WHEN objects.deliveries_index_oid THEN index.indrelid=objects.deliveries_oid AND index.indkey::text='3 10 9 1'
            WHEN objects.nonces_index_oid THEN index.indrelid=objects.nonces_oid AND index.indkey::text='3 1 2'
+           WHEN objects.roles_index_oid THEN index.indrelid=objects.memberships_oid AND index.indkey::text='1 4 2' AND pg_get_expr(index.indpred,index.indrelid)='((capabilities & 2) <> 0)'
            ELSE false END) AS exact
-    FROM objects JOIN pg_index AS index ON index.indexrelid=ANY(ARRAY[endpoints_index_oid,deliveries_index_oid,nonces_index_oid])
+    FROM objects JOIN pg_index AS index ON index.indexrelid=ANY(ARRAY[endpoints_index_oid,deliveries_index_oid,nonces_index_oid,roles_index_oid])
     JOIN pg_class AS relation ON relation.oid=index.indexrelid
     JOIN pg_am AS access_method ON access_method.oid=relation.relam
 ), expected_table_acl(table_oid,privilege_type) AS (
     SELECT expected.* FROM objects, LATERAL (VALUES
         (endpoints_oid,'SELECT'),(endpoints_oid,'INSERT'),(conversations_oid,'SELECT'),(conversations_oid,'INSERT'),
         (memberships_oid,'SELECT'),(memberships_oid,'INSERT'),(messages_oid,'SELECT'),(messages_oid,'INSERT'),
-        (deliveries_oid,'SELECT'),(deliveries_oid,'INSERT'),(cursors_oid,'SELECT'),(cursors_oid,'INSERT'),(cursors_oid,'DELETE'),
+        (deliveries_oid,'SELECT'),(deliveries_oid,'INSERT'),(cursors_oid,'SELECT'),(cursors_oid,'INSERT'),
         (message_idempotency_oid,'SELECT'),(message_idempotency_oid,'INSERT'),
         (conversation_idempotency_oid,'SELECT'),(conversation_idempotency_oid,'INSERT')
     ) AS expected(table_oid,privilege_type)
+    UNION ALL SELECT cursors_oid,'DELETE' FROM objects WHERE $1 >= 40
 ), actual_table_acl AS (
     SELECT relation.oid,acl.privilege_type
     FROM objects JOIN pg_class AS relation
@@ -1140,11 +1148,14 @@ WITH objects AS (
         (endpoints_oid,'machine_id','UPDATE'),(endpoints_oid,'lease_until','UPDATE'),(endpoints_oid,'ownership_generation','UPDATE'),
         (endpoints_oid,'consumer_id','UPDATE'),(endpoints_oid,'consumer_generation','UPDATE'),(endpoints_oid,'consumer_lease_until','UPDATE'),
         (conversations_oid,'next_sequence','UPDATE'),
-        (memberships_oid,'endpoint','UPDATE'),(memberships_oid,'capabilities','UPDATE'),(memberships_oid,'role','UPDATE'),
 		(deliveries_oid,'lease_machine_id','UPDATE'),(deliveries_oid,'lease_token','UPDATE'),(deliveries_oid,'lease_generation','UPDATE'),
-		(deliveries_oid,'ownership_generation','UPDATE'),(deliveries_oid,'consumer_generation','UPDATE'),(deliveries_oid,'lease_until','UPDATE'),(deliveries_oid,'acked_at','UPDATE'),(deliveries_oid,'recipient_endpoint','UPDATE'),
+		(deliveries_oid,'ownership_generation','UPDATE'),(deliveries_oid,'consumer_generation','UPDATE'),(deliveries_oid,'lease_until','UPDATE'),(deliveries_oid,'acked_at','UPDATE'),
         (cursors_oid,'sequence','UPDATE')
     ) AS expected(table_oid,column_name,privilege_type)
+    UNION ALL SELECT memberships_oid,'endpoint','UPDATE' FROM objects WHERE $1 >= 40
+    UNION ALL SELECT memberships_oid,'capabilities','UPDATE' FROM objects WHERE $1 >= 40
+    UNION ALL SELECT memberships_oid,'role','UPDATE' FROM objects WHERE $1 >= 40
+    UNION ALL SELECT deliveries_oid,'recipient_endpoint','UPDATE' FROM objects WHERE $1 >= 40
 ), actual_column_acl AS (
     SELECT attribute.attrelid,attribute.attname,acl.privilege_type
     FROM objects JOIN pg_attribute AS attribute
@@ -1161,6 +1172,7 @@ SELECT endpoints_oid IS NOT NULL AND conversations_oid IS NOT NULL AND membershi
    AND messages_oid IS NOT NULL AND deliveries_oid IS NOT NULL AND cursors_oid IS NOT NULL
    AND message_idempotency_oid IS NOT NULL AND conversation_idempotency_oid IS NOT NULL AND nonces_oid IS NOT NULL
    AND endpoints_index_oid IS NOT NULL AND deliveries_index_oid IS NOT NULL AND nonces_index_oid IS NOT NULL
+   AND ($1 < 40 OR roles_index_oid IS NOT NULL)
    AND consume_oid IS NOT NULL AND (legacy_guard_oid IS NOT NULL OR cutover_guard_oid IS NOT NULL)
 	   AND table_ownership.exact AND columns.exact AND defaults.exact AND constraints.exact AND guards.exact AND function_safety.exact AND index_safety.exact
 	   AND table_acl.exact AND column_acl.exact
@@ -1205,10 +1217,10 @@ SELECT endpoints_oid IS NOT NULL AND conversations_oid IS NOT NULL AND membershi
 	   AND NOT has_column_privilege('punaro_app',conversations_oid,'id','UPDATE')
 	   AND NOT has_column_privilege('punaro_app',conversations_oid,'created_at','UPDATE')
    AND has_table_privilege('punaro_app',memberships_oid,'SELECT') AND has_table_privilege('punaro_app',memberships_oid,'INSERT')
-	   AND NOT has_table_privilege('punaro_app',memberships_oid,'UPDATE')
-	   AND has_column_privilege('punaro_app',memberships_oid,'endpoint','UPDATE')
-	   AND has_column_privilege('punaro_app',memberships_oid,'capabilities','UPDATE')
-	   AND has_column_privilege('punaro_app',memberships_oid,'role','UPDATE')
+	   AND ($1 < 40 OR (NOT has_table_privilege('punaro_app',memberships_oid,'UPDATE')
+	       AND has_column_privilege('punaro_app',memberships_oid,'endpoint','UPDATE')
+	       AND has_column_privilege('punaro_app',memberships_oid,'capabilities','UPDATE')
+	       AND has_column_privilege('punaro_app',memberships_oid,'role','UPDATE')))
    AND has_table_privilege('punaro_app',messages_oid,'SELECT') AND has_table_privilege('punaro_app',messages_oid,'INSERT')
 	   AND has_table_privilege('punaro_app',deliveries_oid,'SELECT') AND has_table_privilege('punaro_app',deliveries_oid,'INSERT')
 	   AND NOT has_table_privilege('punaro_app',deliveries_oid,'UPDATE')
@@ -1221,8 +1233,10 @@ SELECT endpoints_oid IS NOT NULL AND conversations_oid IS NOT NULL AND membershi
 	   AND has_column_privilege('punaro_app',deliveries_oid,'acked_at','UPDATE')
 	   AND NOT has_column_privilege('punaro_app',deliveries_oid,'id','UPDATE')
 	   AND NOT has_column_privilege('punaro_app',deliveries_oid,'message_id','UPDATE')
-	   AND has_column_privilege('punaro_app',deliveries_oid,'recipient_endpoint','UPDATE')
-	   AND has_table_privilege('punaro_app',cursors_oid,'SELECT') AND has_table_privilege('punaro_app',cursors_oid,'INSERT') AND has_table_privilege('punaro_app',cursors_oid,'DELETE')
+	   AND ($1 < 40 OR has_column_privilege('punaro_app',deliveries_oid,'recipient_endpoint','UPDATE'))
+	   AND ($1 >= 40 OR NOT has_column_privilege('punaro_app',deliveries_oid,'recipient_endpoint','UPDATE'))
+	   AND has_table_privilege('punaro_app',cursors_oid,'SELECT') AND has_table_privilege('punaro_app',cursors_oid,'INSERT')
+	   AND ($1 < 40 OR has_table_privilege('punaro_app',cursors_oid,'DELETE'))
 	   AND NOT has_table_privilege('punaro_app',cursors_oid,'UPDATE')
 	   AND has_column_privilege('punaro_app',cursors_oid,'sequence','UPDATE')
 	   AND NOT has_column_privilege('punaro_app',cursors_oid,'recipient_endpoint','UPDATE')
@@ -1232,12 +1246,13 @@ SELECT endpoints_oid IS NOT NULL AND conversations_oid IS NOT NULL AND membershi
    AND NOT has_table_privilege('punaro_app',nonces_oid,'SELECT,INSERT,UPDATE,DELETE,TRUNCATE,REFERENCES,TRIGGER')
    AND NOT has_table_privilege('punaro_app',endpoints_oid,'DELETE,TRUNCATE,REFERENCES,TRIGGER')
    AND NOT has_table_privilege('punaro_app',conversations_oid,'DELETE,TRUNCATE,REFERENCES,TRIGGER')
+   AND ($1 >= 40 OR NOT has_table_privilege('punaro_app',memberships_oid,'UPDATE'))
    AND NOT has_table_privilege('punaro_app',memberships_oid,'DELETE,TRUNCATE,REFERENCES,TRIGGER')
    AND NOT has_table_privilege('punaro_app',messages_oid,'UPDATE,DELETE,TRUNCATE,REFERENCES,TRIGGER')
    AND NOT has_table_privilege('punaro_app',deliveries_oid,'DELETE,TRUNCATE,REFERENCES,TRIGGER')
    AND NOT has_table_privilege('punaro_app',cursors_oid,'UPDATE,TRUNCATE,REFERENCES,TRIGGER')
    AND NOT has_table_privilege('punaro_app',message_idempotency_oid,'UPDATE,DELETE,TRUNCATE,REFERENCES,TRIGGER')
    AND NOT has_table_privilege('punaro_app',conversation_idempotency_oid,'UPDATE,DELETE,TRUNCATE,REFERENCES,TRIGGER')
-FROM objects,table_ownership,columns,defaults,constraints,guards,function_safety,index_safety,table_acl,column_acl`).Scan(&available)
+FROM objects,table_ownership,columns,defaults,constraints,guards,function_safety,index_safety,table_acl,column_acl`, version).Scan(&available)
 	return available, err
 }

--- a/internal/postgres/relay_store.go
+++ b/internal/postgres/relay_store.go
@@ -428,7 +428,7 @@ func (d *Database) AppendMessage(input relay.AppendInput) (relay.Message, bool, 
 		return relay.Message{}, false, relayDatabaseError(err, "append message")
 	}
 	if _, err := tx.ExecContext(context.Background(), `INSERT INTO relay.mail_deliveries(message_id,recipient_endpoint)
-		SELECT membership.endpoint FROM relay.mail_memberships AS membership JOIN relay.mail_endpoints AS endpoint ON endpoint.endpoint=membership.endpoint WHERE membership.conversation_id=$2::uuid AND (membership.capabilities & $3) <> 0 AND membership.endpoint<>$4 AND ($5='' OR (membership.role=$5 AND endpoint.lease_until>$6))`, message.ID, message.ConversationID, relay.CapReceive, message.FromEndpoint, message.TargetRole, input.Now.UTC()); err != nil {
+		SELECT $1::uuid, membership.endpoint FROM relay.mail_memberships AS membership JOIN relay.mail_endpoints AS endpoint ON endpoint.endpoint=membership.endpoint WHERE membership.conversation_id=$2::uuid AND (membership.capabilities & $3) <> 0 AND membership.endpoint<>$4 AND ($5='' OR (membership.role=$5 AND endpoint.lease_until>$6))`, message.ID, message.ConversationID, relay.CapReceive, message.FromEndpoint, message.TargetRole, input.Now.UTC()); err != nil {
 		return relay.Message{}, false, relayDatabaseError(err, "create recipient deliveries")
 	}
 	if len(input.ArtifactIDs) != 0 {
@@ -874,9 +874,9 @@ WITH objects AS (
         (endpoints_oid,'consumer_id','text'::regtype,false),(endpoints_oid,'consumer_generation','bigint'::regtype,true),
         (endpoints_oid,'consumer_lease_until','timestamptz'::regtype,false),
         (conversations_oid,'id','uuid'::regtype,true),(conversations_oid,'next_sequence','bigint'::regtype,true),(conversations_oid,'created_at','timestamptz'::regtype,true),
-        (memberships_oid,'conversation_id','uuid'::regtype,true),(memberships_oid,'endpoint','text'::regtype,true),(memberships_oid,'capabilities','smallint'::regtype,true),
+        (memberships_oid,'conversation_id','uuid'::regtype,true),(memberships_oid,'endpoint','text'::regtype,true),(memberships_oid,'capabilities','smallint'::regtype,true),(memberships_oid,'role','text'::regtype,true),
         (messages_oid,'id','uuid'::regtype,true),(messages_oid,'conversation_id','uuid'::regtype,true),(messages_oid,'sequence','bigint'::regtype,true),
-        (messages_oid,'from_endpoint','text'::regtype,true),(messages_oid,'body','text'::regtype,true),(messages_oid,'created_at','timestamptz'::regtype,true),
+        (messages_oid,'from_endpoint','text'::regtype,true),(messages_oid,'body','text'::regtype,true),(messages_oid,'created_at','timestamptz'::regtype,true),(messages_oid,'target_role','text'::regtype,true),
         (deliveries_oid,'id','uuid'::regtype,true),(deliveries_oid,'message_id','uuid'::regtype,true),(deliveries_oid,'recipient_endpoint','text'::regtype,true),
         (deliveries_oid,'lease_machine_id','text'::regtype,false),(deliveries_oid,'lease_token','uuid'::regtype,false),(deliveries_oid,'lease_generation','bigint'::regtype,true),
         (deliveries_oid,'ownership_generation','bigint'::regtype,false),(deliveries_oid,'consumer_generation','bigint'::regtype,false),
@@ -903,7 +903,8 @@ WITH objects AS (
     SELECT expected.* FROM objects, LATERAL (VALUES
         (endpoints_oid,'ownership_generation','1'),(endpoints_oid,'consumer_generation','0'),
         (conversations_oid,'id','gen_random_uuid()'),(conversations_oid,'next_sequence','0'),(conversations_oid,'created_at','statement_timestamp()'),
-        (messages_oid,'id','gen_random_uuid()'),(deliveries_oid,'id','gen_random_uuid()'),(deliveries_oid,'lease_generation','0'),
+        (memberships_oid,'role',quote_literal('') || '::text'),
+        (messages_oid,'id','gen_random_uuid()'),(messages_oid,'target_role',quote_literal('') || '::text'),(deliveries_oid,'id','gen_random_uuid()'),(deliveries_oid,'lease_generation','0'),
         (cursors_oid,'sequence','0')
     ) AS expected(table_oid,column_name,expression)
 ), actual_defaults AS (
@@ -947,8 +948,8 @@ WITH objects AS (
     SELECT expected.* FROM objects, LATERAL (VALUES
         (endpoints_oid,ARRAY[1]::smallint[]),(endpoints_oid,ARRAY[2]::smallint[]),(endpoints_oid,ARRAY[4]::smallint[]),
         (endpoints_oid,ARRAY[5]::smallint[]),(endpoints_oid,ARRAY[6]::smallint[]),(endpoints_oid,ARRAY[5,7]::smallint[]),
-        (conversations_oid,ARRAY[2]::smallint[]),(memberships_oid,ARRAY[3]::smallint[]),
-        (messages_oid,ARRAY[3]::smallint[]),(messages_oid,ARRAY[5]::smallint[]),
+        (conversations_oid,ARRAY[2]::smallint[]),(memberships_oid,ARRAY[3]::smallint[]),(memberships_oid,ARRAY[4]::smallint[]),
+        (messages_oid,ARRAY[3]::smallint[]),(messages_oid,ARRAY[5]::smallint[]),(messages_oid,ARRAY[7]::smallint[]),
         (deliveries_oid,ARRAY[6]::smallint[]),(deliveries_oid,ARRAY[4,5,7,8,9]::smallint[]),
         (cursors_oid,ARRAY[3]::smallint[]),(message_idempotency_oid,ARRAY[2]::smallint[]),(message_idempotency_oid,ARRAY[3]::smallint[]),
         (conversation_idempotency_oid,ARRAY[2]::smallint[]),(conversation_idempotency_oid,ARRAY[3]::smallint[]),(nonces_oid,ARRAY[2]::smallint[])
@@ -985,7 +986,7 @@ WITH objects AS (
     SELECT count(*) FILTER (WHERE con.contype='p')=9
        AND count(*) FILTER (WHERE con.contype='u')=4
 	       AND count(*) FILTER (WHERE con.contype='f')=10
-	       AND count(*) FILTER (WHERE con.contype='c')=18
+	       AND count(*) FILTER (WHERE con.contype='c')=20
 	       AND NOT EXISTS (SELECT * FROM expected_keys EXCEPT SELECT * FROM actual_keys)
 	       AND NOT EXISTS (SELECT * FROM actual_keys EXCEPT SELECT * FROM expected_keys)
 	       AND NOT EXISTS (SELECT * FROM expected_foreign_keys EXCEPT SELECT * FROM actual_foreign_keys)
@@ -1039,7 +1040,7 @@ WITH objects AS (
     SELECT expected.* FROM objects, LATERAL (VALUES
         (endpoints_oid,'SELECT'),(endpoints_oid,'INSERT'),(conversations_oid,'SELECT'),(conversations_oid,'INSERT'),
         (memberships_oid,'SELECT'),(memberships_oid,'INSERT'),(messages_oid,'SELECT'),(messages_oid,'INSERT'),
-        (deliveries_oid,'SELECT'),(deliveries_oid,'INSERT'),(cursors_oid,'SELECT'),(cursors_oid,'INSERT'),
+        (deliveries_oid,'SELECT'),(deliveries_oid,'INSERT'),(cursors_oid,'SELECT'),(cursors_oid,'INSERT'),(cursors_oid,'DELETE'),
         (message_idempotency_oid,'SELECT'),(message_idempotency_oid,'INSERT'),
         (conversation_idempotency_oid,'SELECT'),(conversation_idempotency_oid,'INSERT')
     ) AS expected(table_oid,privilege_type)
@@ -1058,8 +1059,9 @@ WITH objects AS (
         (endpoints_oid,'machine_id','UPDATE'),(endpoints_oid,'lease_until','UPDATE'),(endpoints_oid,'ownership_generation','UPDATE'),
         (endpoints_oid,'consumer_id','UPDATE'),(endpoints_oid,'consumer_generation','UPDATE'),(endpoints_oid,'consumer_lease_until','UPDATE'),
         (conversations_oid,'next_sequence','UPDATE'),
-        (deliveries_oid,'lease_machine_id','UPDATE'),(deliveries_oid,'lease_token','UPDATE'),(deliveries_oid,'lease_generation','UPDATE'),
-        (deliveries_oid,'ownership_generation','UPDATE'),(deliveries_oid,'consumer_generation','UPDATE'),(deliveries_oid,'lease_until','UPDATE'),(deliveries_oid,'acked_at','UPDATE'),
+        (memberships_oid,'endpoint','UPDATE'),(memberships_oid,'capabilities','UPDATE'),(memberships_oid,'role','UPDATE'),
+		(deliveries_oid,'lease_machine_id','UPDATE'),(deliveries_oid,'lease_token','UPDATE'),(deliveries_oid,'lease_generation','UPDATE'),
+		(deliveries_oid,'ownership_generation','UPDATE'),(deliveries_oid,'consumer_generation','UPDATE'),(deliveries_oid,'lease_until','UPDATE'),(deliveries_oid,'acked_at','UPDATE'),(deliveries_oid,'recipient_endpoint','UPDATE'),
         (cursors_oid,'sequence','UPDATE')
     ) AS expected(table_oid,column_name,privilege_type)
 ), actual_column_acl AS (
@@ -1122,6 +1124,10 @@ SELECT endpoints_oid IS NOT NULL AND conversations_oid IS NOT NULL AND membershi
 	   AND NOT has_column_privilege('punaro_app',conversations_oid,'id','UPDATE')
 	   AND NOT has_column_privilege('punaro_app',conversations_oid,'created_at','UPDATE')
    AND has_table_privilege('punaro_app',memberships_oid,'SELECT') AND has_table_privilege('punaro_app',memberships_oid,'INSERT')
+	   AND NOT has_table_privilege('punaro_app',memberships_oid,'UPDATE')
+	   AND has_column_privilege('punaro_app',memberships_oid,'endpoint','UPDATE')
+	   AND has_column_privilege('punaro_app',memberships_oid,'capabilities','UPDATE')
+	   AND has_column_privilege('punaro_app',memberships_oid,'role','UPDATE')
    AND has_table_privilege('punaro_app',messages_oid,'SELECT') AND has_table_privilege('punaro_app',messages_oid,'INSERT')
 	   AND has_table_privilege('punaro_app',deliveries_oid,'SELECT') AND has_table_privilege('punaro_app',deliveries_oid,'INSERT')
 	   AND NOT has_table_privilege('punaro_app',deliveries_oid,'UPDATE')
@@ -1134,8 +1140,8 @@ SELECT endpoints_oid IS NOT NULL AND conversations_oid IS NOT NULL AND membershi
 	   AND has_column_privilege('punaro_app',deliveries_oid,'acked_at','UPDATE')
 	   AND NOT has_column_privilege('punaro_app',deliveries_oid,'id','UPDATE')
 	   AND NOT has_column_privilege('punaro_app',deliveries_oid,'message_id','UPDATE')
-	   AND NOT has_column_privilege('punaro_app',deliveries_oid,'recipient_endpoint','UPDATE')
-	   AND has_table_privilege('punaro_app',cursors_oid,'SELECT') AND has_table_privilege('punaro_app',cursors_oid,'INSERT')
+	   AND has_column_privilege('punaro_app',deliveries_oid,'recipient_endpoint','UPDATE')
+	   AND has_table_privilege('punaro_app',cursors_oid,'SELECT') AND has_table_privilege('punaro_app',cursors_oid,'INSERT') AND has_table_privilege('punaro_app',cursors_oid,'DELETE')
 	   AND NOT has_table_privilege('punaro_app',cursors_oid,'UPDATE')
 	   AND has_column_privilege('punaro_app',cursors_oid,'sequence','UPDATE')
 	   AND NOT has_column_privilege('punaro_app',cursors_oid,'recipient_endpoint','UPDATE')
@@ -1145,10 +1151,10 @@ SELECT endpoints_oid IS NOT NULL AND conversations_oid IS NOT NULL AND membershi
    AND NOT has_table_privilege('punaro_app',nonces_oid,'SELECT,INSERT,UPDATE,DELETE,TRUNCATE,REFERENCES,TRIGGER')
    AND NOT has_table_privilege('punaro_app',endpoints_oid,'DELETE,TRUNCATE,REFERENCES,TRIGGER')
    AND NOT has_table_privilege('punaro_app',conversations_oid,'DELETE,TRUNCATE,REFERENCES,TRIGGER')
-   AND NOT has_table_privilege('punaro_app',memberships_oid,'UPDATE,DELETE,TRUNCATE,REFERENCES,TRIGGER')
+   AND NOT has_table_privilege('punaro_app',memberships_oid,'DELETE,TRUNCATE,REFERENCES,TRIGGER')
    AND NOT has_table_privilege('punaro_app',messages_oid,'UPDATE,DELETE,TRUNCATE,REFERENCES,TRIGGER')
    AND NOT has_table_privilege('punaro_app',deliveries_oid,'DELETE,TRUNCATE,REFERENCES,TRIGGER')
-   AND NOT has_table_privilege('punaro_app',cursors_oid,'DELETE,TRUNCATE,REFERENCES,TRIGGER')
+   AND NOT has_table_privilege('punaro_app',cursors_oid,'UPDATE,TRUNCATE,REFERENCES,TRIGGER')
    AND NOT has_table_privilege('punaro_app',message_idempotency_oid,'UPDATE,DELETE,TRUNCATE,REFERENCES,TRIGGER')
    AND NOT has_table_privilege('punaro_app',conversation_idempotency_oid,'UPDATE,DELETE,TRUNCATE,REFERENCES,TRIGGER')
 FROM objects,table_ownership,columns,defaults,constraints,guards,function_safety,index_safety,table_acl,column_acl`).Scan(&available)

--- a/internal/postgres/relay_store.go
+++ b/internal/postgres/relay_store.go
@@ -271,12 +271,33 @@ func (d *Database) UpdateMembership(conversationID, machineID, adminEndpoint, pr
 	if err := tx.QueryRowContext(context.Background(), `SELECT lease_until FROM relay.mail_endpoints WHERE endpoint=$1 FOR UPDATE`, member.Endpoint).Scan(&memberLease); err != nil || !memberLease.After(now) {
 		return relay.ErrForbidden
 	}
+	if member.Endpoint != previousEndpoint {
+		var previousExists, replacementExists bool
+		if err := tx.QueryRowContext(context.Background(), `SELECT EXISTS(SELECT 1 FROM relay.mail_memberships WHERE conversation_id=$1::uuid AND endpoint=$2), EXISTS(SELECT 1 FROM relay.mail_memberships WHERE conversation_id=$1::uuid AND endpoint=$3)`, conversationID, previousEndpoint, member.Endpoint).Scan(&previousExists, &replacementExists); err != nil {
+			return errors.New("conversation membership rebind is unavailable")
+		}
+		if previousExists && replacementExists {
+			return relay.ErrForbidden
+		}
+	}
 	if member.Capabilities&relay.CapAdmin == 0 {
 		var otherAdministrators int
 		if err := tx.QueryRowContext(context.Background(), `SELECT count(*) FROM relay.mail_memberships WHERE conversation_id=$1::uuid AND endpoint<>$2 AND (capabilities & $3) <> 0`, conversationID, previousEndpoint, relay.CapAdmin).Scan(&otherAdministrators); err != nil {
 			return errors.New("remaining conversation administrators are unavailable")
 		}
 		if otherAdministrators == 0 {
+			return relay.ErrForbidden
+		}
+	}
+	if member.Capabilities&relay.CapReceive == 0 {
+		var pendingDeliveries bool
+		if err := tx.QueryRowContext(context.Background(), `SELECT EXISTS(
+			SELECT 1 FROM relay.mail_deliveries AS delivery JOIN relay.mail_messages AS message ON message.id=delivery.message_id
+			WHERE delivery.recipient_endpoint=$1 AND delivery.acked_at IS NULL AND message.conversation_id=$2::uuid
+		)`, previousEndpoint, conversationID).Scan(&pendingDeliveries); err != nil {
+			return errors.New("pending recipient deliveries are unavailable")
+		}
+		if pendingDeliveries {
 			return relay.ErrForbidden
 		}
 	}
@@ -1023,8 +1044,10 @@ WITH objects AS (
        AND EXISTS (SELECT 1 FROM pg_constraint WHERE conrelid=endpoints_oid AND contype='c' AND conkey @> ARRAY[5,7]::smallint[] AND conkey <@ ARRAY[5,7]::smallint[] AND pg_get_expr(conbin,conrelid)='((consumer_id IS NULL) = (consumer_lease_until IS NULL))')
        AND EXISTS (SELECT 1 FROM pg_constraint WHERE conrelid=conversations_oid AND contype='c' AND conkey=ARRAY[2]::smallint[] AND pg_get_expr(conbin,conrelid)='(next_sequence >= 0)')
        AND EXISTS (SELECT 1 FROM pg_constraint WHERE conrelid=memberships_oid AND contype='c' AND conkey=ARRAY[3]::smallint[] AND pg_get_expr(conbin,conrelid)='((capabilities >= 1) AND (capabilities <= 7))')
+       AND EXISTS (SELECT 1 FROM pg_constraint WHERE conrelid=memberships_oid AND contype='c' AND conkey=ARRAY[4]::smallint[] AND pg_get_expr(conbin,conrelid)='((role = ''''::text) OR ((char_length(role) >= 1) AND (char_length(role) <= 64) AND (octet_length(role) <= 256) AND (btrim(role) = role) AND (role !~ ''[[:cntrl:]]''::text)))')
        AND EXISTS (SELECT 1 FROM pg_constraint WHERE conrelid=messages_oid AND contype='c' AND conkey=ARRAY[3]::smallint[] AND pg_get_expr(conbin,conrelid)='(sequence > 0)')
        AND EXISTS (SELECT 1 FROM pg_constraint WHERE conrelid=messages_oid AND contype='c' AND conkey=ARRAY[5]::smallint[] AND pg_get_expr(conbin,conrelid)='(octet_length(body) <= 32768)')
+       AND EXISTS (SELECT 1 FROM pg_constraint WHERE conrelid=messages_oid AND contype='c' AND conkey=ARRAY[7]::smallint[] AND pg_get_expr(conbin,conrelid)='((target_role = ''''::text) OR ((char_length(target_role) >= 1) AND (char_length(target_role) <= 64) AND (octet_length(target_role) <= 256) AND (btrim(target_role) = target_role) AND (target_role !~ ''[[:cntrl:]]''::text)))')
        AND EXISTS (SELECT 1 FROM pg_constraint WHERE conrelid=deliveries_oid AND contype='c' AND conkey=ARRAY[6]::smallint[] AND pg_get_expr(conbin,conrelid)='(lease_generation >= 0)')
        AND EXISTS (SELECT 1 FROM pg_constraint WHERE conrelid=deliveries_oid AND contype='c' AND conkey @> ARRAY[4,5,7,8,9]::smallint[] AND conkey <@ ARRAY[4,5,7,8,9]::smallint[] AND pg_get_expr(conbin,conrelid)='(((lease_machine_id IS NULL) AND (lease_token IS NULL) AND (ownership_generation IS NULL) AND (consumer_generation IS NULL) AND (lease_until IS NULL)) OR ((lease_machine_id IS NOT NULL) AND (lease_token IS NOT NULL) AND (ownership_generation IS NOT NULL) AND (consumer_generation IS NOT NULL) AND (lease_until IS NOT NULL)))')
        AND EXISTS (SELECT 1 FROM pg_constraint WHERE conrelid=cursors_oid AND contype='c' AND conkey=ARRAY[3]::smallint[] AND pg_get_expr(conbin,conrelid)='(sequence >= 0)')

--- a/internal/postgres/relay_store.go
+++ b/internal/postgres/relay_store.go
@@ -259,6 +259,12 @@ func (d *Database) UpdateMembership(conversationID, machineID, adminEndpoint, pr
 	if _, err := postgresEndpointOwnershipLocked(tx, adminEndpoint, machineID, now); err != nil {
 		return err
 	}
+	var nextSequence int64
+	if err := tx.QueryRowContext(context.Background(), `SELECT next_sequence FROM relay.mail_conversations WHERE id=$1::uuid FOR UPDATE`, conversationID).Scan(&nextSequence); errors.Is(err, sql.ErrNoRows) {
+		return relay.ErrForbidden
+	} else if err != nil {
+		return errors.New("conversation membership transition is unavailable")
+	}
 	var capabilities relay.Capability
 	err = tx.QueryRowContext(context.Background(), `SELECT capabilities FROM relay.mail_memberships WHERE conversation_id=$1::uuid AND endpoint=$2 FOR UPDATE`, conversationID, adminEndpoint).Scan(&capabilities)
 	if errors.Is(err, sql.ErrNoRows) || capabilities&relay.CapAdmin == 0 {

--- a/internal/postgres/relay_store.go
+++ b/internal/postgres/relay_store.go
@@ -294,7 +294,16 @@ func (d *Database) UpdateMembership(conversationID, machineID, adminEndpoint, pr
 		return errors.New("membership update result is unavailable")
 	}
 	if changed != 1 {
-		return relay.ErrForbidden
+		var endpoint string
+		var capabilities relay.Capability
+		var role string
+		err := tx.QueryRowContext(context.Background(), `SELECT endpoint,capabilities,role FROM relay.mail_memberships WHERE conversation_id=$1::uuid AND endpoint=$2`, conversationID, member.Endpoint).Scan(&endpoint, &capabilities, &role)
+		if errors.Is(err, sql.ErrNoRows) || (err == nil && (endpoint != member.Endpoint || capabilities != member.Capabilities || role != member.Role)) {
+			return relay.ErrForbidden
+		}
+		if err != nil {
+			return errors.New("replayed membership update is unavailable")
+		}
 	}
 	if err := tx.Commit(); err != nil {
 		return relayDatabaseError(err, "commit membership update")
@@ -406,16 +415,42 @@ func (d *Database) AppendMessage(input relay.AppendInput) (relay.Message, bool, 
 	if !errors.Is(err, sql.ErrNoRows) {
 		return relay.Message{}, false, errors.New("message retry state is unavailable")
 	}
-	var recipients int
+	recipients := make([]string, 0)
 	if input.TargetRole == "" {
-		err = tx.QueryRowContext(context.Background(), `SELECT count(*) FROM relay.mail_memberships WHERE conversation_id=$1::uuid AND (capabilities & $2) <> 0 AND endpoint<>$3`, input.ConversationID, relay.CapReceive, input.FromEndpoint).Scan(&recipients)
+		rows, queryErr := tx.QueryContext(context.Background(), `SELECT endpoint FROM relay.mail_memberships WHERE conversation_id=$1::uuid AND (capabilities & $2) <> 0 AND endpoint<>$3 FOR SHARE`, input.ConversationID, relay.CapReceive, input.FromEndpoint)
+		err = queryErr
+		if err == nil {
+			for rows.Next() {
+				var endpoint string
+				if err = rows.Scan(&endpoint); err != nil {
+					break
+				}
+				recipients = append(recipients, endpoint)
+			}
+			if closeErr := rows.Close(); err == nil {
+				err = closeErr
+			}
+		}
 	} else {
-		err = tx.QueryRowContext(context.Background(), `SELECT count(*) FROM relay.mail_memberships AS membership JOIN relay.mail_endpoints AS endpoint ON endpoint.endpoint=membership.endpoint WHERE membership.conversation_id=$1::uuid AND membership.role=$2 AND (membership.capabilities & $3) <> 0 AND membership.endpoint<>$4 AND endpoint.lease_until>$5`, input.ConversationID, input.TargetRole, relay.CapReceive, input.FromEndpoint, input.Now.UTC()).Scan(&recipients)
+		rows, queryErr := tx.QueryContext(context.Background(), `SELECT membership.endpoint FROM relay.mail_memberships AS membership JOIN relay.mail_endpoints AS endpoint ON endpoint.endpoint=membership.endpoint WHERE membership.conversation_id=$1::uuid AND membership.role=$2 AND (membership.capabilities & $3) <> 0 AND membership.endpoint<>$4 AND endpoint.lease_until>$5 FOR SHARE OF membership, endpoint`, input.ConversationID, input.TargetRole, relay.CapReceive, input.FromEndpoint, input.Now.UTC())
+		err = queryErr
+		if err == nil {
+			for rows.Next() {
+				var endpoint string
+				if err = rows.Scan(&endpoint); err != nil {
+					break
+				}
+				recipients = append(recipients, endpoint)
+			}
+			if closeErr := rows.Close(); err == nil {
+				err = closeErr
+			}
+		}
 	}
 	if err != nil {
 		return relay.Message{}, false, relayDatabaseError(err, "find message recipients")
 	}
-	if input.TargetRole != "" && recipients == 0 {
+	if input.TargetRole != "" && len(recipients) == 0 {
 		return relay.Message{}, false, relay.ErrNoEligibleRecipient
 	}
 	message := relay.Message{ID: uuid.NewString(), ConversationID: input.ConversationID, FromEndpoint: input.FromEndpoint, TargetRole: input.TargetRole, Body: input.Body, CreatedAt: input.Now.UTC().Truncate(time.Millisecond)}
@@ -427,9 +462,10 @@ func (d *Database) AppendMessage(input relay.AppendInput) (relay.Message, bool, 
 	if _, err := tx.ExecContext(context.Background(), `INSERT INTO relay.mail_messages(id,conversation_id,sequence,from_endpoint,target_role,body,created_at) VALUES($1::uuid,$2::uuid,$3,$4,$5,$6,$7)`, message.ID, message.ConversationID, message.Sequence, message.FromEndpoint, message.TargetRole, message.Body, message.CreatedAt); err != nil {
 		return relay.Message{}, false, relayDatabaseError(err, "append message")
 	}
-	if _, err := tx.ExecContext(context.Background(), `INSERT INTO relay.mail_deliveries(message_id,recipient_endpoint)
-		SELECT $1::uuid, membership.endpoint FROM relay.mail_memberships AS membership JOIN relay.mail_endpoints AS endpoint ON endpoint.endpoint=membership.endpoint WHERE membership.conversation_id=$2::uuid AND (membership.capabilities & $3) <> 0 AND membership.endpoint<>$4 AND ($5='' OR (membership.role=$5 AND endpoint.lease_until>$6))`, message.ID, message.ConversationID, relay.CapReceive, message.FromEndpoint, message.TargetRole, input.Now.UTC()); err != nil {
-		return relay.Message{}, false, relayDatabaseError(err, "create recipient deliveries")
+	for _, recipient := range recipients {
+		if _, err := tx.ExecContext(context.Background(), `INSERT INTO relay.mail_deliveries(message_id,recipient_endpoint) VALUES($1::uuid,$2)`, message.ID, recipient); err != nil {
+			return relay.Message{}, false, relayDatabaseError(err, "create recipient delivery")
+		}
 	}
 	if len(input.ArtifactIDs) != 0 {
 		encodedArtifacts, err := json.Marshal(input.ArtifactIDs)

--- a/internal/postgres/relay_store.go
+++ b/internal/postgres/relay_store.go
@@ -256,8 +256,22 @@ func (d *Database) UpdateMembership(conversationID, machineID, adminEndpoint, pr
 	}
 	defer cancel()
 	defer func() { _ = tx.Rollback() }()
+	if adminEndpoint == previousEndpoint && member.Endpoint != previousEndpoint {
+		var endpoint string
+		var capabilities relay.Capability
+		var role string
+		err := tx.QueryRowContext(context.Background(), `SELECT endpoint,capabilities,role FROM relay.mail_memberships WHERE conversation_id=$1::uuid AND endpoint=$2`, conversationID, member.Endpoint).Scan(&endpoint, &capabilities, &role)
+		if err == nil && endpoint == member.Endpoint && capabilities == member.Capabilities && role == member.Role {
+			if _, err := postgresEndpointOwnershipLocked(tx, member.Endpoint, machineID, now); err == nil {
+				return tx.Commit()
+			}
+		}
+	}
 	if _, err := postgresEndpointOwnershipLocked(tx, adminEndpoint, machineID, now); err != nil {
 		return err
+	}
+	if _, err := tx.ExecContext(context.Background(), `SELECT pg_advisory_xact_lock(hashtextextended($1::text, 579001230610))`, conversationID); err != nil {
+		return errors.New("conversation membership lock is unavailable")
 	}
 	var nextSequence int64
 	if err := tx.QueryRowContext(context.Background(), `SELECT next_sequence FROM relay.mail_conversations WHERE id=$1::uuid FOR UPDATE`, conversationID).Scan(&nextSequence); errors.Is(err, sql.ErrNoRows) {
@@ -274,7 +288,7 @@ func (d *Database) UpdateMembership(conversationID, machineID, adminEndpoint, pr
 		return errors.New("membership administrator is unavailable")
 	}
 	var memberLease time.Time
-	if err := tx.QueryRowContext(context.Background(), `SELECT lease_until FROM relay.mail_endpoints WHERE endpoint=$1 FOR UPDATE`, member.Endpoint).Scan(&memberLease); err != nil || !memberLease.After(now) {
+	if err := tx.QueryRowContext(context.Background(), `SELECT lease_until FROM relay.mail_endpoints WHERE endpoint=$1`, member.Endpoint).Scan(&memberLease); err != nil || !memberLease.After(now) {
 		return relay.ErrForbidden
 	}
 	if member.Endpoint != previousEndpoint {
@@ -314,6 +328,13 @@ func (d *Database) UpdateMembership(conversationID, machineID, adminEndpoint, pr
 		}
 		if !attachmentSafe {
 			return relay.ErrForbidden
+		}
+		if _, err := tx.ExecContext(context.Background(), `DELETE FROM relay.mail_deliveries AS old_delivery
+			USING relay.mail_messages AS message, relay.mail_deliveries AS replacement
+			WHERE old_delivery.message_id=message.id AND replacement.message_id=old_delivery.message_id
+			  AND old_delivery.recipient_endpoint=$1 AND old_delivery.acked_at IS NULL
+			  AND replacement.recipient_endpoint=$2 AND message.conversation_id=$3::uuid`, previousEndpoint, member.Endpoint, conversationID); err != nil {
+			return relayDatabaseError(err, "reconcile rebound deliveries")
 		}
 		if _, err := tx.ExecContext(context.Background(), `INSERT INTO relay.mail_recipient_cursors(recipient_endpoint,conversation_id,sequence)
 			SELECT $1,conversation_id,sequence FROM relay.mail_recipient_cursors WHERE recipient_endpoint=$2 AND conversation_id=$3::uuid
@@ -420,6 +441,9 @@ func (d *Database) AppendMessage(input relay.AppendInput) (relay.Message, bool, 
 	}
 	if _, err := postgresEndpointOwnershipLocked(tx, input.FromEndpoint, input.SenderMachineID, input.Now); err != nil {
 		return relay.Message{}, false, err
+	}
+	if _, err := tx.ExecContext(context.Background(), `SELECT pg_advisory_xact_lock(hashtextextended($1::text, 579001230610))`, input.ConversationID); err != nil {
+		return relay.Message{}, false, errors.New("conversation send lock is unavailable")
 	}
 	var capabilities relay.Capability
 	err = tx.QueryRowContext(context.Background(), `SELECT capabilities FROM relay.mail_memberships WHERE conversation_id=$1::uuid AND endpoint=$2`, input.ConversationID, input.FromEndpoint).Scan(&capabilities)
@@ -684,12 +708,22 @@ func (d *Database) AckDelivery(machineID, endpoint, deliveryID, token string, ge
 	if err != nil {
 		return err
 	}
+	var conversationID string
+	if err := tx.QueryRowContext(context.Background(), `SELECT message.conversation_id::text
+		FROM relay.mail_deliveries AS delivery JOIN relay.mail_messages AS message ON message.id=delivery.message_id
+		WHERE delivery.id=$1::uuid`, deliveryID).Scan(&conversationID); errors.Is(err, sql.ErrNoRows) {
+		return relay.ErrForbidden
+	} else if err != nil {
+		return errors.New("delivery acknowledgement conversation is unavailable")
+	}
+	if _, err := tx.ExecContext(context.Background(), `SELECT pg_advisory_xact_lock(hashtextextended($1::text, 579001230610))`, conversationID); err != nil {
+		return errors.New("delivery acknowledgement lock is unavailable")
+	}
 	var recipient string
 	var leaseMachine, leaseToken sql.NullString
 	var leaseGeneration int64
 	var leaseOwnership, leaseConsumer sql.NullInt64
 	var leaseUntil, acknowledged sql.NullTime
-	var conversationID string
 	err = tx.QueryRowContext(context.Background(), `SELECT delivery.recipient_endpoint,delivery.lease_machine_id,delivery.lease_token::text,
 		delivery.lease_generation,delivery.ownership_generation,delivery.consumer_generation,delivery.lease_until,delivery.acked_at,message.conversation_id::text
 		FROM relay.mail_deliveries AS delivery JOIN relay.mail_messages AS message ON message.id=delivery.message_id

--- a/internal/postgres/relay_store.go
+++ b/internal/postgres/relay_store.go
@@ -271,7 +271,23 @@ func (d *Database) UpdateMembership(conversationID, machineID, adminEndpoint, pr
 	if err := tx.QueryRowContext(context.Background(), `SELECT lease_until FROM relay.mail_endpoints WHERE endpoint=$1 FOR UPDATE`, member.Endpoint).Scan(&memberLease); err != nil || !memberLease.After(now) {
 		return relay.ErrForbidden
 	}
+	if member.Capabilities&relay.CapAdmin == 0 {
+		var otherAdministrators int
+		if err := tx.QueryRowContext(context.Background(), `SELECT count(*) FROM relay.mail_memberships WHERE conversation_id=$1::uuid AND endpoint<>$2 AND (capabilities & $3) <> 0`, conversationID, previousEndpoint, relay.CapAdmin).Scan(&otherAdministrators); err != nil {
+			return errors.New("remaining conversation administrators are unavailable")
+		}
+		if otherAdministrators == 0 {
+			return relay.ErrForbidden
+		}
+	}
 	if member.Endpoint != previousEndpoint {
+		var attachmentSafe bool
+		if err := tx.QueryRowContext(context.Background(), `SELECT attachment.recipient_rebind_allowed($1,$2,$3::uuid)`, previousEndpoint, member.Endpoint, conversationID).Scan(&attachmentSafe); err != nil {
+			return relayDatabaseError(err, "authorize attachment recipient rebind")
+		}
+		if !attachmentSafe {
+			return relay.ErrForbidden
+		}
 		if _, err := tx.ExecContext(context.Background(), `INSERT INTO relay.mail_recipient_cursors(recipient_endpoint,conversation_id,sequence)
 			SELECT $1,conversation_id,sequence FROM relay.mail_recipient_cursors WHERE recipient_endpoint=$2 AND conversation_id=$3::uuid
 			ON CONFLICT(recipient_endpoint,conversation_id) DO UPDATE SET sequence=GREATEST(relay.mail_recipient_cursors.sequence,excluded.sequence)`, member.Endpoint, previousEndpoint, conversationID); err != nil {

--- a/internal/postgres/relay_store.go
+++ b/internal/postgres/relay_store.go
@@ -159,7 +159,7 @@ func (d *Database) CreateConversationIdempotent(input relay.CreateConversationIn
 	seen := make(map[string]struct{}, len(input.Members))
 	creatorAdmin := false
 	for _, member := range input.Members {
-		if !relay.ValidEndpoint(member.Endpoint) || member.Capabilities == 0 || member.Capabilities & ^(relay.CapSend|relay.CapReceive|relay.CapAdmin) != 0 {
+		if !relay.ValidEndpoint(member.Endpoint) || !relay.ValidRole(member.Role) || member.Capabilities == 0 || member.Capabilities & ^(relay.CapSend|relay.CapReceive|relay.CapAdmin) != 0 {
 			return relay.Conversation{}, errors.New("invalid conversation member")
 		}
 		if _, duplicate := seen[member.Endpoint]; duplicate {
@@ -225,7 +225,7 @@ func (d *Database) CreateConversationIdempotent(input relay.CreateConversationIn
 		return relay.Conversation{}, relayDatabaseError(err, "create conversation")
 	}
 	for _, member := range input.Members {
-		if _, err := tx.ExecContext(context.Background(), `INSERT INTO relay.mail_memberships(conversation_id,endpoint,capabilities) VALUES($1::uuid,$2,$3)`, conversation.ID, member.Endpoint, member.Capabilities); err != nil {
+		if _, err := tx.ExecContext(context.Background(), `INSERT INTO relay.mail_memberships(conversation_id,endpoint,capabilities,role) VALUES($1::uuid,$2,$3,$4)`, conversation.ID, member.Endpoint, member.Capabilities, member.Role); err != nil {
 			return relay.Conversation{}, relayDatabaseError(err, "add conversation member")
 		}
 	}
@@ -242,6 +242,64 @@ func (d *Database) CreateConversationIdempotent(input relay.CreateConversationIn
 		return relay.Conversation{}, relayDatabaseError(err, "commit conversation")
 	}
 	return conversation, nil
+}
+
+// UpdateMembership replaces a role binding after checking the current caller's
+// live conversation-admin authority. The previous endpoint may be detached.
+func (d *Database) UpdateMembership(conversationID, machineID, adminEndpoint, previousEndpoint string, member relay.Member, now time.Time) error {
+	if _, err := uuid.Parse(conversationID); err != nil || !relay.ValidMachineID(machineID) || !relay.ValidEndpoint(adminEndpoint) || !relay.ValidEndpoint(previousEndpoint) || !relay.ValidEndpoint(member.Endpoint) || !relay.ValidRole(member.Role) || member.Capabilities == 0 || member.Capabilities&^(relay.CapSend|relay.CapReceive|relay.CapAdmin) != 0 {
+		return relay.ErrForbidden
+	}
+	tx, cancel, err := d.beginRelayTransaction(nil)
+	if err != nil {
+		return errors.New("membership update cannot start")
+	}
+	defer cancel()
+	defer func() { _ = tx.Rollback() }()
+	if _, err := postgresEndpointOwnershipLocked(tx, adminEndpoint, machineID, now); err != nil {
+		return err
+	}
+	var capabilities relay.Capability
+	err = tx.QueryRowContext(context.Background(), `SELECT capabilities FROM relay.mail_memberships WHERE conversation_id=$1::uuid AND endpoint=$2 FOR UPDATE`, conversationID, adminEndpoint).Scan(&capabilities)
+	if errors.Is(err, sql.ErrNoRows) || capabilities&relay.CapAdmin == 0 {
+		return relay.ErrForbidden
+	}
+	if err != nil {
+		return errors.New("membership administrator is unavailable")
+	}
+	var memberLease time.Time
+	if err := tx.QueryRowContext(context.Background(), `SELECT lease_until FROM relay.mail_endpoints WHERE endpoint=$1 FOR UPDATE`, member.Endpoint).Scan(&memberLease); err != nil || !memberLease.After(now) {
+		return relay.ErrForbidden
+	}
+	if member.Endpoint != previousEndpoint {
+		if _, err := tx.ExecContext(context.Background(), `INSERT INTO relay.mail_recipient_cursors(recipient_endpoint,conversation_id,sequence)
+			SELECT $1,conversation_id,sequence FROM relay.mail_recipient_cursors WHERE recipient_endpoint=$2 AND conversation_id=$3::uuid
+			ON CONFLICT(recipient_endpoint,conversation_id) DO UPDATE SET sequence=GREATEST(relay.mail_recipient_cursors.sequence,excluded.sequence)`, member.Endpoint, previousEndpoint, conversationID); err != nil {
+			return relayDatabaseError(err, "preserve rebound recipient cursor")
+		}
+		if _, err := tx.ExecContext(context.Background(), `DELETE FROM relay.mail_recipient_cursors WHERE recipient_endpoint=$1 AND conversation_id=$2::uuid`, previousEndpoint, conversationID); err != nil {
+			return relayDatabaseError(err, "remove prior recipient cursor")
+		}
+		if _, err := tx.ExecContext(context.Background(), `UPDATE relay.mail_deliveries AS delivery SET recipient_endpoint=$1
+			FROM relay.mail_messages AS message WHERE delivery.message_id=message.id AND delivery.recipient_endpoint=$2 AND delivery.acked_at IS NULL AND message.conversation_id=$3::uuid`, member.Endpoint, previousEndpoint, conversationID); err != nil {
+			return relayDatabaseError(err, "rebind pending deliveries")
+		}
+	}
+	result, err := tx.ExecContext(context.Background(), `UPDATE relay.mail_memberships SET endpoint=$1,capabilities=$2,role=$3 WHERE conversation_id=$4::uuid AND endpoint=$5`, member.Endpoint, member.Capabilities, member.Role, conversationID, previousEndpoint)
+	if err != nil {
+		return relayDatabaseError(err, "update conversation member")
+	}
+	changed, err := result.RowsAffected()
+	if err != nil {
+		return errors.New("membership update result is unavailable")
+	}
+	if changed != 1 {
+		return relay.ErrForbidden
+	}
+	if err := tx.Commit(); err != nil {
+		return relayDatabaseError(err, "commit membership update")
+	}
+	return nil
 }
 
 // AuthorizeSender verifies current PostgreSQL sender authority without mutation.
@@ -271,7 +329,7 @@ func (d *Database) AuthorizeSender(conversationID, machineID, endpoint string, n
 
 // AppendMessage transactionally appends one immutable PostgreSQL relay message.
 func (d *Database) AppendMessage(input relay.AppendInput) (relay.Message, bool, error) {
-	if strings.TrimSpace(input.ConversationID) == "" || !relay.ValidMachineID(input.SenderMachineID) || !relay.ValidEndpoint(input.FromEndpoint) || !relay.ValidRequestToken(input.IdempotencyKey) {
+	if strings.TrimSpace(input.ConversationID) == "" || !relay.ValidMachineID(input.SenderMachineID) || !relay.ValidEndpoint(input.FromEndpoint) || !relay.ValidRole(input.TargetRole) || !relay.ValidRequestToken(input.IdempotencyKey) {
 		return relay.Message{}, false, errors.New("invalid message request")
 	}
 	if len(input.Body) > postgresRelayMaxMessageBytes {
@@ -348,17 +406,29 @@ func (d *Database) AppendMessage(input relay.AppendInput) (relay.Message, bool, 
 	if !errors.Is(err, sql.ErrNoRows) {
 		return relay.Message{}, false, errors.New("message retry state is unavailable")
 	}
-	message := relay.Message{ID: uuid.NewString(), ConversationID: input.ConversationID, FromEndpoint: input.FromEndpoint, Body: input.Body, CreatedAt: input.Now.UTC().Truncate(time.Millisecond)}
+	var recipients int
+	if input.TargetRole == "" {
+		err = tx.QueryRowContext(context.Background(), `SELECT count(*) FROM relay.mail_memberships WHERE conversation_id=$1::uuid AND (capabilities & $2) <> 0 AND endpoint<>$3`, input.ConversationID, relay.CapReceive, input.FromEndpoint).Scan(&recipients)
+	} else {
+		err = tx.QueryRowContext(context.Background(), `SELECT count(*) FROM relay.mail_memberships AS membership JOIN relay.mail_endpoints AS endpoint ON endpoint.endpoint=membership.endpoint WHERE membership.conversation_id=$1::uuid AND membership.role=$2 AND (membership.capabilities & $3) <> 0 AND membership.endpoint<>$4 AND endpoint.lease_until>$5`, input.ConversationID, input.TargetRole, relay.CapReceive, input.FromEndpoint, input.Now.UTC()).Scan(&recipients)
+	}
+	if err != nil {
+		return relay.Message{}, false, relayDatabaseError(err, "find message recipients")
+	}
+	if input.TargetRole != "" && recipients == 0 {
+		return relay.Message{}, false, relay.ErrNoEligibleRecipient
+	}
+	message := relay.Message{ID: uuid.NewString(), ConversationID: input.ConversationID, FromEndpoint: input.FromEndpoint, TargetRole: input.TargetRole, Body: input.Body, CreatedAt: input.Now.UTC().Truncate(time.Millisecond)}
 	if err := tx.QueryRowContext(context.Background(), `UPDATE relay.mail_conversations SET next_sequence=next_sequence+1 WHERE id=$1::uuid RETURNING next_sequence`, input.ConversationID).Scan(&message.Sequence); errors.Is(err, sql.ErrNoRows) {
 		return relay.Message{}, false, relay.ErrForbidden
 	} else if err != nil {
 		return relay.Message{}, false, relayDatabaseError(err, "allocate message sequence")
 	}
-	if _, err := tx.ExecContext(context.Background(), `INSERT INTO relay.mail_messages(id,conversation_id,sequence,from_endpoint,body,created_at) VALUES($1::uuid,$2::uuid,$3,$4,$5,$6)`, message.ID, message.ConversationID, message.Sequence, message.FromEndpoint, message.Body, message.CreatedAt); err != nil {
+	if _, err := tx.ExecContext(context.Background(), `INSERT INTO relay.mail_messages(id,conversation_id,sequence,from_endpoint,target_role,body,created_at) VALUES($1::uuid,$2::uuid,$3,$4,$5,$6,$7)`, message.ID, message.ConversationID, message.Sequence, message.FromEndpoint, message.TargetRole, message.Body, message.CreatedAt); err != nil {
 		return relay.Message{}, false, relayDatabaseError(err, "append message")
 	}
 	if _, err := tx.ExecContext(context.Background(), `INSERT INTO relay.mail_deliveries(message_id,recipient_endpoint)
-		SELECT $1::uuid,endpoint FROM relay.mail_memberships WHERE conversation_id=$2::uuid AND (capabilities & $3) <> 0 AND endpoint<>$4`, message.ID, message.ConversationID, relay.CapReceive, message.FromEndpoint); err != nil {
+		SELECT membership.endpoint FROM relay.mail_memberships AS membership JOIN relay.mail_endpoints AS endpoint ON endpoint.endpoint=membership.endpoint WHERE membership.conversation_id=$2::uuid AND (membership.capabilities & $3) <> 0 AND membership.endpoint<>$4 AND ($5='' OR (membership.role=$5 AND endpoint.lease_until>$6))`, message.ID, message.ConversationID, relay.CapReceive, message.FromEndpoint, message.TargetRole, input.Now.UTC()); err != nil {
 		return relay.Message{}, false, relayDatabaseError(err, "create recipient deliveries")
 	}
 	if len(input.ArtifactIDs) != 0 {
@@ -422,7 +492,7 @@ func (d *Database) LeaseDeliveries(machineID, consumerID, endpoint, conversation
 		return relay.DeliveryLeasePage{}, relayDatabaseError(err, "claim endpoint consumer lease")
 	}
 	query := `SELECT delivery.id::text,delivery.lease_machine_id,delivery.lease_token::text,delivery.lease_generation,delivery.ownership_generation,delivery.consumer_generation,delivery.lease_until,
-		message.id::text,message.conversation_id::text,message.sequence,message.from_endpoint,message.body,message.created_at
+		message.id::text,message.conversation_id::text,message.sequence,message.from_endpoint,message.target_role,message.body,message.created_at
 		FROM relay.mail_deliveries AS delivery JOIN relay.mail_messages AS message ON message.id=delivery.message_id
 		WHERE delivery.recipient_endpoint=$1 AND delivery.acked_at IS NULL
 		  AND (delivery.lease_until IS NULL OR delivery.lease_until<=$2 OR delivery.ownership_generation IS NULL OR delivery.ownership_generation<>$3 OR delivery.consumer_generation IS NULL OR delivery.consumer_generation<>$4 OR delivery.lease_machine_id=$5)`
@@ -450,7 +520,7 @@ func (d *Database) LeaseDeliveries(machineID, consumerID, endpoint, conversation
 	for rows.Next() {
 		var row leasedRow
 		row.delivery.RecipientEndpoint = endpoint
-		if err := rows.Scan(&row.delivery.ID, &row.leaseMachine, &row.leaseToken, &row.delivery.LeaseGeneration, &row.leaseOwnership, &row.leaseConsumer, &row.leaseUntil, &row.delivery.Message.ID, &row.delivery.Message.ConversationID, &row.delivery.Message.Sequence, &row.delivery.Message.FromEndpoint, &row.delivery.Message.Body, &row.delivery.Message.CreatedAt); err != nil {
+		if err := rows.Scan(&row.delivery.ID, &row.leaseMachine, &row.leaseToken, &row.delivery.LeaseGeneration, &row.leaseOwnership, &row.leaseConsumer, &row.leaseUntil, &row.delivery.Message.ID, &row.delivery.Message.ConversationID, &row.delivery.Message.Sequence, &row.delivery.Message.FromEndpoint, &row.delivery.Message.TargetRole, &row.delivery.Message.Body, &row.delivery.Message.CreatedAt); err != nil {
 			_ = rows.Close()
 			return relay.DeliveryLeasePage{}, errors.New("pending delivery is malformed")
 		}
@@ -696,7 +766,7 @@ func postgresEndpointOwnershipLocked(tx *sql.Tx, endpoint, machineID string, now
 
 func postgresMessageByID(tx *sql.Tx, messageID string) (relay.Message, error) {
 	var message relay.Message
-	if err := tx.QueryRowContext(context.Background(), `SELECT id::text,conversation_id::text,sequence,from_endpoint,body,created_at FROM relay.mail_messages WHERE id=$1::uuid`, messageID).Scan(&message.ID, &message.ConversationID, &message.Sequence, &message.FromEndpoint, &message.Body, &message.CreatedAt); err != nil {
+	if err := tx.QueryRowContext(context.Background(), `SELECT id::text,conversation_id::text,sequence,from_endpoint,target_role,body,created_at FROM relay.mail_messages WHERE id=$1::uuid`, messageID).Scan(&message.ID, &message.ConversationID, &message.Sequence, &message.FromEndpoint, &message.TargetRole, &message.Body, &message.CreatedAt); err != nil {
 		return relay.Message{}, errors.New("idempotent message is unavailable")
 	}
 	message.CreatedAt = message.CreatedAt.UTC()

--- a/internal/postgres/state_test.go
+++ b/internal/postgres/state_test.go
@@ -69,8 +69,8 @@ func TestManifestValidationRejectsMutableOrNonContiguousHistory(t *testing.T) {
 
 func TestCurrentManifestRequiresControlPlaneSchema(t *testing.T) {
 	manifest := CurrentManifest()
-	if manifest.MinSupported != 10 || manifest.MaxSupported != 39 || len(manifest.Migrations) != 39 {
-		t.Fatalf("manifest=%#v, want exact v39 compatibility window", manifest)
+	if manifest.MinSupported != 10 || manifest.MaxSupported != 40 || len(manifest.Migrations) != 40 {
+		t.Fatalf("manifest=%#v, want exact v40 compatibility window", manifest)
 	}
 	embedding := manifest.Migrations[23]
 	if embedding.Version != 24 || embedding.Name != "024_memory_embedding_worker_control" ||
@@ -88,7 +88,7 @@ func TestCurrentManifestRequiresControlPlaneSchema(t *testing.T) {
 			want = 10
 		case 12, 13:
 			want = 10
-		case 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39:
+		case 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40:
 			want = 10
 		}
 		if migration.CompatibilityFloor != want {
@@ -201,7 +201,10 @@ func TestCompatibleSchemaCanStillHavePendingMigrations(t *testing.T) {
 	if !migrationPending(SchemaState{Classification: Compatible, Version: 38}, manifest) {
 		t.Fatal("compatible v38 schema must still apply the pending v39 migration")
 	}
-	if migrationPending(SchemaState{Classification: Compatible, Version: 39}, manifest) {
-		t.Fatal("current v39 schema reported a pending migration")
+	if !migrationPending(SchemaState{Classification: Compatible, Version: 39}, manifest) {
+		t.Fatal("compatible v39 schema must still apply the pending v40 migration")
+	}
+	if migrationPending(SchemaState{Classification: Compatible, Version: 40}, manifest) {
+		t.Fatal("current v40 schema reported a pending migration")
 	}
 }

--- a/internal/relay/backend.go
+++ b/internal/relay/backend.go
@@ -26,6 +26,10 @@ func ValidMachineID(value string) bool { return validBoundedText(value, 128, 512
 // ValidEndpoint reports whether a mailbox address has portable durable bounds.
 func ValidEndpoint(value string) bool { return validBoundedText(value, 512, 2048) }
 
+// ValidRole reports whether a durable role label has portable, unambiguous
+// bounds. The empty value denotes the existing unaddressed/broadcast behavior.
+func ValidRole(value string) bool { return value == "" || validBoundedText(value, 64, 256) }
+
 // ValidRequestToken bounds nonces, idempotency keys, and consumer identities.
 func ValidRequestToken(value string) bool { return validBoundedText(value, 128, 512) }
 
@@ -57,6 +61,7 @@ type Backend interface {
 	AdvertiseEndpoints(machineID string, endpoints []string, now time.Time, ttl time.Duration) error
 	AssertEndpointOwnership(machineID, endpoint string, now time.Time) error
 	CreateConversationIdempotent(CreateConversationInput) (Conversation, error)
+	UpdateMembership(conversationID, machineID, adminEndpoint, previousEndpoint string, member Member, now time.Time) error
 	AuthorizeSender(conversationID, machineID, endpoint string, now time.Time) error
 	AppendMessage(AppendInput) (Message, bool, error)
 	LeaseDeliveries(machineID, consumerID, endpoint, conversationID string, now time.Time, ttl time.Duration, limit int) (DeliveryLeasePage, error)

--- a/internal/relay/http.go
+++ b/internal/relay/http.go
@@ -106,6 +106,13 @@ func (h *handler) serveHTTP(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		h.requestInvocation(w, body, machineID, conversationID, now, r.Header.Get("Idempotency-Key"))
+	case r.Method == http.MethodPut && strings.HasPrefix(r.URL.Path, "/v1/conversations/") && strings.HasSuffix(r.URL.Path, "/memberships"):
+		conversationID := strings.TrimSuffix(strings.TrimPrefix(r.URL.Path, "/v1/conversations/"), "/memberships")
+		if conversationID == "" || strings.Contains(conversationID, "/") {
+			writeError(w, http.StatusNotFound, "route not found")
+			return
+		}
+		h.updateMembership(w, body, machineID, conversationID, now)
 	case r.Method == http.MethodPost && strings.HasPrefix(r.URL.Path, "/v1/conversations/") && strings.HasSuffix(r.URL.Path, "/sender-validation"):
 		conversationID := strings.TrimSuffix(strings.TrimPrefix(r.URL.Path, "/v1/conversations/"), "/sender-validation")
 		if conversationID == "" || strings.Contains(conversationID, "/") {
@@ -285,6 +292,7 @@ func (h *handler) createConversation(w http.ResponseWriter, body []byte, machine
 		Members         []struct {
 			Endpoint     string   `json:"endpoint"`
 			Capabilities []string `json:"capabilities"`
+			Role         string   `json:"role"`
 		} `json:"members"`
 	}
 	if err := decodeJSON(body, &request); err != nil {
@@ -306,7 +314,7 @@ func (h *handler) createConversation(w http.ResponseWriter, body []byte, machine
 			writeError(w, http.StatusBadRequest, "invalid conversation capabilities")
 			return
 		}
-		members = append(members, Member{Endpoint: member.Endpoint, Capabilities: capabilities})
+		members = append(members, Member{Endpoint: member.Endpoint, Capabilities: capabilities, Role: member.Role})
 	}
 	conversation, err := h.store.CreateConversationIdempotent(CreateConversationInput{MachineID: machineID, PrincipalID: authority.PrincipalID, CredentialLookupID: authority.CredentialLookupID, CredentialGeneration: authority.CredentialGeneration, ProjectID: request.ProjectID, IdempotencyKey: idempotencyKey, CreatorEndpoint: request.CreatorEndpoint, Members: members, Now: now})
 	if err != nil {
@@ -323,6 +331,7 @@ func (h *handler) appendMessage(w http.ResponseWriter, body []byte, machineID st
 	}
 	var request struct {
 		FromEndpoint string   `json:"from_endpoint"`
+		TargetRole   string   `json:"target_role"`
 		Body         string   `json:"body"`
 		ArtifactIDs  []string `json:"artifact_ids"`
 	}
@@ -334,7 +343,7 @@ func (h *handler) appendMessage(w http.ResponseWriter, body []byte, machineID st
 		writeError(w, http.StatusForbidden, "authorization denied")
 		return
 	}
-	message, duplicate, err := h.store.AppendMessage(AppendInput{ConversationID: conversationID, SenderMachineID: machineID, PrincipalID: authority.PrincipalID, CredentialLookupID: authority.CredentialLookupID, CredentialGeneration: authority.CredentialGeneration, FromEndpoint: request.FromEndpoint, Body: request.Body, ArtifactIDs: request.ArtifactIDs, IdempotencyKey: idempotencyKey, Now: now})
+	message, duplicate, err := h.store.AppendMessage(AppendInput{ConversationID: conversationID, SenderMachineID: machineID, PrincipalID: authority.PrincipalID, CredentialLookupID: authority.CredentialLookupID, CredentialGeneration: authority.CredentialGeneration, FromEndpoint: request.FromEndpoint, TargetRole: request.TargetRole, Body: request.Body, ArtifactIDs: request.ArtifactIDs, IdempotencyKey: idempotencyKey, Now: now})
 	if err != nil {
 		writeStoreError(w, err)
 		return
@@ -458,6 +467,36 @@ func (h *handler) reportInvocation(w http.ResponseWriter, body []byte, machineID
 	w.WriteHeader(http.StatusNoContent)
 }
 
+func (h *handler) updateMembership(w http.ResponseWriter, body []byte, machineID, conversationID string, now time.Time) {
+	var request struct {
+		FromEndpoint     string `json:"from_endpoint"`
+		PreviousEndpoint string `json:"previous_endpoint"`
+		Member           struct {
+			Endpoint     string   `json:"endpoint"`
+			Capabilities []string `json:"capabilities"`
+			Role         string   `json:"role"`
+		} `json:"member"`
+	}
+	if err := decodeJSON(body, &request); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid membership update")
+		return
+	}
+	if !h.auth.AllowsEndpoint(machineID, request.FromEndpoint) {
+		writeError(w, http.StatusForbidden, "authorization denied")
+		return
+	}
+	capabilities, err := parseCapabilities(request.Member.Capabilities)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "invalid conversation capabilities")
+		return
+	}
+	if err := h.store.UpdateMembership(conversationID, machineID, request.FromEndpoint, request.PreviousEndpoint, Member{Endpoint: request.Member.Endpoint, Capabilities: capabilities, Role: request.Member.Role}, now); err != nil {
+		writeStoreError(w, err)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
 func (h *handler) leaseDeliveries(w http.ResponseWriter, body []byte, machineID string, now time.Time) {
 	var request struct {
 		Endpoint       string `json:"endpoint"`
@@ -561,6 +600,8 @@ func writeStoreError(w http.ResponseWriter, err error) {
 		writeError(w, http.StatusForbidden, "authorization denied")
 	case errors.Is(err, ErrConflict):
 		writeError(w, http.StatusConflict, "request conflicts with durable state")
+	case errors.Is(err, ErrNoEligibleRecipient):
+		writeError(w, http.StatusUnprocessableEntity, "no eligible recipient for addressed role")
 	case errors.Is(err, ErrMaintenance):
 		w.Header().Set("Retry-After", "5")
 		writeError(w, http.StatusServiceUnavailable, "relay maintenance in progress")

--- a/internal/relay/http_test.go
+++ b/internal/relay/http_test.go
@@ -100,6 +100,52 @@ func TestHTTPDurableMessageFlowRequiresSignedMachineRequests(t *testing.T) {
 	}
 }
 
+func TestHTTPRoleAddressingRequiresAuthorizedActiveRecipient(t *testing.T) {
+	publicA, privateA, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	publicB, privateB, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	store, err := Open(filepath.Join(t.TempDir(), "relay.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	auth, err := NewAuthenticator(store, []Machine{{ID: "machine-a", PublicKey: publicA, EndpointPrefixes: []string{"agent/a/"}}, {ID: "machine-b", PublicKey: publicB, EndpointPrefixes: []string{"agent/b/"}}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	clock := time.Date(2026, time.July, 13, 12, 0, 0, 0, time.UTC)
+	handler := NewHandler(store, auth, HandlerOptions{Now: func() time.Time { return clock }, EndpointLeaseTTL: time.Minute})
+	serveSigned(t, handler, privateA, "machine-a", http.MethodPut, "/v1/machines/me/endpoints", `{"endpoints":["agent/a/session"]}`, "advertise-a", "")
+	serveSigned(t, handler, privateB, "machine-b", http.MethodPut, "/v1/machines/me/endpoints", `{"endpoints":["agent/b/reviewer","agent/b/other"]}`, "advertise-b", "")
+	created := serveSigned(t, handler, privateA, "machine-a", http.MethodPost, "/v1/conversations", `{"creator_endpoint":"agent/a/session","members":[{"endpoint":"agent/a/session","capabilities":["send","receive","admin"],"role":"coordinator"},{"endpoint":"agent/b/reviewer","capabilities":["receive"],"role":"reviewer"},{"endpoint":"agent/b/other","capabilities":["receive"],"role":"implementer"}]}`, "create", "role-create")
+	var conversation Conversation
+	if created.Code != http.StatusCreated || json.NewDecoder(created.Body).Decode(&conversation) != nil {
+		t.Fatalf("create=%d %s", created.Code, created.Body.String())
+	}
+	unauthorized := serveSigned(t, handler, privateB, "machine-b", http.MethodPut, "/v1/conversations/"+conversation.ID+"/memberships", `{"from_endpoint":"agent/b/reviewer","previous_endpoint":"agent/b/reviewer","member":{"endpoint":"agent/b/reviewer","capabilities":["receive"],"role":"implementer"}}`, "non-admin-change", "")
+	if unauthorized.Code != http.StatusForbidden {
+		t.Fatalf("non-admin change=%d %s", unauthorized.Code, unauthorized.Body.String())
+	}
+	message := serveSigned(t, handler, privateA, "machine-a", http.MethodPost, "/v1/conversations/"+conversation.ID+"/messages", `{"from_endpoint":"agent/a/session","target_role":"reviewer","body":"please review"}`, "role-send", "role-send")
+	if message.Code != http.StatusCreated {
+		t.Fatalf("role send=%d %s", message.Code, message.Body.String())
+	}
+	missing := serveSigned(t, handler, privateA, "machine-a", http.MethodPost, "/v1/conversations/"+conversation.ID+"/messages", `{"from_endpoint":"agent/a/session","target_role":"missing","body":"please review"}`, "missing-send", "missing-send")
+	if missing.Code != http.StatusUnprocessableEntity || !strings.Contains(missing.Body.String(), "no eligible recipient") {
+		t.Fatalf("missing role=%d %s", missing.Code, missing.Body.String())
+	}
+	leaseReviewer := serveSigned(t, handler, privateB, "machine-b", http.MethodPost, "/v1/deliveries/lease", `{"endpoint":"agent/b/reviewer","consumer_id":"reviewer-consumer"}`, "lease-reviewer", "")
+	leaseOther := serveSigned(t, handler, privateB, "machine-b", http.MethodPost, "/v1/deliveries/lease", `{"endpoint":"agent/b/other","consumer_id":"other-consumer"}`, "lease-other", "")
+	if !strings.Contains(leaseReviewer.Body.String(), "please review") || strings.Contains(leaseOther.Body.String(), "please review") {
+		t.Fatalf("role leases reviewer=%s other=%s", leaseReviewer.Body.String(), leaseOther.Body.String())
+	}
+}
+
 type principalEndpointRecordingBackend struct {
 	Backend
 	plainCalls     int

--- a/internal/relay/migration_source.go
+++ b/internal/relay/migration_source.go
@@ -86,8 +86,8 @@ type migrationTableSpec struct {
 var migrationTableSpecs = []migrationTableSpec{
 	{"endpoints", "endpoint,machine_id,lease_until,ownership_generation,consumer_id,consumer_generation,consumer_lease_until", "endpoint"},
 	{"conversations", "id,next_sequence,created_at", "id"},
-	{"memberships", "conversation_id,endpoint,capabilities", "conversation_id,endpoint"},
-	{"messages", "id,conversation_id,sequence,from_endpoint,body,created_at", "id"},
+	{"memberships", "conversation_id,endpoint,capabilities,role", "conversation_id,endpoint"},
+	{"messages", "id,conversation_id,sequence,from_endpoint,target_role,body,created_at", "id"},
 	{"deliveries", "id,message_id,recipient_endpoint,lease_machine_id,lease_token,lease_generation,ownership_generation,consumer_generation,lease_until,acked_at", "id"},
 	{"recipient_cursors", "recipient_endpoint,conversation_id,sequence", "recipient_endpoint,conversation_id"},
 	{"idempotency", "machine_id,key,request_hash,message_id,created_at", "machine_id,key"},
@@ -95,7 +95,7 @@ var migrationTableSpecs = []migrationTableSpec{
 	{"request_nonces", "machine_id,nonce,expires_at", "machine_id,nonce"},
 }
 
-const migrationSourceSchema = "punaro-relay-sqlite-v1:endpoints;conversations;memberships;messages;deliveries;recipient_cursors;idempotency;conversation_idempotency;request_nonces"
+const migrationSourceSchema = "punaro-relay-sqlite-v2:endpoints;conversations;memberships;messages;deliveries;recipient_cursors;idempotency;conversation_idempotency;request_nonces"
 
 // InspectMigrationSource reads an existing source without creating, migrating,
 // checkpointing, or changing its logical cutover state.
@@ -406,8 +406,8 @@ func verifyMigrationSourceSchema(ctx context.Context, q migrationQueryer) error 
 	expectedColumns := map[string][]string{
 		"endpoints":                {"endpoint:TEXT:0:1:-", "machine_id:TEXT:1:0:-", "lease_until:INTEGER:1:0:-", "ownership_generation:INTEGER:1:0:1", "consumer_id:TEXT:0:0:-", "consumer_generation:INTEGER:1:0:0", "consumer_lease_until:INTEGER:0:0:-"},
 		"conversations":            {"id:TEXT:0:1:-", "next_sequence:INTEGER:1:0:0", "created_at:INTEGER:1:0:-"},
-		"memberships":              {"conversation_id:TEXT:1:1:-", "endpoint:TEXT:1:2:-", "capabilities:INTEGER:1:0:-"},
-		"messages":                 {"id:TEXT:0:1:-", "conversation_id:TEXT:1:0:-", "sequence:INTEGER:1:0:-", "from_endpoint:TEXT:1:0:-", "body:TEXT:1:0:-", "created_at:INTEGER:1:0:-"},
+		"memberships":              {"conversation_id:TEXT:1:1:-", "endpoint:TEXT:1:2:-", "capabilities:INTEGER:1:0:-", "role:TEXT:1:0:''"},
+		"messages":                 {"id:TEXT:0:1:-", "conversation_id:TEXT:1:0:-", "sequence:INTEGER:1:0:-", "from_endpoint:TEXT:1:0:-", "target_role:TEXT:1:0:''", "body:TEXT:1:0:-", "created_at:INTEGER:1:0:-"},
 		"deliveries":               {"id:TEXT:0:1:-", "message_id:TEXT:1:0:-", "recipient_endpoint:TEXT:1:0:-", "lease_machine_id:TEXT:0:0:-", "lease_token:TEXT:0:0:-", "lease_generation:INTEGER:1:0:0", "ownership_generation:INTEGER:0:0:-", "consumer_generation:INTEGER:0:0:-", "lease_until:INTEGER:0:0:-", "acked_at:INTEGER:0:0:-"},
 		"recipient_cursors":        {"recipient_endpoint:TEXT:1:1:-", "conversation_id:TEXT:1:2:-", "sequence:INTEGER:1:0:0"},
 		"idempotency":              {"machine_id:TEXT:1:1:-", "key:TEXT:1:2:-", "request_hash:TEXT:1:0:-", "message_id:TEXT:1:0:-", "created_at:INTEGER:1:0:-"},
@@ -592,9 +592,9 @@ func verifyMigrationSourceSchema(ctx context.Context, q migrationQueryer) error 
 	SELECT
         EXISTS (SELECT 1 FROM endpoints WHERE ownership_generation<1 OR consumer_generation<0 OR (consumer_id IS NULL)<>(consumer_lease_until IS NULL))
         OR EXISTS (SELECT 1 FROM conversations WHERE next_sequence<0)
-        OR EXISTS (SELECT 1 FROM memberships WHERE capabilities<1 OR capabilities>7)
+        OR EXISTS (SELECT 1 FROM memberships WHERE capabilities<1 OR capabilities>7 OR NOT (role='' OR (length(CAST(role AS blob))<=256 AND length(role)<=64)))
         OR EXISTS (SELECT 1 FROM memberships AS membership LEFT JOIN endpoints AS endpoint ON endpoint.endpoint=membership.endpoint WHERE endpoint.endpoint IS NULL)
-        OR EXISTS (SELECT 1 FROM messages WHERE sequence<1 OR length(CAST(body AS blob))>32768)
+        OR EXISTS (SELECT 1 FROM messages WHERE sequence<1 OR length(CAST(body AS blob))>32768 OR NOT (target_role='' OR (length(CAST(target_role AS blob))<=256 AND length(target_role)<=64)))
         OR EXISTS (SELECT 1 FROM messages AS message LEFT JOIN endpoints AS endpoint ON endpoint.endpoint=message.from_endpoint WHERE endpoint.endpoint IS NULL)
         OR EXISTS (SELECT 1 FROM messages AS message JOIN conversations AS conversation ON conversation.id=message.conversation_id WHERE message.sequence>conversation.next_sequence)
         OR EXISTS (SELECT 1 FROM deliveries WHERE lease_generation<0 OR (lease_token IS NOT NULL AND (ownership_generation<1 OR consumer_generation<0)) OR (acked_at IS NOT NULL AND lease_token IS NOT NULL) OR ((lease_machine_id IS NULL OR lease_token IS NULL OR ownership_generation IS NULL OR consumer_generation IS NULL OR lease_until IS NULL) AND NOT (lease_machine_id IS NULL AND lease_token IS NULL AND ownership_generation IS NULL AND consumer_generation IS NULL AND lease_until IS NULL)))
@@ -608,8 +608,8 @@ func verifyMigrationSourceSchema(ctx context.Context, q migrationQueryer) error 
 		OR EXISTS (SELECT 1 FROM uuid_values WHERE typeof(value)<>'text' OR length(value)<>36 OR substr(value,9,1)<>'-' OR substr(value,14,1)<>'-' OR substr(value,19,1)<>'-' OR substr(value,24,1)<>'-' OR lower(replace(value,'-','')) GLOB '*[^0-9a-f]*')
 		OR EXISTS (SELECT 1 FROM endpoints WHERE typeof(endpoint)<>'text' OR typeof(machine_id)<>'text' OR typeof(lease_until)<>'integer' OR typeof(ownership_generation)<>'integer' OR (consumer_id IS NOT NULL AND typeof(consumer_id)<>'text') OR typeof(consumer_generation)<>'integer' OR (consumer_lease_until IS NOT NULL AND typeof(consumer_lease_until)<>'integer'))
 		OR EXISTS (SELECT 1 FROM conversations WHERE typeof(next_sequence)<>'integer' OR typeof(created_at)<>'integer')
-		OR EXISTS (SELECT 1 FROM memberships WHERE typeof(endpoint)<>'text' OR typeof(capabilities)<>'integer')
-		OR EXISTS (SELECT 1 FROM messages WHERE typeof(sequence)<>'integer' OR typeof(from_endpoint)<>'text' OR typeof(body)<>'text' OR typeof(created_at)<>'integer')
+		OR EXISTS (SELECT 1 FROM memberships WHERE typeof(endpoint)<>'text' OR typeof(capabilities)<>'integer' OR typeof(role)<>'text')
+		OR EXISTS (SELECT 1 FROM messages WHERE typeof(sequence)<>'integer' OR typeof(from_endpoint)<>'text' OR typeof(target_role)<>'text' OR typeof(body)<>'text' OR typeof(created_at)<>'integer')
 		OR EXISTS (SELECT 1 FROM deliveries WHERE typeof(recipient_endpoint)<>'text' OR (lease_machine_id IS NOT NULL AND typeof(lease_machine_id)<>'text') OR typeof(lease_generation)<>'integer' OR (lease_token IS NOT NULL AND (typeof(lease_token)<>'text' OR length(lease_token)<>64 OR lease_token GLOB '*[^0-9a-f]*')) OR (ownership_generation IS NOT NULL AND typeof(ownership_generation)<>'integer') OR (consumer_generation IS NOT NULL AND typeof(consumer_generation)<>'integer') OR (lease_until IS NOT NULL AND typeof(lease_until)<>'integer') OR (acked_at IS NOT NULL AND typeof(acked_at)<>'integer'))
 		OR EXISTS (SELECT 1 FROM recipient_cursors WHERE typeof(recipient_endpoint)<>'text' OR typeof(sequence)<>'integer')
 		OR EXISTS (SELECT 1 FROM idempotency WHERE typeof(machine_id)<>'text' OR typeof(key)<>'text' OR typeof(request_hash)<>'text' OR typeof(created_at)<>'integer')
@@ -636,6 +636,8 @@ func validateMigrationSourceValue(table, column string, value any) error {
 		valid = ValidRequestToken(text)
 	case "messages.body":
 		valid = ValidMessageBody(text)
+	case "memberships.role", "messages.target_role":
+		valid = ValidRole(text)
 	case "conversations.id", "memberships.conversation_id", "messages.id", "messages.conversation_id", "deliveries.id", "deliveries.message_id", "recipient_cursors.conversation_id", "idempotency.message_id", "conversation_idempotency.conversation_id":
 		valid = uuid.Validate(text) == nil
 	default:

--- a/internal/relay/migration_source.go
+++ b/internal/relay/migration_source.go
@@ -292,7 +292,7 @@ type migrationQueryer interface {
 }
 
 func inspectMigrationSource(ctx context.Context, q migrationQueryer) (MigrationSourceManifest, error) {
-	manifest := MigrationSourceManifest{Version: 1}
+	manifest := MigrationSourceManifest{Version: 2}
 	var storedFingerprint sql.NullString
 	var controlRows int
 	if err := q.QueryRowContext(ctx, `SELECT count(*) FROM relay_migration_control`).Scan(&controlRows); err != nil || controlRows != 1 {

--- a/internal/relay/migration_source_test.go
+++ b/internal/relay/migration_source_test.go
@@ -86,6 +86,16 @@ func TestMigrationSourceManifestAndBarrier(t *testing.T) {
 	if prepared.Phase != MigrationSourcePrepared || prepared.EpochID != epochID || prepared.TargetIdentity != targetID || prepared.Fingerprint == first.Fingerprint {
 		t.Fatalf("prepared manifest=%#v active=%#v", prepared, first)
 	}
+	if reopened, err := Open(path); !errors.Is(err, ErrMigrationSourcePrepared) {
+		if reopened != nil {
+			_ = reopened.Close()
+		}
+		t.Fatalf("open prepared source err=%v", err)
+	}
+	stillPrepared, err := InspectMigrationSource(ctx, path)
+	if err != nil || stillPrepared != prepared {
+		t.Fatalf("opening prepared source mutated manifest=%#v want=%#v err=%v", stillPrepared, prepared, err)
+	}
 	preparedRetry, err := PrepareMigrationSource(ctx, path, epochID, targetID, first.Fingerprint, now.Add(time.Minute))
 	if err != nil || preparedRetry != prepared {
 		t.Fatalf("exact prepare retry=%#v err=%v, want %#v", preparedRetry, err, prepared)

--- a/internal/relay/migration_source_test.go
+++ b/internal/relay/migration_source_test.go
@@ -60,7 +60,7 @@ func TestMigrationSourceManifestAndBarrier(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if first != second || first.Version != 1 || first.SourceID == "" || first.Phase != MigrationSourceActive || first.Fingerprint == "" {
+	if first != second || first.Version != 2 || first.SourceID == "" || first.Phase != MigrationSourceActive || first.Fingerprint == "" {
 		t.Fatalf("unstable manifest first=%#v second=%#v", first, second)
 	}
 	if first.Counts.Endpoints != 2 || first.Counts.Conversations != 1 || first.Counts.Messages != 1 || first.Counts.Deliveries != 1 || first.Counts.MessageIdempotency != 1 || first.Counts.ConversationIdempotency != 1 {

--- a/internal/relay/role_routing_test.go
+++ b/internal/relay/role_routing_test.go
@@ -128,6 +128,9 @@ func TestMembershipRoleChangesRequireAdminAndSurviveRestart(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	if err := store.UpdateMembership(conversation.ID, "machine-admin", "agent/admin", "agent/admin", Member{Endpoint: "agent/admin", Capabilities: CapSend | CapReceive, Role: "coordinator"}, now); !errors.Is(err, ErrForbidden) {
+		t.Fatalf("removing the last administrator err=%v", err)
+	}
 	if _, duplicate, err := store.AppendMessage(AppendInput{ConversationID: conversation.ID, SenderMachineID: "machine-admin", FromEndpoint: "agent/admin", Body: "queued for reviewer", TargetRole: "reviewer", IdempotencyKey: "before-rebind", Now: now}); err != nil || duplicate {
 		t.Fatalf("queue before rebind duplicate=%t err=%v", duplicate, err)
 	}

--- a/internal/relay/role_routing_test.go
+++ b/internal/relay/role_routing_test.go
@@ -1,0 +1,155 @@
+package relay
+
+import (
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestRoleAddressedRoutingTargetsOnlyActiveRoleMembersAndPreservesRetry(t *testing.T) {
+	t.Parallel()
+	store, err := Open(t.TempDir() + "/relay.db")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	now := time.Date(2026, time.August, 3, 12, 0, 0, 0, time.UTC)
+	if err := store.AdvertiseEndpoints("machine-a", []string{"agent/a"}, now, time.Hour); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.AdvertiseEndpoints("machine-b", []string{"agent/reviewer-1", "agent/reviewer-2", "agent/implementer"}, now, time.Hour); err != nil {
+		t.Fatal(err)
+	}
+	conversation, err := store.CreateConversation("agent/a", []Member{
+		{Endpoint: "agent/a", Capabilities: CapSend | CapReceive | CapAdmin, Role: "coordinator"},
+		{Endpoint: "agent/reviewer-1", Capabilities: CapReceive, Role: "reviewer"},
+		{Endpoint: "agent/reviewer-2", Capabilities: CapReceive, Role: "reviewer"},
+		{Endpoint: "agent/implementer", Capabilities: CapReceive, Role: "implementer"},
+	}, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	input := AppendInput{ConversationID: conversation.ID, SenderMachineID: "machine-a", FromEndpoint: "agent/a", Body: "review this", TargetRole: "reviewer", IdempotencyKey: "role-send", Now: now}
+	message, duplicate, err := store.AppendMessage(input)
+	if err != nil || duplicate || message.TargetRole != "reviewer" {
+		t.Fatalf("append=%#v duplicate=%t err=%v", message, duplicate, err)
+	}
+	for _, endpoint := range []string{"agent/reviewer-1", "agent/reviewer-2"} {
+		page, err := store.LeaseDeliveries("machine-b", "consumer-"+endpoint, endpoint, conversation.ID, now, time.Minute, 10)
+		if err != nil || len(page.Deliveries) != 1 || page.Deliveries[0].Message != message {
+			t.Fatalf("role delivery endpoint=%q page=%#v err=%v", endpoint, page, err)
+		}
+	}
+	page, err := store.LeaseDeliveries("machine-b", "consumer-implementer", "agent/implementer", conversation.ID, now, time.Minute, 10)
+	if err != nil || len(page.Deliveries) != 0 {
+		t.Fatalf("non-role recipient page=%#v err=%v", page, err)
+	}
+	if err := store.UpdateMembership(conversation.ID, "machine-a", "agent/a", "agent/reviewer-1", Member{Endpoint: "agent/reviewer-1", Capabilities: CapReceive, Role: "implementer"}, now); err != nil {
+		t.Fatalf("change reviewer role: %v", err)
+	}
+	repeated, duplicate, err := store.AppendMessage(input)
+	if err != nil || !duplicate || repeated != message {
+		t.Fatalf("retry after role change=%#v duplicate=%t err=%v", repeated, duplicate, err)
+	}
+}
+
+func TestRoleLabelsMustBePortable(t *testing.T) {
+	for _, role := range []string{"", "reviewer", "release-manager"} {
+		if !ValidRole(role) {
+			t.Fatalf("expected valid role %q", role)
+		}
+	}
+	for _, role := range []string{" reviewer", "reviewer ", "reviewer\n", string(make([]byte, 65))} {
+		if ValidRole(role) {
+			t.Fatalf("expected invalid role %q", role)
+		}
+	}
+}
+
+func TestRoleAddressedRoutingFailsWithoutEligibleRecipientAndDoesNotConsumeRetry(t *testing.T) {
+	t.Parallel()
+	store, err := Open(t.TempDir() + "/relay.db")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	now := time.Date(2026, time.August, 3, 12, 0, 0, 0, time.UTC)
+	if err := store.AdvertiseEndpoints("machine-a", []string{"agent/a"}, now, time.Hour); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.AdvertiseEndpoints("machine-b", []string{"agent/old-reviewer"}, now, time.Hour); err != nil {
+		t.Fatal(err)
+	}
+	conversation, err := store.CreateConversation("agent/a", []Member{
+		{Endpoint: "agent/a", Capabilities: CapSend | CapReceive | CapAdmin, Role: "coordinator"},
+		{Endpoint: "agent/old-reviewer", Capabilities: CapReceive, Role: "reviewer"},
+	}, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	later := now.Add(time.Second)
+	if err := store.AdvertiseEndpoints("machine-b", nil, later, time.Hour); err != nil {
+		t.Fatal(err)
+	}
+	input := AppendInput{ConversationID: conversation.ID, SenderMachineID: "machine-a", FromEndpoint: "agent/a", Body: "review this", TargetRole: "reviewer", IdempotencyKey: "role-send", Now: later}
+	if _, _, err := store.AppendMessage(input); !errors.Is(err, ErrNoEligibleRecipient) {
+		t.Fatalf("missing recipient err=%v", err)
+	}
+	if err := store.AdvertiseEndpoints("machine-b", []string{"agent/reviewer"}, later, time.Hour); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.UpdateMembership(conversation.ID, "machine-a", "agent/a", "agent/old-reviewer", Member{Endpoint: "agent/reviewer", Capabilities: CapReceive, Role: "reviewer"}, later); err != nil {
+		t.Fatal(err)
+	}
+	message, duplicate, err := store.AppendMessage(input)
+	if err != nil || duplicate || message.Sequence != 1 {
+		t.Fatalf("retry after rebinding message=%#v duplicate=%t err=%v", message, duplicate, err)
+	}
+}
+
+func TestMembershipRoleChangesRequireAdminAndSurviveRestart(t *testing.T) {
+	t.Parallel()
+	path := t.TempDir() + "/relay.db"
+	store, err := Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	now := time.Date(2026, time.August, 3, 12, 0, 0, 0, time.UTC)
+	if err := store.AdvertiseEndpoints("machine-admin", []string{"agent/admin"}, now, time.Hour); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.AdvertiseEndpoints("machine-member", []string{"agent/old", "agent/new"}, now, time.Hour); err != nil {
+		t.Fatal(err)
+	}
+	conversation, err := store.CreateConversation("agent/admin", []Member{
+		{Endpoint: "agent/admin", Capabilities: CapSend | CapReceive | CapAdmin, Role: "coordinator"},
+		{Endpoint: "agent/old", Capabilities: CapReceive, Role: "reviewer"},
+	}, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, duplicate, err := store.AppendMessage(AppendInput{ConversationID: conversation.ID, SenderMachineID: "machine-admin", FromEndpoint: "agent/admin", Body: "queued for reviewer", TargetRole: "reviewer", IdempotencyKey: "before-rebind", Now: now}); err != nil || duplicate {
+		t.Fatalf("queue before rebind duplicate=%t err=%v", duplicate, err)
+	}
+	if err := store.UpdateMembership(conversation.ID, "machine-member", "agent/old", "", Member{Endpoint: "agent/new", Capabilities: CapReceive, Role: "implementer"}, now); !errors.Is(err, ErrForbidden) {
+		t.Fatalf("non-admin role change err=%v", err)
+	}
+	if err := store.UpdateMembership(conversation.ID, "machine-admin", "agent/admin", "agent/old", Member{Endpoint: "agent/new", Capabilities: CapReceive, Role: "implementer"}, now); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatal(err)
+	}
+	store, err = Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	if _, _, err := store.AppendMessage(AppendInput{ConversationID: conversation.ID, SenderMachineID: "machine-admin", FromEndpoint: "agent/admin", Body: "implement", TargetRole: "implementer", IdempotencyKey: "after-restart", Now: now}); err != nil {
+		t.Fatalf("rebound role after restart err=%v", err)
+	}
+	page, err := store.LeaseDeliveries("machine-member", "rebound-consumer", "agent/new", conversation.ID, now, time.Minute, 10)
+	if err != nil || len(page.Deliveries) != 2 || page.Deliveries[0].Message.Body != "queued for reviewer" || page.Deliveries[1].Message.Body != "implement" {
+		t.Fatalf("rebound deliveries=%#v err=%v", page, err)
+	}
+}

--- a/internal/relay/role_routing_test.go
+++ b/internal/relay/role_routing_test.go
@@ -137,6 +137,9 @@ func TestMembershipRoleChangesRequireAdminAndSurviveRestart(t *testing.T) {
 	if err := store.UpdateMembership(conversation.ID, "machine-admin", "agent/admin", "agent/old", Member{Endpoint: "agent/new", Capabilities: CapReceive, Role: "implementer"}, now); err != nil {
 		t.Fatal(err)
 	}
+	if err := store.UpdateMembership(conversation.ID, "machine-admin", "agent/admin", "agent/old", Member{Endpoint: "agent/new", Capabilities: CapReceive, Role: "implementer"}, now); err != nil {
+		t.Fatalf("replayed rebinding: %v", err)
+	}
 	if err := store.Close(); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/relay/role_routing_test.go
+++ b/internal/relay/role_routing_test.go
@@ -44,6 +44,9 @@ func TestRoleAddressedRoutingTargetsOnlyActiveRoleMembersAndPreservesRetry(t *te
 	if err != nil || len(page.Deliveries) != 0 {
 		t.Fatalf("non-role recipient page=%#v err=%v", page, err)
 	}
+	if err := store.UpdateMembership(conversation.ID, "machine-a", "agent/a", "agent/reviewer-1", Member{Endpoint: "agent/reviewer-2", Capabilities: CapReceive, Role: "reviewer"}, now); !errors.Is(err, ErrForbidden) {
+		t.Fatalf("rebind to existing member err=%v", err)
+	}
 	if err := store.UpdateMembership(conversation.ID, "machine-a", "agent/a", "agent/reviewer-1", Member{Endpoint: "agent/reviewer-1", Capabilities: CapReceive, Role: "implementer"}, now); err != nil {
 		t.Fatalf("change reviewer role: %v", err)
 	}
@@ -133,6 +136,9 @@ func TestMembershipRoleChangesRequireAdminAndSurviveRestart(t *testing.T) {
 	}
 	if _, duplicate, err := store.AppendMessage(AppendInput{ConversationID: conversation.ID, SenderMachineID: "machine-admin", FromEndpoint: "agent/admin", Body: "queued for reviewer", TargetRole: "reviewer", IdempotencyKey: "before-rebind", Now: now}); err != nil || duplicate {
 		t.Fatalf("queue before rebind duplicate=%t err=%v", duplicate, err)
+	}
+	if err := store.UpdateMembership(conversation.ID, "machine-admin", "agent/admin", "agent/old", Member{Endpoint: "agent/old", Capabilities: CapSend, Role: "reviewer"}, now); !errors.Is(err, ErrForbidden) {
+		t.Fatalf("remove receive with pending delivery err=%v", err)
 	}
 	if err := store.UpdateMembership(conversation.ID, "machine-member", "agent/old", "", Member{Endpoint: "agent/new", Capabilities: CapReceive, Role: "implementer"}, now); !errors.Is(err, ErrForbidden) {
 		t.Fatalf("non-admin role change err=%v", err)

--- a/internal/relay/store.go
+++ b/internal/relay/store.go
@@ -207,6 +207,26 @@ func Open(database string) (*Store, error) {
 	db.SetMaxOpenConns(1)
 	db.SetMaxIdleConns(1)
 	store := &Store{db: db}
+	var migrationControlExists bool
+	if err := db.QueryRowContext(context.Background(), `SELECT EXISTS (SELECT 1 FROM sqlite_schema WHERE type='table' AND name='relay_migration_control')`).Scan(&migrationControlExists); err != nil {
+		_ = db.Close()
+		return nil, fmt.Errorf("inspect relay migration control: %w", err)
+	}
+	if migrationControlExists {
+		var migrationPhase MigrationSourcePhase
+		if err := db.QueryRowContext(context.Background(), `SELECT phase FROM relay_migration_control WHERE singleton=1`).Scan(&migrationPhase); err != nil {
+			_ = db.Close()
+			return nil, fmt.Errorf("inspect relay migration phase: %w", err)
+		}
+		if migrationPhase == MigrationSourcePrepared {
+			_ = db.Close()
+			return nil, ErrMigrationSourcePrepared
+		}
+		if migrationPhase == MigrationSourceRetired {
+			_ = db.Close()
+			return nil, ErrMigrationSourceRetired
+		}
+	}
 	if err := store.migrate(context.Background()); err != nil {
 		_ = db.Close()
 		return nil, err
@@ -642,6 +662,15 @@ func (s *Store) UpdateMembership(conversationID, machineID, adminEndpoint, previ
 	if err := endpointOwnedBy(tx, adminEndpoint, machineID, now); err != nil {
 		return err
 	}
+	// Serialize every membership transition for this conversation so concurrent
+	// administrators cannot each observe another admin and remove the last one.
+	result, err := tx.ExecContext(context.Background(), "UPDATE conversations SET created_at=created_at WHERE id=?", conversationID)
+	if err != nil {
+		return fmt.Errorf("lock conversation membership transition: %w", err)
+	}
+	if changed, err := result.RowsAffected(); err != nil || changed != 1 {
+		return ErrForbidden
+	}
 	var adminCapabilities Capability
 	if err := tx.QueryRowContext(context.Background(), "SELECT capabilities FROM memberships WHERE conversation_id=? AND endpoint=?", conversationID, adminEndpoint).Scan(&adminCapabilities); errors.Is(err, sql.ErrNoRows) || adminCapabilities&CapAdmin == 0 {
 		return ErrForbidden
@@ -698,7 +727,7 @@ func (s *Store) UpdateMembership(conversationID, machineID, adminEndpoint, previ
 			return fmt.Errorf("rebind pending deliveries: %w", err)
 		}
 	}
-	result, err := tx.ExecContext(context.Background(), "UPDATE memberships SET endpoint=?, capabilities=?, role=? WHERE conversation_id=? AND endpoint=?", member.Endpoint, member.Capabilities, member.Role, conversationID, previousEndpoint)
+	result, err = tx.ExecContext(context.Background(), "UPDATE memberships SET endpoint=?, capabilities=?, role=? WHERE conversation_id=? AND endpoint=?", member.Endpoint, member.Capabilities, member.Role, conversationID, previousEndpoint)
 	if err != nil {
 		return fmt.Errorf("update conversation member: %w", err)
 	}

--- a/internal/relay/store.go
+++ b/internal/relay/store.go
@@ -33,6 +33,10 @@ var (
 	// ErrConflict denotes a valid request that conflicts with durable state,
 	// such as reusing an idempotency key with another request body.
 	ErrConflict = errors.New("relay state conflict")
+	// ErrNoEligibleRecipient means an authorized role-addressed send could not
+	// find a currently attached member with that role. It does not allocate a
+	// message or consume the sender's retry key.
+	ErrNoEligibleRecipient = errors.New("no eligible recipient for addressed role")
 	// ErrMaintenance is a retryable, payload-free refusal while the durable
 	// update fence owns application mutations.
 	ErrMaintenance = errors.New("relay maintenance in progress")
@@ -63,6 +67,7 @@ const (
 type Member struct {
 	Endpoint     string
 	Capabilities Capability
+	Role         string
 }
 
 // Conversation is an immutable identifier returned when a room is created.
@@ -77,6 +82,7 @@ type Message struct {
 	ConversationID string    `json:"conversation_id"`
 	Sequence       int64     `json:"sequence"`
 	FromEndpoint   string    `json:"from_endpoint"`
+	TargetRole     string    `json:"target_role,omitempty"`
 	Body           string    `json:"body"`
 	CreatedAt      time.Time `json:"created_at"`
 }
@@ -107,6 +113,7 @@ type AppendInput struct {
 	CredentialLookupID   string
 	CredentialGeneration int64
 	FromEndpoint         string
+	TargetRole           string
 	Body                 string
 	ArtifactIDs          []string
 	IdempotencyKey       string
@@ -275,6 +282,7 @@ func (s *Store) migrate(ctx context.Context) error {
 			conversation_id TEXT NOT NULL REFERENCES conversations(id) ON DELETE CASCADE,
 			endpoint TEXT NOT NULL,
 			capabilities INTEGER NOT NULL,
+			role TEXT NOT NULL DEFAULT '',
 			PRIMARY KEY (conversation_id, endpoint)
 		)`,
 		`CREATE TABLE IF NOT EXISTS messages (
@@ -282,6 +290,7 @@ func (s *Store) migrate(ctx context.Context) error {
 			conversation_id TEXT NOT NULL REFERENCES conversations(id) ON DELETE CASCADE,
 			sequence INTEGER NOT NULL,
 			from_endpoint TEXT NOT NULL,
+			target_role TEXT NOT NULL DEFAULT '',
 			body TEXT NOT NULL,
 			created_at INTEGER NOT NULL,
 			UNIQUE (conversation_id, sequence)
@@ -378,6 +387,8 @@ func (s *Store) migrate(ctx context.Context) error {
 		{"endpoints", "consumer_lease_until", "INTEGER"},
 		{"deliveries", "ownership_generation", "INTEGER"},
 		{"deliveries", "consumer_generation", "INTEGER"},
+		{"memberships", "role", "TEXT NOT NULL DEFAULT ''"},
+		{"messages", "target_role", "TEXT NOT NULL DEFAULT ''"},
 		{"relay_migration_control", "last_epoch_id", "TEXT"},
 		{"relay_migration_control", "last_target_identity", "TEXT"},
 		{"relay_migration_control", "last_expected_fingerprint", "TEXT"},
@@ -393,7 +404,7 @@ func (s *Store) migrate(ctx context.Context) error {
 }
 
 func ensureSQLiteColumn(ctx context.Context, db *sql.DB, table, name, definition string) error {
-	if table != "endpoints" && table != "deliveries" && table != "invocations" && table != "relay_migration_control" {
+	if table != "endpoints" && table != "deliveries" && table != "invocations" && table != "memberships" && table != "messages" && table != "relay_migration_control" {
 		return errors.New("invalid relay migration table")
 	}
 	rows, err := db.QueryContext(ctx, "PRAGMA table_info("+table+")") // #nosec G202 -- table is restricted above to fixed internal names.
@@ -546,7 +557,7 @@ func (s *Store) createConversation(input CreateConversationInput) (Conversation,
 	seen := make(map[string]struct{}, len(members))
 	creatorAdmin := false
 	for _, member := range members {
-		if !ValidEndpoint(member.Endpoint) || member.Capabilities == 0 || member.Capabilities & ^(CapSend|CapReceive|CapAdmin|CapInvoke) != 0 {
+		if !ValidEndpoint(member.Endpoint) || !ValidRole(member.Role) || member.Capabilities == 0 || member.Capabilities & ^(CapSend|CapReceive|CapAdmin|CapInvoke) != 0 {
 			return Conversation{}, fmt.Errorf("invalid conversation member")
 		}
 		if _, duplicate := seen[member.Endpoint]; duplicate {
@@ -601,7 +612,7 @@ func (s *Store) createConversation(input CreateConversationInput) (Conversation,
 		return Conversation{}, fmt.Errorf("create conversation: %w", err)
 	}
 	for _, member := range members {
-		if _, err := tx.ExecContext(context.Background(), "INSERT INTO memberships(conversation_id, endpoint, capabilities) VALUES (?, ?, ?)", conversation.ID, member.Endpoint, member.Capabilities); err != nil {
+		if _, err := tx.ExecContext(context.Background(), "INSERT INTO memberships(conversation_id, endpoint, capabilities, role) VALUES (?, ?, ?, ?)", conversation.ID, member.Endpoint, member.Capabilities, member.Role); err != nil {
 			return Conversation{}, fmt.Errorf("add conversation member: %w", err)
 		}
 	}
@@ -614,6 +625,61 @@ func (s *Store) createConversation(input CreateConversationInput) (Conversation,
 		return Conversation{}, err
 	}
 	return conversation, nil
+}
+
+// UpdateMembership replaces one member under a live administrator's authority.
+// The prior endpoint may be detached, so an administrator can rebind a durable
+// role after the old local session has stopped; the new endpoint must be active.
+func (s *Store) UpdateMembership(conversationID, machineID, adminEndpoint, previousEndpoint string, member Member, now time.Time) error {
+	if strings.TrimSpace(conversationID) == "" || !ValidMachineID(machineID) || !ValidEndpoint(adminEndpoint) || !ValidEndpoint(previousEndpoint) || !ValidEndpoint(member.Endpoint) || !ValidRole(member.Role) || member.Capabilities == 0 || member.Capabilities&^(CapSend|CapReceive|CapAdmin) != 0 {
+		return ErrForbidden
+	}
+	tx, err := s.db.BeginTx(context.Background(), nil)
+	if err != nil {
+		return err
+	}
+	defer rollback(tx)
+	if err := endpointOwnedBy(tx, adminEndpoint, machineID, now); err != nil {
+		return err
+	}
+	var adminCapabilities Capability
+	if err := tx.QueryRowContext(context.Background(), "SELECT capabilities FROM memberships WHERE conversation_id=? AND endpoint=?", conversationID, adminEndpoint).Scan(&adminCapabilities); errors.Is(err, sql.ErrNoRows) || adminCapabilities&CapAdmin == 0 {
+		return ErrForbidden
+	} else if err != nil {
+		return fmt.Errorf("authorize membership administrator: %w", err)
+	}
+	if err := endpointActive(tx, member.Endpoint, now); err != nil {
+		return err
+	}
+	if member.Endpoint != previousEndpoint {
+		// Keep the role's unacknowledged stream durable across session rebinding.
+		// Advancing the cursor with the greater of either endpoint's history avoids
+		// reopening an acknowledged gap while moving pending delivery ownership.
+		if _, err := tx.ExecContext(context.Background(), `INSERT INTO recipient_cursors(recipient_endpoint, conversation_id, sequence)
+			SELECT ?, conversation_id, sequence FROM recipient_cursors WHERE recipient_endpoint=? AND conversation_id=?
+			ON CONFLICT(recipient_endpoint, conversation_id) DO UPDATE SET sequence=MAX(sequence, excluded.sequence)`, member.Endpoint, previousEndpoint, conversationID); err != nil {
+			return fmt.Errorf("preserve rebound recipient cursor: %w", err)
+		}
+		if _, err := tx.ExecContext(context.Background(), "DELETE FROM recipient_cursors WHERE recipient_endpoint=? AND conversation_id=?", previousEndpoint, conversationID); err != nil {
+			return fmt.Errorf("remove prior recipient cursor: %w", err)
+		}
+		if _, err := tx.ExecContext(context.Background(), `UPDATE deliveries SET recipient_endpoint=?
+			WHERE recipient_endpoint=? AND acked_at IS NULL AND message_id IN (SELECT id FROM messages WHERE conversation_id=?)`, member.Endpoint, previousEndpoint, conversationID); err != nil {
+			return fmt.Errorf("rebind pending deliveries: %w", err)
+		}
+	}
+	result, err := tx.ExecContext(context.Background(), "UPDATE memberships SET endpoint=?, capabilities=?, role=? WHERE conversation_id=? AND endpoint=?", member.Endpoint, member.Capabilities, member.Role, conversationID, previousEndpoint)
+	if err != nil {
+		return fmt.Errorf("update conversation member: %w", err)
+	}
+	changed, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("check conversation member update: %w", err)
+	}
+	if changed != 1 {
+		return ErrForbidden
+	}
+	return tx.Commit()
 }
 
 // AuthorizeSender proves the exact live endpoint may append to a conversation
@@ -645,7 +711,7 @@ func (s *Store) AuthorizeSender(conversationID, machineID, endpoint string, now 
 // AppendMessage accepts one immutable, authorized message and creates one
 // independent durable delivery per receiving endpoint, excluding the sender.
 func (s *Store) AppendMessage(input AppendInput) (Message, bool, error) {
-	if strings.TrimSpace(input.ConversationID) == "" || !ValidMachineID(input.SenderMachineID) || !ValidEndpoint(input.FromEndpoint) || !ValidRequestToken(input.IdempotencyKey) || len(input.ArtifactIDs) != 0 {
+	if strings.TrimSpace(input.ConversationID) == "" || !ValidMachineID(input.SenderMachineID) || !ValidEndpoint(input.FromEndpoint) || !ValidRole(input.TargetRole) || !ValidRequestToken(input.IdempotencyKey) || len(input.ArtifactIDs) != 0 {
 		return Message{}, false, fmt.Errorf("conversation, machine, endpoint, and idempotency key are required")
 	}
 	if len(input.Body) > maxMessageBodyBytes {
@@ -689,30 +755,51 @@ func (s *Store) AppendMessage(input AppendInput) (Message, bool, error) {
 	if !errors.Is(err, sql.ErrNoRows) {
 		return Message{}, false, fmt.Errorf("read idempotency key: %w", err)
 	}
-	message := Message{ID: uuid.NewString(), ConversationID: input.ConversationID, FromEndpoint: input.FromEndpoint, Body: input.Body, CreatedAt: input.Now.UTC().Truncate(time.Millisecond)}
+	var recipients []string
+	if input.TargetRole == "" {
+		rows, err := tx.QueryContext(context.Background(), "SELECT endpoint FROM memberships WHERE conversation_id = ? AND (capabilities & ?) != 0 AND endpoint != ?", input.ConversationID, CapReceive, input.FromEndpoint)
+		if err != nil {
+			return Message{}, false, fmt.Errorf("find recipients: %w", err)
+		}
+		for rows.Next() {
+			var endpoint string
+			if err := rows.Scan(&endpoint); err != nil {
+				_ = rows.Close()
+				return Message{}, false, err
+			}
+			recipients = append(recipients, endpoint)
+		}
+		if err := rows.Close(); err != nil {
+			return Message{}, false, err
+		}
+	} else {
+		rows, err := tx.QueryContext(context.Background(), "SELECT membership.endpoint FROM memberships AS membership JOIN endpoints AS endpoint ON endpoint.endpoint=membership.endpoint WHERE membership.conversation_id=? AND membership.role=? AND (membership.capabilities & ?) != 0 AND membership.endpoint<>? AND endpoint.lease_until>?", input.ConversationID, input.TargetRole, CapReceive, input.FromEndpoint, input.Now.UnixMilli())
+		if err != nil {
+			return Message{}, false, fmt.Errorf("find role recipients: %w", err)
+		}
+		for rows.Next() {
+			var endpoint string
+			if err := rows.Scan(&endpoint); err != nil {
+				_ = rows.Close()
+				return Message{}, false, err
+			}
+			recipients = append(recipients, endpoint)
+		}
+		if err := rows.Close(); err != nil {
+			return Message{}, false, err
+		}
+		if len(recipients) == 0 {
+			return Message{}, false, ErrNoEligibleRecipient
+		}
+	}
+	message := Message{ID: uuid.NewString(), ConversationID: input.ConversationID, FromEndpoint: input.FromEndpoint, TargetRole: input.TargetRole, Body: input.Body, CreatedAt: input.Now.UTC().Truncate(time.Millisecond)}
 	if err := tx.QueryRowContext(context.Background(), "UPDATE conversations SET next_sequence = next_sequence + 1 WHERE id = ? RETURNING next_sequence", input.ConversationID).Scan(&message.Sequence); errors.Is(err, sql.ErrNoRows) {
 		return Message{}, false, ErrForbidden
 	} else if err != nil {
 		return Message{}, false, fmt.Errorf("allocate message sequence: %w", err)
 	}
-	if _, err := tx.ExecContext(context.Background(), `INSERT INTO messages(id, conversation_id, sequence, from_endpoint, body, created_at) VALUES (?, ?, ?, ?, ?, ?)`, message.ID, message.ConversationID, message.Sequence, message.FromEndpoint, message.Body, message.CreatedAt.UnixMilli()); err != nil {
+	if _, err := tx.ExecContext(context.Background(), `INSERT INTO messages(id, conversation_id, sequence, from_endpoint, target_role, body, created_at) VALUES (?, ?, ?, ?, ?, ?, ?)`, message.ID, message.ConversationID, message.Sequence, message.FromEndpoint, message.TargetRole, message.Body, message.CreatedAt.UnixMilli()); err != nil {
 		return Message{}, false, fmt.Errorf("append message: %w", err)
-	}
-	rows, err := tx.QueryContext(context.Background(), "SELECT endpoint FROM memberships WHERE conversation_id = ? AND (capabilities & ?) != 0 AND endpoint != ?", input.ConversationID, CapReceive, input.FromEndpoint)
-	if err != nil {
-		return Message{}, false, fmt.Errorf("find recipients: %w", err)
-	}
-	var recipients []string
-	for rows.Next() {
-		var endpoint string
-		if err := rows.Scan(&endpoint); err != nil {
-			_ = rows.Close()
-			return Message{}, false, err
-		}
-		recipients = append(recipients, endpoint)
-	}
-	if err := rows.Close(); err != nil {
-		return Message{}, false, err
 	}
 	for _, endpoint := range recipients {
 		if _, err := tx.ExecContext(context.Background(), "INSERT INTO deliveries(id, message_id, recipient_endpoint) VALUES (?, ?, ?)", uuid.NewString(), message.ID, endpoint); err != nil {
@@ -766,7 +853,7 @@ func (s *Store) LeaseDeliveries(machineID, consumerID, endpoint, conversationID 
 		return DeliveryLeasePage{}, fmt.Errorf("claim endpoint consumer lease: %w", err)
 	}
 	query := `SELECT d.id, d.lease_machine_id, d.lease_token, d.lease_generation, d.ownership_generation, d.consumer_generation, d.lease_until,
-		m.id, m.conversation_id, m.sequence, m.from_endpoint, m.body, m.created_at
+		m.id, m.conversation_id, m.sequence, m.from_endpoint, m.target_role, m.body, m.created_at
 		FROM deliveries d JOIN messages m ON m.id = d.message_id
 		WHERE d.recipient_endpoint = ? AND d.acked_at IS NULL
 		AND (d.lease_until IS NULL OR d.lease_until <= ? OR d.ownership_generation IS NULL OR d.ownership_generation <> ? OR d.consumer_generation IS NULL OR d.consumer_generation <> ? OR d.lease_machine_id = ?)`
@@ -791,7 +878,7 @@ func (s *Store) LeaseDeliveries(machineID, consumerID, endpoint, conversationID 
 		var leaseUntil, leaseOwnership, leaseConsumer sql.NullInt64
 		var createdAt int64
 		delivery.RecipientEndpoint = endpoint
-		if err := rows.Scan(&delivery.ID, &leaseMachine, &leaseToken, &delivery.LeaseGeneration, &leaseOwnership, &leaseConsumer, &leaseUntil, &delivery.Message.ID, &delivery.Message.ConversationID, &delivery.Message.Sequence, &delivery.Message.FromEndpoint, &delivery.Message.Body, &createdAt); err != nil {
+		if err := rows.Scan(&delivery.ID, &leaseMachine, &leaseToken, &delivery.LeaseGeneration, &leaseOwnership, &leaseConsumer, &leaseUntil, &delivery.Message.ID, &delivery.Message.ConversationID, &delivery.Message.Sequence, &delivery.Message.FromEndpoint, &delivery.Message.TargetRole, &delivery.Message.Body, &createdAt); err != nil {
 			return DeliveryLeasePage{}, err
 		}
 		delivery.Message.CreatedAt = fromMillis(createdAt)
@@ -1061,7 +1148,7 @@ func endpointOwnership(tx *sql.Tx, endpoint, machineID string, now time.Time) (i
 func messageByID(tx *sql.Tx, messageID string) (Message, error) {
 	var message Message
 	var createdAt int64
-	err := tx.QueryRowContext(context.Background(), "SELECT id, conversation_id, sequence, from_endpoint, body, created_at FROM messages WHERE id = ?", messageID).Scan(&message.ID, &message.ConversationID, &message.Sequence, &message.FromEndpoint, &message.Body, &createdAt)
+	err := tx.QueryRowContext(context.Background(), "SELECT id, conversation_id, sequence, from_endpoint, target_role, body, created_at FROM messages WHERE id = ?", messageID).Scan(&message.ID, &message.ConversationID, &message.Sequence, &message.FromEndpoint, &message.TargetRole, &message.Body, &createdAt)
 	if err != nil {
 		return Message{}, fmt.Errorf("read idempotent message: %w", err)
 	}
@@ -1081,6 +1168,9 @@ func createConversationHash(creatorEndpoint string, members []Member) string {
 	normalized := append([]Member(nil), members...)
 	sort.Slice(normalized, func(left, right int) bool {
 		if normalized[left].Endpoint == normalized[right].Endpoint {
+			if normalized[left].Capabilities == normalized[right].Capabilities {
+				return normalized[left].Role < normalized[right].Role
+			}
 			return normalized[left].Capabilities < normalized[right].Capabilities
 		}
 		return normalized[left].Endpoint < normalized[right].Endpoint
@@ -1088,14 +1178,14 @@ func createConversationHash(creatorEndpoint string, members []Member) string {
 	parts := make([]string, 1, 1+len(normalized)*2)
 	parts[0] = creatorEndpoint
 	for _, member := range normalized {
-		parts = append(parts, member.Endpoint, fmt.Sprintf("%d", member.Capabilities))
+		parts = append(parts, member.Endpoint, fmt.Sprintf("%d", member.Capabilities), member.Role)
 	}
 	digest := sha256.Sum256([]byte(strings.Join(parts, "\x00")))
 	return hex.EncodeToString(digest[:])
 }
 
 func appendHash(input AppendInput) string {
-	parts := []string{input.ConversationID, input.FromEndpoint, input.Body}
+	parts := []string{input.ConversationID, input.FromEndpoint, input.TargetRole, input.Body}
 	if len(input.ArtifactIDs) != 0 {
 		parts = append(parts, input.PrincipalID)
 		parts = append(parts, input.ArtifactIDs...)

--- a/internal/relay/store.go
+++ b/internal/relay/store.go
@@ -651,12 +651,33 @@ func (s *Store) UpdateMembership(conversationID, machineID, adminEndpoint, previ
 	if err := endpointActive(tx, member.Endpoint, now); err != nil {
 		return err
 	}
+	if member.Endpoint != previousEndpoint {
+		var previousExists, replacementExists bool
+		if err := tx.QueryRowContext(context.Background(), "SELECT EXISTS(SELECT 1 FROM memberships WHERE conversation_id=? AND endpoint=?), EXISTS(SELECT 1 FROM memberships WHERE conversation_id=? AND endpoint=?)", conversationID, previousEndpoint, conversationID, member.Endpoint).Scan(&previousExists, &replacementExists); err != nil {
+			return fmt.Errorf("inspect conversation membership rebind: %w", err)
+		}
+		if previousExists && replacementExists {
+			return ErrForbidden
+		}
+	}
 	if member.Capabilities&CapAdmin == 0 {
 		var otherAdministrators int
 		if err := tx.QueryRowContext(context.Background(), "SELECT COUNT(*) FROM memberships WHERE conversation_id=? AND endpoint<>? AND (capabilities & ?) <> 0", conversationID, previousEndpoint, CapAdmin).Scan(&otherAdministrators); err != nil {
 			return fmt.Errorf("count remaining conversation administrators: %w", err)
 		}
 		if otherAdministrators == 0 {
+			return ErrForbidden
+		}
+	}
+	if member.Capabilities&CapReceive == 0 {
+		var pendingDeliveries bool
+		if err := tx.QueryRowContext(context.Background(), `SELECT EXISTS(
+			SELECT 1 FROM deliveries AS delivery JOIN messages AS message ON message.id=delivery.message_id
+			WHERE delivery.recipient_endpoint=? AND delivery.acked_at IS NULL AND message.conversation_id=?
+		)`, previousEndpoint, conversationID).Scan(&pendingDeliveries); err != nil {
+			return fmt.Errorf("inspect pending recipient deliveries: %w", err)
+		}
+		if pendingDeliveries {
 			return ErrForbidden
 		}
 	}

--- a/internal/relay/store.go
+++ b/internal/relay/store.go
@@ -651,6 +651,15 @@ func (s *Store) UpdateMembership(conversationID, machineID, adminEndpoint, previ
 	if err := endpointActive(tx, member.Endpoint, now); err != nil {
 		return err
 	}
+	if member.Capabilities&CapAdmin == 0 {
+		var otherAdministrators int
+		if err := tx.QueryRowContext(context.Background(), "SELECT COUNT(*) FROM memberships WHERE conversation_id=? AND endpoint<>? AND (capabilities & ?) <> 0", conversationID, previousEndpoint, CapAdmin).Scan(&otherAdministrators); err != nil {
+			return fmt.Errorf("count remaining conversation administrators: %w", err)
+		}
+		if otherAdministrators == 0 {
+			return ErrForbidden
+		}
+	}
 	if member.Endpoint != previousEndpoint {
 		// Keep the role's unacknowledged stream durable across session rebinding.
 		// Advancing the cursor with the greater of either endpoint's history avoids
@@ -1184,17 +1193,32 @@ func createConversationHash(creatorEndpoint string, members []Member) string {
 		}
 		return normalized[left].Endpoint < normalized[right].Endpoint
 	})
-	parts := make([]string, 1, 1+len(normalized)*2)
-	parts[0] = creatorEndpoint
+	hasRole := false
 	for _, member := range normalized {
-		parts = append(parts, member.Endpoint, fmt.Sprintf("%d", member.Capabilities), member.Role)
+		if member.Role != "" {
+			hasRole = true
+		}
+	}
+	parts := make([]string, 1, 1+len(normalized)*3)
+	parts[0] = creatorEndpoint
+	// Keep the pre-role wire hash for ordinary conversations so a lost response
+	// can be retried across an upgrade without turning into a conflict.
+	for _, member := range normalized {
+		parts = append(parts, member.Endpoint, fmt.Sprintf("%d", member.Capabilities))
+		if hasRole {
+			parts = append(parts, member.Role)
+		}
 	}
 	digest := sha256.Sum256([]byte(strings.Join(parts, "\x00")))
 	return hex.EncodeToString(digest[:])
 }
 
 func appendHash(input AppendInput) string {
-	parts := []string{input.ConversationID, input.FromEndpoint, input.TargetRole, input.Body}
+	parts := []string{input.ConversationID, input.FromEndpoint}
+	if input.TargetRole != "" {
+		parts = append(parts, input.TargetRole)
+	}
+	parts = append(parts, input.Body)
 	if len(input.ArtifactIDs) != 0 {
 		parts = append(parts, input.PrincipalID)
 		parts = append(parts, input.ArtifactIDs...)

--- a/internal/relay/store.go
+++ b/internal/relay/store.go
@@ -659,6 +659,17 @@ func (s *Store) UpdateMembership(conversationID, machineID, adminEndpoint, previ
 		return err
 	}
 	defer rollback(tx)
+	if adminEndpoint == previousEndpoint && member.Endpoint != previousEndpoint {
+		var endpoint string
+		var capabilities Capability
+		var role string
+		err := tx.QueryRowContext(context.Background(), "SELECT endpoint, capabilities, role FROM memberships WHERE conversation_id=? AND endpoint=?", conversationID, member.Endpoint).Scan(&endpoint, &capabilities, &role)
+		if err == nil && endpoint == member.Endpoint && capabilities == member.Capabilities && role == member.Role {
+			if err := endpointOwnedBy(tx, member.Endpoint, machineID, now); err == nil {
+				return tx.Commit()
+			}
+		}
+	}
 	if err := endpointOwnedBy(tx, adminEndpoint, machineID, now); err != nil {
 		return err
 	}
@@ -711,6 +722,15 @@ func (s *Store) UpdateMembership(conversationID, machineID, adminEndpoint, previ
 		}
 	}
 	if member.Endpoint != previousEndpoint {
+		if _, err := tx.ExecContext(context.Background(), `DELETE FROM deliveries
+			WHERE recipient_endpoint=? AND acked_at IS NULL AND message_id IN (
+				SELECT old_delivery.message_id FROM deliveries AS old_delivery
+				JOIN messages AS message ON message.id=old_delivery.message_id
+				JOIN deliveries AS replacement ON replacement.message_id=old_delivery.message_id AND replacement.recipient_endpoint=?
+				WHERE old_delivery.recipient_endpoint=? AND old_delivery.acked_at IS NULL AND message.conversation_id=?
+			)`, previousEndpoint, member.Endpoint, previousEndpoint, conversationID); err != nil {
+			return fmt.Errorf("reconcile rebound deliveries: %w", err)
+		}
 		// Keep the role's unacknowledged stream durable across session rebinding.
 		// Advancing the cursor with the greater of either endpoint's history avoids
 		// reopening an acknowledged gap while moving pending delivery ownership.

--- a/internal/relay/store.go
+++ b/internal/relay/store.go
@@ -631,7 +631,7 @@ func (s *Store) createConversation(input CreateConversationInput) (Conversation,
 // The prior endpoint may be detached, so an administrator can rebind a durable
 // role after the old local session has stopped; the new endpoint must be active.
 func (s *Store) UpdateMembership(conversationID, machineID, adminEndpoint, previousEndpoint string, member Member, now time.Time) error {
-	if strings.TrimSpace(conversationID) == "" || !ValidMachineID(machineID) || !ValidEndpoint(adminEndpoint) || !ValidEndpoint(previousEndpoint) || !ValidEndpoint(member.Endpoint) || !ValidRole(member.Role) || member.Capabilities == 0 || member.Capabilities&^(CapSend|CapReceive|CapAdmin) != 0 {
+	if strings.TrimSpace(conversationID) == "" || !ValidMachineID(machineID) || !ValidEndpoint(adminEndpoint) || !ValidEndpoint(previousEndpoint) || !ValidEndpoint(member.Endpoint) || !ValidRole(member.Role) || member.Capabilities == 0 || member.Capabilities&^(CapSend|CapReceive|CapAdmin|CapInvoke) != 0 {
 		return ErrForbidden
 	}
 	tx, err := s.db.BeginTx(context.Background(), nil)
@@ -677,7 +677,16 @@ func (s *Store) UpdateMembership(conversationID, machineID, adminEndpoint, previ
 		return fmt.Errorf("check conversation member update: %w", err)
 	}
 	if changed != 1 {
-		return ErrForbidden
+		var endpoint string
+		var capabilities Capability
+		var role string
+		err := tx.QueryRowContext(context.Background(), "SELECT endpoint, capabilities, role FROM memberships WHERE conversation_id=? AND endpoint=?", conversationID, member.Endpoint).Scan(&endpoint, &capabilities, &role)
+		if errors.Is(err, sql.ErrNoRows) || (err == nil && (endpoint != member.Endpoint || capabilities != member.Capabilities || role != member.Role)) {
+			return ErrForbidden
+		}
+		if err != nil {
+			return fmt.Errorf("read replayed membership update: %w", err)
+		}
 	}
 	return tx.Commit()
 }

--- a/internal/relay/store_test.go
+++ b/internal/relay/store_test.go
@@ -25,6 +25,32 @@ func TestStoreRejectsNonPortableRequestAndMessageText(t *testing.T) {
 	}
 }
 
+func TestRoleHashesPreserveLegacyEmptyRoleLayout(t *testing.T) {
+	members := []Member{
+		{Endpoint: "agent/b", Capabilities: CapReceive},
+		{Endpoint: "agent/a", Capabilities: CapSend | CapReceive | CapAdmin},
+	}
+	legacyConversation := stableHash("agent/a", "agent/a", "7", "agent/b", "2")
+	if got := createConversationHash("agent/a", members); got != legacyConversation {
+		t.Fatalf("empty-role conversation hash=%s want legacy=%s", got, legacyConversation)
+	}
+	withRoles := append([]Member(nil), members...)
+	withRoles[0].Role = "reviewer"
+	if got := createConversationHash("agent/a", withRoles); got == legacyConversation {
+		t.Fatal("role-bearing conversation reused the legacy hash")
+	}
+
+	input := AppendInput{ConversationID: "conversation-1", FromEndpoint: "agent/a", Body: "body", PrincipalID: "principal-1", ArtifactIDs: []string{"artifact-1"}}
+	legacyAppend := stableHash("conversation-1", "agent/a", "body", "principal-1", "artifact-1")
+	if got := appendHash(input); got != legacyAppend {
+		t.Fatalf("empty-role append hash=%s want legacy=%s", got, legacyAppend)
+	}
+	input.TargetRole = "reviewer"
+	if got := appendHash(input); got == legacyAppend {
+		t.Fatal("role-addressed append reused the legacy hash")
+	}
+}
+
 func TestStoreProvidesDurableAtLeastOnceDelivery(t *testing.T) {
 	t.Parallel()
 	database := filepath.Join(t.TempDir(), "relay.db")


### PR DESCRIPTION
## Summary

Adds validated membership roles and role-addressed delivery to the Punaro relay.

- Routes `target_role` sends exclusively to active eligible receivers.
- Returns a clear no-eligible-recipient error without consuming send idempotency.
- Adds admin-authorized role/binding replacement with cursor and unacknowledged-delivery preservation.
- Persists roles and target roles through SQLite, PostgreSQL, and cutover import.

## Validation

- `make test`
- `make test-race`
- `make staticcheck`
- `make lint`
- `make security`

Closes #58.