### PR TITLE
Load installed adapter profile for direct commands

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -83,6 +83,7 @@ jobs:
       - run: go test ./internal/adapter -run '^TestWindows'
       - run: go test ./internal/trustedattachmentclient -run '^TestWindows'
       - run: go test ./cmd/punaro-attachment -run '^TestWindows'
+      - run: go test ./cmd/punaro-adapter -run '^TestWindows'
       - run: go vet ./...
       - run: go build ./...
       - shell: pwsh

--- a/cmd/punaro-adapter/main.go
+++ b/cmd/punaro-adapter/main.go
@@ -35,6 +35,25 @@ type adapterConfig struct {
 	invokerCommand string
 }
 
+const (
+	adapterProfileFileEnv = "PUNARO_ADAPTER_PROFILE_FILE"
+	maxAdapterProfileSize = 16 << 10
+)
+
+var adapterProfileKeys = map[string]struct{}{
+	"PUNARO_ADAPTER_RELAY_URL":        {},
+	"PUNARO_MACHINE_ID":               {},
+	"PUNARO_MACHINE_PRIVATE_KEY_FILE": {},
+	"PUNARO_ATTACHED_GROUP":           {},
+	"PUNARO_ADAPTER_DATA_DIR":         {},
+	"PUNARO_MAILBOX_STATE_DIR":        {},
+	"PUNARO_ADAPTER_POLL_INTERVAL":    {},
+	"PUNARO_AGENT_MAILBOX_BIN":        {},
+	"PUNARO_CF_ACCESS_CLIENT_ID":      {},
+	"PUNARO_CF_ACCESS_CLIENT_SECRET":  {},
+	"PUNARO_INVOKER_COMMAND":          {},
+}
+
 func main() {
 	var err error
 	switch {
@@ -382,18 +401,27 @@ func runNotifications(ctx context.Context, client *adapter.HTTPRelayClient, wake
 }
 
 func loadConfig() (adapterConfig, error) {
-	relayURL := strings.TrimSpace(os.Getenv("PUNARO_ADAPTER_RELAY_URL"))
-	machineID := strings.TrimSpace(os.Getenv("PUNARO_MACHINE_ID"))
-	keyFile := strings.TrimSpace(os.Getenv("PUNARO_MACHINE_PRIVATE_KEY_FILE"))
-	group := strings.TrimSpace(os.Getenv("PUNARO_ATTACHED_GROUP"))
+	settings, err := loadAdapterProfile()
+	if err != nil {
+		return adapterConfig{}, err
+	}
+	for key := range adapterProfileKeys {
+		if value := strings.TrimSpace(os.Getenv(key)); value != "" {
+			settings[key] = value
+		}
+	}
+	relayURL := settings["PUNARO_ADAPTER_RELAY_URL"]
+	machineID := settings["PUNARO_MACHINE_ID"]
+	keyFile := settings["PUNARO_MACHINE_PRIVATE_KEY_FILE"]
+	group := settings["PUNARO_ATTACHED_GROUP"]
 	if relayURL == "" || machineID == "" || keyFile == "" || group == "" {
-		return adapterConfig{}, fmt.Errorf("PUNARO_ADAPTER_RELAY_URL, PUNARO_MACHINE_ID, PUNARO_MACHINE_PRIVATE_KEY_FILE, and PUNARO_ATTACHED_GROUP are required")
+		return adapterConfig{}, errors.New("adapter configuration is incomplete")
 	}
 	key, err := loadPrivateKey(keyFile)
 	if err != nil {
 		return adapterConfig{}, err
 	}
-	dataDir := strings.TrimSpace(os.Getenv("PUNARO_ADAPTER_DATA_DIR"))
+	dataDir := settings["PUNARO_ADAPTER_DATA_DIR"]
 	if dataDir == "" {
 		dataDir = "./data"
 	}
@@ -404,21 +432,70 @@ func loadConfig() (adapterConfig, error) {
 		}
 	}
 	pollInterval := 30 * time.Second
-	if raw := strings.TrimSpace(os.Getenv("PUNARO_ADAPTER_POLL_INTERVAL")); raw != "" {
+	if raw := settings["PUNARO_ADAPTER_POLL_INTERVAL"]; raw != "" {
 		pollInterval, err = time.ParseDuration(raw)
 		if err != nil || pollInterval < 5*time.Second || pollInterval > 5*time.Minute {
 			return adapterConfig{}, fmt.Errorf("PUNARO_ADAPTER_POLL_INTERVAL must be between 5s and 5m")
 		}
 	}
-	mailboxBinary := strings.TrimSpace(os.Getenv("PUNARO_AGENT_MAILBOX_BIN"))
+	mailboxBinary := settings["PUNARO_AGENT_MAILBOX_BIN"]
 	if mailboxBinary == "" {
 		mailboxBinary = "agent-mailbox"
 	}
-	accessToken := adapter.AccessServiceToken{ClientID: strings.TrimSpace(os.Getenv("PUNARO_CF_ACCESS_CLIENT_ID")), ClientSecret: strings.TrimSpace(os.Getenv("PUNARO_CF_ACCESS_CLIENT_SECRET"))}
+	accessToken := adapter.AccessServiceToken{ClientID: settings["PUNARO_CF_ACCESS_CLIENT_ID"], ClientSecret: settings["PUNARO_CF_ACCESS_CLIENT_SECRET"]}
 	if (accessToken.ClientID == "") != (accessToken.ClientSecret == "") {
 		return adapterConfig{}, fmt.Errorf("both PUNARO_CF_ACCESS_CLIENT_ID and PUNARO_CF_ACCESS_CLIENT_SECRET are required together")
 	}
-	return adapterConfig{relayURL: relayURL, machineID: machineID, privateKey: key, attachedGroup: group, mailboxBinary: mailboxBinary, mailboxState: strings.TrimSpace(os.Getenv("PUNARO_MAILBOX_STATE_DIR")), dataDir: dataDir, pollInterval: pollInterval, accessToken: accessToken, invokerCommand: strings.TrimSpace(os.Getenv("PUNARO_INVOKER_COMMAND"))}, nil
+	return adapterConfig{relayURL: relayURL, machineID: machineID, privateKey: key, attachedGroup: group, mailboxBinary: mailboxBinary, mailboxState: settings["PUNARO_MAILBOX_STATE_DIR"], dataDir: dataDir, pollInterval: pollInterval, accessToken: accessToken, invokerCommand: settings["PUNARO_INVOKER_COMMAND"]}, nil
+}
+
+// loadAdapterProfile reads the installer-managed profile as plain data rather
+// than evaluating it as shell or service-manager syntax. A non-empty process
+// environment setting intentionally overrides the corresponding profile entry.
+func loadAdapterProfile() (map[string]string, error) {
+	path := strings.TrimSpace(os.Getenv(adapterProfileFileEnv))
+	explicitPath := path != ""
+	if !explicitPath {
+		var err error
+		path, err = installedAdapterProfilePath()
+		if err != nil {
+			return nil, errors.New("adapter profile is unavailable")
+		}
+	}
+	if !filepath.IsAbs(path) {
+		return nil, errors.New("adapter profile is unsafe")
+	}
+	// #nosec G703 -- this is the fixed installer profile location or an explicit
+	// local operator override; remote data never selects it.
+	if _, err := os.Lstat(path); err != nil {
+		if !explicitPath && errors.Is(err, os.ErrNotExist) {
+			return map[string]string{}, nil
+		}
+		return nil, errors.New("adapter profile is unavailable")
+	}
+	raw, err := readPrivateFile(path, "adapter profile", maxAdapterProfileSize)
+	if err != nil {
+		return nil, errors.New("adapter profile is unsafe")
+	}
+	settings := make(map[string]string)
+	for _, line := range strings.Split(string(raw), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		name, value, found := strings.Cut(line, "=")
+		if !found || strings.TrimSpace(name) != name || strings.ContainsRune(value, '\x00') {
+			return nil, errors.New("adapter profile is invalid")
+		}
+		if _, allowed := adapterProfileKeys[name]; !allowed {
+			return nil, errors.New("adapter profile is invalid")
+		}
+		if _, duplicate := settings[name]; duplicate {
+			return nil, errors.New("adapter profile is invalid")
+		}
+		settings[name] = strings.TrimSpace(value)
+	}
+	return settings, nil
 }
 
 func loadPrivateKey(path string) (ed25519.PrivateKey, error) {

--- a/cmd/punaro-adapter/main.go
+++ b/cmd/punaro-adapter/main.go
@@ -456,9 +456,8 @@ func loadAdapterProfile() (map[string]string, error) {
 	path := strings.TrimSpace(os.Getenv(adapterProfileFileEnv))
 	explicitPath := path != ""
 	if !explicitPath {
-		var err error
-		path, err = installedAdapterProfilePath()
-		if err != nil {
+		path = installedAdapterProfilePath()
+		if path == "" {
 			// Preserve environment-only deployments when the optional default
 			// profile root is unavailable. An explicitly selected profile still
 			// fails closed below.

--- a/cmd/punaro-adapter/main.go
+++ b/cmd/punaro-adapter/main.go
@@ -459,7 +459,10 @@ func loadAdapterProfile() (map[string]string, error) {
 		var err error
 		path, err = installedAdapterProfilePath()
 		if err != nil {
-			return nil, errors.New("adapter profile is unavailable")
+			// Preserve environment-only deployments when the optional default
+			// profile root is unavailable. An explicitly selected profile still
+			// fails closed below.
+			return map[string]string{}, nil
 		}
 	}
 	if !filepath.IsAbs(path) {

--- a/cmd/punaro-adapter/main_test.go
+++ b/cmd/punaro-adapter/main_test.go
@@ -133,6 +133,8 @@ func TestDirectCommandsLoadInstallerProfileBeforeTheirTransportBoundary(t *testi
 			_, _ = w.Write([]byte(`{"id":"conversation-1"}`))
 		case "/v1/conversations/conversation-1/messages":
 			_, _ = w.Write([]byte(`{"id":"message-1","conversation_id":"conversation-1","sequence":1,"from_endpoint":"agent/a","body":"ignored","created_at":"2026-08-03T00:00:00Z"}`))
+		case "/v1/conversations/conversation-1/invocations":
+			_, _ = w.Write([]byte(`{"id":"invocation-1","status":"pending"}`))
 		default:
 			t.Fatalf("unexpected transport boundary %s %s", r.Method, r.URL.Path)
 		}
@@ -158,6 +160,9 @@ func TestDirectCommandsLoadInstallerProfileBeforeTheirTransportBoundary(t *testi
 	}
 	if err := runAttachmentNotify([]string{"--conversation", "conversation-1", "--from", "agent/a", "--offer-file", offerFile, "--idempotency-key", "offer-1"}); err != nil {
 		t.Fatalf("attachment-notify did not reach its transport boundary: %v", err)
+	}
+	if err := runInvoke([]string{"--conversation", "conversation-1", "--from", "agent/a", "--target", "agent/b", "--idempotency-key", "invoke-1"}); err != nil {
+		t.Fatalf("invoke did not reach its transport boundary: %v", err)
 	}
 }
 

--- a/cmd/punaro-adapter/main_test.go
+++ b/cmd/punaro-adapter/main_test.go
@@ -4,9 +4,15 @@ import (
 	"crypto/ed25519"
 	"crypto/rand"
 	"encoding/base64"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
+
+	attachmentv3 "github.com/rock3r/punaro/internal/attachment/v3"
+	"github.com/zeebo/blake3"
 )
 
 func TestParseSendArgsRequiresExplicitIdempotencyKey(t *testing.T) {
@@ -50,6 +56,8 @@ func TestParseInvokeArgsRequiresExplicitContentFreeTargetAndRetryKey(t *testing.
 }
 
 func TestLoadConfigRequiresPrivateKeyAndAttachmentGroup(t *testing.T) {
+	clearAdapterEnvironment(t)
+	t.Setenv("HOME", t.TempDir())
 	t.Setenv("PUNARO_ADAPTER_RELAY_URL", "https://relay.example")
 	t.Setenv("PUNARO_MACHINE_ID", "machine-a")
 	t.Setenv("PUNARO_MACHINE_PRIVATE_KEY_FILE", "")
@@ -60,6 +68,8 @@ func TestLoadConfigRequiresPrivateKeyAndAttachmentGroup(t *testing.T) {
 }
 
 func TestLoadConfigLoadsPrivateKeyWithoutLoggingIt(t *testing.T) {
+	clearAdapterEnvironment(t)
+	t.Setenv("HOME", t.TempDir())
 	_, private, err := ed25519.GenerateKey(rand.Reader)
 	if err != nil {
 		t.Fatal(err)
@@ -109,4 +119,157 @@ func TestLoadPrivateKeyRejectsUnsafeFileModesAndSymlinks(t *testing.T) {
 	if _, err := loadPrivateKey(symlink); err == nil {
 		t.Fatal("symlinked private key accepted")
 	}
+}
+
+func TestDirectCommandsLoadInstallerProfileBeforeTheirTransportBoundary(t *testing.T) {
+	clearAdapterEnvironment(t)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("X-Punaro-Machine") != "profile-machine" {
+			t.Fatal("direct command did not use the profile machine identity")
+		}
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/v1/conversations":
+			_, _ = w.Write([]byte(`{"id":"conversation-1"}`))
+		case "/v1/conversations/conversation-1/messages":
+			_, _ = w.Write([]byte(`{"id":"message-1","conversation_id":"conversation-1","sequence":1,"from_endpoint":"agent/a","body":"ignored","created_at":"2026-08-03T00:00:00Z"}`))
+		default:
+			t.Fatalf("unexpected transport boundary %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	profile := writeInstallerProfile(t, server.URL)
+	t.Setenv("HOME", filepath.Dir(filepath.Dir(filepath.Dir(profile))))
+	bodyFile := filepath.Join(t.TempDir(), "body.txt")
+	if err := os.WriteFile(bodyFile, []byte("profile-backed direct send"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	offerFile := filepath.Join(t.TempDir(), "offer.cde")
+	if err := os.WriteFile(offerFile, testOfferPayload(t), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := runCreate([]string{"--creator", "agent/a", "--member", "agent/a:send,receive,admin", "--idempotency-key", "create-1"}); err != nil {
+		t.Fatalf("create did not reach its transport boundary: %v", err)
+	}
+	if err := runSend([]string{"--conversation", "conversation-1", "--from", "agent/a", "--body-file", bodyFile, "--idempotency-key", "send-1"}); err != nil {
+		t.Fatalf("send did not reach its transport boundary: %v", err)
+	}
+	if err := runAttachmentNotify([]string{"--conversation", "conversation-1", "--from", "agent/a", "--offer-file", offerFile, "--idempotency-key", "offer-1"}); err != nil {
+		t.Fatalf("attachment-notify did not reach its transport boundary: %v", err)
+	}
+}
+
+func TestLoadConfigFailsClosedForUnsafeOrMalformedProfileWithoutLeakingItsContents(t *testing.T) {
+	clearAdapterEnvironment(t)
+	secret := "profile-secret-must-not-appear"
+	profile := filepath.Join(t.TempDir(), "adapter.env")
+	if err := os.WriteFile(profile, []byte("PUNARO_CF_ACCESS_CLIENT_SECRET="+secret+"\nnot-valid\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PUNARO_ADAPTER_PROFILE_FILE", profile)
+	// #nosec G302 -- this fixture deliberately makes the profile group-readable.
+	if err := os.Chmod(profile, 0o640); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := loadConfig(); err == nil || strings.Contains(err.Error(), secret) {
+		t.Fatalf("group-readable profile error=%v", err)
+	}
+	if err := os.Chmod(profile, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := loadConfig(); err == nil || strings.Contains(err.Error(), secret) {
+		t.Fatalf("malformed profile error=%v", err)
+	}
+	symlink := filepath.Join(t.TempDir(), "adapter-link")
+	if err := os.Symlink(profile, symlink); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PUNARO_ADAPTER_PROFILE_FILE", symlink)
+	if _, err := loadConfig(); err == nil || strings.Contains(err.Error(), secret) {
+		t.Fatalf("symlinked profile error=%v", err)
+	}
+}
+
+func TestEnvironmentSettingsExplicitlyOverrideInstalledProfile(t *testing.T) {
+	clearAdapterEnvironment(t)
+	profile := writeInstallerProfile(t, "https://profile.example")
+	t.Setenv("HOME", filepath.Dir(filepath.Dir(filepath.Dir(profile))))
+	t.Setenv("PUNARO_MACHINE_ID", "explicit-machine")
+	config, err := loadConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if config.machineID != "explicit-machine" {
+		t.Fatalf("machine ID=%q, want explicit override", config.machineID)
+	}
+}
+
+func writeInstallerProfile(t *testing.T, relayURL string) string {
+	t.Helper()
+	_, private, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	home := t.TempDir()
+	configDir := filepath.Join(home, ".config", "punaro")
+	if err := os.MkdirAll(configDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	keyFile := filepath.Join(configDir, "machine.key")
+	if err := os.WriteFile(keyFile, []byte(base64.RawURLEncoding.EncodeToString(private)), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	dataDir := filepath.Join(home, ".local", "state", "punaro-adapter")
+	if err := os.MkdirAll(dataDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	profile := filepath.Join(configDir, "adapter.env")
+	contents := strings.Join([]string{
+		"# Created by the installer.",
+		"PUNARO_ADAPTER_RELAY_URL=" + relayURL,
+		"PUNARO_MACHINE_ID=profile-machine",
+		"PUNARO_MACHINE_PRIVATE_KEY_FILE=" + keyFile,
+		"PUNARO_ATTACHED_GROUP=group/punaro-attached",
+		"PUNARO_ADAPTER_DATA_DIR=" + dataDir,
+		"PUNARO_MAILBOX_STATE_DIR=" + filepath.Join(home, ".local", "state", "ai-agent", "mailbox"),
+		"PUNARO_ADAPTER_POLL_INTERVAL=30s",
+		"PUNARO_AGENT_MAILBOX_BIN=agent-mailbox",
+		"",
+	}, "\n")
+	if err := os.WriteFile(profile, []byte(contents), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return profile
+}
+
+func clearAdapterEnvironment(t *testing.T) {
+	t.Helper()
+	t.Setenv(adapterProfileFileEnv, "")
+	for key := range adapterProfileKeys {
+		t.Setenv(key, "")
+	}
+}
+
+func testOfferPayload(t *testing.T) []byte {
+	t.Helper()
+	private := ed25519.NewKeyFromSeed(make([]byte, ed25519.SeedSize))
+	manifest := attachmentv3.Manifest{Audience: [32]byte{1}, TransferID: [16]byte{2}, ConversationID: [16]byte{3}, SenderDeviceID: [16]byte{4}, SenderGeneration: 1, RecipientDeviceID: [16]byte{5}, RecipientGeneration: 1, DirectoryHead: [32]byte{6}, MembershipCommitment: [32]byte{7}, RevocationEpoch: 1, IssuedAt: 1, ExpiresAt: 2, ContentSalt: [32]byte{8}, PlaintextCommitment: [32]byte{9}, ChunkSize: 1, ChunkCount: 1, PlaintextSize: 1, SignerKeyID: [32]byte{10}}
+	if err := attachmentv3.SignManifest(&manifest, private); err != nil {
+		t.Fatal(err)
+	}
+	rawManifest, err := attachmentv3.EncodeManifest(manifest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	envelope := attachmentv3.Envelope{Audience: manifest.Audience, TransferID: manifest.TransferID, ConversationID: manifest.ConversationID, SenderDeviceID: manifest.SenderDeviceID, SenderGeneration: manifest.SenderGeneration, RecipientDeviceID: manifest.RecipientDeviceID, RecipientGeneration: manifest.RecipientGeneration, RecipientHPKEKeyID: [32]byte{11}, ManifestCommitment: blake3.Sum256(rawManifest), EncapsulatedKey: [32]byte{12}, Ciphertext: make([]byte, 16), SignerKeyID: manifest.SignerKeyID}
+	if err := attachmentv3.SignEnvelope(&envelope, private); err != nil {
+		t.Fatal(err)
+	}
+	offer, err := attachmentv3.EncodeOfferPayload(manifest, envelope, [32]byte{13})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return offer
 }

--- a/cmd/punaro-adapter/private_file_acl_darwin.go
+++ b/cmd/punaro-adapter/private_file_acl_darwin.go
@@ -1,4 +1,4 @@
-//go:build darwin
+//go:build darwin && cgo
 
 package main
 

--- a/cmd/punaro-adapter/private_file_acl_darwin.go
+++ b/cmd/punaro-adapter/private_file_acl_darwin.go
@@ -1,0 +1,33 @@
+//go:build darwin
+
+package main
+
+/*
+#include <sys/acl.h>
+#include <errno.h>
+
+static int punaro_has_extended_acl(int fd) {
+	errno = 0;
+	acl_t acl = acl_get_fd_np(fd, ACL_TYPE_EXTENDED);
+	// APFS reports either ENOATTR or ENOENT for a file with no extended ACL.
+	if (acl == NULL) return (errno == ENOATTR || errno == ENOENT) ? 0 : 1;
+	acl_entry_t entry;
+	int result = acl_get_entry(acl, ACL_FIRST_ENTRY, &entry);
+	while (result == 0) {
+		acl_tag_t tag;
+		if (acl_get_tag_type(entry, &tag) != 0 ||
+		    tag == ACL_EXTENDED_ALLOW || tag == ACL_EXTENDED_DENY) {
+			acl_free(acl);
+			return 1;
+		}
+		result = acl_get_entry(acl, ACL_NEXT_ENTRY, &entry);
+	}
+	acl_free(acl);
+	return 0;
+}
+*/
+import "C"
+
+func hasExtendedACL(fd int) bool {
+	return C.punaro_has_extended_acl(C.int(fd)) != 0
+}

--- a/cmd/punaro-adapter/private_file_acl_darwin_nocgo.go
+++ b/cmd/punaro-adapter/private_file_acl_darwin_nocgo.go
@@ -1,0 +1,9 @@
+//go:build darwin && !cgo
+
+package main
+
+// Without the macOS ACL APIs, the adapter cannot prove a private file lacks
+// an extended grant. Reject it rather than accepting a possibly shared secret.
+func hasExtendedACL(int) bool {
+	return true
+}

--- a/cmd/punaro-adapter/private_file_acl_darwin_test.go
+++ b/cmd/punaro-adapter/private_file_acl_darwin_test.go
@@ -3,6 +3,7 @@
 package main
 
 import (
+	"context"
 	"os/exec"
 	"path/filepath"
 	"strings"
@@ -13,7 +14,8 @@ func TestLoadConfigRejectsProfileWithMacOSACL(t *testing.T) {
 	clearAdapterEnvironment(t)
 	profile := writeInstallerProfile(t, "https://profile.example")
 	t.Setenv("HOME", filepath.Dir(filepath.Dir(filepath.Dir(profile))))
-	command := exec.Command("chmod", "+a", "everyone allow read", profile)
+	// #nosec G204 -- this Darwin-only test invokes the fixed system chmod path.
+	command := exec.CommandContext(context.Background(), "chmod", "+a", "everyone allow read", profile)
 	if output, err := command.CombinedOutput(); err != nil {
 		t.Fatalf("add ACL test fixture: %v (%s)", err, output)
 	}

--- a/cmd/punaro-adapter/private_file_acl_darwin_test.go
+++ b/cmd/punaro-adapter/private_file_acl_darwin_test.go
@@ -1,0 +1,24 @@
+//go:build darwin
+
+package main
+
+import (
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestLoadConfigRejectsProfileWithMacOSACL(t *testing.T) {
+	clearAdapterEnvironment(t)
+	profile := writeInstallerProfile(t, "https://profile.example")
+	t.Setenv("HOME", filepath.Dir(filepath.Dir(filepath.Dir(profile))))
+	command := exec.Command("chmod", "+a", "everyone allow read", profile)
+	if output, err := command.CombinedOutput(); err != nil {
+		t.Fatalf("add ACL test fixture: %v (%s)", err, output)
+	}
+
+	if _, err := loadConfig(); err == nil || !strings.Contains(err.Error(), "adapter profile is unsafe") {
+		t.Fatalf("ACL profile error=%v, want sanitized profile rejection", err)
+	}
+}

--- a/cmd/punaro-adapter/private_file_acl_other.go
+++ b/cmd/punaro-adapter/private_file_acl_other.go
@@ -1,0 +1,7 @@
+//go:build !windows && !darwin
+
+package main
+
+func hasExtendedACL(int) bool {
+	return false
+}

--- a/cmd/punaro-adapter/private_file_unix.go
+++ b/cmd/punaro-adapter/private_file_unix.go
@@ -21,7 +21,7 @@ func readPrivateFile(path, label string, maximum int) ([]byte, error) {
 	file := os.NewFile(uintptr(fd), path)
 	defer func() { _ = file.Close() }()
 	info, err := file.Stat()
-	if err != nil || !info.Mode().IsRegular() || info.Mode().Perm()&0o077 != 0 {
+	if err != nil || !info.Mode().IsRegular() || info.Mode().Perm()&0o077 != 0 || hasExtendedACL(fd) {
 		return nil, fmt.Errorf("%s file must be a private regular file", label)
 	}
 	raw, err := io.ReadAll(io.LimitReader(file, int64(maximum)+1))

--- a/cmd/punaro-adapter/private_file_unix.go
+++ b/cmd/punaro-adapter/private_file_unix.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"syscall"
 
 	"golang.org/x/sys/unix"
 )
@@ -21,7 +22,7 @@ func readPrivateFile(path, label string, maximum int) ([]byte, error) {
 	file := os.NewFile(uintptr(fd), path)
 	defer func() { _ = file.Close() }()
 	info, err := file.Stat()
-	if err != nil || !info.Mode().IsRegular() || info.Mode().Perm()&0o077 != 0 || hasExtendedACL(fd) {
+	if err != nil || !isPrivateRegularFile(info, fd) {
 		return nil, fmt.Errorf("%s file must be a private regular file", label)
 	}
 	raw, err := io.ReadAll(io.LimitReader(file, int64(maximum)+1))
@@ -32,4 +33,16 @@ func readPrivateFile(path, label string, maximum int) ([]byte, error) {
 		return nil, fmt.Errorf("invalid %s file", label)
 	}
 	return raw, nil
+}
+
+func isPrivateRegularFile(info os.FileInfo, fd int) bool {
+	return info.Mode().IsRegular() &&
+		info.Mode().Perm()&0o077 == 0 &&
+		isOwnedByEffectiveUser(info) &&
+		!hasExtendedACL(fd)
+}
+
+func isOwnedByEffectiveUser(info os.FileInfo) bool {
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	return ok && stat.Uid == uint32(os.Geteuid())
 }

--- a/cmd/punaro-adapter/private_file_unix.go
+++ b/cmd/punaro-adapter/private_file_unix.go
@@ -44,5 +44,6 @@ func isPrivateRegularFile(info os.FileInfo, fd int) bool {
 
 func isOwnedByEffectiveUser(info os.FileInfo) bool {
 	stat, ok := info.Sys().(*syscall.Stat_t)
+	// #nosec G115 -- os.Geteuid returns the platform uid_t, represented as a non-negative int.
 	return ok && stat.Uid == uint32(os.Geteuid())
 }

--- a/cmd/punaro-adapter/private_file_unix_test.go
+++ b/cmd/punaro-adapter/private_file_unix_test.go
@@ -1,0 +1,32 @@
+//go:build !windows
+
+package main
+
+import (
+	"io/fs"
+	"os"
+	"syscall"
+	"testing"
+	"time"
+)
+
+func TestPrivateFileRequiresEffectiveOwner(t *testing.T) {
+	uid := uint32(os.Geteuid())
+	if isOwnedByEffectiveUser(privateFileInfo{sys: &syscall.Stat_t{Uid: uid + 1}}) {
+		t.Fatal("private file owned by another user was accepted")
+	}
+	if !isOwnedByEffectiveUser(privateFileInfo{sys: &syscall.Stat_t{Uid: uid}}) {
+		t.Fatal("private file owned by the effective user was rejected")
+	}
+}
+
+type privateFileInfo struct {
+	sys any
+}
+
+func (privateFileInfo) Name() string       { return "profile" }
+func (privateFileInfo) Size() int64        { return 0 }
+func (privateFileInfo) Mode() fs.FileMode  { return 0o600 }
+func (privateFileInfo) ModTime() time.Time { return time.Time{} }
+func (privateFileInfo) IsDir() bool        { return false }
+func (info privateFileInfo) Sys() any      { return info.sys }

--- a/cmd/punaro-adapter/private_file_unix_test.go
+++ b/cmd/punaro-adapter/private_file_unix_test.go
@@ -11,11 +11,20 @@ import (
 )
 
 func TestPrivateFileRequiresEffectiveOwner(t *testing.T) {
-	uid := uint32(os.Geteuid())
-	if isOwnedByEffectiveUser(privateFileInfo{sys: &syscall.Stat_t{Uid: uid + 1}}) {
+	info, err := os.Stat(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		t.Fatal("temporary directory did not provide Unix file metadata")
+	}
+	other := *stat
+	other.Uid ^= 1
+	if isOwnedByEffectiveUser(privateFileInfo{sys: &other}) {
 		t.Fatal("private file owned by another user was accepted")
 	}
-	if !isOwnedByEffectiveUser(privateFileInfo{sys: &syscall.Stat_t{Uid: uid}}) {
+	if !isOwnedByEffectiveUser(info) {
 		t.Fatal("private file owned by the effective user was rejected")
 	}
 }

--- a/cmd/punaro-adapter/private_file_windows.go
+++ b/cmd/punaro-adapter/private_file_windows.go
@@ -72,7 +72,7 @@ func privateWindowsACL(path string) bool {
 	}
 	// Protect-PunaroPath emits one FullControl ACE for the current SID, with no
 	// inherited or shared grants. DACL() also rejects absent/null DACLs.
-	if dacl, _, err := sd.DACL(); err != nil || dacl == nil {
+	if dacl, _, err := sd.DACL(); err != nil || dacl == nil || dacl.AceCount != 1 {
 		return false
 	}
 	want := "D:P(A;;FA;;;" + user.User.Sid.String() + ")"

--- a/cmd/punaro-adapter/private_file_windows.go
+++ b/cmd/punaro-adapter/private_file_windows.go
@@ -7,7 +7,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
-	"strings"
+	"unsafe"
 
 	"golang.org/x/sys/windows"
 )
@@ -49,9 +49,9 @@ func readPrivateFile(path, label string, maximum int) ([]byte, error) {
 	return raw, nil
 }
 
-// privateWindowsACL accepts only the exact protected, current-user-only DACL
-// written by the Windows installer. This prevents an explicit profile path
-// from weakening the confidentiality boundary for embedded service secrets.
+// privateWindowsACL accepts only a protected, current-user-only FullControl
+// DACL. This prevents an explicit profile path from weakening the
+// confidentiality boundary for embedded service secrets.
 func privateWindowsACL(path string) bool {
 	token := windows.GetCurrentProcessToken()
 	user, err := token.GetTokenUser()
@@ -74,7 +74,14 @@ func privateWindowsACL(path string) bool {
 	// inherited or shared grants. DACL() also rejects absent/null DACLs.
 	if dacl, _, err := sd.DACL(); err != nil || dacl == nil || dacl.AceCount != 1 {
 		return false
+	} else {
+		var ace *windows.ACCESS_ALLOWED_ACE
+		if windows.GetAce(dacl, 0, &ace) != nil || ace == nil ||
+			ace.Header.AceType != windows.ACCESS_ALLOWED_ACE_TYPE || ace.Header.AceFlags != 0 ||
+			ace.Mask != windows.ACCESS_MASK(0x1f01ff) {
+			return false
+		}
+		aceSID := (*windows.SID)(unsafe.Pointer(&ace.SidStart))
+		return aceSID.Equals(user.User.Sid)
 	}
-	want := "D:P(A;;FA;;;" + user.User.Sid.String() + ")"
-	return strings.HasSuffix(sd.String(), want)
 }

--- a/cmd/punaro-adapter/private_file_windows.go
+++ b/cmd/punaro-adapter/private_file_windows.go
@@ -7,6 +7,9 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
+
+	"golang.org/x/sys/windows"
 )
 
 // The Windows installer grants the current user an exclusive ACL on the
@@ -20,6 +23,9 @@ func readPrivateFile(path, label string, maximum int) ([]byte, error) {
 	// an absolute, non-reparse regular file under the installer-owned ACL.
 	info, err := os.Lstat(path)
 	if err != nil || !info.Mode().IsRegular() || info.Mode()&os.ModeSymlink != 0 {
+		return nil, fmt.Errorf("%s file must be a private regular file", label)
+	}
+	if !privateWindowsACL(path) {
 		return nil, fmt.Errorf("%s file must be a private regular file", label)
 	}
 	// #nosec G304,G703 -- validated absolute local configuration path; remote data
@@ -41,4 +47,34 @@ func readPrivateFile(path, label string, maximum int) ([]byte, error) {
 		return nil, fmt.Errorf("invalid %s file", label)
 	}
 	return raw, nil
+}
+
+// privateWindowsACL accepts only the exact protected, current-user-only DACL
+// written by the Windows installer. This prevents an explicit profile path
+// from weakening the confidentiality boundary for embedded service secrets.
+func privateWindowsACL(path string) bool {
+	token := windows.GetCurrentProcessToken()
+	user, err := token.GetTokenUser()
+	if err != nil || user.User.Sid == nil {
+		return false
+	}
+	sd, err := windows.GetNamedSecurityInfo(path, windows.SE_FILE_OBJECT, windows.OWNER_SECURITY_INFORMATION|windows.DACL_SECURITY_INFORMATION)
+	if err != nil {
+		return false
+	}
+	owner, _, err := sd.Owner()
+	if err != nil || owner == nil || !owner.Equals(user.User.Sid) {
+		return false
+	}
+	control, _, err := sd.Control()
+	if err != nil || control&windows.SE_DACL_PROTECTED == 0 {
+		return false
+	}
+	// Protect-PunaroPath emits one FullControl ACE for the current SID, with no
+	// inherited or shared grants. DACL() also rejects absent/null DACLs.
+	if dacl, _, err := sd.DACL(); err != nil || dacl == nil {
+		return false
+	}
+	want := "D:P(A;;FA;;;" + user.User.Sid.String() + ")"
+	return strings.HasSuffix(sd.String(), want)
 }

--- a/cmd/punaro-adapter/private_file_windows.go
+++ b/cmd/punaro-adapter/private_file_windows.go
@@ -72,16 +72,17 @@ func privateWindowsACL(path string) bool {
 	}
 	// Protect-PunaroPath emits one FullControl ACE for the current SID, with no
 	// inherited or shared grants. DACL() also rejects absent/null DACLs.
-	if dacl, _, err := sd.DACL(); err != nil || dacl == nil || dacl.AceCount != 1 {
+	dacl, _, err := sd.DACL()
+	if err != nil || dacl == nil || dacl.AceCount != 1 {
 		return false
-	} else {
-		var ace *windows.ACCESS_ALLOWED_ACE
-		if windows.GetAce(dacl, 0, &ace) != nil || ace == nil ||
-			ace.Header.AceType != windows.ACCESS_ALLOWED_ACE_TYPE || ace.Header.AceFlags != 0 ||
-			ace.Mask != windows.ACCESS_MASK(0x1f01ff) {
-			return false
-		}
-		aceSID := (*windows.SID)(unsafe.Pointer(&ace.SidStart))
-		return aceSID.Equals(user.User.Sid)
 	}
+	var ace *windows.ACCESS_ALLOWED_ACE
+	if windows.GetAce(dacl, 0, &ace) != nil || ace == nil ||
+		ace.Header.AceType != windows.ACCESS_ALLOWED_ACE_TYPE || ace.Header.AceFlags != 0 ||
+		ace.Mask != windows.ACCESS_MASK(0x1f01ff) {
+		return false
+	}
+	// #nosec G103 -- SidStart is the documented flexible-array start of this ACE's SID.
+	aceSID := (*windows.SID)(unsafe.Pointer(&ace.SidStart))
+	return aceSID.Equals(user.User.Sid)
 }

--- a/cmd/punaro-adapter/profile_path_unix.go
+++ b/cmd/punaro-adapter/profile_path_unix.go
@@ -7,10 +7,10 @@ import (
 	"path/filepath"
 )
 
-func installedAdapterProfilePath() (string, error) {
+func installedAdapterProfilePath() string {
 	home, err := os.UserHomeDir()
 	if err != nil {
-		return "", err
+		return ""
 	}
-	return filepath.Join(home, ".config", "punaro", "adapter.env"), nil
+	return filepath.Join(home, ".config", "punaro", "adapter.env")
 }

--- a/cmd/punaro-adapter/profile_path_unix.go
+++ b/cmd/punaro-adapter/profile_path_unix.go
@@ -1,0 +1,16 @@
+//go:build !windows
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+)
+
+func installedAdapterProfilePath() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, ".config", "punaro", "adapter.env"), nil
+}

--- a/cmd/punaro-adapter/profile_path_windows.go
+++ b/cmd/punaro-adapter/profile_path_windows.go
@@ -1,0 +1,18 @@
+//go:build windows
+
+package main
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+func installedAdapterProfilePath() (string, error) {
+	root := strings.TrimSpace(os.Getenv("LOCALAPPDATA"))
+	if root == "" {
+		return "", errors.New("LOCALAPPDATA is unavailable")
+	}
+	return filepath.Join(root, "Punaro", "config", "adapter.env"), nil
+}

--- a/cmd/punaro-adapter/profile_path_windows.go
+++ b/cmd/punaro-adapter/profile_path_windows.go
@@ -3,16 +3,15 @@
 package main
 
 import (
-	"errors"
 	"os"
 	"path/filepath"
 	"strings"
 )
 
-func installedAdapterProfilePath() (string, error) {
+func installedAdapterProfilePath() string {
 	root := strings.TrimSpace(os.Getenv("LOCALAPPDATA"))
 	if root == "" {
-		return "", errors.New("LOCALAPPDATA is unavailable")
+		return ""
 	}
-	return filepath.Join(root, "Punaro", "config", "adapter.env"), nil
+	return filepath.Join(root, "Punaro", "config", "adapter.env")
 }

--- a/cmd/punaro-adapter/profile_path_windows_test.go
+++ b/cmd/punaro-adapter/profile_path_windows_test.go
@@ -1,0 +1,51 @@
+//go:build windows
+
+package main
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/base64"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestLoadConfigUsesWindowsInstalledProfile(t *testing.T) {
+	clearAdapterEnvironment(t)
+	localAppData := t.TempDir()
+	t.Setenv("LOCALAPPDATA", localAppData)
+	configDir := filepath.Join(localAppData, "Punaro", "config")
+	if err := os.MkdirAll(configDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	_, private, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	keyFile := filepath.Join(configDir, "machine.key")
+	if err := os.WriteFile(keyFile, []byte(base64.RawURLEncoding.EncodeToString(private)), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	profile := filepath.Join(configDir, "adapter.env")
+	contents := strings.Join([]string{
+		"PUNARO_ADAPTER_RELAY_URL=https://relay.example",
+		"PUNARO_MACHINE_ID=windows-profile-machine",
+		"PUNARO_MACHINE_PRIVATE_KEY_FILE=" + keyFile,
+		"PUNARO_ATTACHED_GROUP=group/punaro-attached",
+		"PUNARO_ADAPTER_DATA_DIR=" + filepath.Join(localAppData, "Punaro", "state"),
+		"",
+	}, "\n")
+	if err := os.WriteFile(profile, []byte(contents), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	config, err := loadConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if config.machineID != "windows-profile-machine" {
+		t.Fatalf("machine ID=%q, want Windows profile value", config.machineID)
+	}
+}

--- a/cmd/punaro-adapter/profile_path_windows_test.go
+++ b/cmd/punaro-adapter/profile_path_windows_test.go
@@ -15,6 +15,32 @@ import (
 
 func TestWindowsLoadConfigUsesInstalledProfile(t *testing.T) {
 	clearAdapterEnvironment(t)
+	setupWindowsProfile(t)
+
+	config, err := loadConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if config.machineID != "windows-profile-machine" {
+		t.Fatalf("machine ID=%q, want Windows profile value", config.machineID)
+	}
+}
+
+func TestWindowsLoadConfigRejectsSharedProfileACL(t *testing.T) {
+	clearAdapterEnvironment(t)
+	profile := setupWindowsProfile(t)
+	command := exec.Command("icacls.exe", profile, "/grant", "*S-1-1-0:(R)")
+	if output, err := command.CombinedOutput(); err != nil {
+		t.Fatalf("share test fixture: %v (%s)", err, output)
+	}
+
+	if _, err := loadConfig(); err == nil || !strings.Contains(err.Error(), "adapter profile file must be a private regular file") {
+		t.Fatalf("shared profile error=%v, want private-file rejection", err)
+	}
+}
+
+func setupWindowsProfile(t *testing.T) string {
+	t.Helper()
 	localAppData := t.TempDir()
 	t.Setenv("LOCALAPPDATA", localAppData)
 	configDir := filepath.Join(localAppData, "Punaro", "config")
@@ -44,14 +70,7 @@ func TestWindowsLoadConfigUsesInstalledProfile(t *testing.T) {
 	protectWindowsFixture(t, configDir)
 	protectWindowsFixture(t, keyFile)
 	protectWindowsFixture(t, profile)
-
-	config, err := loadConfig()
-	if err != nil {
-		t.Fatal(err)
-	}
-	if config.machineID != "windows-profile-machine" {
-		t.Fatalf("machine ID=%q, want Windows profile value", config.machineID)
-	}
+	return profile
 }
 
 func protectWindowsFixture(t *testing.T, path string) {

--- a/cmd/punaro-adapter/profile_path_windows_test.go
+++ b/cmd/punaro-adapter/profile_path_windows_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 )
@@ -50,7 +51,7 @@ func TestWindowsLoadConfigAllowsEnvironmentWithoutProfileRoot(t *testing.T) {
 	if err := os.WriteFile(keyFile, []byte(base64.RawURLEncoding.EncodeToString(private)), 0o600); err != nil {
 		t.Fatal(err)
 	}
-	protectWindowsFixture(t, keyFile)
+	protectWindowsFixture(t, keyFile, false)
 	t.Setenv("PUNARO_ADAPTER_RELAY_URL", "https://relay.example")
 	t.Setenv("PUNARO_MACHINE_ID", "environment-machine")
 	t.Setenv("PUNARO_MACHINE_PRIVATE_KEY_FILE", keyFile)
@@ -94,19 +95,17 @@ func setupWindowsProfile(t *testing.T) string {
 	if err := os.WriteFile(profile, []byte(contents), 0o600); err != nil {
 		t.Fatal(err)
 	}
-	protectWindowsFixture(t, configDir)
-	protectWindowsFixture(t, keyFile)
-	protectWindowsFixture(t, profile)
+	protectWindowsFixture(t, configDir, true)
+	protectWindowsFixture(t, keyFile, false)
+	protectWindowsFixture(t, profile, false)
 	return profile
 }
 
-func protectWindowsFixture(t *testing.T, path string) {
+func protectWindowsFixture(t *testing.T, path string, directory bool) {
 	t.Helper()
-	user := os.Getenv("USERNAME")
-	if user == "" {
-		t.Fatal("Windows user name is unavailable")
-	}
-	command := exec.Command("icacls.exe", path, "/inheritance:r", "/grant:r", user+":(F)")
+	// Keep the fixture ACL identical to Protect-PunaroPath in install-client.ps1.
+	script := `$ErrorActionPreference = 'Stop'; $path = $args[0]; $directory = [bool]::Parse($args[1]); $sid = [System.Security.Principal.WindowsIdentity]::GetCurrent().User; $acl = Get-Acl -LiteralPath $path; $acl.SetAccessRuleProtection($true, $false); $acl.SetOwner($sid); if ($directory) { $inheritance = [System.Security.AccessControl.InheritanceFlags]::ContainerInherit -bor [System.Security.AccessControl.InheritanceFlags]::ObjectInherit } else { $inheritance = [System.Security.AccessControl.InheritanceFlags]::None }; $rule = New-Object -TypeName System.Security.AccessControl.FileSystemAccessRule -ArgumentList @($sid, [System.Security.AccessControl.FileSystemRights]::FullControl, $inheritance, [System.Security.AccessControl.PropagationFlags]::None, [System.Security.AccessControl.AccessControlType]::Allow); $acl.SetAccessRule($rule); Set-Acl -LiteralPath $path -AclObject $acl`
+	command := exec.Command("powershell.exe", "-NoProfile", "-NonInteractive", "-Command", script, path, strconv.FormatBool(directory))
 	if output, err := command.CombinedOutput(); err != nil {
 		t.Fatalf("protect test fixture: %v (%s)", err, output)
 	}

--- a/cmd/punaro-adapter/profile_path_windows_test.go
+++ b/cmd/punaro-adapter/profile_path_windows_test.go
@@ -7,10 +7,11 @@ import (
 	"crypto/rand"
 	"encoding/base64"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"golang.org/x/sys/windows"
 )
 
 func TestWindowsLoadConfigUsesInstalledProfile(t *testing.T) {
@@ -29,10 +30,7 @@ func TestWindowsLoadConfigUsesInstalledProfile(t *testing.T) {
 func TestWindowsLoadConfigRejectsSharedProfileACL(t *testing.T) {
 	clearAdapterEnvironment(t)
 	profile := setupWindowsProfile(t)
-	command := exec.Command("icacls.exe", profile, "/grant", "*S-1-1-0:(R)")
-	if output, err := command.CombinedOutput(); err != nil {
-		t.Fatalf("share test fixture: %v (%s)", err, output)
-	}
+	setWindowsFixtureACL(t, profile, "(A;;FR;;;WD)")
 
 	if _, err := loadConfig(); err == nil || !strings.Contains(err.Error(), "adapter profile is unsafe") {
 		t.Fatalf("shared profile error=%v, want sanitized profile rejection", err)
@@ -50,7 +48,7 @@ func TestWindowsLoadConfigAllowsEnvironmentWithoutProfileRoot(t *testing.T) {
 	if err := os.WriteFile(keyFile, []byte(base64.RawURLEncoding.EncodeToString(private)), 0o600); err != nil {
 		t.Fatal(err)
 	}
-	protectWindowsFixture(t, keyFile, false)
+	protectWindowsFixture(t, keyFile)
 	t.Setenv("PUNARO_ADAPTER_RELAY_URL", "https://relay.example")
 	t.Setenv("PUNARO_MACHINE_ID", "environment-machine")
 	t.Setenv("PUNARO_MACHINE_PRIVATE_KEY_FILE", keyFile)
@@ -94,22 +92,32 @@ func setupWindowsProfile(t *testing.T) string {
 	if err := os.WriteFile(profile, []byte(contents), 0o600); err != nil {
 		t.Fatal(err)
 	}
-	protectWindowsFixture(t, configDir, true)
-	protectWindowsFixture(t, keyFile, false)
-	protectWindowsFixture(t, profile, false)
+	protectWindowsFixture(t, keyFile)
+	protectWindowsFixture(t, profile)
 	return profile
 }
 
-func protectWindowsFixture(t *testing.T, path string, directory bool) {
+func protectWindowsFixture(t *testing.T, path string) {
 	t.Helper()
-	// Keep the fixture ACL identical to Protect-PunaroPath in install-client.ps1.
-	inheritance := `[System.Security.AccessControl.InheritanceFlags]::None`
-	if directory {
-		inheritance = `[System.Security.AccessControl.InheritanceFlags]::ContainerInherit -bor [System.Security.AccessControl.InheritanceFlags]::ObjectInherit`
+	setWindowsFixtureACL(t, path, "")
+}
+
+func setWindowsFixtureACL(t *testing.T, path, additionalACE string) {
+	t.Helper()
+	user, err := windows.GetCurrentProcessToken().GetTokenUser()
+	if err != nil || user.User.Sid == nil {
+		t.Fatalf("current Windows user: %v", err)
 	}
-	script := `$ErrorActionPreference = 'Stop'; $path = $args[0]; $sid = [System.Security.Principal.WindowsIdentity]::GetCurrent().User; $acl = Get-Acl -LiteralPath $path; $acl.SetAccessRuleProtection($true, $false); $acl.SetOwner($sid); $inheritance = ` + inheritance + `; $rule = New-Object -TypeName System.Security.AccessControl.FileSystemAccessRule -ArgumentList @($sid, [System.Security.AccessControl.FileSystemRights]::FullControl, $inheritance, [System.Security.AccessControl.PropagationFlags]::None, [System.Security.AccessControl.AccessControlType]::Allow); $acl.SetAccessRule($rule); Set-Acl -LiteralPath $path -AclObject $acl`
-	command := exec.Command("powershell.exe", "-NoProfile", "-NonInteractive", "-Command", script, path)
-	if output, err := command.CombinedOutput(); err != nil {
-		t.Fatalf("protect test fixture: %v (%s)", err, output)
+	sid := user.User.Sid.String()
+	sd, err := windows.SecurityDescriptorFromString("O:" + sid + "D:P(A;;FA;;;" + sid + ")" + additionalACE)
+	if err != nil {
+		t.Fatalf("build test ACL: %v", err)
+	}
+	dacl, _, err := sd.DACL()
+	if err != nil || dacl == nil {
+		t.Fatalf("read test ACL: %v", err)
+	}
+	if err := windows.SetNamedSecurityInfo(path, windows.SE_FILE_OBJECT, windows.OWNER_SECURITY_INFORMATION|windows.DACL_SECURITY_INFORMATION|windows.PROTECTED_DACL_SECURITY_INFORMATION, user.User.Sid, nil, dacl, nil); err != nil {
+		t.Fatalf("protect test fixture: %v", err)
 	}
 }

--- a/cmd/punaro-adapter/profile_path_windows_test.go
+++ b/cmd/punaro-adapter/profile_path_windows_test.go
@@ -34,8 +34,8 @@ func TestWindowsLoadConfigRejectsSharedProfileACL(t *testing.T) {
 		t.Fatalf("share test fixture: %v (%s)", err, output)
 	}
 
-	if _, err := loadConfig(); err == nil || !strings.Contains(err.Error(), "adapter profile file must be a private regular file") {
-		t.Fatalf("shared profile error=%v, want private-file rejection", err)
+	if _, err := loadConfig(); err == nil || !strings.Contains(err.Error(), "adapter profile is unsafe") {
+		t.Fatalf("shared profile error=%v, want sanitized profile rejection", err)
 	}
 }
 

--- a/cmd/punaro-adapter/profile_path_windows_test.go
+++ b/cmd/punaro-adapter/profile_path_windows_test.go
@@ -9,7 +9,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"strconv"
 	"strings"
 	"testing"
 )
@@ -104,8 +103,12 @@ func setupWindowsProfile(t *testing.T) string {
 func protectWindowsFixture(t *testing.T, path string, directory bool) {
 	t.Helper()
 	// Keep the fixture ACL identical to Protect-PunaroPath in install-client.ps1.
-	script := `$ErrorActionPreference = 'Stop'; $path = $args[0]; $directory = [bool]::Parse($args[1]); $sid = [System.Security.Principal.WindowsIdentity]::GetCurrent().User; $acl = Get-Acl -LiteralPath $path; $acl.SetAccessRuleProtection($true, $false); $acl.SetOwner($sid); if ($directory) { $inheritance = [System.Security.AccessControl.InheritanceFlags]::ContainerInherit -bor [System.Security.AccessControl.InheritanceFlags]::ObjectInherit } else { $inheritance = [System.Security.AccessControl.InheritanceFlags]::None }; $rule = New-Object -TypeName System.Security.AccessControl.FileSystemAccessRule -ArgumentList @($sid, [System.Security.AccessControl.FileSystemRights]::FullControl, $inheritance, [System.Security.AccessControl.PropagationFlags]::None, [System.Security.AccessControl.AccessControlType]::Allow); $acl.SetAccessRule($rule); Set-Acl -LiteralPath $path -AclObject $acl`
-	command := exec.Command("powershell.exe", "-NoProfile", "-NonInteractive", "-Command", script, path, strconv.FormatBool(directory))
+	inheritance := `[System.Security.AccessControl.InheritanceFlags]::None`
+	if directory {
+		inheritance = `[System.Security.AccessControl.InheritanceFlags]::ContainerInherit -bor [System.Security.AccessControl.InheritanceFlags]::ObjectInherit`
+	}
+	script := `$ErrorActionPreference = 'Stop'; $path = $args[0]; $sid = [System.Security.Principal.WindowsIdentity]::GetCurrent().User; $acl = Get-Acl -LiteralPath $path; $acl.SetAccessRuleProtection($true, $false); $acl.SetOwner($sid); $inheritance = ` + inheritance + `; $rule = New-Object -TypeName System.Security.AccessControl.FileSystemAccessRule -ArgumentList @($sid, [System.Security.AccessControl.FileSystemRights]::FullControl, $inheritance, [System.Security.AccessControl.PropagationFlags]::None, [System.Security.AccessControl.AccessControlType]::Allow); $acl.SetAccessRule($rule); Set-Acl -LiteralPath $path -AclObject $acl`
+	command := exec.Command("powershell.exe", "-NoProfile", "-NonInteractive", "-Command", script, path)
 	if output, err := command.CombinedOutput(); err != nil {
 		t.Fatalf("protect test fixture: %v (%s)", err, output)
 	}

--- a/cmd/punaro-adapter/profile_path_windows_test.go
+++ b/cmd/punaro-adapter/profile_path_windows_test.go
@@ -7,6 +7,7 @@ import (
 	"crypto/rand"
 	"encoding/base64"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -40,6 +41,9 @@ func TestWindowsLoadConfigUsesInstalledProfile(t *testing.T) {
 	if err := os.WriteFile(profile, []byte(contents), 0o600); err != nil {
 		t.Fatal(err)
 	}
+	protectWindowsFixture(t, configDir)
+	protectWindowsFixture(t, keyFile)
+	protectWindowsFixture(t, profile)
 
 	config, err := loadConfig()
 	if err != nil {
@@ -47,5 +51,17 @@ func TestWindowsLoadConfigUsesInstalledProfile(t *testing.T) {
 	}
 	if config.machineID != "windows-profile-machine" {
 		t.Fatalf("machine ID=%q, want Windows profile value", config.machineID)
+	}
+}
+
+func protectWindowsFixture(t *testing.T, path string) {
+	t.Helper()
+	user := os.Getenv("USERNAME")
+	if user == "" {
+		t.Fatal("Windows user name is unavailable")
+	}
+	command := exec.Command("icacls.exe", path, "/inheritance:r", "/grant:r", user+":(F)")
+	if output, err := command.CombinedOutput(); err != nil {
+		t.Fatalf("protect test fixture: %v (%s)", err, output)
 	}
 }

--- a/cmd/punaro-adapter/profile_path_windows_test.go
+++ b/cmd/punaro-adapter/profile_path_windows_test.go
@@ -12,7 +12,7 @@ import (
 	"testing"
 )
 
-func TestLoadConfigUsesWindowsInstalledProfile(t *testing.T) {
+func TestWindowsLoadConfigUsesInstalledProfile(t *testing.T) {
 	clearAdapterEnvironment(t)
 	localAppData := t.TempDir()
 	t.Setenv("LOCALAPPDATA", localAppData)

--- a/cmd/punaro-adapter/profile_path_windows_test.go
+++ b/cmd/punaro-adapter/profile_path_windows_test.go
@@ -39,6 +39,33 @@ func TestWindowsLoadConfigRejectsSharedProfileACL(t *testing.T) {
 	}
 }
 
+func TestWindowsLoadConfigAllowsEnvironmentWithoutProfileRoot(t *testing.T) {
+	clearAdapterEnvironment(t)
+	t.Setenv("LOCALAPPDATA", "")
+	_, private, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	keyFile := filepath.Join(t.TempDir(), "machine.key")
+	if err := os.WriteFile(keyFile, []byte(base64.RawURLEncoding.EncodeToString(private)), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	protectWindowsFixture(t, keyFile)
+	t.Setenv("PUNARO_ADAPTER_RELAY_URL", "https://relay.example")
+	t.Setenv("PUNARO_MACHINE_ID", "environment-machine")
+	t.Setenv("PUNARO_MACHINE_PRIVATE_KEY_FILE", keyFile)
+	t.Setenv("PUNARO_ATTACHED_GROUP", "group/punaro-attached")
+	t.Setenv("PUNARO_ADAPTER_DATA_DIR", t.TempDir())
+
+	config, err := loadConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if config.machineID != "environment-machine" {
+		t.Fatalf("machine ID=%q, want environment value", config.machineID)
+	}
+}
+
 func setupWindowsProfile(t *testing.T) string {
 	t.Helper()
 	localAppData := t.TempDir()

--- a/deploy/launchd/punaro-adapter.plist
+++ b/deploy/launchd/punaro-adapter.plist
@@ -8,7 +8,7 @@
   <array>
     <string>/bin/sh</string>
     <string>-c</string>
-    <string>set -a; . "$HOME/.config/punaro/adapter.env"; set +a; exec "$HOME/.local/bin/punaro-adapter"</string>
+    <string>exec "$HOME/.local/bin/punaro-adapter"</string>
   </array>
   <key>RunAtLoad</key>
   <true/>

--- a/deploy/systemd/user/punaro-adapter.env.example
+++ b/deploy/systemd/user/punaro-adapter.env.example
@@ -1,4 +1,5 @@
-# Copy to ~/.config/punaro/adapter.env and set mode 0600.
+# Copy to ~/.config/punaro/adapter.env and set mode 0600. punaro-adapter reads
+# this profile itself for both direct commands and the managed user service.
 # This file belongs to the same unprivileged account that owns the attached
 # agent-mailbox state. Add that machine's distinct Access client ID and secret
 # only to the private copy, never to this example or source control.

--- a/deploy/systemd/user/punaro-adapter.service
+++ b/deploy/systemd/user/punaro-adapter.service
@@ -3,7 +3,6 @@ Description=Punaro machine mailbox adapter
 
 [Service]
 Type=exec
-EnvironmentFile=%h/.config/punaro/adapter.env
 ExecStart=%h/.local/bin/punaro-adapter
 Restart=on-failure
 RestartSec=3

--- a/deploy/windows/Run-PunaroAdapter.ps1
+++ b/deploy/windows/Run-PunaroAdapter.ps1
@@ -2,7 +2,5 @@ Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
 $root = $PSScriptRoot
-. (Join-Path $PSScriptRoot 'Import-PunaroEnvironment.ps1')
-Import-PunaroEnvironment -Path (Join-Path $root 'config\adapter.env')
 & (Join-Path $root 'bin\punaro-adapter.exe')
 exit $LASTEXITCODE

--- a/docs/alpha-text-relay.md
+++ b/docs/alpha-text-relay.md
@@ -119,8 +119,9 @@ another machine.
 
 For a macOS agent machine, install the reviewed
 `deploy/launchd/punaro-adapter.plist` template as
-`~/Library/LaunchAgents/org.punaro.adapter.plist`. It sources the same
-owner-only `~/.config/punaro/adapter.env` rather than embedding credentials in
+`~/Library/LaunchAgents/org.punaro.adapter.plist`. The adapter itself validates
+and reads the same owner-only `~/.config/punaro/adapter.env` profile used by
+interactive commands, rather than embedding or shell-sourcing credentials in
 the plist. Validate it with `plutil -lint`, then bootstrap it as the interactive
 user with `launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/org.punaro.adapter.plist`.
 Use `launchctl print gui/$(id -u)/org.punaro.adapter` to verify it is running.
@@ -180,6 +181,10 @@ punaro-adapter send \
 
 The explicit idempotency key must be retained for retrying the same logical
 reply. The command emits only a message ID and sequence, not the message body.
+It automatically uses the installed adapter profile. A deliberately supplied
+non-empty adapter environment setting overrides its matching profile value;
+use `PUNARO_ADAPTER_PROFILE_FILE` only to select another absolute, owner-only
+profile.
 
 ## Retired v3 attachment evidence
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -165,6 +165,21 @@ and local paths. It refuses to overwrite an existing key, enrollment record,
 configuration file, or project skill that does not match. To revoke a client,
 follow the [alpha onboarding revocation procedure](alpha-text-relay.md#onboard-and-revoke-a-machine): remove attached aliases, remove the relay enrollment, revoke the machine's Access token, stop the service, and securely erase its key.
 
+### Adapter profile for direct commands and the service
+
+The installed `punaro-adapter` validates and reads the same owner-only,
+non-symlinked profile for direct `create`, `send`, and `attachment-notify`
+commands and for the managed adapter service. On macOS and Linux that profile
+is `~/.config/punaro/adapter.env`; on Windows it is
+`%LOCALAPPDATA%\Punaro\config\adapter.env`. Do not source the file in a shell
+or copy its values into a command line.
+
+A non-empty adapter setting in the process environment intentionally overrides
+the corresponding profile setting, for controlled service-manager or debugging
+use. `PUNARO_ADAPTER_PROFILE_FILE` is the explicit alternative profile path;
+it must be absolute and satisfy the same private regular-file checks. The
+default profile remains the supported interactive path.
+
 ## 4. Retired v2/v3 attachment evidence
 
 Do not execute the historical provisioning helpers retained in the source tree

--- a/scripts/verify-deployment-files.sh
+++ b/scripts/verify-deployment-files.sh
@@ -41,7 +41,7 @@ for expected in \
 	'<string>org.punaro.adapter</string>' \
 	'<key>KeepAlive</key>' \
 	'<true/>' \
-	'<string>set -a; . "$HOME/.config/punaro/adapter.env"; set +a; exec "$HOME/.local/bin/punaro-adapter"</string>'; do
+	'<string>exec "$HOME/.local/bin/punaro-adapter"</string>'; do
 	if ! grep -Fq "$expected" "$launch_agent"; then
 		printf '%s\n' "adapter LaunchAgent is missing required setting: $expected" >&2
 		exit 1
@@ -74,8 +74,8 @@ for expected in \
 	fi
 done
 
-if ! grep -Fqx 'EnvironmentFile=%h/.config/punaro/adapter.env' "$unit"; then
-	printf '%s\n' 'adapter user unit must read the owner-only adapter environment file' >&2
+if grep -Fqx 'EnvironmentFile=%h/.config/punaro/adapter.env' "$unit"; then
+	printf '%s\n' 'adapter user unit must let punaro-adapter validate and load its own profile' >&2
 	exit 1
 fi
 


### PR DESCRIPTION
## Summary

Fixes #102.

- Load the installed private adapter profile for direct `create`, `send`, and `attachment-notify` commands, using the same validated path as managed services.
- Parse an allowlisted plain-data profile, reject malformed, group-readable, and symlinked files without exposing values, and retain explicit non-empty environment overrides.
- Update service launchers and client/operator documentation so both execution modes follow one supported profile contract.

## Validation

- Focused CLI transport/profile tests (written red first)
- `make ci`