### PR TITLE
feat: unify fresh server installation inputs

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1321,6 +1321,18 @@ upgrade-required, newer, dirty, and incompatible states before service start,
 waits boundedly for readiness, then runs doctor. Initial pristine migration is
 part of `init`; raw daemon and Compose startup remain non-migrating.
 
+The unified fresh-server declaration includes public relay-machine authority,
+device authentication, ingress, memory read/mutation opt-ins, and trusted
+attachment storage. Relay authority is read only from a protected bounded file
+and canonicalized before the owner bootstrap; trusted attachments require an
+existing private blob directory beneath daemon data. A new declaration with
+relay authority enables PostgreSQL relay storage immediately, while the
+separate mail-cutover preparatory enrollment remains dark until its
+owner-controlled cutover marker. Invalid, incomplete, or contradictory inputs
+fail before any listener or database mutation. Older published templates remain
+valid only as matched generations during explicit lifecycle recovery; the
+operator never hand-edits generated runtime files to upgrade a server.
+
 Internet and existing-proxy profiles require a canonical HTTPS public URL and
 a loopback origin. Trusted-LAN plaintext is an explicit exception requiring a
 concrete private or link-local bind, a containing private/link-local CIDR, and

--- a/cmd/punaro/main.go
+++ b/cmd/punaro/main.go
@@ -766,7 +766,7 @@ func createBackupWithUpdate(ctx context.Context, installation operator.Installat
 	}
 	options := punarobackup.CreateOptions{
 		BackupRoot:       installation.BackupDir,
-		BlobRoot:         filepath.Join(installation.DataDir, "blobs"),
+		BlobRoot:         backupBlobRoot(installation),
 		InstallationFile: operator.ConfigFile(installation.Directory),
 		EnvironmentFile:  operator.EnvFile(installation.Directory),
 		ComposeFile:      operator.OverrideFile(installation.Directory),
@@ -888,6 +888,7 @@ func restoreBackup(ctx context.Context, request restoreRequest) (punarobackup.St
 	}
 	target := punarobackup.RestoreTarget{
 		InstallationDirectory: filepath.Join(canonicalInstallationParent, filepath.Base(request.Directory)),
+		BlobRoot:              backupBlobRoot(prepared),
 		BackupRoot:            canonicalNewBackup,
 		OwnerDSNFile:          canonicalOwnerDSN,
 		AppDSNFile:            canonicalAppDSN,
@@ -1027,6 +1028,13 @@ func restoreBackup(ctx context.Context, request restoreRequest) (punarobackup.St
 		return punarobackup.State{}, errors.New("restored installation identity changed")
 	}
 	return state, nil
+}
+
+func backupBlobRoot(installation operator.Installation) string {
+	if installation.TrustedAttachmentsEnabled {
+		return installation.TrustedAttachmentBlobDir
+	}
+	return filepath.Join(installation.DataDir, "blobs")
 }
 
 func receiptMatchesBinding(receipt operator.UpdateRecoveryReceipt, binding punarobackup.UpdateBinding) bool {

--- a/cmd/punaro/main.go
+++ b/cmd/punaro/main.go
@@ -415,7 +415,7 @@ func runInit(args []string, stdout, stderr io.Writer) int {
 		}
 		return createOwner(ctx, ownerFile, name)
 	}
-	installation, err := operator.Init(context.Background(), operator.InitOptions{Directory: *directory, DataDir: *dataDir, BackupDir: *backupDir, Image: *image, OwnerDSNFile: *ownerDSN, AppDSNFile: *appDSN, OwnerName: *ownerName, Ingress: ingress.Policy{Mode: ingress.Mode(*mode), ListenAddr: *listen, PublicURL: *publicURL, TrustedLAN: *trustedLAN, AllowPlaintext: *allowLANHTTP}, HealthListenAddr: *healthListen, MemoryAPIEnabled: *memoryAPI, MemoryMutationsEnabled: *memoryMutations, TrustedAttachmentsEnabled: *trustedAttachments, TrustedAttachmentBlobDir: *trustedAttachmentBlobDir, RelayMachinesJSON: relayMachinesJSON}, bootstrap)
+	installation, err := operator.Init(context.Background(), operator.InitOptions{Directory: *directory, DataDir: *dataDir, BackupDir: *backupDir, Image: *image, OwnerDSNFile: *ownerDSN, AppDSNFile: *appDSN, OwnerName: *ownerName, Ingress: ingress.Policy{Mode: ingress.Mode(*mode), ListenAddr: *listen, PublicURL: *publicURL, TrustedLAN: *trustedLAN, AllowPlaintext: *allowLANHTTP}, HealthListenAddr: *healthListen, MemoryAPIEnabled: *memoryAPI, MemoryMutationsEnabled: *memoryMutations, TrustedAttachmentsEnabled: *trustedAttachments, TrustedAttachmentBlobDir: *trustedAttachmentBlobDir, RelayEnabled: relayMachinesJSON != "", RelayMachinesJSON: relayMachinesJSON}, bootstrap)
 	if err != nil {
 		_, _ = fmt.Fprintf(stderr, "punaro init failed: %v\n", err)
 		return 1

--- a/cmd/punaro/main.go
+++ b/cmd/punaro/main.go
@@ -367,6 +367,9 @@ func runInit(args []string, stdout, stderr io.Writer) int {
 	allowLANHTTP := flags.Bool("allow-lan-http", false, "explicitly allow plaintext credentials from the trusted LAN")
 	memoryAPI := flags.Bool("memory-api", false, "enable the authenticated native memory API")
 	memoryMutations := flags.Bool("memory-mutations", false, "enable authenticated canonical memory mutations (requires --memory-api)")
+	relayMachinesFile := flags.String("relay-machines-file", "", "protected relay machine enrollment JSON file")
+	trustedAttachments := flags.Bool("trusted-attachments", false, "enable trusted attachment storage")
+	trustedAttachmentBlobDir := flags.String("trusted-attachment-blob-dir", "", "existing private attachment blob directory below --data-dir")
 	healthListen := flags.String("health-listen-addr", "127.0.0.1:8081", "distinct loopback-only health listener")
 	resume := flags.Bool("resume", false, "resume a durably staged initialization")
 	if flags.Parse(args) != nil || flags.NArg() != 0 || *directory == "" {
@@ -382,6 +385,15 @@ func runInit(args []string, stdout, stderr io.Writer) int {
 	}
 	if *dataDir == "" || *backupDir == "" || *image == "" || *ownerDSN == "" || *appDSN == "" || *ownerName == "" || *mode == "" {
 		return 2
+	}
+	relayMachinesJSON := ""
+	if *relayMachinesFile != "" {
+		var err error
+		relayMachinesJSON, err = operator.ReadRelayMachinesFile(*relayMachinesFile)
+		if err != nil {
+			_, _ = fmt.Fprintln(stderr, "punaro init failed: relay enrollment file is unavailable")
+			return 1
+		}
 	}
 	bootstrap := func(ctx context.Context, ownerFile, name string) (punaropostgres.Principal, error) {
 		state, err := inspectSchema(ctx, *appDSN)
@@ -403,7 +415,7 @@ func runInit(args []string, stdout, stderr io.Writer) int {
 		}
 		return createOwner(ctx, ownerFile, name)
 	}
-	installation, err := operator.Init(context.Background(), operator.InitOptions{Directory: *directory, DataDir: *dataDir, BackupDir: *backupDir, Image: *image, OwnerDSNFile: *ownerDSN, AppDSNFile: *appDSN, OwnerName: *ownerName, Ingress: ingress.Policy{Mode: ingress.Mode(*mode), ListenAddr: *listen, PublicURL: *publicURL, TrustedLAN: *trustedLAN, AllowPlaintext: *allowLANHTTP}, HealthListenAddr: *healthListen, MemoryAPIEnabled: *memoryAPI, MemoryMutationsEnabled: *memoryMutations}, bootstrap)
+	installation, err := operator.Init(context.Background(), operator.InitOptions{Directory: *directory, DataDir: *dataDir, BackupDir: *backupDir, Image: *image, OwnerDSNFile: *ownerDSN, AppDSNFile: *appDSN, OwnerName: *ownerName, Ingress: ingress.Policy{Mode: ingress.Mode(*mode), ListenAddr: *listen, PublicURL: *publicURL, TrustedLAN: *trustedLAN, AllowPlaintext: *allowLANHTTP}, HealthListenAddr: *healthListen, MemoryAPIEnabled: *memoryAPI, MemoryMutationsEnabled: *memoryMutations, TrustedAttachmentsEnabled: *trustedAttachments, TrustedAttachmentBlobDir: *trustedAttachmentBlobDir, RelayMachinesJSON: relayMachinesJSON}, bootstrap)
 	if err != nil {
 		_, _ = fmt.Fprintf(stderr, "punaro init failed: %v\n", err)
 		return 1

--- a/cmd/punaro/main.go
+++ b/cmd/punaro/main.go
@@ -888,11 +888,13 @@ func restoreBackup(ctx context.Context, request restoreRequest) (punarobackup.St
 	}
 	target := punarobackup.RestoreTarget{
 		InstallationDirectory: filepath.Join(canonicalInstallationParent, filepath.Base(request.Directory)),
-		BlobRoot:              backupBlobRoot(prepared),
 		BackupRoot:            canonicalNewBackup,
 		OwnerDSNFile:          canonicalOwnerDSN,
 		AppDSNFile:            canonicalAppDSN,
 		DatabaseIdentity:      targetIdentity,
+	}
+	if prepared.TrustedAttachmentsEnabled {
+		target.BlobRoot = prepared.TrustedAttachmentBlobDir
 	}
 	if updateMarker != nil {
 		target.UpdateID = updateMarker.UpdateID

--- a/cmd/punaro/main.go
+++ b/cmd/punaro/main.go
@@ -903,7 +903,7 @@ func restoreBackup(ctx context.Context, request restoreRequest) (punarobackup.St
 	finalizationStage := ""
 	state, err := punarobackup.Restore(ctx, punarobackup.RestoreOptions{
 		BackupDirectory: request.BackupDirectory,
-		TargetDataDir:   request.DataDir,
+		TargetDataDir:   prepared.DataDir,
 		Target:          target,
 		Preflight: func(preflightCtx context.Context) error {
 			currentIdentity, identityErr := postgresDatabaseIdentity(preflightCtx, request.AppDSNFile)

--- a/cmd/punaro/main_test.go
+++ b/cmd/punaro/main_test.go
@@ -417,6 +417,17 @@ func testInstallation(t *testing.T) string {
 	return directory
 }
 
+func TestBackupBlobRootUsesConfiguredTrustedAttachmentDirectory(t *testing.T) {
+	installation := operator.Installation{DataDir: "/var/lib/punaro-data", TrustedAttachmentsEnabled: true, TrustedAttachmentBlobDir: "/var/lib/punaro-data/attachments"}
+	if got, want := backupBlobRoot(installation), installation.TrustedAttachmentBlobDir; got != want {
+		t.Fatalf("blob root=%q want=%q", got, want)
+	}
+	installation.TrustedAttachmentsEnabled = false
+	if got, want := backupBlobRoot(installation), "/var/lib/punaro-data/blobs"; got != want {
+		t.Fatalf("legacy blob root=%q want=%q", got, want)
+	}
+}
+
 func preserveDependencies(t *testing.T) {
 	t.Helper()
 	originalInspect, originalOwner, originalMigrate, originalMaintenance := inspectSchema, inspectOwner, migratePristinePair, maintenanceActive

--- a/cmd/punaro/main_test.go
+++ b/cmd/punaro/main_test.go
@@ -853,7 +853,8 @@ func TestInitMigratesPristineBeforeCreatingOwner(t *testing.T) {
 		t.Fatalf("code=%d sequence=%v stdout=%q stderr=%q", code, sequence, stdout.String(), stderr.String())
 	}
 	installation, err := operator.Load(filepath.Join(root, "install"))
-	if err != nil || !installation.RelayEnabled || !installation.TrustedAttachmentsEnabled || installation.TrustedAttachmentBlobDir != filepath.Join(root, "data", "attachments") {
+	wantBlobDir, canonicalErr := filepath.EvalSymlinks(filepath.Join(root, "data", "attachments"))
+	if err != nil || canonicalErr != nil || !installation.RelayEnabled || !installation.TrustedAttachmentsEnabled || installation.TrustedAttachmentBlobDir != wantBlobDir {
 		t.Fatalf("installation=%#v err=%v", installation, err)
 	}
 }

--- a/cmd/punaro/main_test.go
+++ b/cmd/punaro/main_test.go
@@ -806,7 +806,7 @@ func TestDoctorFailsForConfigurationDriftAndRoleMismatch(t *testing.T) {
 func TestInitMigratesPristineBeforeCreatingOwner(t *testing.T) {
 	preserveDependencies(t)
 	root := t.TempDir()
-	for _, name := range []string{"data", "backup"} {
+	for _, name := range []string{"data", "backup", "data/attachments"} {
 		if err := os.Mkdir(filepath.Join(root, name), 0o700); err != nil {
 			t.Fatal(err)
 		}
@@ -815,6 +815,10 @@ func TestInitMigratesPristineBeforeCreatingOwner(t *testing.T) {
 		if err := os.WriteFile(filepath.Join(root, name), []byte("postgres://invalid\n"), 0o600); err != nil {
 			t.Fatal(err)
 		}
+	}
+	relayMachines := filepath.Join(root, "relay-machines.json")
+	if err := os.WriteFile(relayMachines, []byte(`[{"id":"machine-a","public_key":"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA","endpoint_prefixes":["agent/a/"],"endpoints":[],"attachment_device_id":""}]`), 0o600); err != nil {
+		t.Fatal(err)
 	}
 	sequence := []string{}
 	inspectSchema = func(context.Context, string) (punaropostgres.SchemaState, error) {
@@ -832,10 +836,14 @@ func TestInitMigratesPristineBeforeCreatingOwner(t *testing.T) {
 		sequence = append(sequence, "owner")
 		return punaropostgres.Principal{ID: "11111111-1111-4111-8111-111111111111"}, nil
 	}
-	args := []string{"init", "--directory", filepath.Join(root, "install"), "--data-dir", filepath.Join(root, "data"), "--backup-dir", filepath.Join(root, "backup"), "--image", cliTestImage, "--owner-dsn-file", filepath.Join(root, "owner.dsn"), "--app-dsn-file", filepath.Join(root, "app.dsn"), "--owner-name", "operator", "--mode", "internet", "--public-url", "https://punaro.example"}
+	args := []string{"init", "--directory", filepath.Join(root, "install"), "--data-dir", filepath.Join(root, "data"), "--backup-dir", filepath.Join(root, "backup"), "--image", cliTestImage, "--owner-dsn-file", filepath.Join(root, "owner.dsn"), "--app-dsn-file", filepath.Join(root, "app.dsn"), "--owner-name", "operator", "--mode", "internet", "--public-url", "https://punaro.example", "--relay-machines-file", relayMachines, "--trusted-attachments", "--trusted-attachment-blob-dir", filepath.Join(root, "data", "attachments")}
 	var stdout, stderr bytes.Buffer
 	if code := run(args, &stdout, &stderr); code != 0 || strings.Join(sequence, ",") != "inspect,migrate,inspect,owner" {
 		t.Fatalf("code=%d sequence=%v stdout=%q stderr=%q", code, sequence, stdout.String(), stderr.String())
+	}
+	installation, err := operator.Load(filepath.Join(root, "install"))
+	if err != nil || !installation.RelayEnabled || !installation.TrustedAttachmentsEnabled || installation.TrustedAttachmentBlobDir != filepath.Join(root, "data", "attachments") {
+		t.Fatalf("installation=%#v err=%v", installation, err)
 	}
 }
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,17 +1,24 @@
 # Installation guide
 
-Punaro has two intentionally separate installation paths:
+Punaro has a supported unified server lifecycle and separate per-machine client
+installers:
 
-- **Server**: one Linux systemd relay, owned by an operator. It remains
-  loopback-only; a separately configured authenticated ingress reaches it.
+- **Server**: one Linux operator lifecycle, initialized once with `punaro init`.
+  It generates the complete daemon configuration from explicit inputs and
+  keeps the service, database, health listener, and credentials host-local.
 - **Client**: one adapter for each agent machine and user account. Each gets a
   unique machine key, Access token, and `agent/<machine>/` endpoint namespace.
 
 The scripts build from the source checkout you run them from. Use a reviewed,
 pinned checkout or a verified release artifact; do not pipe a network download
-into a shell. Neither installer accepts or prints secret values.
+into a shell. Neither installer accepts or prints secret values. For the
+supported fresh server path, follow the [production Compose lifecycle](production-compose.md#first-installation).
+It is the sole path that configures relay authority, device authentication,
+trusted attachment storage, memory APIs, ingress, and lifecycle recovery
+together. `scripts/install-server.sh` below is retained only for historical
+alpha relay deployments; do not use it for a new unified server.
 
-## 1. Install the server
+## Historical alpha server installer (not for new unified servers)
 
 First collect the **public** client enrollment records into one JSON array on
 the relay host. The client installer prints each record; it contains a public
@@ -130,8 +137,10 @@ if you decline it during client setup.
 
 ## 3. Approve and configure the client
 
-1. Add the printed JSON record to the relay's `PUNARO_RELAY_MACHINES_JSON`,
-   then restart `punarod`. Do not widen it to `codex/` or `claude/`.
+1. For a new unified server, add the printed JSON record to the protected
+   relay-machine file before the initial `punaro init --relay-machines-file`.
+   Do not hand-edit `PUNARO_RELAY_MACHINES_JSON` or widen a namespace to
+   `codex/` or `claude/`.
 2. Create a **distinct** Cloudflare Access service token and policy for this
    machine, if the relay is Access-protected. Use a secret manager or editor to
    add its paired client ID and secret to the owner-only

--- a/docs/production-compose.md
+++ b/docs/production-compose.md
@@ -71,8 +71,18 @@ Set `PUNARO_COMPOSE_PROJECT_NAME` once to a unique, lowercase installation ID
 explicitly to Docker Compose, preventing another checkout or an ambient
 `COMPOSE_PROJECT_NAME` from sharing or deleting this installation's volumes.
 
-Create private, non-overlapping daemon data, backup, and installation
-directories outside the repository, then initialize and start the daemon:
+Create private, non-overlapping daemon data, backup, attachment-blob, and
+installation directories outside the repository. Collect the public relay
+machine records into one owner-only JSON file. This file is declarative input,
+not a secret: it contains public keys and exclusive endpoint prefixes only.
+The initial `punaro init` is the one supported server configuration boundary;
+do not hand-edit the generated environment or Compose files.
+
+To enable every currently supported surface on a fresh installation, initialize
+and start the daemon with the explicit opt-ins below. Omit either optional flag
+to keep that surface dark. The attachment blob directory must already exist,
+be private, and be beneath `DATA_DIR`; credentials and operator state must
+remain outside `DATA_DIR`.
 
 ```sh
 scripts/production-compose up -d postgres-bootstrap
@@ -86,14 +96,31 @@ punaro init \
   --app-dsn-file APP_DSN_FILE \
   --owner-name 'Production operator' \
   --mode proxy \
-  --public-url "$PUNARO_PUBLIC_URL"
+  --public-url "$PUNARO_PUBLIC_URL" \
+  --relay-machines-file RELAY_MACHINES_FILE \
+  --trusted-attachments \
+  --trusted-attachment-blob-dir DATA_DIR/attachments
 punaro up --directory INSTALLATION_DIR
 ```
+
+`--relay-machines-file` is read only after protected-file checks and is
+canonicalized before any database mutation. `--trusted-attachments` requires
+its blob-directory argument; a stray blob-directory argument, unsafe path, or
+contradictory opt-in fails before listeners start. The generated runtime uses
+PostgreSQL relay authority and device authentication, while its daemon,
+database, health endpoint, and Compose credentials remain host-local.
 
 For every later release, use `punaro update --directory INSTALLATION_DIR` with
 the protected release metadata distributed for that release. This preserves the
 same durable update journal and recovery path as the initial installation; do
 not replace `PUNARO_IMAGE` and restart the reference bundle directly.
+
+Existing installations retain their published configuration through upgrade and
+recovery. Re-run `punaro init --resume --directory INSTALLATION_DIR` only after
+an interrupted first initialization; it never reinterprets new optional inputs
+or opens a listener before the durable marker is complete. Backup and restore
+continue to use their explicit lifecycle commands and a new target staging
+directory rather than overwriting a live installation.
 
 The application and PostgreSQL bind only to `127.0.0.1` for a separately
 configured local tunnel or reverse proxy. The bundle defines no published ports;

--- a/internal/backup/restore.go
+++ b/internal/backup/restore.go
@@ -157,6 +157,9 @@ func Restore(ctx context.Context, options RestoreOptions) (State, error) {
 		if err := os.RemoveAll(stage); err != nil || os.Mkdir(stage, 0o700) != nil {
 			return fail(PhasePreflight, "restore blob staging cannot be reserved")
 		}
+		if options.Target.BlobRoot != "" && os.MkdirAll(filepath.Join(stage, blobRelative), 0o700) != nil {
+			return fail(PhasePreflight, "restore attachment staging cannot be reserved")
+		}
 		for _, entry := range manifest.Files {
 			if !strings.HasPrefix(entry.Path, "blobs/") {
 				continue

--- a/internal/backup/restore.go
+++ b/internal/backup/restore.go
@@ -50,6 +50,7 @@ type RestoreOptions struct {
 // RestoreTarget binds every non-secret target identity to the durable journal.
 type RestoreTarget struct {
 	InstallationDirectory string `json:"installation_directory"`
+	BlobRoot              string `json:"blob_root,omitempty"`
 	BackupRoot            string `json:"backup_root"`
 	OwnerDSNFile          string `json:"owner_dsn_file"`
 	AppDSNFile            string `json:"app_dsn_file"`
@@ -85,6 +86,14 @@ func Restore(ctx context.Context, options RestoreOptions) (State, error) {
 	}
 	if options.Preflight == nil || options.RestoreDump == nil || options.RotateTimeline == nil || options.Finalize == nil || !filepath.IsAbs(options.TargetDataDir) || filepath.Clean(options.TargetDataDir) != options.TargetDataDir || !validRestoreTarget(options.Target) {
 		return fail(PhasePreflight, "restore inputs are invalid")
+	}
+	blobRoot := options.Target.BlobRoot
+	if blobRoot == "" {
+		blobRoot = filepath.Join(options.TargetDataDir, "blobs")
+	}
+	blobRelative, blobErr := filepath.Rel(options.TargetDataDir, blobRoot)
+	if blobErr != nil || !validRelativePath(blobRelative) {
+		return fail(PhasePreflight, "restore blob root is invalid")
 	}
 	manifest, err := Verify(options.BackupDirectory)
 	if err != nil {
@@ -157,8 +166,8 @@ func Restore(ctx context.Context, options RestoreOptions) (State, error) {
 				return fail(PhasePreflight, "backup blob path is invalid")
 			}
 			source := filepath.Join(options.BackupDirectory, filepath.FromSlash(entry.Path))
-			destination := filepath.Join(stage, "blobs", filepath.FromSlash(relative))
-			if err := copyProtectedFile(source, destination, entry.Size); err != nil || verifyFile(stage, entry) != nil {
+			destination := filepath.Join(stage, blobRelative, filepath.FromSlash(relative))
+			if err := copyProtectedFile(source, destination, entry.Size); err != nil || verifyBlobFile(filepath.Join(stage, blobRelative), entry) != nil {
 				return fail(PhasePreflight, "verified backup blob could not be staged")
 			}
 		}
@@ -170,7 +179,7 @@ func Restore(ctx context.Context, options RestoreOptions) (State, error) {
 	if info, statErr := os.Lstat(options.TargetDataDir); statErr == nil && info.IsDir() {
 		blobVerificationRoot = options.TargetDataDir
 	}
-	if err := verifyManifestBlobs(blobVerificationRoot, manifest); err != nil {
+	if err := verifyManifestBlobs(filepath.Join(blobVerificationRoot, blobRelative), manifest); err != nil {
 		if blobVerificationRoot == options.TargetDataDir {
 			return fail(PhaseDataPublished, "published restore blobs do not match the verified backup")
 		}
@@ -237,7 +246,7 @@ func Restore(ctx context.Context, options RestoreOptions) (State, error) {
 			return fail(PhaseDataPublished, "restore data was published but its journal marker is not durable; retry the exact restore command")
 		}
 	}
-	if err := verifyManifestBlobs(options.TargetDataDir, manifest); err != nil {
+	if err := verifyManifestBlobs(blobRoot, manifest); err != nil {
 		return fail(PhaseDataPublished, "published restore blobs do not match the verified backup")
 	}
 
@@ -281,6 +290,9 @@ func validRestoreTarget(target RestoreTarget) bool {
 			return false
 		}
 	}
+	if target.BlobRoot != "" && (!filepath.IsAbs(target.BlobRoot) || filepath.Clean(target.BlobRoot) != target.BlobRoot) {
+		return false
+	}
 	decoded, err := hex.DecodeString(target.DatabaseIdentity)
 	if target.OwnerDSNFile == target.AppDSNFile || err != nil || len(decoded) != 32 || hex.EncodeToString(decoded) != target.DatabaseIdentity {
 		return false
@@ -298,12 +310,21 @@ func validRestoreTarget(target RestoreTarget) bool {
 func verifyManifestBlobs(root string, manifest Manifest) error {
 	for _, entry := range manifest.Files {
 		if strings.HasPrefix(entry.Path, "blobs/") {
-			if err := verifyFile(root, entry); err != nil {
+			if err := verifyBlobFile(root, entry); err != nil {
 				return err
 			}
 		}
 	}
 	return nil
+}
+
+func verifyBlobFile(root string, entry File) error {
+	relative := strings.TrimPrefix(entry.Path, "blobs/")
+	if !validRelativePath(relative) {
+		return errors.New("backup blob path is invalid")
+	}
+	entry.Path = relative
+	return verifyFile(root, entry)
 }
 
 func manifestFile(manifest Manifest, path string) (File, bool) {

--- a/internal/backup/restore_test.go
+++ b/internal/backup/restore_test.go
@@ -16,11 +16,13 @@ func TestRestorePublishesVerifiedBlobsAfterDatabaseAndTimeline(t *testing.T) {
 	targetParent := t.TempDir()
 	requirePrivate(t, targetParent)
 	target := filepath.Join(targetParent, "restored-data")
+	targetConfig := restoreTargetFixture(targetParent)
+	targetConfig.BlobRoot = filepath.Join(target, "attachments")
 	called := []string{}
 	state, err := Restore(context.Background(), RestoreOptions{
 		BackupDirectory: backupDirectory,
 		TargetDataDir:   target,
-		Target:          restoreTargetFixture(targetParent),
+		Target:          targetConfig,
 		Preflight:       func(context.Context) error { return nil },
 		RestoreDump: func(_ context.Context, dump io.Reader) error {
 			called = append(called, "database")
@@ -49,7 +51,7 @@ func TestRestorePublishesVerifiedBlobsAfterDatabaseAndTimeline(t *testing.T) {
 		t.Fatalf("unexpected restored state: %#v", state)
 	}
 	// #nosec G304 -- fixed child of the private test restore target.
-	if body, err := os.ReadFile(filepath.Join(target, "blobs", "ready")); err != nil || string(body) != "blob" {
+	if body, err := os.ReadFile(filepath.Join(target, "attachments", "ready")); err != nil || string(body) != "blob" {
 		t.Fatalf("restored blob=%q err=%v", body, err)
 	}
 }

--- a/internal/backup/restore_test.go
+++ b/internal/backup/restore_test.go
@@ -56,6 +56,24 @@ func TestRestorePublishesVerifiedBlobsAfterDatabaseAndTimeline(t *testing.T) {
 	}
 }
 
+func TestRestoreCreatesConfiguredEmptyBlobRoot(t *testing.T) {
+	backupDirectory, _ := createRestoreFixture(t, false)
+	targetParent := t.TempDir()
+	requirePrivate(t, targetParent)
+	target := filepath.Join(targetParent, "restored-data")
+	targetConfig := restoreTargetFixture(targetParent)
+	targetConfig.BlobRoot = filepath.Join(target, "attachments")
+	_, err := Restore(context.Background(), RestoreOptions{BackupDirectory: backupDirectory, TargetDataDir: target, Target: targetConfig, Preflight: func(context.Context) error { return nil }, RestoreDump: func(context.Context, io.Reader) error { return nil }, RotateTimeline: func(_ context.Context, manifest Manifest) (State, error) {
+		return State{InstallationID: manifest.State.InstallationID, TimelineID: "7c016e76-aadb-48f8-b460-e75f7d90e888", ChangeSequence: manifest.State.ChangeSequence}, nil
+	}, Finalize: func(context.Context, State) error { return nil }})
+	if err != nil {
+		t.Fatalf("restore: %v", err)
+	}
+	if info, statErr := os.Stat(targetConfig.BlobRoot); statErr != nil || !info.IsDir() {
+		t.Fatalf("attachment root info=%v err=%v", info, statErr)
+	}
+}
+
 func TestRestoreResumesAfterPublishedFinalizationFailureWithoutRepeatingMutation(t *testing.T) {
 	backupDirectory, _ := createRestoreFixture(t, true)
 	targetParent := t.TempDir()

--- a/internal/operator/installation.go
+++ b/internal/operator/installation.go
@@ -269,6 +269,16 @@ func validateInit(options InitOptions) (Installation, error) {
 		if !attachmentBlobDirectoryContained(options.DataDir, options.TrustedAttachmentBlobDir) {
 			return Installation{}, errors.New("trusted attachment blob directory must resolve beneath the data directory")
 		}
+		canonicalData, err := filepath.EvalSymlinks(options.DataDir)
+		if err != nil {
+			return Installation{}, errors.New("data directory cannot be resolved")
+		}
+		canonicalBlob, err := filepath.EvalSymlinks(options.TrustedAttachmentBlobDir)
+		if err != nil {
+			return Installation{}, errors.New("trusted attachment blob directory cannot be resolved")
+		}
+		installation.DataDir = canonicalData
+		installation.TrustedAttachmentBlobDir = canonicalBlob
 	}
 	dataInfo, dataErr := os.Stat(options.DataDir)
 	backupInfo, backupErr := os.Stat(options.BackupDir)

--- a/internal/operator/installation.go
+++ b/internal/operator/installation.go
@@ -611,7 +611,18 @@ func attachmentContainerBlobDir(installation Installation) string {
 	if !installation.TrustedAttachmentsEnabled {
 		return ""
 	}
-	relative, _ := filepath.Rel(installation.DataDir, installation.TrustedAttachmentBlobDir)
+	canonicalData, err := filepath.EvalSymlinks(installation.DataDir)
+	if err != nil {
+		return ""
+	}
+	canonicalBlob, err := filepath.EvalSymlinks(installation.TrustedAttachmentBlobDir)
+	if err != nil {
+		return ""
+	}
+	relative, err := filepath.Rel(canonicalData, canonicalBlob)
+	if err != nil || !nestedPath(canonicalData, canonicalBlob) {
+		return ""
+	}
 	return filepath.ToSlash(filepath.Join("/var/lib/punaro", relative))
 }
 

--- a/internal/operator/installation.go
+++ b/internal/operator/installation.go
@@ -265,6 +265,9 @@ func validateInit(options InitOptions) (Installation, error) {
 		if err := requireTrustedPrivateDirectory(options.TrustedAttachmentBlobDir); err != nil {
 			return Installation{}, fmt.Errorf("trusted attachment blob directory: %w", err)
 		}
+		if !attachmentBlobDirectoryContained(options.DataDir, options.TrustedAttachmentBlobDir) {
+			return Installation{}, errors.New("trusted attachment blob directory must resolve beneath the data directory")
+		}
 	}
 	dataInfo, dataErr := os.Stat(options.DataDir)
 	backupInfo, backupErr := os.Stat(options.BackupDir)
@@ -334,7 +337,7 @@ func validateStatic(options InitOptions) (Installation, error) {
 		return Installation{}, errors.New("memory mutations require the memory API")
 	}
 	if options.TrustedAttachmentsEnabled {
-		if !filepath.IsAbs(options.TrustedAttachmentBlobDir) || filepath.Clean(options.TrustedAttachmentBlobDir) != options.TrustedAttachmentBlobDir || !nestedPath(options.DataDir, options.TrustedAttachmentBlobDir) {
+		if !filepath.IsAbs(options.TrustedAttachmentBlobDir) || filepath.Clean(options.TrustedAttachmentBlobDir) != options.TrustedAttachmentBlobDir || !safeEnvPath(options.TrustedAttachmentBlobDir) || !nestedPath(options.DataDir, options.TrustedAttachmentBlobDir) {
 			return Installation{}, errors.New("trusted attachments require a private blob directory beneath the data directory")
 		}
 	} else if options.TrustedAttachmentBlobDir != "" {
@@ -346,6 +349,9 @@ func validateStatic(options InitOptions) (Installation, error) {
 		relayMachines, err = canonicalRelayMachinesJSON(options.RelayMachinesJSON)
 		if err != nil {
 			return Installation{}, err
+		}
+		if !listener.IsLoopback(policy.ListenAddr) {
+			return Installation{}, errors.New("relay authority requires a loopback device listener")
 		}
 	}
 	return Installation{Version: 1, Directory: options.Directory, DataDir: options.DataDir, BackupDir: options.BackupDir, Image: options.Image, OwnerDSNFile: options.OwnerDSNFile, AppDSNFile: options.AppDSNFile, OwnerName: options.OwnerName, Ingress: policy, HealthListenAddr: healthListenAddr, HealthURL: localURL(healthListenAddr), MemoryAPIEnabled: options.MemoryAPIEnabled, MemoryMutationsEnabled: options.MemoryMutationsEnabled, TrustedAttachmentsEnabled: options.TrustedAttachmentsEnabled, TrustedAttachmentBlobDir: options.TrustedAttachmentBlobDir, RelayEnabled: relayMachines != "", RelayMachinesJSON: relayMachines}, nil
@@ -387,6 +393,9 @@ func Load(directory string) (Installation, error) {
 	}
 	if installation.HealthListenAddr != validated.HealthListenAddr || installation.HealthURL != validated.HealthURL {
 		return Installation{}, errors.New("published installation health URL is invalid")
+	}
+	if installation.TrustedAttachmentsEnabled && !attachmentBlobDirectoryContained(installation.DataDir, installation.TrustedAttachmentBlobDir) {
+		return Installation{}, errors.New("published installation trusted attachment directory is invalid")
 	}
 	installation.Directory = directory
 	return installation, nil
@@ -478,6 +487,9 @@ func CheckPaths(installation Installation) []string {
 		if err := requireTrustedPrivateDirectory(installation.TrustedAttachmentBlobDir); err != nil {
 			failures = append(failures, "trusted attachment blob directory unavailable or unsafe")
 		}
+		if !attachmentBlobDirectoryContained(installation.DataDir, installation.TrustedAttachmentBlobDir) {
+			failures = append(failures, "trusted attachment blob directory is outside data directory")
+		}
 	}
 	if overlaps, err := canonicalDirectoriesOverlap(installation.DataDir, installation.BackupDir); err == nil && overlaps {
 		failures = append(failures, "data and backup directories overlap")
@@ -506,9 +518,9 @@ func CheckPaths(installation Installation) []string {
 		if envAvailable {
 			envCurrent = string(body) == daemonEnv(installation)
 			envPreTrustedAttachments = !installation.TrustedAttachmentsEnabled && string(body) == preTrustedAttachmentsDaemonEnv(installation)
-			envPreMemoryMutations = !installation.MemoryMutationsEnabled && string(body) == preMemoryMutationsDaemonEnv(installation)
-			envPreMemoryAPI = !installation.MemoryAPIEnabled && string(body) == preMemoryAPIDaemonEnv(installation)
-			envLegacy = !installation.MemoryAPIEnabled && installation.MailCutover == nil && installation.RelayMachinesJSON == "" && string(body) == legacyDaemonEnv(installation)
+			envPreMemoryMutations = !installation.TrustedAttachmentsEnabled && !installation.MemoryMutationsEnabled && string(body) == preMemoryMutationsDaemonEnv(installation)
+			envPreMemoryAPI = !installation.TrustedAttachmentsEnabled && !installation.MemoryAPIEnabled && string(body) == preMemoryAPIDaemonEnv(installation)
+			envLegacy = !installation.TrustedAttachmentsEnabled && !installation.MemoryAPIEnabled && installation.MailCutover == nil && installation.RelayMachinesJSON == "" && string(body) == legacyDaemonEnv(installation)
 		}
 		if !envCurrent && !envPreTrustedAttachments && !envPreMemoryMutations && !envPreMemoryAPI && !envLegacy {
 			failures = append(failures, "generated daemon environment does not match installation configuration")
@@ -525,9 +537,9 @@ func CheckPaths(installation Installation) []string {
 		if overrideAvailable {
 			overrideCurrent = string(body) == composeOverride()
 			overridePreTrustedAttachments = !installation.TrustedAttachmentsEnabled && string(body) == preTrustedAttachmentsComposeOverride()
-			overridePreMemoryMutations = !installation.MemoryMutationsEnabled && string(body) == preMemoryMutationsComposeOverride()
-			overridePreMemoryAPI = !installation.MemoryAPIEnabled && string(body) == preMemoryAPIComposeOverride()
-			overrideLegacy = !installation.MemoryAPIEnabled && installation.MailCutover == nil && installation.RelayMachinesJSON == "" && string(body) == legacyComposeOverride()
+			overridePreMemoryMutations = !installation.TrustedAttachmentsEnabled && !installation.MemoryMutationsEnabled && string(body) == preMemoryMutationsComposeOverride()
+			overridePreMemoryAPI = !installation.TrustedAttachmentsEnabled && !installation.MemoryAPIEnabled && string(body) == preMemoryAPIComposeOverride()
+			overrideLegacy = !installation.TrustedAttachmentsEnabled && !installation.MemoryAPIEnabled && installation.MailCutover == nil && installation.RelayMachinesJSON == "" && string(body) == legacyComposeOverride()
 		}
 		if !overrideCurrent && !overridePreTrustedAttachments && !overridePreMemoryMutations && !overridePreMemoryAPI && !overrideLegacy {
 			failures = append(failures, "generated Compose override does not match installation configuration")
@@ -713,6 +725,18 @@ func safeEnvPath(value string) bool {
 func nestedPath(parent, child string) bool {
 	relative, err := filepath.Rel(filepath.Clean(parent), filepath.Clean(child))
 	return err == nil && relative != "." && relative != ".." && !strings.HasPrefix(relative, ".."+string(filepath.Separator))
+}
+
+func attachmentBlobDirectoryContained(dataDir, blobDir string) bool {
+	canonicalData, err := filepath.EvalSymlinks(dataDir)
+	if err != nil {
+		return false
+	}
+	canonicalBlob, err := filepath.EvalSymlinks(blobDir)
+	if err != nil {
+		return false
+	}
+	return nestedPath(canonicalData, canonicalBlob)
 }
 
 func canonicalDirectoriesOverlap(first, second string) (bool, error) {

--- a/internal/operator/installation.go
+++ b/internal/operator/installation.go
@@ -277,6 +277,9 @@ func validateInit(options InitOptions) (Installation, error) {
 		if err != nil {
 			return Installation{}, errors.New("trusted attachment blob directory cannot be resolved")
 		}
+		if !filepath.IsAbs(canonicalData) || filepath.Clean(canonicalData) != canonicalData || !safeEnvPath(canonicalData) || !filepath.IsAbs(canonicalBlob) || filepath.Clean(canonicalBlob) != canonicalBlob || !safeEnvPath(canonicalBlob) || !nestedPath(canonicalData, canonicalBlob) {
+			return Installation{}, errors.New("resolved trusted attachment paths are unsafe")
+		}
 		installation.DataDir = canonicalData
 		installation.TrustedAttachmentBlobDir = canonicalBlob
 	}

--- a/internal/operator/installation.go
+++ b/internal/operator/installation.go
@@ -115,6 +115,7 @@ type InitOptions struct {
 	MemoryMutationsEnabled    bool
 	TrustedAttachmentsEnabled bool
 	TrustedAttachmentBlobDir  string
+	RelayEnabled              bool
 	RelayMachinesJSON         string
 }
 
@@ -219,7 +220,7 @@ func Resume(ctx context.Context, directory string, recoverOwner RecoverOwner) (I
 		return Installation{}, errors.New("initialization staging configuration is corrupt")
 	}
 	installation.Directory = directory
-	if _, err := validateStatic(InitOptions{Directory: directory, DataDir: installation.DataDir, BackupDir: installation.BackupDir, Image: installation.Image, OwnerDSNFile: installation.OwnerDSNFile, AppDSNFile: installation.AppDSNFile, OwnerName: installation.OwnerName, Ingress: installation.Ingress, HealthListenAddr: installation.HealthListenAddr, MemoryAPIEnabled: installation.MemoryAPIEnabled, MemoryMutationsEnabled: installation.MemoryMutationsEnabled, TrustedAttachmentsEnabled: installation.TrustedAttachmentsEnabled, TrustedAttachmentBlobDir: installation.TrustedAttachmentBlobDir, RelayMachinesJSON: installation.RelayMachinesJSON}); err != nil {
+	if _, err := validateStatic(InitOptions{Directory: directory, DataDir: installation.DataDir, BackupDir: installation.BackupDir, Image: installation.Image, OwnerDSNFile: installation.OwnerDSNFile, AppDSNFile: installation.AppDSNFile, OwnerName: installation.OwnerName, Ingress: installation.Ingress, HealthListenAddr: installation.HealthListenAddr, MemoryAPIEnabled: installation.MemoryAPIEnabled, MemoryMutationsEnabled: installation.MemoryMutationsEnabled, TrustedAttachmentsEnabled: installation.TrustedAttachmentsEnabled, TrustedAttachmentBlobDir: installation.TrustedAttachmentBlobDir, RelayEnabled: installation.RelayEnabled, RelayMachinesJSON: installation.RelayMachinesJSON}); err != nil {
 		return Installation{}, errors.New("initialization staging configuration is invalid")
 	}
 	if failures := CheckPaths(installation); len(failures) != 0 {
@@ -350,11 +351,14 @@ func validateStatic(options InitOptions) (Installation, error) {
 		if err != nil {
 			return Installation{}, err
 		}
-		if !listener.IsLoopback(policy.ListenAddr) {
-			return Installation{}, errors.New("relay authority requires a loopback device listener")
-		}
 	}
-	return Installation{Version: 1, Directory: options.Directory, DataDir: options.DataDir, BackupDir: options.BackupDir, Image: options.Image, OwnerDSNFile: options.OwnerDSNFile, AppDSNFile: options.AppDSNFile, OwnerName: options.OwnerName, Ingress: policy, HealthListenAddr: healthListenAddr, HealthURL: localURL(healthListenAddr), MemoryAPIEnabled: options.MemoryAPIEnabled, MemoryMutationsEnabled: options.MemoryMutationsEnabled, TrustedAttachmentsEnabled: options.TrustedAttachmentsEnabled, TrustedAttachmentBlobDir: options.TrustedAttachmentBlobDir, RelayEnabled: relayMachines != "", RelayMachinesJSON: relayMachines}, nil
+	if options.RelayEnabled && relayMachines == "" {
+		return Installation{}, errors.New("enabled relay requires machine enrollment")
+	}
+	if options.RelayEnabled && !listener.IsLoopback(policy.ListenAddr) {
+		return Installation{}, errors.New("relay authority requires a loopback device listener")
+	}
+	return Installation{Version: 1, Directory: options.Directory, DataDir: options.DataDir, BackupDir: options.BackupDir, Image: options.Image, OwnerDSNFile: options.OwnerDSNFile, AppDSNFile: options.AppDSNFile, OwnerName: options.OwnerName, Ingress: policy, HealthListenAddr: healthListenAddr, HealthURL: localURL(healthListenAddr), MemoryAPIEnabled: options.MemoryAPIEnabled, MemoryMutationsEnabled: options.MemoryMutationsEnabled, TrustedAttachmentsEnabled: options.TrustedAttachmentsEnabled, TrustedAttachmentBlobDir: options.TrustedAttachmentBlobDir, RelayEnabled: options.RelayEnabled, RelayMachinesJSON: relayMachines}, nil
 }
 
 // Load reads only a completely published installation marker.
@@ -387,7 +391,7 @@ func Load(directory string) (Installation, error) {
 	if installation.RelayEnabled && installation.RelayMachinesJSON == "" {
 		return Installation{}, errors.New("published installation relay configuration is invalid")
 	}
-	validated, err := validateStatic(InitOptions{Directory: directory, DataDir: installation.DataDir, BackupDir: installation.BackupDir, Image: installation.Image, OwnerDSNFile: installation.OwnerDSNFile, AppDSNFile: installation.AppDSNFile, OwnerName: installation.OwnerName, Ingress: installation.Ingress, HealthListenAddr: installation.HealthListenAddr, MemoryAPIEnabled: installation.MemoryAPIEnabled, MemoryMutationsEnabled: installation.MemoryMutationsEnabled, TrustedAttachmentsEnabled: installation.TrustedAttachmentsEnabled, TrustedAttachmentBlobDir: installation.TrustedAttachmentBlobDir, RelayMachinesJSON: installation.RelayMachinesJSON})
+	validated, err := validateStatic(InitOptions{Directory: directory, DataDir: installation.DataDir, BackupDir: installation.BackupDir, Image: installation.Image, OwnerDSNFile: installation.OwnerDSNFile, AppDSNFile: installation.AppDSNFile, OwnerName: installation.OwnerName, Ingress: installation.Ingress, HealthListenAddr: installation.HealthListenAddr, MemoryAPIEnabled: installation.MemoryAPIEnabled, MemoryMutationsEnabled: installation.MemoryMutationsEnabled, TrustedAttachmentsEnabled: installation.TrustedAttachmentsEnabled, TrustedAttachmentBlobDir: installation.TrustedAttachmentBlobDir, RelayEnabled: installation.RelayEnabled, RelayMachinesJSON: installation.RelayMachinesJSON})
 	if err != nil {
 		return Installation{}, errors.New("published installation configuration is invalid")
 	}

--- a/internal/operator/installation.go
+++ b/internal/operator/installation.go
@@ -77,39 +77,45 @@ func validateRelayMachinesJSON(raw string) error {
 // Installation is the content-free operator configuration. DSN values remain
 // in separately protected files and are never copied here.
 type Installation struct {
-	Version                int                     `json:"version"`
-	Directory              string                  `json:"-"`
-	DataDir                string                  `json:"data_dir"`
-	BackupDir              string                  `json:"backup_dir"`
-	Image                  string                  `json:"image"`
-	OwnerDSNFile           string                  `json:"owner_dsn_file"`
-	AppDSNFile             string                  `json:"app_dsn_file"`
-	OwnerPrincipalID       string                  `json:"owner_principal_id"`
-	OwnerName              string                  `json:"owner_name"`
-	RuntimeUID             string                  `json:"runtime_uid"`
-	RuntimeGID             string                  `json:"runtime_gid"`
-	Ingress                ingress.Policy          `json:"ingress"`
-	HealthListenAddr       string                  `json:"health_listen_addr"`
-	HealthURL              string                  `json:"health_url"`
-	MemoryAPIEnabled       bool                    `json:"memory_api_enabled"`
-	MemoryMutationsEnabled bool                    `json:"memory_mutations_enabled"`
-	RelayMachinesJSON      string                  `json:"relay_machines_json,omitempty"`
-	MailCutover            *MailCutoverPublication `json:"mail_cutover,omitempty"`
+	Version                   int                     `json:"version"`
+	Directory                 string                  `json:"-"`
+	DataDir                   string                  `json:"data_dir"`
+	BackupDir                 string                  `json:"backup_dir"`
+	Image                     string                  `json:"image"`
+	OwnerDSNFile              string                  `json:"owner_dsn_file"`
+	AppDSNFile                string                  `json:"app_dsn_file"`
+	OwnerPrincipalID          string                  `json:"owner_principal_id"`
+	OwnerName                 string                  `json:"owner_name"`
+	RuntimeUID                string                  `json:"runtime_uid"`
+	RuntimeGID                string                  `json:"runtime_gid"`
+	Ingress                   ingress.Policy          `json:"ingress"`
+	HealthListenAddr          string                  `json:"health_listen_addr"`
+	HealthURL                 string                  `json:"health_url"`
+	MemoryAPIEnabled          bool                    `json:"memory_api_enabled"`
+	MemoryMutationsEnabled    bool                    `json:"memory_mutations_enabled"`
+	TrustedAttachmentsEnabled bool                    `json:"trusted_attachments_enabled"`
+	TrustedAttachmentBlobDir  string                  `json:"trusted_attachment_blob_dir,omitempty"`
+	RelayEnabled              bool                    `json:"relay_enabled"`
+	RelayMachinesJSON         string                  `json:"relay_machines_json,omitempty"`
+	MailCutover               *MailCutoverPublication `json:"mail_cutover,omitempty"`
 }
 
 // InitOptions is the complete explicit input to a first installation.
 type InitOptions struct {
-	Directory              string
-	DataDir                string
-	BackupDir              string
-	Image                  string
-	OwnerDSNFile           string
-	AppDSNFile             string
-	OwnerName              string
-	Ingress                ingress.Policy
-	HealthListenAddr       string
-	MemoryAPIEnabled       bool
-	MemoryMutationsEnabled bool
+	Directory                 string
+	DataDir                   string
+	BackupDir                 string
+	Image                     string
+	OwnerDSNFile              string
+	AppDSNFile                string
+	OwnerName                 string
+	Ingress                   ingress.Policy
+	HealthListenAddr          string
+	MemoryAPIEnabled          bool
+	MemoryMutationsEnabled    bool
+	TrustedAttachmentsEnabled bool
+	TrustedAttachmentBlobDir  string
+	RelayMachinesJSON         string
 }
 
 // BootstrapOwner is the only database mutation performed by Init.
@@ -213,7 +219,7 @@ func Resume(ctx context.Context, directory string, recoverOwner RecoverOwner) (I
 		return Installation{}, errors.New("initialization staging configuration is corrupt")
 	}
 	installation.Directory = directory
-	if _, err := validateStatic(InitOptions{Directory: directory, DataDir: installation.DataDir, BackupDir: installation.BackupDir, Image: installation.Image, OwnerDSNFile: installation.OwnerDSNFile, AppDSNFile: installation.AppDSNFile, OwnerName: installation.OwnerName, Ingress: installation.Ingress, HealthListenAddr: installation.HealthListenAddr, MemoryAPIEnabled: installation.MemoryAPIEnabled, MemoryMutationsEnabled: installation.MemoryMutationsEnabled}); err != nil {
+	if _, err := validateStatic(InitOptions{Directory: directory, DataDir: installation.DataDir, BackupDir: installation.BackupDir, Image: installation.Image, OwnerDSNFile: installation.OwnerDSNFile, AppDSNFile: installation.AppDSNFile, OwnerName: installation.OwnerName, Ingress: installation.Ingress, HealthListenAddr: installation.HealthListenAddr, MemoryAPIEnabled: installation.MemoryAPIEnabled, MemoryMutationsEnabled: installation.MemoryMutationsEnabled, TrustedAttachmentsEnabled: installation.TrustedAttachmentsEnabled, TrustedAttachmentBlobDir: installation.TrustedAttachmentBlobDir, RelayMachinesJSON: installation.RelayMachinesJSON}); err != nil {
 		return Installation{}, errors.New("initialization staging configuration is invalid")
 	}
 	if failures := CheckPaths(installation); len(failures) != 0 {
@@ -254,6 +260,11 @@ func validateInit(options InitOptions) (Installation, error) {
 	}
 	if err := requireTrustedPrivateDirectory(options.BackupDir); err != nil {
 		return Installation{}, fmt.Errorf("backup directory: %w", err)
+	}
+	if options.TrustedAttachmentsEnabled {
+		if err := requireTrustedPrivateDirectory(options.TrustedAttachmentBlobDir); err != nil {
+			return Installation{}, fmt.Errorf("trusted attachment blob directory: %w", err)
+		}
 	}
 	dataInfo, dataErr := os.Stat(options.DataDir)
 	backupInfo, backupErr := os.Stat(options.BackupDir)
@@ -322,7 +333,22 @@ func validateStatic(options InitOptions) (Installation, error) {
 	if options.MemoryMutationsEnabled && !options.MemoryAPIEnabled {
 		return Installation{}, errors.New("memory mutations require the memory API")
 	}
-	return Installation{Version: 1, Directory: options.Directory, DataDir: options.DataDir, BackupDir: options.BackupDir, Image: options.Image, OwnerDSNFile: options.OwnerDSNFile, AppDSNFile: options.AppDSNFile, OwnerName: options.OwnerName, Ingress: policy, HealthListenAddr: healthListenAddr, HealthURL: localURL(healthListenAddr), MemoryAPIEnabled: options.MemoryAPIEnabled, MemoryMutationsEnabled: options.MemoryMutationsEnabled}, nil
+	if options.TrustedAttachmentsEnabled {
+		if !filepath.IsAbs(options.TrustedAttachmentBlobDir) || filepath.Clean(options.TrustedAttachmentBlobDir) != options.TrustedAttachmentBlobDir || !nestedPath(options.DataDir, options.TrustedAttachmentBlobDir) {
+			return Installation{}, errors.New("trusted attachments require a private blob directory beneath the data directory")
+		}
+	} else if options.TrustedAttachmentBlobDir != "" {
+		return Installation{}, errors.New("trusted attachment blob directory requires trusted attachments")
+	}
+	relayMachines := ""
+	if options.RelayMachinesJSON != "" {
+		var err error
+		relayMachines, err = canonicalRelayMachinesJSON(options.RelayMachinesJSON)
+		if err != nil {
+			return Installation{}, err
+		}
+	}
+	return Installation{Version: 1, Directory: options.Directory, DataDir: options.DataDir, BackupDir: options.BackupDir, Image: options.Image, OwnerDSNFile: options.OwnerDSNFile, AppDSNFile: options.AppDSNFile, OwnerName: options.OwnerName, Ingress: policy, HealthListenAddr: healthListenAddr, HealthURL: localURL(healthListenAddr), MemoryAPIEnabled: options.MemoryAPIEnabled, MemoryMutationsEnabled: options.MemoryMutationsEnabled, TrustedAttachmentsEnabled: options.TrustedAttachmentsEnabled, TrustedAttachmentBlobDir: options.TrustedAttachmentBlobDir, RelayEnabled: relayMachines != "", RelayMachinesJSON: relayMachines}, nil
 }
 
 // Load reads only a completely published installation marker.
@@ -352,7 +378,10 @@ func Load(directory string) (Installation, error) {
 			return Installation{}, errors.New("published installation relay enrollment is invalid")
 		}
 	}
-	validated, err := validateStatic(InitOptions{Directory: directory, DataDir: installation.DataDir, BackupDir: installation.BackupDir, Image: installation.Image, OwnerDSNFile: installation.OwnerDSNFile, AppDSNFile: installation.AppDSNFile, OwnerName: installation.OwnerName, Ingress: installation.Ingress, HealthListenAddr: installation.HealthListenAddr, MemoryAPIEnabled: installation.MemoryAPIEnabled, MemoryMutationsEnabled: installation.MemoryMutationsEnabled})
+	if installation.RelayEnabled && installation.RelayMachinesJSON == "" {
+		return Installation{}, errors.New("published installation relay configuration is invalid")
+	}
+	validated, err := validateStatic(InitOptions{Directory: directory, DataDir: installation.DataDir, BackupDir: installation.BackupDir, Image: installation.Image, OwnerDSNFile: installation.OwnerDSNFile, AppDSNFile: installation.AppDSNFile, OwnerName: installation.OwnerName, Ingress: installation.Ingress, HealthListenAddr: installation.HealthListenAddr, MemoryAPIEnabled: installation.MemoryAPIEnabled, MemoryMutationsEnabled: installation.MemoryMutationsEnabled, TrustedAttachmentsEnabled: installation.TrustedAttachmentsEnabled, TrustedAttachmentBlobDir: installation.TrustedAttachmentBlobDir, RelayMachinesJSON: installation.RelayMachinesJSON})
 	if err != nil {
 		return Installation{}, errors.New("published installation configuration is invalid")
 	}
@@ -445,6 +474,11 @@ func CheckPaths(installation Installation) []string {
 	if err := requireTrustedPrivateDirectory(installation.BackupDir); err != nil {
 		failures = append(failures, "backup directory unavailable or unsafe")
 	}
+	if installation.TrustedAttachmentsEnabled {
+		if err := requireTrustedPrivateDirectory(installation.TrustedAttachmentBlobDir); err != nil {
+			failures = append(failures, "trusted attachment blob directory unavailable or unsafe")
+		}
+	}
 	if overlaps, err := canonicalDirectoriesOverlap(installation.DataDir, installation.BackupDir); err == nil && overlaps {
 		failures = append(failures, "data and backup directories overlap")
 	}
@@ -462,7 +496,7 @@ func CheckPaths(installation Installation) []string {
 		failures = append(failures, "daemon-writable data directory overlaps database credentials or operator state")
 	}
 	envPath := EnvFile(installation.Directory)
-	envAvailable, envCurrent, envPreMemoryMutations, envPreMemoryAPI, envLegacy := false, false, false, false, false
+	envAvailable, envCurrent, envPreTrustedAttachments, envPreMemoryMutations, envPreMemoryAPI, envLegacy := false, false, false, false, false, false
 	if err := requireTrustedProtectedFile(envPath, 64<<10); err != nil {
 		failures = append(failures, "generated daemon environment unavailable or unsafe")
 	} else {
@@ -471,16 +505,17 @@ func CheckPaths(installation Installation) []string {
 		envAvailable = err == nil
 		if envAvailable {
 			envCurrent = string(body) == daemonEnv(installation)
+			envPreTrustedAttachments = !installation.TrustedAttachmentsEnabled && string(body) == preTrustedAttachmentsDaemonEnv(installation)
 			envPreMemoryMutations = !installation.MemoryMutationsEnabled && string(body) == preMemoryMutationsDaemonEnv(installation)
 			envPreMemoryAPI = !installation.MemoryAPIEnabled && string(body) == preMemoryAPIDaemonEnv(installation)
 			envLegacy = !installation.MemoryAPIEnabled && installation.MailCutover == nil && installation.RelayMachinesJSON == "" && string(body) == legacyDaemonEnv(installation)
 		}
-		if !envCurrent && !envPreMemoryMutations && !envPreMemoryAPI && !envLegacy {
+		if !envCurrent && !envPreTrustedAttachments && !envPreMemoryMutations && !envPreMemoryAPI && !envLegacy {
 			failures = append(failures, "generated daemon environment does not match installation configuration")
 		}
 	}
 	overridePath := OverrideFile(installation.Directory)
-	overrideAvailable, overrideCurrent, overridePreMemoryMutations, overridePreMemoryAPI, overrideLegacy := false, false, false, false, false
+	overrideAvailable, overrideCurrent, overridePreTrustedAttachments, overridePreMemoryMutations, overridePreMemoryAPI, overrideLegacy := false, false, false, false, false, false
 	if err := requireTrustedProtectedFile(overridePath, 64<<10); err != nil {
 		failures = append(failures, "generated Compose override unavailable or unsafe")
 	} else {
@@ -489,17 +524,18 @@ func CheckPaths(installation Installation) []string {
 		overrideAvailable = err == nil
 		if overrideAvailable {
 			overrideCurrent = string(body) == composeOverride()
+			overridePreTrustedAttachments = !installation.TrustedAttachmentsEnabled && string(body) == preTrustedAttachmentsComposeOverride()
 			overridePreMemoryMutations = !installation.MemoryMutationsEnabled && string(body) == preMemoryMutationsComposeOverride()
 			overridePreMemoryAPI = !installation.MemoryAPIEnabled && string(body) == preMemoryAPIComposeOverride()
 			overrideLegacy = !installation.MemoryAPIEnabled && installation.MailCutover == nil && installation.RelayMachinesJSON == "" && string(body) == legacyComposeOverride()
 		}
-		if !overrideCurrent && !overridePreMemoryMutations && !overridePreMemoryAPI && !overrideLegacy {
+		if !overrideCurrent && !overridePreTrustedAttachments && !overridePreMemoryMutations && !overridePreMemoryAPI && !overrideLegacy {
 			failures = append(failures, "generated Compose override does not match installation configuration")
 		}
 	}
 	if envAvailable && overrideAvailable {
-		sameGeneration := envCurrent && overrideCurrent || envPreMemoryMutations && overridePreMemoryMutations || envPreMemoryAPI && overridePreMemoryAPI || envLegacy && overrideLegacy
-		if !sameGeneration && (envCurrent || envPreMemoryMutations || envPreMemoryAPI || envLegacy) && (overrideCurrent || overridePreMemoryMutations || overridePreMemoryAPI || overrideLegacy) {
+		sameGeneration := envCurrent && overrideCurrent || envPreTrustedAttachments && overridePreTrustedAttachments || envPreMemoryMutations && overridePreMemoryMutations || envPreMemoryAPI && overridePreMemoryAPI || envLegacy && overrideLegacy
+		if !sameGeneration && (envCurrent || envPreTrustedAttachments || envPreMemoryMutations || envPreMemoryAPI || envLegacy) && (overrideCurrent || overridePreTrustedAttachments || overridePreMemoryMutations || overridePreMemoryAPI || overrideLegacy) {
 			failures = append(failures, "generated daemon environment does not match installation configuration")
 			failures = append(failures, "generated Compose override does not match installation configuration")
 		}
@@ -522,9 +558,13 @@ func localURL(listenAddr string) string {
 
 func daemonEnv(installation Installation) string {
 	relayStore, relayEnabled, credentialTransition := "sqlite", "false", "false"
+	if installation.RelayEnabled {
+		relayStore, relayEnabled = "postgres", "true"
+	}
 	if installation.MailCutover != nil {
 		relayStore, relayEnabled, credentialTransition = "postgres", "true", "true"
 	}
+	blobDir := attachmentContainerBlobDir(installation)
 	return strings.Join([]string{
 		"PUNARO_IMAGE=" + installation.Image,
 		"PUNARO_HOST_DATA_DIR=" + installation.DataDir,
@@ -536,6 +576,8 @@ func daemonEnv(installation Installation) string {
 		"PUNARO_DEVICE_AUTH_ENABLED=true",
 		fmt.Sprintf("PUNARO_MEMORY_API_ENABLED=%t", installation.MemoryAPIEnabled),
 		fmt.Sprintf("PUNARO_MEMORY_MUTATIONS_ENABLED=%t", installation.MemoryMutationsEnabled),
+		fmt.Sprintf("PUNARO_TRUSTED_ATTACHMENTS_ENABLED=%t", installation.TrustedAttachmentsEnabled),
+		"PUNARO_TRUSTED_ATTACHMENT_BLOB_DIR=" + blobDir,
 		"PUNARO_RELAY_ENABLED=" + relayEnabled,
 		"PUNARO_RELAY_MACHINES_JSON='" + installation.RelayMachinesJSON + "'",
 		"PUNARO_RELAY_STORE=" + relayStore,
@@ -549,8 +591,23 @@ func daemonEnv(installation Installation) string {
 	}, "\n") + "\n"
 }
 
+func attachmentContainerBlobDir(installation Installation) string {
+	if !installation.TrustedAttachmentsEnabled {
+		return ""
+	}
+	relative, _ := filepath.Rel(installation.DataDir, installation.TrustedAttachmentBlobDir)
+	return filepath.ToSlash(filepath.Join("/var/lib/punaro", relative))
+}
+
 func preMemoryMutationsDaemonEnv(installation Installation) string {
-	return strings.Replace(daemonEnv(installation), fmt.Sprintf("PUNARO_MEMORY_MUTATIONS_ENABLED=%t\n", installation.MemoryMutationsEnabled), "", 1)
+	return strings.Replace(preTrustedAttachmentsDaemonEnv(installation), fmt.Sprintf("PUNARO_MEMORY_MUTATIONS_ENABLED=%t\n", installation.MemoryMutationsEnabled), "", 1)
+}
+
+func preTrustedAttachmentsDaemonEnv(installation Installation) string {
+	return strings.NewReplacer(
+		fmt.Sprintf("PUNARO_TRUSTED_ATTACHMENTS_ENABLED=%t\n", installation.TrustedAttachmentsEnabled), "",
+		"PUNARO_TRUSTED_ATTACHMENT_BLOB_DIR="+attachmentContainerBlobDir(installation)+"\n", "",
+	).Replace(daemonEnv(installation))
 }
 
 func legacyDaemonEnv(installation Installation) string {
@@ -564,6 +621,13 @@ func legacyDaemonEnv(installation Installation) string {
 
 func preMemoryAPIDaemonEnv(installation Installation) string {
 	return strings.Replace(preMemoryMutationsDaemonEnv(installation), fmt.Sprintf("PUNARO_MEMORY_API_ENABLED=%t\n", installation.MemoryAPIEnabled), "", 1)
+}
+
+func preTrustedAttachmentsComposeOverride() string {
+	return strings.NewReplacer(
+		"      PUNARO_TRUSTED_ATTACHMENTS_ENABLED: ${PUNARO_TRUSTED_ATTACHMENTS_ENABLED:-false}\n", "",
+		"      PUNARO_TRUSTED_ATTACHMENT_BLOB_DIR: ${PUNARO_TRUSTED_ATTACHMENT_BLOB_DIR:-}\n", "",
+	).Replace(composeOverride())
 }
 
 func composeOverride() string {
@@ -590,6 +654,8 @@ func composeOverride() string {
       PUNARO_DEVICE_AUTH_ENABLED: ${PUNARO_DEVICE_AUTH_ENABLED:?required}
       PUNARO_MEMORY_API_ENABLED: ${PUNARO_MEMORY_API_ENABLED:-false}
       PUNARO_MEMORY_MUTATIONS_ENABLED: ${PUNARO_MEMORY_MUTATIONS_ENABLED:-false}
+      PUNARO_TRUSTED_ATTACHMENTS_ENABLED: ${PUNARO_TRUSTED_ATTACHMENTS_ENABLED:-false}
+      PUNARO_TRUSTED_ATTACHMENT_BLOB_DIR: ${PUNARO_TRUSTED_ATTACHMENT_BLOB_DIR:-}
       PUNARO_RELAY_ENABLED: ${PUNARO_RELAY_ENABLED:?required}
       PUNARO_RELAY_MACHINES_JSON: ${PUNARO_RELAY_MACHINES_JSON:-}
       PUNARO_RELAY_STORE: ${PUNARO_RELAY_STORE:?required}
@@ -610,7 +676,7 @@ func composeOverride() string {
 }
 
 func preMemoryMutationsComposeOverride() string {
-	return strings.Replace(composeOverride(), "      PUNARO_MEMORY_MUTATIONS_ENABLED: ${PUNARO_MEMORY_MUTATIONS_ENABLED:-false}\n", "", 1)
+	return strings.Replace(preTrustedAttachmentsComposeOverride(), "      PUNARO_MEMORY_MUTATIONS_ENABLED: ${PUNARO_MEMORY_MUTATIONS_ENABLED:-false}\n", "", 1)
 }
 
 func legacyComposeOverride() string {

--- a/internal/operator/installation_test.go
+++ b/internal/operator/installation_test.go
@@ -219,6 +219,28 @@ func TestInitRejectsAttachmentDirectoryResolvedOutsideDataBeforeBootstrap(t *tes
 	}
 }
 
+func TestAttachmentContainerBlobDirUsesResolvedPath(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink containment is covered by Unix path semantics")
+	}
+	root := t.TempDir()
+	dataDir := filepath.Join(root, "data")
+	realBlobDir := filepath.Join(dataDir, "resolved", "attachments")
+	if err := os.MkdirAll(realBlobDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(filepath.Join(dataDir, "resolved"), filepath.Join(dataDir, "linked")); err != nil {
+		t.Fatal(err)
+	}
+	installation := Installation{DataDir: dataDir, TrustedAttachmentsEnabled: true, TrustedAttachmentBlobDir: filepath.Join(dataDir, "linked", "attachments")}
+	if !attachmentBlobDirectoryContained(installation.DataDir, installation.TrustedAttachmentBlobDir) {
+		t.Fatal("resolved blob directory was rejected")
+	}
+	if got, want := attachmentContainerBlobDir(installation), "/var/lib/punaro/resolved/attachments"; got != want {
+		t.Fatalf("container blob path=%q want=%q", got, want)
+	}
+}
+
 func TestLoadRejectsEnabledRelayWithoutAuthority(t *testing.T) {
 	options := validInitOptions(t)
 	installation, err := Init(context.Background(), options, func(_ context.Context, _, name string) (punaropostgres.Principal, error) {

--- a/internal/operator/installation_test.go
+++ b/internal/operator/installation_test.go
@@ -148,6 +148,75 @@ func TestInitRejectsUnsafeUnifiedOptionalInputsBeforeBootstrap(t *testing.T) {
 	}
 }
 
+func TestInitRejectsDotenvUnsafeTrustedAttachmentBlobPath(t *testing.T) {
+	options := validInitOptions(t)
+	options.TrustedAttachmentsEnabled = true
+	options.TrustedAttachmentBlobDir = filepath.Join(options.DataDir, "attachments#unsafe")
+	if _, err := validateStatic(options); err == nil {
+		t.Fatal("dotenv-unsafe attachment blob path was accepted")
+	}
+}
+
+func TestCheckPathsRejectsAttachmentDarkLegacyTemplate(t *testing.T) {
+	options := validInitOptions(t)
+	options.MemoryAPIEnabled = true
+	options.TrustedAttachmentsEnabled = true
+	options.TrustedAttachmentBlobDir = filepath.Join(options.DataDir, "attachments")
+	if err := os.Mkdir(options.TrustedAttachmentBlobDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	installation, err := Init(context.Background(), options, func(_ context.Context, _, name string) (punaropostgres.Principal, error) {
+		return punaropostgres.Principal{ID: "11111111-1111-4111-8111-111111111111", DisplayName: name}, nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(EnvFile(installation.Directory), []byte(preMemoryMutationsDaemonEnv(installation)), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(OverrideFile(installation.Directory), []byte(preMemoryMutationsComposeOverride()), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if failures := CheckPaths(installation); !containsFailure(failures, "generated daemon environment does not match installation configuration") || !containsFailure(failures, "generated Compose override does not match installation configuration") {
+		t.Fatalf("attachment-dark templates accepted: %v", failures)
+	}
+}
+
+func TestInitRejectsRelayAuthorityWithLANListenerBeforeBootstrap(t *testing.T) {
+	options := validInitOptions(t)
+	options.RelayMachinesJSON = testRelayMachinesJSON
+	options.Ingress = ingress.Policy{Mode: ingress.LAN, ListenAddr: "192.168.1.10:8080", TrustedLAN: "192.168.1.0/24", AllowPlaintext: true}
+	called := false
+	if _, err := Init(context.Background(), options, func(context.Context, string, string) (punaropostgres.Principal, error) {
+		called = true
+		return punaropostgres.Principal{}, nil
+	}); err == nil || called {
+		t.Fatalf("LAN relay authority err=%v bootstrap=%t", err, called)
+	}
+}
+
+func TestInitRejectsAttachmentDirectoryResolvedOutsideDataBeforeBootstrap(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink containment is covered by Unix path semantics")
+	}
+	options := validInitOptions(t)
+	outside := filepath.Join(filepath.Dir(options.DataDir), "outside")
+	if err := os.Mkdir(outside, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(filepath.Join(outside, "attachments"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(outside, filepath.Join(options.DataDir, "nested")); err != nil {
+		t.Fatal(err)
+	}
+	options.TrustedAttachmentsEnabled = true
+	options.TrustedAttachmentBlobDir = filepath.Join(options.DataDir, "nested", "attachments")
+	if attachmentBlobDirectoryContained(options.DataDir, options.TrustedAttachmentBlobDir) {
+		t.Fatalf("escaped attachment directory was accepted: data=%q blob=%q", options.DataDir, options.TrustedAttachmentBlobDir)
+	}
+}
+
 func TestLoadRejectsEnabledRelayWithoutAuthority(t *testing.T) {
 	options := validInitOptions(t)
 	installation, err := Init(context.Background(), options, func(_ context.Context, _, name string) (punaropostgres.Principal, error) {

--- a/internal/operator/installation_test.go
+++ b/internal/operator/installation_test.go
@@ -2,6 +2,7 @@ package operator
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"os"
 	"path/filepath"
@@ -105,6 +106,66 @@ func TestInitRejectsMemoryMutationsWithoutReadAPI(t *testing.T) {
 	options.MemoryMutationsEnabled = true
 	if _, err := validateStatic(options); err == nil || !strings.Contains(err.Error(), "require the memory API") {
 		t.Fatalf("memory mutations without read API err=%v", err)
+	}
+}
+
+func TestInitPublishesUnifiedRelayAndTrustedAttachmentSurface(t *testing.T) {
+	options := validInitOptions(t)
+	options.RelayMachinesJSON = testRelayMachinesJSON
+	options.TrustedAttachmentsEnabled = true
+	options.TrustedAttachmentBlobDir = filepath.Join(options.DataDir, "attachments")
+	if err := os.Mkdir(options.TrustedAttachmentBlobDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	installation, err := Init(context.Background(), options, func(_ context.Context, _, name string) (punaropostgres.Principal, error) {
+		return punaropostgres.Principal{ID: "11111111-1111-4111-8111-111111111111", DisplayName: name}, nil
+	})
+	if err != nil {
+		t.Fatalf("init: %v", err)
+	}
+	environment, err := os.ReadFile(EnvFile(installation.Directory))
+	if err != nil || !strings.Contains(string(environment), "PUNARO_RELAY_ENABLED=true\n") || !strings.Contains(string(environment), "PUNARO_RELAY_STORE=postgres\n") || !strings.Contains(string(environment), "PUNARO_TRUSTED_ATTACHMENTS_ENABLED=true\n") || !strings.Contains(string(environment), "PUNARO_TRUSTED_ATTACHMENT_BLOB_DIR=/var/lib/punaro/attachments\n") {
+		t.Fatalf("environment=%q err=%v", environment, err)
+	}
+	if len(CheckPaths(installation)) != 0 {
+		t.Fatalf("paths=%v", CheckPaths(installation))
+	}
+}
+
+func TestInitRejectsUnsafeUnifiedOptionalInputsBeforeBootstrap(t *testing.T) {
+	options := validInitOptions(t)
+	options.TrustedAttachmentsEnabled = true
+	options.TrustedAttachmentBlobDir = filepath.Join(options.DataDir, "missing-attachments")
+	called := false
+	if _, err := Init(context.Background(), options, func(context.Context, string, string) (punaropostgres.Principal, error) {
+		called = true
+		return punaropostgres.Principal{}, nil
+	}); err == nil || called {
+		t.Fatalf("missing attachment storage err=%v bootstrap=%t", err, called)
+	}
+	if _, err := os.Stat(options.Directory); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("invalid input created installation directory: %v", err)
+	}
+}
+
+func TestLoadRejectsEnabledRelayWithoutAuthority(t *testing.T) {
+	options := validInitOptions(t)
+	installation, err := Init(context.Background(), options, func(_ context.Context, _, name string) (punaropostgres.Principal, error) {
+		return punaropostgres.Principal{ID: "11111111-1111-4111-8111-111111111111", DisplayName: name}, nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	installation.RelayEnabled = true
+	body, err := json.Marshal(installation)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(installation.Directory, configName), body, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Load(installation.Directory); err == nil || !strings.Contains(err.Error(), "relay configuration") {
+		t.Fatalf("enabled relay without authority err=%v", err)
 	}
 }
 
@@ -870,6 +931,40 @@ func TestMailCutoverRelayConfigurationRepairsExactLegacyTemplates(t *testing.T) 
 	environment, err := os.ReadFile(EnvFile(installation.Directory))
 	if err != nil || !strings.Contains(string(environment), "PUNARO_RELAY_ENABLED=false\n") || !strings.Contains(string(environment), "PUNARO_RELAY_MACHINES_JSON='"+testRelayMachinesJSON+"'\n") {
 		t.Fatalf("environment=%q err=%v", environment, err)
+	}
+}
+
+func TestMailCutoverRelayRecoveryAcceptsPreTrustedAttachmentTemplates(t *testing.T) {
+	options := validInitOptions(t)
+	options.MemoryAPIEnabled = true
+	installation, err := Init(context.Background(), options, func(context.Context, string, string) (punaropostgres.Principal, error) {
+		return punaropostgres.Principal{ID: "11111111-1111-4111-8111-111111111111"}, nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(EnvFile(installation.Directory), []byte(preTrustedAttachmentsDaemonEnv(installation)), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(OverrideFile(installation.Directory), []byte(preTrustedAttachmentsComposeOverride()), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	candidate := installation
+	candidate.RelayMachinesJSON = testRelayMachinesJSON
+	if _, err := publishMailCutoverInstallation(installation.Directory, candidate, func(step string) error {
+		if step == "environment" {
+			return errors.New("injected post-environment crash")
+		}
+		return nil
+	}); err == nil {
+		t.Fatal("injected publication crash was accepted")
+	}
+	path := filepath.Join(filepath.Dir(installation.Directory), "relay-machines.json")
+	if err := os.WriteFile(path, []byte(testRelayMachinesJSON), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if recovered, err := ConfigureMailCutoverRelayMachines(installation.Directory, path); err != nil || recovered.RelayMachinesJSON != testRelayMachinesJSON || len(CheckPaths(recovered)) != 0 {
+		t.Fatalf("recovered=%#v err=%v failures=%v", recovered, err, CheckPaths(recovered))
 	}
 }
 

--- a/internal/operator/installation_test.go
+++ b/internal/operator/installation_test.go
@@ -111,6 +111,7 @@ func TestInitRejectsMemoryMutationsWithoutReadAPI(t *testing.T) {
 
 func TestInitPublishesUnifiedRelayAndTrustedAttachmentSurface(t *testing.T) {
 	options := validInitOptions(t)
+	options.RelayEnabled = true
 	options.RelayMachinesJSON = testRelayMachinesJSON
 	options.TrustedAttachmentsEnabled = true
 	options.TrustedAttachmentBlobDir = filepath.Join(options.DataDir, "attachments")
@@ -184,6 +185,7 @@ func TestCheckPathsRejectsAttachmentDarkLegacyTemplate(t *testing.T) {
 
 func TestInitRejectsRelayAuthorityWithLANListenerBeforeBootstrap(t *testing.T) {
 	options := validInitOptions(t)
+	options.RelayEnabled = true
 	options.RelayMachinesJSON = testRelayMachinesJSON
 	options.Ingress = ingress.Policy{Mode: ingress.LAN, ListenAddr: "192.168.1.10:8080", TrustedLAN: "192.168.1.0/24", AllowPlaintext: true}
 	called := false
@@ -1000,6 +1002,25 @@ func TestMailCutoverRelayConfigurationRepairsExactLegacyTemplates(t *testing.T) 
 	environment, err := os.ReadFile(EnvFile(installation.Directory))
 	if err != nil || !strings.Contains(string(environment), "PUNARO_RELAY_ENABLED=false\n") || !strings.Contains(string(environment), "PUNARO_RELAY_MACHINES_JSON='"+testRelayMachinesJSON+"'\n") {
 		t.Fatalf("environment=%q err=%v", environment, err)
+	}
+}
+
+func TestLoadAllowsDarkRelayEnrollmentOnLANListener(t *testing.T) {
+	options := validInitOptions(t)
+	options.Ingress = ingress.Policy{Mode: ingress.LAN, ListenAddr: "192.168.1.10:8080", TrustedLAN: "192.168.1.0/24", AllowPlaintext: true}
+	installation, err := Init(context.Background(), options, func(_ context.Context, _, name string) (punaropostgres.Principal, error) {
+		return punaropostgres.Principal{ID: "11111111-1111-4111-8111-111111111111", DisplayName: name}, nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	configured := configureTestRelayMachines(t, installation)
+	if configured.RelayEnabled {
+		t.Fatal("mail cutover enrollment enabled the relay")
+	}
+	loaded, err := Load(installation.Directory)
+	if err != nil || loaded.RelayEnabled || loaded.RelayMachinesJSON != testRelayMachinesJSON {
+		t.Fatalf("loaded=%#v err=%v", loaded, err)
 	}
 }
 

--- a/internal/operator/installation_test.go
+++ b/internal/operator/installation_test.go
@@ -241,6 +241,33 @@ func TestAttachmentContainerBlobDirUsesResolvedPath(t *testing.T) {
 	}
 }
 
+func TestTrustedAttachmentPathResolvesForPublication(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink containment is covered by Unix path semantics")
+	}
+	options := validInitOptions(t)
+	resolved := filepath.Join(options.DataDir, "resolved", "attachments")
+	if err := os.MkdirAll(resolved, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(filepath.Join(options.DataDir, "resolved"), filepath.Join(options.DataDir, "linked")); err != nil {
+		t.Fatal(err)
+	}
+	configured := filepath.Join(options.DataDir, "linked", "attachments")
+	canonical, err := filepath.EvalSymlinks(configured)
+	if err != nil {
+		t.Fatal(err)
+	}
+	canonicalData, err := filepath.EvalSymlinks(options.DataDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	installation := Installation{DataDir: canonicalData, TrustedAttachmentsEnabled: true, TrustedAttachmentBlobDir: canonical}
+	if canonical != filepath.Join(canonicalData, "resolved", "attachments") || attachmentContainerBlobDir(installation) != "/var/lib/punaro/resolved/attachments" {
+		t.Fatalf("canonical=%q data=%q container=%q", canonical, canonicalData, attachmentContainerBlobDir(installation))
+	}
+}
+
 func TestLoadRejectsEnabledRelayWithoutAuthority(t *testing.T) {
 	options := validInitOptions(t)
 	installation, err := Init(context.Background(), options, func(_ context.Context, _, name string) (punaropostgres.Principal, error) {

--- a/internal/operator/mail_cutover.go
+++ b/internal/operator/mail_cutover.go
@@ -257,21 +257,21 @@ func LoadMailCutoverRecovery(directory string) (Installation, error) {
 				preTrustedAttachmentsOld = preTrustedAttachmentsComposeOverride()
 			}
 		}
-		if !base.MemoryMutationsEnabled {
+		if !base.TrustedAttachmentsEnabled && !base.MemoryMutationsEnabled {
 			if file.path == EnvFile(directory) {
 				preMemoryMutationsOld = preMemoryMutationsDaemonEnv(base)
 			} else {
 				preMemoryMutationsOld = preMemoryMutationsComposeOverride()
 			}
 		}
-		if !base.MemoryAPIEnabled {
+		if !base.TrustedAttachmentsEnabled && !base.MemoryAPIEnabled {
 			if file.path == EnvFile(directory) {
 				preMemoryAPIOld = preMemoryAPIDaemonEnv(base)
 			} else {
 				preMemoryAPIOld = preMemoryAPIComposeOverride()
 			}
 		}
-		if !base.MemoryAPIEnabled && base.MailCutover == nil && base.RelayMachinesJSON == "" {
+		if !base.TrustedAttachmentsEnabled && !base.MemoryAPIEnabled && base.MailCutover == nil && base.RelayMachinesJSON == "" {
 			if file.path == EnvFile(directory) {
 				legacyOld = legacyDaemonEnv(base)
 			} else {

--- a/internal/operator/mail_cutover.go
+++ b/internal/operator/mail_cutover.go
@@ -66,14 +66,7 @@ func publishMailCutover(directory string, publication MailCutoverPublication, af
 // ConfigureMailCutoverRelayMachines durably records the exact non-secret
 // static relay authority before any irreversible source transition begins.
 func ConfigureMailCutoverRelayMachines(directory, enrollmentFile string) (Installation, error) {
-	if !filepath.IsAbs(enrollmentFile) || filepath.Clean(enrollmentFile) != enrollmentFile || requireTrustedProtectedFile(enrollmentFile, maxRelayMachinesBytes) != nil {
-		return Installation{}, errors.New("mail cutover relay enrollment file is unavailable")
-	}
-	body, err := os.ReadFile(enrollmentFile) // #nosec G304 -- explicit protected operator input.
-	if err != nil {
-		return Installation{}, errors.New("mail cutover relay enrollment file is unavailable")
-	}
-	canonical, err := canonicalRelayMachinesJSON(string(body))
+	canonical, err := ReadRelayMachinesFile(enrollmentFile)
 	if err != nil {
 		return Installation{}, err
 	}
@@ -92,6 +85,23 @@ func ConfigureMailCutoverRelayMachines(directory, enrollmentFile string) (Instal
 	}
 	installation.RelayMachinesJSON = canonical
 	return publishMailCutoverInstallation(directory, installation, nil)
+}
+
+// ReadRelayMachinesFile loads a protected, bounded relay enrollment file for
+// either initial installation or an explicit mail-cutover transition.
+func ReadRelayMachinesFile(enrollmentFile string) (string, error) {
+	if !filepath.IsAbs(enrollmentFile) || filepath.Clean(enrollmentFile) != enrollmentFile || requireTrustedProtectedFile(enrollmentFile, maxRelayMachinesBytes) != nil {
+		return "", errors.New("relay enrollment file is unavailable")
+	}
+	body, err := os.ReadFile(enrollmentFile) // #nosec G304 -- explicit protected operator input.
+	if err != nil {
+		return "", errors.New("relay enrollment file is unavailable")
+	}
+	canonical, err := canonicalRelayMachinesJSON(string(body))
+	if err != nil {
+		return "", err
+	}
+	return canonical, nil
 }
 
 func publishMailCutoverInstallation(directory string, installation Installation, afterStep func(string) error) (Installation, error) {
@@ -239,7 +249,14 @@ func LoadMailCutoverRecovery(directory string) (Installation, error) {
 			return Installation{}, errors.New("mail cutover recovery file is unavailable")
 		}
 		body, err := os.ReadFile(file.path) // #nosec G304 -- validated fixed generated path.
-		legacyOld, preMemoryAPIOld, preMemoryMutationsOld := "", "", ""
+		legacyOld, preTrustedAttachmentsOld, preMemoryAPIOld, preMemoryMutationsOld := "", "", "", ""
+		if !base.TrustedAttachmentsEnabled {
+			if file.path == EnvFile(directory) {
+				preTrustedAttachmentsOld = preTrustedAttachmentsDaemonEnv(base)
+			} else {
+				preTrustedAttachmentsOld = preTrustedAttachmentsComposeOverride()
+			}
+		}
 		if !base.MemoryMutationsEnabled {
 			if file.path == EnvFile(directory) {
 				preMemoryMutationsOld = preMemoryMutationsDaemonEnv(base)
@@ -261,7 +278,7 @@ func LoadMailCutoverRecovery(directory string) (Installation, error) {
 				legacyOld = legacyComposeOverride()
 			}
 		}
-		if err != nil || string(body) != file.old && string(body) != file.intended && string(body) != preMemoryMutationsOld && string(body) != preMemoryAPIOld && string(body) != legacyOld {
+		if err != nil || string(body) != file.old && string(body) != file.intended && string(body) != preTrustedAttachmentsOld && string(body) != preMemoryMutationsOld && string(body) != preMemoryAPIOld && string(body) != legacyOld {
 			return Installation{}, errors.New("mail cutover recovery file does not match either durable state")
 		}
 	}

--- a/internal/operator/restore.go
+++ b/internal/operator/restore.go
@@ -55,7 +55,7 @@ func ParseInstallationArtifact(body []byte) (Installation, error) {
 		return Installation{}, errors.New("backup installation configuration is invalid")
 	}
 	validationDirectory := filepath.Join(filepath.VolumeName(os.TempDir())+string(filepath.Separator), ".punaro-backup-source")
-	validated, err := validateStatic(InitOptions{Directory: validationDirectory, DataDir: installation.DataDir, BackupDir: installation.BackupDir, Image: installation.Image, OwnerDSNFile: installation.OwnerDSNFile, AppDSNFile: installation.AppDSNFile, OwnerName: installation.OwnerName, Ingress: installation.Ingress, HealthListenAddr: installation.HealthListenAddr, MemoryAPIEnabled: installation.MemoryAPIEnabled, MemoryMutationsEnabled: installation.MemoryMutationsEnabled})
+	validated, err := validateStatic(InitOptions{Directory: validationDirectory, DataDir: installation.DataDir, BackupDir: installation.BackupDir, Image: installation.Image, OwnerDSNFile: installation.OwnerDSNFile, AppDSNFile: installation.AppDSNFile, OwnerName: installation.OwnerName, Ingress: installation.Ingress, HealthListenAddr: installation.HealthListenAddr, MemoryAPIEnabled: installation.MemoryAPIEnabled, MemoryMutationsEnabled: installation.MemoryMutationsEnabled, TrustedAttachmentsEnabled: installation.TrustedAttachmentsEnabled, TrustedAttachmentBlobDir: installation.TrustedAttachmentBlobDir, RelayEnabled: installation.RelayEnabled, RelayMachinesJSON: installation.RelayMachinesJSON})
 	if err != nil || validated.HealthURL != installation.HealthURL {
 		return Installation{}, errors.New("backup installation configuration is invalid")
 	}
@@ -116,7 +116,14 @@ func PrepareRestore(options RestoreOptions) (Installation, error) {
 	if err != nil {
 		return Installation{}, err
 	}
-	installation, err := validateStatic(InitOptions{Directory: options.Directory, DataDir: options.DataDir, BackupDir: options.BackupDir, Image: options.Source.Image, OwnerDSNFile: options.OwnerDSNFile, AppDSNFile: options.AppDSNFile, OwnerName: options.Source.OwnerName, Ingress: options.Source.Ingress, HealthListenAddr: options.Source.HealthListenAddr, MemoryAPIEnabled: options.Source.MemoryAPIEnabled, MemoryMutationsEnabled: options.Source.MemoryMutationsEnabled})
+	blobDir := ""
+	if options.Source.TrustedAttachmentsEnabled {
+		blobDir, err = remapAttachmentBlobDir(options.Source, options.DataDir)
+		if err != nil {
+			return Installation{}, err
+		}
+	}
+	installation, err := validateStatic(InitOptions{Directory: options.Directory, DataDir: options.DataDir, BackupDir: options.BackupDir, Image: options.Source.Image, OwnerDSNFile: options.OwnerDSNFile, AppDSNFile: options.AppDSNFile, OwnerName: options.Source.OwnerName, Ingress: options.Source.Ingress, HealthListenAddr: options.Source.HealthListenAddr, MemoryAPIEnabled: options.Source.MemoryAPIEnabled, MemoryMutationsEnabled: options.Source.MemoryMutationsEnabled, TrustedAttachmentsEnabled: options.Source.TrustedAttachmentsEnabled, TrustedAttachmentBlobDir: blobDir, RelayEnabled: options.Source.RelayEnabled, RelayMachinesJSON: options.Source.RelayMachinesJSON})
 	if err != nil {
 		return Installation{}, err
 	}
@@ -136,7 +143,7 @@ func PrepareRestore(options RestoreOptions) (Installation, error) {
 // PublishRestore atomically publishes generated configuration after verified
 // database/timeline/blob restore has created the new data directory.
 func PublishRestore(installation Installation) error {
-	if uuid.Validate(installation.OwnerPrincipalID) != nil || requireTrustedPrivateDirectory(installation.DataDir) != nil || requireTrustedPrivateDirectory(installation.BackupDir) != nil || requireTrustedProtectedFile(installation.OwnerDSNFile, 64<<10) != nil || requireTrustedProtectedFile(installation.AppDSNFile, 64<<10) != nil {
+	if uuid.Validate(installation.OwnerPrincipalID) != nil || requireTrustedPrivateDirectory(installation.DataDir) != nil || requireTrustedPrivateDirectory(installation.BackupDir) != nil || requireTrustedProtectedFile(installation.OwnerDSNFile, 64<<10) != nil || requireTrustedProtectedFile(installation.AppDSNFile, 64<<10) != nil || installation.TrustedAttachmentsEnabled && (requireTrustedPrivateDirectory(installation.TrustedAttachmentBlobDir) != nil || !attachmentBlobDirectoryContained(installation.DataDir, installation.TrustedAttachmentBlobDir)) {
 		return errors.New("restored installation inputs are unavailable or unsafe")
 	}
 	if existing, err := Load(installation.Directory); err == nil {
@@ -166,6 +173,17 @@ func PublishRestore(installation Installation) error {
 	}
 	published = true
 	return nil
+}
+
+func remapAttachmentBlobDir(source Installation, targetDataDir string) (string, error) {
+	if !filepath.IsAbs(source.DataDir) || filepath.Clean(source.DataDir) != source.DataDir || !filepath.IsAbs(source.TrustedAttachmentBlobDir) || filepath.Clean(source.TrustedAttachmentBlobDir) != source.TrustedAttachmentBlobDir || !nestedPath(source.DataDir, source.TrustedAttachmentBlobDir) {
+		return "", errors.New("restore source attachment directory is invalid")
+	}
+	relative, err := filepath.Rel(source.DataDir, source.TrustedAttachmentBlobDir)
+	if err != nil {
+		return "", errors.New("restore source attachment directory is invalid")
+	}
+	return filepath.Join(targetDataDir, relative), nil
 }
 
 func canonicalPlannedPath(path string) (string, error) {

--- a/internal/operator/restore_test.go
+++ b/internal/operator/restore_test.go
@@ -68,6 +68,50 @@ func TestPrepareAndPublishRestoreCreatesOnlyNewInstallation(t *testing.T) {
 	}
 }
 
+func TestPrepareRestorePreservesUnifiedRelayAndAttachmentSettings(t *testing.T) {
+	root := t.TempDir()
+	if err := os.Chmod(root, 0o700); err != nil { // #nosec G302 -- private test directory.
+		t.Fatal(err)
+	}
+	backupDir := filepath.Join(root, "backups")
+	if err := os.Mkdir(backupDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	ownerDSN := filepath.Join(root, "target-owner.dsn")
+	appDSN := filepath.Join(root, "target-app.dsn")
+	protectedFile(t, ownerDSN)
+	protectedFile(t, appDSN)
+	options := RestoreOptions{
+		Source:       Installation{Version: 1, Image: testImage, OwnerPrincipalID: "11111111-1111-4111-8111-111111111111", OwnerName: "Primary operator", Ingress: ingress.Policy{Mode: ingress.Internet, ListenAddr: "127.0.0.1:8080", PublicURL: "https://punaro.example"}, HealthListenAddr: "127.0.0.1:8081", HealthURL: "http://127.0.0.1:8081", TrustedAttachmentsEnabled: true, TrustedAttachmentBlobDir: "/retired/punaro-data/attachments", RelayEnabled: true, RelayMachinesJSON: testRelayMachinesJSON},
+		Directory:    filepath.Join(root, "restored-installation"),
+		DataDir:      filepath.Join(root, "restored-data"),
+		BackupDir:    backupDir,
+		OwnerDSNFile: ownerDSN,
+		AppDSNFile:   appDSN,
+	}
+	options.Source.DataDir = "/retired/punaro-data"
+	installation, err := PrepareRestore(options)
+	if err != nil {
+		t.Fatalf("prepare: %v", err)
+	}
+	if !installation.TrustedAttachmentsEnabled || installation.TrustedAttachmentBlobDir != filepath.Join(options.DataDir, "attachments") || !installation.RelayEnabled || installation.RelayMachinesJSON != testRelayMachinesJSON {
+		t.Fatalf("prepared installation=%#v", installation)
+	}
+	if err := os.Mkdir(options.DataDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(installation.TrustedAttachmentBlobDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := PublishRestore(installation); err != nil {
+		t.Fatalf("publish: %v", err)
+	}
+	loaded, err := Load(options.Directory)
+	if err != nil || !loaded.TrustedAttachmentsEnabled || loaded.TrustedAttachmentBlobDir != installation.TrustedAttachmentBlobDir || !loaded.RelayEnabled || loaded.RelayMachinesJSON != testRelayMachinesJSON {
+		t.Fatalf("loaded=%#v err=%v", loaded, err)
+	}
+}
+
 func TestPrepareRestoreRefusesExistingOrOverlappingTargets(t *testing.T) {
 	tests := []struct {
 		name   string

--- a/scripts/test-production-compose-bootstrap.sh
+++ b/scripts/test-production-compose-bootstrap.sh
@@ -15,7 +15,8 @@ if ! docker compose version >/dev/null 2>&1; then
 	echo 'production Compose bootstrap test requires Docker Compose v2' >&2
 	exit 0
 fi
-temporary=$(mktemp -d)
+temporary_root=${PUNARO_TEST_TMPDIR:-${TMPDIR:-/tmp}}
+temporary=$(mktemp -d "$temporary_root/punaro-production-bootstrap.XXXXXX")
 project="punaro-production-bootstrap-${GITHUB_RUN_ID:-local}-$$"
 cleanup() {
 	docker compose --project-name "$project" --file "$root/deploy/compose/production.yaml" down --volumes --remove-orphans >/dev/null 2>&1 || true
@@ -31,12 +32,15 @@ app_dsn="$temporary/app.dsn"
 data_dir="$temporary/data"
 backup_dir="$temporary/backup"
 installation_dir="$temporary/installation"
+relay_machines="$temporary/relay-machines.json"
 printf '%s\n' 'production-owner-password' >"$owner_password"
 printf '%s\n' 'initial-incorrect-app-password' >"$app_password"
 printf '%s\n' 'postgres://punaro_owner:production-owner-password@127.0.0.1:5432/punaro?sslmode=disable' >"$owner_dsn"
 printf '%s\n' 'postgres://punaro_app:production-app-password@127.0.0.1:5432/punaro?sslmode=disable' >"$app_dsn"
 chmod 600 "$owner_password" "$app_password" "$owner_dsn" "$app_dsn"
-mkdir -m 700 "$data_dir" "$backup_dir"
+mkdir -m 700 "$data_dir" "$data_dir/attachments" "$backup_dir"
+printf '%s\n' '[{"id":"machine-a","public_key":"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA","endpoint_prefixes":["agent/a/"],"endpoints":[],"attachment_device_id":""}]' >"$relay_machines"
+chmod 600 "$relay_machines"
 
 export PUNARO_IMAGE='example.invalid/punaro@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
 export PUNARO_RUNTIME_UID="$(id -u)"
@@ -200,8 +204,15 @@ docker compose --project-name "$project" --file "$root/deploy/compose/production
 	--app-dsn-file "$app_dsn" \
 	--owner-name 'production bootstrap' \
 	--mode proxy \
-	--public-url "$PUNARO_PUBLIC_URL")
+	--public-url "$PUNARO_PUBLIC_URL" \
+	--relay-machines-file "$relay_machines" \
+	--trusted-attachments \
+	--trusted-attachment-blob-dir "$data_dir/attachments")
 test -f "$installation_dir/installation.json"
+grep -Fxq 'PUNARO_RELAY_ENABLED=true' "$installation_dir/punarod.env"
+grep -Fxq 'PUNARO_RELAY_STORE=postgres' "$installation_dir/punarod.env"
+grep -Fxq 'PUNARO_TRUSTED_ATTACHMENTS_ENABLED=true' "$installation_dir/punarod.env"
+grep -Fxq 'PUNARO_TRUSTED_ATTACHMENT_BLOB_DIR=/var/lib/punaro/attachments' "$installation_dir/punarod.env"
 docker compose --project-name "$project" --file "$root/deploy/compose/production.yaml" run --rm --no-deps --entrypoint psql -e PGPASSWORD='production-app-password' postgres-bootstrap --host 127.0.0.1 --username punaro_app --dbname punaro --tuples-only --no-align --command 'SELECT 1 FROM auth.installation_owner LIMIT 1' | grep -Fxq 1
 docker compose --project-name "$project" --file "$root/deploy/compose/production.yaml" run --rm --no-deps --entrypoint psql -e PGPASSWORD='production-app-password' postgres-bootstrap --host 127.0.0.1 --username punaro_app --dbname punaro --command 'SELECT 1 FROM relay.projects LIMIT 1'
 docker compose --project-name "$project" --file "$root/deploy/compose/production.yaml" run --rm --no-deps --entrypoint psql -e PGPASSWORD='production-owner-password' postgres-bootstrap --host 127.0.0.1 --username punaro_owner --dbname punaro --command 'GRANT TRUNCATE ON relay.projects TO punaro_app'


### PR DESCRIPTION
## Summary

- make `punaro init` the declarative fresh-server boundary for relay authority and trusted attachment storage
- require protected relay enrollment files and private attachment storage beneath daemon data
- preserve dark legacy mail-cutover enrollment and recover interrupted older generated-template transitions
- document the unified production path and exercise it against disposable PostgreSQL Compose infrastructure

## Validation

- `make test`
- `make test-race`
- `make staticcheck`
- `make security`
- `make lint` (includes Windows build/installer checks)
- `PUNARO_TEST_TMPDIR="$PWD" ./scripts/test-production-compose-bootstrap.sh`
