### PR TITLE
test: add remote MCP release E2E evidence

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ test-real-relay-e2e:
 
 remote-mcp-e2e:
 	@test -n "$${PUNARO_REMOTE_MCP_E2E_CONFIG:-}" || { printf '%s\n' 'set PUNARO_REMOTE_MCP_E2E_CONFIG to a private release-candidate config' >&2; exit 2; }
-	@case "$${GOFLAGS:-}" in *-overlay*) printf '%s\n' 'remote-mcp-e2e rejects GOFLAGS build overlays' >&2; exit 2;; esac
+	@case "$$(go env GOFLAGS)" in *-overlay*) printf '%s\n' 'remote-mcp-e2e rejects GOFLAGS build overlays' >&2; exit 2;; esac
 	PUNARO_REMOTE_MCP_E2E_LIVE=1 GOCACHE="$${GOCACHE:-/tmp/punaro-go-cache}" go test -tags=e2e ./internal/mcphttp -run '^TestRemoteMCPE2EReleaseCandidate$$' -count=1
 
 test-postgres:

--- a/Makefile
+++ b/Makefile
@@ -29,8 +29,7 @@ test-real-relay-e2e:
 
 remote-mcp-e2e:
 	@test -n "$${PUNARO_REMOTE_MCP_E2E_CONFIG:-}" || { printf '%s\n' 'set PUNARO_REMOTE_MCP_E2E_CONFIG to a private release-candidate config' >&2; exit 2; }
-	@case "$$(go env GOFLAGS)" in *-overlay*) printf '%s\n' 'remote-mcp-e2e rejects GOFLAGS build overlays' >&2; exit 2;; esac
-	PUNARO_REMOTE_MCP_E2E_LIVE=1 GOCACHE="$${GOCACHE:-/tmp/punaro-go-cache}" go test -tags=e2e ./internal/mcphttp -run '^TestRemoteMCPE2EReleaseCandidate$$' -count=1
+	GOENV=off GOFLAGS= PUNARO_REMOTE_MCP_E2E_LIVE=1 GOCACHE="$${GOCACHE:-/tmp/punaro-go-cache}" go test -tags=e2e ./internal/mcphttp -run '^TestRemoteMCPE2EReleaseCandidate$$' -count=1
 
 test-postgres:
 	./scripts/test-postgres-integration.sh

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ memory-client:
 
 test:
 	go test -covermode=atomic ./...
-	go test -tags=e2e ./internal/mcphttp
+	PUNARO_REMOTE_MCP_E2E_LIVE= PUNARO_REMOTE_MCP_E2E_CONFIG= go test -tags=e2e ./internal/mcphttp
 
 test-race:
 	go test -race -count=1 ./...
@@ -29,6 +29,7 @@ test-real-relay-e2e:
 
 remote-mcp-e2e:
 	@test -n "$${PUNARO_REMOTE_MCP_E2E_CONFIG:-}" || { printf '%s\n' 'set PUNARO_REMOTE_MCP_E2E_CONFIG to a private release-candidate config' >&2; exit 2; }
+	@case "$${GOFLAGS:-}" in *-overlay*) printf '%s\n' 'remote-mcp-e2e rejects GOFLAGS build overlays' >&2; exit 2;; esac
 	PUNARO_REMOTE_MCP_E2E_LIVE=1 GOCACHE="$${GOCACHE:-/tmp/punaro-go-cache}" go test -tags=e2e ./internal/mcphttp -run '^TestRemoteMCPE2EReleaseCandidate$$' -count=1
 
 test-postgres:

--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,7 @@ memory-client:
 
 test:
 	go test -covermode=atomic ./...
+	go test -tags=e2e ./internal/mcphttp
 
 test-race:
 	go test -race -count=1 ./...
@@ -28,7 +29,7 @@ test-real-relay-e2e:
 
 remote-mcp-e2e:
 	@test -n "$${PUNARO_REMOTE_MCP_E2E_CONFIG:-}" || { printf '%s\n' 'set PUNARO_REMOTE_MCP_E2E_CONFIG to a private release-candidate config' >&2; exit 2; }
-	GOCACHE="$${GOCACHE:-/tmp/punaro-go-cache}" go test -tags=e2e ./internal/mcphttp -run '^TestRemoteMCPE2EReleaseCandidate$$' -count=1
+	PUNARO_REMOTE_MCP_E2E_LIVE=1 GOCACHE="$${GOCACHE:-/tmp/punaro-go-cache}" go test -tags=e2e ./internal/mcphttp -run '^TestRemoteMCPE2EReleaseCandidate$$' -count=1
 
 test-postgres:
 	./scripts/test-postgres-integration.sh

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: test test-race test-postgres memory-onboarding-e2e test-real-relay-e2e vet staticcheck golangci windows-build vuln gosec secrets lint security ci fmt dockerfile-lint workflow-lint deployment-lint release-gates fuzz operator-binary trusted-attachment-client memory-client
+.PHONY: test test-race test-postgres remote-mcp-e2e memory-onboarding-e2e test-real-relay-e2e vet staticcheck golangci windows-build vuln gosec secrets lint security ci fmt dockerfile-lint workflow-lint deployment-lint release-gates fuzz operator-binary trusted-attachment-client memory-client
 
 PUNARO_OPERATOR_OUTPUT ?= ./bin/punaro
 PUNARO_TRUSTED_ATTACHMENT_OUTPUT ?= ./bin/punaro-trusted-attachment
@@ -25,6 +25,10 @@ test-race:
 test-real-relay-e2e:
 	@test "$(shell uname -s)" = Darwin || { printf '%s\n' 'test-real-relay-e2e requires a disposable macOS GUI login for the supported LaunchAgent lifecycle' >&2; exit 2; }
 	PUNARO_REAL_RELAY_E2E=1 go test -tags=e2e -count=1 -timeout=8m ./cmd/punaro-adapter -run '^TestE2ERealTwoClientRelayLifecycle$$'
+
+remote-mcp-e2e:
+	@test -n "$${PUNARO_REMOTE_MCP_E2E_CONFIG:-}" || { printf '%s\n' 'set PUNARO_REMOTE_MCP_E2E_CONFIG to a private release-candidate config' >&2; exit 2; }
+	GOCACHE="$${GOCACHE:-/tmp/punaro-go-cache}" go test -tags=e2e ./internal/mcphttp -run '^TestRemoteMCPE2EReleaseCandidate$$' -count=1
 
 test-postgres:
 	./scripts/test-postgres-integration.sh

--- a/docs/remote-mcp-e2e.md
+++ b/docs/remote-mcp-e2e.md
@@ -99,8 +99,8 @@ the endpoint, tokens, request bodies, response bodies, and topology on failure.
 Its own TLS-backed fixture validates the complete harness flow locally; the
 release command remains the authoritative deployed-candidate check.
 `candidate_commit` must match `git rev-parse HEAD` in the checkout that runs
-the command, and that checkout must have no changes (including untracked
-files), so release evidence cannot be attributed to another build or a
+the command, and that checkout must have no changes (including untracked or
+ignored files), so release evidence cannot be attributed to another build or a
 modified test harness.
 Record its CI job URL, exact command result, candidate commit, deployment image
 digest, approvers, residual risk, and rollback reference in the final

--- a/docs/remote-mcp-e2e.md
+++ b/docs/remote-mcp-e2e.md
@@ -1,0 +1,85 @@
+# Remote MCP release-candidate E2E evidence
+
+The remote MCP release candidate is qualified with a black-box test against a
+disposable deployed endpoint. The test does not provision an endpoint, mint
+tokens, or infer deployment topology. An operator supplies a private test
+configuration after deploying the exact candidate commit.
+
+Run the test from the candidate checkout:
+
+```sh
+PUNARO_REMOTE_MCP_E2E_CONFIG=/private/punaro/remote-mcp-e2e.json make remote-mcp-e2e
+```
+
+The target fails when the configuration variable is unset. The tagged Go test
+skips without it only so ordinary developer test runs cannot accidentally touch
+a remote deployment.
+
+Keep the configuration outside the repository, readable only by the release
+operator, and never attach it to CI logs or the release record. Its shape is:
+
+```json
+{
+  "candidate_commit": "0123456789abcdef0123456789abcdef01234567",
+  "endpoint": "https://candidate.example.invalid/mcp",
+  "resource": "https://candidate.example.invalid/mcp",
+  "authorization_server": "https://issuer.example.invalid",
+  "tokens": {
+    "valid": "private-token-for-the-authorized-read-only-tool",
+    "invalid": "private-malformed-or-unrecognized-token",
+    "wrong_issuer": "private-token-from-a-different-issuer",
+    "wrong_audience": "private-token-for-a-different-resource",
+    "expired": "private-expired-token",
+    "revoked": "private-token-or-subject-revoked-before-the-test",
+    "no_scope": "private-valid-token-with-no-required-scope",
+    "insufficient_scope": "private-valid-token-that-cannot-invoke-the-forbidden-tool"
+  },
+  "authorized_tool": {
+    "name": "candidate_read_only_tool",
+    "arguments": {"query": "release-candidate-e2e"}
+  },
+  "forbidden_tool": {
+    "name": "candidate_out_of_scope_tool",
+    "arguments": {},
+    "expected_status": 403
+  },
+  "redaction_probe": "remote-mcp-e2e-redaction-probe"
+}
+```
+
+`candidate_commit` must be the deployed 40-character lowercase Git commit.
+`endpoint` and `resource` must be the same canonical HTTPS MCP resource;
+`authorization_server` is the canonical HTTPS issuer. The tool arguments must
+be JSON objects with no duplicate keys. Every token and the redaction probe
+must be a distinct, at-least-16-character OAuth bearer value made only of
+letters, digits, `-._~+/=`. Values above are placeholders, not usable
+credentials.
+
+Prepare a token suite that proves each distinct failure boundary. `valid` must
+invoke only the configured read-only `authorized_tool`. `no_scope` must be a
+valid token without any required MCP default scope. `insufficient_scope` must
+be valid but lack the operation-specific scope for `forbidden_tool`.
+`wrong_issuer`, `wrong_audience`, `expired`, and `revoked` must each fail for
+that stated reason at the candidate boundary, not merely be arbitrary malformed
+strings. Use disposable principals, resources, and data; no test request should
+name a production project or contain user content.
+
+The test proves all of the following against the candidate:
+
+- OAuth protected-resource discovery and the unauthenticated challenge;
+- malformed, wrong-issuer, wrong-audience, expired, and revoked bearers fail
+  with `401` and an `invalid_token` challenge;
+- missing required scope and tool-specific insufficient scope fail closed;
+- duplicate-member JSON-RPC input fails without executing a request;
+- a valid scoped bearer reaches its configured tool; and
+- failure headers and bodies do not echo any supplied token or the redaction
+  probe.
+
+The test logs only the candidate commit on success and intentionally withholds
+the endpoint, tokens, request bodies, response bodies, and topology on failure.
+Its own TLS-backed fixture validates the complete harness flow locally; the
+release command remains the authoritative deployed-candidate check.
+Record its CI job URL, exact command result, candidate commit, deployment image
+digest, approvers, residual risk, and rollback reference in the final
+release-evidence record under `docs/release-evidence/` only after the release
+process has the required protected-branch and environment approvals.

--- a/docs/remote-mcp-e2e.md
+++ b/docs/remote-mcp-e2e.md
@@ -57,8 +57,9 @@ operator, and never attach it to CI logs or the release record. Its shape is:
 `candidate_commit` must be the deployed 40-character lowercase Git commit.
 `endpoint` and `resource` must be the same canonical HTTPS MCP resource;
 `authorization_server` is the canonical HTTPS issuer. The tool arguments must
-be JSON objects with no duplicate keys. `protocol_version` is the MCP protocol
-version the disposable client must negotiate with the candidate. Every token and the redaction probe
+be JSON objects with no duplicate keys. `protocol_version` must be the supported
+MCP version `2024-11-05`, which the disposable client negotiates with the
+candidate. Every token and the redaction probe
 must be a distinct, at-least-16-character OAuth bearer value made only of
 letters, digits, `-._~+/=`. Values above are placeholders, not usable
 credentials. `authorized_tool.expected_result` must be the exact non-error MCP

--- a/docs/remote-mcp-e2e.md
+++ b/docs/remote-mcp-e2e.md
@@ -101,9 +101,10 @@ release command remains the authoritative deployed-candidate check.
 `candidate_commit` must match `git rev-parse HEAD` in the checkout that runs
 the command, and that checkout must have no changes (including untracked or
 ignored files), so release evidence cannot be attributed to another build or a
-modified test harness. The release target also rejects `GOFLAGS` build overlays,
-and the ordinary test target clears the remote-E2E environment variables before
-running its offline fixture.
+modified test harness. The release target also rejects `GOFLAGS` build overlays
+from either the environment or Go's persisted environment file, and the ordinary
+test target clears the remote-E2E environment variables before running its
+offline fixture.
 Record its CI job URL, exact command result, candidate commit, deployment image
 digest, approvers, residual risk, and rollback reference in the final
 release-evidence record under `docs/release-evidence/` only after the release

--- a/docs/remote-mcp-e2e.md
+++ b/docs/remote-mcp-e2e.md
@@ -66,9 +66,11 @@ tool result for the disposable probe. It must contain at least one non-empty
 text content item; the harness validates it and the request ID exactly.
 
 Prepare a token suite that proves each distinct failure boundary. `valid` must
-invoke only the configured read-only `authorized_tool`. `no_scope` must be a
-valid token without any required MCP default scope. `insufficient_scope` must
-be valid but lack the operation-specific scope for `forbidden_tool`.
+invoke the configured read-only `authorized_tool` but be denied the
+`forbidden_tool`. `no_scope` must be a valid token without any required MCP
+default scope. `insufficient_scope` must invoke `authorized_tool` successfully
+but lack the operation-specific scope for `forbidden_tool`, which must return
+`403` for both scoped credentials.
 `wrong_issuer`, `wrong_audience`, `expired`, and `revoked` must each fail for
 that stated reason at the candidate boundary, not merely be arbitrary malformed
 strings. Set `revoked.expected_status` to `401` for a revoked token (which must
@@ -95,6 +97,8 @@ The test logs only the candidate commit on success and intentionally withholds
 the endpoint, tokens, request bodies, response bodies, and topology on failure.
 Its own TLS-backed fixture validates the complete harness flow locally; the
 release command remains the authoritative deployed-candidate check.
+`candidate_commit` must match `git rev-parse HEAD` in the checkout that runs
+the command, so release evidence cannot be attributed to another build.
 Record its CI job URL, exact command result, candidate commit, deployment image
 digest, approvers, residual risk, and rollback reference in the final
 release-evidence record under `docs/release-evidence/` only after the release

--- a/docs/remote-mcp-e2e.md
+++ b/docs/remote-mcp-e2e.md
@@ -98,7 +98,8 @@ the endpoint, tokens, request bodies, response bodies, and topology on failure.
 Its own TLS-backed fixture validates the complete harness flow locally; the
 release command remains the authoritative deployed-candidate check.
 `candidate_commit` must match `git rev-parse HEAD` in the checkout that runs
-the command, so release evidence cannot be attributed to another build.
+the command, and that checkout must have no tracked changes, so release
+evidence cannot be attributed to another build or a modified test harness.
 Record its CI job URL, exact command result, candidate commit, deployment image
 digest, approvers, residual risk, and rollback reference in the final
 release-evidence record under `docs/release-evidence/` only after the release

--- a/docs/remote-mcp-e2e.md
+++ b/docs/remote-mcp-e2e.md
@@ -30,7 +30,10 @@ operator, and never attach it to CI logs or the release record. Its shape is:
     "wrong_issuer": "private-token-from-a-different-issuer",
     "wrong_audience": "private-token-for-a-different-resource",
     "expired": "private-expired-token",
-    "revoked": "private-token-or-subject-revoked-before-the-test",
+    "revoked": {
+      "token": "private-token-or-subject-revoked-before-the-test",
+      "expected_status": 403
+    },
     "no_scope": "private-valid-token-with-no-required-scope",
     "insufficient_scope": "private-valid-token-that-cannot-invoke-the-forbidden-tool"
   },
@@ -66,14 +69,18 @@ valid token without any required MCP default scope. `insufficient_scope` must
 be valid but lack the operation-specific scope for `forbidden_tool`.
 `wrong_issuer`, `wrong_audience`, `expired`, and `revoked` must each fail for
 that stated reason at the candidate boundary, not merely be arbitrary malformed
-strings. Use disposable principals, resources, and data; no test request should
-name a production project or contain user content.
+strings. Set `revoked.expected_status` to `401` for a revoked token (which must
+return `invalid_token`) or `403` for a token whose bound subject was disabled
+or unbound (which must have no authentication challenge). Use disposable
+principals, resources, and data; no test request should name a production
+project or contain user content.
 
 The test proves all of the following against the candidate:
 
 - OAuth protected-resource discovery and the unauthenticated challenge;
-- malformed, wrong-issuer, wrong-audience, expired, and revoked bearers fail
-  with `401` and an `invalid_token` challenge;
+- malformed, wrong-issuer, wrong-audience, and expired bearers fail with `401`
+  and an `invalid_token` challenge; a revoked token fails the configured `401`
+  token-revocation or `403` disabled-subject boundary;
 - missing required scope and tool-specific insufficient scope fail closed;
 - duplicate-member JSON-RPC input fails without executing a request;
 - a valid scoped bearer reaches its configured tool; and

--- a/docs/remote-mcp-e2e.md
+++ b/docs/remote-mcp-e2e.md
@@ -98,8 +98,9 @@ the endpoint, tokens, request bodies, response bodies, and topology on failure.
 Its own TLS-backed fixture validates the complete harness flow locally; the
 release command remains the authoritative deployed-candidate check.
 `candidate_commit` must match `git rev-parse HEAD` in the checkout that runs
-the command, and that checkout must have no tracked changes, so release
-evidence cannot be attributed to another build or a modified test harness.
+the command, and that checkout must have no changes (including untracked
+files), so release evidence cannot be attributed to another build or a
+modified test harness.
 Record its CI job URL, exact command result, candidate commit, deployment image
 digest, approvers, residual risk, and rollback reference in the final
 release-evidence record under `docs/release-evidence/` only after the release

--- a/docs/remote-mcp-e2e.md
+++ b/docs/remote-mcp-e2e.md
@@ -12,8 +12,8 @@ PUNARO_REMOTE_MCP_E2E_CONFIG=/private/punaro/remote-mcp-e2e.json make remote-mcp
 ```
 
 The target fails when the configuration variable is unset. The tagged Go test
-skips without it only so ordinary developer test runs cannot accidentally touch
-a remote deployment.
+skips unless the target explicitly enables it, so ordinary developer and CI
+test runs execute the offline TLS harness but cannot touch a remote deployment.
 
 Keep the configuration outside the repository, readable only by the release
 operator, and never attach it to CI logs or the release record. Its shape is:

--- a/docs/remote-mcp-e2e.md
+++ b/docs/remote-mcp-e2e.md
@@ -24,6 +24,7 @@ operator, and never attach it to CI logs or the release record. Its shape is:
   "endpoint": "https://candidate.example.invalid/mcp",
   "resource": "https://candidate.example.invalid/mcp",
   "authorization_server": "https://issuer.example.invalid",
+  "protocol_version": "2024-11-05",
   "tokens": {
     "valid": "private-token-for-the-authorized-read-only-tool",
     "invalid": "private-malformed-or-unrecognized-token",
@@ -56,7 +57,8 @@ operator, and never attach it to CI logs or the release record. Its shape is:
 `candidate_commit` must be the deployed 40-character lowercase Git commit.
 `endpoint` and `resource` must be the same canonical HTTPS MCP resource;
 `authorization_server` is the canonical HTTPS issuer. The tool arguments must
-be JSON objects with no duplicate keys. Every token and the redaction probe
+be JSON objects with no duplicate keys. `protocol_version` is the MCP protocol
+version the disposable client must negotiate with the candidate. Every token and the redaction probe
 must be a distinct, at-least-16-character OAuth bearer value made only of
 letters, digits, `-._~+/=`. Values above are placeholders, not usable
 credentials. `authorized_tool.expected_result` must be the exact non-error MCP
@@ -82,6 +84,8 @@ The test proves all of the following against the candidate:
   and an `invalid_token` challenge; a revoked token fails the configured `401`
   token-revocation or `403` disabled-subject boundary;
 - missing required scope and tool-specific insufficient scope fail closed;
+- the MCP `initialize` / `notifications/initialized` lifecycle negotiates the
+  configured protocol before any tool invocation;
 - duplicate-member JSON-RPC input fails without executing a request;
 - a valid scoped bearer reaches its configured tool; and
 - failure headers and bodies do not echo any supplied token or the redaction

--- a/docs/remote-mcp-e2e.md
+++ b/docs/remote-mcp-e2e.md
@@ -101,10 +101,10 @@ release command remains the authoritative deployed-candidate check.
 `candidate_commit` must match `git rev-parse HEAD` in the checkout that runs
 the command, and that checkout must have no changes (including untracked or
 ignored files), so release evidence cannot be attributed to another build or a
-modified test harness. The release target also rejects `GOFLAGS` build overlays
-from either the environment or Go's persisted environment file, and the ordinary
-test target clears the remote-E2E environment variables before running its
-offline fixture.
+modified test harness. The release target clears all `GOFLAGS` and disables
+Go's persisted environment file before invoking the test, and the ordinary test
+target clears the remote-E2E environment variables before running its offline
+fixture.
 Record its CI job URL, exact command result, candidate commit, deployment image
 digest, approvers, residual risk, and rollback reference in the final
 release-evidence record under `docs/release-evidence/` only after the release

--- a/docs/remote-mcp-e2e.md
+++ b/docs/remote-mcp-e2e.md
@@ -36,7 +36,10 @@ operator, and never attach it to CI logs or the release record. Its shape is:
   },
   "authorized_tool": {
     "name": "candidate_read_only_tool",
-    "arguments": {"query": "release-candidate-e2e"}
+    "arguments": {"query": "release-candidate-e2e"},
+    "expected_result": {
+      "content": [{"type": "text", "text": "release-candidate-e2e"}]
+    }
   },
   "forbidden_tool": {
     "name": "candidate_out_of_scope_tool",
@@ -53,7 +56,9 @@ operator, and never attach it to CI logs or the release record. Its shape is:
 be JSON objects with no duplicate keys. Every token and the redaction probe
 must be a distinct, at-least-16-character OAuth bearer value made only of
 letters, digits, `-._~+/=`. Values above are placeholders, not usable
-credentials.
+credentials. `authorized_tool.expected_result` must be the exact non-error MCP
+tool result for the disposable probe. It must contain at least one non-empty
+text content item; the harness validates it and the request ID exactly.
 
 Prepare a token suite that proves each distinct failure boundary. `valid` must
 invoke only the configured read-only `authorized_tool`. `no_scope` must be a

--- a/docs/remote-mcp-e2e.md
+++ b/docs/remote-mcp-e2e.md
@@ -101,7 +101,9 @@ release command remains the authoritative deployed-candidate check.
 `candidate_commit` must match `git rev-parse HEAD` in the checkout that runs
 the command, and that checkout must have no changes (including untracked or
 ignored files), so release evidence cannot be attributed to another build or a
-modified test harness.
+modified test harness. The release target also rejects `GOFLAGS` build overlays,
+and the ordinary test target clears the remote-E2E environment variables before
+running its offline fixture.
 Record its CI job URL, exact command result, candidate commit, deployment image
 digest, approvers, residual risk, and rollback reference in the final
 release-evidence record under `docs/release-evidence/` only after the release

--- a/internal/mcphttp/remote_mcp_e2e_test.go
+++ b/internal/mcphttp/remote_mcp_e2e_test.go
@@ -643,6 +643,9 @@ func runRemoteMCPE2EReleaseCandidateWithClient(t *testing.T, config remoteMCPE2E
 	unauthorized := remoteMCPE2EDo(t, client, http.MethodPost, config.Endpoint, "", remoteMCPE2ERequest(t, "tools/list", map[string]any{}))
 	remoteMCPE2ERequireStatus(t, unauthorized, http.StatusUnauthorized)
 	remoteMCPE2ERedacted(t, unauthorized, config.sensitiveValues())
+	if !validRemoteMCPE2EOAuthFailureBody(unauthorized) {
+		t.Fatal("unauthenticated request exposed a successful MCP result")
+	}
 	challenge := unauthorized.Header.Get("WWW-Authenticate")
 	metadataURL, metadataOK := remoteMCPE2EChallengeParameter(challenge, "resource_metadata")
 	scope, scopeOK := remoteMCPE2EChallengeParameter(challenge, "scope")

--- a/internal/mcphttp/remote_mcp_e2e_test.go
+++ b/internal/mcphttp/remote_mcp_e2e_test.go
@@ -11,6 +11,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"os"
+	"os/exec"
 	"path"
 	"reflect"
 	"slices"
@@ -85,7 +86,7 @@ func TestRemoteMCPE2EConfigRejectsIncompleteOrUnsafeInputs(t *testing.T) {
 	}
 	for _, replacement := range [][]byte{
 		bytes.Replace(valid, []byte(`"https://mcp.example.test/mcp"`), []byte(`"http://mcp.example.test/mcp"`), 1),
-		bytes.Replace(valid, []byte(`"expected_status":403`), []byte(`"expected_status":200`), 1),
+		bytes.Replace(valid, []byte(`"forbidden_tool":{"name":"punaro_memory_propose","arguments":{},"expected_status":403}`), []byte(`"forbidden_tool":{"name":"punaro_memory_propose","arguments":{},"expected_status":200}`), 1),
 		bytes.Replace(valid, []byte(`"token":"ffffffffffffffff","expected_status":403`), []byte(`"token":"ffffffffffffffff","expected_status":418`), 1),
 		bytes.Replace(valid, []byte(`"valid":"aaaaaaaaaaaaaaaa"`), []byte(`"valid":""`), 1),
 		bytes.Replace(valid, []byte(`"valid":"aaaaaaaaaaaaaaaa"`), []byte(`"valid":"bad\nvalue"`), 1),
@@ -179,8 +180,18 @@ func TestRemoteMCPE2EInitializeRequiresNegotiatedProtocol(t *testing.T) {
 	}
 }
 
+func TestRemoteMCPE2ECandidateCommitMustMatchCheckout(t *testing.T) {
+	if err := validateRemoteMCPE2ECandidateCommit("0123456789abcdef0123456789abcdef01234567", "0123456789abcdef0123456789abcdef01234567"); err != nil {
+		t.Fatalf("matching candidate commit rejected: %v", err)
+	}
+	if err := validateRemoteMCPE2ECandidateCommit("0123456789abcdef0123456789abcdef01234567", "fedcba9876543210fedcba9876543210fedcba98"); err == nil {
+		t.Fatal("mismatched candidate commit accepted")
+	}
+}
+
 func TestRemoteMCPE2EReleaseCandidateHarness(t *testing.T) {
 	var config remoteMCPE2EConfig
+	var insufficientScopeAuthorized, validForbidden bool
 	server := httptest.NewTLSServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
 		if request.Method == http.MethodGet && request.URL.Path == "/.well-known/oauth-protected-resource/mcp" {
 			response.Header().Set("Content-Type", "application/json")
@@ -203,16 +214,18 @@ func TestRemoteMCPE2EReleaseCandidateHarness(t *testing.T) {
 			response.WriteHeader(http.StatusForbidden)
 			return
 		}
-		if token == config.Tokens.InsufficientScope {
-			response.WriteHeader(http.StatusForbidden)
-			return
-		}
-		if token != config.Tokens.Valid {
+		if token != config.Tokens.Valid && token != config.Tokens.InsufficientScope {
 			response.Header().Set("WWW-Authenticate", `Bearer error="invalid_token"`)
 			response.WriteHeader(http.StatusUnauthorized)
 			return
 		}
 		body, _ := io.ReadAll(request.Body)
+		if token == config.Tokens.InsufficientScope && bytes.Contains(body, []byte(`"name":"punaro_memory_search"`)) {
+			insufficientScopeAuthorized = true
+		}
+		if token == config.Tokens.Valid && bytes.Contains(body, []byte(`"name":"punaro_memory_propose"`)) {
+			validForbidden = true
+		}
 		if bytes.HasPrefix(body, []byte("[")) || bytes.Contains(body, []byte(`"method":"tools/list","method"`)) || bytes.Contains(body, []byte(`"id":{}`)) || bytes.Contains(body, []byte(`"extra":true`)) {
 			response.WriteHeader(http.StatusBadRequest)
 			return
@@ -226,11 +239,18 @@ func TestRemoteMCPE2EReleaseCandidateHarness(t *testing.T) {
 			response.WriteHeader(http.StatusAccepted)
 			return
 		}
+		if bytes.Contains(body, []byte(`"name":"punaro_memory_propose"`)) {
+			response.WriteHeader(http.StatusForbidden)
+			return
+		}
 		_, _ = response.Write([]byte(`{"jsonrpc":"2.0","id":"remote-mcp-e2e","result":{"content":[{"type":"text","text":"release-candidate-e2e"}]}}`))
 	}))
 	defer server.Close()
 	config = remoteMCPE2EFixtureConfig(t, server.URL+"/mcp")
 	runRemoteMCPE2EReleaseCandidateWithClient(t, config, server.Client())
+	if !insufficientScopeAuthorized || !validForbidden {
+		t.Fatal("scope-boundary probes were not exercised")
+	}
 }
 
 func remoteMCPE2EFixtureConfig(t *testing.T, endpoint string) remoteMCPE2EConfig {
@@ -271,7 +291,30 @@ func loadRemoteMCPE2EConfig(t *testing.T) remoteMCPE2EConfig {
 	if err != nil {
 		t.Fatal("remote MCP E2E configuration is invalid")
 	}
+	checkedOutCommit, err := checkedOutRemoteMCPE2ECommit()
+	if err != nil || validateRemoteMCPE2ECandidateCommit(config.CandidateCommit, checkedOutCommit) != nil {
+		t.Fatal("remote MCP E2E candidate commit does not match the checkout")
+	}
 	return config
+}
+
+func checkedOutRemoteMCPE2ECommit() (string, error) {
+	output, err := exec.Command("git", "rev-parse", "HEAD").Output() // #nosec G204 -- fixed local Git command binds evidence to the checkout.
+	if err != nil {
+		return "", errors.New("candidate commit unavailable")
+	}
+	commit := strings.TrimSpace(string(output))
+	if !validCommit(commit) {
+		return "", errors.New("candidate commit unavailable")
+	}
+	return commit, nil
+}
+
+func validateRemoteMCPE2ECandidateCommit(configured, checkedOut string) error {
+	if configured != checkedOut {
+		return errors.New("candidate commit mismatch")
+	}
+	return nil
 }
 
 func readRemoteMCPE2EConfig(reader io.Reader) ([]byte, error) {
@@ -305,7 +348,7 @@ func parseRemoteMCPE2EConfig(raw []byte) (remoteMCPE2EConfig, error) {
 		}
 		seen[token] = struct{}{}
 	}
-	if !validRemoteMCPE2ETool(config.AuthorizedTool.Name, config.AuthorizedTool.Arguments) || !validRemoteMCPE2EToolResult(config.AuthorizedTool.ExpectedResult) || !validRemoteMCPE2ETool(config.ForbiddenTool.Name, config.ForbiddenTool.Arguments) || config.ForbiddenTool.ExpectedStatus < 400 || config.ForbiddenTool.ExpectedStatus > 499 || config.Tokens.Revoked.ExpectedStatus != http.StatusUnauthorized && config.Tokens.Revoked.ExpectedStatus != http.StatusForbidden {
+	if !validRemoteMCPE2ETool(config.AuthorizedTool.Name, config.AuthorizedTool.Arguments) || !validRemoteMCPE2EToolResult(config.AuthorizedTool.ExpectedResult) || !validRemoteMCPE2ETool(config.ForbiddenTool.Name, config.ForbiddenTool.Arguments) || config.ForbiddenTool.ExpectedStatus != http.StatusForbidden || config.Tokens.Revoked.ExpectedStatus != http.StatusUnauthorized && config.Tokens.Revoked.ExpectedStatus != http.StatusForbidden {
 		return remoteMCPE2EConfig{}, errors.New("invalid remote MCP E2E configuration")
 	}
 	return config, nil
@@ -463,19 +506,25 @@ func runRemoteMCPE2EReleaseCandidateWithClient(t *testing.T, config remoteMCPE2E
 		remoteMCPE2ERequireJSONRPCFailure(t, malformed)
 	}
 
-	initialized := remoteMCPE2EDo(t, client, http.MethodPost, config.Endpoint, config.Tokens.Valid, remoteMCPE2ERequestWithID(t, "remote-mcp-e2e-initialize", "initialize", map[string]any{"protocolVersion": config.ProtocolVersion, "capabilities": map[string]any{}, "clientInfo": map[string]string{"name": "punaro-remote-mcp-e2e", "version": "1"}}))
-	remoteMCPE2ERequireInitializeSuccess(t, initialized, config.ProtocolVersion)
-	sessionID := initialized.Header.Get("Mcp-Session-Id")
-	notification := remoteMCPE2EDoWithSession(t, client, http.MethodPost, config.Endpoint, config.Tokens.Valid, sessionID, remoteMCPE2ENotification(t, "notifications/initialized", map[string]any{}))
-	remoteMCPE2ERequireInitializedNotification(t, notification)
-
-	authorized := remoteMCPE2EDoWithSession(t, client, http.MethodPost, config.Endpoint, config.Tokens.Valid, sessionID, remoteMCPE2ERequest(t, "tools/call", map[string]any{"name": config.AuthorizedTool.Name, "arguments": config.AuthorizedTool.Arguments}))
+	validSessionID := remoteMCPE2EInitializeSession(t, client, config, config.Tokens.Valid)
+	authorized := remoteMCPE2EDoWithSession(t, client, http.MethodPost, config.Endpoint, config.Tokens.Valid, validSessionID, remoteMCPE2ERequest(t, "tools/call", map[string]any{"name": config.AuthorizedTool.Name, "arguments": config.AuthorizedTool.Arguments}))
 	remoteMCPE2ERequireJSONRPCSuccess(t, authorized, config.AuthorizedTool.ExpectedResult)
 
-	forbidden := remoteMCPE2EDoWithSession(t, client, http.MethodPost, config.Endpoint, config.Tokens.InsufficientScope, sessionID, remoteMCPE2ERequest(t, "tools/call", map[string]any{"name": config.ForbiddenTool.Name, "arguments": config.ForbiddenTool.Arguments}))
-	remoteMCPE2ERequireStatus(t, forbidden, config.ForbiddenTool.ExpectedStatus)
-	remoteMCPE2ERedacted(t, forbidden, config.sensitiveValues())
-	remoteMCPE2ERequireJSONRPCFailure(t, forbidden)
+	insufficientScopeSessionID := remoteMCPE2EInitializeSession(t, client, config, config.Tokens.InsufficientScope)
+	insufficientScopeAuthorized := remoteMCPE2EDoWithSession(t, client, http.MethodPost, config.Endpoint, config.Tokens.InsufficientScope, insufficientScopeSessionID, remoteMCPE2ERequest(t, "tools/call", map[string]any{"name": config.AuthorizedTool.Name, "arguments": config.AuthorizedTool.Arguments}))
+	remoteMCPE2ERequireJSONRPCSuccess(t, insufficientScopeAuthorized, config.AuthorizedTool.ExpectedResult)
+	for _, probe := range []struct {
+		token     string
+		sessionID string
+	}{
+		{token: config.Tokens.InsufficientScope, sessionID: insufficientScopeSessionID},
+		{token: config.Tokens.Valid, sessionID: validSessionID},
+	} {
+		forbidden := remoteMCPE2EDoWithSession(t, client, http.MethodPost, config.Endpoint, probe.token, probe.sessionID, remoteMCPE2ERequest(t, "tools/call", map[string]any{"name": config.ForbiddenTool.Name, "arguments": config.ForbiddenTool.Arguments}))
+		remoteMCPE2ERequireStatus(t, forbidden, config.ForbiddenTool.ExpectedStatus)
+		remoteMCPE2ERedacted(t, forbidden, config.sensitiveValues())
+		remoteMCPE2ERequireJSONRPCFailure(t, forbidden)
+	}
 
 	redacted := remoteMCPE2EDo(t, client, http.MethodPost, config.Endpoint, config.RedactionProbe, remoteMCPE2ERequest(t, "tools/list", map[string]any{"probe": config.RedactionProbe}))
 	remoteMCPE2ERequireStatus(t, redacted, http.StatusUnauthorized)
@@ -584,6 +633,16 @@ func remoteMCPE2ERequireInitializeSuccess(t *testing.T, response remoteMCPE2ERes
 	if !validRemoteMCPE2EInitializeSuccess(response, expectedProtocolVersion) {
 		t.Fatal("MCP initialize did not negotiate the configured protocol")
 	}
+}
+
+func remoteMCPE2EInitializeSession(t *testing.T, client *http.Client, config remoteMCPE2EConfig, token string) string {
+	t.Helper()
+	initialized := remoteMCPE2EDo(t, client, http.MethodPost, config.Endpoint, token, remoteMCPE2ERequestWithID(t, "remote-mcp-e2e-initialize", "initialize", map[string]any{"protocolVersion": config.ProtocolVersion, "capabilities": map[string]any{}, "clientInfo": map[string]string{"name": "punaro-remote-mcp-e2e", "version": "1"}}))
+	remoteMCPE2ERequireInitializeSuccess(t, initialized, config.ProtocolVersion)
+	sessionID := initialized.Header.Get("Mcp-Session-Id")
+	notification := remoteMCPE2EDoWithSession(t, client, http.MethodPost, config.Endpoint, token, sessionID, remoteMCPE2ENotification(t, "notifications/initialized", map[string]any{}))
+	remoteMCPE2ERequireInitializedNotification(t, notification)
+	return sessionID
 }
 
 func validRemoteMCPE2EInitializeSuccess(response remoteMCPE2EResponse, expectedProtocolVersion string) bool {

--- a/internal/mcphttp/remote_mcp_e2e_test.go
+++ b/internal/mcphttp/remote_mcp_e2e_test.go
@@ -12,6 +12,7 @@ import (
 	"net/url"
 	"os"
 	"path"
+	"reflect"
 	"slices"
 	"strings"
 	"testing"
@@ -40,8 +41,9 @@ type remoteMCPE2EConfig struct {
 		InsufficientScope string `json:"insufficient_scope"`
 	} `json:"tokens"`
 	AuthorizedTool struct {
-		Name      string          `json:"name"`
-		Arguments json.RawMessage `json:"arguments"`
+		Name           string          `json:"name"`
+		Arguments      json.RawMessage `json:"arguments"`
+		ExpectedResult json.RawMessage `json:"expected_result"`
 	} `json:"authorized_tool"`
 	ForbiddenTool struct {
 		Name           string          `json:"name"`
@@ -69,7 +71,7 @@ func TestRemoteMCPE2EConfigRejectsIncompleteOrUnsafeInputs(t *testing.T) {
 		"resource":"https://mcp.example.test/mcp",
 		"authorization_server":"https://auth.example.test",
 		"tokens":{"valid":"aaaaaaaaaaaaaaaa","invalid":"bbbbbbbbbbbbbbbb","wrong_issuer":"cccccccccccccccc","wrong_audience":"dddddddddddddddd","expired":"eeeeeeeeeeeeeeee","revoked":"ffffffffffffffff","no_scope":"gggggggggggggggg","insufficient_scope":"hhhhhhhhhhhhhhhh"},
-		"authorized_tool":{"name":"punaro_memory_search","arguments":{"query":"e2e"}},
+		"authorized_tool":{"name":"punaro_memory_search","arguments":{"query":"e2e"},"expected_result":{"content":[{"type":"text","text":"release-candidate-e2e"}]}},
 		"forbidden_tool":{"name":"punaro_memory_propose","arguments":{},"expected_status":403},
 		"redaction_probe":"not-a-secret-redaction-probe"
 	}`)
@@ -83,10 +85,39 @@ func TestRemoteMCPE2EConfigRejectsIncompleteOrUnsafeInputs(t *testing.T) {
 		bytes.Replace(valid, []byte(`"valid":"aaaaaaaaaaaaaaaa"`), []byte(`"valid":"bad\nvalue"`), 1),
 		bytes.Replace(valid, []byte(`"redaction_probe":"not-a-secret-redaction-probe"`), []byte(`"redaction_probe":"bad\"value"`), 1),
 		bytes.Replace(valid, []byte(`{"query":"e2e"}`), []byte(`{"query":"e2e","query":"other"}`), 1),
+		bytes.Replace(valid, []byte(`"expected_result":{"content":[{"type":"text","text":"release-candidate-e2e"}]}`), []byte(`"expected_result":{}`), 1),
 		append(append([]byte(nil), valid[:len(valid)-1]...), []byte(`,"candidate_commit":"0123456789abcdef0123456789abcdef01234567"}`)...),
 	} {
 		if _, err := parseRemoteMCPE2EConfig(replacement); err == nil {
 			t.Fatal("unsafe E2E config accepted")
+		}
+	}
+}
+
+func TestRemoteMCPE2EChallengeRequiresExactResourceMetadata(t *testing.T) {
+	const want = "https://mcp.example.test/.well-known/oauth-protected-resource/mcp"
+	challenge := `Bearer realm="punaro-mcp", resource_metadata="` + want + `", scope="memory.search memory.read memory.propose"`
+	if got, ok := remoteMCPE2EChallengeParameter(challenge, "resource_metadata"); !ok || got != want {
+		t.Fatalf("resource_metadata=%q ok=%t", got, ok)
+	}
+	if _, ok := remoteMCPE2EChallengeParameter(`Bearer resource_metadata="https://other.example.test"`, "scope"); ok {
+		t.Fatal("missing challenge parameter accepted")
+	}
+}
+
+func TestRemoteMCPE2EJSONRPCSuccessRequiresExactCorrelatedToolResult(t *testing.T) {
+	want := json.RawMessage(`{"content":[{"type":"text","text":"release-candidate-e2e"}]}`)
+	valid := remoteMCPE2EResponse{Status: http.StatusOK, Body: []byte(`{"jsonrpc":"2.0","id":"remote-mcp-e2e","result":{"content":[{"type":"text","text":"release-candidate-e2e"}]}}`)}
+	if !validRemoteMCPE2EJSONRPCSuccess(valid, want) {
+		t.Fatal("valid correlated MCP tool result rejected")
+	}
+	for _, response := range []remoteMCPE2EResponse{
+		{Status: http.StatusOK, Body: []byte(`{"jsonrpc":"2.0","id":"wrong","result":{"content":[{"type":"text","text":"release-candidate-e2e"}]}}`)},
+		{Status: http.StatusOK, Body: []byte(`{"jsonrpc":"2.0","id":"remote-mcp-e2e","result":{}}`)},
+		{Status: http.StatusOK, Body: []byte(`{"jsonrpc":"2.0","id":"remote-mcp-e2e","result":{"content":[{"type":"text","text":"other"}]}}`)},
+	} {
+		if validRemoteMCPE2EJSONRPCSuccess(response, want) {
+			t.Fatal("uncorrelated or invalid MCP tool result accepted")
 		}
 	}
 }
@@ -106,7 +137,7 @@ func TestRemoteMCPE2EReleaseCandidateHarness(t *testing.T) {
 		}
 		token := strings.TrimPrefix(request.Header.Get("Authorization"), "Bearer ")
 		if token == "" {
-			response.Header().Set("WWW-Authenticate", `Bearer realm="punaro-mcp", resource_metadata="https://metadata.example.test", scope="memory.search memory.read memory.propose"`)
+			response.Header().Set("WWW-Authenticate", `Bearer realm="punaro-mcp", resource_metadata="https://`+request.Host+`/.well-known/oauth-protected-resource/mcp", scope="memory.search memory.read memory.propose"`)
 			response.WriteHeader(http.StatusUnauthorized)
 			return
 		}
@@ -130,7 +161,7 @@ func TestRemoteMCPE2EReleaseCandidateHarness(t *testing.T) {
 			return
 		}
 		response.Header().Set("Content-Type", "application/json")
-		_, _ = response.Write([]byte(`{"jsonrpc":"2.0","id":"remote-mcp-e2e","result":{}}`))
+		_, _ = response.Write([]byte(`{"jsonrpc":"2.0","id":"remote-mcp-e2e","result":{"content":[{"type":"text","text":"release-candidate-e2e"}]}}`))
 	}))
 	defer server.Close()
 	config = remoteMCPE2EFixtureConfig(t, server.URL+"/mcp")
@@ -145,7 +176,7 @@ func remoteMCPE2EFixtureConfig(t *testing.T, endpoint string) remoteMCPE2EConfig
 		"resource":"` + endpoint + `",
 		"authorization_server":"https://auth.example.test",
 		"tokens":{"valid":"aaaaaaaaaaaaaaaa","invalid":"bbbbbbbbbbbbbbbb","wrong_issuer":"cccccccccccccccc","wrong_audience":"dddddddddddddddd","expired":"eeeeeeeeeeeeeeee","revoked":"ffffffffffffffff","no_scope":"gggggggggggggggg","insufficient_scope":"hhhhhhhhhhhhhhhh"},
-		"authorized_tool":{"name":"punaro_memory_search","arguments":{"query":"e2e"}},
+		"authorized_tool":{"name":"punaro_memory_search","arguments":{"query":"e2e"},"expected_result":{"content":[{"type":"text","text":"release-candidate-e2e"}]}},
 		"forbidden_tool":{"name":"punaro_memory_propose","arguments":{},"expected_status":403},
 		"redaction_probe":"not-a-secret-redaction-probe"
 	}`))
@@ -198,7 +229,7 @@ func parseRemoteMCPE2EConfig(raw []byte) (remoteMCPE2EConfig, error) {
 		}
 		seen[token] = struct{}{}
 	}
-	if !validRemoteMCPE2ETool(config.AuthorizedTool.Name, config.AuthorizedTool.Arguments) || !validRemoteMCPE2ETool(config.ForbiddenTool.Name, config.ForbiddenTool.Arguments) || config.ForbiddenTool.ExpectedStatus < 400 || config.ForbiddenTool.ExpectedStatus > 499 {
+	if !validRemoteMCPE2ETool(config.AuthorizedTool.Name, config.AuthorizedTool.Arguments) || !validRemoteMCPE2EToolResult(config.AuthorizedTool.ExpectedResult) || !validRemoteMCPE2ETool(config.ForbiddenTool.Name, config.ForbiddenTool.Arguments) || config.ForbiddenTool.ExpectedStatus < 400 || config.ForbiddenTool.ExpectedStatus > 499 {
 		return remoteMCPE2EConfig{}, errors.New("invalid remote MCP E2E configuration")
 	}
 	return config, nil
@@ -232,6 +263,28 @@ func validRemoteMCPE2ETool(name string, arguments json.RawMessage) bool {
 		return false
 	}
 	return true
+}
+
+func validRemoteMCPE2EToolResult(raw json.RawMessage) bool {
+	if !validJSONObject(raw, maxJSONRPCDepth) {
+		return false
+	}
+	var result struct {
+		Content []struct {
+			Type string `json:"type"`
+			Text string `json:"text"`
+		} `json:"content"`
+		IsError bool `json:"isError"`
+	}
+	if json.Unmarshal(raw, &result) != nil || result.IsError || len(result.Content) == 0 {
+		return false
+	}
+	for _, content := range result.Content {
+		if content.Type == "text" && content.Text != "" {
+			return true
+		}
+	}
+	return false
 }
 
 func validRemoteMCPE2EBearer(value string) bool {
@@ -284,7 +337,9 @@ func runRemoteMCPE2EReleaseCandidateWithClient(t *testing.T, config remoteMCPE2E
 	remoteMCPE2ERequireStatus(t, unauthorized, http.StatusUnauthorized)
 	remoteMCPE2ERedacted(t, unauthorized, config.sensitiveValues())
 	challenge := unauthorized.Header.Get("WWW-Authenticate")
-	if !strings.Contains(challenge, "Bearer") || !strings.Contains(challenge, "resource_metadata=") || !strings.Contains(challenge, `scope="memory.search memory.read memory.propose"`) {
+	metadataURL, metadataOK := remoteMCPE2EChallengeParameter(challenge, "resource_metadata")
+	scope, scopeOK := remoteMCPE2EChallengeParameter(challenge, "scope")
+	if !metadataOK || metadataURL != remoteMCPE2EMetadataURL(t, config.Resource) || !scopeOK || scope != defaultScopeChallenge {
 		t.Fatal("unauthorized request did not return the OAuth discovery challenge")
 	}
 
@@ -316,7 +371,7 @@ func runRemoteMCPE2EReleaseCandidateWithClient(t *testing.T, config remoteMCPE2E
 	}
 
 	authorized := remoteMCPE2EDo(t, client, http.MethodPost, config.Endpoint, config.Tokens.Valid, remoteMCPE2ERequest(t, "tools/call", map[string]any{"name": config.AuthorizedTool.Name, "arguments": config.AuthorizedTool.Arguments}))
-	remoteMCPE2ERequireJSONRPCSuccess(t, authorized)
+	remoteMCPE2ERequireJSONRPCSuccess(t, authorized, config.AuthorizedTool.ExpectedResult)
 
 	forbidden := remoteMCPE2EDo(t, client, http.MethodPost, config.Endpoint, config.Tokens.InsufficientScope, remoteMCPE2ERequest(t, "tools/call", map[string]any{"name": config.ForbiddenTool.Name, "arguments": config.ForbiddenTool.Arguments}))
 	remoteMCPE2ERequireStatus(t, forbidden, config.ForbiddenTool.ExpectedStatus)
@@ -379,19 +434,107 @@ func remoteMCPE2ERequireStatus(t *testing.T, response remoteMCPE2EResponse, expe
 	}
 }
 
-func remoteMCPE2ERequireJSONRPCSuccess(t *testing.T, response remoteMCPE2EResponse) {
+func remoteMCPE2ERequireJSONRPCSuccess(t *testing.T, response remoteMCPE2EResponse, expectedResult json.RawMessage) {
 	t.Helper()
-	if response.Status < 200 || response.Status > 299 {
-		t.Fatalf("authorized MCP request status=%d", response.Status)
+	if !validRemoteMCPE2EJSONRPCSuccess(response, expectedResult) {
+		t.Fatal("authorized MCP request did not return a JSON-RPC result")
+	}
+}
+
+func validRemoteMCPE2EJSONRPCSuccess(response remoteMCPE2EResponse, expectedResult json.RawMessage) bool {
+	if response.Status < 200 || response.Status > 299 || !validJSONRPCValue(response.Body, maxJSONRPCDepth) || !validRemoteMCPE2EToolResult(expectedResult) {
+		return false
 	}
 	var envelope struct {
 		JSONRPC string          `json:"jsonrpc"`
+		ID      json.RawMessage `json:"id"`
 		Result  json.RawMessage `json:"result"`
 		Error   json.RawMessage `json:"error"`
 	}
-	if json.Unmarshal(response.Body, &envelope) != nil || envelope.JSONRPC != "2.0" || len(envelope.Result) == 0 || len(envelope.Error) != 0 {
-		t.Fatal("authorized MCP request did not return a JSON-RPC result")
+	if json.Unmarshal(response.Body, &envelope) != nil || envelope.JSONRPC != "2.0" || len(envelope.Error) != 0 || !jsonRawMessageEquals(envelope.ID, json.RawMessage(`"remote-mcp-e2e"`)) || !jsonRawMessageEquals(envelope.Result, expectedResult) {
+		return false
 	}
+	return validRemoteMCPE2EToolResult(envelope.Result)
+}
+
+func jsonRawMessageEquals(left, right json.RawMessage) bool {
+	var leftValue, rightValue any
+	leftDecoder := json.NewDecoder(bytes.NewReader(left))
+	leftDecoder.UseNumber()
+	rightDecoder := json.NewDecoder(bytes.NewReader(right))
+	rightDecoder.UseNumber()
+	return leftDecoder.Decode(&leftValue) == nil && leftDecoder.Decode(&struct{}{}) == io.EOF && rightDecoder.Decode(&rightValue) == nil && rightDecoder.Decode(&struct{}{}) == io.EOF && reflect.DeepEqual(leftValue, rightValue)
+}
+
+func remoteMCPE2EChallengeParameter(challenge, wanted string) (string, bool) {
+	scheme, remaining, found := strings.Cut(strings.TrimSpace(challenge), " ")
+	if !found || !strings.EqualFold(scheme, "Bearer") {
+		return "", false
+	}
+	parameters := make(map[string]string)
+	for {
+		remaining = strings.TrimLeft(remaining, " ")
+		if remaining == "" {
+			break
+		}
+		nameEnd := strings.IndexByte(remaining, '=')
+		if nameEnd <= 0 {
+			return "", false
+		}
+		name := remaining[:nameEnd]
+		remaining = remaining[nameEnd+1:]
+		if !validRemoteMCPE2EChallengeName(name) || !strings.HasPrefix(remaining, `"`) {
+			return "", false
+		}
+		remaining = remaining[1:]
+		var value strings.Builder
+		closed := false
+		for len(remaining) > 0 {
+			character := remaining[0]
+			remaining = remaining[1:]
+			if character == '"' {
+				closed = true
+				break
+			}
+			if character == '\\' {
+				if len(remaining) == 0 || remaining[0] != '"' && remaining[0] != '\\' {
+					return "", false
+				}
+				character = remaining[0]
+				remaining = remaining[1:]
+			}
+			value.WriteByte(character)
+		}
+		if !closed {
+			return "", false
+		}
+		if _, duplicate := parameters[name]; duplicate {
+			return "", false
+		}
+		parameters[name] = value.String()
+		remaining = strings.TrimLeft(remaining, " ")
+		if remaining == "" {
+			break
+		}
+		if !strings.HasPrefix(remaining, ",") {
+			return "", false
+		}
+		remaining = remaining[1:]
+	}
+	value, found := parameters[wanted]
+	return value, found
+}
+
+func validRemoteMCPE2EChallengeName(value string) bool {
+	if value == "" {
+		return false
+	}
+	for _, character := range []byte(value) {
+		if !(character >= 'a' && character <= 'z' || character >= 'A' && character <= 'Z' || character >= '0' && character <= '9' || character == '_' || character == '-') {
+			return false
+		}
+	}
+	return true
 }
 
 func remoteMCPE2ERequireJSONRPCFailure(t *testing.T, response remoteMCPE2EResponse) {

--- a/internal/mcphttp/remote_mcp_e2e_test.go
+++ b/internal/mcphttp/remote_mcp_e2e_test.go
@@ -3,10 +3,12 @@
 package mcphttp
 
 import (
+	"bufio"
 	"bytes"
 	"encoding/json"
 	"errors"
 	"io"
+	"mime"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -114,14 +116,14 @@ func TestRemoteMCPE2EChallengeRequiresExactResourceMetadata(t *testing.T) {
 
 func TestRemoteMCPE2EJSONRPCSuccessRequiresExactCorrelatedToolResult(t *testing.T) {
 	want := json.RawMessage(`{"content":[{"type":"text","text":"release-candidate-e2e"}]}`)
-	valid := remoteMCPE2EResponse{Status: http.StatusOK, Body: []byte(`{"jsonrpc":"2.0","id":"remote-mcp-e2e","result":{"content":[{"type":"text","text":"release-candidate-e2e"}]}}`)}
+	valid := remoteMCPE2EResponse{Status: http.StatusOK, Header: http.Header{"Content-Type": []string{"application/json"}}, Body: []byte(`{"jsonrpc":"2.0","id":"remote-mcp-e2e","result":{"content":[{"type":"text","text":"release-candidate-e2e"}]}}`)}
 	if !validRemoteMCPE2EJSONRPCSuccess(valid, want) {
 		t.Fatal("valid correlated MCP tool result rejected")
 	}
 	for _, response := range []remoteMCPE2EResponse{
-		{Status: http.StatusOK, Body: []byte(`{"jsonrpc":"2.0","id":"wrong","result":{"content":[{"type":"text","text":"release-candidate-e2e"}]}}`)},
-		{Status: http.StatusOK, Body: []byte(`{"jsonrpc":"2.0","id":"remote-mcp-e2e","result":{}}`)},
-		{Status: http.StatusOK, Body: []byte(`{"jsonrpc":"2.0","id":"remote-mcp-e2e","result":{"content":[{"type":"text","text":"other"}]}}`)},
+		{Status: http.StatusOK, Header: http.Header{"Content-Type": []string{"application/json"}}, Body: []byte(`{"jsonrpc":"2.0","id":"wrong","result":{"content":[{"type":"text","text":"release-candidate-e2e"}]}}`)},
+		{Status: http.StatusOK, Header: http.Header{"Content-Type": []string{"application/json"}}, Body: []byte(`{"jsonrpc":"2.0","id":"remote-mcp-e2e","result":{}}`)},
+		{Status: http.StatusOK, Header: http.Header{"Content-Type": []string{"application/json"}}, Body: []byte(`{"jsonrpc":"2.0","id":"remote-mcp-e2e","result":{"content":[{"type":"text","text":"other"}]}}`)},
 	} {
 		if validRemoteMCPE2EJSONRPCSuccess(response, want) {
 			t.Fatal("uncorrelated or invalid MCP tool result accepted")
@@ -170,13 +172,33 @@ func TestRemoteMCPE2EJSONRPCFailureRejectsServerErrors(t *testing.T) {
 }
 
 func TestRemoteMCPE2EInitializeRequiresNegotiatedProtocol(t *testing.T) {
-	valid := remoteMCPE2EResponse{Status: http.StatusOK, Body: []byte(`{"jsonrpc":"2.0","id":"remote-mcp-e2e-initialize","result":{"protocolVersion":"2024-11-05","capabilities":{},"serverInfo":{"name":"candidate","version":"1"}}}`)}
+	valid := remoteMCPE2EResponse{Status: http.StatusOK, Header: http.Header{"Content-Type": []string{"application/json"}}, Body: []byte(`{"jsonrpc":"2.0","id":"remote-mcp-e2e-initialize","result":{"protocolVersion":"2024-11-05","capabilities":{},"serverInfo":{"name":"candidate","version":"1"}}}`)}
 	if !validRemoteMCPE2EInitializeSuccess(valid, "2024-11-05") {
 		t.Fatal("valid initialize response rejected")
 	}
-	wrongVersion := remoteMCPE2EResponse{Status: http.StatusOK, Body: []byte(`{"jsonrpc":"2.0","id":"remote-mcp-e2e-initialize","result":{"protocolVersion":"other","capabilities":{},"serverInfo":{"name":"candidate","version":"1"}}}`)}
+	wrongVersion := remoteMCPE2EResponse{Status: http.StatusOK, Header: http.Header{"Content-Type": []string{"application/json"}}, Body: []byte(`{"jsonrpc":"2.0","id":"remote-mcp-e2e-initialize","result":{"protocolVersion":"other","capabilities":{},"serverInfo":{"name":"candidate","version":"1"}}}`)}
 	if validRemoteMCPE2EInitializeSuccess(wrongVersion, "2024-11-05") {
 		t.Fatal("wrong initialize protocol accepted")
+	}
+}
+
+func TestRemoteMCPE2EInitializedNotificationRequiresAccepted(t *testing.T) {
+	if !validRemoteMCPE2EInitializedNotification(remoteMCPE2EResponse{Status: http.StatusAccepted}) {
+		t.Fatal("accepted initialized notification rejected")
+	}
+	if validRemoteMCPE2EInitializedNotification(remoteMCPE2EResponse{Status: http.StatusOK}) {
+		t.Fatal("non-accepted initialized notification accepted")
+	}
+}
+
+func TestRemoteMCPE2EJSONRPCResponseRequiresSupportedMediaType(t *testing.T) {
+	response := remoteMCPE2EResponse{Status: http.StatusOK, Header: http.Header{"Content-Type": []string{"application/json"}}, Body: []byte(`{"jsonrpc":"2.0","id":"remote-mcp-e2e","result":{"content":[{"type":"text","text":"release-candidate-e2e"}]}}`)}
+	if !validRemoteMCPE2EJSONRPCSuccess(response, json.RawMessage(`{"content":[{"type":"text","text":"release-candidate-e2e"}]}`)) {
+		t.Fatal("JSON MCP response rejected")
+	}
+	response.Header.Set("Content-Type", "text/plain")
+	if validRemoteMCPE2EJSONRPCSuccess(response, json.RawMessage(`{"content":[{"type":"text","text":"release-candidate-e2e"}]}`)) {
+		t.Fatal("unsupported MCP response media type accepted")
 	}
 }
 
@@ -232,7 +254,16 @@ func TestRemoteMCPE2EReleaseCandidateHarness(t *testing.T) {
 		}
 		response.Header().Set("Content-Type", "application/json")
 		if bytes.Contains(body, []byte(`"method":"initialize"`)) {
+			if token == config.Tokens.Valid {
+				response.Header().Set("Mcp-Session-Id", "fixture-valid-session")
+			} else {
+				response.Header().Set("Mcp-Session-Id", "fixture-insufficient-scope-session")
+			}
 			_, _ = response.Write([]byte(`{"jsonrpc":"2.0","id":"remote-mcp-e2e-initialize","result":{"protocolVersion":"2024-11-05","capabilities":{},"serverInfo":{"name":"candidate","version":"1"}}}`))
+			return
+		}
+		if token == config.Tokens.Valid && request.Header.Get("Mcp-Session-Id") != "fixture-valid-session" || token == config.Tokens.InsufficientScope && request.Header.Get("Mcp-Session-Id") != "fixture-insufficient-scope-session" {
+			response.WriteHeader(http.StatusBadRequest)
 			return
 		}
 		if bytes.Contains(body, []byte(`"method":"notifications/initialized"`)) {
@@ -495,18 +526,18 @@ func runRemoteMCPE2EReleaseCandidateWithClient(t *testing.T, config remoteMCPE2E
 		t.Fatal("missing required scope did not return an insufficient-scope challenge")
 	}
 
+	validSessionID := remoteMCPE2EInitializeSession(t, client, config, config.Tokens.Valid)
 	for _, malformedRequest := range [][]byte{
 		[]byte(`[{"jsonrpc":"2.0","id":1,"method":"tools/list"}]`),
 		[]byte(`{"jsonrpc":"2.0","id":1,"method":"tools/list","method":"tools/call"}`),
 		[]byte(`{"jsonrpc":"2.0","id":{},"method":"tools/list"}`),
 		[]byte(`{"jsonrpc":"2.0","id":1,"method":"tools/list","extra":true}`),
 	} {
-		malformed := remoteMCPE2EDo(t, client, http.MethodPost, config.Endpoint, config.Tokens.Valid, malformedRequest)
+		malformed := remoteMCPE2EDoWithSession(t, client, http.MethodPost, config.Endpoint, config.Tokens.Valid, validSessionID, malformedRequest)
 		remoteMCPE2ERedacted(t, malformed, config.sensitiveValues())
 		remoteMCPE2ERequireJSONRPCFailure(t, malformed)
 	}
 
-	validSessionID := remoteMCPE2EInitializeSession(t, client, config, config.Tokens.Valid)
 	authorized := remoteMCPE2EDoWithSession(t, client, http.MethodPost, config.Endpoint, config.Tokens.Valid, validSessionID, remoteMCPE2ERequest(t, "tools/call", map[string]any{"name": config.AuthorizedTool.Name, "arguments": config.AuthorizedTool.Arguments}))
 	remoteMCPE2ERequireJSONRPCSuccess(t, authorized, config.AuthorizedTool.ExpectedResult)
 
@@ -646,7 +677,8 @@ func remoteMCPE2EInitializeSession(t *testing.T, client *http.Client, config rem
 }
 
 func validRemoteMCPE2EInitializeSuccess(response remoteMCPE2EResponse, expectedProtocolVersion string) bool {
-	if response.Status < 200 || response.Status > 299 || !validJSONRPCValue(response.Body, maxJSONRPCDepth) {
+	payload, supported := remoteMCPE2EJSONRPCPayload(response)
+	if response.Status < 200 || response.Status > 299 || !supported || !validJSONRPCValue(payload, maxJSONRPCDepth) {
 		return false
 	}
 	var envelope struct {
@@ -662,18 +694,23 @@ func validRemoteMCPE2EInitializeSuccess(response remoteMCPE2EResponse, expectedP
 		} `json:"result"`
 		Error json.RawMessage `json:"error"`
 	}
-	return json.Unmarshal(response.Body, &envelope) == nil && envelope.JSONRPC == "2.0" && len(envelope.Error) == 0 && jsonRawMessageEquals(envelope.ID, json.RawMessage(`"remote-mcp-e2e-initialize"`)) && envelope.Result.ProtocolVersion == expectedProtocolVersion && validJSONObject(envelope.Result.Capabilities, maxJSONRPCDepth) && envelope.Result.ServerInfo.Name != "" && envelope.Result.ServerInfo.Version != ""
+	return json.Unmarshal(payload, &envelope) == nil && envelope.JSONRPC == "2.0" && len(envelope.Error) == 0 && jsonRawMessageEquals(envelope.ID, json.RawMessage(`"remote-mcp-e2e-initialize"`)) && envelope.Result.ProtocolVersion == expectedProtocolVersion && validJSONObject(envelope.Result.Capabilities, maxJSONRPCDepth) && envelope.Result.ServerInfo.Name != "" && envelope.Result.ServerInfo.Version != ""
 }
 
 func remoteMCPE2ERequireInitializedNotification(t *testing.T, response remoteMCPE2EResponse) {
 	t.Helper()
-	if response.Status < 200 || response.Status > 299 || len(response.Body) != 0 {
+	if !validRemoteMCPE2EInitializedNotification(response) {
 		t.Fatal("MCP initialized notification did not complete")
 	}
 }
 
+func validRemoteMCPE2EInitializedNotification(response remoteMCPE2EResponse) bool {
+	return response.Status == http.StatusAccepted && len(response.Body) == 0
+}
+
 func validRemoteMCPE2EJSONRPCSuccess(response remoteMCPE2EResponse, expectedResult json.RawMessage) bool {
-	if response.Status < 200 || response.Status > 299 || !validJSONRPCValue(response.Body, maxJSONRPCDepth) || !validRemoteMCPE2EToolResult(expectedResult) {
+	payload, supported := remoteMCPE2EJSONRPCPayload(response)
+	if response.Status < 200 || response.Status > 299 || !supported || !validJSONRPCValue(payload, maxJSONRPCDepth) || !validRemoteMCPE2EToolResult(expectedResult) {
 		return false
 	}
 	var envelope struct {
@@ -682,7 +719,7 @@ func validRemoteMCPE2EJSONRPCSuccess(response remoteMCPE2EResponse, expectedResu
 		Result  json.RawMessage `json:"result"`
 		Error   json.RawMessage `json:"error"`
 	}
-	if json.Unmarshal(response.Body, &envelope) != nil || envelope.JSONRPC != "2.0" || len(envelope.Error) != 0 || !jsonRawMessageEquals(envelope.ID, json.RawMessage(`"remote-mcp-e2e"`)) || !jsonRawMessageEquals(envelope.Result, expectedResult) {
+	if json.Unmarshal(payload, &envelope) != nil || envelope.JSONRPC != "2.0" || len(envelope.Error) != 0 || !jsonRawMessageEquals(envelope.ID, json.RawMessage(`"remote-mcp-e2e"`)) || !jsonRawMessageEquals(envelope.Result, expectedResult) {
 		return false
 	}
 	return validRemoteMCPE2EToolResult(envelope.Result)
@@ -779,7 +816,8 @@ func validRemoteMCPE2EJSONRPCFailure(response remoteMCPE2EResponse) bool {
 	if response.Status >= 400 && response.Status < 500 {
 		return true
 	}
-	if response.Status < 200 || response.Status > 299 || !validJSONRPCValue(response.Body, maxJSONRPCDepth) {
+	payload, supported := remoteMCPE2EJSONRPCPayload(response)
+	if response.Status < 200 || response.Status > 299 || !supported || !validJSONRPCValue(payload, maxJSONRPCDepth) {
 		return false
 	}
 	var envelope struct {
@@ -787,7 +825,50 @@ func validRemoteMCPE2EJSONRPCFailure(response remoteMCPE2EResponse) bool {
 		Result  json.RawMessage `json:"result"`
 		Error   json.RawMessage `json:"error"`
 	}
-	return json.Unmarshal(response.Body, &envelope) == nil && envelope.JSONRPC == "2.0" && len(envelope.Result) == 0 && len(envelope.Error) != 0
+	return json.Unmarshal(payload, &envelope) == nil && envelope.JSONRPC == "2.0" && len(envelope.Result) == 0 && len(envelope.Error) != 0
+}
+
+func remoteMCPE2EJSONRPCPayload(response remoteMCPE2EResponse) ([]byte, bool) {
+	mediaType, _, err := mime.ParseMediaType(response.Header.Get("Content-Type"))
+	if err != nil {
+		return nil, false
+	}
+	switch mediaType {
+	case "application/json":
+		return response.Body, true
+	case "text/event-stream":
+		return remoteMCPE2ESSEPayload(response.Body)
+	default:
+		return nil, false
+	}
+}
+
+func remoteMCPE2ESSEPayload(body []byte) ([]byte, bool) {
+	scanner := bufio.NewScanner(bytes.NewReader(body))
+	scanner.Buffer(make([]byte, 1024), maxRemoteMCPE2EResponse)
+	var eventData [][]byte
+	var lines []string
+	dispatch := func() {
+		if len(lines) > 0 {
+			eventData = append(eventData, []byte(strings.Join(lines, "\n")))
+			lines = nil
+		}
+	}
+	for scanner.Scan() {
+		line := strings.TrimSuffix(scanner.Text(), "\r")
+		if line == "" {
+			dispatch()
+			continue
+		}
+		if value, found := strings.CutPrefix(line, "data:"); found {
+			lines = append(lines, strings.TrimPrefix(value, " "))
+		}
+	}
+	dispatch()
+	if scanner.Err() != nil || len(eventData) != 1 {
+		return nil, false
+	}
+	return eventData[0], true
 }
 
 func remoteMCPE2ERedacted(t *testing.T, response remoteMCPE2EResponse, sensitive []string) {

--- a/internal/mcphttp/remote_mcp_e2e_test.go
+++ b/internal/mcphttp/remote_mcp_e2e_test.go
@@ -24,6 +24,7 @@ import (
 
 const (
 	remoteMCPE2EConfigEnv   = "PUNARO_REMOTE_MCP_E2E_CONFIG"
+	remoteMCPE2ELiveEnv     = "PUNARO_REMOTE_MCP_E2E_LIVE"
 	maxRemoteMCPE2EConfig   = 64 << 10
 	maxRemoteMCPE2EResponse = 1 << 20
 )
@@ -67,9 +68,20 @@ type remoteMCPE2EResponse struct {
 }
 
 func TestRemoteMCPE2EReleaseCandidate(t *testing.T) {
+	if !remoteMCPE2ELiveEnabled(os.Getenv(remoteMCPE2ELiveEnv)) {
+		t.Skip("set PUNARO_REMOTE_MCP_E2E_LIVE=1 to run the deployed remote MCP release-candidate test")
+	}
 	config := loadRemoteMCPE2EConfig(t)
 	runRemoteMCPE2EReleaseCandidate(t, config)
 }
+
+func TestRemoteMCPE2ELiveActivationIsExplicit(t *testing.T) {
+	if !remoteMCPE2ELiveEnabled("1") || remoteMCPE2ELiveEnabled("") || remoteMCPE2ELiveEnabled("true") {
+		t.Fatal("remote MCP live activation is not explicit")
+	}
+}
+
+func remoteMCPE2ELiveEnabled(value string) bool { return value == "1" }
 
 func TestRemoteMCPE2EConfigRejectsIncompleteOrUnsafeInputs(t *testing.T) {
 	valid := []byte(`{

--- a/internal/mcphttp/remote_mcp_e2e_test.go
+++ b/internal/mcphttp/remote_mcp_e2e_test.go
@@ -259,6 +259,16 @@ func TestRemoteMCPE2EJSONRPCResponseRequiresSupportedMediaType(t *testing.T) {
 	}
 }
 
+func TestRemoteMCPE2EToolListRequiresConfiguredTool(t *testing.T) {
+	valid := remoteMCPE2EResponse{Status: http.StatusOK, Header: http.Header{"Content-Type": []string{"application/json"}}, Body: []byte(`{"jsonrpc":"2.0","id":"remote-mcp-e2e-tools-list","result":{"tools":[{"name":"punaro_memory_search"}]}}`)}
+	if !validRemoteMCPE2EToolList(valid, "punaro_memory_search") {
+		t.Fatal("configured tool listing rejected")
+	}
+	if validRemoteMCPE2EToolList(valid, "punaro_memory_propose") {
+		t.Fatal("listing without configured tool accepted")
+	}
+}
+
 func TestRemoteMCPE2ESSEPayloadRequiresTerminatingBlankLine(t *testing.T) {
 	valid := []byte("data: {\"jsonrpc\":\"2.0\"}\n\n")
 	if _, ok := remoteMCPE2ESSEPayload(valid); !ok {
@@ -355,6 +365,10 @@ func TestRemoteMCPE2EReleaseCandidateHarness(t *testing.T) {
 		}
 		if bytes.Contains(body, []byte(`"method":"notifications/initialized"`)) {
 			response.WriteHeader(http.StatusAccepted)
+			return
+		}
+		if bytes.Contains(body, []byte(`"method":"tools/list"`)) {
+			_, _ = response.Write([]byte(`{"jsonrpc":"2.0","id":"remote-mcp-e2e-tools-list","result":{"tools":[{"name":"punaro_memory_search"}]}}`))
 			return
 		}
 		if bytes.Contains(body, []byte(`"name":"punaro_memory_propose"`)) {
@@ -632,6 +646,10 @@ func runRemoteMCPE2EReleaseCandidateWithClient(t *testing.T, config remoteMCPE2E
 		remoteMCPE2ERedacted(t, malformed, config.sensitiveValues())
 		remoteMCPE2ERequireJSONRPCFailureWithExpectedID(t, malformed, malformedRequest.expectedID)
 	}
+	listed := remoteMCPE2EDoWithMCPContext(t, client, http.MethodPost, config.Endpoint, config.Tokens.Valid, validSessionID, config.ProtocolVersion, remoteMCPE2ERequestWithID(t, "remote-mcp-e2e-tools-list", "tools/list", map[string]any{}))
+	if !validRemoteMCPE2EToolList(listed, config.AuthorizedTool.Name) {
+		t.Fatal("authenticated MCP tool listing did not advertise the authorized tool")
+	}
 
 	authorized := remoteMCPE2EDoWithMCPContext(t, client, http.MethodPost, config.Endpoint, config.Tokens.Valid, validSessionID, config.ProtocolVersion, remoteMCPE2ERequest(t, "tools/call", map[string]any{"name": config.AuthorizedTool.Name, "arguments": config.AuthorizedTool.Arguments}))
 	remoteMCPE2ERequireJSONRPCSuccess(t, authorized, config.AuthorizedTool.ExpectedResult)
@@ -844,6 +862,32 @@ func validRemoteMCPE2EJSONRPCSuccess(response remoteMCPE2EResponse, expectedResu
 	return validRemoteMCPE2EToolResult(envelope.Result)
 }
 
+func validRemoteMCPE2EToolList(response remoteMCPE2EResponse, expectedTool string) bool {
+	payload, supported := remoteMCPE2EJSONRPCPayload(response)
+	if response.Status != http.StatusOK || !supported || !validJSONRPCValue(payload, maxJSONRPCDepth) {
+		return false
+	}
+	var envelope struct {
+		JSONRPC string `json:"jsonrpc"`
+		ID      string `json:"id"`
+		Result  struct {
+			Tools []struct {
+				Name string `json:"name"`
+			} `json:"tools"`
+		} `json:"result"`
+		Error json.RawMessage `json:"error"`
+	}
+	if json.Unmarshal(payload, &envelope) != nil || envelope.JSONRPC != "2.0" || envelope.ID != "remote-mcp-e2e-tools-list" || len(envelope.Error) != 0 {
+		return false
+	}
+	for _, tool := range envelope.Result.Tools {
+		if tool.Name == expectedTool {
+			return true
+		}
+	}
+	return false
+}
+
 func jsonRawMessageEquals(left, right json.RawMessage) bool {
 	var leftValue, rightValue any
 	leftDecoder := json.NewDecoder(bytes.NewReader(left))
@@ -944,19 +988,27 @@ func remoteMCPE2ERequireJSONRPCFailureWithExpectedID(t *testing.T, response remo
 
 func validRemoteMCPE2EJSONRPCFailureWithExpectedID(response remoteMCPE2EResponse, expectedID json.RawMessage) bool {
 	if response.Status >= 400 && response.Status < 500 {
-		return true
+		payload, supported := remoteMCPE2EJSONRPCPayload(response)
+		if !supported || len(payload) == 0 {
+			return true
+		}
+		return validRemoteMCPE2EJSONRPCErrorEnvelope(payload, nil)
 	}
 	payload, supported := remoteMCPE2EJSONRPCPayload(response)
 	if response.Status < 200 || response.Status > 299 || !supported || !validJSONRPCValue(payload, maxJSONRPCDepth) {
 		return false
 	}
+	return validRemoteMCPE2EJSONRPCErrorEnvelope(payload, expectedID)
+}
+
+func validRemoteMCPE2EJSONRPCErrorEnvelope(payload, expectedID json.RawMessage) bool {
 	var envelope struct {
 		JSONRPC string          `json:"jsonrpc"`
 		Result  json.RawMessage `json:"result"`
 		Error   json.RawMessage `json:"error"`
 		ID      json.RawMessage `json:"id"`
 	}
-	if json.Unmarshal(payload, &envelope) != nil || envelope.JSONRPC != "2.0" || len(envelope.Result) != 0 || len(envelope.Error) == 0 || len(expectedID) == 0 || !remoteMCPE2EJSONValuesEqual(envelope.ID, expectedID) {
+	if json.Unmarshal(payload, &envelope) != nil || envelope.JSONRPC != "2.0" || len(envelope.Result) != 0 || len(envelope.Error) == 0 || (len(expectedID) != 0 && !remoteMCPE2EJSONValuesEqual(envelope.ID, expectedID)) {
 		return false
 	}
 	var rpcError struct {

--- a/internal/mcphttp/remote_mcp_e2e_test.go
+++ b/internal/mcphttp/remote_mcp_e2e_test.go
@@ -203,6 +203,22 @@ func TestRemoteMCPE2EJSONRPCFailureRejectsServerErrors(t *testing.T) {
 	}
 }
 
+func TestRemoteMCPE2EJSONRPCFailureRequiresStructuredErrorAndRequestID(t *testing.T) {
+	valid := remoteMCPE2EResponse{Status: http.StatusOK, Header: http.Header{"Content-Type": []string{"application/json"}}, Body: []byte(`{"jsonrpc":"2.0","id":1,"error":{"code":-32600,"message":"Invalid Request"}}`)}
+	if !validRemoteMCPE2EJSONRPCFailureWithExpectedID(valid, json.RawMessage(`1`)) {
+		t.Fatal("valid structured JSON-RPC error rejected")
+	}
+	for _, response := range []remoteMCPE2EResponse{
+		{Status: http.StatusOK, Header: http.Header{"Content-Type": []string{"application/json"}}, Body: []byte(`{"jsonrpc":"2.0","id":1,"error":null}`)},
+		{Status: http.StatusOK, Header: http.Header{"Content-Type": []string{"application/json"}}, Body: []byte(`{"jsonrpc":"2.0","id":1,"error":{"code":"-32600","message":"Invalid Request"}}`)},
+		{Status: http.StatusOK, Header: http.Header{"Content-Type": []string{"application/json"}}, Body: []byte(`{"jsonrpc":"2.0","id":2,"error":{"code":-32600,"message":"Invalid Request"}}`)},
+	} {
+		if validRemoteMCPE2EJSONRPCFailureWithExpectedID(response, json.RawMessage(`1`)) {
+			t.Fatal("invalid JSON-RPC error accepted")
+		}
+	}
+}
+
 func TestRemoteMCPE2EInitializeRequiresNegotiatedProtocol(t *testing.T) {
 	valid := remoteMCPE2EResponse{Status: http.StatusOK, Header: http.Header{"Content-Type": []string{"application/json"}}, Body: []byte(`{"jsonrpc":"2.0","id":"remote-mcp-e2e-initialize","result":{"protocolVersion":"2024-11-05","capabilities":{},"serverInfo":{"name":"candidate","version":"1"}}}`)}
 	if !validRemoteMCPE2EInitializeSuccess(valid, "2024-11-05") {
@@ -579,15 +595,18 @@ func runRemoteMCPE2EReleaseCandidateWithClient(t *testing.T, config remoteMCPE2E
 	}
 
 	validSessionID := remoteMCPE2EInitializeSession(t, client, config, config.Tokens.Valid)
-	for _, malformedRequest := range [][]byte{
-		[]byte(`[{"jsonrpc":"2.0","id":1,"method":"tools/list"}]`),
-		[]byte(`{"jsonrpc":"2.0","id":1,"method":"tools/call","method":"tools/list"}`),
-		[]byte(`{"jsonrpc":"2.0","id":{},"method":"tools/list"}`),
-		[]byte(`{"jsonrpc":"2.0","id":1,"method":"tools/list","extra":true}`),
+	for _, malformedRequest := range []struct {
+		body       []byte
+		expectedID json.RawMessage
+	}{
+		{body: []byte(`[{"jsonrpc":"2.0","id":1,"method":"tools/list"}]`)},
+		{body: []byte(`{"jsonrpc":"2.0","id":1,"method":"tools/call","method":"tools/list"}`), expectedID: json.RawMessage(`1`)},
+		{body: []byte(`{"jsonrpc":"2.0","id":{},"method":"tools/list"}`), expectedID: json.RawMessage(`null`)},
+		{body: []byte(`{"jsonrpc":"2.0","id":1,"method":"tools/list","extra":true}`), expectedID: json.RawMessage(`1`)},
 	} {
-		malformed := remoteMCPE2EDoWithMCPContext(t, client, http.MethodPost, config.Endpoint, config.Tokens.Valid, validSessionID, config.ProtocolVersion, malformedRequest)
+		malformed := remoteMCPE2EDoWithMCPContext(t, client, http.MethodPost, config.Endpoint, config.Tokens.Valid, validSessionID, config.ProtocolVersion, malformedRequest.body)
 		remoteMCPE2ERedacted(t, malformed, config.sensitiveValues())
-		remoteMCPE2ERequireJSONRPCFailure(t, malformed)
+		remoteMCPE2ERequireJSONRPCFailureWithExpectedID(t, malformed, malformedRequest.expectedID)
 	}
 
 	authorized := remoteMCPE2EDoWithMCPContext(t, client, http.MethodPost, config.Endpoint, config.Tokens.Valid, validSessionID, config.ProtocolVersion, remoteMCPE2ERequest(t, "tools/call", map[string]any{"name": config.AuthorizedTool.Name, "arguments": config.AuthorizedTool.Arguments}))
@@ -889,6 +908,17 @@ func remoteMCPE2ERequireJSONRPCFailure(t *testing.T, response remoteMCPE2ERespon
 }
 
 func validRemoteMCPE2EJSONRPCFailure(response remoteMCPE2EResponse) bool {
+	return validRemoteMCPE2EJSONRPCFailureWithExpectedID(response, nil)
+}
+
+func remoteMCPE2ERequireJSONRPCFailureWithExpectedID(t *testing.T, response remoteMCPE2EResponse, expectedID json.RawMessage) {
+	t.Helper()
+	if !validRemoteMCPE2EJSONRPCFailureWithExpectedID(response, expectedID) {
+		t.Fatal("MCP request did not fail closed")
+	}
+}
+
+func validRemoteMCPE2EJSONRPCFailureWithExpectedID(response remoteMCPE2EResponse, expectedID json.RawMessage) bool {
 	if response.Status >= 400 && response.Status < 500 {
 		return true
 	}
@@ -900,8 +930,21 @@ func validRemoteMCPE2EJSONRPCFailure(response remoteMCPE2EResponse) bool {
 		JSONRPC string          `json:"jsonrpc"`
 		Result  json.RawMessage `json:"result"`
 		Error   json.RawMessage `json:"error"`
+		ID      json.RawMessage `json:"id"`
 	}
-	return json.Unmarshal(payload, &envelope) == nil && envelope.JSONRPC == "2.0" && len(envelope.Result) == 0 && len(envelope.Error) != 0
+	if json.Unmarshal(payload, &envelope) != nil || envelope.JSONRPC != "2.0" || len(envelope.Result) != 0 || len(envelope.Error) == 0 || len(expectedID) == 0 || !remoteMCPE2EJSONValuesEqual(envelope.ID, expectedID) {
+		return false
+	}
+	var rpcError struct {
+		Code    int    `json:"code"`
+		Message string `json:"message"`
+	}
+	return json.Unmarshal(envelope.Error, &rpcError) == nil && rpcError.Message != ""
+}
+
+func remoteMCPE2EJSONValuesEqual(left, right json.RawMessage) bool {
+	var leftValue, rightValue any
+	return json.Unmarshal(left, &leftValue) == nil && json.Unmarshal(right, &rightValue) == nil && reflect.DeepEqual(leftValue, rightValue)
 }
 
 func remoteMCPE2EJSONRPCPayload(response remoteMCPE2EResponse) ([]byte, bool) {

--- a/internal/mcphttp/remote_mcp_e2e_test.go
+++ b/internal/mcphttp/remote_mcp_e2e_test.go
@@ -16,7 +16,6 @@ import (
 	"os/exec"
 	"path"
 	"reflect"
-	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -288,6 +287,10 @@ func TestRemoteMCPE2EDiscoveryMetadataRejectsDuplicateMembers(t *testing.T) {
 	duplicate := []byte(`{"resource":"https://other.example.test/mcp","resource":"https://mcp.example.test/mcp","authorization_servers":["https://auth.example.test"]}`)
 	if validRemoteMCPE2EDiscoveryMetadata(duplicate, "https://mcp.example.test/mcp", "https://auth.example.test") {
 		t.Fatal("duplicate discovery metadata accepted")
+	}
+	extraAuthorizationServer := []byte(`{"resource":"https://mcp.example.test/mcp","authorization_servers":["https://auth.example.test","https://other.example.test"]}`)
+	if validRemoteMCPE2EDiscoveryMetadata(extraAuthorizationServer, "https://mcp.example.test/mcp", "https://auth.example.test") {
+		t.Fatal("discovery metadata with an extra authorization server accepted")
 	}
 }
 
@@ -663,7 +666,7 @@ func validRemoteMCPE2EDiscoveryMetadata(raw []byte, expectedResource, expectedAu
 		Resource             string   `json:"resource"`
 		AuthorizationServers []string `json:"authorization_servers"`
 	}
-	return json.Unmarshal(raw, &document) == nil && document.Resource == expectedResource && slices.Contains(document.AuthorizationServers, expectedAuthorizationServer)
+	return json.Unmarshal(raw, &document) == nil && document.Resource == expectedResource && len(document.AuthorizationServers) == 1 && document.AuthorizationServers[0] == expectedAuthorizationServer
 }
 
 func remoteMCPE2EMetadataURL(t *testing.T, resource string) string {

--- a/internal/mcphttp/remote_mcp_e2e_test.go
+++ b/internal/mcphttp/remote_mcp_e2e_test.go
@@ -367,7 +367,10 @@ func loadRemoteMCPE2EConfig(t *testing.T) remoteMCPE2EConfig {
 		t.Fatal("remote MCP E2E configuration is invalid")
 	}
 	checkedOutCommit, err := checkedOutRemoteMCPE2ECommit()
-	if err != nil || validateRemoteMCPE2ECandidateCommit(config.CandidateCommit, checkedOutCommit) != nil {
+	if err != nil {
+		t.Fatalf("remote MCP E2E candidate checkout cannot be verified: %v", err)
+	}
+	if validateRemoteMCPE2ECandidateCommit(config.CandidateCommit, checkedOutCommit) != nil {
 		t.Fatal("remote MCP E2E candidate commit does not match the checkout")
 	}
 	return config

--- a/internal/mcphttp/remote_mcp_e2e_test.go
+++ b/internal/mcphttp/remote_mcp_e2e_test.go
@@ -229,6 +229,10 @@ func TestRemoteMCPE2EInitializeRequiresNegotiatedProtocol(t *testing.T) {
 	if validRemoteMCPE2EInitializeSuccess(wrongVersion, "2024-11-05") {
 		t.Fatal("wrong initialize protocol accepted")
 	}
+	valid.Status = http.StatusCreated
+	if validRemoteMCPE2EInitializeSuccess(valid, "2024-11-05") {
+		t.Fatal("non-OK initialize response accepted")
+	}
 }
 
 func TestRemoteMCPE2EInitializedNotificationRequiresAccepted(t *testing.T) {
@@ -248,6 +252,11 @@ func TestRemoteMCPE2EJSONRPCResponseRequiresSupportedMediaType(t *testing.T) {
 	response.Header.Set("Content-Type", "text/plain")
 	if validRemoteMCPE2EJSONRPCSuccess(response, json.RawMessage(`{"content":[{"type":"text","text":"release-candidate-e2e"}]}`)) {
 		t.Fatal("unsupported MCP response media type accepted")
+	}
+	response.Header.Set("Content-Type", "application/json")
+	response.Status = http.StatusCreated
+	if validRemoteMCPE2EJSONRPCSuccess(response, json.RawMessage(`{"content":[{"type":"text","text":"release-candidate-e2e"}]}`)) {
+		t.Fatal("non-OK JSON-RPC response accepted")
 	}
 }
 
@@ -785,7 +794,7 @@ func remoteMCPE2EInitializeSession(t *testing.T, client *http.Client, config rem
 
 func validRemoteMCPE2EInitializeSuccess(response remoteMCPE2EResponse, expectedProtocolVersion string) bool {
 	payload, supported := remoteMCPE2EJSONRPCPayload(response)
-	if response.Status < 200 || response.Status > 299 || !supported || !validJSONRPCValue(payload, maxJSONRPCDepth) {
+	if response.Status != http.StatusOK || !supported || !validJSONRPCValue(payload, maxJSONRPCDepth) {
 		return false
 	}
 	var envelope struct {
@@ -817,7 +826,7 @@ func validRemoteMCPE2EInitializedNotification(response remoteMCPE2EResponse) boo
 
 func validRemoteMCPE2EJSONRPCSuccess(response remoteMCPE2EResponse, expectedResult json.RawMessage) bool {
 	payload, supported := remoteMCPE2EJSONRPCPayload(response)
-	if response.Status < 200 || response.Status > 299 || !supported || !validJSONRPCValue(payload, maxJSONRPCDepth) || !validRemoteMCPE2EToolResult(expectedResult) {
+	if response.Status != http.StatusOK || !supported || !validJSONRPCValue(payload, maxJSONRPCDepth) || !validRemoteMCPE2EToolResult(expectedResult) {
 		return false
 	}
 	var envelope struct {

--- a/internal/mcphttp/remote_mcp_e2e_test.go
+++ b/internal/mcphttp/remote_mcp_e2e_test.go
@@ -992,7 +992,7 @@ func validRemoteMCPE2EJSONRPCFailureWithExpectedID(response remoteMCPE2EResponse
 		if !supported || len(payload) == 0 {
 			return true
 		}
-		return validRemoteMCPE2EJSONRPCErrorEnvelope(payload, nil)
+		return validRemoteMCPE2EJSONRPCErrorEnvelope(payload, expectedID)
 	}
 	payload, supported := remoteMCPE2EJSONRPCPayload(response)
 	if response.Status < 200 || response.Status > 299 || !supported || !validJSONRPCValue(payload, maxJSONRPCDepth) {

--- a/internal/mcphttp/remote_mcp_e2e_test.go
+++ b/internal/mcphttp/remote_mcp_e2e_test.go
@@ -285,16 +285,25 @@ func TestRemoteMCPE2EJSONRPCResponseRequiresSupportedMediaType(t *testing.T) {
 }
 
 func TestRemoteMCPE2EToolListRequiresConfiguredTool(t *testing.T) {
-	valid := remoteMCPE2EResponse{Status: http.StatusOK, Header: http.Header{"Content-Type": []string{"application/json"}}, Body: []byte(`{"jsonrpc":"2.0","id":"remote-mcp-e2e-tools-list","result":{"tools":[{"name":"punaro_memory_search","inputSchema":{"type":"object"}}]}}`)}
-	if !validRemoteMCPE2EToolList(valid, "punaro_memory_search") {
+	arguments := json.RawMessage(`{"query":"e2e"}`)
+	valid := remoteMCPE2EResponse{Status: http.StatusOK, Header: http.Header{"Content-Type": []string{"application/json"}}, Body: []byte(`{"jsonrpc":"2.0","id":"remote-mcp-e2e-tools-list","result":{"tools":[{"name":"punaro_memory_search","inputSchema":{"type":"object","properties":{"query":{"type":"string"}}}}]}}`)}
+	if !validRemoteMCPE2EToolList(valid, "punaro_memory_search", arguments) {
 		t.Fatal("configured tool listing rejected")
 	}
-	if validRemoteMCPE2EToolList(valid, "punaro_memory_propose") {
+	if validRemoteMCPE2EToolList(valid, "punaro_memory_propose", arguments) {
 		t.Fatal("listing without configured tool accepted")
 	}
 	missingSchema := remoteMCPE2EResponse{Status: http.StatusOK, Header: http.Header{"Content-Type": []string{"application/json"}}, Body: []byte(`{"jsonrpc":"2.0","id":"remote-mcp-e2e-tools-list","result":{"tools":[{"name":"punaro_memory_search"}]}}`)}
-	if validRemoteMCPE2EToolList(missingSchema, "punaro_memory_search") {
+	if validRemoteMCPE2EToolList(missingSchema, "punaro_memory_search", arguments) {
 		t.Fatal("configured tool without input schema accepted")
+	}
+	malformedSchema := remoteMCPE2EResponse{Status: http.StatusOK, Header: http.Header{"Content-Type": []string{"application/json"}}, Body: []byte(`{"jsonrpc":"2.0","id":"remote-mcp-e2e-tools-list","result":{"tools":[{"name":"punaro_memory_search","inputSchema":{"type":"object","properties":[]}}]}}`)}
+	if validRemoteMCPE2EToolList(malformedSchema, "punaro_memory_search", arguments) {
+		t.Fatal("configured tool with malformed input schema accepted")
+	}
+	missingArgumentSchema := remoteMCPE2EResponse{Status: http.StatusOK, Header: http.Header{"Content-Type": []string{"application/json"}}, Body: []byte(`{"jsonrpc":"2.0","id":"remote-mcp-e2e-tools-list","result":{"tools":[{"name":"punaro_memory_search","inputSchema":{"type":"object","properties":{"other":{"type":"string"}}}}]}}`)}
+	if validRemoteMCPE2EToolList(missingArgumentSchema, "punaro_memory_search", arguments) {
+		t.Fatal("configured tool schema without configured argument accepted")
 	}
 }
 
@@ -406,7 +415,7 @@ func TestRemoteMCPE2EReleaseCandidateHarness(t *testing.T) {
 			return
 		}
 		if bytes.Contains(body, []byte(`"method":"tools/list"`)) {
-			_, _ = response.Write([]byte(`{"jsonrpc":"2.0","id":"remote-mcp-e2e-tools-list","result":{"tools":[{"name":"punaro_memory_search","inputSchema":{"type":"object"}}]}}`))
+			_, _ = response.Write([]byte(`{"jsonrpc":"2.0","id":"remote-mcp-e2e-tools-list","result":{"tools":[{"name":"punaro_memory_search","inputSchema":{"type":"object","properties":{"query":{"type":"string"}}}}]}}`))
 			return
 		}
 		if bytes.Contains(body, []byte(`"name":"punaro_memory_propose"`)) {
@@ -686,7 +695,7 @@ func runRemoteMCPE2EReleaseCandidateWithClient(t *testing.T, config remoteMCPE2E
 		remoteMCPE2ERequireJSONRPCFailureWithExpectedID(t, malformed, malformedRequest.expectedID)
 	}
 	listed := remoteMCPE2EDoWithMCPContext(t, client, http.MethodPost, config.Endpoint, config.Tokens.Valid, validSessionID, config.ProtocolVersion, remoteMCPE2ERequestWithID(t, "remote-mcp-e2e-tools-list", "tools/list", map[string]any{}))
-	if !validRemoteMCPE2EToolList(listed, config.AuthorizedTool.Name) {
+	if !validRemoteMCPE2EToolList(listed, config.AuthorizedTool.Name, config.AuthorizedTool.Arguments) {
 		t.Fatal("authenticated MCP tool listing did not advertise the authorized tool")
 	}
 
@@ -904,7 +913,7 @@ func validRemoteMCPE2EJSONRPCSuccess(response remoteMCPE2EResponse, expectedResu
 	return validRemoteMCPE2EToolResult(envelope.Result)
 }
 
-func validRemoteMCPE2EToolList(response remoteMCPE2EResponse, expectedTool string) bool {
+func validRemoteMCPE2EToolList(response remoteMCPE2EResponse, expectedTool string, expectedArguments json.RawMessage) bool {
 	payload, supported := remoteMCPE2EJSONRPCPayload(response)
 	if response.Status != http.StatusOK || !supported || !validJSONRPCValue(payload, maxJSONRPCDepth) {
 		return false
@@ -924,21 +933,53 @@ func validRemoteMCPE2EToolList(response remoteMCPE2EResponse, expectedTool strin
 		return false
 	}
 	for _, tool := range envelope.Result.Tools {
-		if tool.Name == expectedTool && validRemoteMCPE2EToolInputSchema(tool.InputSchema) {
+		if tool.Name == expectedTool && validRemoteMCPE2EToolInputSchema(tool.InputSchema, expectedArguments) {
 			return true
 		}
 	}
 	return false
 }
 
-func validRemoteMCPE2EToolInputSchema(raw json.RawMessage) bool {
+func validRemoteMCPE2EToolInputSchema(raw, expectedArguments json.RawMessage) bool {
 	if !validJSONObject(raw, maxJSONRPCDepth) {
 		return false
 	}
 	var schema struct {
-		Type string `json:"type"`
+		Type       string                     `json:"type"`
+		Properties map[string]json.RawMessage `json:"properties"`
+		Required   []string                   `json:"required"`
 	}
-	return json.Unmarshal(raw, &schema) == nil && schema.Type == "object"
+	if json.Unmarshal(raw, &schema) != nil || schema.Type != "object" || !validJSONObject(expectedArguments, maxJSONRPCDepth) {
+		return false
+	}
+	for name, property := range schema.Properties {
+		if name == "" || !validJSONObject(property, maxJSONRPCDepth) {
+			return false
+		}
+	}
+	required := make(map[string]struct{}, len(schema.Required))
+	for _, name := range schema.Required {
+		if name == "" {
+			return false
+		}
+		if _, duplicate := required[name]; duplicate {
+			return false
+		}
+		required[name] = struct{}{}
+		if _, found := schema.Properties[name]; !found {
+			return false
+		}
+	}
+	var arguments map[string]json.RawMessage
+	if json.Unmarshal(expectedArguments, &arguments) != nil {
+		return false
+	}
+	for name := range arguments {
+		if _, found := schema.Properties[name]; !found {
+			return false
+		}
+	}
+	return true
 }
 
 func jsonRawMessageEquals(left, right json.RawMessage) bool {

--- a/internal/mcphttp/remote_mcp_e2e_test.go
+++ b/internal/mcphttp/remote_mcp_e2e_test.go
@@ -180,6 +180,10 @@ func TestRemoteMCPE2ERevocationRequiresConfiguredClosedRejection(t *testing.T) {
 	if validRemoteMCPE2ERevocationResponse(invalidToken, http.StatusForbidden) || validRemoteMCPE2ERevocationResponse(inactiveSubject, http.StatusUnauthorized) {
 		t.Fatal("revocation accepted the wrong rejection boundary")
 	}
+	resultLeak := remoteMCPE2EResponse{Status: http.StatusForbidden, Header: http.Header{"Content-Type": []string{"application/json"}}, Body: []byte(`{"jsonrpc":"2.0","id":"remote-mcp-e2e","result":{"tools":[]}}`)}
+	if validRemoteMCPE2EOAuthFailureBody(resultLeak) {
+		t.Fatal("revoked bearer response exposing a JSON-RPC result accepted")
+	}
 }
 
 func TestRemoteMCPE2EConfigReadIsBounded(t *testing.T) {
@@ -650,6 +654,9 @@ func runRemoteMCPE2EReleaseCandidateWithClient(t *testing.T, config remoteMCPE2E
 	}
 	revoked := remoteMCPE2EDo(t, client, http.MethodPost, config.Endpoint, config.Tokens.Revoked.Token, remoteMCPE2ERequest(t, "tools/list", map[string]any{}))
 	remoteMCPE2ERedacted(t, revoked, config.sensitiveValues())
+	if !validRemoteMCPE2EOAuthFailureBody(revoked) {
+		t.Fatal("revoked bearer response exposed a JSON-RPC result")
+	}
 	if !validRemoteMCPE2ERevocationResponse(revoked, config.Tokens.Revoked.ExpectedStatus) {
 		t.Fatal("revoked bearer did not return the configured closed rejection")
 	}
@@ -705,6 +712,9 @@ func runRemoteMCPE2EReleaseCandidateWithClient(t *testing.T, config remoteMCPE2E
 	redacted := remoteMCPE2EDo(t, client, http.MethodPost, config.Endpoint, config.RedactionProbe, remoteMCPE2ERequest(t, "tools/list", map[string]any{"probe": config.RedactionProbe}))
 	remoteMCPE2ERequireStatus(t, redacted, http.StatusUnauthorized)
 	remoteMCPE2ERedacted(t, redacted, config.sensitiveValues())
+	if !validRemoteMCPE2EOAuthFailureBody(redacted) {
+		t.Fatal("redaction probe response exposed a JSON-RPC result")
+	}
 	t.Logf("remote MCP release-candidate E2E evidence passed for candidate_commit=%s", config.CandidateCommit)
 }
 

--- a/internal/mcphttp/remote_mcp_e2e_test.go
+++ b/internal/mcphttp/remote_mcp_e2e_test.go
@@ -210,6 +210,7 @@ func TestRemoteMCPE2EJSONRPCFailureRequiresStructuredErrorAndRequestID(t *testin
 	}
 	for _, response := range []remoteMCPE2EResponse{
 		{Status: http.StatusOK, Header: http.Header{"Content-Type": []string{"application/json"}}, Body: []byte(`{"jsonrpc":"2.0","id":1,"error":null}`)},
+		{Status: http.StatusOK, Header: http.Header{"Content-Type": []string{"application/json"}}, Body: []byte(`{"jsonrpc":"2.0","id":1,"error":{"code":0,"message":"Invalid Request"}}`)},
 		{Status: http.StatusOK, Header: http.Header{"Content-Type": []string{"application/json"}}, Body: []byte(`{"jsonrpc":"2.0","id":1,"error":{"code":"-32600","message":"Invalid Request"}}`)},
 		{Status: http.StatusOK, Header: http.Header{"Content-Type": []string{"application/json"}}, Body: []byte(`{"jsonrpc":"2.0","id":2,"error":{"code":-32600,"message":"Invalid Request"}}`)},
 	} {
@@ -939,7 +940,7 @@ func validRemoteMCPE2EJSONRPCFailureWithExpectedID(response remoteMCPE2EResponse
 		Code    int    `json:"code"`
 		Message string `json:"message"`
 	}
-	return json.Unmarshal(envelope.Error, &rpcError) == nil && rpcError.Message != ""
+	return json.Unmarshal(envelope.Error, &rpcError) == nil && rpcError.Code != 0 && rpcError.Message != ""
 }
 
 func remoteMCPE2EJSONValuesEqual(left, right json.RawMessage) bool {

--- a/internal/mcphttp/remote_mcp_e2e_test.go
+++ b/internal/mcphttp/remote_mcp_e2e_test.go
@@ -251,6 +251,17 @@ func TestRemoteMCPE2EJSONRPCResponseRequiresSupportedMediaType(t *testing.T) {
 	}
 }
 
+func TestRemoteMCPE2ESSEPayloadRequiresTerminatingBlankLine(t *testing.T) {
+	valid := []byte("data: {\"jsonrpc\":\"2.0\"}\n\n")
+	if _, ok := remoteMCPE2ESSEPayload(valid); !ok {
+		t.Fatal("terminated SSE event rejected")
+	}
+	unterminated := []byte("data: {\"jsonrpc\":\"2.0\"}\n")
+	if _, ok := remoteMCPE2ESSEPayload(unterminated); ok {
+		t.Fatal("unterminated SSE event accepted")
+	}
+}
+
 func TestRemoteMCPE2ECandidateCommitMustMatchCheckout(t *testing.T) {
 	if err := validateRemoteMCPE2ECandidateCommit("0123456789abcdef0123456789abcdef01234567", "0123456789abcdef0123456789abcdef01234567"); err != nil {
 		t.Fatalf("matching candidate commit rejected: %v", err)
@@ -984,8 +995,7 @@ func remoteMCPE2ESSEPayload(body []byte) ([]byte, bool) {
 			lines = append(lines, strings.TrimPrefix(value, " "))
 		}
 	}
-	dispatch()
-	if scanner.Err() != nil || len(eventData) != 1 {
+	if scanner.Err() != nil || len(lines) != 0 || len(eventData) != 1 {
 		return nil, false
 	}
 	return eventData[0], true

--- a/internal/mcphttp/remote_mcp_e2e_test.go
+++ b/internal/mcphttp/remote_mcp_e2e_test.go
@@ -31,12 +31,15 @@ type remoteMCPE2EConfig struct {
 	Resource            string `json:"resource"`
 	AuthorizationServer string `json:"authorization_server"`
 	Tokens              struct {
-		Valid             string `json:"valid"`
-		Invalid           string `json:"invalid"`
-		WrongIssuer       string `json:"wrong_issuer"`
-		WrongAudience     string `json:"wrong_audience"`
-		Expired           string `json:"expired"`
-		Revoked           string `json:"revoked"`
+		Valid         string `json:"valid"`
+		Invalid       string `json:"invalid"`
+		WrongIssuer   string `json:"wrong_issuer"`
+		WrongAudience string `json:"wrong_audience"`
+		Expired       string `json:"expired"`
+		Revoked       struct {
+			Token          string `json:"token"`
+			ExpectedStatus int    `json:"expected_status"`
+		} `json:"revoked"`
 		NoScope           string `json:"no_scope"`
 		InsufficientScope string `json:"insufficient_scope"`
 	} `json:"tokens"`
@@ -70,7 +73,7 @@ func TestRemoteMCPE2EConfigRejectsIncompleteOrUnsafeInputs(t *testing.T) {
 		"endpoint":"https://mcp.example.test/mcp",
 		"resource":"https://mcp.example.test/mcp",
 		"authorization_server":"https://auth.example.test",
-		"tokens":{"valid":"aaaaaaaaaaaaaaaa","invalid":"bbbbbbbbbbbbbbbb","wrong_issuer":"cccccccccccccccc","wrong_audience":"dddddddddddddddd","expired":"eeeeeeeeeeeeeeee","revoked":"ffffffffffffffff","no_scope":"gggggggggggggggg","insufficient_scope":"hhhhhhhhhhhhhhhh"},
+		"tokens":{"valid":"aaaaaaaaaaaaaaaa","invalid":"bbbbbbbbbbbbbbbb","wrong_issuer":"cccccccccccccccc","wrong_audience":"dddddddddddddddd","expired":"eeeeeeeeeeeeeeee","revoked":{"token":"ffffffffffffffff","expected_status":403},"no_scope":"gggggggggggggggg","insufficient_scope":"hhhhhhhhhhhhhhhh"},
 		"authorized_tool":{"name":"punaro_memory_search","arguments":{"query":"e2e"},"expected_result":{"content":[{"type":"text","text":"release-candidate-e2e"}]}},
 		"forbidden_tool":{"name":"punaro_memory_propose","arguments":{},"expected_status":403},
 		"redaction_probe":"not-a-secret-redaction-probe"
@@ -81,6 +84,7 @@ func TestRemoteMCPE2EConfigRejectsIncompleteOrUnsafeInputs(t *testing.T) {
 	for _, replacement := range [][]byte{
 		bytes.Replace(valid, []byte(`"https://mcp.example.test/mcp"`), []byte(`"http://mcp.example.test/mcp"`), 1),
 		bytes.Replace(valid, []byte(`"expected_status":403`), []byte(`"expected_status":200`), 1),
+		bytes.Replace(valid, []byte(`"token":"ffffffffffffffff","expected_status":403`), []byte(`"token":"ffffffffffffffff","expected_status":418`), 1),
 		bytes.Replace(valid, []byte(`"valid":"aaaaaaaaaaaaaaaa"`), []byte(`"valid":""`), 1),
 		bytes.Replace(valid, []byte(`"valid":"aaaaaaaaaaaaaaaa"`), []byte(`"valid":"bad\nvalue"`), 1),
 		bytes.Replace(valid, []byte(`"redaction_probe":"not-a-secret-redaction-probe"`), []byte(`"redaction_probe":"bad\"value"`), 1),
@@ -119,6 +123,20 @@ func TestRemoteMCPE2EJSONRPCSuccessRequiresExactCorrelatedToolResult(t *testing.
 		if validRemoteMCPE2EJSONRPCSuccess(response, want) {
 			t.Fatal("uncorrelated or invalid MCP tool result accepted")
 		}
+	}
+}
+
+func TestRemoteMCPE2ERevocationRequiresConfiguredClosedRejection(t *testing.T) {
+	invalidToken := remoteMCPE2EResponse{Status: http.StatusUnauthorized, Header: http.Header{"Www-Authenticate": []string{`Bearer error="invalid_token"`}}}
+	inactiveSubject := remoteMCPE2EResponse{Status: http.StatusForbidden}
+	if !validRemoteMCPE2ERevocationResponse(invalidToken, http.StatusUnauthorized) {
+		t.Fatal("token revocation rejection rejected")
+	}
+	if !validRemoteMCPE2ERevocationResponse(inactiveSubject, http.StatusForbidden) {
+		t.Fatal("inactive subject revocation rejection rejected")
+	}
+	if validRemoteMCPE2ERevocationResponse(invalidToken, http.StatusForbidden) || validRemoteMCPE2ERevocationResponse(inactiveSubject, http.StatusUnauthorized) {
+		t.Fatal("revocation accepted the wrong rejection boundary")
 	}
 }
 
@@ -175,7 +193,7 @@ func remoteMCPE2EFixtureConfig(t *testing.T, endpoint string) remoteMCPE2EConfig
 		"endpoint":"` + endpoint + `",
 		"resource":"` + endpoint + `",
 		"authorization_server":"https://auth.example.test",
-		"tokens":{"valid":"aaaaaaaaaaaaaaaa","invalid":"bbbbbbbbbbbbbbbb","wrong_issuer":"cccccccccccccccc","wrong_audience":"dddddddddddddddd","expired":"eeeeeeeeeeeeeeee","revoked":"ffffffffffffffff","no_scope":"gggggggggggggggg","insufficient_scope":"hhhhhhhhhhhhhhhh"},
+		"tokens":{"valid":"aaaaaaaaaaaaaaaa","invalid":"bbbbbbbbbbbbbbbb","wrong_issuer":"cccccccccccccccc","wrong_audience":"dddddddddddddddd","expired":"eeeeeeeeeeeeeeee","revoked":{"token":"ffffffffffffffff","expected_status":401},"no_scope":"gggggggggggggggg","insufficient_scope":"hhhhhhhhhhhhhhhh"},
 		"authorized_tool":{"name":"punaro_memory_search","arguments":{"query":"e2e"},"expected_result":{"content":[{"type":"text","text":"release-candidate-e2e"}]}},
 		"forbidden_tool":{"name":"punaro_memory_propose","arguments":{},"expected_status":403},
 		"redaction_probe":"not-a-secret-redaction-probe"
@@ -229,7 +247,7 @@ func parseRemoteMCPE2EConfig(raw []byte) (remoteMCPE2EConfig, error) {
 		}
 		seen[token] = struct{}{}
 	}
-	if !validRemoteMCPE2ETool(config.AuthorizedTool.Name, config.AuthorizedTool.Arguments) || !validRemoteMCPE2EToolResult(config.AuthorizedTool.ExpectedResult) || !validRemoteMCPE2ETool(config.ForbiddenTool.Name, config.ForbiddenTool.Arguments) || config.ForbiddenTool.ExpectedStatus < 400 || config.ForbiddenTool.ExpectedStatus > 499 {
+	if !validRemoteMCPE2ETool(config.AuthorizedTool.Name, config.AuthorizedTool.Arguments) || !validRemoteMCPE2EToolResult(config.AuthorizedTool.ExpectedResult) || !validRemoteMCPE2ETool(config.ForbiddenTool.Name, config.ForbiddenTool.Arguments) || config.ForbiddenTool.ExpectedStatus < 400 || config.ForbiddenTool.ExpectedStatus > 499 || config.Tokens.Revoked.ExpectedStatus != http.StatusUnauthorized && config.Tokens.Revoked.ExpectedStatus != http.StatusForbidden {
 		return remoteMCPE2EConfig{}, errors.New("invalid remote MCP E2E configuration")
 	}
 	return config, nil
@@ -300,7 +318,7 @@ func validRemoteMCPE2EBearer(value string) bool {
 }
 
 func (config remoteMCPE2EConfig) tokens() []string {
-	return []string{config.Tokens.Valid, config.Tokens.Invalid, config.Tokens.WrongIssuer, config.Tokens.WrongAudience, config.Tokens.Expired, config.Tokens.Revoked, config.Tokens.NoScope, config.Tokens.InsufficientScope}
+	return []string{config.Tokens.Valid, config.Tokens.Invalid, config.Tokens.WrongIssuer, config.Tokens.WrongAudience, config.Tokens.Expired, config.Tokens.Revoked.Token, config.Tokens.NoScope, config.Tokens.InsufficientScope}
 }
 
 func (config remoteMCPE2EConfig) sensitiveValues() []string {
@@ -343,13 +361,18 @@ func runRemoteMCPE2EReleaseCandidateWithClient(t *testing.T, config remoteMCPE2E
 		t.Fatal("unauthorized request did not return the OAuth discovery challenge")
 	}
 
-	for _, token := range []string{config.Tokens.Invalid, config.Tokens.WrongIssuer, config.Tokens.WrongAudience, config.Tokens.Expired, config.Tokens.Revoked} {
+	for _, token := range []string{config.Tokens.Invalid, config.Tokens.WrongIssuer, config.Tokens.WrongAudience, config.Tokens.Expired} {
 		response := remoteMCPE2EDo(t, client, http.MethodPost, config.Endpoint, token, remoteMCPE2ERequest(t, "tools/list", map[string]any{}))
 		remoteMCPE2ERequireStatus(t, response, http.StatusUnauthorized)
 		remoteMCPE2ERedacted(t, response, config.sensitiveValues())
 		if !strings.Contains(response.Header.Get("WWW-Authenticate"), `error="invalid_token"`) {
 			t.Fatal("invalid bearer token did not return the OAuth invalid-token challenge")
 		}
+	}
+	revoked := remoteMCPE2EDo(t, client, http.MethodPost, config.Endpoint, config.Tokens.Revoked.Token, remoteMCPE2ERequest(t, "tools/list", map[string]any{}))
+	remoteMCPE2ERedacted(t, revoked, config.sensitiveValues())
+	if !validRemoteMCPE2ERevocationResponse(revoked, config.Tokens.Revoked.ExpectedStatus) {
+		t.Fatal("revoked bearer did not return the configured closed rejection")
 	}
 
 	noScope := remoteMCPE2EDo(t, client, http.MethodPost, config.Endpoint, config.Tokens.NoScope, remoteMCPE2ERequest(t, "tools/list", map[string]any{}))
@@ -438,6 +461,21 @@ func remoteMCPE2ERequireJSONRPCSuccess(t *testing.T, response remoteMCPE2ERespon
 	t.Helper()
 	if !validRemoteMCPE2EJSONRPCSuccess(response, expectedResult) {
 		t.Fatal("authorized MCP request did not return a JSON-RPC result")
+	}
+}
+
+func validRemoteMCPE2ERevocationResponse(response remoteMCPE2EResponse, expectedStatus int) bool {
+	if response.Status != expectedStatus {
+		return false
+	}
+	switch expectedStatus {
+	case http.StatusUnauthorized:
+		errorCode, found := remoteMCPE2EChallengeParameter(response.Header.Get("WWW-Authenticate"), "error")
+		return found && errorCode == "invalid_token"
+	case http.StatusForbidden:
+		return response.Header.Get("WWW-Authenticate") == ""
+	default:
+		return false
 	}
 }
 

--- a/internal/mcphttp/remote_mcp_e2e_test.go
+++ b/internal/mcphttp/remote_mcp_e2e_test.go
@@ -30,6 +30,7 @@ type remoteMCPE2EConfig struct {
 	Endpoint            string `json:"endpoint"`
 	Resource            string `json:"resource"`
 	AuthorizationServer string `json:"authorization_server"`
+	ProtocolVersion     string `json:"protocol_version"`
 	Tokens              struct {
 		Valid         string `json:"valid"`
 		Invalid       string `json:"invalid"`
@@ -73,6 +74,7 @@ func TestRemoteMCPE2EConfigRejectsIncompleteOrUnsafeInputs(t *testing.T) {
 		"endpoint":"https://mcp.example.test/mcp",
 		"resource":"https://mcp.example.test/mcp",
 		"authorization_server":"https://auth.example.test",
+		"protocol_version":"2024-11-05",
 		"tokens":{"valid":"aaaaaaaaaaaaaaaa","invalid":"bbbbbbbbbbbbbbbb","wrong_issuer":"cccccccccccccccc","wrong_audience":"dddddddddddddddd","expired":"eeeeeeeeeeeeeeee","revoked":{"token":"ffffffffffffffff","expected_status":403},"no_scope":"gggggggggggggggg","insufficient_scope":"hhhhhhhhhhhhhhhh"},
 		"authorized_tool":{"name":"punaro_memory_search","arguments":{"query":"e2e"},"expected_result":{"content":[{"type":"text","text":"release-candidate-e2e"}]}},
 		"forbidden_tool":{"name":"punaro_memory_propose","arguments":{},"expected_status":403},
@@ -140,6 +142,43 @@ func TestRemoteMCPE2ERevocationRequiresConfiguredClosedRejection(t *testing.T) {
 	}
 }
 
+func TestRemoteMCPE2EConfigReadIsBounded(t *testing.T) {
+	if _, err := readRemoteMCPE2EConfig(strings.NewReader(strings.Repeat("x", maxRemoteMCPE2EConfig+1))); err == nil {
+		t.Fatal("oversized E2E config accepted")
+	}
+}
+
+func TestRemoteMCPE2EOAuthErrorChallengeIsStructured(t *testing.T) {
+	valid := remoteMCPE2EResponse{Status: http.StatusUnauthorized, Header: http.Header{"Www-Authenticate": []string{`Bearer error="invalid_token"`}}}
+	if !validRemoteMCPE2EOAuthErrorChallenge(valid, "invalid_token") {
+		t.Fatal("valid Bearer error challenge rejected")
+	}
+	invalid := remoteMCPE2EResponse{Status: http.StatusUnauthorized, Header: http.Header{"Www-Authenticate": []string{`Basic error="invalid_token"`}}}
+	if validRemoteMCPE2EOAuthErrorChallenge(invalid, "invalid_token") {
+		t.Fatal("non-Bearer error challenge accepted")
+	}
+}
+
+func TestRemoteMCPE2EJSONRPCFailureRejectsServerErrors(t *testing.T) {
+	if validRemoteMCPE2EJSONRPCFailure(remoteMCPE2EResponse{Status: http.StatusInternalServerError}) {
+		t.Fatal("server error accepted as malformed-request rejection")
+	}
+	if !validRemoteMCPE2EJSONRPCFailure(remoteMCPE2EResponse{Status: http.StatusBadRequest}) {
+		t.Fatal("client error rejected as malformed-request rejection")
+	}
+}
+
+func TestRemoteMCPE2EInitializeRequiresNegotiatedProtocol(t *testing.T) {
+	valid := remoteMCPE2EResponse{Status: http.StatusOK, Body: []byte(`{"jsonrpc":"2.0","id":"remote-mcp-e2e-initialize","result":{"protocolVersion":"2024-11-05","capabilities":{},"serverInfo":{"name":"candidate","version":"1"}}}`)}
+	if !validRemoteMCPE2EInitializeSuccess(valid, "2024-11-05") {
+		t.Fatal("valid initialize response rejected")
+	}
+	wrongVersion := remoteMCPE2EResponse{Status: http.StatusOK, Body: []byte(`{"jsonrpc":"2.0","id":"remote-mcp-e2e-initialize","result":{"protocolVersion":"other","capabilities":{},"serverInfo":{"name":"candidate","version":"1"}}}`)}
+	if validRemoteMCPE2EInitializeSuccess(wrongVersion, "2024-11-05") {
+		t.Fatal("wrong initialize protocol accepted")
+	}
+}
+
 func TestRemoteMCPE2EReleaseCandidateHarness(t *testing.T) {
 	var config remoteMCPE2EConfig
 	server := httptest.NewTLSServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
@@ -179,6 +218,14 @@ func TestRemoteMCPE2EReleaseCandidateHarness(t *testing.T) {
 			return
 		}
 		response.Header().Set("Content-Type", "application/json")
+		if bytes.Contains(body, []byte(`"method":"initialize"`)) {
+			_, _ = response.Write([]byte(`{"jsonrpc":"2.0","id":"remote-mcp-e2e-initialize","result":{"protocolVersion":"2024-11-05","capabilities":{},"serverInfo":{"name":"candidate","version":"1"}}}`))
+			return
+		}
+		if bytes.Contains(body, []byte(`"method":"notifications/initialized"`)) {
+			response.WriteHeader(http.StatusAccepted)
+			return
+		}
 		_, _ = response.Write([]byte(`{"jsonrpc":"2.0","id":"remote-mcp-e2e","result":{"content":[{"type":"text","text":"release-candidate-e2e"}]}}`))
 	}))
 	defer server.Close()
@@ -193,6 +240,7 @@ func remoteMCPE2EFixtureConfig(t *testing.T, endpoint string) remoteMCPE2EConfig
 		"endpoint":"` + endpoint + `",
 		"resource":"` + endpoint + `",
 		"authorization_server":"https://auth.example.test",
+		"protocol_version":"2024-11-05",
 		"tokens":{"valid":"aaaaaaaaaaaaaaaa","invalid":"bbbbbbbbbbbbbbbb","wrong_issuer":"cccccccccccccccc","wrong_audience":"dddddddddddddddd","expired":"eeeeeeeeeeeeeeee","revoked":{"token":"ffffffffffffffff","expected_status":401},"no_scope":"gggggggggggggggg","insufficient_scope":"hhhhhhhhhhhhhhhh"},
 		"authorized_tool":{"name":"punaro_memory_search","arguments":{"query":"e2e"},"expected_result":{"content":[{"type":"text","text":"release-candidate-e2e"}]}},
 		"forbidden_tool":{"name":"punaro_memory_propose","arguments":{},"expected_status":403},
@@ -210,18 +258,28 @@ func loadRemoteMCPE2EConfig(t *testing.T) remoteMCPE2EConfig {
 	if configPath == "" {
 		t.Skip("set PUNARO_REMOTE_MCP_E2E_CONFIG to run the remote MCP release-candidate E2E test")
 	}
-	contents, err := os.ReadFile(configPath) // #nosec G304 -- operator-selected private E2E configuration.
+	file, err := os.Open(configPath) // #nosec G304 -- operator-selected private E2E configuration.
 	if err != nil {
 		t.Fatal("remote MCP E2E configuration is unavailable")
 	}
-	if len(contents) > maxRemoteMCPE2EConfig {
-		t.Fatal("remote MCP E2E configuration is too large")
+	defer file.Close()
+	contents, err := readRemoteMCPE2EConfig(file)
+	if err != nil {
+		t.Fatal("remote MCP E2E configuration is invalid")
 	}
 	config, err := parseRemoteMCPE2EConfig(contents)
 	if err != nil {
 		t.Fatal("remote MCP E2E configuration is invalid")
 	}
 	return config
+}
+
+func readRemoteMCPE2EConfig(reader io.Reader) ([]byte, error) {
+	contents, err := io.ReadAll(io.LimitReader(reader, maxRemoteMCPE2EConfig+1))
+	if err != nil || len(contents) > maxRemoteMCPE2EConfig {
+		return nil, errors.New("invalid remote MCP E2E configuration")
+	}
+	return contents, nil
 }
 
 func parseRemoteMCPE2EConfig(raw []byte) (remoteMCPE2EConfig, error) {
@@ -234,7 +292,7 @@ func parseRemoteMCPE2EConfig(raw []byte) (remoteMCPE2EConfig, error) {
 	if err := decoder.Decode(&config); err != nil || decoder.Decode(&struct{}{}) != io.EOF {
 		return remoteMCPE2EConfig{}, errors.New("invalid remote MCP E2E configuration")
 	}
-	if !validCommit(config.CandidateCommit) || !validRemoteMCPE2EURL(config.Endpoint, true) || config.Endpoint != config.Resource || !validRemoteMCPE2EURL(config.Resource, true) || !validRemoteMCPE2EURL(config.AuthorizationServer, false) || !validRemoteMCPE2EBearer(config.RedactionProbe) {
+	if !validCommit(config.CandidateCommit) || !validRemoteMCPE2EURL(config.Endpoint, true) || config.Endpoint != config.Resource || !validRemoteMCPE2EURL(config.Resource, true) || !validRemoteMCPE2EURL(config.AuthorizationServer, false) || !validRemoteMCPE2EProtocolVersion(config.ProtocolVersion) || !validRemoteMCPE2EBearer(config.RedactionProbe) {
 		return remoteMCPE2EConfig{}, errors.New("invalid remote MCP E2E configuration")
 	}
 	seen := map[string]struct{}{config.RedactionProbe: {}}
@@ -251,6 +309,18 @@ func parseRemoteMCPE2EConfig(raw []byte) (remoteMCPE2EConfig, error) {
 		return remoteMCPE2EConfig{}, errors.New("invalid remote MCP E2E configuration")
 	}
 	return config, nil
+}
+
+func validRemoteMCPE2EProtocolVersion(value string) bool {
+	if len(value) == 0 || len(value) > 32 || strings.TrimSpace(value) != value {
+		return false
+	}
+	for _, character := range value {
+		if !(character >= '0' && character <= '9' || character == '-') {
+			return false
+		}
+	}
+	return true
 }
 
 func validCommit(raw string) bool {
@@ -365,7 +435,7 @@ func runRemoteMCPE2EReleaseCandidateWithClient(t *testing.T, config remoteMCPE2E
 		response := remoteMCPE2EDo(t, client, http.MethodPost, config.Endpoint, token, remoteMCPE2ERequest(t, "tools/list", map[string]any{}))
 		remoteMCPE2ERequireStatus(t, response, http.StatusUnauthorized)
 		remoteMCPE2ERedacted(t, response, config.sensitiveValues())
-		if !strings.Contains(response.Header.Get("WWW-Authenticate"), `error="invalid_token"`) {
+		if !validRemoteMCPE2EOAuthErrorChallenge(response, "invalid_token") {
 			t.Fatal("invalid bearer token did not return the OAuth invalid-token challenge")
 		}
 	}
@@ -378,7 +448,7 @@ func runRemoteMCPE2EReleaseCandidateWithClient(t *testing.T, config remoteMCPE2E
 	noScope := remoteMCPE2EDo(t, client, http.MethodPost, config.Endpoint, config.Tokens.NoScope, remoteMCPE2ERequest(t, "tools/list", map[string]any{}))
 	remoteMCPE2ERequireStatus(t, noScope, http.StatusForbidden)
 	remoteMCPE2ERedacted(t, noScope, config.sensitiveValues())
-	if !strings.Contains(noScope.Header.Get("WWW-Authenticate"), `error="insufficient_scope"`) {
+	if !validRemoteMCPE2EOAuthErrorChallenge(noScope, "insufficient_scope") {
 		t.Fatal("missing required scope did not return an insufficient-scope challenge")
 	}
 
@@ -393,10 +463,16 @@ func runRemoteMCPE2EReleaseCandidateWithClient(t *testing.T, config remoteMCPE2E
 		remoteMCPE2ERequireJSONRPCFailure(t, malformed)
 	}
 
-	authorized := remoteMCPE2EDo(t, client, http.MethodPost, config.Endpoint, config.Tokens.Valid, remoteMCPE2ERequest(t, "tools/call", map[string]any{"name": config.AuthorizedTool.Name, "arguments": config.AuthorizedTool.Arguments}))
+	initialized := remoteMCPE2EDo(t, client, http.MethodPost, config.Endpoint, config.Tokens.Valid, remoteMCPE2ERequestWithID(t, "remote-mcp-e2e-initialize", "initialize", map[string]any{"protocolVersion": config.ProtocolVersion, "capabilities": map[string]any{}, "clientInfo": map[string]string{"name": "punaro-remote-mcp-e2e", "version": "1"}}))
+	remoteMCPE2ERequireInitializeSuccess(t, initialized, config.ProtocolVersion)
+	sessionID := initialized.Header.Get("Mcp-Session-Id")
+	notification := remoteMCPE2EDoWithSession(t, client, http.MethodPost, config.Endpoint, config.Tokens.Valid, sessionID, remoteMCPE2ENotification(t, "notifications/initialized", map[string]any{}))
+	remoteMCPE2ERequireInitializedNotification(t, notification)
+
+	authorized := remoteMCPE2EDoWithSession(t, client, http.MethodPost, config.Endpoint, config.Tokens.Valid, sessionID, remoteMCPE2ERequest(t, "tools/call", map[string]any{"name": config.AuthorizedTool.Name, "arguments": config.AuthorizedTool.Arguments}))
 	remoteMCPE2ERequireJSONRPCSuccess(t, authorized, config.AuthorizedTool.ExpectedResult)
 
-	forbidden := remoteMCPE2EDo(t, client, http.MethodPost, config.Endpoint, config.Tokens.InsufficientScope, remoteMCPE2ERequest(t, "tools/call", map[string]any{"name": config.ForbiddenTool.Name, "arguments": config.ForbiddenTool.Arguments}))
+	forbidden := remoteMCPE2EDoWithSession(t, client, http.MethodPost, config.Endpoint, config.Tokens.InsufficientScope, sessionID, remoteMCPE2ERequest(t, "tools/call", map[string]any{"name": config.ForbiddenTool.Name, "arguments": config.ForbiddenTool.Arguments}))
 	remoteMCPE2ERequireStatus(t, forbidden, config.ForbiddenTool.ExpectedStatus)
 	remoteMCPE2ERedacted(t, forbidden, config.sensitiveValues())
 	remoteMCPE2ERequireJSONRPCFailure(t, forbidden)
@@ -417,15 +493,32 @@ func remoteMCPE2EMetadataURL(t *testing.T, resource string) string {
 }
 
 func remoteMCPE2ERequest(t *testing.T, method string, params any) []byte {
+	return remoteMCPE2ERequestWithID(t, "remote-mcp-e2e", method, params)
+}
+
+func remoteMCPE2ERequestWithID(t *testing.T, id, method string, params any) []byte {
 	t.Helper()
-	raw, err := json.Marshal(map[string]any{"jsonrpc": "2.0", "id": "remote-mcp-e2e", "method": method, "params": params})
+	raw, err := json.Marshal(map[string]any{"jsonrpc": "2.0", "id": id, "method": method, "params": params})
 	if err != nil {
 		t.Fatal("remote MCP E2E request could not be encoded")
 	}
 	return raw
 }
 
+func remoteMCPE2ENotification(t *testing.T, method string, params any) []byte {
+	t.Helper()
+	raw, err := json.Marshal(map[string]any{"jsonrpc": "2.0", "method": method, "params": params})
+	if err != nil {
+		t.Fatal("remote MCP E2E notification could not be encoded")
+	}
+	return raw
+}
+
 func remoteMCPE2EDo(t *testing.T, client *http.Client, method, endpoint, token string, body []byte) remoteMCPE2EResponse {
+	return remoteMCPE2EDoWithSession(t, client, method, endpoint, token, "", body)
+}
+
+func remoteMCPE2EDoWithSession(t *testing.T, client *http.Client, method, endpoint, token, sessionID string, body []byte) remoteMCPE2EResponse {
 	t.Helper()
 	request, err := http.NewRequestWithContext(t.Context(), method, endpoint, bytes.NewReader(body))
 	if err != nil {
@@ -437,6 +530,9 @@ func remoteMCPE2EDo(t *testing.T, client *http.Client, method, endpoint, token s
 	}
 	if token != "" {
 		request.Header.Set("Authorization", "Bearer "+token)
+	}
+	if sessionID != "" {
+		request.Header.Set("Mcp-Session-Id", sessionID)
 	}
 	response, err := client.Do(request)
 	if err != nil {
@@ -470,12 +566,50 @@ func validRemoteMCPE2ERevocationResponse(response remoteMCPE2EResponse, expected
 	}
 	switch expectedStatus {
 	case http.StatusUnauthorized:
-		errorCode, found := remoteMCPE2EChallengeParameter(response.Header.Get("WWW-Authenticate"), "error")
-		return found && errorCode == "invalid_token"
+		return validRemoteMCPE2EOAuthErrorChallenge(response, "invalid_token")
 	case http.StatusForbidden:
 		return response.Header.Get("WWW-Authenticate") == ""
 	default:
 		return false
+	}
+}
+
+func validRemoteMCPE2EOAuthErrorChallenge(response remoteMCPE2EResponse, expectedError string) bool {
+	errorCode, found := remoteMCPE2EChallengeParameter(response.Header.Get("WWW-Authenticate"), "error")
+	return found && errorCode == expectedError
+}
+
+func remoteMCPE2ERequireInitializeSuccess(t *testing.T, response remoteMCPE2EResponse, expectedProtocolVersion string) {
+	t.Helper()
+	if !validRemoteMCPE2EInitializeSuccess(response, expectedProtocolVersion) {
+		t.Fatal("MCP initialize did not negotiate the configured protocol")
+	}
+}
+
+func validRemoteMCPE2EInitializeSuccess(response remoteMCPE2EResponse, expectedProtocolVersion string) bool {
+	if response.Status < 200 || response.Status > 299 || !validJSONRPCValue(response.Body, maxJSONRPCDepth) {
+		return false
+	}
+	var envelope struct {
+		JSONRPC string          `json:"jsonrpc"`
+		ID      json.RawMessage `json:"id"`
+		Result  struct {
+			ProtocolVersion string          `json:"protocolVersion"`
+			Capabilities    json.RawMessage `json:"capabilities"`
+			ServerInfo      struct {
+				Name    string `json:"name"`
+				Version string `json:"version"`
+			} `json:"serverInfo"`
+		} `json:"result"`
+		Error json.RawMessage `json:"error"`
+	}
+	return json.Unmarshal(response.Body, &envelope) == nil && envelope.JSONRPC == "2.0" && len(envelope.Error) == 0 && jsonRawMessageEquals(envelope.ID, json.RawMessage(`"remote-mcp-e2e-initialize"`)) && envelope.Result.ProtocolVersion == expectedProtocolVersion && validJSONObject(envelope.Result.Capabilities, maxJSONRPCDepth) && envelope.Result.ServerInfo.Name != "" && envelope.Result.ServerInfo.Version != ""
+}
+
+func remoteMCPE2ERequireInitializedNotification(t *testing.T, response remoteMCPE2EResponse) {
+	t.Helper()
+	if response.Status < 200 || response.Status > 299 || len(response.Body) != 0 {
+		t.Fatal("MCP initialized notification did not complete")
 	}
 }
 
@@ -577,17 +711,24 @@ func validRemoteMCPE2EChallengeName(value string) bool {
 
 func remoteMCPE2ERequireJSONRPCFailure(t *testing.T, response remoteMCPE2EResponse) {
 	t.Helper()
-	if response.Status >= 400 {
-		return
+	if !validRemoteMCPE2EJSONRPCFailure(response) {
+		t.Fatal("MCP request did not fail closed")
+	}
+}
+
+func validRemoteMCPE2EJSONRPCFailure(response remoteMCPE2EResponse) bool {
+	if response.Status >= 400 && response.Status < 500 {
+		return true
+	}
+	if response.Status < 200 || response.Status > 299 || !validJSONRPCValue(response.Body, maxJSONRPCDepth) {
+		return false
 	}
 	var envelope struct {
 		JSONRPC string          `json:"jsonrpc"`
 		Result  json.RawMessage `json:"result"`
 		Error   json.RawMessage `json:"error"`
 	}
-	if json.Unmarshal(response.Body, &envelope) != nil || envelope.JSONRPC != "2.0" || len(envelope.Result) != 0 || len(envelope.Error) == 0 {
-		t.Fatal("MCP request did not fail closed")
-	}
+	return json.Unmarshal(response.Body, &envelope) == nil && envelope.JSONRPC == "2.0" && len(envelope.Result) == 0 && len(envelope.Error) != 0
 }
 
 func remoteMCPE2ERedacted(t *testing.T, response remoteMCPE2EResponse, sensitive []string) {

--- a/internal/mcphttp/remote_mcp_e2e_test.go
+++ b/internal/mcphttp/remote_mcp_e2e_test.go
@@ -146,6 +146,9 @@ func TestRemoteMCPE2ECleanCheckoutRejectsTrackedChanges(t *testing.T) {
 	if validRemoteMCPE2ECleanCheckoutStatus("?? internal/mcphttp/override_test.go\n") {
 		t.Fatal("untracked checkout change accepted")
 	}
+	if validRemoteMCPE2ECleanCheckoutStatus("!! internal/mcphttp/override_test.go\n") {
+		t.Fatal("ignored test input accepted")
+	}
 }
 
 func TestRemoteMCPE2EJSONRPCSuccessRequiresExactCorrelatedToolResult(t *testing.T) {
@@ -275,12 +278,25 @@ func TestRemoteMCPE2EJSONRPCResponseRequiresSupportedMediaType(t *testing.T) {
 }
 
 func TestRemoteMCPE2EToolListRequiresConfiguredTool(t *testing.T) {
-	valid := remoteMCPE2EResponse{Status: http.StatusOK, Header: http.Header{"Content-Type": []string{"application/json"}}, Body: []byte(`{"jsonrpc":"2.0","id":"remote-mcp-e2e-tools-list","result":{"tools":[{"name":"punaro_memory_search"}]}}`)}
+	valid := remoteMCPE2EResponse{Status: http.StatusOK, Header: http.Header{"Content-Type": []string{"application/json"}}, Body: []byte(`{"jsonrpc":"2.0","id":"remote-mcp-e2e-tools-list","result":{"tools":[{"name":"punaro_memory_search","inputSchema":{"type":"object"}}]}}`)}
 	if !validRemoteMCPE2EToolList(valid, "punaro_memory_search") {
 		t.Fatal("configured tool listing rejected")
 	}
 	if validRemoteMCPE2EToolList(valid, "punaro_memory_propose") {
 		t.Fatal("listing without configured tool accepted")
+	}
+	missingSchema := remoteMCPE2EResponse{Status: http.StatusOK, Header: http.Header{"Content-Type": []string{"application/json"}}, Body: []byte(`{"jsonrpc":"2.0","id":"remote-mcp-e2e-tools-list","result":{"tools":[{"name":"punaro_memory_search"}]}}`)}
+	if validRemoteMCPE2EToolList(missingSchema, "punaro_memory_search") {
+		t.Fatal("configured tool without input schema accepted")
+	}
+}
+
+func TestRemoteMCPE2ENoScopeFailureDoesNotExposeJSONRPCResult(t *testing.T) {
+	if !validRemoteMCPE2EOAuthFailureBody(remoteMCPE2EResponse{Status: http.StatusForbidden, Header: http.Header{"Content-Type": []string{"application/json"}}, Body: []byte(`{"error":"insufficient_scope"}`)}) {
+		t.Fatal("OAuth insufficient-scope error response rejected")
+	}
+	if validRemoteMCPE2EOAuthFailureBody(remoteMCPE2EResponse{Status: http.StatusForbidden, Header: http.Header{"Content-Type": []string{"application/json"}}, Body: []byte(`{"jsonrpc":"2.0","id":"remote-mcp-e2e","result":{"tools":[]}}`)}) {
+		t.Fatal("no-scope response exposing a JSON-RPC result accepted")
 	}
 }
 
@@ -383,7 +399,7 @@ func TestRemoteMCPE2EReleaseCandidateHarness(t *testing.T) {
 			return
 		}
 		if bytes.Contains(body, []byte(`"method":"tools/list"`)) {
-			_, _ = response.Write([]byte(`{"jsonrpc":"2.0","id":"remote-mcp-e2e-tools-list","result":{"tools":[{"name":"punaro_memory_search"}]}}`))
+			_, _ = response.Write([]byte(`{"jsonrpc":"2.0","id":"remote-mcp-e2e-tools-list","result":{"tools":[{"name":"punaro_memory_search","inputSchema":{"type":"object"}}]}}`))
 			return
 		}
 		if bytes.Contains(body, []byte(`"name":"punaro_memory_propose"`)) {
@@ -453,7 +469,7 @@ func checkedOutRemoteMCPE2ECommit() (string, error) {
 	if err != nil {
 		return "", errors.New("candidate commit unavailable")
 	}
-	status, err := exec.Command("git", "status", "--porcelain").Output() // #nosec G204 -- fixed local Git command rejects checkout changes from release evidence.
+	status, err := exec.Command("git", "status", "--porcelain", "--ignored").Output() // #nosec G204 -- fixed local Git command rejects tracked, untracked, and ignored checkout changes from release evidence.
 	if err != nil || !validRemoteMCPE2ECleanCheckoutStatus(string(status)) {
 		return "", errors.New("candidate checkout is not clean")
 	}
@@ -638,6 +654,9 @@ func runRemoteMCPE2EReleaseCandidateWithClient(t *testing.T, config remoteMCPE2E
 	noScope := remoteMCPE2EDo(t, client, http.MethodPost, config.Endpoint, config.Tokens.NoScope, remoteMCPE2ERequest(t, "tools/list", map[string]any{}))
 	remoteMCPE2ERequireStatus(t, noScope, http.StatusForbidden)
 	remoteMCPE2ERedacted(t, noScope, config.sensitiveValues())
+	if !validRemoteMCPE2EOAuthFailureBody(noScope) {
+		t.Fatal("missing required scope response exposed a JSON-RPC result")
+	}
 	if !validRemoteMCPE2EOAuthErrorChallenge(noScope, "insufficient_scope") {
 		t.Fatal("missing required scope did not return an insufficient-scope challenge")
 	}
@@ -882,7 +901,8 @@ func validRemoteMCPE2EToolList(response remoteMCPE2EResponse, expectedTool strin
 		ID      string `json:"id"`
 		Result  struct {
 			Tools []struct {
-				Name string `json:"name"`
+				Name        string          `json:"name"`
+				InputSchema json.RawMessage `json:"inputSchema"`
 			} `json:"tools"`
 		} `json:"result"`
 		Error json.RawMessage `json:"error"`
@@ -891,11 +911,21 @@ func validRemoteMCPE2EToolList(response remoteMCPE2EResponse, expectedTool strin
 		return false
 	}
 	for _, tool := range envelope.Result.Tools {
-		if tool.Name == expectedTool {
+		if tool.Name == expectedTool && validRemoteMCPE2EToolInputSchema(tool.InputSchema) {
 			return true
 		}
 	}
 	return false
+}
+
+func validRemoteMCPE2EToolInputSchema(raw json.RawMessage) bool {
+	if !validJSONObject(raw, maxJSONRPCDepth) {
+		return false
+	}
+	var schema struct {
+		Type string `json:"type"`
+	}
+	return json.Unmarshal(raw, &schema) == nil && schema.Type == "object"
 }
 
 func jsonRawMessageEquals(left, right json.RawMessage) bool {

--- a/internal/mcphttp/remote_mcp_e2e_test.go
+++ b/internal/mcphttp/remote_mcp_e2e_test.go
@@ -975,11 +975,49 @@ func validRemoteMCPE2EToolInputSchema(raw, expectedArguments json.RawMessage) bo
 		return false
 	}
 	for name := range arguments {
-		if _, found := schema.Properties[name]; !found {
+		property, found := schema.Properties[name]
+		if !found || !validRemoteMCPE2ESchemaValue(arguments[name], property) {
+			return false
+		}
+	}
+	for name := range required {
+		if _, found := arguments[name]; !found {
 			return false
 		}
 	}
 	return true
+}
+
+func validRemoteMCPE2ESchemaValue(value, property json.RawMessage) bool {
+	var definition struct {
+		Type string `json:"type"`
+	}
+	if json.Unmarshal(property, &definition) != nil {
+		return false
+	}
+	switch definition.Type {
+	case "string":
+		var target string
+		return json.Unmarshal(value, &target) == nil
+	case "boolean":
+		var target bool
+		return json.Unmarshal(value, &target) == nil
+	case "number":
+		var target json.Number
+		return json.Unmarshal(value, &target) == nil
+	case "integer":
+		var target json.Number
+		return json.Unmarshal(value, &target) == nil && !strings.ContainsAny(target.String(), ".eE")
+	case "object":
+		return validJSONObject(value, maxJSONRPCDepth)
+	case "array":
+		var target []json.RawMessage
+		return json.Unmarshal(value, &target) == nil
+	case "null":
+		return bytes.Equal(bytes.TrimSpace(value), []byte("null"))
+	default:
+		return false
+	}
 }
 
 func jsonRawMessageEquals(left, right json.RawMessage) bool {
@@ -1033,6 +1071,7 @@ func remoteMCPE2EChallengeParameter(challenge, wanted string) (string, bool) {
 		if !closed {
 			return "", false
 		}
+		name = strings.ToLower(name)
 		if _, duplicate := parameters[name]; duplicate {
 			return "", false
 		}
@@ -1046,7 +1085,7 @@ func remoteMCPE2EChallengeParameter(challenge, wanted string) (string, bool) {
 		}
 		remaining = remaining[1:]
 	}
-	value, found := parameters[wanted]
+	value, found := parameters[strings.ToLower(wanted)]
 	return value, found
 }
 

--- a/internal/mcphttp/remote_mcp_e2e_test.go
+++ b/internal/mcphttp/remote_mcp_e2e_test.go
@@ -211,6 +211,17 @@ func TestRemoteMCPE2ECandidateCommitMustMatchCheckout(t *testing.T) {
 	}
 }
 
+func TestRemoteMCPE2EDiscoveryMetadataRejectsDuplicateMembers(t *testing.T) {
+	valid := []byte(`{"resource":"https://mcp.example.test/mcp","authorization_servers":["https://auth.example.test"]}`)
+	if !validRemoteMCPE2EDiscoveryMetadata(valid, "https://mcp.example.test/mcp", "https://auth.example.test") {
+		t.Fatal("valid discovery metadata rejected")
+	}
+	duplicate := []byte(`{"resource":"https://other.example.test/mcp","resource":"https://mcp.example.test/mcp","authorization_servers":["https://auth.example.test"]}`)
+	if validRemoteMCPE2EDiscoveryMetadata(duplicate, "https://mcp.example.test/mcp", "https://auth.example.test") {
+		t.Fatal("duplicate discovery metadata accepted")
+	}
+}
+
 func TestRemoteMCPE2EReleaseCandidateHarness(t *testing.T) {
 	var config remoteMCPE2EConfig
 	var insufficientScopeAuthorized, validForbidden bool
@@ -263,6 +274,10 @@ func TestRemoteMCPE2EReleaseCandidateHarness(t *testing.T) {
 			return
 		}
 		if token == config.Tokens.Valid && request.Header.Get("Mcp-Session-Id") != "fixture-valid-session" || token == config.Tokens.InsufficientScope && request.Header.Get("Mcp-Session-Id") != "fixture-insufficient-scope-session" {
+			response.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		if request.Header.Get("Mcp-Protocol-Version") != config.ProtocolVersion {
 			response.WriteHeader(http.StatusBadRequest)
 			return
 		}
@@ -487,11 +502,7 @@ func runRemoteMCPE2EReleaseCandidateWithClient(t *testing.T, config remoteMCPE2E
 	if metadata.Status != http.StatusOK || !strings.Contains(metadata.Header.Get("Content-Type"), "application/json") || metadata.Header.Get("Cache-Control") != "no-store" {
 		t.Fatal("protected-resource discovery did not return the required metadata response")
 	}
-	var document struct {
-		Resource             string   `json:"resource"`
-		AuthorizationServers []string `json:"authorization_servers"`
-	}
-	if json.Unmarshal(metadata.Body, &document) != nil || document.Resource != config.Resource || !slices.Contains(document.AuthorizationServers, config.AuthorizationServer) {
+	if !validRemoteMCPE2EDiscoveryMetadata(metadata.Body, config.Resource, config.AuthorizationServer) {
 		t.Fatal("protected-resource discovery metadata is invalid")
 	}
 
@@ -533,16 +544,16 @@ func runRemoteMCPE2EReleaseCandidateWithClient(t *testing.T, config remoteMCPE2E
 		[]byte(`{"jsonrpc":"2.0","id":{},"method":"tools/list"}`),
 		[]byte(`{"jsonrpc":"2.0","id":1,"method":"tools/list","extra":true}`),
 	} {
-		malformed := remoteMCPE2EDoWithSession(t, client, http.MethodPost, config.Endpoint, config.Tokens.Valid, validSessionID, malformedRequest)
+		malformed := remoteMCPE2EDoWithMCPContext(t, client, http.MethodPost, config.Endpoint, config.Tokens.Valid, validSessionID, config.ProtocolVersion, malformedRequest)
 		remoteMCPE2ERedacted(t, malformed, config.sensitiveValues())
 		remoteMCPE2ERequireJSONRPCFailure(t, malformed)
 	}
 
-	authorized := remoteMCPE2EDoWithSession(t, client, http.MethodPost, config.Endpoint, config.Tokens.Valid, validSessionID, remoteMCPE2ERequest(t, "tools/call", map[string]any{"name": config.AuthorizedTool.Name, "arguments": config.AuthorizedTool.Arguments}))
+	authorized := remoteMCPE2EDoWithMCPContext(t, client, http.MethodPost, config.Endpoint, config.Tokens.Valid, validSessionID, config.ProtocolVersion, remoteMCPE2ERequest(t, "tools/call", map[string]any{"name": config.AuthorizedTool.Name, "arguments": config.AuthorizedTool.Arguments}))
 	remoteMCPE2ERequireJSONRPCSuccess(t, authorized, config.AuthorizedTool.ExpectedResult)
 
 	insufficientScopeSessionID := remoteMCPE2EInitializeSession(t, client, config, config.Tokens.InsufficientScope)
-	insufficientScopeAuthorized := remoteMCPE2EDoWithSession(t, client, http.MethodPost, config.Endpoint, config.Tokens.InsufficientScope, insufficientScopeSessionID, remoteMCPE2ERequest(t, "tools/call", map[string]any{"name": config.AuthorizedTool.Name, "arguments": config.AuthorizedTool.Arguments}))
+	insufficientScopeAuthorized := remoteMCPE2EDoWithMCPContext(t, client, http.MethodPost, config.Endpoint, config.Tokens.InsufficientScope, insufficientScopeSessionID, config.ProtocolVersion, remoteMCPE2ERequest(t, "tools/call", map[string]any{"name": config.AuthorizedTool.Name, "arguments": config.AuthorizedTool.Arguments}))
 	remoteMCPE2ERequireJSONRPCSuccess(t, insufficientScopeAuthorized, config.AuthorizedTool.ExpectedResult)
 	for _, probe := range []struct {
 		token     string
@@ -551,7 +562,7 @@ func runRemoteMCPE2EReleaseCandidateWithClient(t *testing.T, config remoteMCPE2E
 		{token: config.Tokens.InsufficientScope, sessionID: insufficientScopeSessionID},
 		{token: config.Tokens.Valid, sessionID: validSessionID},
 	} {
-		forbidden := remoteMCPE2EDoWithSession(t, client, http.MethodPost, config.Endpoint, probe.token, probe.sessionID, remoteMCPE2ERequest(t, "tools/call", map[string]any{"name": config.ForbiddenTool.Name, "arguments": config.ForbiddenTool.Arguments}))
+		forbidden := remoteMCPE2EDoWithMCPContext(t, client, http.MethodPost, config.Endpoint, probe.token, probe.sessionID, config.ProtocolVersion, remoteMCPE2ERequest(t, "tools/call", map[string]any{"name": config.ForbiddenTool.Name, "arguments": config.ForbiddenTool.Arguments}))
 		remoteMCPE2ERequireStatus(t, forbidden, config.ForbiddenTool.ExpectedStatus)
 		remoteMCPE2ERedacted(t, forbidden, config.sensitiveValues())
 		remoteMCPE2ERequireJSONRPCFailure(t, forbidden)
@@ -561,6 +572,17 @@ func runRemoteMCPE2EReleaseCandidateWithClient(t *testing.T, config remoteMCPE2E
 	remoteMCPE2ERequireStatus(t, redacted, http.StatusUnauthorized)
 	remoteMCPE2ERedacted(t, redacted, config.sensitiveValues())
 	t.Logf("remote MCP release-candidate E2E evidence passed for candidate_commit=%s", config.CandidateCommit)
+}
+
+func validRemoteMCPE2EDiscoveryMetadata(raw []byte, expectedResource, expectedAuthorizationServer string) bool {
+	if !validJSONObject(raw, maxJSONRPCDepth) {
+		return false
+	}
+	var document struct {
+		Resource             string   `json:"resource"`
+		AuthorizationServers []string `json:"authorization_servers"`
+	}
+	return json.Unmarshal(raw, &document) == nil && document.Resource == expectedResource && slices.Contains(document.AuthorizationServers, expectedAuthorizationServer)
 }
 
 func remoteMCPE2EMetadataURL(t *testing.T, resource string) string {
@@ -599,6 +621,10 @@ func remoteMCPE2EDo(t *testing.T, client *http.Client, method, endpoint, token s
 }
 
 func remoteMCPE2EDoWithSession(t *testing.T, client *http.Client, method, endpoint, token, sessionID string, body []byte) remoteMCPE2EResponse {
+	return remoteMCPE2EDoWithMCPContext(t, client, method, endpoint, token, sessionID, "", body)
+}
+
+func remoteMCPE2EDoWithMCPContext(t *testing.T, client *http.Client, method, endpoint, token, sessionID, protocolVersion string, body []byte) remoteMCPE2EResponse {
 	t.Helper()
 	request, err := http.NewRequestWithContext(t.Context(), method, endpoint, bytes.NewReader(body))
 	if err != nil {
@@ -613,6 +639,9 @@ func remoteMCPE2EDoWithSession(t *testing.T, client *http.Client, method, endpoi
 	}
 	if sessionID != "" {
 		request.Header.Set("Mcp-Session-Id", sessionID)
+	}
+	if protocolVersion != "" {
+		request.Header.Set("Mcp-Protocol-Version", protocolVersion)
 	}
 	response, err := client.Do(request)
 	if err != nil {
@@ -671,7 +700,7 @@ func remoteMCPE2EInitializeSession(t *testing.T, client *http.Client, config rem
 	initialized := remoteMCPE2EDo(t, client, http.MethodPost, config.Endpoint, token, remoteMCPE2ERequestWithID(t, "remote-mcp-e2e-initialize", "initialize", map[string]any{"protocolVersion": config.ProtocolVersion, "capabilities": map[string]any{}, "clientInfo": map[string]string{"name": "punaro-remote-mcp-e2e", "version": "1"}}))
 	remoteMCPE2ERequireInitializeSuccess(t, initialized, config.ProtocolVersion)
 	sessionID := initialized.Header.Get("Mcp-Session-Id")
-	notification := remoteMCPE2EDoWithSession(t, client, http.MethodPost, config.Endpoint, token, sessionID, remoteMCPE2ENotification(t, "notifications/initialized", map[string]any{}))
+	notification := remoteMCPE2EDoWithMCPContext(t, client, http.MethodPost, config.Endpoint, token, sessionID, config.ProtocolVersion, remoteMCPE2ENotification(t, "notifications/initialized", map[string]any{}))
 	remoteMCPE2ERequireInitializedNotification(t, notification)
 	return sessionID
 }

--- a/internal/mcphttp/remote_mcp_e2e_test.go
+++ b/internal/mcphttp/remote_mcp_e2e_test.go
@@ -141,6 +141,9 @@ func TestRemoteMCPE2ECleanCheckoutRejectsTrackedChanges(t *testing.T) {
 	if validRemoteMCPE2ECleanCheckoutStatus(" M internal/mcphttp/remote_mcp_e2e_test.go\n") {
 		t.Fatal("tracked checkout change accepted")
 	}
+	if validRemoteMCPE2ECleanCheckoutStatus("?? internal/mcphttp/override_test.go\n") {
+		t.Fatal("untracked checkout change accepted")
+	}
 }
 
 func TestRemoteMCPE2EJSONRPCSuccessRequiresExactCorrelatedToolResult(t *testing.T) {
@@ -381,7 +384,7 @@ func checkedOutRemoteMCPE2ECommit() (string, error) {
 	if err != nil {
 		return "", errors.New("candidate commit unavailable")
 	}
-	status, err := exec.Command("git", "status", "--porcelain", "--untracked-files=no").Output() // #nosec G204 -- fixed local Git command rejects tracked changes from release evidence.
+	status, err := exec.Command("git", "status", "--porcelain").Output() // #nosec G204 -- fixed local Git command rejects checkout changes from release evidence.
 	if err != nil || !validRemoteMCPE2ECleanCheckoutStatus(string(status)) {
 		return "", errors.New("candidate checkout is not clean")
 	}

--- a/internal/mcphttp/remote_mcp_e2e_test.go
+++ b/internal/mcphttp/remote_mcp_e2e_test.go
@@ -126,6 +126,23 @@ func TestRemoteMCPE2EChallengeRequiresExactResourceMetadata(t *testing.T) {
 	}
 }
 
+func TestRemoteMCPE2EMetadataURLPreservesEscapedResourcePath(t *testing.T) {
+	const resource = "https://mcp.example.test/mcp%20release"
+	const want = "https://mcp.example.test/.well-known/oauth-protected-resource/mcp%20release"
+	if got := remoteMCPE2EMetadataURL(t, resource); got != want {
+		t.Fatalf("metadata URL = %q, want %q", got, want)
+	}
+}
+
+func TestRemoteMCPE2ECleanCheckoutRejectsTrackedChanges(t *testing.T) {
+	if !validRemoteMCPE2ECleanCheckoutStatus("") {
+		t.Fatal("clean checkout rejected")
+	}
+	if validRemoteMCPE2ECleanCheckoutStatus(" M internal/mcphttp/remote_mcp_e2e_test.go\n") {
+		t.Fatal("tracked checkout change accepted")
+	}
+}
+
 func TestRemoteMCPE2EJSONRPCSuccessRequiresExactCorrelatedToolResult(t *testing.T) {
 	want := json.RawMessage(`{"content":[{"type":"text","text":"release-candidate-e2e"}]}`)
 	valid := remoteMCPE2EResponse{Status: http.StatusOK, Header: http.Header{"Content-Type": []string{"application/json"}}, Body: []byte(`{"jsonrpc":"2.0","id":"remote-mcp-e2e","result":{"content":[{"type":"text","text":"release-candidate-e2e"}]}}`)}
@@ -271,7 +288,7 @@ func TestRemoteMCPE2EReleaseCandidateHarness(t *testing.T) {
 		if token == config.Tokens.Valid && bytes.Contains(body, []byte(`"name":"punaro_memory_propose"`)) {
 			validForbidden = true
 		}
-		if bytes.HasPrefix(body, []byte("[")) || bytes.Contains(body, []byte(`"method":"tools/list","method"`)) || bytes.Contains(body, []byte(`"id":{}`)) || bytes.Contains(body, []byte(`"extra":true`)) {
+		if bytes.HasPrefix(body, []byte("[")) || bytes.Count(body, []byte(`"method"`)) > 1 || bytes.Contains(body, []byte(`"id":{}`)) || bytes.Contains(body, []byte(`"extra":true`)) {
 			response.WriteHeader(http.StatusBadRequest)
 			return
 		}
@@ -361,12 +378,18 @@ func checkedOutRemoteMCPE2ECommit() (string, error) {
 	if err != nil {
 		return "", errors.New("candidate commit unavailable")
 	}
+	status, err := exec.Command("git", "status", "--porcelain", "--untracked-files=no").Output() // #nosec G204 -- fixed local Git command rejects tracked changes from release evidence.
+	if err != nil || !validRemoteMCPE2ECleanCheckoutStatus(string(status)) {
+		return "", errors.New("candidate checkout is not clean")
+	}
 	commit := strings.TrimSpace(string(output))
 	if !validCommit(commit) {
 		return "", errors.New("candidate commit unavailable")
 	}
 	return commit, nil
 }
+
+func validRemoteMCPE2ECleanCheckoutStatus(status string) bool { return status == "" }
 
 func validateRemoteMCPE2ECandidateCommit(configured, checkedOut string) error {
 	if configured != checkedOut {
@@ -552,7 +575,7 @@ func runRemoteMCPE2EReleaseCandidateWithClient(t *testing.T, config remoteMCPE2E
 	validSessionID := remoteMCPE2EInitializeSession(t, client, config, config.Tokens.Valid)
 	for _, malformedRequest := range [][]byte{
 		[]byte(`[{"jsonrpc":"2.0","id":1,"method":"tools/list"}]`),
-		[]byte(`{"jsonrpc":"2.0","id":1,"method":"tools/list","method":"tools/call"}`),
+		[]byte(`{"jsonrpc":"2.0","id":1,"method":"tools/call","method":"tools/list"}`),
 		[]byte(`{"jsonrpc":"2.0","id":{},"method":"tools/list"}`),
 		[]byte(`{"jsonrpc":"2.0","id":1,"method":"tools/list","extra":true}`),
 	} {
@@ -603,7 +626,13 @@ func remoteMCPE2EMetadataURL(t *testing.T, resource string) string {
 	if err != nil {
 		t.Fatal("remote MCP resource is invalid")
 	}
-	return (&url.URL{Scheme: parsed.Scheme, Host: parsed.Host, Path: "/.well-known/oauth-protected-resource" + parsed.EscapedPath()}).String()
+	const prefix = "/.well-known/oauth-protected-resource"
+	return (&url.URL{
+		Scheme:  parsed.Scheme,
+		Host:    parsed.Host,
+		Path:    prefix + parsed.Path,
+		RawPath: prefix + parsed.EscapedPath(),
+	}).String()
 }
 
 func remoteMCPE2ERequest(t *testing.T, method string, params any) []byte {

--- a/internal/mcphttp/remote_mcp_e2e_test.go
+++ b/internal/mcphttp/remote_mcp_e2e_test.go
@@ -1,0 +1,423 @@
+//go:build e2e
+
+package mcphttp
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+)
+
+const (
+	remoteMCPE2EConfigEnv   = "PUNARO_REMOTE_MCP_E2E_CONFIG"
+	maxRemoteMCPE2EConfig   = 64 << 10
+	maxRemoteMCPE2EResponse = 1 << 20
+)
+
+type remoteMCPE2EConfig struct {
+	CandidateCommit     string `json:"candidate_commit"`
+	Endpoint            string `json:"endpoint"`
+	Resource            string `json:"resource"`
+	AuthorizationServer string `json:"authorization_server"`
+	Tokens              struct {
+		Valid             string `json:"valid"`
+		Invalid           string `json:"invalid"`
+		WrongIssuer       string `json:"wrong_issuer"`
+		WrongAudience     string `json:"wrong_audience"`
+		Expired           string `json:"expired"`
+		Revoked           string `json:"revoked"`
+		NoScope           string `json:"no_scope"`
+		InsufficientScope string `json:"insufficient_scope"`
+	} `json:"tokens"`
+	AuthorizedTool struct {
+		Name      string          `json:"name"`
+		Arguments json.RawMessage `json:"arguments"`
+	} `json:"authorized_tool"`
+	ForbiddenTool struct {
+		Name           string          `json:"name"`
+		Arguments      json.RawMessage `json:"arguments"`
+		ExpectedStatus int             `json:"expected_status"`
+	} `json:"forbidden_tool"`
+	RedactionProbe string `json:"redaction_probe"`
+}
+
+type remoteMCPE2EResponse struct {
+	Status int
+	Header http.Header
+	Body   []byte
+}
+
+func TestRemoteMCPE2EReleaseCandidate(t *testing.T) {
+	config := loadRemoteMCPE2EConfig(t)
+	runRemoteMCPE2EReleaseCandidate(t, config)
+}
+
+func TestRemoteMCPE2EConfigRejectsIncompleteOrUnsafeInputs(t *testing.T) {
+	valid := []byte(`{
+		"candidate_commit":"0123456789abcdef0123456789abcdef01234567",
+		"endpoint":"https://mcp.example.test/mcp",
+		"resource":"https://mcp.example.test/mcp",
+		"authorization_server":"https://auth.example.test",
+		"tokens":{"valid":"aaaaaaaaaaaaaaaa","invalid":"bbbbbbbbbbbbbbbb","wrong_issuer":"cccccccccccccccc","wrong_audience":"dddddddddddddddd","expired":"eeeeeeeeeeeeeeee","revoked":"ffffffffffffffff","no_scope":"gggggggggggggggg","insufficient_scope":"hhhhhhhhhhhhhhhh"},
+		"authorized_tool":{"name":"punaro_memory_search","arguments":{"query":"e2e"}},
+		"forbidden_tool":{"name":"punaro_memory_propose","arguments":{},"expected_status":403},
+		"redaction_probe":"not-a-secret-redaction-probe"
+	}`)
+	if _, err := parseRemoteMCPE2EConfig(valid); err != nil {
+		t.Fatalf("valid config rejected: %v", err)
+	}
+	for _, replacement := range [][]byte{
+		bytes.Replace(valid, []byte(`"https://mcp.example.test/mcp"`), []byte(`"http://mcp.example.test/mcp"`), 1),
+		bytes.Replace(valid, []byte(`"expected_status":403`), []byte(`"expected_status":200`), 1),
+		bytes.Replace(valid, []byte(`"valid":"aaaaaaaaaaaaaaaa"`), []byte(`"valid":""`), 1),
+		bytes.Replace(valid, []byte(`"valid":"aaaaaaaaaaaaaaaa"`), []byte(`"valid":"bad\nvalue"`), 1),
+		bytes.Replace(valid, []byte(`"redaction_probe":"not-a-secret-redaction-probe"`), []byte(`"redaction_probe":"bad\"value"`), 1),
+		bytes.Replace(valid, []byte(`{"query":"e2e"}`), []byte(`{"query":"e2e","query":"other"}`), 1),
+		append(append([]byte(nil), valid[:len(valid)-1]...), []byte(`,"candidate_commit":"0123456789abcdef0123456789abcdef01234567"}`)...),
+	} {
+		if _, err := parseRemoteMCPE2EConfig(replacement); err == nil {
+			t.Fatal("unsafe E2E config accepted")
+		}
+	}
+}
+
+func TestRemoteMCPE2EReleaseCandidateHarness(t *testing.T) {
+	var config remoteMCPE2EConfig
+	server := httptest.NewTLSServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+		if request.Method == http.MethodGet && request.URL.Path == "/.well-known/oauth-protected-resource/mcp" {
+			response.Header().Set("Content-Type", "application/json")
+			response.Header().Set("Cache-Control", "no-store")
+			_ = json.NewEncoder(response).Encode(map[string]any{"resource": config.Resource, "authorization_servers": []string{config.AuthorizationServer}})
+			return
+		}
+		if request.URL.Path != "/mcp" {
+			response.WriteHeader(http.StatusNotFound)
+			return
+		}
+		token := strings.TrimPrefix(request.Header.Get("Authorization"), "Bearer ")
+		if token == "" {
+			response.Header().Set("WWW-Authenticate", `Bearer realm="punaro-mcp", resource_metadata="https://metadata.example.test", scope="memory.search memory.read memory.propose"`)
+			response.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		if token == config.Tokens.NoScope {
+			response.Header().Set("WWW-Authenticate", `Bearer error="insufficient_scope"`)
+			response.WriteHeader(http.StatusForbidden)
+			return
+		}
+		if token == config.Tokens.InsufficientScope {
+			response.WriteHeader(http.StatusForbidden)
+			return
+		}
+		if token != config.Tokens.Valid {
+			response.Header().Set("WWW-Authenticate", `Bearer error="invalid_token"`)
+			response.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		body, _ := io.ReadAll(request.Body)
+		if bytes.HasPrefix(body, []byte("[")) || bytes.Contains(body, []byte(`"method":"tools/list","method"`)) || bytes.Contains(body, []byte(`"id":{}`)) || bytes.Contains(body, []byte(`"extra":true`)) {
+			response.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		response.Header().Set("Content-Type", "application/json")
+		_, _ = response.Write([]byte(`{"jsonrpc":"2.0","id":"remote-mcp-e2e","result":{}}`))
+	}))
+	defer server.Close()
+	config = remoteMCPE2EFixtureConfig(t, server.URL+"/mcp")
+	runRemoteMCPE2EReleaseCandidateWithClient(t, config, server.Client())
+}
+
+func remoteMCPE2EFixtureConfig(t *testing.T, endpoint string) remoteMCPE2EConfig {
+	t.Helper()
+	config, err := parseRemoteMCPE2EConfig([]byte(`{
+		"candidate_commit":"0123456789abcdef0123456789abcdef01234567",
+		"endpoint":"` + endpoint + `",
+		"resource":"` + endpoint + `",
+		"authorization_server":"https://auth.example.test",
+		"tokens":{"valid":"aaaaaaaaaaaaaaaa","invalid":"bbbbbbbbbbbbbbbb","wrong_issuer":"cccccccccccccccc","wrong_audience":"dddddddddddddddd","expired":"eeeeeeeeeeeeeeee","revoked":"ffffffffffffffff","no_scope":"gggggggggggggggg","insufficient_scope":"hhhhhhhhhhhhhhhh"},
+		"authorized_tool":{"name":"punaro_memory_search","arguments":{"query":"e2e"}},
+		"forbidden_tool":{"name":"punaro_memory_propose","arguments":{},"expected_status":403},
+		"redaction_probe":"not-a-secret-redaction-probe"
+	}`))
+	if err != nil {
+		t.Fatal("remote MCP E2E fixture configuration is invalid")
+	}
+	return config
+}
+
+func loadRemoteMCPE2EConfig(t *testing.T) remoteMCPE2EConfig {
+	t.Helper()
+	configPath := os.Getenv(remoteMCPE2EConfigEnv)
+	if configPath == "" {
+		t.Skip("set PUNARO_REMOTE_MCP_E2E_CONFIG to run the remote MCP release-candidate E2E test")
+	}
+	contents, err := os.ReadFile(configPath) // #nosec G304 -- operator-selected private E2E configuration.
+	if err != nil {
+		t.Fatal("remote MCP E2E configuration is unavailable")
+	}
+	if len(contents) > maxRemoteMCPE2EConfig {
+		t.Fatal("remote MCP E2E configuration is too large")
+	}
+	config, err := parseRemoteMCPE2EConfig(contents)
+	if err != nil {
+		t.Fatal("remote MCP E2E configuration is invalid")
+	}
+	return config
+}
+
+func parseRemoteMCPE2EConfig(raw []byte) (remoteMCPE2EConfig, error) {
+	if !validJSONRPCValue(raw, maxJSONRPCDepth) {
+		return remoteMCPE2EConfig{}, errors.New("invalid remote MCP E2E configuration")
+	}
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	decoder.DisallowUnknownFields()
+	var config remoteMCPE2EConfig
+	if err := decoder.Decode(&config); err != nil || decoder.Decode(&struct{}{}) != io.EOF {
+		return remoteMCPE2EConfig{}, errors.New("invalid remote MCP E2E configuration")
+	}
+	if !validCommit(config.CandidateCommit) || !validRemoteMCPE2EURL(config.Endpoint, true) || config.Endpoint != config.Resource || !validRemoteMCPE2EURL(config.Resource, true) || !validRemoteMCPE2EURL(config.AuthorizationServer, false) || !validRemoteMCPE2EBearer(config.RedactionProbe) {
+		return remoteMCPE2EConfig{}, errors.New("invalid remote MCP E2E configuration")
+	}
+	seen := map[string]struct{}{config.RedactionProbe: {}}
+	for _, token := range config.tokens() {
+		if !validRemoteMCPE2EBearer(token) {
+			return remoteMCPE2EConfig{}, errors.New("invalid remote MCP E2E configuration")
+		}
+		if _, duplicate := seen[token]; duplicate {
+			return remoteMCPE2EConfig{}, errors.New("invalid remote MCP E2E configuration")
+		}
+		seen[token] = struct{}{}
+	}
+	if !validRemoteMCPE2ETool(config.AuthorizedTool.Name, config.AuthorizedTool.Arguments) || !validRemoteMCPE2ETool(config.ForbiddenTool.Name, config.ForbiddenTool.Arguments) || config.ForbiddenTool.ExpectedStatus < 400 || config.ForbiddenTool.ExpectedStatus > 499 {
+		return remoteMCPE2EConfig{}, errors.New("invalid remote MCP E2E configuration")
+	}
+	return config, nil
+}
+
+func validCommit(raw string) bool {
+	if len(raw) != 40 {
+		return false
+	}
+	for _, character := range raw {
+		if !(character >= '0' && character <= '9' || character >= 'a' && character <= 'f') {
+			return false
+		}
+	}
+	return true
+}
+
+func validRemoteMCPE2EURL(raw string, requirePath bool) bool {
+	parsed, err := url.Parse(raw)
+	if err != nil || parsed.Scheme != "https" || parsed.Host == "" || parsed.User != nil || parsed.RawQuery != "" || parsed.Fragment != "" || parsed.String() != raw || strings.Contains(parsed.Host, "@") {
+		return false
+	}
+	if requirePath {
+		return parsed.Path != "" && parsed.Path != "/" && path.Clean(parsed.EscapedPath()) == parsed.EscapedPath()
+	}
+	return parsed.Path == "" || parsed.Path == "/"
+}
+
+func validRemoteMCPE2ETool(name string, arguments json.RawMessage) bool {
+	if name == "" || len(name) > 128 || strings.TrimSpace(name) != name || !validJSONObject(arguments, maxJSONRPCDepth) {
+		return false
+	}
+	return true
+}
+
+func validRemoteMCPE2EBearer(value string) bool {
+	if len(value) < 16 || len(value) > 16<<10 {
+		return false
+	}
+	for _, character := range []byte(value) {
+		if !(character >= 'A' && character <= 'Z' || character >= 'a' && character <= 'z' || character >= '0' && character <= '9' || strings.ContainsRune("-._~+/=", rune(character))) {
+			return false
+		}
+	}
+	return true
+}
+
+func (config remoteMCPE2EConfig) tokens() []string {
+	return []string{config.Tokens.Valid, config.Tokens.Invalid, config.Tokens.WrongIssuer, config.Tokens.WrongAudience, config.Tokens.Expired, config.Tokens.Revoked, config.Tokens.NoScope, config.Tokens.InsufficientScope}
+}
+
+func (config remoteMCPE2EConfig) sensitiveValues() []string {
+	return append(config.tokens(), config.RedactionProbe)
+}
+
+func runRemoteMCPE2EReleaseCandidate(t *testing.T, config remoteMCPE2EConfig) {
+	t.Helper()
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.Proxy = nil
+	defer transport.CloseIdleConnections()
+	client := &http.Client{Transport: transport, Timeout: 15 * time.Second, CheckRedirect: func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse }}
+	runRemoteMCPE2EReleaseCandidateWithClient(t, config, client)
+}
+
+func runRemoteMCPE2EReleaseCandidateWithClient(t *testing.T, config remoteMCPE2EConfig, client *http.Client) {
+	t.Helper()
+	if client == nil {
+		t.Fatal("remote MCP E2E HTTP client is unavailable")
+	}
+	metadata := remoteMCPE2EDo(t, client, http.MethodGet, remoteMCPE2EMetadataURL(t, config.Resource), "", nil)
+	if metadata.Status != http.StatusOK || !strings.Contains(metadata.Header.Get("Content-Type"), "application/json") || metadata.Header.Get("Cache-Control") != "no-store" {
+		t.Fatal("protected-resource discovery did not return the required metadata response")
+	}
+	var document struct {
+		Resource             string   `json:"resource"`
+		AuthorizationServers []string `json:"authorization_servers"`
+	}
+	if json.Unmarshal(metadata.Body, &document) != nil || document.Resource != config.Resource || !slices.Contains(document.AuthorizationServers, config.AuthorizationServer) {
+		t.Fatal("protected-resource discovery metadata is invalid")
+	}
+
+	unauthorized := remoteMCPE2EDo(t, client, http.MethodPost, config.Endpoint, "", remoteMCPE2ERequest(t, "tools/list", map[string]any{}))
+	remoteMCPE2ERequireStatus(t, unauthorized, http.StatusUnauthorized)
+	remoteMCPE2ERedacted(t, unauthorized, config.sensitiveValues())
+	challenge := unauthorized.Header.Get("WWW-Authenticate")
+	if !strings.Contains(challenge, "Bearer") || !strings.Contains(challenge, "resource_metadata=") || !strings.Contains(challenge, `scope="memory.search memory.read memory.propose"`) {
+		t.Fatal("unauthorized request did not return the OAuth discovery challenge")
+	}
+
+	for _, token := range []string{config.Tokens.Invalid, config.Tokens.WrongIssuer, config.Tokens.WrongAudience, config.Tokens.Expired, config.Tokens.Revoked} {
+		response := remoteMCPE2EDo(t, client, http.MethodPost, config.Endpoint, token, remoteMCPE2ERequest(t, "tools/list", map[string]any{}))
+		remoteMCPE2ERequireStatus(t, response, http.StatusUnauthorized)
+		remoteMCPE2ERedacted(t, response, config.sensitiveValues())
+		if !strings.Contains(response.Header.Get("WWW-Authenticate"), `error="invalid_token"`) {
+			t.Fatal("invalid bearer token did not return the OAuth invalid-token challenge")
+		}
+	}
+
+	noScope := remoteMCPE2EDo(t, client, http.MethodPost, config.Endpoint, config.Tokens.NoScope, remoteMCPE2ERequest(t, "tools/list", map[string]any{}))
+	remoteMCPE2ERequireStatus(t, noScope, http.StatusForbidden)
+	remoteMCPE2ERedacted(t, noScope, config.sensitiveValues())
+	if !strings.Contains(noScope.Header.Get("WWW-Authenticate"), `error="insufficient_scope"`) {
+		t.Fatal("missing required scope did not return an insufficient-scope challenge")
+	}
+
+	for _, malformedRequest := range [][]byte{
+		[]byte(`[{"jsonrpc":"2.0","id":1,"method":"tools/list"}]`),
+		[]byte(`{"jsonrpc":"2.0","id":1,"method":"tools/list","method":"tools/call"}`),
+		[]byte(`{"jsonrpc":"2.0","id":{},"method":"tools/list"}`),
+		[]byte(`{"jsonrpc":"2.0","id":1,"method":"tools/list","extra":true}`),
+	} {
+		malformed := remoteMCPE2EDo(t, client, http.MethodPost, config.Endpoint, config.Tokens.Valid, malformedRequest)
+		remoteMCPE2ERedacted(t, malformed, config.sensitiveValues())
+		remoteMCPE2ERequireJSONRPCFailure(t, malformed)
+	}
+
+	authorized := remoteMCPE2EDo(t, client, http.MethodPost, config.Endpoint, config.Tokens.Valid, remoteMCPE2ERequest(t, "tools/call", map[string]any{"name": config.AuthorizedTool.Name, "arguments": config.AuthorizedTool.Arguments}))
+	remoteMCPE2ERequireJSONRPCSuccess(t, authorized)
+
+	forbidden := remoteMCPE2EDo(t, client, http.MethodPost, config.Endpoint, config.Tokens.InsufficientScope, remoteMCPE2ERequest(t, "tools/call", map[string]any{"name": config.ForbiddenTool.Name, "arguments": config.ForbiddenTool.Arguments}))
+	remoteMCPE2ERequireStatus(t, forbidden, config.ForbiddenTool.ExpectedStatus)
+	remoteMCPE2ERedacted(t, forbidden, config.sensitiveValues())
+	remoteMCPE2ERequireJSONRPCFailure(t, forbidden)
+
+	redacted := remoteMCPE2EDo(t, client, http.MethodPost, config.Endpoint, config.RedactionProbe, remoteMCPE2ERequest(t, "tools/list", map[string]any{"probe": config.RedactionProbe}))
+	remoteMCPE2ERequireStatus(t, redacted, http.StatusUnauthorized)
+	remoteMCPE2ERedacted(t, redacted, config.sensitiveValues())
+	t.Logf("remote MCP release-candidate E2E evidence passed for candidate_commit=%s", config.CandidateCommit)
+}
+
+func remoteMCPE2EMetadataURL(t *testing.T, resource string) string {
+	t.Helper()
+	parsed, err := url.Parse(resource)
+	if err != nil {
+		t.Fatal("remote MCP resource is invalid")
+	}
+	return (&url.URL{Scheme: parsed.Scheme, Host: parsed.Host, Path: "/.well-known/oauth-protected-resource" + parsed.EscapedPath()}).String()
+}
+
+func remoteMCPE2ERequest(t *testing.T, method string, params any) []byte {
+	t.Helper()
+	raw, err := json.Marshal(map[string]any{"jsonrpc": "2.0", "id": "remote-mcp-e2e", "method": method, "params": params})
+	if err != nil {
+		t.Fatal("remote MCP E2E request could not be encoded")
+	}
+	return raw
+}
+
+func remoteMCPE2EDo(t *testing.T, client *http.Client, method, endpoint, token string, body []byte) remoteMCPE2EResponse {
+	t.Helper()
+	request, err := http.NewRequestWithContext(t.Context(), method, endpoint, bytes.NewReader(body))
+	if err != nil {
+		t.Fatal("remote MCP E2E request could not be created")
+	}
+	request.Header.Set("Accept", "application/json, text/event-stream")
+	if len(body) > 0 {
+		request.Header.Set("Content-Type", "application/json")
+	}
+	if token != "" {
+		request.Header.Set("Authorization", "Bearer "+token)
+	}
+	response, err := client.Do(request)
+	if err != nil {
+		t.Fatal("remote MCP E2E request failed")
+	}
+	defer response.Body.Close()
+	body, err = io.ReadAll(io.LimitReader(response.Body, maxRemoteMCPE2EResponse+1))
+	if err != nil || len(body) > maxRemoteMCPE2EResponse {
+		t.Fatal("remote MCP E2E response is invalid")
+	}
+	return remoteMCPE2EResponse{Status: response.StatusCode, Header: response.Header.Clone(), Body: body}
+}
+
+func remoteMCPE2ERequireStatus(t *testing.T, response remoteMCPE2EResponse, expected int) {
+	t.Helper()
+	if response.Status != expected {
+		t.Fatalf("remote MCP E2E response status=%d, want %d", response.Status, expected)
+	}
+}
+
+func remoteMCPE2ERequireJSONRPCSuccess(t *testing.T, response remoteMCPE2EResponse) {
+	t.Helper()
+	if response.Status < 200 || response.Status > 299 {
+		t.Fatalf("authorized MCP request status=%d", response.Status)
+	}
+	var envelope struct {
+		JSONRPC string          `json:"jsonrpc"`
+		Result  json.RawMessage `json:"result"`
+		Error   json.RawMessage `json:"error"`
+	}
+	if json.Unmarshal(response.Body, &envelope) != nil || envelope.JSONRPC != "2.0" || len(envelope.Result) == 0 || len(envelope.Error) != 0 {
+		t.Fatal("authorized MCP request did not return a JSON-RPC result")
+	}
+}
+
+func remoteMCPE2ERequireJSONRPCFailure(t *testing.T, response remoteMCPE2EResponse) {
+	t.Helper()
+	if response.Status >= 400 {
+		return
+	}
+	var envelope struct {
+		JSONRPC string          `json:"jsonrpc"`
+		Result  json.RawMessage `json:"result"`
+		Error   json.RawMessage `json:"error"`
+	}
+	if json.Unmarshal(response.Body, &envelope) != nil || envelope.JSONRPC != "2.0" || len(envelope.Result) != 0 || len(envelope.Error) == 0 {
+		t.Fatal("MCP request did not fail closed")
+	}
+}
+
+func remoteMCPE2ERedacted(t *testing.T, response remoteMCPE2EResponse, sensitive []string) {
+	t.Helper()
+	values := string(response.Body)
+	for _, headerValues := range response.Header {
+		values += "\n" + strings.Join(headerValues, "\n")
+	}
+	for _, value := range sensitive {
+		if strings.Contains(values, value) {
+			t.Fatal("remote MCP failure exposed a protected request value")
+		}
+	}
+}

--- a/internal/mcphttp/remote_mcp_e2e_test.go
+++ b/internal/mcphttp/remote_mcp_e2e_test.go
@@ -209,6 +209,9 @@ func TestRemoteMCPE2EOAuthFailureDoesNotExposeJSONRPCResult(t *testing.T) {
 	if validRemoteMCPE2EOAuthFailureBody(remoteMCPE2EResponse{Status: http.StatusUnauthorized, Header: http.Header{"Content-Type": []string{"application/json"}}, Body: []byte(`{"jsonrpc":"2.0","id":"remote-mcp-e2e","result":{"tools":[]}}`)}) {
 		t.Fatal("OAuth failure response exposing a JSON-RPC result accepted")
 	}
+	if validRemoteMCPE2EOAuthFailureBody(remoteMCPE2EResponse{Status: http.StatusUnauthorized, Header: http.Header{"Content-Type": []string{"text/event-stream"}}, Body: []byte("data: {\"jsonrpc\":\"2.0\",\"id\":\"remote-mcp-e2e\",\"result\":{\"tools\":[]}}\n")}) {
+		t.Fatal("unterminated SSE OAuth failure response accepted")
+	}
 }
 
 func TestRemoteMCPE2EJSONRPCFailureRejectsServerErrors(t *testing.T) {
@@ -1020,9 +1023,12 @@ func validRemoteMCPE2EJSONRPCFailure(response remoteMCPE2EResponse) bool {
 }
 
 func validRemoteMCPE2EOAuthFailureBody(response remoteMCPE2EResponse) bool {
+	if len(response.Body) == 0 {
+		return true
+	}
 	payload, supported := remoteMCPE2EJSONRPCPayload(response)
 	if !supported || len(payload) == 0 {
-		return true
+		return false
 	}
 	if !validJSONRPCValue(payload, maxJSONRPCDepth) {
 		return false

--- a/internal/mcphttp/remote_mcp_e2e_test.go
+++ b/internal/mcphttp/remote_mcp_e2e_test.go
@@ -22,10 +22,11 @@ import (
 )
 
 const (
-	remoteMCPE2EConfigEnv   = "PUNARO_REMOTE_MCP_E2E_CONFIG"
-	remoteMCPE2ELiveEnv     = "PUNARO_REMOTE_MCP_E2E_LIVE"
-	maxRemoteMCPE2EConfig   = 64 << 10
-	maxRemoteMCPE2EResponse = 1 << 20
+	remoteMCPE2EConfigEnv       = "PUNARO_REMOTE_MCP_E2E_CONFIG"
+	remoteMCPE2ELiveEnv         = "PUNARO_REMOTE_MCP_E2E_LIVE"
+	maxRemoteMCPE2EConfig       = 64 << 10
+	maxRemoteMCPE2EResponse     = 1 << 20
+	remoteMCPE2EProtocolVersion = "2024-11-05"
 )
 
 type remoteMCPE2EConfig struct {
@@ -103,6 +104,8 @@ func TestRemoteMCPE2EConfigRejectsIncompleteOrUnsafeInputs(t *testing.T) {
 		bytes.Replace(valid, []byte(`"token":"ffffffffffffffff","expected_status":403`), []byte(`"token":"ffffffffffffffff","expected_status":418`), 1),
 		bytes.Replace(valid, []byte(`"valid":"aaaaaaaaaaaaaaaa"`), []byte(`"valid":""`), 1),
 		bytes.Replace(valid, []byte(`"valid":"aaaaaaaaaaaaaaaa"`), []byte(`"valid":"bad\nvalue"`), 1),
+		bytes.Replace(valid, []byte(`"protocol_version":"2024-11-05"`), []byte(`"protocol_version":"1"`), 1),
+		bytes.Replace(valid, []byte(`"protocol_version":"2024-11-05"`), []byte(`"protocol_version":"2025-03-26"`), 1),
 		bytes.Replace(valid, []byte(`"redaction_probe":"not-a-secret-redaction-probe"`), []byte(`"redaction_probe":"bad\"value"`), 1),
 		bytes.Replace(valid, []byte(`{"query":"e2e"}`), []byte(`{"query":"e2e","query":"other"}`), 1),
 		bytes.Replace(valid, []byte(`"expected_result":{"content":[{"type":"text","text":"release-candidate-e2e"}]}`), []byte(`"expected_result":{}`), 1),
@@ -190,6 +193,18 @@ func TestRemoteMCPE2EOAuthErrorChallengeIsStructured(t *testing.T) {
 	invalid := remoteMCPE2EResponse{Status: http.StatusUnauthorized, Header: http.Header{"Www-Authenticate": []string{`Basic error="invalid_token"`}}}
 	if validRemoteMCPE2EOAuthErrorChallenge(invalid, "invalid_token") {
 		t.Fatal("non-Bearer error challenge accepted")
+	}
+}
+
+func TestRemoteMCPE2EOAuthFailureDoesNotExposeJSONRPCResult(t *testing.T) {
+	if !validRemoteMCPE2EOAuthFailureBody(remoteMCPE2EResponse{Status: http.StatusUnauthorized}) {
+		t.Fatal("empty OAuth failure response rejected")
+	}
+	if !validRemoteMCPE2EOAuthFailureBody(remoteMCPE2EResponse{Status: http.StatusUnauthorized, Header: http.Header{"Content-Type": []string{"application/json"}}, Body: []byte(`{"error":"invalid_token"}`)}) {
+		t.Fatal("non-JSON-RPC OAuth error response rejected")
+	}
+	if validRemoteMCPE2EOAuthFailureBody(remoteMCPE2EResponse{Status: http.StatusUnauthorized, Header: http.Header{"Content-Type": []string{"application/json"}}, Body: []byte(`{"jsonrpc":"2.0","id":"remote-mcp-e2e","result":{"tools":[]}}`)}) {
+		t.Fatal("OAuth failure response exposing a JSON-RPC result accepted")
 	}
 }
 
@@ -496,15 +511,7 @@ func parseRemoteMCPE2EConfig(raw []byte) (remoteMCPE2EConfig, error) {
 }
 
 func validRemoteMCPE2EProtocolVersion(value string) bool {
-	if len(value) == 0 || len(value) > 32 || strings.TrimSpace(value) != value {
-		return false
-	}
-	for _, character := range value {
-		if !(character >= '0' && character <= '9' || character == '-') {
-			return false
-		}
-	}
-	return true
+	return value == remoteMCPE2EProtocolVersion
 }
 
 func validCommit(raw string) bool {
@@ -615,6 +622,9 @@ func runRemoteMCPE2EReleaseCandidateWithClient(t *testing.T, config remoteMCPE2E
 		response := remoteMCPE2EDo(t, client, http.MethodPost, config.Endpoint, token, remoteMCPE2ERequest(t, "tools/list", map[string]any{}))
 		remoteMCPE2ERequireStatus(t, response, http.StatusUnauthorized)
 		remoteMCPE2ERedacted(t, response, config.sensitiveValues())
+		if !validRemoteMCPE2EOAuthFailureBody(response) {
+			t.Fatal("invalid bearer token response exposed a JSON-RPC result")
+		}
 		if !validRemoteMCPE2EOAuthErrorChallenge(response, "invalid_token") {
 			t.Fatal("invalid bearer token did not return the OAuth invalid-token challenge")
 		}
@@ -977,6 +987,22 @@ func remoteMCPE2ERequireJSONRPCFailure(t *testing.T, response remoteMCPE2ERespon
 
 func validRemoteMCPE2EJSONRPCFailure(response remoteMCPE2EResponse) bool {
 	return validRemoteMCPE2EJSONRPCFailureWithExpectedID(response, nil)
+}
+
+func validRemoteMCPE2EOAuthFailureBody(response remoteMCPE2EResponse) bool {
+	payload, supported := remoteMCPE2EJSONRPCPayload(response)
+	if !supported || len(payload) == 0 {
+		return true
+	}
+	if !validJSONRPCValue(payload, maxJSONRPCDepth) {
+		return false
+	}
+	var object map[string]json.RawMessage
+	if json.Unmarshal(payload, &object) != nil {
+		return false
+	}
+	_, hasResult := object["result"]
+	return !hasResult
 }
 
 func remoteMCPE2ERequireJSONRPCFailureWithExpectedID(t *testing.T, response remoteMCPE2EResponse, expectedID json.RawMessage) {

--- a/internal/mcphttp/remote_mcp_e2e_test.go
+++ b/internal/mcphttp/remote_mcp_e2e_test.go
@@ -998,6 +998,9 @@ func validRemoteMCPE2ESchemaValue(value, property json.RawMessage) bool {
 	if json.Unmarshal(property, &definition) != nil {
 		return false
 	}
+	if bytes.Equal(bytes.TrimSpace(value), []byte("null")) {
+		return definition.Type == "null"
+	}
 	switch definition.Type {
 	case "string":
 		var target string
@@ -1017,7 +1020,7 @@ func validRemoteMCPE2ESchemaValue(value, property json.RawMessage) bool {
 		var target []json.RawMessage
 		return json.Unmarshal(value, &target) == nil
 	case "null":
-		return bytes.Equal(bytes.TrimSpace(value), []byte("null"))
+		return false
 	default:
 		return false
 	}


### PR DESCRIPTION
## Summary

Adds a reproducible, environment-agnostic release-candidate E2E harness for the remote MCP endpoint.

- requires a private, operator-provided candidate configuration instead of committing endpoint topology or OAuth tokens;
- verifies discovery/challenge, invalid issuer/audience/expired/revoked bearers, required and tool-specific scopes, strict JSON-RPC rejection, authorized tool invocation, and response redaction;
- adds a TLS-backed local harness fixture plus an explicit `make remote-mcp-e2e` release command that cannot silently skip; and
- documents the disposable-token preparation and release-evidence handoff.

Closes #105.

## Validation

- `GOCACHE=/tmp/punaro-issue-105-go-cache go test -tags=e2e ./internal/mcphttp -count=1`
- `GOCACHE=/tmp/punaro-issue-105-go-cache make test`
- `GOCACHE=/tmp/punaro-issue-105-go-cache make test-race`
- `GOCACHE=/tmp/punaro-issue-105-go-cache make security`
- `GOCACHE=/tmp/punaro-issue-105-go-cache make lint`

The deployed-candidate command intentionally requires `PUNARO_REMOTE_MCP_E2E_CONFIG` and will run only with the release operator's disposable endpoint and token suite.
