### PR TITLE
feat: add secure cross-platform device enrollment

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1271,6 +1271,25 @@ M-9 bridge. Fresh enrollment, protected credential persistence, and
 platform-specific sidecar creation belong to the client onboarding flow; the
 owner-controlled server cutover remains the irreversible authority boundary.
 
+The supported onboarding client is `punaro-enroll`. `prepare` creates a
+private current-user state directory and records only the canonical HTTPS
+origin plus a fresh opaque binding in the versioned non-secret sidecar. It
+prints that public binding for the server owner to use in the exact
+least-privilege `trusted-agent` grant preview. `redeem` reads the server's
+short-lived enrollment JSON only from a protected local file, requires its
+binding to equal the sidecar before any request, and posts only to that stored
+origin. Before any network operation it creates a protected recovery journal
+containing the code and fresh idempotency UUID. Server retry with that UUID
+yields the same credential; successful persistence removes the journal. No
+command-line argument, environment variable, sidecar, normal output, or
+diagnostic includes the code or bearer credential. POSIX storage rejects
+symlinks, non-regular files, non-owner files, and group/other-readable state.
+Windows storage rejects reparse points and requires a protected DACL with the
+current user as owner and sole FullControl ACE. Malformed, cross-device,
+cross-origin, unavailable, expired, already-used, or revoked enrollment fails
+closed; only the server owner can issue a replacement, rotate a credential, or
+revoke it.
+
 The supported cutover action is `punaro mail cutover`. Its dry-run reads the
 service-owned `relay.db` from the installation data directory and prints the
 source fingerprint, exact counts, and PostgreSQL target identity without a

--- a/cmd/punaro-enroll/main.go
+++ b/cmd/punaro-enroll/main.go
@@ -217,7 +217,7 @@ func runRedeem(args []string, stdout, stderr io.Writer, recoveryOnly bool) int {
 				return enrollmentError(stderr, "enrollment recovery could not be created", 1)
 			}
 			journal = redemptionJournal{EnrollmentID: material.EnrollmentID, ClientBinding: material.ClientBinding, Code: material.Code, IdempotencyKey: key.String(), CredentialPath: *credentialPath}
-			if err := writePrivateAtomicNew(journalPath, mustJSON(journal)); err != nil {
+			if !journalCanPersistCredential(journal) || writePrivateAtomicNew(journalPath, mustJSON(journal)) != nil {
 				return enrollmentError(stderr, "enrollment recovery could not be created", 1)
 			}
 		}
@@ -242,7 +242,7 @@ func runRedeem(args []string, stdout, stderr io.Writer, recoveryOnly bool) int {
 		return enrollmentError(stderr, "enrollment is temporarily unavailable; retry this command", 1)
 	}
 	journal.Credential = response.Credential
-	if err := writePrivateAtomic(journalPath, mustJSON(journal)); err != nil {
+	if !journalFits(journal) || writePrivateAtomic(journalPath, mustJSON(journal)) != nil {
 		return enrollmentError(stderr, "enrollment recovery could not be made durable; retry this command", 1)
 	}
 	if err := writeCredential(*credentialPath, response.Credential); err != nil {
@@ -310,6 +310,19 @@ func mustJSON(value any) []byte {
 		return nil
 	}
 	return append(raw, '\n')
+}
+
+// journalCanPersistCredential reserves room for the server credential before
+// the first request. That way every accepted destination has a recovery
+// journal that remains readable after redemption has committed remotely.
+func journalCanPersistCredential(value redemptionJournal) bool {
+	value.Credential = "00000000-0000-4000-8000-000000000000." + strings.Repeat("A", 43)
+	return journalFits(value)
+}
+
+func journalFits(value redemptionJournal) bool {
+	raw := mustJSON(value)
+	return len(raw) > 0 && len(raw) <= maxEnrollmentFile
 }
 
 func loadIdentity(path string) (clientidentity.State, error) {

--- a/cmd/punaro-enroll/main.go
+++ b/cmd/punaro-enroll/main.go
@@ -80,6 +80,7 @@ type redemptionJournal struct {
 	ClientBinding  string `json:"client_binding"`
 	Code           string `json:"code"`
 	IdempotencyKey string `json:"idempotency_key"`
+	CredentialPath string `json:"credential_path"`
 	Credential     string `json:"credential,omitempty"`
 }
 
@@ -174,6 +175,9 @@ func runRedeem(args []string, stdout, stderr io.Writer, recoveryOnly bool) int {
 		if journalErr != nil {
 			return enrollmentError(stderr, "no recoverable enrollment was found", 2)
 		}
+		if journal.CredentialPath != *credentialPath {
+			return enrollmentError(stderr, "existing enrollment recovery is bound to a different credential destination", 2)
+		}
 		if err := preflightCredentialDestination(*credentialPath, journal.Credential); err != nil {
 			return enrollmentError(stderr, "private credential destination is unavailable", 2)
 		}
@@ -190,6 +194,9 @@ func runRedeem(args []string, stdout, stderr io.Writer, recoveryOnly bool) int {
 			if journal.EnrollmentID != material.EnrollmentID || journal.ClientBinding != material.ClientBinding || journal.Code != material.Code {
 				return enrollmentError(stderr, "existing enrollment recovery does not match material", 2)
 			}
+			if journal.CredentialPath != *credentialPath {
+				return enrollmentError(stderr, "existing enrollment recovery is bound to a different credential destination", 2)
+			}
 			if err := preflightCredentialDestination(*credentialPath, journal.Credential); err != nil {
 				return enrollmentError(stderr, "private credential destination is unavailable", 2)
 			}
@@ -203,7 +210,7 @@ func runRedeem(args []string, stdout, stderr io.Writer, recoveryOnly bool) int {
 			if err != nil {
 				return enrollmentError(stderr, "enrollment recovery could not be created", 1)
 			}
-			journal = redemptionJournal{EnrollmentID: material.EnrollmentID, ClientBinding: material.ClientBinding, Code: material.Code, IdempotencyKey: key.String()}
+			journal = redemptionJournal{EnrollmentID: material.EnrollmentID, ClientBinding: material.ClientBinding, Code: material.Code, IdempotencyKey: key.String(), CredentialPath: *credentialPath}
 			if err := writePrivateNew(journalPath, mustJSON(journal)); err != nil {
 				return enrollmentError(stderr, "enrollment recovery could not be created", 1)
 			}
@@ -427,7 +434,7 @@ func loadJournal(path string) (redemptionJournal, error) {
 		return redemptionJournal{}, err
 	}
 	var value redemptionJournal
-	if err := decodeFields(raw, &value, []string{"enrollment_id", "client_binding", "code", "idempotency_key"}, []string{"credential"}); err != nil || !validJournal(value) {
+	if err := decodeFields(raw, &value, []string{"enrollment_id", "client_binding", "code", "idempotency_key", "credential_path"}, []string{"credential"}); err != nil || !validJournal(value) {
 		return redemptionJournal{}, errors.New("invalid recovery journal")
 	}
 	return value, nil
@@ -437,7 +444,7 @@ func validMaterial(value enrollmentMaterial) bool {
 	return validUUID(value.EnrollmentID) && validUUID(value.ClientBinding) && validCode(value.Code)
 }
 func validJournal(value redemptionJournal) bool {
-	return validMaterial(enrollmentMaterial{EnrollmentID: value.EnrollmentID, ClientBinding: value.ClientBinding, Code: value.Code}) && validUUID(value.IdempotencyKey) && (value.Credential == "" || validStoredCredential(value.Credential))
+	return validMaterial(enrollmentMaterial{EnrollmentID: value.EnrollmentID, ClientBinding: value.ClientBinding, Code: value.Code}) && validUUID(value.IdempotencyKey) && safeStateDir(value.CredentialPath) && (value.Credential == "" || validStoredCredential(value.Credential))
 }
 func validUUID(value string) bool {
 	parsed, err := uuid.Parse(value)

--- a/cmd/punaro-enroll/main.go
+++ b/cmd/punaro-enroll/main.go
@@ -27,6 +27,7 @@ const (
 	identityFileName      = "client-identity.json"
 	redemptionJournalName = "redemption-recovery.json"
 	maxEnrollmentFile     = 4096
+	maxEnrollmentMaterial = 64 * 1024
 )
 
 var newEnrollmentHTTPClient = func() *http.Client {
@@ -71,6 +72,7 @@ type redemptionJournal struct {
 	ClientBinding  string `json:"client_binding"`
 	Code           string `json:"code"`
 	IdempotencyKey string `json:"idempotency_key"`
+	Credential     string `json:"credential,omitempty"`
 }
 
 type redemptionResponse struct {
@@ -154,7 +156,7 @@ func runRedeem(args []string, stdout, stderr io.Writer, recoveryOnly bool) int {
 		if journalErr != nil {
 			return enrollmentError(stderr, "no recoverable enrollment was found", 2)
 		}
-		if err := preflightCredentialDestination(*credentialPath, true); err != nil {
+		if err := preflightCredentialDestination(*credentialPath, journal.Credential); err != nil {
 			return enrollmentError(stderr, "private credential destination is unavailable", 2)
 		}
 	} else {
@@ -170,13 +172,13 @@ func runRedeem(args []string, stdout, stderr io.Writer, recoveryOnly bool) int {
 			if journal.EnrollmentID != material.EnrollmentID || journal.ClientBinding != material.ClientBinding || journal.Code != material.Code {
 				return enrollmentError(stderr, "existing enrollment recovery does not match material", 2)
 			}
-			if err := preflightCredentialDestination(*credentialPath, true); err != nil {
+			if err := preflightCredentialDestination(*credentialPath, journal.Credential); err != nil {
 				return enrollmentError(stderr, "private credential destination is unavailable", 2)
 			}
 		case !errors.Is(journalErr, os.ErrNotExist):
 			return enrollmentError(stderr, "private enrollment state is unsafe", 2)
 		default:
-			if err := preflightCredentialDestination(*credentialPath, false); err != nil {
+			if err := preflightCredentialDestination(*credentialPath, ""); err != nil {
 				return enrollmentError(stderr, "private credential destination is unavailable", 2)
 			}
 			key, err := uuid.NewRandom()
@@ -205,6 +207,13 @@ func runRedeem(args []string, stdout, stderr io.Writer, recoveryOnly bool) int {
 	if result != redemptionSucceeded {
 		return enrollmentError(stderr, "enrollment is temporarily unavailable; retry this command", 1)
 	}
+	if journal.Credential != "" && journal.Credential != response.Credential {
+		return enrollmentError(stderr, "enrollment is temporarily unavailable; retry this command", 1)
+	}
+	journal.Credential = response.Credential
+	if err := writePrivateAtomic(journalPath, mustJSON(journal)); err != nil {
+		return enrollmentError(stderr, "enrollment recovery could not be made durable; retry this command", 1)
+	}
 	if err := writeCredential(*credentialPath, response.Credential); err != nil {
 		return enrollmentError(stderr, "credential persistence failed; retry this command", 1)
 	}
@@ -218,7 +227,7 @@ func runRedeem(args []string, stdout, stderr io.Writer, recoveryOnly bool) int {
 	}{Origin: state.Origin, LookupID: response.LookupID, Generation: response.Generation})
 }
 
-func preflightCredentialDestination(path string, recoveryInProgress bool) error {
+func preflightCredentialDestination(path, expectedCredential string) error {
 	_, err := os.Lstat(path)
 	if errors.Is(err, os.ErrNotExist) {
 		return nil
@@ -226,13 +235,16 @@ func preflightCredentialDestination(path string, recoveryInProgress bool) error 
 	if err != nil {
 		return err
 	}
-	if recoveryInProgress {
+	if expectedCredential != "" {
 		// A matching credential can already be present if the process crashed
-		// after persistence and before removing the journal. Verify that it is a
-		// protected private file, then let the idempotent response comparison in
-		// writeCredential complete that interrupted recovery.
-		_, err := readPrivate(path, maxEnrollmentFile)
-		return err
+		// after persistence and before removing the journal. The journal stores
+		// the server-confirmed value before it publishes the credential, so an
+		// unrelated protected state file cannot be mistaken for that credential.
+		raw, err := readPrivate(path, maxEnrollmentFile)
+		if err != nil || string(raw) != expectedCredential+"\n" {
+			return errors.New("credential destination exists")
+		}
+		return nil
 	}
 	// A credential path is single-use. Treat every existing entry, including a
 	// regular private credential, as unavailable before the first redemption so
@@ -278,7 +290,7 @@ func loadIdentity(path string) (clientidentity.State, error) {
 }
 
 func loadMaterial(path string) (enrollmentMaterial, error) {
-	raw, err := readPrivate(path, maxEnrollmentFile)
+	raw, err := readPrivate(path, maxEnrollmentMaterial)
 	if err != nil {
 		return enrollmentMaterial{}, err
 	}
@@ -353,7 +365,7 @@ func loadJournal(path string) (redemptionJournal, error) {
 		return redemptionJournal{}, err
 	}
 	var value redemptionJournal
-	if err := decodeExact(raw, &value, "enrollment_id", "client_binding", "code", "idempotency_key"); err != nil || !validJournal(value) {
+	if err := decodeFields(raw, &value, []string{"enrollment_id", "client_binding", "code", "idempotency_key"}, []string{"credential"}); err != nil || !validJournal(value) {
 		return redemptionJournal{}, errors.New("invalid recovery journal")
 	}
 	return value, nil
@@ -363,7 +375,7 @@ func validMaterial(value enrollmentMaterial) bool {
 	return validUUID(value.EnrollmentID) && validUUID(value.ClientBinding) && validCode(value.Code)
 }
 func validJournal(value redemptionJournal) bool {
-	return validMaterial(enrollmentMaterial{EnrollmentID: value.EnrollmentID, ClientBinding: value.ClientBinding, Code: value.Code}) && validUUID(value.IdempotencyKey)
+	return validMaterial(enrollmentMaterial{EnrollmentID: value.EnrollmentID, ClientBinding: value.ClientBinding, Code: value.Code}) && validUUID(value.IdempotencyKey) && (value.Credential == "" || validStoredCredential(value.Credential))
 }
 func validUUID(value string) bool {
 	parsed, err := uuid.Parse(value)
@@ -376,6 +388,15 @@ func validCode(value string) bool {
 func validCredential(value, lookupID string) bool {
 	prefix, secret, found := strings.Cut(value, ".")
 	if !found || prefix != lookupID || !validUUID(prefix) || strings.ContainsAny(secret, " \t\r\n") {
+		return false
+	}
+	decoded, err := base64.RawURLEncoding.Strict().DecodeString(secret)
+	return err == nil && len(decoded) == 32 && base64.RawURLEncoding.EncodeToString(decoded) == secret
+}
+
+func validStoredCredential(value string) bool {
+	prefix, secret, found := strings.Cut(value, ".")
+	if !found || !validUUID(prefix) || strings.ContainsAny(secret, " \t\r\n") {
 		return false
 	}
 	decoded, err := base64.RawURLEncoding.Strict().DecodeString(secret)

--- a/cmd/punaro-enroll/main.go
+++ b/cmd/punaro-enroll/main.go
@@ -215,23 +215,6 @@ func runRedeem(args []string, stdout, stderr io.Writer, recoveryOnly bool) int {
 	if err := syncPrivateDirectory(*stateDir); err != nil {
 		return enrollmentError(stderr, "enrollment recovery could not be made durable; retry this command", 1)
 	}
-	if journal.Credential != "" {
-		// The credential checkpoint is written before its destination is
-		// published. Complete that local operation without asking the server to
-		// replay an enrollment that may already have aged out of its bounded
-		// replay window.
-		if err := writeCredential(*credentialPath, journal.Credential); err != nil {
-			return enrollmentError(stderr, "credential persistence failed; retry this command", 1)
-		}
-		if err := removePrivate(journalPath); err != nil && !errors.Is(err, os.ErrNotExist) {
-			return enrollmentError(stderr, "credential persisted; remove the private recovery file before continuing", 1)
-		}
-		lookupID, _, _ := strings.Cut(journal.Credential, ".")
-		return writeJSON(stdout, struct {
-			Origin   string `json:"origin"`
-			LookupID string `json:"lookup_id"`
-		}{Origin: state.Origin, LookupID: lookupID})
-	}
 	response, result := postRedemption(state.Origin, journal, accessToken)
 	if result == redemptionRejected {
 		if err := removePrivate(journalPath); err != nil && !errors.Is(err, os.ErrNotExist) {

--- a/cmd/punaro-enroll/main.go
+++ b/cmd/punaro-enroll/main.go
@@ -6,6 +6,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/base64"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"flag"
@@ -43,6 +44,21 @@ type enrollmentMaterial struct {
 	EnrollmentID  string `json:"enrollment_id"`
 	ClientBinding string `json:"client_binding"`
 	Code          string `json:"code"`
+}
+
+type enrollmentEnvelope struct {
+	EnrollmentID  string            `json:"enrollment_id"`
+	ClientBinding string            `json:"client_binding"`
+	Code          string            `json:"code"`
+	ExpiresAt     time.Time         `json:"expires_at"`
+	PreviewHash   string            `json:"preview_hash"`
+	Grants        []json.RawMessage `json:"grants"`
+}
+
+type enrollmentGrantPreview struct {
+	Scope      string `json:"scope"`
+	ProjectID  string `json:"project_id"`
+	Capability string `json:"capability"`
 }
 
 type accessMaterial struct {
@@ -267,10 +283,46 @@ func loadMaterial(path string) (enrollmentMaterial, error) {
 		return enrollmentMaterial{}, err
 	}
 	var value enrollmentMaterial
-	if err := decodeExact(raw, &value, "enrollment_id", "client_binding", "code"); err != nil || !validMaterial(value) {
+	if err := decodeExact(raw, &value, "enrollment_id", "client_binding", "code"); err == nil && validMaterial(value) {
+		return value, nil
+	}
+	var envelope enrollmentEnvelope
+	if err := decodeExact(raw, &envelope, "enrollment_id", "client_binding", "code", "expires_at", "preview_hash", "grants"); err != nil || !validMaterial(enrollmentMaterial{EnrollmentID: envelope.EnrollmentID, ClientBinding: envelope.ClientBinding, Code: envelope.Code}) || envelope.ExpiresAt.IsZero() || !validPreviewHash(envelope.PreviewHash) || !validGrantPreview(envelope.Grants) {
 		return enrollmentMaterial{}, errors.New("invalid enrollment material")
 	}
-	return value, nil
+	return enrollmentMaterial{EnrollmentID: envelope.EnrollmentID, ClientBinding: envelope.ClientBinding, Code: envelope.Code}, nil
+}
+
+func validPreviewHash(value string) bool {
+	decoded, err := hex.DecodeString(value)
+	return err == nil && len(decoded) == 32 && hex.EncodeToString(decoded) == value
+}
+
+func validGrantPreview(rawGrants []json.RawMessage) bool {
+	if len(rawGrants) == 0 {
+		return false
+	}
+	for _, raw := range rawGrants {
+		var grant enrollmentGrantPreview
+		if err := decodeFields(raw, &grant, []string{"scope", "capability"}, []string{"project_id"}); err != nil || !validGrantPreviewItem(grant) {
+			return false
+		}
+	}
+	return true
+}
+
+func validGrantPreviewItem(grant enrollmentGrantPreview) bool {
+	if grant.Capability == "" || len(grant.Capability) > 128 || strings.ContainsAny(grant.Capability, " \t\r\n") {
+		return false
+	}
+	switch grant.Scope {
+	case "installation", "all_projects":
+		return grant.ProjectID == ""
+	case "project":
+		return validUUID(grant.ProjectID)
+	default:
+		return false
+	}
 }
 
 func loadAccessToken(path string) (adapter.AccessServiceToken, error) {

--- a/cmd/punaro-enroll/main.go
+++ b/cmd/punaro-enroll/main.go
@@ -5,6 +5,7 @@ package main
 import (
 	"bytes"
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"flag"
@@ -253,6 +254,15 @@ func validCode(value string) bool {
 	return len(value) == 43 && !strings.ContainsAny(value, " \t\r\n")
 }
 
+func validCredential(value, lookupID string) bool {
+	prefix, secret, found := strings.Cut(value, ".")
+	if !found || prefix != lookupID || !validUUID(prefix) || strings.ContainsAny(secret, " \t\r\n") {
+		return false
+	}
+	decoded, err := base64.RawURLEncoding.Strict().DecodeString(secret)
+	return err == nil && len(decoded) == 32 && base64.RawURLEncoding.EncodeToString(decoded) == secret
+}
+
 func decodeExact(raw []byte, target any, fields ...string) error {
 	return decodeFields(raw, target, fields, nil)
 }
@@ -310,7 +320,7 @@ func decodeFields(raw []byte, target any, required, optional []string) error {
 
 func decodeRedemptionResponse(raw []byte) (redemptionResponse, error) {
 	var value redemptionResponse
-	if err := decodeFields(raw, &value, []string{"principal_id", "lookup_id", "credential", "generation"}, []string{"expires_at"}); err != nil || !validUUID(value.PrincipalID) || !validUUID(value.LookupID) || value.Credential == "" || strings.ContainsAny(value.Credential, " \t\r\n") || value.Generation < 1 {
+	if err := decodeFields(raw, &value, []string{"principal_id", "lookup_id", "credential", "generation"}, []string{"expires_at"}); err != nil || !validUUID(value.PrincipalID) || !validUUID(value.LookupID) || !validCredential(value.Credential, value.LookupID) || value.Generation < 1 {
 		return redemptionResponse{}, errors.New("invalid redemption response")
 	}
 	return value, nil

--- a/cmd/punaro-enroll/main.go
+++ b/cmd/punaro-enroll/main.go
@@ -117,6 +117,9 @@ func runRedeem(args []string, stdout, stderr io.Writer, recoveryOnly bool) int {
 	if !safeStateDir(*stateDir) || !safeStateChild(*stateDir, *credentialPath) || privateDir(*stateDir) != nil {
 		return enrollmentError(stderr, "private enrollment state is unsafe", 2)
 	}
+	if err := preflightCredentialDestination(*credentialPath); err != nil {
+		return enrollmentError(stderr, "private credential destination is unavailable", 2)
+	}
 	state, err := loadIdentity(filepath.Join(*stateDir, identityFileName))
 	if err != nil || state.LegacyMachineID != "" {
 		return enrollmentError(stderr, "private enrollment state is unsafe", 2)
@@ -180,6 +183,20 @@ func runRedeem(args []string, stdout, stderr io.Writer, recoveryOnly bool) int {
 		LookupID   string `json:"lookup_id"`
 		Generation int64  `json:"generation"`
 	}{Origin: state.Origin, LookupID: response.LookupID, Generation: response.Generation})
+}
+
+func preflightCredentialDestination(path string) error {
+	_, err := os.Lstat(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	// A credential path is single-use. Treat every existing entry, including a
+	// regular private credential, as unavailable before redemption so no server
+	// principal is minted when the response cannot be persisted locally.
+	return errors.New("credential destination exists")
 }
 
 func invalid(stderr io.Writer) int { return enrollmentError(stderr, "invalid arguments", 2) }

--- a/cmd/punaro-enroll/main.go
+++ b/cmd/punaro-enroll/main.go
@@ -156,9 +156,12 @@ func runRedeem(args []string, stdout, stderr io.Writer, recoveryOnly bool) int {
 	if journal.ClientBinding != state.ClientBinding || !validJournal(journal) {
 		return enrollmentError(stderr, "private enrollment state is unsafe", 2)
 	}
+	if err := syncPrivateDirectory(*stateDir); err != nil {
+		return enrollmentError(stderr, "enrollment recovery could not be made durable; retry this command", 1)
+	}
 	response, result := postRedemption(state.Origin, journal)
 	if result == redemptionRejected {
-		if err := os.Remove(journalPath); err != nil && !errors.Is(err, os.ErrNotExist) {
+		if err := removePrivate(journalPath); err != nil && !errors.Is(err, os.ErrNotExist) {
 			return enrollmentError(stderr, "enrollment was rejected; remove the private recovery file before requesting a new enrollment", 1)
 		}
 		return enrollmentError(stderr, "enrollment was rejected; request a new enrollment", 1)
@@ -169,7 +172,7 @@ func runRedeem(args []string, stdout, stderr io.Writer, recoveryOnly bool) int {
 	if err := writeCredential(*credentialPath, response.Credential); err != nil {
 		return enrollmentError(stderr, "credential persistence failed; retry this command", 1)
 	}
-	if err := os.Remove(journalPath); err != nil && !errors.Is(err, os.ErrNotExist) {
+	if err := removePrivate(journalPath); err != nil && !errors.Is(err, os.ErrNotExist) {
 		return enrollmentError(stderr, "credential persisted; remove the private recovery file before continuing", 1)
 	}
 	return writeJSON(stdout, struct {

--- a/cmd/punaro-enroll/main.go
+++ b/cmd/punaro-enroll/main.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/rock3r/punaro/internal/adapter"
 	"github.com/rock3r/punaro/internal/clientidentity"
 )
 
@@ -42,6 +43,11 @@ type enrollmentMaterial struct {
 	EnrollmentID  string `json:"enrollment_id"`
 	ClientBinding string `json:"client_binding"`
 	Code          string `json:"code"`
+}
+
+type accessMaterial struct {
+	ClientID     string `json:"client_id"`
+	ClientSecret string `json:"client_secret"`
 }
 
 type redemptionJournal struct {
@@ -111,6 +117,7 @@ func runRedeem(args []string, stdout, stderr io.Writer, recoveryOnly bool) int {
 	stateDir := flags.String("state-dir", "", "absolute private enrollment state directory")
 	materialPath := flags.String("enrollment-file", "", "absolute protected enrollment material file")
 	credentialPath := flags.String("credential-file", "", "absolute private credential destination under state-dir")
+	accessPath := flags.String("access-file", "", "absolute protected Cloudflare Access service-token file")
 	if flags.Parse(args) != nil || flags.NArg() != 0 || *stateDir == "" || *credentialPath == "" || (!recoveryOnly && *materialPath == "") || (recoveryOnly && *materialPath != "") {
 		return invalid(stderr)
 	}
@@ -120,6 +127,10 @@ func runRedeem(args []string, stdout, stderr io.Writer, recoveryOnly bool) int {
 	state, err := loadIdentity(filepath.Join(*stateDir, identityFileName))
 	if err != nil || state.LegacyMachineID != "" {
 		return enrollmentError(stderr, "private enrollment state is unsafe", 2)
+	}
+	accessToken, err := loadAccessToken(*accessPath)
+	if err != nil {
+		return enrollmentError(stderr, "Access admission material is invalid", 2)
 	}
 	journalPath := filepath.Join(*stateDir, redemptionJournalName)
 	journal, journalErr := loadJournal(journalPath)
@@ -168,7 +179,7 @@ func runRedeem(args []string, stdout, stderr io.Writer, recoveryOnly bool) int {
 	if err := syncPrivateDirectory(*stateDir); err != nil {
 		return enrollmentError(stderr, "enrollment recovery could not be made durable; retry this command", 1)
 	}
-	response, result := postRedemption(state.Origin, journal)
+	response, result := postRedemption(state.Origin, journal, accessToken)
 	if result == redemptionRejected {
 		if err := removePrivate(journalPath); err != nil && !errors.Is(err, os.ErrNotExist) {
 			return enrollmentError(stderr, "enrollment was rejected; remove the private recovery file before requesting a new enrollment", 1)
@@ -260,6 +271,28 @@ func loadMaterial(path string) (enrollmentMaterial, error) {
 		return enrollmentMaterial{}, errors.New("invalid enrollment material")
 	}
 	return value, nil
+}
+
+func loadAccessToken(path string) (adapter.AccessServiceToken, error) {
+	if path == "" {
+		return adapter.AccessServiceToken{}, nil
+	}
+	if !filepath.IsAbs(path) || filepath.Clean(path) != path {
+		return adapter.AccessServiceToken{}, errors.New("unsafe Access material")
+	}
+	raw, err := readPrivate(path, maxEnrollmentFile)
+	if err != nil {
+		return adapter.AccessServiceToken{}, err
+	}
+	var value accessMaterial
+	if err := decodeExact(raw, &value, "client_id", "client_secret"); err != nil || !validAccessValue(value.ClientID) || !validAccessValue(value.ClientSecret) {
+		return adapter.AccessServiceToken{}, errors.New("invalid Access material")
+	}
+	return adapter.AccessServiceToken{ClientID: value.ClientID, ClientSecret: value.ClientSecret}, nil
+}
+
+func validAccessValue(value string) bool {
+	return value != "" && !strings.ContainsAny(value, " \t\r\n")
 }
 
 func loadJournal(path string) (redemptionJournal, error) {
@@ -368,7 +401,7 @@ const (
 	redemptionSucceeded
 )
 
-func postRedemption(origin string, journal redemptionJournal) (redemptionResponse, redemptionResult) {
+func postRedemption(origin string, journal redemptionJournal, accessToken adapter.AccessServiceToken) (redemptionResponse, redemptionResult) {
 	body, err := json.Marshal(journal)
 	if err != nil {
 		return redemptionResponse{}, redemptionUnavailable
@@ -378,7 +411,17 @@ func postRedemption(origin string, journal redemptionJournal) (redemptionRespons
 		return redemptionResponse{}, redemptionUnavailable
 	}
 	request.Header.Set("Content-Type", "application/json")
-	response, err := newEnrollmentHTTPClient().Do(request)
+	client, err := adapter.OpenAccessSession(context.Background(), origin, newEnrollmentHTTPClient(), accessToken)
+	if err != nil {
+		return redemptionResponse{}, redemptionUnavailable
+	}
+	if accessToken.ClientID != "" {
+		request.Header.Set("CF-Access-Client-Id", accessToken.ClientID)
+		request.Header.Set("CF-Access-Client-Secret", accessToken.ClientSecret)
+	}
+	clientCopy := *client
+	clientCopy.CheckRedirect = func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse }
+	response, err := clientCopy.Do(request)
 	if err != nil {
 		return redemptionResponse{}, redemptionUnavailable
 	}

--- a/cmd/punaro-enroll/main.go
+++ b/cmd/punaro-enroll/main.go
@@ -117,9 +117,6 @@ func runRedeem(args []string, stdout, stderr io.Writer, recoveryOnly bool) int {
 	if !safeStateDir(*stateDir) || !safeStateChild(*stateDir, *credentialPath) || privateDir(*stateDir) != nil {
 		return enrollmentError(stderr, "private enrollment state is unsafe", 2)
 	}
-	if err := preflightCredentialDestination(*credentialPath); err != nil {
-		return enrollmentError(stderr, "private credential destination is unavailable", 2)
-	}
 	state, err := loadIdentity(filepath.Join(*stateDir, identityFileName))
 	if err != nil || state.LegacyMachineID != "" {
 		return enrollmentError(stderr, "private enrollment state is unsafe", 2)
@@ -129,6 +126,9 @@ func runRedeem(args []string, stdout, stderr io.Writer, recoveryOnly bool) int {
 	if recoveryOnly {
 		if journalErr != nil {
 			return enrollmentError(stderr, "no recoverable enrollment was found", 2)
+		}
+		if err := preflightCredentialDestination(*credentialPath, true); err != nil {
+			return enrollmentError(stderr, "private credential destination is unavailable", 2)
 		}
 	} else {
 		material, err := loadMaterial(*materialPath)
@@ -143,9 +143,15 @@ func runRedeem(args []string, stdout, stderr io.Writer, recoveryOnly bool) int {
 			if journal.EnrollmentID != material.EnrollmentID || journal.ClientBinding != material.ClientBinding || journal.Code != material.Code {
 				return enrollmentError(stderr, "existing enrollment recovery does not match material", 2)
 			}
+			if err := preflightCredentialDestination(*credentialPath, true); err != nil {
+				return enrollmentError(stderr, "private credential destination is unavailable", 2)
+			}
 		case !errors.Is(journalErr, os.ErrNotExist):
 			return enrollmentError(stderr, "private enrollment state is unsafe", 2)
 		default:
+			if err := preflightCredentialDestination(*credentialPath, false); err != nil {
+				return enrollmentError(stderr, "private credential destination is unavailable", 2)
+			}
 			key, err := uuid.NewRandom()
 			if err != nil {
 				return enrollmentError(stderr, "enrollment recovery could not be created", 1)
@@ -185,7 +191,7 @@ func runRedeem(args []string, stdout, stderr io.Writer, recoveryOnly bool) int {
 	}{Origin: state.Origin, LookupID: response.LookupID, Generation: response.Generation})
 }
 
-func preflightCredentialDestination(path string) error {
+func preflightCredentialDestination(path string, recoveryInProgress bool) error {
 	_, err := os.Lstat(path)
 	if errors.Is(err, os.ErrNotExist) {
 		return nil
@@ -193,9 +199,17 @@ func preflightCredentialDestination(path string) error {
 	if err != nil {
 		return err
 	}
+	if recoveryInProgress {
+		// A matching credential can already be present if the process crashed
+		// after persistence and before removing the journal. Verify that it is a
+		// protected private file, then let the idempotent response comparison in
+		// writeCredential complete that interrupted recovery.
+		_, err := readPrivate(path, maxEnrollmentFile)
+		return err
+	}
 	// A credential path is single-use. Treat every existing entry, including a
-	// regular private credential, as unavailable before redemption so no server
-	// principal is minted when the response cannot be persisted locally.
+	// regular private credential, as unavailable before the first redemption so
+	// no server principal is minted when the response cannot be persisted.
 	return errors.New("credential destination exists")
 }
 

--- a/cmd/punaro-enroll/main.go
+++ b/cmd/punaro-enroll/main.go
@@ -137,7 +137,7 @@ func runPrepare(args []string, stdout, stderr io.Writer) int {
 	if errors.Is(err, os.ErrNotExist) {
 		binding := uuid.NewString()
 		state = clientidentity.State{Version: clientidentity.Version, Origin: canonical, ClientBinding: binding}
-		if err := writePrivateNew(identityPath, mustEncodeIdentity(state)); err != nil {
+		if err := writePrivateAtomicNew(identityPath, mustEncodeIdentity(state)); err != nil {
 			return enrollmentError(stderr, "state preparation failed", 2)
 		}
 	} else if err != nil || state.Match(canonical, state.ClientBinding, "") != nil || state.LegacyMachineID != "" {

--- a/cmd/punaro-enroll/main.go
+++ b/cmd/punaro-enroll/main.go
@@ -561,7 +561,7 @@ func postRedemption(origin string, journal redemptionJournal, accessToken adapte
 		return redemptionResponse{}, redemptionUnavailable
 	}
 	defer func() { _ = response.Body.Close() }()
-	if response.StatusCode == http.StatusBadRequest || (response.StatusCode == http.StatusUnauthorized && response.Header.Get("WWW-Authenticate") == "Bearer" && responseDeclaresUnauthenticated(response.Body)) {
+	if (response.StatusCode == http.StatusBadRequest && response.Header.Get("Cache-Control") == "no-store" && responseDeclaresMalformed(response.Body)) || (response.StatusCode == http.StatusUnauthorized && response.Header.Get("WWW-Authenticate") == "Bearer" && responseDeclaresUnauthenticated(response.Body)) {
 		return redemptionResponse{}, redemptionRejected
 	}
 	if response.StatusCode != http.StatusCreated || response.Header.Get("Cache-Control") != "no-store" {
@@ -579,6 +579,14 @@ func postRedemption(origin string, journal redemptionJournal, accessToken adapte
 }
 
 func responseDeclaresUnauthenticated(body io.Reader) bool {
+	return responseDeclaresError(body, "unauthenticated")
+}
+
+func responseDeclaresMalformed(body io.Reader) bool {
+	return responseDeclaresError(body, "request is malformed")
+}
+
+func responseDeclaresError(body io.Reader, expected string) bool {
 	raw, err := io.ReadAll(io.LimitReader(body, 1025))
 	if err != nil || len(raw) > 1024 {
 		return false
@@ -586,5 +594,5 @@ func responseDeclaresUnauthenticated(body io.Reader) bool {
 	var value struct {
 		Error string `json:"error"`
 	}
-	return decodeExact(raw, &value, "error") == nil && value.Error == "unauthenticated"
+	return decodeExact(raw, &value, "error") == nil && value.Error == expected
 }

--- a/cmd/punaro-enroll/main.go
+++ b/cmd/punaro-enroll/main.go
@@ -158,7 +158,7 @@ func runRedeem(args []string, stdout, stderr io.Writer, recoveryOnly bool) int {
 	if flags.Parse(args) != nil || flags.NArg() != 0 || *stateDir == "" || *credentialPath == "" || (!recoveryOnly && *materialPath == "") || (recoveryOnly && *materialPath != "") {
 		return invalid(stderr)
 	}
-	if !safeStateDir(*stateDir) || !safeStateChild(*stateDir, *credentialPath) || strings.EqualFold(filepath.Base(*credentialPath), redemptionJournalName) || privateDir(*stateDir) != nil {
+	if !safeStateDir(*stateDir) || !safeStateChild(*stateDir, *credentialPath) || reservedStateFileName(filepath.Base(*credentialPath)) || privateDir(*stateDir) != nil {
 		return enrollmentError(stderr, "private enrollment state is unsafe", 2)
 	}
 	state, err := loadIdentity(filepath.Join(*stateDir, identityFileName))

--- a/cmd/punaro-enroll/main.go
+++ b/cmd/punaro-enroll/main.go
@@ -27,7 +27,9 @@ const (
 	identityFileName      = "client-identity.json"
 	redemptionJournalName = "redemption-recovery.json"
 	maxEnrollmentFile     = 4096
-	maxEnrollmentMaterial = 64 * 1024
+	// maxEnrollmentMaterial bounds the two JSON records emitted by
+	// `punaro-admin client add --yes` at its 100-project limit.
+	maxEnrollmentMaterial = 512 * 1024
 )
 
 var newEnrollmentHTTPClient = func() *http.Client {
@@ -54,6 +56,12 @@ type enrollmentEnvelope struct {
 	ExpiresAt     time.Time         `json:"expires_at"`
 	PreviewHash   string            `json:"preview_hash"`
 	Grants        []json.RawMessage `json:"grants"`
+}
+
+type enrollmentPreview struct {
+	Template    string            `json:"template"`
+	PreviewHash string            `json:"preview_hash"`
+	Grants      []json.RawMessage `json:"grants"`
 }
 
 type enrollmentGrantPreview struct {
@@ -149,7 +157,7 @@ func runRedeem(args []string, stdout, stderr io.Writer, recoveryOnly bool) int {
 	if flags.Parse(args) != nil || flags.NArg() != 0 || *stateDir == "" || *credentialPath == "" || (!recoveryOnly && *materialPath == "") || (recoveryOnly && *materialPath != "") {
 		return invalid(stderr)
 	}
-	if !safeStateDir(*stateDir) || !safeStateChild(*stateDir, *credentialPath) || filepath.Base(*credentialPath) == redemptionJournalName || privateDir(*stateDir) != nil {
+	if !safeStateDir(*stateDir) || !safeStateChild(*stateDir, *credentialPath) || strings.EqualFold(filepath.Base(*credentialPath), redemptionJournalName) || privateDir(*stateDir) != nil {
 		return enrollmentError(stderr, "private enrollment state is unsafe", 2)
 	}
 	state, err := loadIdentity(filepath.Join(*stateDir, identityFileName))
@@ -308,11 +316,55 @@ func loadMaterial(path string) (enrollmentMaterial, error) {
 	if err := decodeExact(raw, &value, "enrollment_id", "client_binding", "code"); err == nil && validMaterial(value) {
 		return value, nil
 	}
-	var envelope enrollmentEnvelope
-	if err := decodeExact(raw, &envelope, "enrollment_id", "client_binding", "code", "expires_at", "preview_hash", "grants"); err != nil || !validMaterial(enrollmentMaterial{EnrollmentID: envelope.EnrollmentID, ClientBinding: envelope.ClientBinding, Code: envelope.Code}) || envelope.ExpiresAt.IsZero() || !validPreviewHash(envelope.PreviewHash) || !validGrantPreview(envelope.Grants) {
+	if envelope, err := decodeEnrollmentEnvelope(raw); err == nil {
+		return materialFromEnvelope(envelope), nil
+	}
+	records, err := decodeJSONRecords(raw)
+	if err != nil || len(records) != 2 {
 		return enrollmentMaterial{}, errors.New("invalid enrollment material")
 	}
-	return enrollmentMaterial{EnrollmentID: envelope.EnrollmentID, ClientBinding: envelope.ClientBinding, Code: envelope.Code}, nil
+	var preview enrollmentPreview
+	if err := decodeExact(records[0], &preview, "template", "preview_hash", "grants"); err != nil || preview.Template != "trusted-agent" || !validPreviewHash(preview.PreviewHash) || !validGrantPreview(preview.Grants) {
+		return enrollmentMaterial{}, errors.New("invalid enrollment material")
+	}
+	envelope, err := decodeEnrollmentEnvelope(records[1])
+	if err != nil || preview.PreviewHash != envelope.PreviewHash || !sameGrantPreview(preview.Grants, envelope.Grants) {
+		return enrollmentMaterial{}, errors.New("invalid enrollment material")
+	}
+	return materialFromEnvelope(envelope), nil
+}
+
+func decodeEnrollmentEnvelope(raw []byte) (enrollmentEnvelope, error) {
+	var envelope enrollmentEnvelope
+	if err := decodeExact(raw, &envelope, "enrollment_id", "client_binding", "code", "expires_at", "preview_hash", "grants"); err != nil || !validMaterial(enrollmentMaterial{EnrollmentID: envelope.EnrollmentID, ClientBinding: envelope.ClientBinding, Code: envelope.Code}) || envelope.ExpiresAt.IsZero() || !validPreviewHash(envelope.PreviewHash) || !validGrantPreview(envelope.Grants) {
+		return enrollmentEnvelope{}, errors.New("invalid enrollment material")
+	}
+	return envelope, nil
+}
+
+func materialFromEnvelope(envelope enrollmentEnvelope) enrollmentMaterial {
+	return enrollmentMaterial{EnrollmentID: envelope.EnrollmentID, ClientBinding: envelope.ClientBinding, Code: envelope.Code}
+}
+
+func decodeJSONRecords(raw []byte) ([]json.RawMessage, error) {
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	var records []json.RawMessage
+	for {
+		var record json.RawMessage
+		if err := decoder.Decode(&record); err != nil {
+			if errors.Is(err, io.EOF) {
+				return records, nil
+			}
+			return nil, errors.New("invalid JSON records")
+		}
+		records = append(records, record)
+	}
+}
+
+func sameGrantPreview(preview, envelope []json.RawMessage) bool {
+	left, leftErr := json.Marshal(preview)
+	right, rightErr := json.Marshal(envelope)
+	return leftErr == nil && rightErr == nil && bytes.Equal(left, right)
 }
 
 func validPreviewHash(value string) bool {

--- a/cmd/punaro-enroll/main.go
+++ b/cmd/punaro-enroll/main.go
@@ -137,7 +137,7 @@ func runRedeem(args []string, stdout, stderr io.Writer, recoveryOnly bool) int {
 	if flags.Parse(args) != nil || flags.NArg() != 0 || *stateDir == "" || *credentialPath == "" || (!recoveryOnly && *materialPath == "") || (recoveryOnly && *materialPath != "") {
 		return invalid(stderr)
 	}
-	if !safeStateDir(*stateDir) || !safeStateChild(*stateDir, *credentialPath) || privateDir(*stateDir) != nil {
+	if !safeStateDir(*stateDir) || !safeStateChild(*stateDir, *credentialPath) || filepath.Base(*credentialPath) == redemptionJournalName || privateDir(*stateDir) != nil {
 		return enrollmentError(stderr, "private enrollment state is unsafe", 2)
 	}
 	state, err := loadIdentity(filepath.Join(*stateDir, identityFileName))
@@ -478,7 +478,7 @@ func postRedemption(origin string, journal redemptionJournal, accessToken adapte
 		return redemptionResponse{}, redemptionUnavailable
 	}
 	defer func() { _ = response.Body.Close() }()
-	if response.StatusCode == http.StatusUnauthorized || response.StatusCode == http.StatusForbidden || response.StatusCode == http.StatusBadRequest {
+	if response.StatusCode == http.StatusBadRequest || (response.StatusCode == http.StatusUnauthorized && response.Header.Get("WWW-Authenticate") == "Bearer" && responseDeclaresUnauthenticated(response.Body)) {
 		return redemptionResponse{}, redemptionRejected
 	}
 	if response.StatusCode != http.StatusCreated || response.Header.Get("Cache-Control") != "no-store" {
@@ -493,4 +493,15 @@ func postRedemption(origin string, journal redemptionJournal, accessToken adapte
 		return redemptionResponse{}, redemptionUnavailable
 	}
 	return value, redemptionSucceeded
+}
+
+func responseDeclaresUnauthenticated(body io.Reader) bool {
+	raw, err := io.ReadAll(io.LimitReader(body, 1025))
+	if err != nil || len(raw) > 1024 {
+		return false
+	}
+	var value struct {
+		Error string `json:"error"`
+	}
+	return decodeExact(raw, &value, "error") == nil && value.Error == "unauthenticated"
 }

--- a/cmd/punaro-enroll/main.go
+++ b/cmd/punaro-enroll/main.go
@@ -224,7 +224,7 @@ func runRedeem(args []string, stdout, stderr io.Writer, recoveryOnly bool) int {
 	}
 	response, result := postRedemption(state.Origin, journal, accessToken)
 	if result == redemptionRejected {
-		if err := removePrivate(journalPath); err != nil && !errors.Is(err, os.ErrNotExist) {
+		if err := removeJournalIfCurrent(journalPath, journal); err != nil {
 			return enrollmentError(stderr, "enrollment was rejected; remove the private recovery file before requesting a new enrollment", 1)
 		}
 		return enrollmentError(stderr, "enrollment was rejected; request a new enrollment", 1)
@@ -242,7 +242,7 @@ func runRedeem(args []string, stdout, stderr io.Writer, recoveryOnly bool) int {
 	if err := writeCredential(*credentialPath, response.Credential); err != nil {
 		return enrollmentError(stderr, "credential persistence failed; retry this command", 1)
 	}
-	if err := removePrivate(journalPath); err != nil && !errors.Is(err, os.ErrNotExist) {
+	if err := removeJournalIfCurrent(journalPath, journal); err != nil {
 		return enrollmentError(stderr, "credential persisted; remove the private recovery file before continuing", 1)
 	}
 	return writeJSON(stdout, struct {
@@ -438,6 +438,22 @@ func loadJournal(path string) (redemptionJournal, error) {
 		return redemptionJournal{}, errors.New("invalid recovery journal")
 	}
 	return value, nil
+}
+
+// removeJournalIfCurrent prevents a delayed redemption response from deleting
+// recovery state created by a later enrollment attempt in the same state dir.
+func removeJournalIfCurrent(path string, expected redemptionJournal) error {
+	current, err := loadJournal(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	if current != expected {
+		return nil
+	}
+	return removePrivate(path)
 }
 
 func validMaterial(value enrollmentMaterial) bool {

--- a/cmd/punaro-enroll/main.go
+++ b/cmd/punaro-enroll/main.go
@@ -453,8 +453,13 @@ func removeJournalIfCurrent(path string, expected redemptionJournal) error {
 	if current != expected {
 		return nil
 	}
-	return removePrivate(path)
+	if err := removeJournalFile(path); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return err
+	}
+	return nil
 }
+
+var removeJournalFile = removePrivate
 
 func validMaterial(value enrollmentMaterial) bool {
 	return validUUID(value.EnrollmentID) && validUUID(value.ClientBinding) && validCode(value.Code)

--- a/cmd/punaro-enroll/main.go
+++ b/cmd/punaro-enroll/main.go
@@ -75,6 +75,13 @@ type redemptionJournal struct {
 	Credential     string `json:"credential,omitempty"`
 }
 
+type redemptionRequest struct {
+	EnrollmentID   string `json:"enrollment_id"`
+	ClientBinding  string `json:"client_binding"`
+	Code           string `json:"code"`
+	IdempotencyKey string `json:"idempotency_key"`
+}
+
 type redemptionResponse struct {
 	PrincipalID string    `json:"principal_id"`
 	LookupID    string    `json:"lookup_id"`
@@ -478,7 +485,7 @@ const (
 )
 
 func postRedemption(origin string, journal redemptionJournal, accessToken adapter.AccessServiceToken) (redemptionResponse, redemptionResult) {
-	body, err := json.Marshal(journal)
+	body, err := json.Marshal(redemptionRequest{EnrollmentID: journal.EnrollmentID, ClientBinding: journal.ClientBinding, Code: journal.Code, IdempotencyKey: journal.IdempotencyKey})
 	if err != nil {
 		return redemptionResponse{}, redemptionUnavailable
 	}

--- a/cmd/punaro-enroll/main.go
+++ b/cmd/punaro-enroll/main.go
@@ -215,6 +215,23 @@ func runRedeem(args []string, stdout, stderr io.Writer, recoveryOnly bool) int {
 	if err := syncPrivateDirectory(*stateDir); err != nil {
 		return enrollmentError(stderr, "enrollment recovery could not be made durable; retry this command", 1)
 	}
+	if journal.Credential != "" {
+		// The credential checkpoint is written before its destination is
+		// published. Complete that local operation without asking the server to
+		// replay an enrollment that may already have aged out of its bounded
+		// replay window.
+		if err := writeCredential(*credentialPath, journal.Credential); err != nil {
+			return enrollmentError(stderr, "credential persistence failed; retry this command", 1)
+		}
+		if err := removePrivate(journalPath); err != nil && !errors.Is(err, os.ErrNotExist) {
+			return enrollmentError(stderr, "credential persisted; remove the private recovery file before continuing", 1)
+		}
+		lookupID, _, _ := strings.Cut(journal.Credential, ".")
+		return writeJSON(stdout, struct {
+			Origin   string `json:"origin"`
+			LookupID string `json:"lookup_id"`
+		}{Origin: state.Origin, LookupID: lookupID})
+	}
 	response, result := postRedemption(state.Origin, journal, accessToken)
 	if result == redemptionRejected {
 		if err := removePrivate(journalPath); err != nil && !errors.Is(err, os.ErrNotExist) {

--- a/cmd/punaro-enroll/main.go
+++ b/cmd/punaro-enroll/main.go
@@ -1,0 +1,357 @@
+// punaro-enroll creates and redeems a device-bound client enrollment without
+// accepting secret material in command arguments or environment variables.
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/rock3r/punaro/internal/clientidentity"
+)
+
+const (
+	identityFileName      = "client-identity.json"
+	redemptionJournalName = "redemption-recovery.json"
+	maxEnrollmentFile     = 4096
+)
+
+var newEnrollmentHTTPClient = func() *http.Client {
+	return &http.Client{Timeout: 10 * time.Second, CheckRedirect: func(*http.Request, []*http.Request) error {
+		return http.ErrUseLastResponse
+	}}
+}
+
+type publicEnrollment struct {
+	Origin        string `json:"origin"`
+	ClientBinding string `json:"client_binding"`
+}
+
+type enrollmentMaterial struct {
+	EnrollmentID  string `json:"enrollment_id"`
+	ClientBinding string `json:"client_binding"`
+	Code          string `json:"code"`
+}
+
+type redemptionJournal struct {
+	EnrollmentID   string `json:"enrollment_id"`
+	ClientBinding  string `json:"client_binding"`
+	Code           string `json:"code"`
+	IdempotencyKey string `json:"idempotency_key"`
+}
+
+type redemptionResponse struct {
+	PrincipalID string    `json:"principal_id"`
+	LookupID    string    `json:"lookup_id"`
+	Credential  string    `json:"credential"`
+	Generation  int64     `json:"generation"`
+	ExpiresAt   time.Time `json:"expires_at"`
+}
+
+func main() { os.Exit(run(os.Args[1:], os.Stdout, os.Stderr)) }
+
+func run(args []string, stdout, stderr io.Writer) int {
+	if len(args) == 0 {
+		_, _ = fmt.Fprintln(stderr, "usage: punaro-enroll prepare|redeem|recover")
+		return 2
+	}
+	switch args[0] {
+	case "prepare":
+		return runPrepare(args[1:], stdout, stderr)
+	case "redeem":
+		return runRedeem(args[1:], stdout, stderr, false)
+	case "recover":
+		return runRedeem(args[1:], stdout, stderr, true)
+	default:
+		_, _ = fmt.Fprintln(stderr, "usage: punaro-enroll prepare|redeem|recover")
+		return 2
+	}
+}
+
+func runPrepare(args []string, stdout, stderr io.Writer) int {
+	flags := flag.NewFlagSet("prepare", flag.ContinueOnError)
+	flags.SetOutput(io.Discard)
+	origin := flags.String("origin", "", "fixed Punaro HTTPS origin")
+	stateDir := flags.String("state-dir", "", "absolute private enrollment state directory")
+	if flags.Parse(args) != nil || flags.NArg() != 0 || *stateDir == "" {
+		return invalid(stderr)
+	}
+	canonical, ok := clientidentity.CanonicalOrigin(*origin)
+	if !ok || !safeStateDir(*stateDir) || ensurePrivateDir(*stateDir) != nil {
+		return enrollmentError(stderr, "state preparation failed", 2)
+	}
+	identityPath := filepath.Join(*stateDir, identityFileName)
+	state, err := loadIdentity(identityPath)
+	if errors.Is(err, os.ErrNotExist) {
+		binding := uuid.NewString()
+		state = clientidentity.State{Version: clientidentity.Version, Origin: canonical, ClientBinding: binding}
+		if err := writePrivateNew(identityPath, mustEncodeIdentity(state)); err != nil {
+			return enrollmentError(stderr, "state preparation failed", 2)
+		}
+	} else if err != nil || state.Match(canonical, state.ClientBinding, "") != nil || state.LegacyMachineID != "" {
+		return enrollmentError(stderr, "state preparation failed", 2)
+	}
+	return writeJSON(stdout, publicEnrollment{Origin: state.Origin, ClientBinding: state.ClientBinding})
+}
+
+func runRedeem(args []string, stdout, stderr io.Writer, recoveryOnly bool) int {
+	flags := flag.NewFlagSet("redeem", flag.ContinueOnError)
+	flags.SetOutput(io.Discard)
+	stateDir := flags.String("state-dir", "", "absolute private enrollment state directory")
+	materialPath := flags.String("enrollment-file", "", "absolute protected enrollment material file")
+	credentialPath := flags.String("credential-file", "", "absolute private credential destination under state-dir")
+	if flags.Parse(args) != nil || flags.NArg() != 0 || *stateDir == "" || *credentialPath == "" || (!recoveryOnly && *materialPath == "") || (recoveryOnly && *materialPath != "") {
+		return invalid(stderr)
+	}
+	if !safeStateDir(*stateDir) || !safeStateChild(*stateDir, *credentialPath) || privateDir(*stateDir) != nil {
+		return enrollmentError(stderr, "private enrollment state is unsafe", 2)
+	}
+	state, err := loadIdentity(filepath.Join(*stateDir, identityFileName))
+	if err != nil || state.LegacyMachineID != "" {
+		return enrollmentError(stderr, "private enrollment state is unsafe", 2)
+	}
+	journalPath := filepath.Join(*stateDir, redemptionJournalName)
+	journal, journalErr := loadJournal(journalPath)
+	if recoveryOnly {
+		if journalErr != nil {
+			return enrollmentError(stderr, "no recoverable enrollment was found", 2)
+		}
+	} else {
+		material, err := loadMaterial(*materialPath)
+		if err != nil {
+			return enrollmentError(stderr, "enrollment material is invalid", 2)
+		}
+		if material.ClientBinding != state.ClientBinding {
+			return enrollmentError(stderr, "enrollment material does not match this device", 2)
+		}
+		switch {
+		case journalErr == nil:
+			if journal.EnrollmentID != material.EnrollmentID || journal.ClientBinding != material.ClientBinding || journal.Code != material.Code {
+				return enrollmentError(stderr, "existing enrollment recovery does not match material", 2)
+			}
+		case !errors.Is(journalErr, os.ErrNotExist):
+			return enrollmentError(stderr, "private enrollment state is unsafe", 2)
+		default:
+			key, err := uuid.NewRandom()
+			if err != nil {
+				return enrollmentError(stderr, "enrollment recovery could not be created", 1)
+			}
+			journal = redemptionJournal{EnrollmentID: material.EnrollmentID, ClientBinding: material.ClientBinding, Code: material.Code, IdempotencyKey: key.String()}
+			if err := writePrivateNew(journalPath, mustJSON(journal)); err != nil {
+				return enrollmentError(stderr, "enrollment recovery could not be created", 1)
+			}
+		}
+	}
+	if journal.ClientBinding != state.ClientBinding || !validJournal(journal) {
+		return enrollmentError(stderr, "private enrollment state is unsafe", 2)
+	}
+	response, result := postRedemption(state.Origin, journal)
+	if result == redemptionRejected {
+		if err := os.Remove(journalPath); err != nil && !errors.Is(err, os.ErrNotExist) {
+			return enrollmentError(stderr, "enrollment was rejected; remove the private recovery file before requesting a new enrollment", 1)
+		}
+		return enrollmentError(stderr, "enrollment was rejected; request a new enrollment", 1)
+	}
+	if result != redemptionSucceeded {
+		return enrollmentError(stderr, "enrollment is temporarily unavailable; retry this command", 1)
+	}
+	if err := writeCredential(*credentialPath, response.Credential); err != nil {
+		return enrollmentError(stderr, "credential persistence failed; retry this command", 1)
+	}
+	if err := os.Remove(journalPath); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return enrollmentError(stderr, "credential persisted; remove the private recovery file before continuing", 1)
+	}
+	return writeJSON(stdout, struct {
+		Origin     string `json:"origin"`
+		LookupID   string `json:"lookup_id"`
+		Generation int64  `json:"generation"`
+	}{Origin: state.Origin, LookupID: response.LookupID, Generation: response.Generation})
+}
+
+func invalid(stderr io.Writer) int { return enrollmentError(stderr, "invalid arguments", 2) }
+func enrollmentError(stderr io.Writer, message string, code int) int {
+	_, _ = fmt.Fprintf(stderr, "punaro-enroll: %s\n", message)
+	return code
+}
+
+func writeJSON(destination io.Writer, value any) int {
+	if err := json.NewEncoder(destination).Encode(value); err != nil {
+		return 1
+	}
+	return 0
+}
+
+func mustEncodeIdentity(value clientidentity.State) []byte {
+	raw, err := value.Encode()
+	if err != nil {
+		return nil
+	}
+	return append(raw, '\n')
+}
+
+func mustJSON(value any) []byte {
+	raw, err := json.Marshal(value)
+	if err != nil {
+		return nil
+	}
+	return append(raw, '\n')
+}
+
+func loadIdentity(path string) (clientidentity.State, error) {
+	raw, err := readPrivate(path, maxEnrollmentFile)
+	if err != nil {
+		return clientidentity.State{}, err
+	}
+	return clientidentity.Parse(raw)
+}
+
+func loadMaterial(path string) (enrollmentMaterial, error) {
+	raw, err := readPrivate(path, maxEnrollmentFile)
+	if err != nil {
+		return enrollmentMaterial{}, err
+	}
+	var value enrollmentMaterial
+	if err := decodeExact(raw, &value, "enrollment_id", "client_binding", "code"); err != nil || !validMaterial(value) {
+		return enrollmentMaterial{}, errors.New("invalid enrollment material")
+	}
+	return value, nil
+}
+
+func loadJournal(path string) (redemptionJournal, error) {
+	raw, err := readPrivate(path, maxEnrollmentFile)
+	if err != nil {
+		return redemptionJournal{}, err
+	}
+	var value redemptionJournal
+	if err := decodeExact(raw, &value, "enrollment_id", "client_binding", "code", "idempotency_key"); err != nil || !validJournal(value) {
+		return redemptionJournal{}, errors.New("invalid recovery journal")
+	}
+	return value, nil
+}
+
+func validMaterial(value enrollmentMaterial) bool {
+	return validUUID(value.EnrollmentID) && validUUID(value.ClientBinding) && validCode(value.Code)
+}
+func validJournal(value redemptionJournal) bool {
+	return validMaterial(enrollmentMaterial{EnrollmentID: value.EnrollmentID, ClientBinding: value.ClientBinding, Code: value.Code}) && validUUID(value.IdempotencyKey)
+}
+func validUUID(value string) bool {
+	parsed, err := uuid.Parse(value)
+	return err == nil && parsed.String() == value
+}
+func validCode(value string) bool {
+	return len(value) == 43 && !strings.ContainsAny(value, " \t\r\n")
+}
+
+func decodeExact(raw []byte, target any, fields ...string) error {
+	return decodeFields(raw, target, fields, nil)
+}
+
+func decodeFields(raw []byte, target any, required, optional []string) error {
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	token, err := decoder.Token()
+	if err != nil || token != json.Delim('{') {
+		return errors.New("invalid object")
+	}
+	expected := make(map[string]bool, len(required))
+	allowed := make(map[string]bool, len(required)+len(optional))
+	seen := make(map[string]bool, len(required)+len(optional))
+	for _, field := range required {
+		expected[field] = false
+		allowed[field] = true
+	}
+	for _, field := range optional {
+		allowed[field] = true
+	}
+	for decoder.More() {
+		token, err := decoder.Token()
+		field, ok := token.(string)
+		if err != nil || !ok {
+			return errors.New("invalid object")
+		}
+		if _, known := allowed[field]; !known {
+			return errors.New("invalid object")
+		}
+		if seen[field] {
+			return errors.New("invalid object")
+		}
+		var value json.RawMessage
+		if err := decoder.Decode(&value); err != nil {
+			return errors.New("invalid object")
+		}
+		seen[field] = true
+		if _, required := expected[field]; required {
+			expected[field] = true
+		}
+	}
+	if token, err := decoder.Token(); err != nil || token != json.Delim('}') || decoder.Decode(&struct{}{}) != io.EOF {
+		return errors.New("invalid object")
+	}
+	for _, present := range expected {
+		if !present {
+			return errors.New("incomplete object")
+		}
+	}
+	if json.Unmarshal(raw, target) != nil {
+		return errors.New("invalid object")
+	}
+	return nil
+}
+
+func decodeRedemptionResponse(raw []byte) (redemptionResponse, error) {
+	var value redemptionResponse
+	if err := decodeFields(raw, &value, []string{"principal_id", "lookup_id", "credential", "generation"}, []string{"expires_at"}); err != nil || !validUUID(value.PrincipalID) || !validUUID(value.LookupID) || value.Credential == "" || strings.ContainsAny(value.Credential, " \t\r\n") || value.Generation < 1 {
+		return redemptionResponse{}, errors.New("invalid redemption response")
+	}
+	return value, nil
+}
+
+type redemptionResult uint8
+
+const (
+	redemptionUnavailable redemptionResult = iota
+	redemptionRejected
+	redemptionSucceeded
+)
+
+func postRedemption(origin string, journal redemptionJournal) (redemptionResponse, redemptionResult) {
+	body, err := json.Marshal(journal)
+	if err != nil {
+		return redemptionResponse{}, redemptionUnavailable
+	}
+	request, err := http.NewRequestWithContext(context.Background(), http.MethodPost, origin+"/v1/enrollments/redeem", bytes.NewReader(body))
+	if err != nil {
+		return redemptionResponse{}, redemptionUnavailable
+	}
+	request.Header.Set("Content-Type", "application/json")
+	response, err := newEnrollmentHTTPClient().Do(request)
+	if err != nil {
+		return redemptionResponse{}, redemptionUnavailable
+	}
+	defer func() { _ = response.Body.Close() }()
+	if response.StatusCode == http.StatusUnauthorized || response.StatusCode == http.StatusForbidden || response.StatusCode == http.StatusBadRequest {
+		return redemptionResponse{}, redemptionRejected
+	}
+	if response.StatusCode != http.StatusCreated || response.Header.Get("Cache-Control") != "no-store" {
+		return redemptionResponse{}, redemptionUnavailable
+	}
+	raw, err := io.ReadAll(io.LimitReader(response.Body, maxEnrollmentFile+1))
+	if err != nil || len(raw) > maxEnrollmentFile {
+		return redemptionResponse{}, redemptionUnavailable
+	}
+	value, err := decodeRedemptionResponse(raw)
+	if err != nil {
+		return redemptionResponse{}, redemptionUnavailable
+	}
+	return value, redemptionSucceeded
+}

--- a/cmd/punaro-enroll/main.go
+++ b/cmd/punaro-enroll/main.go
@@ -126,6 +126,9 @@ func runPrepare(args []string, stdout, stderr io.Writer) int {
 	} else if err != nil || state.Match(canonical, state.ClientBinding, "") != nil || state.LegacyMachineID != "" {
 		return enrollmentError(stderr, "state preparation failed", 2)
 	}
+	if err := syncPrivateDirectory(*stateDir); err != nil {
+		return enrollmentError(stderr, "state preparation failed", 2)
+	}
 	return writeJSON(stdout, publicEnrollment{Origin: state.Origin, ClientBinding: state.ClientBinding})
 }
 

--- a/cmd/punaro-enroll/main.go
+++ b/cmd/punaro-enroll/main.go
@@ -561,7 +561,7 @@ func postRedemption(origin string, journal redemptionJournal, accessToken adapte
 		return redemptionResponse{}, redemptionUnavailable
 	}
 	defer func() { _ = response.Body.Close() }()
-	if (response.StatusCode == http.StatusBadRequest && response.Header.Get("Cache-Control") == "no-store" && responseDeclaresMalformed(response.Body)) || (response.StatusCode == http.StatusUnauthorized && response.Header.Get("WWW-Authenticate") == "Bearer" && responseDeclaresUnauthenticated(response.Body)) {
+	if (response.StatusCode == http.StatusBadRequest && response.Header.Get("Cache-Control") == "no-store" && responseDeclaresMalformed(response.Body)) || (response.StatusCode == http.StatusUnauthorized && response.Header.Get("Cache-Control") == "no-store" && response.Header.Get("WWW-Authenticate") == "Bearer" && responseDeclaresUnauthenticated(response.Body)) {
 		return redemptionResponse{}, redemptionRejected
 	}
 	if response.StatusCode != http.StatusCreated || response.Header.Get("Cache-Control") != "no-store" {

--- a/cmd/punaro-enroll/main.go
+++ b/cmd/punaro-enroll/main.go
@@ -26,6 +26,7 @@ import (
 const (
 	identityFileName      = "client-identity.json"
 	redemptionJournalName = "redemption-recovery.json"
+	redemptionLockName    = "redemption-recovery.lock"
 	maxEnrollmentFile     = 4096
 	// maxEnrollmentMaterial bounds the two JSON records emitted by
 	// `punaro-admin client add --yes` at its 100-project limit.
@@ -165,6 +166,11 @@ func runRedeem(args []string, stdout, stderr io.Writer, recoveryOnly bool) int {
 	if err != nil || state.LegacyMachineID != "" {
 		return enrollmentError(stderr, "private enrollment state is unsafe", 2)
 	}
+	unlock, err := lockEnrollmentState(*stateDir)
+	if err != nil {
+		return enrollmentError(stderr, "private enrollment state is unavailable; retry this command", 1)
+	}
+	defer unlock()
 	accessToken, err := loadAccessToken(*accessPath)
 	if err != nil {
 		return enrollmentError(stderr, "Access admission material is invalid", 2)
@@ -211,7 +217,7 @@ func runRedeem(args []string, stdout, stderr io.Writer, recoveryOnly bool) int {
 				return enrollmentError(stderr, "enrollment recovery could not be created", 1)
 			}
 			journal = redemptionJournal{EnrollmentID: material.EnrollmentID, ClientBinding: material.ClientBinding, Code: material.Code, IdempotencyKey: key.String(), CredentialPath: *credentialPath}
-			if err := writePrivateNew(journalPath, mustJSON(journal)); err != nil {
+			if err := writePrivateAtomicNew(journalPath, mustJSON(journal)); err != nil {
 				return enrollmentError(stderr, "enrollment recovery could not be created", 1)
 			}
 		}

--- a/cmd/punaro-enroll/main_test.go
+++ b/cmd/punaro-enroll/main_test.go
@@ -299,6 +299,31 @@ func TestRecoverRejectsADifferentCredentialDestination(t *testing.T) {
 	}
 }
 
+func TestRemoveJournalIfCurrentPreservesAReplacementJournal(t *testing.T) {
+	stateDir := filepath.Join(t.TempDir(), "state")
+	if err := ensurePrivateDir(stateDir); err != nil {
+		t.Fatal(err)
+	}
+	journalPath := filepath.Join(stateDir, redemptionJournalName)
+	old := redemptionJournal{EnrollmentID: "33333333-3333-4333-8333-333333333333", ClientBinding: "11111111-1111-4111-8111-111111111111", Code: strings.Repeat("A", 43), IdempotencyKey: "44444444-4444-4444-8444-444444444444", CredentialPath: filepath.Join(stateDir, "credential")}
+	if err := writePrivateNew(journalPath, mustJSON(old)); err != nil {
+		t.Fatal(err)
+	}
+	replacement := old
+	replacement.EnrollmentID = "55555555-5555-4555-8555-555555555555"
+	replacement.IdempotencyKey = "66666666-6666-4666-8666-666666666666"
+	if err := writePrivateAtomic(journalPath, mustJSON(replacement)); err != nil {
+		t.Fatal(err)
+	}
+	if err := removeJournalIfCurrent(journalPath, old); err != nil {
+		t.Fatal(err)
+	}
+	current, err := loadJournal(journalPath)
+	if err != nil || current != replacement {
+		t.Fatalf("replacement journal err=%v current=%#v", err, current)
+	}
+}
+
 func TestRedeemSendsProtectedAccessServiceToken(t *testing.T) {
 	credential := "22222222-2222-4222-8222-222222222222." + strings.Repeat("A", 43)
 	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/cmd/punaro-enroll/main_test.go
+++ b/cmd/punaro-enroll/main_test.go
@@ -1,0 +1,142 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestPrepareThenRedeemKeepsSecretsOutOfOutputAndRecoversIdempotently(t *testing.T) {
+	stateDir := filepath.Join(t.TempDir(), "state")
+	var prepared publicEnrollment
+	credential := "punaro_device_" + "credential_secret"
+	calls := 0
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		if r.Method != http.MethodPost || r.URL.Path != "/v1/enrollments/redeem" || r.Header.Get("Content-Type") != "application/json" {
+			t.Fatalf("request=%s %s headers=%v", r.Method, r.URL.Path, r.Header)
+		}
+		body, err := io.ReadAll(r.Body)
+		if err != nil || !strings.Contains(string(body), prepared.ClientBinding) || !strings.Contains(string(body), `"idempotency_key"`) {
+			t.Fatalf("body=%q err=%v", body, err)
+		}
+		if calls == 1 {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			return
+		}
+		w.Header().Set("Cache-Control", "no-store")
+		w.WriteHeader(http.StatusCreated)
+		_, _ = io.WriteString(w, `{"principal_id":"11111111-1111-4111-8111-111111111111","lookup_id":"22222222-2222-4222-8222-222222222222","credential":"`+credential+`","generation":1}`)
+	}))
+	defer server.Close()
+	var firstOut, firstErr bytes.Buffer
+	if code := run([]string{"prepare", "--origin", server.URL, "--state-dir", stateDir}, &firstOut, &firstErr); code != 0 || firstErr.Len() != 0 {
+		t.Fatalf("prepare code=%d stdout=%q stderr=%q", code, firstOut.String(), firstErr.String())
+	}
+	if err := json.Unmarshal(firstOut.Bytes(), &prepared); err != nil || prepared.Origin != server.URL || prepared.ClientBinding == "" {
+		t.Fatalf("prepare=%q parsed=%#v err=%v", firstOut.String(), prepared, err)
+	}
+	original := newEnrollmentHTTPClient
+	newEnrollmentHTTPClient = func() *http.Client { return server.Client() }
+	t.Cleanup(func() { newEnrollmentHTTPClient = original })
+
+	material := filepath.Join(t.TempDir(), "material.json")
+	if err := os.WriteFile(material, []byte(`{"enrollment_id":"33333333-3333-4333-8333-333333333333","client_binding":"`+prepared.ClientBinding+`","code":"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	credentialFile := filepath.Join(stateDir, "device.credential")
+	var firstRedeemOut, firstRedeemErr bytes.Buffer
+	if code := run([]string{"redeem", "--state-dir", stateDir, "--enrollment-file", material, "--credential-file", credentialFile}, &firstRedeemOut, &firstRedeemErr); code != 1 || !strings.Contains(firstRedeemErr.String(), "retry") {
+		t.Fatalf("first redeem code=%d stdout=%q stderr=%q", code, firstRedeemOut.String(), firstRedeemErr.String())
+	}
+	if raw, err := os.ReadFile(filepath.Join(stateDir, redemptionJournalName)); err != nil || !strings.Contains(string(raw), `"code"`) { // #nosec G304 -- test reads a recovery file created below its own private fixture.
+		t.Fatalf("recovery journal err=%v raw=%q", err, raw)
+	}
+	var secondOut, secondErr bytes.Buffer
+	if code := run([]string{"redeem", "--state-dir", stateDir, "--enrollment-file", material, "--credential-file", credentialFile}, &secondOut, &secondErr); code != 0 || secondErr.Len() != 0 {
+		t.Fatalf("second redeem code=%d stdout=%q stderr=%q", code, secondOut.String(), secondErr.String())
+	}
+	if calls != 2 || strings.Contains(firstOut.String()+firstRedeemOut.String()+firstRedeemErr.String()+secondOut.String()+secondErr.String(), credential) || strings.Contains(secondOut.String(), "code") {
+		t.Fatalf("calls=%d output leaked secret: prepare=%q first=%q/%q second=%q/%q", calls, firstOut.String(), firstRedeemOut.String(), firstRedeemErr.String(), secondOut.String(), secondErr.String())
+	}
+	if raw, err := os.ReadFile(credentialFile); err != nil || string(raw) != credential+"\n" { // #nosec G304 -- test reads the credential created below its own private fixture.
+		t.Fatalf("credential err=%v raw=%q", err, raw)
+	}
+	if _, err := os.Lstat(filepath.Join(stateDir, redemptionJournalName)); !os.IsNotExist(err) {
+		t.Fatalf("recovery journal remains: %v", err)
+	}
+}
+
+func TestRedeemFailsClosedForBindingMismatchWithoutContactingOrigin(t *testing.T) {
+	stateDir := filepath.Join(t.TempDir(), "state")
+	if code := run([]string{"prepare", "--origin", "https://punaro.test", "--state-dir", stateDir}, io.Discard, io.Discard); code != 0 {
+		t.Fatal("prepare failed")
+	}
+	material := filepath.Join(t.TempDir(), "material.json")
+	if err := os.WriteFile(material, []byte(`{"enrollment_id":"33333333-3333-4333-8333-333333333333","client_binding":"44444444-4444-4444-8444-444444444444","code":"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	var stdout, stderr bytes.Buffer
+	if code := run([]string{"redeem", "--state-dir", stateDir, "--enrollment-file", material, "--credential-file", filepath.Join(stateDir, "credential")}, &stdout, &stderr); code != 2 || stdout.Len() != 0 || stderr.String() != "punaro-enroll: enrollment material does not match this device\n" {
+		t.Fatalf("code=%d stdout=%q stderr=%q", code, stdout.String(), stderr.String())
+	}
+}
+
+func TestEnrollmentMaterialRejectsDuplicateOrUnknownFields(t *testing.T) {
+	directory := t.TempDir()
+	for name, raw := range map[string]string{
+		"duplicate": `{"enrollment_id":"33333333-3333-4333-8333-333333333333","enrollment_id":"33333333-3333-4333-8333-333333333333","client_binding":"44444444-4444-4444-8444-444444444444","code":"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"}`,
+		"unknown":   `{"enrollment_id":"33333333-3333-4333-8333-333333333333","client_binding":"44444444-4444-4444-8444-444444444444","code":"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA","origin":"https://attacker.test"}`,
+	} {
+		path := filepath.Join(directory, name+".json")
+		if err := os.WriteFile(path, []byte(raw), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := loadMaterial(path); err == nil {
+			t.Fatalf("%s material was accepted", name)
+		}
+	}
+}
+
+func TestRedemptionResponseAcceptsOptionalExpiryWithoutRelaxingItsSchema(t *testing.T) {
+	response, err := decodeRedemptionResponse([]byte(`{"principal_id":"11111111-1111-4111-8111-111111111111","lookup_id":"22222222-2222-4222-8222-222222222222","credential":"punaro_device_credential","generation":1,"expires_at":"2030-01-02T03:04:05Z"}`))
+	if err != nil || response.ExpiresAt.IsZero() {
+		t.Fatalf("expiring response err=%v response=%#v", err, response)
+	}
+	if _, err := decodeRedemptionResponse([]byte(`{"principal_id":"11111111-1111-4111-8111-111111111111","lookup_id":"22222222-2222-4222-822222222222","credential":"punaro_device_credential","generation":1,"expires_at":"invalid"}`)); err == nil {
+		t.Fatal("invalid expiry was accepted")
+	}
+}
+
+func TestRejectedEnrollmentClearsRecoverySoReplacementCanProceed(t *testing.T) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusUnauthorized) }))
+	defer server.Close()
+	original := newEnrollmentHTTPClient
+	newEnrollmentHTTPClient = func() *http.Client { return server.Client() }
+	t.Cleanup(func() { newEnrollmentHTTPClient = original })
+	stateDir := filepath.Join(t.TempDir(), "state")
+	if code := run([]string{"prepare", "--origin", server.URL, "--state-dir", stateDir}, io.Discard, io.Discard); code != 0 {
+		t.Fatal("prepare failed")
+	}
+	identity, err := loadIdentity(filepath.Join(stateDir, identityFileName))
+	if err != nil {
+		t.Fatal(err)
+	}
+	material := filepath.Join(t.TempDir(), "material.json")
+	if err := os.WriteFile(material, []byte(`{"enrollment_id":"33333333-3333-4333-8333-333333333333","client_binding":"`+identity.ClientBinding+`","code":"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	var stderr bytes.Buffer
+	if code := run([]string{"redeem", "--state-dir", stateDir, "--enrollment-file", material, "--credential-file", filepath.Join(stateDir, "credential")}, io.Discard, &stderr); code != 1 || !strings.Contains(stderr.String(), "request a new enrollment") {
+		t.Fatalf("code=%d stderr=%q", code, stderr.String())
+	}
+	if _, err := os.Lstat(filepath.Join(stateDir, redemptionJournalName)); !os.IsNotExist(err) {
+		t.Fatalf("rejected enrollment recovery was retained: %v", err)
+	}
+}

--- a/cmd/punaro-enroll/main_test.go
+++ b/cmd/punaro-enroll/main_test.go
@@ -70,6 +70,27 @@ func TestPrepareThenRedeemKeepsSecretsOutOfOutputAndRecoversIdempotently(t *test
 	}
 }
 
+func TestPrepareRetriesIdentityDirectorySyncBeforePublishingBinding(t *testing.T) {
+	originalSync := syncPrivateDirectory
+	firstSync := true
+	syncPrivateDirectory = func(string) error {
+		if firstSync {
+			firstSync = false
+			return os.ErrInvalid
+		}
+		return nil
+	}
+	t.Cleanup(func() { syncPrivateDirectory = originalSync })
+	stateDir := filepath.Join(t.TempDir(), "state")
+	if code := run([]string{"prepare", "--origin", "https://punaro.test", "--state-dir", stateDir}, io.Discard, io.Discard); code != 2 {
+		t.Fatalf("first prepare code=%d", code)
+	}
+	var stdout, stderr bytes.Buffer
+	if code := run([]string{"prepare", "--origin", "https://punaro.test", "--state-dir", stateDir}, &stdout, &stderr); code != 0 || stderr.Len() != 0 || !strings.Contains(stdout.String(), "client_binding") {
+		t.Fatalf("retry code=%d stdout=%q stderr=%q", code, stdout.String(), stderr.String())
+	}
+}
+
 func TestRedeemFailsClosedForBindingMismatchWithoutContactingOrigin(t *testing.T) {
 	stateDir := filepath.Join(t.TempDir(), "state")
 	if code := run([]string{"prepare", "--origin", "https://punaro.test", "--state-dir", stateDir}, io.Discard, io.Discard); code != 0 {

--- a/cmd/punaro-enroll/main_test.go
+++ b/cmd/punaro-enroll/main_test.go
@@ -152,7 +152,7 @@ func TestRecoverCompletesWhenCredentialWasPersistedBeforeJournalCleanup(t *testi
 	if err != nil {
 		t.Fatal(err)
 	}
-	journal := redemptionJournal{EnrollmentID: "33333333-3333-4333-8333-333333333333", ClientBinding: identity.ClientBinding, Code: strings.Repeat("A", 43), IdempotencyKey: "44444444-4444-4444-8444-444444444444"}
+	journal := redemptionJournal{EnrollmentID: "33333333-3333-4333-8333-333333333333", ClientBinding: identity.ClientBinding, Code: strings.Repeat("A", 43), IdempotencyKey: "44444444-4444-4444-8444-444444444444", Credential: credential}
 	if err := writePrivateNew(filepath.Join(stateDir, redemptionJournalName), mustJSON(journal)); err != nil {
 		t.Fatal(err)
 	}
@@ -240,6 +240,14 @@ func TestEnrollmentMaterialAcceptsStrictAdminEnvelope(t *testing.T) {
 	if _, err := loadMaterial(invalid); err == nil {
 		t.Fatal("admin envelope accepted an unknown grant field")
 	}
+	longGrants := "[" + strings.TrimSuffix(strings.Repeat(`{"scope":"installation","capability":"project.create"},`, 100), ",") + "]"
+	longEnvelope := `{"enrollment_id":"33333333-3333-4333-8333-333333333333","client_binding":"44444444-4444-4444-8444-444444444444","code":"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA","expires_at":"2030-01-02T03:04:05Z","preview_hash":"0000000000000000000000000000000000000000000000000000000000000000","grants":` + longGrants + `}`
+	if len(longEnvelope) <= maxEnrollmentFile {
+		t.Fatalf("long enrollment material=%d bytes", len(longEnvelope))
+	}
+	if _, err := loadMaterial(writeTestMaterial(t, longEnvelope)); err != nil {
+		t.Fatalf("large admin envelope rejected: %v", err)
+	}
 }
 
 func TestRedemptionResponseAcceptsOptionalExpiryWithoutRelaxingItsSchema(t *testing.T) {
@@ -305,6 +313,32 @@ func TestAccessDenialRetainsRecoveryJournal(t *testing.T) {
 				t.Fatalf("Access denial removed recovery journal: %v", err)
 			}
 		})
+	}
+}
+
+func TestRecoverRejectsUnrelatedExistingCredentialBeforeContactingOrigin(t *testing.T) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		t.Fatal("recovery contacted the origin before rejecting an unrelated credential file")
+	}))
+	defer server.Close()
+	original := newEnrollmentHTTPClient
+	newEnrollmentHTTPClient = func() *http.Client { return server.Client() }
+	t.Cleanup(func() { newEnrollmentHTTPClient = original })
+	stateDir := filepath.Join(t.TempDir(), "state")
+	if code := run([]string{"prepare", "--origin", server.URL, "--state-dir", stateDir}, io.Discard, io.Discard); code != 0 {
+		t.Fatal("prepare failed")
+	}
+	identity, err := loadIdentity(filepath.Join(stateDir, identityFileName))
+	if err != nil {
+		t.Fatal(err)
+	}
+	journal := redemptionJournal{EnrollmentID: "33333333-3333-4333-8333-333333333333", ClientBinding: identity.ClientBinding, Code: strings.Repeat("A", 43), IdempotencyKey: "44444444-4444-4444-8444-444444444444"}
+	if err := writePrivateNew(filepath.Join(stateDir, redemptionJournalName), mustJSON(journal)); err != nil {
+		t.Fatal(err)
+	}
+	var stderr bytes.Buffer
+	if code := run([]string{"recover", "--state-dir", stateDir, "--credential-file", filepath.Join(stateDir, identityFileName)}, io.Discard, &stderr); code != 2 || !strings.Contains(stderr.String(), "private credential destination is unavailable") {
+		t.Fatalf("code=%d stderr=%q", code, stderr.String())
 	}
 }
 

--- a/cmd/punaro-enroll/main_test.go
+++ b/cmd/punaro-enroll/main_test.go
@@ -146,6 +146,34 @@ func TestRecoverCompletesWhenCredentialWasPersistedBeforeJournalCleanup(t *testi
 	}
 }
 
+func TestRedeemSendsProtectedAccessServiceToken(t *testing.T) {
+	credential := "22222222-2222-4222-8222-222222222222." + strings.Repeat("A", 43)
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("CF-Access-Client-Id") != "access-id" || r.Header.Get("CF-Access-Client-Secret") != "access-secret" {
+			t.Fatalf("Access headers were missing: %#v", r.Header)
+		}
+		w.Header().Set("Cache-Control", "no-store")
+		w.WriteHeader(http.StatusCreated)
+		_, _ = io.WriteString(w, `{"principal_id":"11111111-1111-4111-8111-111111111111","lookup_id":"22222222-2222-4222-8222-222222222222","credential":"`+credential+`","generation":1}`)
+	}))
+	defer server.Close()
+	original := newEnrollmentHTTPClient
+	newEnrollmentHTTPClient = func() *http.Client { return server.Client() }
+	t.Cleanup(func() { newEnrollmentHTTPClient = original })
+	stateDir := filepath.Join(t.TempDir(), "state")
+	var prepared publicEnrollment
+	var preparedOut bytes.Buffer
+	if code := run([]string{"prepare", "--origin", server.URL, "--state-dir", stateDir}, &preparedOut, io.Discard); code != 0 || json.Unmarshal(preparedOut.Bytes(), &prepared) != nil {
+		t.Fatalf("prepare code=%d output=%q", code, preparedOut.String())
+	}
+	material := writeTestMaterial(t, `{"enrollment_id":"33333333-3333-4333-8333-333333333333","client_binding":"`+prepared.ClientBinding+`","code":"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"}`)
+	accessFile := writeTestMaterial(t, `{"client_id":"access-id","client_secret":"access-secret"}`)
+	var stdout, stderr bytes.Buffer
+	if code := run([]string{"redeem", "--state-dir", stateDir, "--enrollment-file", material, "--credential-file", filepath.Join(stateDir, "credential"), "--access-file", accessFile}, &stdout, &stderr); code != 0 || stderr.Len() != 0 {
+		t.Fatalf("redeem code=%d stdout=%q stderr=%q", code, stdout.String(), stderr.String())
+	}
+}
+
 func TestEnsurePrivateDirCreatesNestedStateDirectory(t *testing.T) {
 	stateDir := filepath.Join(t.TempDir(), "first", "second", "state")
 	if err := ensurePrivateDir(stateDir); err != nil {

--- a/cmd/punaro-enroll/main_test.go
+++ b/cmd/punaro-enroll/main_test.go
@@ -82,6 +82,34 @@ func TestRedeemFailsClosedForBindingMismatchWithoutContactingOrigin(t *testing.T
 	}
 }
 
+func TestRedeemPreflightsCredentialDestinationBeforeContactingOrigin(t *testing.T) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		t.Fatal("redemption contacted the origin before preflighting credential destination")
+	}))
+	defer server.Close()
+	original := newEnrollmentHTTPClient
+	newEnrollmentHTTPClient = func() *http.Client { return server.Client() }
+	t.Cleanup(func() { newEnrollmentHTTPClient = original })
+	stateDir := filepath.Join(t.TempDir(), "state")
+	var prepared publicEnrollment
+	var preparedOut bytes.Buffer
+	if code := run([]string{"prepare", "--origin", server.URL, "--state-dir", stateDir}, &preparedOut, io.Discard); code != 0 || json.Unmarshal(preparedOut.Bytes(), &prepared) != nil {
+		t.Fatalf("prepare code=%d output=%q", code, preparedOut.String())
+	}
+	material := writeTestMaterial(t, `{"enrollment_id":"33333333-3333-4333-8333-333333333333","client_binding":"`+prepared.ClientBinding+`","code":"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"}`)
+	credentialPath := filepath.Join(stateDir, "credential")
+	if err := writePrivateNew(credentialPath, []byte("existing credential\n")); err != nil {
+		t.Fatal(err)
+	}
+	var stderr bytes.Buffer
+	if code := run([]string{"redeem", "--state-dir", stateDir, "--enrollment-file", material, "--credential-file", credentialPath}, io.Discard, &stderr); code != 2 || stderr.String() != "punaro-enroll: private credential destination is unavailable\n" {
+		t.Fatalf("code=%d stderr=%q", code, stderr.String())
+	}
+	if _, err := os.Lstat(filepath.Join(stateDir, redemptionJournalName)); !os.IsNotExist(err) {
+		t.Fatalf("preflight created a recovery journal: %v", err)
+	}
+}
+
 func TestEnsurePrivateDirCreatesNestedStateDirectory(t *testing.T) {
 	stateDir := filepath.Join(t.TempDir(), "first", "second", "state")
 	if err := ensurePrivateDir(stateDir); err != nil {

--- a/cmd/punaro-enroll/main_test.go
+++ b/cmd/punaro-enroll/main_test.go
@@ -110,6 +110,42 @@ func TestRedeemPreflightsCredentialDestinationBeforeContactingOrigin(t *testing.
 	}
 }
 
+func TestRecoverCompletesWhenCredentialWasPersistedBeforeJournalCleanup(t *testing.T) {
+	credential := "22222222-2222-4222-8222-222222222222." + strings.Repeat("A", 43)
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Cache-Control", "no-store")
+		w.WriteHeader(http.StatusCreated)
+		_, _ = io.WriteString(w, `{"principal_id":"11111111-1111-4111-8111-111111111111","lookup_id":"22222222-2222-4222-8222-222222222222","credential":"`+credential+`","generation":1}`)
+	}))
+	defer server.Close()
+	original := newEnrollmentHTTPClient
+	newEnrollmentHTTPClient = func() *http.Client { return server.Client() }
+	t.Cleanup(func() { newEnrollmentHTTPClient = original })
+	stateDir := filepath.Join(t.TempDir(), "state")
+	if code := run([]string{"prepare", "--origin", server.URL, "--state-dir", stateDir}, io.Discard, io.Discard); code != 0 {
+		t.Fatal("prepare failed")
+	}
+	identity, err := loadIdentity(filepath.Join(stateDir, identityFileName))
+	if err != nil {
+		t.Fatal(err)
+	}
+	journal := redemptionJournal{EnrollmentID: "33333333-3333-4333-8333-333333333333", ClientBinding: identity.ClientBinding, Code: strings.Repeat("A", 43), IdempotencyKey: "44444444-4444-4444-8444-444444444444"}
+	if err := writePrivateNew(filepath.Join(stateDir, redemptionJournalName), mustJSON(journal)); err != nil {
+		t.Fatal(err)
+	}
+	credentialPath := filepath.Join(stateDir, "credential")
+	if err := writePrivateNew(credentialPath, []byte(credential+"\n")); err != nil {
+		t.Fatal(err)
+	}
+	var stdout, stderr bytes.Buffer
+	if code := run([]string{"recover", "--state-dir", stateDir, "--credential-file", credentialPath}, &stdout, &stderr); code != 0 || stderr.Len() != 0 {
+		t.Fatalf("recover code=%d stdout=%q stderr=%q", code, stdout.String(), stderr.String())
+	}
+	if _, err := os.Lstat(filepath.Join(stateDir, redemptionJournalName)); !os.IsNotExist(err) {
+		t.Fatalf("recovery journal remains: %v", err)
+	}
+}
+
 func TestEnsurePrivateDirCreatesNestedStateDirectory(t *testing.T) {
 	stateDir := filepath.Join(t.TempDir(), "first", "second", "state")
 	if err := ensurePrivateDir(stateDir); err != nil {

--- a/cmd/punaro-enroll/main_test.go
+++ b/cmd/punaro-enroll/main_test.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -260,6 +261,48 @@ func TestRecoverCompletesWhenCredentialWasPersistedBeforeJournalCleanup(t *testi
 	}
 	if _, err := os.Lstat(filepath.Join(stateDir, redemptionJournalName)); !os.IsNotExist(err) {
 		t.Fatalf("recovery journal remains: %v", err)
+	}
+}
+
+func TestRecoverPersistsCheckpointedCredentialWithoutOrigin(t *testing.T) {
+	credential := "22222222-2222-4222-8222-222222222222." + strings.Repeat("A", 43)
+	var contacted atomic.Bool
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		contacted.Store(true)
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+	original := newEnrollmentHTTPClient
+	newEnrollmentHTTPClient = func() *http.Client { return server.Client() }
+	t.Cleanup(func() { newEnrollmentHTTPClient = original })
+	stateDir := filepath.Join(t.TempDir(), "state")
+	if code := run([]string{"prepare", "--origin", server.URL, "--state-dir", stateDir}, io.Discard, io.Discard); code != 0 {
+		t.Fatal("prepare failed")
+	}
+	identity, err := loadIdentity(filepath.Join(stateDir, identityFileName))
+	if err != nil {
+		t.Fatal(err)
+	}
+	journal := redemptionJournal{EnrollmentID: "33333333-3333-4333-8333-333333333333", ClientBinding: identity.ClientBinding, Code: strings.Repeat("A", 43), IdempotencyKey: "44444444-4444-4444-8444-444444444444", Credential: credential}
+	if err := writePrivateNew(filepath.Join(stateDir, redemptionJournalName), mustJSON(journal)); err != nil {
+		t.Fatal(err)
+	}
+	credentialPath := filepath.Join(stateDir, "credential")
+	var stdout, stderr bytes.Buffer
+	if code := run([]string{"recover", "--state-dir", stateDir, "--credential-file", credentialPath}, &stdout, &stderr); code != 0 || stderr.Len() != 0 {
+		t.Fatalf("recover code=%d stdout=%q stderr=%q", code, stdout.String(), stderr.String())
+	}
+	if contacted.Load() {
+		t.Fatal("checkpointed recovery contacted the origin")
+	}
+	if raw, err := readPrivate(credentialPath, maxEnrollmentFile); err != nil || string(raw) != credential+"\n" {
+		t.Fatalf("credential err=%v raw=%q", err, raw)
+	}
+	if _, err := os.Lstat(filepath.Join(stateDir, redemptionJournalName)); !os.IsNotExist(err) {
+		t.Fatalf("recovery journal remains: %v", err)
+	}
+	if strings.Contains(stdout.String(), credential) {
+		t.Fatalf("checkpointed recovery leaked credential in stdout: %q", stdout.String())
 	}
 }
 

--- a/cmd/punaro-enroll/main_test.go
+++ b/cmd/punaro-enroll/main_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -75,23 +76,86 @@ func TestPrepareThenRedeemKeepsSecretsOutOfOutputAndRecoversIdempotently(t *test
 }
 
 func TestPrepareRetriesIdentityDirectorySyncBeforePublishingBinding(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX directory-sync durability contract")
+	}
+	stateDir := filepath.Join(t.TempDir(), "state")
+	parentDir := filepath.Dir(stateDir)
 	originalSync := syncPrivateDirectory
-	firstSync := true
-	syncPrivateDirectory = func(string) error {
-		if firstSync {
-			firstSync = false
-			return os.ErrInvalid
+	parentSyncs := 0
+	syncPrivateDirectory = func(path string) error {
+		if path == parentDir {
+			parentSyncs++
+			if parentSyncs == 1 {
+				return os.ErrInvalid
+			}
 		}
 		return nil
 	}
 	t.Cleanup(func() { syncPrivateDirectory = originalSync })
-	stateDir := filepath.Join(t.TempDir(), "state")
 	if code := run([]string{"prepare", "--origin", "https://punaro.test", "--state-dir", stateDir}, io.Discard, io.Discard); code != 2 {
 		t.Fatalf("first prepare code=%d", code)
 	}
 	var stdout, stderr bytes.Buffer
 	if code := run([]string{"prepare", "--origin", "https://punaro.test", "--state-dir", stateDir}, &stdout, &stderr); code != 0 || stderr.Len() != 0 || !strings.Contains(stdout.String(), "client_binding") {
 		t.Fatalf("retry code=%d stdout=%q stderr=%q", code, stdout.String(), stderr.String())
+	}
+	if parentSyncs != 2 {
+		t.Fatalf("state directory parent syncs=%d", parentSyncs)
+	}
+}
+
+func TestUnverifiedBadRequestRetainsRecoveryJournal(t *testing.T) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = io.WriteString(w, `{"error":"request is malformed"}`)
+	}))
+	defer server.Close()
+	original := newEnrollmentHTTPClient
+	newEnrollmentHTTPClient = func() *http.Client { return server.Client() }
+	t.Cleanup(func() { newEnrollmentHTTPClient = original })
+	stateDir := filepath.Join(t.TempDir(), "state")
+	if code := run([]string{"prepare", "--origin", server.URL, "--state-dir", stateDir}, io.Discard, io.Discard); code != 0 {
+		t.Fatal("prepare failed")
+	}
+	identity, err := loadIdentity(filepath.Join(stateDir, identityFileName))
+	if err != nil {
+		t.Fatal(err)
+	}
+	material := writeTestMaterial(t, `{"enrollment_id":"33333333-3333-4333-8333-333333333333","client_binding":"`+identity.ClientBinding+`","code":"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"}`)
+	var stderr bytes.Buffer
+	if code := run([]string{"redeem", "--state-dir", stateDir, "--enrollment-file", material, "--credential-file", filepath.Join(stateDir, "credential")}, io.Discard, &stderr); code != 1 || !strings.Contains(stderr.String(), "retry") {
+		t.Fatalf("code=%d stderr=%q", code, stderr.String())
+	}
+	if _, err := os.Lstat(filepath.Join(stateDir, redemptionJournalName)); err != nil {
+		t.Fatalf("unverified bad request removed recovery journal: %v", err)
+	}
+}
+
+func TestVerifiedBadRequestClearsRecoveryJournal(t *testing.T) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Cache-Control", "no-store")
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = io.WriteString(w, `{"error":"request is malformed"}`)
+	}))
+	defer server.Close()
+	original := newEnrollmentHTTPClient
+	newEnrollmentHTTPClient = func() *http.Client { return server.Client() }
+	t.Cleanup(func() { newEnrollmentHTTPClient = original })
+	stateDir := filepath.Join(t.TempDir(), "state")
+	if code := run([]string{"prepare", "--origin", server.URL, "--state-dir", stateDir}, io.Discard, io.Discard); code != 0 {
+		t.Fatal("prepare failed")
+	}
+	identity, err := loadIdentity(filepath.Join(stateDir, identityFileName))
+	if err != nil {
+		t.Fatal(err)
+	}
+	material := writeTestMaterial(t, `{"enrollment_id":"33333333-3333-4333-8333-333333333333","client_binding":"`+identity.ClientBinding+`","code":"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"}`)
+	if code := run([]string{"redeem", "--state-dir", stateDir, "--enrollment-file", material, "--credential-file", filepath.Join(stateDir, "credential")}, io.Discard, io.Discard); code != 1 {
+		t.Fatalf("code=%d", code)
+	}
+	if _, err := os.Lstat(filepath.Join(stateDir, redemptionJournalName)); !os.IsNotExist(err) {
+		t.Fatalf("verified bad request retained recovery journal: %v", err)
 	}
 }
 

--- a/cmd/punaro-enroll/main_test.go
+++ b/cmd/punaro-enroll/main_test.go
@@ -389,6 +389,7 @@ func TestRedemptionResponseAcceptsOptionalExpiryWithoutRelaxingItsSchema(t *test
 
 func TestRejectedEnrollmentClearsRecoverySoReplacementCanProceed(t *testing.T) {
 	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Cache-Control", "no-store")
 		w.Header().Set("WWW-Authenticate", "Bearer")
 		w.WriteHeader(http.StatusUnauthorized)
 		_, _ = io.WriteString(w, `{"error":"unauthenticated"}`)
@@ -412,6 +413,34 @@ func TestRejectedEnrollmentClearsRecoverySoReplacementCanProceed(t *testing.T) {
 	}
 	if _, err := os.Lstat(filepath.Join(stateDir, redemptionJournalName)); !os.IsNotExist(err) {
 		t.Fatalf("rejected enrollment recovery was retained: %v", err)
+	}
+}
+
+func TestUnverifiedUnauthorizedRetainsRecoveryJournal(t *testing.T) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("WWW-Authenticate", "Bearer")
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = io.WriteString(w, `{"error":"unauthenticated"}`)
+	}))
+	defer server.Close()
+	original := newEnrollmentHTTPClient
+	newEnrollmentHTTPClient = func() *http.Client { return server.Client() }
+	t.Cleanup(func() { newEnrollmentHTTPClient = original })
+	stateDir := filepath.Join(t.TempDir(), "state")
+	if code := run([]string{"prepare", "--origin", server.URL, "--state-dir", stateDir}, io.Discard, io.Discard); code != 0 {
+		t.Fatal("prepare failed")
+	}
+	identity, err := loadIdentity(filepath.Join(stateDir, identityFileName))
+	if err != nil {
+		t.Fatal(err)
+	}
+	material := writeTestMaterial(t, `{"enrollment_id":"33333333-3333-4333-8333-333333333333","client_binding":"`+identity.ClientBinding+`","code":"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"}`)
+	var stderr bytes.Buffer
+	if code := run([]string{"redeem", "--state-dir", stateDir, "--enrollment-file", material, "--credential-file", filepath.Join(stateDir, "credential")}, io.Discard, &stderr); code != 1 || !strings.Contains(stderr.String(), "retry") {
+		t.Fatalf("code=%d stderr=%q", code, stderr.String())
+	}
+	if _, err := os.Lstat(filepath.Join(stateDir, redemptionJournalName)); err != nil {
+		t.Fatalf("unverified unauthorized response removed recovery journal: %v", err)
 	}
 }
 

--- a/cmd/punaro-enroll/main_test.go
+++ b/cmd/punaro-enroll/main_test.go
@@ -11,7 +11,6 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
-	"sync/atomic"
 	"testing"
 	"time"
 
@@ -261,48 +260,6 @@ func TestRecoverCompletesWhenCredentialWasPersistedBeforeJournalCleanup(t *testi
 	}
 	if _, err := os.Lstat(filepath.Join(stateDir, redemptionJournalName)); !os.IsNotExist(err) {
 		t.Fatalf("recovery journal remains: %v", err)
-	}
-}
-
-func TestRecoverPersistsCheckpointedCredentialWithoutOrigin(t *testing.T) {
-	credential := "22222222-2222-4222-8222-222222222222." + strings.Repeat("A", 43)
-	var contacted atomic.Bool
-	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		contacted.Store(true)
-		w.WriteHeader(http.StatusInternalServerError)
-	}))
-	defer server.Close()
-	original := newEnrollmentHTTPClient
-	newEnrollmentHTTPClient = func() *http.Client { return server.Client() }
-	t.Cleanup(func() { newEnrollmentHTTPClient = original })
-	stateDir := filepath.Join(t.TempDir(), "state")
-	if code := run([]string{"prepare", "--origin", server.URL, "--state-dir", stateDir}, io.Discard, io.Discard); code != 0 {
-		t.Fatal("prepare failed")
-	}
-	identity, err := loadIdentity(filepath.Join(stateDir, identityFileName))
-	if err != nil {
-		t.Fatal(err)
-	}
-	journal := redemptionJournal{EnrollmentID: "33333333-3333-4333-8333-333333333333", ClientBinding: identity.ClientBinding, Code: strings.Repeat("A", 43), IdempotencyKey: "44444444-4444-4444-8444-444444444444", Credential: credential}
-	if err := writePrivateNew(filepath.Join(stateDir, redemptionJournalName), mustJSON(journal)); err != nil {
-		t.Fatal(err)
-	}
-	credentialPath := filepath.Join(stateDir, "credential")
-	var stdout, stderr bytes.Buffer
-	if code := run([]string{"recover", "--state-dir", stateDir, "--credential-file", credentialPath}, &stdout, &stderr); code != 0 || stderr.Len() != 0 {
-		t.Fatalf("recover code=%d stdout=%q stderr=%q", code, stdout.String(), stderr.String())
-	}
-	if contacted.Load() {
-		t.Fatal("checkpointed recovery contacted the origin")
-	}
-	if raw, err := readPrivate(credentialPath, maxEnrollmentFile); err != nil || string(raw) != credential+"\n" {
-		t.Fatalf("credential err=%v raw=%q", err, raw)
-	}
-	if _, err := os.Lstat(filepath.Join(stateDir, redemptionJournalName)); !os.IsNotExist(err) {
-		t.Fatalf("recovery journal remains: %v", err)
-	}
-	if strings.Contains(stdout.String(), credential) {
-		t.Fatalf("checkpointed recovery leaked credential in stdout: %q", stdout.String())
 	}
 }
 

--- a/cmd/punaro-enroll/main_test.go
+++ b/cmd/punaro-enroll/main_test.go
@@ -75,6 +75,19 @@ func TestPrepareThenRedeemKeepsSecretsOutOfOutputAndRecoversIdempotently(t *test
 	}
 }
 
+func TestRedeemRejectsCredentialPathsThatCannotFitRecoveryJournal(t *testing.T) {
+	journal := redemptionJournal{
+		EnrollmentID:   "33333333-3333-4333-8333-333333333333",
+		ClientBinding:  "11111111-1111-4111-8111-111111111111",
+		Code:           strings.Repeat("A", 43),
+		IdempotencyKey: "44444444-4444-4444-8444-444444444444",
+		CredentialPath: "/state/" + strings.Repeat("a", maxEnrollmentFile),
+	}
+	if journalCanPersistCredential(journal) {
+		t.Fatal("credential path that exceeds the recovery-journal limit was accepted")
+	}
+}
+
 func TestPrepareRetriesIdentityDirectorySyncBeforePublishingBinding(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("POSIX directory-sync durability contract")

--- a/cmd/punaro-enroll/main_test.go
+++ b/cmd/punaro-enroll/main_test.go
@@ -324,6 +324,24 @@ func TestRemoveJournalIfCurrentPreservesAReplacementJournal(t *testing.T) {
 	}
 }
 
+func TestRemoveJournalIfCurrentToleratesConcurrentRemoval(t *testing.T) {
+	stateDir := filepath.Join(t.TempDir(), "state")
+	if err := ensurePrivateDir(stateDir); err != nil {
+		t.Fatal(err)
+	}
+	journalPath := filepath.Join(stateDir, redemptionJournalName)
+	journal := redemptionJournal{EnrollmentID: "33333333-3333-4333-8333-333333333333", ClientBinding: "11111111-1111-4111-8111-111111111111", Code: strings.Repeat("A", 43), IdempotencyKey: "44444444-4444-4444-8444-444444444444", CredentialPath: filepath.Join(stateDir, "credential")}
+	if err := writePrivateNew(journalPath, mustJSON(journal)); err != nil {
+		t.Fatal(err)
+	}
+	original := removeJournalFile
+	removeJournalFile = func(string) error { return os.ErrNotExist }
+	t.Cleanup(func() { removeJournalFile = original })
+	if err := removeJournalIfCurrent(journalPath, journal); err != nil {
+		t.Fatalf("concurrent journal removal reported as failure: %v", err)
+	}
+}
+
 func TestRedeemSendsProtectedAccessServiceToken(t *testing.T) {
 	credential := "22222222-2222-4222-8222-222222222222." + strings.Repeat("A", 43)
 	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/cmd/punaro-enroll/main_test.go
+++ b/cmd/punaro-enroll/main_test.go
@@ -246,11 +246,11 @@ func TestRecoverCompletesWhenCredentialWasPersistedBeforeJournalCleanup(t *testi
 	if err != nil {
 		t.Fatal(err)
 	}
-	journal := redemptionJournal{EnrollmentID: "33333333-3333-4333-8333-333333333333", ClientBinding: identity.ClientBinding, Code: strings.Repeat("A", 43), IdempotencyKey: "44444444-4444-4444-8444-444444444444", Credential: credential}
+	credentialPath := filepath.Join(stateDir, "credential")
+	journal := redemptionJournal{EnrollmentID: "33333333-3333-4333-8333-333333333333", ClientBinding: identity.ClientBinding, Code: strings.Repeat("A", 43), IdempotencyKey: "44444444-4444-4444-8444-444444444444", CredentialPath: credentialPath, Credential: credential}
 	if err := writePrivateNew(filepath.Join(stateDir, redemptionJournalName), mustJSON(journal)); err != nil {
 		t.Fatal(err)
 	}
-	credentialPath := filepath.Join(stateDir, "credential")
 	if err := writePrivateNew(credentialPath, []byte(credential+"\n")); err != nil {
 		t.Fatal(err)
 	}
@@ -260,6 +260,42 @@ func TestRecoverCompletesWhenCredentialWasPersistedBeforeJournalCleanup(t *testi
 	}
 	if _, err := os.Lstat(filepath.Join(stateDir, redemptionJournalName)); !os.IsNotExist(err) {
 		t.Fatalf("recovery journal remains: %v", err)
+	}
+}
+
+func TestRecoverRejectsADifferentCredentialDestination(t *testing.T) {
+	calls := 0
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		calls++
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer server.Close()
+	original := newEnrollmentHTTPClient
+	newEnrollmentHTTPClient = func() *http.Client { return server.Client() }
+	t.Cleanup(func() { newEnrollmentHTTPClient = original })
+	stateDir := filepath.Join(t.TempDir(), "state")
+	if code := run([]string{"prepare", "--origin", server.URL, "--state-dir", stateDir}, io.Discard, io.Discard); code != 0 {
+		t.Fatal("prepare failed")
+	}
+	identity, err := loadIdentity(filepath.Join(stateDir, identityFileName))
+	if err != nil {
+		t.Fatal(err)
+	}
+	material := writeTestMaterial(t, `{"enrollment_id":"33333333-3333-4333-8333-333333333333","client_binding":"`+identity.ClientBinding+`","code":"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"}`)
+	credentialA := filepath.Join(stateDir, "credential-a")
+	if code := run([]string{"redeem", "--state-dir", stateDir, "--enrollment-file", material, "--credential-file", credentialA}, io.Discard, io.Discard); code != 1 {
+		t.Fatalf("initial redeem code=%d", code)
+	}
+	credentialB := filepath.Join(stateDir, "credential-b")
+	var stderr bytes.Buffer
+	if code := run([]string{"recover", "--state-dir", stateDir, "--credential-file", credentialB}, io.Discard, &stderr); code != 2 || !strings.Contains(stderr.String(), "bound to a different credential destination") {
+		t.Fatalf("recover code=%d stderr=%q", code, stderr.String())
+	}
+	if calls != 1 {
+		t.Fatalf("recovery contacted origin after destination mismatch: %d calls", calls)
+	}
+	if _, err := os.Lstat(filepath.Join(stateDir, redemptionJournalName)); err != nil {
+		t.Fatalf("recovery journal was removed: %v", err)
 	}
 }
 
@@ -488,7 +524,7 @@ func TestRecoverRejectsUnrelatedExistingCredentialBeforeContactingOrigin(t *test
 	if err != nil {
 		t.Fatal(err)
 	}
-	journal := redemptionJournal{EnrollmentID: "33333333-3333-4333-8333-333333333333", ClientBinding: identity.ClientBinding, Code: strings.Repeat("A", 43), IdempotencyKey: "44444444-4444-4444-8444-444444444444"}
+	journal := redemptionJournal{EnrollmentID: "33333333-3333-4333-8333-333333333333", ClientBinding: identity.ClientBinding, Code: strings.Repeat("A", 43), IdempotencyKey: "44444444-4444-4444-8444-444444444444", CredentialPath: filepath.Join(stateDir, identityFileName)}
 	if err := writePrivateNew(filepath.Join(stateDir, redemptionJournalName), mustJSON(journal)); err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/punaro-enroll/main_test.go
+++ b/cmd/punaro-enroll/main_test.go
@@ -110,6 +110,29 @@ func TestRedeemPreflightsCredentialDestinationBeforeContactingOrigin(t *testing.
 	}
 }
 
+func TestRedeemRejectsRecoveryJournalAsCredentialDestinationBeforeContactingOrigin(t *testing.T) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		t.Fatal("redemption contacted the origin before rejecting the reserved credential path")
+	}))
+	defer server.Close()
+	original := newEnrollmentHTTPClient
+	newEnrollmentHTTPClient = func() *http.Client { return server.Client() }
+	t.Cleanup(func() { newEnrollmentHTTPClient = original })
+	stateDir := filepath.Join(t.TempDir(), "state")
+	var prepared publicEnrollment
+	var preparedOut bytes.Buffer
+	if code := run([]string{"prepare", "--origin", server.URL, "--state-dir", stateDir}, &preparedOut, io.Discard); code != 0 || json.Unmarshal(preparedOut.Bytes(), &prepared) != nil {
+		t.Fatalf("prepare code=%d output=%q", code, preparedOut.String())
+	}
+	material := writeTestMaterial(t, `{"enrollment_id":"33333333-3333-4333-8333-333333333333","client_binding":"`+prepared.ClientBinding+`","code":"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"}`)
+	if code := run([]string{"redeem", "--state-dir", stateDir, "--enrollment-file", material, "--credential-file", filepath.Join(stateDir, redemptionJournalName)}, io.Discard, io.Discard); code != 2 {
+		t.Fatalf("code=%d", code)
+	}
+	if _, err := os.Lstat(filepath.Join(stateDir, redemptionJournalName)); !os.IsNotExist(err) {
+		t.Fatalf("reserved credential path created a recovery journal: %v", err)
+	}
+}
+
 func TestRecoverCompletesWhenCredentialWasPersistedBeforeJournalCleanup(t *testing.T) {
 	credential := "22222222-2222-4222-8222-222222222222." + strings.Repeat("A", 43)
 	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
@@ -230,7 +253,11 @@ func TestRedemptionResponseAcceptsOptionalExpiryWithoutRelaxingItsSchema(t *test
 }
 
 func TestRejectedEnrollmentClearsRecoverySoReplacementCanProceed(t *testing.T) {
-	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusUnauthorized) }))
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("WWW-Authenticate", "Bearer")
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = io.WriteString(w, `{"error":"unauthenticated"}`)
+	}))
 	defer server.Close()
 	original := newEnrollmentHTTPClient
 	newEnrollmentHTTPClient = func() *http.Client { return server.Client() }
@@ -250,6 +277,34 @@ func TestRejectedEnrollmentClearsRecoverySoReplacementCanProceed(t *testing.T) {
 	}
 	if _, err := os.Lstat(filepath.Join(stateDir, redemptionJournalName)); !os.IsNotExist(err) {
 		t.Fatalf("rejected enrollment recovery was retained: %v", err)
+	}
+}
+
+func TestAccessDenialRetainsRecoveryJournal(t *testing.T) {
+	for _, status := range []int{http.StatusUnauthorized, http.StatusForbidden} {
+		t.Run(http.StatusText(status), func(t *testing.T) {
+			server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(status) }))
+			defer server.Close()
+			original := newEnrollmentHTTPClient
+			newEnrollmentHTTPClient = func() *http.Client { return server.Client() }
+			t.Cleanup(func() { newEnrollmentHTTPClient = original })
+			stateDir := filepath.Join(t.TempDir(), "state")
+			if code := run([]string{"prepare", "--origin", server.URL, "--state-dir", stateDir}, io.Discard, io.Discard); code != 0 {
+				t.Fatal("prepare failed")
+			}
+			identity, err := loadIdentity(filepath.Join(stateDir, identityFileName))
+			if err != nil {
+				t.Fatal(err)
+			}
+			material := writeTestMaterial(t, `{"enrollment_id":"33333333-3333-4333-8333-333333333333","client_binding":"`+identity.ClientBinding+`","code":"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"}`)
+			var stderr bytes.Buffer
+			if code := run([]string{"redeem", "--state-dir", stateDir, "--enrollment-file", material, "--credential-file", filepath.Join(stateDir, "credential")}, io.Discard, &stderr); code != 1 || !strings.Contains(stderr.String(), "retry") {
+				t.Fatalf("code=%d stderr=%q", code, stderr.String())
+			}
+			if _, err := os.Lstat(filepath.Join(stateDir, redemptionJournalName)); err != nil {
+				t.Fatalf("Access denial removed recovery journal: %v", err)
+			}
+		})
 	}
 }
 

--- a/cmd/punaro-enroll/main_test.go
+++ b/cmd/punaro-enroll/main_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -10,6 +11,9 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
+
+	punaropostgres "github.com/rock3r/punaro/internal/postgres"
 )
 
 func TestPrepareThenRedeemKeepsSecretsOutOfOutputAndRecoversIdempotently(t *testing.T) {
@@ -146,7 +150,8 @@ func TestRedeemRejectsRecoveryJournalAsCredentialDestinationBeforeContactingOrig
 		t.Fatalf("prepare code=%d output=%q", code, preparedOut.String())
 	}
 	material := writeTestMaterial(t, `{"enrollment_id":"33333333-3333-4333-8333-333333333333","client_binding":"`+prepared.ClientBinding+`","code":"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"}`)
-	if code := run([]string{"redeem", "--state-dir", stateDir, "--enrollment-file", material, "--credential-file", filepath.Join(stateDir, redemptionJournalName)}, io.Discard, io.Discard); code != 2 {
+	caseVariant := strings.ToUpper(redemptionJournalName)
+	if code := run([]string{"redeem", "--state-dir", stateDir, "--enrollment-file", material, "--credential-file", filepath.Join(stateDir, caseVariant)}, io.Discard, io.Discard); code != 2 {
 		t.Fatalf("code=%d", code)
 	}
 	if _, err := os.Lstat(filepath.Join(stateDir, redemptionJournalName)); !os.IsNotExist(err) {
@@ -272,6 +277,39 @@ func TestEnrollmentMaterialAcceptsStrictAdminEnvelope(t *testing.T) {
 	}
 	if _, err := loadMaterial(writeTestMaterial(t, longEnvelope)); err != nil {
 		t.Fatalf("large admin envelope rejected: %v", err)
+	}
+}
+
+func TestEnrollmentMaterialAcceptsExactAdminOutputAtProjectLimit(t *testing.T) {
+	projectIDs := make([]string, 100)
+	for i := range projectIDs {
+		projectIDs[i] = fmt.Sprintf("%08d-0000-4000-8000-000000000000", i+1)
+	}
+	grants, previewHash, err := punaropostgres.PreviewTrustedAgentEnrollment(projectIDs, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	preview := struct {
+		Template    string                     `json:"template"`
+		PreviewHash string                     `json:"preview_hash"`
+		Grants      []punaropostgres.GrantSpec `json:"grants"`
+	}{Template: "trusted-agent", PreviewHash: previewHash, Grants: grants}
+	pending := punaropostgres.PendingEnrollment{ID: "33333333-3333-4333-8333-333333333333", ClientBinding: "44444444-4444-4444-8444-444444444444", Code: strings.Repeat("A", 43), ExpiresAt: time.Date(2030, 1, 2, 3, 4, 5, 0, time.UTC), PreviewHash: previewHash, Grants: grants}
+	previewRaw, err := json.MarshalIndent(preview, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	pendingRaw, err := json.MarshalIndent(pending, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	output := append(append(previewRaw, '\n'), append(pendingRaw, '\n')...)
+	if len(output) <= 64*1024 || len(output) > maxEnrollmentMaterial {
+		t.Fatalf("bounded admin output has unexpected size: %d", len(output))
+	}
+	material, err := loadMaterial(writeTestMaterial(t, string(output)))
+	if err != nil || material.EnrollmentID != pending.ID {
+		t.Fatalf("exact admin output material=%#v err=%v", material, err)
 	}
 }
 

--- a/cmd/punaro-enroll/main_test.go
+++ b/cmd/punaro-enroll/main_test.go
@@ -156,7 +156,11 @@ func TestRedeemRejectsRecoveryJournalAsCredentialDestinationBeforeContactingOrig
 
 func TestRecoverCompletesWhenCredentialWasPersistedBeforeJournalCleanup(t *testing.T) {
 	credential := "22222222-2222-4222-8222-222222222222." + strings.Repeat("A", 43)
-	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		if err != nil || strings.Contains(string(body), `"credential"`) {
+			t.Fatalf("recovery body=%q err=%v", body, err)
+		}
 		w.Header().Set("Cache-Control", "no-store")
 		w.WriteHeader(http.StatusCreated)
 		_, _ = io.WriteString(w, `{"principal_id":"11111111-1111-4111-8111-111111111111","lookup_id":"22222222-2222-4222-8222-222222222222","credential":"`+credential+`","generation":1}`)

--- a/cmd/punaro-enroll/main_test.go
+++ b/cmd/punaro-enroll/main_test.go
@@ -108,7 +108,7 @@ func TestRedeemFailsClosedForBindingMismatchWithoutContactingOrigin(t *testing.T
 }
 
 func TestRedeemPreflightsCredentialDestinationBeforeContactingOrigin(t *testing.T) {
-	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
 		t.Fatal("redemption contacted the origin before preflighting credential destination")
 	}))
 	defer server.Close()
@@ -136,7 +136,7 @@ func TestRedeemPreflightsCredentialDestinationBeforeContactingOrigin(t *testing.
 }
 
 func TestRedeemRejectsRecoveryJournalAsCredentialDestinationBeforeContactingOrigin(t *testing.T) {
-	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
 		t.Fatal("redemption contacted the origin before rejecting the reserved credential path")
 	}))
 	defer server.Close()
@@ -380,7 +380,7 @@ func TestAccessDenialRetainsRecoveryJournal(t *testing.T) {
 }
 
 func TestRecoverRejectsUnrelatedExistingCredentialBeforeContactingOrigin(t *testing.T) {
-	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
 		t.Fatal("recovery contacted the origin before rejecting an unrelated credential file")
 	}))
 	defer server.Close()

--- a/cmd/punaro-enroll/main_test.go
+++ b/cmd/punaro-enroll/main_test.go
@@ -15,7 +15,7 @@ import (
 func TestPrepareThenRedeemKeepsSecretsOutOfOutputAndRecoversIdempotently(t *testing.T) {
 	stateDir := filepath.Join(t.TempDir(), "state")
 	var prepared publicEnrollment
-	credential := "punaro_device_" + "credential_secret"
+	credential := "22222222-2222-4222-8222-222222222222." + strings.Repeat("A", 43)
 	calls := 0
 	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		calls++
@@ -105,7 +105,7 @@ func TestEnrollmentMaterialRejectsDuplicateOrUnknownFields(t *testing.T) {
 }
 
 func TestRedemptionResponseAcceptsOptionalExpiryWithoutRelaxingItsSchema(t *testing.T) {
-	response, err := decodeRedemptionResponse([]byte(`{"principal_id":"11111111-1111-4111-8111-111111111111","lookup_id":"22222222-2222-4222-8222-222222222222","credential":"punaro_device_credential","generation":1,"expires_at":"2030-01-02T03:04:05Z"}`))
+	response, err := decodeRedemptionResponse([]byte(`{"principal_id":"11111111-1111-4111-8111-111111111111","lookup_id":"22222222-2222-4222-8222-222222222222","credential":"22222222-2222-4222-8222-222222222222.` + strings.Repeat("A", 43) + `","generation":1,"expires_at":"2030-01-02T03:04:05Z"}`))
 	if err != nil || response.ExpiresAt.IsZero() {
 		t.Fatalf("expiring response err=%v response=%#v", err, response)
 	}

--- a/cmd/punaro-enroll/main_test.go
+++ b/cmd/punaro-enroll/main_test.go
@@ -207,6 +207,18 @@ func TestEnrollmentMaterialRejectsDuplicateOrUnknownFields(t *testing.T) {
 	}
 }
 
+func TestEnrollmentMaterialAcceptsStrictAdminEnvelope(t *testing.T) {
+	path := writeTestMaterial(t, `{"enrollment_id":"33333333-3333-4333-8333-333333333333","client_binding":"44444444-4444-4444-8444-444444444444","code":"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA","expires_at":"2030-01-02T03:04:05Z","preview_hash":"0000000000000000000000000000000000000000000000000000000000000000","grants":[{"scope":"installation","capability":"project.create"}]}`)
+	material, err := loadMaterial(path)
+	if err != nil || material.EnrollmentID != "33333333-3333-4333-8333-333333333333" {
+		t.Fatalf("admin envelope material=%#v err=%v", material, err)
+	}
+	invalid := writeTestMaterial(t, `{"enrollment_id":"33333333-3333-4333-8333-333333333333","client_binding":"44444444-4444-4444-8444-444444444444","code":"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA","expires_at":"2030-01-02T03:04:05Z","preview_hash":"0000000000000000000000000000000000000000000000000000000000000000","grants":[{"scope":"installation","capability":"project.create","ignored":true}]}`)
+	if _, err := loadMaterial(invalid); err == nil {
+		t.Fatal("admin envelope accepted an unknown grant field")
+	}
+}
+
 func TestRedemptionResponseAcceptsOptionalExpiryWithoutRelaxingItsSchema(t *testing.T) {
 	response, err := decodeRedemptionResponse([]byte(`{"principal_id":"11111111-1111-4111-8111-111111111111","lookup_id":"22222222-2222-4222-8222-222222222222","credential":"22222222-2222-4222-8222-222222222222.` + strings.Repeat("A", 43) + `","generation":1,"expires_at":"2030-01-02T03:04:05Z"}`))
 	if err != nil || response.ExpiresAt.IsZero() {

--- a/cmd/punaro-enroll/main_test.go
+++ b/cmd/punaro-enroll/main_test.go
@@ -46,10 +46,7 @@ func TestPrepareThenRedeemKeepsSecretsOutOfOutputAndRecoversIdempotently(t *test
 	newEnrollmentHTTPClient = func() *http.Client { return server.Client() }
 	t.Cleanup(func() { newEnrollmentHTTPClient = original })
 
-	material := filepath.Join(t.TempDir(), "material.json")
-	if err := os.WriteFile(material, []byte(`{"enrollment_id":"33333333-3333-4333-8333-333333333333","client_binding":"`+prepared.ClientBinding+`","code":"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"}`), 0o600); err != nil {
-		t.Fatal(err)
-	}
+	material := writeTestMaterial(t, `{"enrollment_id":"33333333-3333-4333-8333-333333333333","client_binding":"`+prepared.ClientBinding+`","code":"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"}`)
 	credentialFile := filepath.Join(stateDir, "device.credential")
 	var firstRedeemOut, firstRedeemErr bytes.Buffer
 	if code := run([]string{"redeem", "--state-dir", stateDir, "--enrollment-file", material, "--credential-file", credentialFile}, &firstRedeemOut, &firstRedeemErr); code != 1 || !strings.Contains(firstRedeemErr.String(), "retry") {
@@ -78,26 +75,29 @@ func TestRedeemFailsClosedForBindingMismatchWithoutContactingOrigin(t *testing.T
 	if code := run([]string{"prepare", "--origin", "https://punaro.test", "--state-dir", stateDir}, io.Discard, io.Discard); code != 0 {
 		t.Fatal("prepare failed")
 	}
-	material := filepath.Join(t.TempDir(), "material.json")
-	if err := os.WriteFile(material, []byte(`{"enrollment_id":"33333333-3333-4333-8333-333333333333","client_binding":"44444444-4444-4444-8444-444444444444","code":"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"}`), 0o600); err != nil {
-		t.Fatal(err)
-	}
+	material := writeTestMaterial(t, `{"enrollment_id":"33333333-3333-4333-8333-333333333333","client_binding":"44444444-4444-4444-8444-444444444444","code":"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"}`)
 	var stdout, stderr bytes.Buffer
 	if code := run([]string{"redeem", "--state-dir", stateDir, "--enrollment-file", material, "--credential-file", filepath.Join(stateDir, "credential")}, &stdout, &stderr); code != 2 || stdout.Len() != 0 || stderr.String() != "punaro-enroll: enrollment material does not match this device\n" {
 		t.Fatalf("code=%d stdout=%q stderr=%q", code, stdout.String(), stderr.String())
 	}
 }
 
+func TestEnsurePrivateDirCreatesNestedStateDirectory(t *testing.T) {
+	stateDir := filepath.Join(t.TempDir(), "first", "second", "state")
+	if err := ensurePrivateDir(stateDir); err != nil {
+		t.Fatalf("ensure private state directory: %v", err)
+	}
+	if err := privateDir(stateDir); err != nil {
+		t.Fatalf("created state directory is not private: %v", err)
+	}
+}
+
 func TestEnrollmentMaterialRejectsDuplicateOrUnknownFields(t *testing.T) {
-	directory := t.TempDir()
 	for name, raw := range map[string]string{
 		"duplicate": `{"enrollment_id":"33333333-3333-4333-8333-333333333333","enrollment_id":"33333333-3333-4333-8333-333333333333","client_binding":"44444444-4444-4444-8444-444444444444","code":"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"}`,
 		"unknown":   `{"enrollment_id":"33333333-3333-4333-8333-333333333333","client_binding":"44444444-4444-4444-8444-444444444444","code":"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA","origin":"https://attacker.test"}`,
 	} {
-		path := filepath.Join(directory, name+".json")
-		if err := os.WriteFile(path, []byte(raw), 0o600); err != nil {
-			t.Fatal(err)
-		}
+		path := writeTestMaterial(t, raw)
 		if _, err := loadMaterial(path); err == nil {
 			t.Fatalf("%s material was accepted", name)
 		}
@@ -128,10 +128,7 @@ func TestRejectedEnrollmentClearsRecoverySoReplacementCanProceed(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	material := filepath.Join(t.TempDir(), "material.json")
-	if err := os.WriteFile(material, []byte(`{"enrollment_id":"33333333-3333-4333-8333-333333333333","client_binding":"`+identity.ClientBinding+`","code":"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"}`), 0o600); err != nil {
-		t.Fatal(err)
-	}
+	material := writeTestMaterial(t, `{"enrollment_id":"33333333-3333-4333-8333-333333333333","client_binding":"`+identity.ClientBinding+`","code":"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"}`)
 	var stderr bytes.Buffer
 	if code := run([]string{"redeem", "--state-dir", stateDir, "--enrollment-file", material, "--credential-file", filepath.Join(stateDir, "credential")}, io.Discard, &stderr); code != 1 || !strings.Contains(stderr.String(), "request a new enrollment") {
 		t.Fatalf("code=%d stderr=%q", code, stderr.String())
@@ -139,4 +136,17 @@ func TestRejectedEnrollmentClearsRecoverySoReplacementCanProceed(t *testing.T) {
 	if _, err := os.Lstat(filepath.Join(stateDir, redemptionJournalName)); !os.IsNotExist(err) {
 		t.Fatalf("rejected enrollment recovery was retained: %v", err)
 	}
+}
+
+func writeTestMaterial(t *testing.T, raw string) string {
+	t.Helper()
+	directory := filepath.Join(t.TempDir(), "material")
+	if err := ensurePrivateDir(directory); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(directory, "material.json")
+	if err := writePrivateNew(path, []byte(raw)); err != nil {
+		t.Fatal(err)
+	}
+	return path
 }

--- a/cmd/punaro-enroll/main_test.go
+++ b/cmd/punaro-enroll/main_test.go
@@ -156,6 +156,17 @@ func TestEnsurePrivateDirCreatesNestedStateDirectory(t *testing.T) {
 	}
 }
 
+func TestSafeStateChildRejectsNonCanonicalTraversal(t *testing.T) {
+	directory := filepath.Join(t.TempDir(), "state")
+	if !safeStateChild(directory, filepath.Join(directory, "credential")) {
+		t.Fatal("direct state child was rejected")
+	}
+	nonCanonical := directory + string(filepath.Separator) + "link" + string(filepath.Separator) + ".." + string(filepath.Separator) + "credential"
+	if safeStateChild(directory, nonCanonical) {
+		t.Fatal("non-canonical child path was accepted")
+	}
+}
+
 func TestEnrollmentMaterialRejectsDuplicateOrUnknownFields(t *testing.T) {
 	for name, raw := range map[string]string{
 		"duplicate": `{"enrollment_id":"33333333-3333-4333-8333-333333333333","enrollment_id":"33333333-3333-4333-8333-333333333333","client_binding":"44444444-4444-4444-8444-444444444444","code":"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"}`,

--- a/cmd/punaro-enroll/private_file_unix.go
+++ b/cmd/punaro-enroll/private_file_unix.go
@@ -219,7 +219,7 @@ func writeCredential(path, credential string) error {
 	} else if !errors.Is(err, os.ErrNotExist) {
 		return err
 	}
-	return writePrivateNew(path, []byte(credential+"\n"))
+	return writePrivateAtomic(path, []byte(credential+"\n"))
 }
 func privateFile(info os.FileInfo) bool {
 	return info.Mode().IsRegular() && info.Mode().Perm()&0o077 == 0 && ownedByCurrentUser(info)

--- a/cmd/punaro-enroll/private_file_unix.go
+++ b/cmd/punaro-enroll/private_file_unix.go
@@ -14,7 +14,7 @@ import (
 
 func safeStateDir(path string) bool { return filepath.IsAbs(path) && filepath.Clean(path) == path }
 func safeStateChild(directory, path string) bool {
-	return safeStateDir(directory) && filepath.Dir(path) == directory && filepath.Base(path) != "." && filepath.Base(path) != ".."
+	return safeStateDir(directory) && filepath.IsAbs(path) && filepath.Clean(path) == path && filepath.Dir(path) == directory && filepath.Base(path) != "." && filepath.Base(path) != ".."
 }
 
 func ensurePrivateDir(path string) error {

--- a/cmd/punaro-enroll/private_file_unix.go
+++ b/cmd/punaro-enroll/private_file_unix.go
@@ -1,0 +1,99 @@
+//go:build !windows
+
+package main
+
+import (
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"syscall"
+
+	"golang.org/x/sys/unix"
+)
+
+func safeStateDir(path string) bool { return filepath.IsAbs(path) && filepath.Clean(path) == path }
+func safeStateChild(directory, path string) bool {
+	return safeStateDir(directory) && filepath.Dir(path) == directory && filepath.Base(path) != "." && filepath.Base(path) != ".."
+}
+
+func ensurePrivateDir(path string) error {
+	if err := os.MkdirAll(path, 0o700); err != nil {
+		return err
+	}
+	return privateDir(path)
+}
+func privateDir(path string) error {
+	info, err := os.Lstat(path)
+	if err != nil || !info.IsDir() || info.Mode()&os.ModeSymlink != 0 || info.Mode().Perm()&0o077 != 0 || !ownedByCurrentUser(info) {
+		return errors.New("unsafe private directory")
+	}
+	return nil
+}
+func readPrivate(path string, maximum int) ([]byte, error) {
+	if !filepath.IsAbs(path) {
+		return nil, errors.New("unsafe private file")
+	}
+	fd, err := unix.Open(path, unix.O_RDONLY|unix.O_CLOEXEC|unix.O_NOFOLLOW, 0)
+	if err != nil {
+		return nil, err
+	}
+	file := os.NewFile(uintptr(fd), path) // #nosec G115 -- unix.Open returns a non-negative descriptor for os.NewFile.
+	defer func() { _ = file.Close() }()
+	info, err := file.Stat()
+	if err != nil || !privateFile(info) {
+		return nil, errors.New("unsafe private file")
+	}
+	raw, err := io.ReadAll(io.LimitReader(file, int64(maximum)+1))
+	if err != nil || len(raw) == 0 || len(raw) > maximum {
+		return nil, errors.New("invalid private file")
+	}
+	return raw, nil
+}
+func writePrivateNew(path string, raw []byte) error {
+	if len(raw) == 0 || !filepath.IsAbs(path) {
+		return errors.New("unsafe private file")
+	}
+	file, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600) // #nosec G304 -- fixed child of the validated private state directory.
+	if err != nil {
+		return err
+	}
+	if _, err := file.Write(raw); err != nil {
+		_ = file.Close()
+		return err
+	}
+	if err := file.Sync(); err != nil {
+		_ = file.Close()
+		return err
+	}
+	return file.Close()
+}
+func writeCredential(path, credential string) error {
+	if credential == "" || stringsContainsWhitespace(credential) {
+		return errors.New("invalid credential")
+	}
+	if raw, err := readPrivate(path, maxEnrollmentFile); err == nil {
+		if string(raw) == credential+"\n" {
+			return nil
+		}
+		return errors.New("credential exists")
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return err
+	}
+	return writePrivateNew(path, []byte(credential+"\n"))
+}
+func privateFile(info os.FileInfo) bool {
+	return info.Mode().IsRegular() && info.Mode().Perm()&0o077 == 0 && ownedByCurrentUser(info)
+}
+func ownedByCurrentUser(info os.FileInfo) bool {
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	return ok && stat.Uid == uint32(os.Geteuid()) // #nosec G115 -- effective UID is non-negative and represents uid_t.
+}
+func stringsContainsWhitespace(value string) bool {
+	for _, r := range value {
+		if r == ' ' || r == '\t' || r == '\r' || r == '\n' {
+			return true
+		}
+	}
+	return false
+}

--- a/cmd/punaro-enroll/private_file_unix.go
+++ b/cmd/punaro-enroll/private_file_unix.go
@@ -23,7 +23,13 @@ func ensurePrivateDir(path string) error {
 		if !info.IsDir() || info.Mode()&os.ModeSymlink != 0 {
 			return errors.New("unsafe private directory")
 		}
-		return privateDir(path)
+		if err := privateDir(path); err != nil {
+			return err
+		}
+		// A previous attempt may have created this state directory but failed
+		// before its parent directory entry was durable. Re-sync that parent
+		// before an existing state directory can be reused to publish a binding.
+		return syncPrivateDirectory(filepath.Dir(path))
 	}
 	if !errors.Is(err, os.ErrNotExist) {
 		return err
@@ -180,7 +186,7 @@ func syncPrivateDirectoryImpl(path string) error {
 		// invariant without allowing an already-written journal to poison all
 		// later recovery attempts.
 		if errors.Is(err, unix.EINVAL) || errors.Is(err, unix.ENOTSUP) {
-			unix.Sync()
+			unix.Sync() // #nosec G104 -- unix.Sync has no return value to check. //nolint:errcheck
 			return nil
 		}
 		return err
@@ -197,7 +203,7 @@ func removePrivate(path string) error {
 		// journal that survives a crash is harmless: recovering it replays the
 		// same idempotency key. Do not convert a successful enrollment into a
 		// failure merely because its best-effort cleanup could not be synced.
-		unix.Sync()
+		unix.Sync() // #nosec G104 -- unix.Sync has no return value to check. //nolint:errcheck
 	}
 	return nil
 }

--- a/cmd/punaro-enroll/private_file_unix.go
+++ b/cmd/punaro-enroll/private_file_unix.go
@@ -132,6 +132,40 @@ func writePrivateNew(path string, raw []byte) error {
 	return nil
 }
 
+func writePrivateAtomic(path string, raw []byte) error {
+	file, err := os.CreateTemp(filepath.Dir(path), "."+filepath.Base(path)+".tmp-*")
+	if err != nil {
+		return err
+	}
+	temporary := file.Name()
+	removeOnFailure := true
+	defer func() {
+		if removeOnFailure {
+			_ = os.Remove(temporary)
+		}
+	}()
+	if err := file.Chmod(0o600); err != nil {
+		_ = file.Close()
+		return err
+	}
+	if _, err := file.Write(raw); err != nil {
+		_ = file.Close()
+		return err
+	}
+	if err := file.Sync(); err != nil {
+		_ = file.Close()
+		return err
+	}
+	if err := file.Close(); err != nil {
+		return err
+	}
+	if err := os.Rename(temporary, path); err != nil {
+		return err
+	}
+	removeOnFailure = false
+	return syncPrivateDirectory(filepath.Dir(path))
+}
+
 var syncPrivateDirectory = syncPrivateDirectoryImpl
 
 func syncPrivateDirectoryImpl(path string) error {

--- a/cmd/punaro-enroll/private_file_unix.go
+++ b/cmd/punaro-enroll/private_file_unix.go
@@ -72,13 +72,22 @@ func readPrivate(path string, maximum int) ([]byte, error) {
 	if !filepath.IsAbs(path) {
 		return nil, errors.New("unsafe private file")
 	}
-	fd, err := unix.Open(path, unix.O_RDONLY|unix.O_CLOEXEC|unix.O_NOFOLLOW, 0)
+	info, err := os.Lstat(path)
+	if err != nil {
+		return nil, err
+	}
+	if !privateFile(info) {
+		return nil, errors.New("unsafe private file")
+	}
+	// O_NONBLOCK avoids a FIFO replacement blocking between the pre-open
+	// Lstat and the post-open fstat validation below.
+	fd, err := unix.Open(path, unix.O_RDONLY|unix.O_CLOEXEC|unix.O_NOFOLLOW|unix.O_NONBLOCK, 0)
 	if err != nil {
 		return nil, err
 	}
 	file := os.NewFile(uintptr(fd), path) // #nosec G115 -- unix.Open returns a non-negative descriptor for os.NewFile.
 	defer func() { _ = file.Close() }()
-	info, err := file.Stat()
+	info, err = file.Stat()
 	if err != nil || !privateFile(info) {
 		return nil, errors.New("unsafe private file")
 	}

--- a/cmd/punaro-enroll/private_file_unix.go
+++ b/cmd/punaro-enroll/private_file_unix.go
@@ -18,8 +18,46 @@ func safeStateChild(directory, path string) bool {
 }
 
 func ensurePrivateDir(path string) error {
-	if err := os.MkdirAll(path, 0o700); err != nil {
+	info, err := os.Lstat(path)
+	if err == nil {
+		if !info.IsDir() || info.Mode()&os.ModeSymlink != 0 {
+			return errors.New("unsafe private directory")
+		}
+		return privateDir(path)
+	}
+	if !errors.Is(err, os.ErrNotExist) {
 		return err
+	}
+
+	// Create one directory at a time so each newly published directory entry
+	// can be synced before files are placed below it. MkdirAll cannot tell us
+	// which entries this invocation created.
+	missing := []string{path}
+	for parent := filepath.Dir(path); ; parent = filepath.Dir(parent) {
+		info, err := os.Lstat(parent)
+		if err == nil {
+			if !info.IsDir() || info.Mode()&os.ModeSymlink != 0 {
+				return errors.New("unsafe private directory")
+			}
+			break
+		}
+		if !errors.Is(err, os.ErrNotExist) || parent == filepath.Dir(parent) {
+			return err
+		}
+		missing = append(missing, parent)
+	}
+	for index := len(missing) - 1; index >= 0; index-- {
+		directory := missing[index]
+		if err := os.Mkdir(directory, 0o700); err != nil {
+			if !errors.Is(err, os.ErrExist) {
+				return err
+			}
+		} else if err := syncPrivateDirectory(filepath.Dir(directory)); err != nil {
+			return err
+		}
+		if err := privateDir(directory); err != nil {
+			return err
+		}
 	}
 	return privateDir(path)
 }

--- a/cmd/punaro-enroll/private_file_unix.go
+++ b/cmd/punaro-enroll/private_file_unix.go
@@ -58,6 +58,12 @@ func writePrivateNew(path string, raw []byte) error {
 	if err != nil {
 		return err
 	}
+	removeOnFailure := true
+	defer func() {
+		if removeOnFailure {
+			_ = os.Remove(path) // #nosec G703 -- exclusive new child of the validated private state directory.
+		}
+	}()
 	if _, err := file.Write(raw); err != nil {
 		_ = file.Close()
 		return err
@@ -66,7 +72,23 @@ func writePrivateNew(path string, raw []byte) error {
 		_ = file.Close()
 		return err
 	}
-	return file.Close()
+	if err := file.Close(); err != nil {
+		return err
+	}
+	if err := syncPrivateDirectory(filepath.Dir(path)); err != nil {
+		return err
+	}
+	removeOnFailure = false
+	return nil
+}
+
+func syncPrivateDirectory(path string) error {
+	fd, err := unix.Open(path, unix.O_RDONLY|unix.O_CLOEXEC|unix.O_DIRECTORY|unix.O_NOFOLLOW, 0)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = unix.Close(fd) }()
+	return unix.Fsync(fd)
 }
 func writeCredential(path, credential string) error {
 	if credential == "" || stringsContainsWhitespace(credential) {

--- a/cmd/punaro-enroll/private_file_unix.go
+++ b/cmd/punaro-enroll/private_file_unix.go
@@ -18,7 +18,31 @@ func safeStateChild(directory, path string) bool {
 	return safeStateDir(directory) && filepath.IsAbs(path) && filepath.Clean(path) == path && filepath.Dir(path) == directory && filepath.Base(path) != "." && filepath.Base(path) != ".."
 }
 
-func reservedStateFileName(name string) bool { return strings.EqualFold(name, redemptionJournalName) }
+func reservedStateFileName(name string) bool {
+	return strings.EqualFold(name, redemptionJournalName) || strings.EqualFold(name, redemptionLockName)
+}
+
+func lockEnrollmentState(stateDir string) (func(), error) {
+	path := filepath.Join(stateDir, redemptionLockName)
+	fd, err := unix.Open(path, unix.O_RDWR|unix.O_CREAT|unix.O_CLOEXEC|unix.O_NOFOLLOW, 0o600)
+	if err != nil {
+		return nil, err
+	}
+	file := os.NewFile(uintptr(fd), path) // #nosec G115 -- unix.Open returns a non-negative descriptor for os.NewFile.
+	info, err := file.Stat()
+	if err != nil || !privateFile(info) {
+		_ = file.Close()
+		return nil, errors.New("unsafe enrollment lock")
+	}
+	if err := unix.Flock(fd, unix.LOCK_EX); err != nil {
+		_ = file.Close()
+		return nil, err
+	}
+	return func() {
+		_ = unix.Flock(fd, unix.LOCK_UN)
+		_ = file.Close()
+	}, nil
+}
 
 func ensurePrivateDir(path string) error {
 	info, err := os.Lstat(path)

--- a/cmd/punaro-enroll/private_file_unix.go
+++ b/cmd/punaro-enroll/private_file_unix.go
@@ -45,6 +45,13 @@ func ensurePrivateDir(path string) error {
 			if !info.IsDir() || info.Mode()&os.ModeSymlink != 0 {
 				return errors.New("unsafe private directory")
 			}
+			// A reused intermediate directory may have been created by an earlier
+			// failed attempt. Re-sync its own parent before publishing children.
+			if grandparent := filepath.Dir(parent); grandparent != parent {
+				if err := syncPrivateDirectory(grandparent); err != nil {
+					return err
+				}
+			}
 			break
 		}
 		if !errors.Is(err, os.ErrNotExist) || parent == filepath.Dir(parent) {
@@ -172,6 +179,46 @@ func writePrivateAtomic(path string, raw []byte) error {
 	return syncPrivateDirectory(filepath.Dir(path))
 }
 
+// writePrivateAtomicNew publishes a complete private file without replacing a
+// destination created after the caller's preflight. Hard-link publication is
+// atomic on the same filesystem and fails when the destination already exists.
+func writePrivateAtomicNew(path string, raw []byte) error {
+	file, err := os.CreateTemp(filepath.Dir(path), "."+filepath.Base(path)+".tmp-*")
+	if err != nil {
+		return err
+	}
+	temporary := file.Name()
+	removeTemporary := true
+	defer func() {
+		if removeTemporary {
+			_ = os.Remove(temporary)
+		}
+	}()
+	if err := file.Chmod(0o600); err != nil {
+		_ = file.Close()
+		return err
+	}
+	if _, err := file.Write(raw); err != nil {
+		_ = file.Close()
+		return err
+	}
+	if err := file.Sync(); err != nil {
+		_ = file.Close()
+		return err
+	}
+	if err := file.Close(); err != nil {
+		return err
+	}
+	if err := os.Link(temporary, path); err != nil {
+		return err
+	}
+	if err := os.Remove(temporary); err != nil {
+		return err
+	}
+	removeTemporary = false
+	return syncPrivateDirectory(filepath.Dir(path))
+}
+
 var syncPrivateDirectory = syncPrivateDirectoryImpl
 
 func syncPrivateDirectoryImpl(path string) error {
@@ -219,7 +266,7 @@ func writeCredential(path, credential string) error {
 	} else if !errors.Is(err, os.ErrNotExist) {
 		return err
 	}
-	return writePrivateAtomic(path, []byte(credential+"\n"))
+	return writePrivateAtomicNew(path, []byte(credential+"\n"))
 }
 func privateFile(info os.FileInfo) bool {
 	return info.Mode().IsRegular() && info.Mode().Perm()&0o077 == 0 && ownedByCurrentUser(info)

--- a/cmd/punaro-enroll/private_file_unix.go
+++ b/cmd/punaro-enroll/private_file_unix.go
@@ -75,10 +75,13 @@ func writePrivateNew(path string, raw []byte) error {
 	if err := file.Close(); err != nil {
 		return err
 	}
+	// The private file is complete and durable at this point. Preserve it if
+	// syncing the containing directory is unsupported or fails so a retry can
+	// recover rather than being blocked by an erased post-write state.
+	removeOnFailure = false
 	if err := syncPrivateDirectory(filepath.Dir(path)); err != nil {
 		return err
 	}
-	removeOnFailure = false
 	return nil
 }
 

--- a/cmd/punaro-enroll/private_file_unix.go
+++ b/cmd/punaro-enroll/private_file_unix.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 	"syscall"
 
 	"golang.org/x/sys/unix"
@@ -16,6 +17,8 @@ func safeStateDir(path string) bool { return filepath.IsAbs(path) && filepath.Cl
 func safeStateChild(directory, path string) bool {
 	return safeStateDir(directory) && filepath.IsAbs(path) && filepath.Clean(path) == path && filepath.Dir(path) == directory && filepath.Base(path) != "." && filepath.Base(path) != ".."
 }
+
+func reservedStateFileName(name string) bool { return strings.EqualFold(name, redemptionJournalName) }
 
 func ensurePrivateDir(path string) error {
 	info, err := os.Lstat(path)

--- a/cmd/punaro-enroll/private_file_unix.go
+++ b/cmd/punaro-enroll/private_file_unix.go
@@ -140,7 +140,18 @@ func syncPrivateDirectoryImpl(path string) error {
 		return err
 	}
 	defer func() { _ = unix.Close(fd) }()
-	return unix.Fsync(fd)
+	if err := unix.Fsync(fd); err != nil {
+		// Some supported filesystems do not implement directory fsync. A global
+		// synchronous flush is slower, but preserves the durable-publication
+		// invariant without allowing an already-written journal to poison all
+		// later recovery attempts.
+		if errors.Is(err, unix.EINVAL) || errors.Is(err, unix.ENOTSUP) {
+			unix.Sync()
+			return nil
+		}
+		return err
+	}
+	return nil
 }
 
 func removePrivate(path string) error {

--- a/cmd/punaro-enroll/private_file_unix.go
+++ b/cmd/punaro-enroll/private_file_unix.go
@@ -158,7 +158,14 @@ func removePrivate(path string) error {
 	if err := os.Remove(path); err != nil {
 		return err
 	}
-	return syncPrivateDirectory(filepath.Dir(path))
+	if err := syncPrivateDirectory(filepath.Dir(path)); err != nil {
+		// The credential is already safely persisted when this is called. A
+		// journal that survives a crash is harmless: recovering it replays the
+		// same idempotency key. Do not convert a successful enrollment into a
+		// failure merely because its best-effort cleanup could not be synced.
+		unix.Sync()
+	}
+	return nil
 }
 func writeCredential(path, credential string) error {
 	if credential == "" || stringsContainsWhitespace(credential) {

--- a/cmd/punaro-enroll/private_file_unix.go
+++ b/cmd/punaro-enroll/private_file_unix.go
@@ -132,13 +132,22 @@ func writePrivateNew(path string, raw []byte) error {
 	return nil
 }
 
-func syncPrivateDirectory(path string) error {
+var syncPrivateDirectory = syncPrivateDirectoryImpl
+
+func syncPrivateDirectoryImpl(path string) error {
 	fd, err := unix.Open(path, unix.O_RDONLY|unix.O_CLOEXEC|unix.O_DIRECTORY|unix.O_NOFOLLOW, 0)
 	if err != nil {
 		return err
 	}
 	defer func() { _ = unix.Close(fd) }()
 	return unix.Fsync(fd)
+}
+
+func removePrivate(path string) error {
+	if err := os.Remove(path); err != nil {
+		return err
+	}
+	return syncPrivateDirectory(filepath.Dir(path))
 }
 func writeCredential(path, credential string) error {
 	if credential == "" || stringsContainsWhitespace(credential) {

--- a/cmd/punaro-enroll/private_file_unix.go
+++ b/cmd/punaro-enroll/private_file_unix.go
@@ -61,8 +61,14 @@ func ensurePrivateDir(path string) error {
 	}
 	for index := len(missing) - 1; index >= 0; index-- {
 		directory := missing[index]
-		if err := os.Mkdir(directory, 0o700); err != nil {
+		if err := mkdirPrivateDirectory(directory, 0o700); err != nil {
 			if !errors.Is(err, os.ErrExist) {
+				return err
+			}
+			// A concurrent creator may have published the entry but crashed
+			// before syncing its parent. Make that raced entry durable before
+			// accepting it and publishing anything beneath it.
+			if err := syncPrivateDirectory(filepath.Dir(directory)); err != nil {
 				return err
 			}
 		} else if err := syncPrivateDirectory(filepath.Dir(directory)); err != nil {
@@ -219,7 +225,10 @@ func writePrivateAtomicNew(path string, raw []byte) error {
 	return syncPrivateDirectory(filepath.Dir(path))
 }
 
-var syncPrivateDirectory = syncPrivateDirectoryImpl
+var (
+	mkdirPrivateDirectory = os.Mkdir
+	syncPrivateDirectory  = syncPrivateDirectoryImpl
+)
 
 func syncPrivateDirectoryImpl(path string) error {
 	fd, err := unix.Open(path, unix.O_RDONLY|unix.O_CLOEXEC|unix.O_DIRECTORY|unix.O_NOFOLLOW, 0)

--- a/cmd/punaro-enroll/private_file_unix_test.go
+++ b/cmd/punaro-enroll/private_file_unix_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"golang.org/x/sys/unix"
 )
@@ -89,5 +90,43 @@ func TestEnsurePrivateDirSyncsParentWhenConcurrentCreatorWins(t *testing.T) {
 	}
 	if !syncedParent {
 		t.Fatal("parent of concurrently created directory was not synced")
+	}
+}
+
+func TestLockEnrollmentStateSerializesConcurrentRedeems(t *testing.T) {
+	directory := filepath.Join(t.TempDir(), "state")
+	if err := ensurePrivateDir(directory); err != nil {
+		t.Fatal(err)
+	}
+	unlock, err := lockEnrollmentState(directory)
+	if err != nil {
+		t.Fatal(err)
+	}
+	type result struct {
+		unlock func()
+		err    error
+	}
+	second := make(chan result, 1)
+	go func() {
+		release, err := lockEnrollmentState(directory)
+		second <- result{unlock: release, err: err}
+	}()
+	select {
+	case got := <-second:
+		if got.unlock != nil {
+			got.unlock()
+		}
+		t.Fatalf("second redemption acquired lock early: %v", got.err)
+	case <-time.After(50 * time.Millisecond):
+	}
+	unlock()
+	select {
+	case got := <-second:
+		if got.err != nil {
+			t.Fatal(got.err)
+		}
+		got.unlock()
+	case <-time.After(time.Second):
+		t.Fatal("second redemption did not acquire lock after release")
 	}
 }

--- a/cmd/punaro-enroll/private_file_unix_test.go
+++ b/cmd/punaro-enroll/private_file_unix_test.go
@@ -3,6 +3,8 @@
 package main
 
 import (
+	"errors"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -20,5 +22,25 @@ func TestReadPrivateRejectsFIFOWithoutOpeningIt(t *testing.T) {
 	}
 	if _, err := readPrivate(path, 64); err == nil {
 		t.Fatal("FIFO was accepted as a private file")
+	}
+}
+
+func TestRemovePrivateDoesNotPoisonACompletedEnrollmentWhenDirectorySyncFails(t *testing.T) {
+	directory := filepath.Join(t.TempDir(), "state")
+	if err := ensurePrivateDir(directory); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(directory, "recovery")
+	if err := os.WriteFile(path, []byte("journal"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	original := syncPrivateDirectory
+	syncPrivateDirectory = func(string) error { return errors.New("directory sync failed") }
+	t.Cleanup(func() { syncPrivateDirectory = original })
+	if err := removePrivate(path); err != nil {
+		t.Fatalf("successful unlink reported as failure: %v", err)
+	}
+	if _, err := os.Lstat(path); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("recovery file remains after unlink: %v", err)
 	}
 }

--- a/cmd/punaro-enroll/private_file_unix_test.go
+++ b/cmd/punaro-enroll/private_file_unix_test.go
@@ -1,0 +1,24 @@
+//go:build !windows
+
+package main
+
+import (
+	"path/filepath"
+	"testing"
+
+	"golang.org/x/sys/unix"
+)
+
+func TestReadPrivateRejectsFIFOWithoutOpeningIt(t *testing.T) {
+	directory := filepath.Join(t.TempDir(), "state")
+	if err := ensurePrivateDir(directory); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(directory, "material")
+	if err := unix.Mkfifo(path, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := readPrivate(path, 64); err == nil {
+		t.Fatal("FIFO was accepted as a private file")
+	}
+}

--- a/cmd/punaro-enroll/private_file_unix_test.go
+++ b/cmd/punaro-enroll/private_file_unix_test.go
@@ -62,3 +62,32 @@ func TestWritePrivateAtomicNewDoesNotReplaceExistingDestination(t *testing.T) {
 		t.Fatalf("destination err=%v raw=%q", err, raw)
 	}
 }
+
+func TestEnsurePrivateDirSyncsParentWhenConcurrentCreatorWins(t *testing.T) {
+	directory := filepath.Join(t.TempDir(), "state")
+	originalMkdir := mkdirPrivateDirectory
+	originalSync := syncPrivateDirectory
+	t.Cleanup(func() {
+		mkdirPrivateDirectory = originalMkdir
+		syncPrivateDirectory = originalSync
+	})
+	mkdirPrivateDirectory = func(path string, mode os.FileMode) error {
+		if err := os.Mkdir(path, mode); err != nil {
+			return err
+		}
+		return os.ErrExist
+	}
+	var syncedParent bool
+	syncPrivateDirectory = func(path string) error {
+		if path == filepath.Dir(directory) {
+			syncedParent = true
+		}
+		return nil
+	}
+	if err := ensurePrivateDir(directory); err != nil {
+		t.Fatal(err)
+	}
+	if !syncedParent {
+		t.Fatal("parent of concurrently created directory was not synced")
+	}
+}

--- a/cmd/punaro-enroll/private_file_unix_test.go
+++ b/cmd/punaro-enroll/private_file_unix_test.go
@@ -44,3 +44,21 @@ func TestRemovePrivateDoesNotPoisonACompletedEnrollmentWhenDirectorySyncFails(t 
 		t.Fatalf("recovery file remains after unlink: %v", err)
 	}
 }
+
+func TestWritePrivateAtomicNewDoesNotReplaceExistingDestination(t *testing.T) {
+	directory := filepath.Join(t.TempDir(), "state")
+	if err := ensurePrivateDir(directory); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(directory, "credential")
+	if err := writePrivateNew(path, []byte("original\n")); err != nil {
+		t.Fatal(err)
+	}
+	if err := writePrivateAtomicNew(path, []byte("replacement\n")); err == nil {
+		t.Fatal("atomic new publication replaced an existing destination")
+	}
+	raw, err := readPrivate(path, 64)
+	if err != nil || string(raw) != "original\n" {
+		t.Fatalf("destination err=%v raw=%q", err, raw)
+	}
+}

--- a/cmd/punaro-enroll/private_file_windows.go
+++ b/cmd/punaro-enroll/private_file_windows.go
@@ -58,8 +58,16 @@ func ensurePrivateDir(path string) error {
 		} else {
 			created = true
 		}
-		if created && protectWindowsPath(directory) != nil {
-			return errors.New("could not protect private directory")
+		if created {
+			if err := protectWindowsPath(directory); err != nil {
+				_ = os.Remove(directory) // #nosec G703 -- exact empty directory created by this invocation.
+				return errors.New("could not protect private directory")
+			}
+			if err := privateDir(directory); err != nil {
+				_ = os.Remove(directory) // #nosec G703 -- exact new directory failed post-protection verification.
+				return err
+			}
+			continue
 		}
 		if err := privateDir(directory); err != nil {
 			return err
@@ -186,7 +194,9 @@ func privateWindowsACL(path string) bool {
 	return aceSID.Equals(user.User.Sid)
 }
 
-func protectWindowsPath(path string) error {
+var protectWindowsPath = protectWindowsPathImpl
+
+func protectWindowsPathImpl(path string) error {
 	token := windows.GetCurrentProcessToken()
 	user, err := token.GetTokenUser()
 	if err != nil || user.User.Sid == nil {

--- a/cmd/punaro-enroll/private_file_windows.go
+++ b/cmd/punaro-enroll/private_file_windows.go
@@ -164,6 +164,9 @@ func writeCredential(path, credential string) error {
 	return writePrivateNew(path, []byte(credential+"\n"))
 }
 
+func syncPrivateDirectory(string) error { return nil }
+func removePrivate(path string) error   { return os.Remove(path) }
+
 func privateWindowsACL(path string) bool {
 	token := windows.GetCurrentProcessToken()
 	user, err := token.GetTokenUser()

--- a/cmd/punaro-enroll/private_file_windows.go
+++ b/cmd/punaro-enroll/private_file_windows.go
@@ -280,7 +280,11 @@ func removePrivate(path string) error {
 	if err := os.Remove(path); err != nil {
 		return err
 	}
-	return syncPrivateDirectory(filepath.Dir(path))
+	// The caller's durable credential is already published. Attempt to flush
+	// the unlink, but do not turn that completed enrollment into a false
+	// failure when the directory metadata barrier is unavailable.
+	_ = syncPrivateDirectory(filepath.Dir(path))
+	return nil
 }
 
 func privateWindowsACL(path string) bool {

--- a/cmd/punaro-enroll/private_file_windows.go
+++ b/cmd/punaro-enroll/private_file_windows.go
@@ -15,7 +15,7 @@ import (
 
 func safeStateDir(path string) bool { return filepath.IsAbs(path) && filepath.Clean(path) == path }
 func safeStateChild(directory, path string) bool {
-	return safeStateDir(directory) && filepath.Dir(path) == directory && filepath.Base(path) != "." && filepath.Base(path) != ".."
+	return safeStateDir(directory) && filepath.IsAbs(path) && filepath.Clean(path) == path && filepath.Dir(path) == directory && filepath.Base(path) != "." && filepath.Base(path) != ".."
 }
 
 func ensurePrivateDir(path string) error {

--- a/cmd/punaro-enroll/private_file_windows.go
+++ b/cmd/punaro-enroll/private_file_windows.go
@@ -190,7 +190,48 @@ func writePrivateAtomic(path string, raw []byte) error {
 	return nil
 }
 
-func writePrivateAtomicNew(path string, raw []byte) error { return writePrivateAtomic(path, raw) }
+func writePrivateAtomicNew(path string, raw []byte) error {
+	file, err := os.CreateTemp(filepath.Dir(path), "."+filepath.Base(path)+".tmp-*")
+	if err != nil {
+		return err
+	}
+	temporary := file.Name()
+	removeTemporary := true
+	defer func() {
+		if removeTemporary {
+			_ = os.Remove(temporary)
+		}
+	}()
+	if err := file.Close(); err != nil {
+		return err
+	}
+	if err := protectWindowsPath(temporary); err != nil || !privateWindowsACL(temporary) {
+		return errors.New("could not protect private file")
+	}
+	file, err = os.OpenFile(temporary, os.O_WRONLY|os.O_TRUNC, 0) // #nosec G304 -- DACL is verified private before this secret write.
+	if err != nil {
+		return err
+	}
+	if _, err := file.Write(raw); err != nil {
+		_ = file.Close()
+		return err
+	}
+	if err := file.Sync(); err != nil {
+		_ = file.Close()
+		return err
+	}
+	if err := file.Close(); err != nil {
+		return err
+	}
+	if err := os.Link(temporary, path); err != nil {
+		return err
+	}
+	if err := os.Remove(temporary); err != nil {
+		return err
+	}
+	removeTemporary = false
+	return nil
+}
 func writeCredential(path, credential string) error {
 	if credential == "" || strings.ContainsAny(credential, " \t\r\n") {
 		return errors.New("invalid credential")

--- a/cmd/punaro-enroll/private_file_windows.go
+++ b/cmd/punaro-enroll/private_file_windows.go
@@ -15,7 +15,8 @@ import (
 
 func safeStateDir(path string) bool { return filepath.IsAbs(path) && filepath.Clean(path) == path }
 func safeStateChild(directory, path string) bool {
-	return safeStateDir(directory) && filepath.IsAbs(path) && filepath.Clean(path) == path && filepath.Dir(path) == directory && filepath.Base(path) != "." && filepath.Base(path) != ".."
+	base := filepath.Base(path)
+	return safeStateDir(directory) && filepath.IsAbs(path) && filepath.Clean(path) == path && filepath.Dir(path) == directory && base != "." && base != ".." && !strings.Contains(base, ":")
 }
 
 // Win32 normalizes trailing dots and spaces in ordinary file paths, so those

--- a/cmd/punaro-enroll/private_file_windows.go
+++ b/cmd/punaro-enroll/private_file_windows.go
@@ -36,15 +36,23 @@ func lockEnrollmentState(stateDir string) (func(), error) {
 	if err != nil {
 		return nil, err
 	}
+	cleanupCreated := func() {
+		if created {
+			_ = os.Remove(path) // #nosec G703 -- exact lock file created by this invocation.
+		}
+	}
 	if created {
 		if err := file.Close(); err != nil {
+			cleanupCreated()
 			return nil, err
 		}
 		if err := protectWindowsPath(path); err != nil || !privateWindowsACL(path) {
+			cleanupCreated()
 			return nil, errors.New("could not protect enrollment lock")
 		}
 		file, err = os.OpenFile(path, os.O_RDWR, 0) // #nosec G304 -- fixed private state child.
 		if err != nil {
+			cleanupCreated()
 			return nil, err
 		}
 	} else if !privateWindowsACL(path) {
@@ -54,6 +62,7 @@ func lockEnrollmentState(stateDir string) (func(), error) {
 	overlapped := windows.Overlapped{}
 	if err := windows.LockFileEx(windows.Handle(file.Fd()), windows.LOCKFILE_EXCLUSIVE_LOCK, 0, 1, 0, &overlapped); err != nil {
 		_ = file.Close()
+		cleanupCreated()
 		return nil, err
 	}
 	return func() {

--- a/cmd/punaro-enroll/private_file_windows.go
+++ b/cmd/punaro-enroll/private_file_windows.go
@@ -201,7 +201,7 @@ func writeCredential(path, credential string) error {
 	} else if !errors.Is(err, os.ErrNotExist) {
 		return err
 	}
-	return writePrivateNew(path, []byte(credential+"\n"))
+	return writePrivateAtomic(path, []byte(credential+"\n"))
 }
 
 var syncPrivateDirectory = func(string) error { return nil }

--- a/cmd/punaro-enroll/private_file_windows.go
+++ b/cmd/punaro-enroll/private_file_windows.go
@@ -19,11 +19,51 @@ func safeStateChild(directory, path string) bool {
 }
 
 func ensurePrivateDir(path string) error {
-	if err := os.MkdirAll(path, 0o700); err != nil {
+	info, err := os.Lstat(path)
+	if err == nil {
+		if !info.IsDir() || info.Mode()&os.ModeSymlink != 0 {
+			return errors.New("unsafe private directory")
+		}
+		return privateDir(path)
+	}
+	if !errors.Is(err, os.ErrNotExist) {
 		return err
 	}
-	if err := protectWindowsPath(path); err != nil {
-		return err
+
+	// Existing directories are never re-ACLed: a mistyped state path must fail
+	// closed rather than changing the permissions of a user directory. Build
+	// missing parents explicitly so only paths this invocation created receive
+	// the private DACL.
+	missing := []string{path}
+	for parent := filepath.Dir(path); ; parent = filepath.Dir(parent) {
+		info, err := os.Lstat(parent)
+		if err == nil {
+			if !info.IsDir() || info.Mode()&os.ModeSymlink != 0 {
+				return errors.New("unsafe private directory")
+			}
+			break
+		}
+		if !errors.Is(err, os.ErrNotExist) || parent == filepath.Dir(parent) {
+			return err
+		}
+		missing = append(missing, parent)
+	}
+	for index := len(missing) - 1; index >= 0; index-- {
+		directory := missing[index]
+		created := false
+		if err := os.Mkdir(directory, 0o700); err != nil {
+			if !errors.Is(err, os.ErrExist) {
+				return err
+			}
+		} else {
+			created = true
+		}
+		if created && protectWindowsPath(directory) != nil {
+			return errors.New("could not protect private directory")
+		}
+		if err := privateDir(directory); err != nil {
+			return err
+		}
 	}
 	return privateDir(path)
 }

--- a/cmd/punaro-enroll/private_file_windows.go
+++ b/cmd/punaro-enroll/private_file_windows.go
@@ -149,6 +149,46 @@ func writePrivateNew(path string, raw []byte) error {
 	removeOnFailure = false
 	return nil
 }
+
+func writePrivateAtomic(path string, raw []byte) error {
+	file, err := os.CreateTemp(filepath.Dir(path), "."+filepath.Base(path)+".tmp-*")
+	if err != nil {
+		return err
+	}
+	temporary := file.Name()
+	removeOnFailure := true
+	defer func() {
+		if removeOnFailure {
+			_ = os.Remove(temporary)
+		}
+	}()
+	if err := file.Close(); err != nil {
+		return err
+	}
+	if err := protectWindowsPath(temporary); err != nil || !privateWindowsACL(temporary) {
+		return errors.New("could not protect private file")
+	}
+	file, err = os.OpenFile(temporary, os.O_WRONLY|os.O_TRUNC, 0) // #nosec G304 -- DACL is verified private before this secret write.
+	if err != nil {
+		return err
+	}
+	if _, err := file.Write(raw); err != nil {
+		_ = file.Close()
+		return err
+	}
+	if err := file.Sync(); err != nil {
+		_ = file.Close()
+		return err
+	}
+	if err := file.Close(); err != nil {
+		return err
+	}
+	if err := os.Rename(temporary, path); err != nil {
+		return err
+	}
+	removeOnFailure = false
+	return nil
+}
 func writeCredential(path, credential string) error {
 	if credential == "" || strings.ContainsAny(credential, " \t\r\n") {
 		return errors.New("invalid credential")

--- a/cmd/punaro-enroll/private_file_windows.go
+++ b/cmd/punaro-enroll/private_file_windows.go
@@ -204,8 +204,9 @@ func writeCredential(path, credential string) error {
 	return writePrivateNew(path, []byte(credential+"\n"))
 }
 
-func syncPrivateDirectory(string) error { return nil }
-func removePrivate(path string) error   { return os.Remove(path) }
+var syncPrivateDirectory = func(string) error { return nil }
+
+func removePrivate(path string) error { return os.Remove(path) }
 
 func privateWindowsACL(path string) bool {
 	token := windows.GetCurrentProcessToken()

--- a/cmd/punaro-enroll/private_file_windows.go
+++ b/cmd/punaro-enroll/private_file_windows.go
@@ -1,0 +1,156 @@
+//go:build windows
+
+package main
+
+import (
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+func safeStateDir(path string) bool { return filepath.IsAbs(path) && filepath.Clean(path) == path }
+func safeStateChild(directory, path string) bool {
+	return safeStateDir(directory) && filepath.Dir(path) == directory && filepath.Base(path) != "." && filepath.Base(path) != ".."
+}
+
+func ensurePrivateDir(path string) error {
+	if err := os.MkdirAll(path, 0o700); err != nil {
+		return err
+	}
+	if err := protectWindowsPath(path); err != nil {
+		return err
+	}
+	return privateDir(path)
+}
+func privateDir(path string) error {
+	info, err := os.Lstat(path)
+	if err != nil || !info.IsDir() || info.Mode()&os.ModeSymlink != 0 || !privateWindowsACL(path) {
+		return errors.New("unsafe private directory")
+	}
+	return nil
+}
+func readPrivate(path string, maximum int) ([]byte, error) {
+	if !filepath.IsAbs(path) {
+		return nil, errors.New("unsafe private file")
+	}
+	info, err := os.Lstat(path)
+	if err != nil {
+		return nil, err
+	}
+	if !info.Mode().IsRegular() || info.Mode()&os.ModeSymlink != 0 || !privateWindowsACL(path) {
+		return nil, errors.New("unsafe private file")
+	}
+	file, err := os.Open(path) // #nosec G304 -- validated absolute local private file; remote data never selects it.
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = file.Close() }()
+	opened, err := file.Stat()
+	if err != nil || !opened.Mode().IsRegular() || !os.SameFile(info, opened) {
+		return nil, errors.New("private file changed while opening")
+	}
+	raw, err := io.ReadAll(io.LimitReader(file, int64(maximum)+1))
+	if err != nil || len(raw) == 0 || len(raw) > maximum {
+		return nil, errors.New("invalid private file")
+	}
+	return raw, nil
+}
+func writePrivateNew(path string, raw []byte) error {
+	if len(raw) == 0 || !filepath.IsAbs(path) {
+		return errors.New("unsafe private file")
+	}
+	file, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600) // #nosec G304 -- fixed child of validated private state.
+	if err != nil {
+		return err
+	}
+	if err := file.Close(); err != nil {
+		return err
+	}
+	// The file is deliberately empty while it has the inherited creation ACL.
+	// Install the verified exclusive DACL before opening it again to write a
+	// credential or enrollment code.
+	if err := protectWindowsPath(path); err != nil || !privateWindowsACL(path) {
+		return errors.New("could not protect private file")
+	}
+	file, err = os.OpenFile(path, os.O_WRONLY|os.O_TRUNC, 0) // #nosec G304 -- DACL is verified private before this secret write.
+	if err != nil {
+		return err
+	}
+	if _, err := file.Write(raw); err != nil {
+		_ = file.Close()
+		return err
+	}
+	if err := file.Sync(); err != nil {
+		_ = file.Close()
+		return err
+	}
+	return file.Close()
+}
+func writeCredential(path, credential string) error {
+	if credential == "" || strings.ContainsAny(credential, " \t\r\n") {
+		return errors.New("invalid credential")
+	}
+	if raw, err := readPrivate(path, maxEnrollmentFile); err == nil {
+		if string(raw) == credential+"\n" {
+			return nil
+		}
+		return errors.New("credential exists")
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return err
+	}
+	return writePrivateNew(path, []byte(credential+"\n"))
+}
+
+func privateWindowsACL(path string) bool {
+	token := windows.GetCurrentProcessToken()
+	user, err := token.GetTokenUser()
+	if err != nil || user.User.Sid == nil {
+		return false
+	}
+	sd, err := windows.GetNamedSecurityInfo(path, windows.SE_FILE_OBJECT, windows.OWNER_SECURITY_INFORMATION|windows.DACL_SECURITY_INFORMATION)
+	if err != nil {
+		return false
+	}
+	owner, _, err := sd.Owner()
+	if err != nil || owner == nil || !owner.Equals(user.User.Sid) {
+		return false
+	}
+	control, _, err := sd.Control()
+	if err != nil || control&windows.SE_DACL_PROTECTED == 0 {
+		return false
+	}
+	dacl, _, err := sd.DACL()
+	if err != nil || dacl == nil || dacl.AceCount != 1 {
+		return false
+	}
+	var ace *windows.ACCESS_ALLOWED_ACE
+	if windows.GetAce(dacl, 0, &ace) != nil || ace == nil || ace.Header.AceType != windows.ACCESS_ALLOWED_ACE_TYPE || ace.Header.AceFlags != 0 || ace.Mask&windows.ACCESS_MASK(0x1f01ff) != windows.ACCESS_MASK(0x1f01ff) {
+		return false
+	}
+	aceSID := (*windows.SID)(unsafe.Pointer(&ace.SidStart)) // #nosec G103 -- SidStart is the documented flexible-array start of this ACE's SID.
+	return aceSID.Equals(user.User.Sid)
+}
+
+func protectWindowsPath(path string) error {
+	token := windows.GetCurrentProcessToken()
+	user, err := token.GetTokenUser()
+	if err != nil || user.User.Sid == nil {
+		return errors.New("current user is unavailable")
+	}
+	acl, err := windows.ACLFromEntries([]windows.EXPLICIT_ACCESS{{
+		// Use the expanded file FullControl mask rather than GENERIC_ALL so the
+		// post-write verifier sees exactly the DACL shape it accepts.
+		AccessPermissions: windows.ACCESS_MASK(0x1f01ff),
+		AccessMode:        windows.GRANT_ACCESS,
+		Trustee:           windows.TRUSTEE{TrusteeForm: windows.TRUSTEE_IS_SID, TrusteeValue: windows.TrusteeValueFromSID(user.User.Sid)},
+	}}, nil)
+	if err != nil {
+		return err
+	}
+	return windows.SetNamedSecurityInfo(path, windows.SE_FILE_OBJECT, windows.OWNER_SECURITY_INFORMATION|windows.DACL_SECURITY_INFORMATION|windows.PROTECTED_DACL_SECURITY_INFORMATION, user.User.Sid, nil, acl, nil)
+}

--- a/cmd/punaro-enroll/private_file_windows.go
+++ b/cmd/punaro-enroll/private_file_windows.go
@@ -68,6 +68,12 @@ func writePrivateNew(path string, raw []byte) error {
 	if err != nil {
 		return err
 	}
+	removeOnFailure := true
+	defer func() {
+		if removeOnFailure {
+			_ = os.Remove(path) // #nosec G703 -- exclusive new child of the validated private state directory.
+		}
+	}()
 	if err := file.Close(); err != nil {
 		return err
 	}
@@ -89,7 +95,11 @@ func writePrivateNew(path string, raw []byte) error {
 		_ = file.Close()
 		return err
 	}
-	return file.Close()
+	if err := file.Close(); err != nil {
+		return err
+	}
+	removeOnFailure = false
+	return nil
 }
 func writeCredential(path, credential string) error {
 	if credential == "" || strings.ContainsAny(credential, " \t\r\n") {

--- a/cmd/punaro-enroll/private_file_windows.go
+++ b/cmd/punaro-enroll/private_file_windows.go
@@ -189,6 +189,8 @@ func writePrivateAtomic(path string, raw []byte) error {
 	removeOnFailure = false
 	return nil
 }
+
+func writePrivateAtomicNew(path string, raw []byte) error { return writePrivateAtomic(path, raw) }
 func writeCredential(path, credential string) error {
 	if credential == "" || strings.ContainsAny(credential, " \t\r\n") {
 		return errors.New("invalid credential")
@@ -201,7 +203,7 @@ func writeCredential(path, credential string) error {
 	} else if !errors.Is(err, os.ErrNotExist) {
 		return err
 	}
-	return writePrivateAtomic(path, []byte(credential+"\n"))
+	return writePrivateAtomicNew(path, []byte(credential+"\n"))
 }
 
 var syncPrivateDirectory = func(string) error { return nil }

--- a/cmd/punaro-enroll/private_file_windows.go
+++ b/cmd/punaro-enroll/private_file_windows.go
@@ -16,7 +16,11 @@ import (
 func safeStateDir(path string) bool { return filepath.IsAbs(path) && filepath.Clean(path) == path }
 func safeStateChild(directory, path string) bool {
 	base := filepath.Base(path)
-	return safeStateDir(directory) && filepath.IsAbs(path) && filepath.Clean(path) == path && filepath.Dir(path) == directory && base != "." && base != ".." && !strings.Contains(base, ":")
+	// A tilde is legal in a Win32 filename, but it can also be an NTFS 8.3
+	// short-name alias for the recovery journal or lock. Credentials are named
+	// by this local CLI, so reserve it rather than letting an alias redirect a
+	// later recovery-file operation.
+	return safeStateDir(directory) && filepath.IsAbs(path) && filepath.Clean(path) == path && filepath.Dir(path) == directory && base != "." && base != ".." && !strings.ContainsAny(base, ":~")
 }
 
 // Win32 normalizes trailing dots and spaces in ordinary file paths, so those

--- a/cmd/punaro-enroll/private_file_windows.go
+++ b/cmd/punaro-enroll/private_file_windows.go
@@ -22,7 +22,44 @@ func safeStateChild(directory, path string) bool {
 // Win32 normalizes trailing dots and spaces in ordinary file paths, so those
 // spellings must remain reserved alongside the journal's canonical name.
 func reservedStateFileName(name string) bool {
-	return strings.EqualFold(strings.TrimRight(name, ". "), redemptionJournalName)
+	name = strings.TrimRight(name, ". ")
+	return strings.EqualFold(name, redemptionJournalName) || strings.EqualFold(name, redemptionLockName)
+}
+
+func lockEnrollmentState(stateDir string) (func(), error) {
+	path := filepath.Join(stateDir, redemptionLockName)
+	file, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE|os.O_EXCL, 0o600) // #nosec G304 -- fixed private state child.
+	created := err == nil
+	if errors.Is(err, os.ErrExist) {
+		file, err = os.OpenFile(path, os.O_RDWR, 0) // #nosec G304 -- fixed private state child.
+	}
+	if err != nil {
+		return nil, err
+	}
+	if created {
+		if err := file.Close(); err != nil {
+			return nil, err
+		}
+		if err := protectWindowsPath(path); err != nil || !privateWindowsACL(path) {
+			return nil, errors.New("could not protect enrollment lock")
+		}
+		file, err = os.OpenFile(path, os.O_RDWR, 0) // #nosec G304 -- fixed private state child.
+		if err != nil {
+			return nil, err
+		}
+	} else if !privateWindowsACL(path) {
+		_ = file.Close()
+		return nil, errors.New("unsafe enrollment lock")
+	}
+	overlapped := windows.Overlapped{}
+	if err := windows.LockFileEx(windows.Handle(file.Fd()), windows.LOCKFILE_EXCLUSIVE_LOCK, 0, 1, 0, &overlapped); err != nil {
+		_ = file.Close()
+		return nil, err
+	}
+	return func() {
+		_ = windows.UnlockFileEx(windows.Handle(file.Fd()), 0, 1, 0, &overlapped)
+		_ = file.Close()
+	}, nil
 }
 
 func ensurePrivateDir(path string) error {

--- a/cmd/punaro-enroll/private_file_windows.go
+++ b/cmd/punaro-enroll/private_file_windows.go
@@ -32,41 +32,23 @@ func reservedStateFileName(name string) bool {
 
 func lockEnrollmentState(stateDir string) (func(), error) {
 	path := filepath.Join(stateDir, redemptionLockName)
-	file, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE|os.O_EXCL, 0o600) // #nosec G304 -- fixed private state child.
-	created := err == nil
-	if errors.Is(err, os.ErrExist) {
-		file, err = os.OpenFile(path, os.O_RDWR, 0) // #nosec G304 -- fixed private state child.
+	// Publish a fully protected file atomically. Creating the final lock path
+	// first would expose a crash window where its inherited DACL permanently
+	// poisons all later redemptions.
+	if err := writePrivateAtomicNew(path, []byte("lock\n")); err != nil && !errors.Is(err, os.ErrExist) {
+		return nil, err
 	}
+	file, err := os.OpenFile(path, os.O_RDWR, 0) // #nosec G304 -- fixed private state child.
 	if err != nil {
 		return nil, err
 	}
-	cleanupCreated := func() {
-		if created {
-			_ = os.Remove(path) // #nosec G703 -- exact lock file created by this invocation.
-		}
-	}
-	if created {
-		if err := file.Close(); err != nil {
-			cleanupCreated()
-			return nil, err
-		}
-		if err := protectWindowsPath(path); err != nil || !privateWindowsACL(path) {
-			cleanupCreated()
-			return nil, errors.New("could not protect enrollment lock")
-		}
-		file, err = os.OpenFile(path, os.O_RDWR, 0) // #nosec G304 -- fixed private state child.
-		if err != nil {
-			cleanupCreated()
-			return nil, err
-		}
-	} else if !privateWindowsACL(path) {
+	if !privateWindowsACL(path) {
 		_ = file.Close()
 		return nil, errors.New("unsafe enrollment lock")
 	}
 	overlapped := windows.Overlapped{}
 	if err := windows.LockFileEx(windows.Handle(file.Fd()), windows.LOCKFILE_EXCLUSIVE_LOCK, 0, 1, 0, &overlapped); err != nil {
 		_ = file.Close()
-		cleanupCreated()
 		return nil, err
 	}
 	return func() {

--- a/cmd/punaro-enroll/private_file_windows.go
+++ b/cmd/punaro-enroll/private_file_windows.go
@@ -24,7 +24,10 @@ func ensurePrivateDir(path string) error {
 		if !info.IsDir() || info.Mode()&os.ModeSymlink != 0 {
 			return errors.New("unsafe private directory")
 		}
-		return privateDir(path)
+		if err := privateDir(path); err != nil {
+			return err
+		}
+		return syncPrivateDirectory(filepath.Dir(path))
 	}
 	if !errors.Is(err, os.ErrNotExist) {
 		return err
@@ -41,6 +44,11 @@ func ensurePrivateDir(path string) error {
 			if !info.IsDir() || info.Mode()&os.ModeSymlink != 0 {
 				return errors.New("unsafe private directory")
 			}
+			if grandparent := filepath.Dir(parent); grandparent != parent {
+				if err := syncPrivateDirectory(grandparent); err != nil {
+					return err
+				}
+			}
 			break
 		}
 		if !errors.Is(err, os.ErrNotExist) || parent == filepath.Dir(parent) {
@@ -55,6 +63,9 @@ func ensurePrivateDir(path string) error {
 			if !errors.Is(err, os.ErrExist) {
 				return err
 			}
+			if err := syncPrivateDirectory(filepath.Dir(directory)); err != nil {
+				return err
+			}
 		} else {
 			created = true
 		}
@@ -65,6 +76,9 @@ func ensurePrivateDir(path string) error {
 			}
 			if err := privateDir(directory); err != nil {
 				_ = os.Remove(directory) // #nosec G703 -- exact new directory failed post-protection verification.
+				return err
+			}
+			if err := syncPrivateDirectory(filepath.Dir(directory)); err != nil {
 				return err
 			}
 			continue
@@ -147,7 +161,7 @@ func writePrivateNew(path string, raw []byte) error {
 		return err
 	}
 	removeOnFailure = false
-	return nil
+	return syncPrivateDirectory(filepath.Dir(path))
 }
 
 func writePrivateAtomic(path string, raw []byte) error {
@@ -187,7 +201,7 @@ func writePrivateAtomic(path string, raw []byte) error {
 		return err
 	}
 	removeOnFailure = false
-	return nil
+	return syncPrivateDirectory(filepath.Dir(path))
 }
 
 func writePrivateAtomicNew(path string, raw []byte) error {
@@ -230,7 +244,7 @@ func writePrivateAtomicNew(path string, raw []byte) error {
 		return err
 	}
 	removeTemporary = false
-	return nil
+	return syncPrivateDirectory(filepath.Dir(path))
 }
 func writeCredential(path, credential string) error {
 	if credential == "" || strings.ContainsAny(credential, " \t\r\n") {
@@ -247,9 +261,27 @@ func writeCredential(path, credential string) error {
 	return writePrivateAtomicNew(path, []byte(credential+"\n"))
 }
 
-var syncPrivateDirectory = func(string) error { return nil }
+var syncPrivateDirectory = syncPrivateDirectoryImpl
 
-func removePrivate(path string) error { return os.Remove(path) }
+func syncPrivateDirectoryImpl(path string) error {
+	name, err := windows.UTF16PtrFromString(path)
+	if err != nil {
+		return err
+	}
+	handle, err := windows.CreateFile(name, windows.GENERIC_WRITE, windows.FILE_SHARE_READ|windows.FILE_SHARE_WRITE|windows.FILE_SHARE_DELETE, nil, windows.OPEN_EXISTING, windows.FILE_FLAG_BACKUP_SEMANTICS, 0)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = windows.CloseHandle(handle) }()
+	return windows.FlushFileBuffers(handle)
+}
+
+func removePrivate(path string) error {
+	if err := os.Remove(path); err != nil {
+		return err
+	}
+	return syncPrivateDirectory(filepath.Dir(path))
+}
 
 func privateWindowsACL(path string) bool {
 	token := windows.GetCurrentProcessToken()

--- a/cmd/punaro-enroll/private_file_windows.go
+++ b/cmd/punaro-enroll/private_file_windows.go
@@ -18,6 +18,12 @@ func safeStateChild(directory, path string) bool {
 	return safeStateDir(directory) && filepath.IsAbs(path) && filepath.Clean(path) == path && filepath.Dir(path) == directory && filepath.Base(path) != "." && filepath.Base(path) != ".."
 }
 
+// Win32 normalizes trailing dots and spaces in ordinary file paths, so those
+// spellings must remain reserved alongside the journal's canonical name.
+func reservedStateFileName(name string) bool {
+	return strings.EqualFold(strings.TrimRight(name, ". "), redemptionJournalName)
+}
+
 func ensurePrivateDir(path string) error {
 	info, err := os.Lstat(path)
 	if err == nil {

--- a/cmd/punaro-enroll/private_file_windows_test.go
+++ b/cmd/punaro-enroll/private_file_windows_test.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 	"unsafe"
 
 	"golang.org/x/sys/windows"
@@ -119,6 +120,44 @@ func TestRemovePrivateDoesNotReportFailureAfterSuccessfulUnlink(t *testing.T) {
 	}
 	if _, err := os.Lstat(path); !errors.Is(err, os.ErrNotExist) {
 		t.Fatalf("recovery file remains after unlink: %v", err)
+	}
+}
+
+func TestLockEnrollmentStateSerializesConcurrentRedeems(t *testing.T) {
+	directory := filepath.Join(t.TempDir(), "state")
+	if err := ensurePrivateDir(directory); err != nil {
+		t.Fatal(err)
+	}
+	unlock, err := lockEnrollmentState(directory)
+	if err != nil {
+		t.Fatal(err)
+	}
+	type result struct {
+		unlock func()
+		err    error
+	}
+	second := make(chan result, 1)
+	go func() {
+		release, err := lockEnrollmentState(directory)
+		second <- result{unlock: release, err: err}
+	}()
+	select {
+	case got := <-second:
+		if got.unlock != nil {
+			got.unlock()
+		}
+		t.Fatalf("second redemption acquired lock early: %v", got.err)
+	case <-time.After(50 * time.Millisecond):
+	}
+	unlock()
+	select {
+	case got := <-second:
+		if got.err != nil {
+			t.Fatal(got.err)
+		}
+		got.unlock()
+	case <-time.After(time.Second):
+		t.Fatal("second redemption did not acquire lock after release")
 	}
 }
 

--- a/cmd/punaro-enroll/private_file_windows_test.go
+++ b/cmd/punaro-enroll/private_file_windows_test.go
@@ -62,6 +62,13 @@ func TestReservedStateFileNameRejectsWindowsAliases(t *testing.T) {
 	}
 }
 
+func TestSafeStateChildRejectsAlternateDataStreams(t *testing.T) {
+	directory := filepath.Join(t.TempDir(), "state")
+	if safeStateChild(directory, filepath.Join(directory, "credential:stream")) {
+		t.Fatal("alternate-data-stream credential path was accepted")
+	}
+}
+
 func TestEnsurePrivateDirRejectsExistingUnsafeDirectoryWithoutChangingIt(t *testing.T) {
 	directory := t.TempDir()
 	if privateWindowsACL(directory) {

--- a/cmd/punaro-enroll/private_file_windows_test.go
+++ b/cmd/punaro-enroll/private_file_windows_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"unsafe"
 
@@ -50,6 +51,14 @@ func TestWindowsPrivateDACL(t *testing.T) {
 	raw, err := readPrivate(file, 64)
 	if err != nil || string(raw) != "private\n" {
 		t.Fatalf("private file round trip failed: %v %q", err, raw)
+	}
+}
+
+func TestReservedStateFileNameRejectsWindowsAliases(t *testing.T) {
+	for _, name := range []string{redemptionJournalName, strings.ToUpper(redemptionJournalName), redemptionJournalName + ".", redemptionJournalName + " "} {
+		if !reservedStateFileName(name) {
+			t.Fatalf("reserved journal alias was accepted: %q", name)
+		}
 	}
 }
 

--- a/cmd/punaro-enroll/private_file_windows_test.go
+++ b/cmd/punaro-enroll/private_file_windows_test.go
@@ -76,6 +76,16 @@ func TestEnsurePrivateDirProtectsOnlyNewNestedDirectories(t *testing.T) {
 	}
 }
 
+func TestSyncPrivateDirectoryFlushesMetadata(t *testing.T) {
+	directory := filepath.Join(t.TempDir(), "state")
+	if err := ensurePrivateDir(directory); err != nil {
+		t.Fatal(err)
+	}
+	if err := syncPrivateDirectory(directory); err != nil {
+		t.Fatalf("flush private directory metadata: %v", err)
+	}
+}
+
 func TestEnsurePrivateDirRemovesNewDirectoryWhenACLProtectionFails(t *testing.T) {
 	original := protectWindowsPath
 	protectWindowsPath = func(string) error { return errors.New("ACL failure") }

--- a/cmd/punaro-enroll/private_file_windows_test.go
+++ b/cmd/punaro-enroll/private_file_windows_test.go
@@ -75,3 +75,16 @@ func TestEnsurePrivateDirProtectsOnlyNewNestedDirectories(t *testing.T) {
 		t.Fatal("new state directory is not private")
 	}
 }
+
+func TestEnsurePrivateDirRemovesNewDirectoryWhenACLProtectionFails(t *testing.T) {
+	original := protectWindowsPath
+	protectWindowsPath = func(string) error { return errors.New("ACL failure") }
+	t.Cleanup(func() { protectWindowsPath = original })
+	directory := filepath.Join(t.TempDir(), "new-state")
+	if err := ensurePrivateDir(directory); err == nil {
+		t.Fatal("ACL protection failure was accepted")
+	}
+	if _, err := os.Lstat(directory); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("failed directory remains: %v", err)
+	}
+}

--- a/cmd/punaro-enroll/private_file_windows_test.go
+++ b/cmd/punaro-enroll/private_file_windows_test.go
@@ -52,3 +52,26 @@ func TestWindowsPrivateDACL(t *testing.T) {
 		t.Fatalf("private file round trip failed: %v %q", err, raw)
 	}
 }
+
+func TestEnsurePrivateDirRejectsExistingUnsafeDirectoryWithoutChangingIt(t *testing.T) {
+	directory := t.TempDir()
+	if privateWindowsACL(directory) {
+		t.Skip("temporary directory is already private")
+	}
+	if err := ensurePrivateDir(directory); err == nil {
+		t.Fatal("existing directory with inherited ACL was accepted")
+	}
+	if privateWindowsACL(directory) {
+		t.Fatal("existing directory ACL was changed")
+	}
+}
+
+func TestEnsurePrivateDirProtectsOnlyNewNestedDirectories(t *testing.T) {
+	directory := filepath.Join(t.TempDir(), "new", "nested", "state")
+	if err := ensurePrivateDir(directory); err != nil {
+		t.Fatalf("ensure private state directory: %v", err)
+	}
+	if !privateWindowsACL(directory) {
+		t.Fatal("new state directory is not private")
+	}
+}

--- a/cmd/punaro-enroll/private_file_windows_test.go
+++ b/cmd/punaro-enroll/private_file_windows_test.go
@@ -86,6 +86,26 @@ func TestSyncPrivateDirectoryFlushesMetadata(t *testing.T) {
 	}
 }
 
+func TestRemovePrivateDoesNotReportFailureAfterSuccessfulUnlink(t *testing.T) {
+	directory := filepath.Join(t.TempDir(), "state")
+	if err := ensurePrivateDir(directory); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(directory, "recovery")
+	if err := writePrivateNew(path, []byte("journal")); err != nil {
+		t.Fatal(err)
+	}
+	original := syncPrivateDirectory
+	syncPrivateDirectory = func(string) error { return errors.New("directory sync failed") }
+	t.Cleanup(func() { syncPrivateDirectory = original })
+	if err := removePrivate(path); err != nil {
+		t.Fatalf("successful unlink reported as failure: %v", err)
+	}
+	if _, err := os.Lstat(path); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("recovery file remains after unlink: %v", err)
+	}
+}
+
 func TestEnsurePrivateDirRemovesNewDirectoryWhenACLProtectionFails(t *testing.T) {
 	original := protectWindowsPath
 	protectWindowsPath = func(string) error { return errors.New("ACL failure") }

--- a/cmd/punaro-enroll/private_file_windows_test.go
+++ b/cmd/punaro-enroll/private_file_windows_test.go
@@ -1,0 +1,54 @@
+//go:build windows
+
+package main
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+func TestWindowsPrivateDACL(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "private")
+	if err := os.Mkdir(path, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := protectWindowsPath(path); err != nil {
+		t.Fatal(err)
+	}
+	sd, err := windows.GetNamedSecurityInfo(path, windows.SE_FILE_OBJECT, windows.OWNER_SECURITY_INFORMATION|windows.DACL_SECURITY_INFORMATION)
+	if err != nil {
+		t.Fatal(err)
+	}
+	control, _, err := sd.Control()
+	if err != nil {
+		t.Fatal(err)
+	}
+	dacl, _, err := sd.DACL()
+	if err != nil || dacl == nil || dacl.AceCount != 1 {
+		t.Fatalf("DACL is not one exclusive ACE: %v", err)
+	}
+	var ace *windows.ACCESS_ALLOWED_ACE
+	if err := windows.GetAce(dacl, 0, &ace); err != nil || ace == nil {
+		t.Fatalf("private ACE is unavailable: %v", err)
+	}
+	if !privateWindowsACL(path) {
+		aceSID := (*windows.SID)(unsafe.Pointer(&ace.SidStart)) // #nosec G103 -- SidStart is the documented flexible-array start of this test ACE's SID.
+		t.Fatalf("private DACL rejected: control=%#x type=%d flags=%d mask=%#x sid=%s", control, ace.Header.AceType, ace.Header.AceFlags, ace.Mask, aceSID.String())
+	}
+	file := filepath.Join(path, "credential")
+	if _, err := readPrivate(file, 64); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("missing private file error=%v", err)
+	}
+	if err := writePrivateNew(file, []byte("private\n")); err != nil {
+		t.Fatal(err)
+	}
+	raw, err := readPrivate(file, 64)
+	if err != nil || string(raw) != "private\n" {
+		t.Fatalf("private file round trip failed: %v %q", err, raw)
+	}
+}

--- a/cmd/punaro-enroll/private_file_windows_test.go
+++ b/cmd/punaro-enroll/private_file_windows_test.go
@@ -161,6 +161,22 @@ func TestLockEnrollmentStateSerializesConcurrentRedeems(t *testing.T) {
 	}
 }
 
+func TestLockEnrollmentStateRemovesNewLockWhenProtectionFails(t *testing.T) {
+	directory := filepath.Join(t.TempDir(), "state")
+	if err := ensurePrivateDir(directory); err != nil {
+		t.Fatal(err)
+	}
+	original := protectWindowsPath
+	protectWindowsPath = func(string) error { return errors.New("ACL failure") }
+	t.Cleanup(func() { protectWindowsPath = original })
+	if _, err := lockEnrollmentState(directory); err == nil {
+		t.Fatal("lock protection failure was accepted")
+	}
+	if _, err := os.Lstat(filepath.Join(directory, redemptionLockName)); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("failed lock remains: %v", err)
+	}
+}
+
 func TestEnsurePrivateDirRemovesNewDirectoryWhenACLProtectionFails(t *testing.T) {
 	original := protectWindowsPath
 	protectWindowsPath = func(string) error { return errors.New("ACL failure") }

--- a/cmd/punaro-enroll/private_file_windows_test.go
+++ b/cmd/punaro-enroll/private_file_windows_test.go
@@ -70,6 +70,13 @@ func TestSafeStateChildRejectsAlternateDataStreams(t *testing.T) {
 	}
 }
 
+func TestSafeStateChildRejectsPotentialShortNameAliases(t *testing.T) {
+	directory := filepath.Join(t.TempDir(), "state")
+	if safeStateChild(directory, filepath.Join(directory, "REDEMP~1.JSO")) {
+		t.Fatal("potential 8.3 recovery-file alias was accepted")
+	}
+}
+
 func TestEnsurePrivateDirRejectsExistingUnsafeDirectoryWithoutChangingIt(t *testing.T) {
 	directory := t.TempDir()
 	if privateWindowsACL(directory) {

--- a/cmd/punaro-memory/onboarding_e2e_test.go
+++ b/cmd/punaro-memory/onboarding_e2e_test.go
@@ -199,7 +199,11 @@ func TestInstalledMemoryClientOnboardingE2E(t *testing.T) {
 	if err != nil {
 		t.Fatal("disposable enrollment setup failed")
 	}
-	material := writePrivateFile(t, enrollmentState, "enrollment-material.json", fmt.Sprintf(`{"enrollment_id":%q,"client_binding":%q,"code":%q}`, pending.ID, pending.ClientBinding, pending.Code))
+	pendingRaw, err := json.Marshal(pending)
+	if err != nil {
+		t.Fatal("encode enrollment material")
+	}
+	material := writePrivateFile(t, enrollmentState, "enrollment-material.json", string(pendingRaw))
 	credentialFile := filepath.Join(enrollmentState, "device.credential")
 	redeemed := runE2ECommand(t, e2eEnv(clientHome, proxy.caFile), enroller, "redeem", "--state-dir", enrollmentState, "--enrollment-file", material, "--credential-file", credentialFile)
 	if bytes.Contains(redeemed, []byte(pending.Code)) || bytes.Contains(redeemed, []byte(`"credential"`)) {

--- a/cmd/punaro-memory/onboarding_e2e_test.go
+++ b/cmd/punaro-memory/onboarding_e2e_test.go
@@ -172,26 +172,39 @@ func TestInstalledMemoryClientOnboardingE2E(t *testing.T) {
 	if err != nil {
 		t.Fatal("isolated E2E project setup failed")
 	}
-	_, previewHash, err := punaropostgres.PreviewTrustedAgentEnrollment([]string{project.ProjectID}, false)
-	if err != nil {
-		t.Fatal("enrollment preview setup failed")
-	}
-	pending, err := admin.CreateEnrollment(ctx, owner.ID, punaropostgres.EnrollmentRequest{ClientBinding: uuid.NewString(), Label: "memory E2E client", ProjectIDs: []string{project.ProjectID}, TTL: time.Minute}, previewHash)
-	if err != nil {
-		t.Fatal("disposable enrollment setup failed")
-	}
-
 	relay := startE2ERelay(t, fixture, appDSNFile)
 	defer relay.stop(t)
 	proxy := startE2ETLSProxy(t, relay.address)
 	defer proxy.close(t)
-	credential := redeemE2EEnrollment(t, proxy.client(), proxy.origin(), pending)
 
 	clientHome := filepath.Join(fixture, "client-home")
 	mailbox := writeE2EMailbox(t, fixture)
 	runE2ECommand(t, e2eEnv(clientHome, ""), "sh", filepath.Join(e2eRepositoryRoot(t), "scripts", "install-client.sh"), "--relay-url", proxy.origin(), "--machine-id", "memory-e2e", "--agent-mailbox-bin", mailbox)
 	memory := filepath.Join(clientHome, ".local", "bin", "punaro-memory")
-	credentialFile := writePrivateFile(t, filepath.Join(clientHome, ".config", "punaro"), "memory-device-credential", credential)
+	enroller := filepath.Join(clientHome, ".local", "bin", "punaro-enroll")
+	enrollmentState := filepath.Join(clientHome, ".config", "punaro", "device-enrollment")
+	preparedRaw := runE2ECommand(t, e2eEnv(clientHome, proxy.caFile), enroller, "prepare", "--origin", proxy.origin(), "--state-dir", enrollmentState)
+	var prepared struct {
+		Origin        string `json:"origin"`
+		ClientBinding string `json:"client_binding"`
+	}
+	if json.Unmarshal(preparedRaw, &prepared) != nil || prepared.Origin != proxy.origin() || prepared.ClientBinding == "" {
+		t.Fatal("installed enrollment client did not create a public binding")
+	}
+	_, previewHash, err := punaropostgres.PreviewTrustedAgentEnrollment([]string{project.ProjectID}, false)
+	if err != nil {
+		t.Fatal("enrollment preview setup failed")
+	}
+	pending, err := admin.CreateEnrollment(ctx, owner.ID, punaropostgres.EnrollmentRequest{ClientBinding: prepared.ClientBinding, Label: "memory E2E client", ProjectIDs: []string{project.ProjectID}, TTL: time.Minute}, previewHash)
+	if err != nil {
+		t.Fatal("disposable enrollment setup failed")
+	}
+	material := writePrivateFile(t, enrollmentState, "enrollment-material.json", fmt.Sprintf(`{"enrollment_id":%q,"client_binding":%q,"code":%q}`, pending.ID, pending.ClientBinding, pending.Code))
+	credentialFile := filepath.Join(enrollmentState, "device.credential")
+	redeemed := runE2ECommand(t, e2eEnv(clientHome, proxy.caFile), enroller, "redeem", "--state-dir", enrollmentState, "--enrollment-file", material, "--credential-file", credentialFile)
+	if bytes.Contains(redeemed, []byte(pending.Code)) || bytes.Contains(redeemed, []byte(`"credential"`)) {
+		t.Fatal("installed enrollment client leaked secret material")
+	}
 	profile := filepath.Join(clientHome, ".config", "punaro", "memory-profile.json")
 	runE2ECommand(t, e2eEnv(clientHome, proxy.caFile), memory, "profile-write", "--profile", profile, "--origin", proxy.origin(), "--credential-file", credentialFile, "--project", project.ProjectID)
 

--- a/cmd/punaro-memory/onboarding_e2e_test.go
+++ b/cmd/punaro-memory/onboarding_e2e_test.go
@@ -191,7 +191,7 @@ func TestInstalledMemoryClientOnboardingE2E(t *testing.T) {
 	if json.Unmarshal(preparedRaw, &prepared) != nil || prepared.Origin != proxy.origin() || prepared.ClientBinding == "" {
 		t.Fatal("installed enrollment client did not create a public binding")
 	}
-	_, previewHash, err := punaropostgres.PreviewTrustedAgentEnrollment([]string{project.ProjectID}, false)
+	grants, previewHash, err := punaropostgres.PreviewTrustedAgentEnrollment([]string{project.ProjectID}, false)
 	if err != nil {
 		t.Fatal("enrollment preview setup failed")
 	}
@@ -199,11 +199,19 @@ func TestInstalledMemoryClientOnboardingE2E(t *testing.T) {
 	if err != nil {
 		t.Fatal("disposable enrollment setup failed")
 	}
-	pendingRaw, err := json.Marshal(pending)
+	previewRaw, err := json.MarshalIndent(struct {
+		Template    string                     `json:"template"`
+		PreviewHash string                     `json:"preview_hash"`
+		Grants      []punaropostgres.GrantSpec `json:"grants"`
+	}{Template: "trusted-agent", PreviewHash: previewHash, Grants: grants}, "", "  ")
+	if err != nil {
+		t.Fatal("encode enrollment preview")
+	}
+	pendingRaw, err := json.MarshalIndent(pending, "", "  ")
 	if err != nil {
 		t.Fatal("encode enrollment material")
 	}
-	material := writePrivateFile(t, enrollmentState, "enrollment-material.json", string(pendingRaw))
+	material := writePrivateFile(t, enrollmentState, "enrollment-material.json", string(previewRaw)+"\n"+string(pendingRaw)+"\n")
 	credentialFile := filepath.Join(enrollmentState, "device.credential")
 	redeemed := runE2ECommand(t, e2eEnv(clientHome, proxy.caFile), enroller, "redeem", "--state-dir", enrollmentState, "--enrollment-file", material, "--credential-file", credentialFile)
 	if bytes.Contains(redeemed, []byte(pending.Code)) || bytes.Contains(redeemed, []byte(`"credential"`)) {

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -217,6 +217,59 @@ the local sidecar cannot repair, bypass, or broaden those decisions. After
 SQLite retirement, rollback is restore or forward repair, not a client profile
 edit.
 
+### Supported device-credential enrollment
+
+Installers now include `punaro-enroll` (`punaro-enroll.exe` on Windows). It is
+the supported way to make the public per-device enrollment binding and persist
+the returned bearer credential. It never accepts an enrollment code, bearer
+credential, private key, or Access secret in an argument or environment
+variable.
+
+On the client, create state for the fixed origin. The directory must be new or
+private and owned by the current user. On macOS/Linux use a directory below
+`~/.config/punaro`; on Windows use one below `%LOCALAPPDATA%\Punaro`:
+
+```sh
+punaro-enroll prepare \
+  --origin https://punaro.example \
+  --state-dir "$HOME/.config/punaro/device-enrollment"
+```
+
+The command prints only the canonical origin and an opaque `client_binding`.
+Give that public value to the server owner. The owner previews and creates the
+least-privilege grant with `punaro-admin client add`; the owner chooses the
+projects and cannot be overridden by the client. Treat its resulting JSON as
+short-lived enrollment material: transfer it through an approved protected
+channel into a current-user-only regular file on that client. Do not paste it
+into terminal commands, shell history, environment variables, diagnostic
+bundles, or source-controlled configuration.
+
+Redeem that protected file on the client:
+
+```sh
+punaro-enroll redeem \
+  --state-dir "$HOME/.config/punaro/device-enrollment" \
+  --enrollment-file /absolute/private/enrollment-material.json \
+  --credential-file "$HOME/.config/punaro/device-enrollment/device.credential"
+```
+
+`punaro-enroll` checks the exact binding before any network request, contacts
+only the canonical HTTPS origin selected during `prepare`, and writes a private
+recovery journal before redemption. If a network interruption occurs, rerun
+the same `redeem` command; if the transfer file is gone, use `punaro-enroll
+recover` with the state and credential paths. The retry has the same idempotency
+key, so it cannot mint a second device credential. A rejected (including
+expired, already-used, or revoked) enrollment fails closed and tells the user
+to request a new enrollment; its private recovery journal is removed so the
+replacement material is not blocked. After success, remove the transferred material
+through its approved secret-handling process; the identity sidecar remains
+non-secret and the recovery journal is removed.
+
+The server owner rotates or revokes a device with `punaro-admin credential
+rotate` or `punaro-admin credential revoke`, using the content-free credential
+inventory. Rotation and revocation are server-controlled: a local identity
+sidecar or copied credential cannot restore access.
+
 ## 4. Retired v2/v3 attachment evidence
 
 Do not execute the historical provisioning helpers retained in the source tree

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -238,9 +238,11 @@ punaro-enroll prepare \
 The command prints only the canonical origin and an opaque `client_binding`.
 Give that public value to the server owner. The owner previews and creates the
 least-privilege grant with `punaro-admin client add`; the owner chooses the
-projects and cannot be overridden by the client. Treat its exact resulting JSON
-as short-lived enrollment material: transfer it unchanged through an approved protected
-channel into a current-user-only regular file on that client. Do not paste it
+projects and cannot be overridden by the client. With `--yes`, that command
+prints the confirmed preview followed by the pending enrollment object. Treat
+the complete exact output as short-lived enrollment material: transfer it
+unchanged through an approved protected channel into a current-user-only regular
+file on that client. Do not paste it
 into terminal commands, shell history, environment variables, diagnostic
 bundles, or source-controlled configuration.
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -286,7 +286,9 @@ the same `redeem` command; if the transfer file is gone, use `punaro-enroll
 recover` with the state and credential paths. The retry has the same idempotency
 key, so it cannot mint a second device credential. The server retains that
 recovery record for 24 hours after redemption; after that, request a new
-enrollment instead. A rejected (including
+enrollment unless the private recovery journal already contains its credential
+checkpoint, in which case `recover` completes the local write without another
+server request. A rejected (including
 expired, already-used, or revoked) enrollment fails closed and tells the user
 to request a new enrollment; its private recovery journal is removed so the
 replacement material is not blocked. After success, remove the transferred material

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -284,7 +284,9 @@ only the canonical HTTPS origin selected during `prepare`, and writes a private
 recovery journal before redemption. If a network interruption occurs, rerun
 the same `redeem` command; if the transfer file is gone, use `punaro-enroll
 recover` with the state and credential paths. The retry has the same idempotency
-key, so it cannot mint a second device credential. A rejected (including
+key, so it cannot mint a second device credential. The server retains that
+recovery record for 24 hours after redemption; after that, request a new
+enrollment instead. A rejected (including
 expired, already-used, or revoked) enrollment fails closed and tells the user
 to request a new enrollment; its private recovery journal is removed so the
 replacement material is not blocked. After success, remove the transferred material

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -283,8 +283,9 @@ for the installed relay adapter; do not reuse it on another device.
 only the canonical HTTPS origin selected during `prepare`, and writes a private
 recovery journal before redemption. If a network interruption occurs, rerun
 the same `redeem` command; if the transfer file is gone, use `punaro-enroll
-recover` with the state and credential paths. The retry has the same idempotency
-key, so it cannot mint a second device credential. The server retains that
+recover` with the state and credential paths, and include the same
+`--access-file` when the origin is Access-protected. The retry has the same
+idempotency key, so it cannot mint a second device credential. The server retains that
 recovery record while its credential and principal remain active; after either
 expires, is revoked, or is disabled, request a new enrollment. A rejected
 (including

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -253,6 +253,30 @@ punaro-enroll redeem \
   --credential-file "$HOME/.config/punaro/device-enrollment/device.credential"
 ```
 
+If the public origin is protected by Cloudflare Access, create a distinct
+service token for this device and have its secret manager write the paired
+values into a current-user-only, non-symlinked JSON file such as:
+
+```json
+{"client_id":"...","client_secret":"..."}
+```
+
+Pass only that protected file path to the same command:
+
+```sh
+punaro-enroll redeem \
+  --state-dir "$HOME/.config/punaro/device-enrollment" \
+  --enrollment-file /absolute/private/enrollment-material.json \
+  --credential-file "$HOME/.config/punaro/device-enrollment/device.credential" \
+  --access-file /absolute/private/cloudflare-access.json
+```
+
+The command uses the service token only to establish an origin-scoped Access
+session and send the admission headers; it never accepts, prints, or stores
+either value in arguments, environment variables, generated profile defaults,
+or diagnostics. Continue to keep the token in the owner-only adapter profile
+for the installed relay adapter; do not reuse it on another device.
+
 `punaro-enroll` checks the exact binding before any network request, contacts
 only the canonical HTTPS origin selected during `prepare`, and writes a private
 recovery journal before redemption. If a network interruption occurs, rerun

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -238,8 +238,8 @@ punaro-enroll prepare \
 The command prints only the canonical origin and an opaque `client_binding`.
 Give that public value to the server owner. The owner previews and creates the
 least-privilege grant with `punaro-admin client add`; the owner chooses the
-projects and cannot be overridden by the client. Treat its resulting JSON as
-short-lived enrollment material: transfer it through an approved protected
+projects and cannot be overridden by the client. Treat its exact resulting JSON
+as short-lived enrollment material: transfer it unchanged through an approved protected
 channel into a current-user-only regular file on that client. Do not paste it
 into terminal commands, shell history, environment variables, diagnostic
 bundles, or source-controlled configuration.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -285,10 +285,9 @@ recovery journal before redemption. If a network interruption occurs, rerun
 the same `redeem` command; if the transfer file is gone, use `punaro-enroll
 recover` with the state and credential paths. The retry has the same idempotency
 key, so it cannot mint a second device credential. The server retains that
-recovery record for 24 hours after redemption; after that, request a new
-enrollment unless the private recovery journal already contains its credential
-checkpoint, in which case `recover` completes the local write without another
-server request. A rejected (including
+recovery record while its credential and principal remain active; after either
+expires, is revoked, or is disabled, request a new enrollment. A rejected
+(including
 expired, already-used, or revoked) enrollment fails closed and tells the user
 to request a new enrollment; its private recovery journal is removed so the
 replacement material is not blocked. After success, remove the transferred material

--- a/internal/adapter/client.go
+++ b/internal/adapter/client.go
@@ -36,7 +36,7 @@ type AccessServiceToken struct {
 // cookie jar; callers must still attach the service-token headers to their
 // protected request. It is deliberately usable by bootstrap clients, which
 // cannot sign an adapter request before device enrollment completes.
-func OpenAccessSession(ctx context.Context, rawURL string, client *http.Client, token AccessServiceToken) (*http.Client, error) {
+func OpenAccessSession(_ context.Context, rawURL string, client *http.Client, token AccessServiceToken) (*http.Client, error) {
 	baseURL, err := url.Parse(rawURL)
 	if err != nil || baseURL.Scheme == "" || baseURL.Host == "" || baseURL.RawQuery != "" || baseURL.Fragment != "" {
 		return nil, fmt.Errorf("invalid relay URL")
@@ -51,17 +51,10 @@ func OpenAccessSession(ctx context.Context, rawURL string, client *http.Client, 
 		client = http.DefaultClient
 	}
 	clientCopy := *client
-	if token.ClientID == "" || loopbackHost(baseURL.Hostname()) {
-		return &clientCopy, nil
-	}
-	jar, err := cookiejar.New(nil)
-	if err != nil {
-		return nil, fmt.Errorf("create Cloudflare Access cookie jar: %w", err)
-	}
-	clientCopy.Jar = jar
-	if err := (&accessSession{baseURL: baseURL, client: &clientCopy, token: token}).ensure(ctx); err != nil {
-		return nil, err
-	}
+	// Service-token policies authenticate each protected request from its
+	// headers. They do not necessarily mint a browser cookie, so probing a
+	// relay-only path for CF_Authorization would reject valid admission before
+	// the caller can make its authenticated request.
 	return &clientCopy, nil
 }
 

--- a/internal/adapter/client.go
+++ b/internal/adapter/client.go
@@ -31,6 +31,40 @@ type AccessServiceToken struct {
 	ClientSecret string
 }
 
+// OpenAccessSession establishes a Cloudflare Access session for an HTTPS
+// origin using a service token. The returned client owns an origin-scoped
+// cookie jar; callers must still attach the service-token headers to their
+// protected request. It is deliberately usable by bootstrap clients, which
+// cannot sign an adapter request before device enrollment completes.
+func OpenAccessSession(ctx context.Context, rawURL string, client *http.Client, token AccessServiceToken) (*http.Client, error) {
+	baseURL, err := url.Parse(rawURL)
+	if err != nil || baseURL.Scheme == "" || baseURL.Host == "" || baseURL.RawQuery != "" || baseURL.Fragment != "" {
+		return nil, fmt.Errorf("invalid relay URL")
+	}
+	if baseURL.Scheme != "https" && (baseURL.Scheme != "http" || !loopbackHost(baseURL.Hostname())) {
+		return nil, fmt.Errorf("relay URL must use HTTPS except for a loopback development listener")
+	}
+	if (token.ClientID == "") != (token.ClientSecret == "") {
+		return nil, fmt.Errorf("cloudflare Access service token must contain both ID and secret")
+	}
+	if client == nil {
+		client = http.DefaultClient
+	}
+	clientCopy := *client
+	if token.ClientID == "" || loopbackHost(baseURL.Hostname()) {
+		return &clientCopy, nil
+	}
+	jar, err := cookiejar.New(nil)
+	if err != nil {
+		return nil, fmt.Errorf("create Cloudflare Access cookie jar: %w", err)
+	}
+	clientCopy.Jar = jar
+	if err := (&accessSession{baseURL: baseURL, client: &clientCopy, token: token}).ensure(ctx); err != nil {
+		return nil, err
+	}
+	return &clientCopy, nil
+}
+
 // HTTPRelayClient is the signed HTTPS client used by one enrolled adapter.
 type HTTPRelayClient struct {
 	baseURL     *url.URL

--- a/internal/adapter/client_test.go
+++ b/internal/adapter/client_test.go
@@ -11,7 +11,6 @@ import (
 	"net/http"
 	"net/http/cookiejar"
 	"net/http/httptest"
-	"net/url"
 	"strings"
 	"testing"
 	"time"
@@ -477,40 +476,17 @@ func TestHTTPRelayClientEstablishesAccessSessionWithoutReplayingSignedRequest(t 
 	}
 }
 
-func TestOpenAccessSessionEstablishesBootstrapSession(t *testing.T) {
-	step := 0
-	client, err := OpenAccessSession(context.Background(), "https://relay.example", &http.Client{Transport: roundTripperFunc(func(request *http.Request) (*http.Response, error) {
-		step++
-		if request.Header.Get("CF-Access-Client-Id") != "access-id" || request.Header.Get("CF-Access-Client-Secret") != "access-secret" {
-			t.Fatalf("request %d omitted Access headers", step)
-		}
-		switch step {
-		case 1:
-			if request.URL.Host != "relay.example" || request.URL.Path != "/.well-known/punaro-access-session" {
-				t.Fatalf("unexpected first session request: %s", request.URL)
-			}
-			return testHTTPResponse(request, http.StatusFound, http.Header{"Location": []string{"https://team.cloudflareaccess.com/session"}}), nil
-		case 2:
-			if request.URL.Host != "team.cloudflareaccess.com" {
-				t.Fatalf("unexpected Access request: %s", request.URL)
-			}
-			return testHTTPResponse(request, http.StatusFound, http.Header{"Location": []string{"https://relay.example/.well-known/punaro-access-session"}}), nil
-		case 3:
-			if request.URL.Host != "relay.example" {
-				t.Fatalf("unexpected returning session request: %s", request.URL)
-			}
-			return testHTTPResponse(request, http.StatusNotFound, http.Header{"Set-Cookie": []string{"CF_Authorization=session; Path=/; Secure"}}), nil
-		default:
-			t.Fatalf("unexpected request %d: %s", step, request.URL)
-			return nil, nil
-		}
+func TestOpenAccessSessionSkipsCookiePreflightForServiceTokens(t *testing.T) {
+	requests := 0
+	client, err := OpenAccessSession(context.Background(), "https://relay.example", &http.Client{Transport: roundTripperFunc(func(*http.Request) (*http.Response, error) {
+		requests++
+		return nil, errors.New("service-token bootstrap should not preflight")
 	})}, AccessServiceToken{ClientID: "access-id", ClientSecret: "access-secret"})
 	if err != nil {
 		t.Fatal(err)
 	}
-	origin, err := url.Parse("https://relay.example")
-	if err != nil || !hasAccessAuthorizationCookie(client.Jar, origin) {
-		t.Fatal("bootstrap Access session cookie was not retained")
+	if requests != 0 || client.Jar != nil {
+		t.Fatalf("requests=%d jar=%v", requests, client.Jar)
 	}
 }
 

--- a/internal/adapter/client_test.go
+++ b/internal/adapter/client_test.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"net/http/cookiejar"
 	"net/http/httptest"
+	"net/url"
 	"strings"
 	"testing"
 	"time"
@@ -473,6 +474,43 @@ func TestHTTPRelayClientEstablishesAccessSessionWithoutReplayingSignedRequest(t 
 	}
 	if step != 4 {
 		t.Fatalf("request count=%d want 4", step)
+	}
+}
+
+func TestOpenAccessSessionEstablishesBootstrapSession(t *testing.T) {
+	step := 0
+	client, err := OpenAccessSession(context.Background(), "https://relay.example", &http.Client{Transport: roundTripperFunc(func(request *http.Request) (*http.Response, error) {
+		step++
+		if request.Header.Get("CF-Access-Client-Id") != "access-id" || request.Header.Get("CF-Access-Client-Secret") != "access-secret" {
+			t.Fatalf("request %d omitted Access headers", step)
+		}
+		switch step {
+		case 1:
+			if request.URL.Host != "relay.example" || request.URL.Path != "/.well-known/punaro-access-session" {
+				t.Fatalf("unexpected first session request: %s", request.URL)
+			}
+			return testHTTPResponse(request, http.StatusFound, http.Header{"Location": []string{"https://team.cloudflareaccess.com/session"}}), nil
+		case 2:
+			if request.URL.Host != "team.cloudflareaccess.com" {
+				t.Fatalf("unexpected Access request: %s", request.URL)
+			}
+			return testHTTPResponse(request, http.StatusFound, http.Header{"Location": []string{"https://relay.example/.well-known/punaro-access-session"}}), nil
+		case 3:
+			if request.URL.Host != "relay.example" {
+				t.Fatalf("unexpected returning session request: %s", request.URL)
+			}
+			return testHTTPResponse(request, http.StatusNotFound, http.Header{"Set-Cookie": []string{"CF_Authorization=session; Path=/; Secure"}}), nil
+		default:
+			t.Fatalf("unexpected request %d: %s", step, request.URL)
+			return nil, nil
+		}
+	})}, AccessServiceToken{ClientID: "access-id", ClientSecret: "access-secret"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	origin, err := url.Parse("https://relay.example")
+	if err != nil || !hasAccessAuthorizationCookie(client.Jar, origin) {
+		t.Fatal("bootstrap Access session cookie was not retained")
 	}
 }
 

--- a/internal/clientidentity/state.go
+++ b/internal/clientidentity/state.go
@@ -161,6 +161,11 @@ func canonicalOrigin(raw string) (string, bool) {
 	return parsed.String(), true
 }
 
+// CanonicalOrigin validates and canonicalizes the one fixed HTTPS authority a
+// native client is allowed to contact. Callers must persist the returned value
+// before accepting credentials or network input.
+func CanonicalOrigin(raw string) (string, bool) { return canonicalOrigin(raw) }
+
 func canonicalHost(hostname string) string {
 	if strings.Contains(hostname, ":") {
 		return "[" + hostname + "]"

--- a/internal/postgres/device_auth_integration_test.go
+++ b/internal/postgres/device_auth_integration_test.go
@@ -181,6 +181,47 @@ func testDeviceAuthIntegration(ctx context.Context, t *testing.T, app *Database,
 		t.Fatalf("revoked credential error=%v", err)
 	}
 
+	recoveryRequest := EnrollmentRequest{ClientBinding: uuid.NewString(), Label: "recoverable client", AllProjects: true, TTL: time.Minute, CredentialTTL: time.Minute}
+	recoveryPending, err := admin.CreateEnrollment(ctx, owner.ID, recoveryRequest, pruneHash)
+	if err != nil {
+		t.Fatal(err)
+	}
+	recoveryKey := uuid.NewString()
+	recoveryCredential, err := app.RedeemEnrollment(ctx, RedeemEnrollment{EnrollmentID: recoveryPending.ID, ClientBinding: recoveryRequest.ClientBinding, Code: recoveryPending.Code, IdempotencyKey: recoveryKey})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ownerDB.ExecContext(ctx, `UPDATE auth.pending_enrollments SET created_at = statement_timestamp() - interval '2 seconds', expires_at = statement_timestamp() - interval '1 second' WHERE id = $1`, recoveryPending.ID); err != nil {
+		t.Fatal(err)
+	}
+	activePruneTrigger := EnrollmentRequest{ClientBinding: uuid.NewString(), Label: "active credential prune trigger", AllProjects: true, TTL: time.Minute}
+	if _, err := admin.CreateEnrollment(ctx, owner.ID, activePruneTrigger, pruneHash); err != nil {
+		t.Fatalf("create enrollment after expired recovery enrollment: %v", err)
+	}
+	var redeemedRows, redeemedGrantRows int
+	if err := ownerDB.QueryRowContext(ctx, `SELECT
+        (SELECT count(*) FROM auth.pending_enrollments WHERE id = $1),
+		(SELECT count(*) FROM auth.pending_enrollment_grants WHERE enrollment_id = $1)`, recoveryPending.ID).Scan(&redeemedRows, &redeemedGrantRows); err != nil || redeemedRows != 1 || redeemedGrantRows == 0 {
+		t.Fatalf("expired redeemed enrollment rows=%d grants=%d err=%v, want retained recovery", redeemedRows, redeemedGrantRows, err)
+	}
+	if _, err := app.RedeemEnrollment(ctx, RedeemEnrollment{EnrollmentID: recoveryPending.ID, ClientBinding: recoveryRequest.ClientBinding, Code: recoveryPending.Code, IdempotencyKey: recoveryKey}); err != nil {
+		t.Fatalf("active credential replay: %v", err)
+	}
+	if _, err := ownerDB.ExecContext(ctx, `UPDATE auth.device_credentials SET created_at = statement_timestamp() - interval '2 seconds', expires_at = statement_timestamp() - interval '1 second' WHERE lookup_id = $1`, recoveryCredential.LookupID); err != nil {
+		t.Fatal(err)
+	}
+	latePruneTrigger := EnrollmentRequest{ClientBinding: uuid.NewString(), Label: "expired credential prune trigger", AllProjects: true, TTL: time.Minute}
+	if _, err := admin.CreateEnrollment(ctx, owner.ID, latePruneTrigger, pruneHash); err != nil {
+		t.Fatalf("create enrollment after credential expiry: %v", err)
+	}
+	if _, err := app.RedeemEnrollment(ctx, RedeemEnrollment{EnrollmentID: recoveryPending.ID, ClientBinding: recoveryRequest.ClientBinding, Code: recoveryPending.Code, IdempotencyKey: recoveryKey}); !errors.Is(err, ErrInvalidEnrollment) {
+		t.Fatalf("expired credential replay error=%v", err)
+	}
+	if err := ownerDB.QueryRowContext(ctx, `SELECT
+        (SELECT count(*) FROM auth.pending_enrollments WHERE id = $1),
+        (SELECT count(*) FROM auth.pending_enrollment_grants WHERE enrollment_id = $1)`, recoveryPending.ID).Scan(&redeemedRows, &redeemedGrantRows); err != nil || redeemedRows != 0 || redeemedGrantRows != 0 {
+		t.Fatalf("expired credential recovery rows=%d grants=%d err=%v, want pruned", redeemedRows, redeemedGrantRows, err)
+	}
 	expiredRequest := EnrollmentRequest{ClientBinding: uuid.NewString(), Label: "expired client", AllProjects: true, TTL: time.Minute}
 	_, expiredHash, err := PreviewTrustedAgentEnrollment(nil, true)
 	if err != nil {
@@ -189,22 +230,6 @@ func testDeviceAuthIntegration(ctx context.Context, t *testing.T, app *Database,
 	expiredPending, err := admin.CreateEnrollment(ctx, owner.ID, expiredRequest, expiredHash)
 	if err != nil {
 		t.Fatal(err)
-	}
-	var redeemedRows, redeemedGrantRows int
-	if err := ownerDB.QueryRowContext(ctx, `SELECT
-        (SELECT count(*) FROM auth.pending_enrollments WHERE id = $1),
-		(SELECT count(*) FROM auth.pending_enrollment_grants WHERE enrollment_id = $1)`, pending.ID).Scan(&redeemedRows, &redeemedGrantRows); err != nil || redeemedRows != 1 || redeemedGrantRows == 0 {
-		t.Fatalf("expired redeemed enrollment rows=%d grants=%d err=%v, want retained recovery", redeemedRows, redeemedGrantRows, err)
-	}
-	if _, err := ownerDB.ExecContext(ctx, `UPDATE auth.pending_enrollments SET redeemed_at = statement_timestamp() - make_interval(secs => $2) WHERE id = $1`, pending.ID, int64(enrollmentReplayRetention/time.Second)+1); err != nil {
-		t.Fatal(err)
-	}
-	latePruneTrigger := EnrollmentRequest{ClientBinding: uuid.NewString(), Label: "late prune trigger", AllProjects: true, TTL: time.Minute}
-	if _, err := admin.CreateEnrollment(ctx, owner.ID, latePruneTrigger, pruneHash); err != nil {
-		t.Fatalf("create enrollment after replay retention: %v", err)
-	}
-	if _, err := app.RedeemEnrollment(ctx, RedeemEnrollment{EnrollmentID: pending.ID, ClientBinding: request.ClientBinding, Code: pending.Code, IdempotencyKey: redeemKey}); !errors.Is(err, ErrInvalidEnrollment) {
-		t.Fatalf("expired replay retention error=%v", err)
 	}
 	if _, err := ownerDB.ExecContext(ctx, `UPDATE auth.pending_enrollments SET created_at = statement_timestamp() - interval '2 seconds', expires_at = statement_timestamp() - interval '1 second' WHERE id = $1`, expiredPending.ID); err != nil {
 		t.Fatal(err)

--- a/internal/postgres/device_auth_integration_test.go
+++ b/internal/postgres/device_auth_integration_test.go
@@ -180,11 +180,16 @@ func testDeviceAuthIntegration(ctx context.Context, t *testing.T, app *Database,
 	if _, err := app.AuthenticateDevice(ctx, rotated.Encoded); !errors.Is(err, ErrUnauthenticated) {
 		t.Fatalf("revoked credential error=%v", err)
 	}
-
 	recoveryRequest := EnrollmentRequest{ClientBinding: uuid.NewString(), Label: "recoverable client", AllProjects: true, TTL: time.Minute, CredentialTTL: time.Minute}
 	recoveryPending, err := admin.CreateEnrollment(ctx, owner.ID, recoveryRequest, pruneHash)
 	if err != nil {
 		t.Fatal(err)
+	}
+	var rotatedRows, rotatedGrantRows int
+	if err := ownerDB.QueryRowContext(ctx, `SELECT
+        (SELECT count(*) FROM auth.pending_enrollments WHERE id = $1),
+        (SELECT count(*) FROM auth.pending_enrollment_grants WHERE enrollment_id = $1)`, pending.ID).Scan(&rotatedRows, &rotatedGrantRows); err != nil || rotatedRows != 0 || rotatedGrantRows != 0 {
+		t.Fatalf("rotated credential recovery rows=%d grants=%d err=%v, want pruned", rotatedRows, rotatedGrantRows, err)
 	}
 	recoveryKey := uuid.NewString()
 	recoveryCredential, err := app.RedeemEnrollment(ctx, RedeemEnrollment{EnrollmentID: recoveryPending.ID, ClientBinding: recoveryRequest.ClientBinding, Code: recoveryPending.Code, IdempotencyKey: recoveryKey})

--- a/internal/postgres/device_auth_integration_test.go
+++ b/internal/postgres/device_auth_integration_test.go
@@ -112,8 +112,9 @@ func testDeviceAuthIntegration(ctx context.Context, t *testing.T, app *Database,
 	if _, err := ownerDB.ExecContext(ctx, `UPDATE auth.pending_enrollments SET expires_at = statement_timestamp() - interval '1 second' WHERE id = $1`, pending.ID); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := app.RedeemEnrollment(ctx, RedeemEnrollment{EnrollmentID: pending.ID, ClientBinding: request.ClientBinding, Code: pending.Code, IdempotencyKey: redeemKey}); !errors.Is(err, ErrInvalidEnrollment) {
-		t.Fatalf("expired redemption retry error=%v", err)
+	expiredReplay, err := app.RedeemEnrollment(ctx, RedeemEnrollment{EnrollmentID: pending.ID, ClientBinding: request.ClientBinding, Code: pending.Code, IdempotencyKey: redeemKey})
+	if err != nil || expiredReplay.Encoded != credential.Encoded || expiredReplay.LookupID != credential.LookupID {
+		t.Fatalf("expired redemption retry=%#v err=%v", expiredReplay, err)
 	}
 	if _, err := app.RedeemEnrollment(ctx, RedeemEnrollment{EnrollmentID: pending.ID, ClientBinding: request.ClientBinding, Code: pending.Code, IdempotencyKey: uuid.NewString()}); !errors.Is(err, ErrInvalidEnrollment) {
 		t.Fatalf("single-use replay error=%v", err)

--- a/internal/postgres/device_auth_integration_test.go
+++ b/internal/postgres/device_auth_integration_test.go
@@ -196,6 +196,16 @@ func testDeviceAuthIntegration(ctx context.Context, t *testing.T, app *Database,
 		(SELECT count(*) FROM auth.pending_enrollment_grants WHERE enrollment_id = $1)`, pending.ID).Scan(&redeemedRows, &redeemedGrantRows); err != nil || redeemedRows != 1 || redeemedGrantRows == 0 {
 		t.Fatalf("expired redeemed enrollment rows=%d grants=%d err=%v, want retained recovery", redeemedRows, redeemedGrantRows, err)
 	}
+	if _, err := ownerDB.ExecContext(ctx, `UPDATE auth.pending_enrollments SET redeemed_at = statement_timestamp() - make_interval(secs => $2) WHERE id = $1`, pending.ID, int64(enrollmentReplayRetention/time.Second)+1); err != nil {
+		t.Fatal(err)
+	}
+	latePruneTrigger := EnrollmentRequest{ClientBinding: uuid.NewString(), Label: "late prune trigger", AllProjects: true, TTL: time.Minute}
+	if _, err := admin.CreateEnrollment(ctx, owner.ID, latePruneTrigger, pruneHash); err != nil {
+		t.Fatalf("create enrollment after replay retention: %v", err)
+	}
+	if _, err := app.RedeemEnrollment(ctx, RedeemEnrollment{EnrollmentID: pending.ID, ClientBinding: request.ClientBinding, Code: pending.Code, IdempotencyKey: redeemKey}); !errors.Is(err, ErrInvalidEnrollment) {
+		t.Fatalf("expired replay retention error=%v", err)
+	}
 	if _, err := ownerDB.ExecContext(ctx, `UPDATE auth.pending_enrollments SET created_at = statement_timestamp() - interval '2 seconds', expires_at = statement_timestamp() - interval '1 second' WHERE id = $1`, expiredPending.ID); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/postgres/device_auth_integration_test.go
+++ b/internal/postgres/device_auth_integration_test.go
@@ -112,6 +112,14 @@ func testDeviceAuthIntegration(ctx context.Context, t *testing.T, app *Database,
 	if _, err := ownerDB.ExecContext(ctx, `UPDATE auth.pending_enrollments SET expires_at = statement_timestamp() - interval '1 second' WHERE id = $1`, pending.ID); err != nil {
 		t.Fatal(err)
 	}
+	pruneTrigger := EnrollmentRequest{ClientBinding: uuid.NewString(), Label: "prune trigger", AllProjects: true, TTL: time.Minute}
+	_, pruneHash, err := PreviewTrustedAgentEnrollment(nil, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := admin.CreateEnrollment(ctx, owner.ID, pruneTrigger, pruneHash); err != nil {
+		t.Fatalf("create enrollment after expired redemption: %v", err)
+	}
 	expiredReplay, err := app.RedeemEnrollment(ctx, RedeemEnrollment{EnrollmentID: pending.ID, ClientBinding: request.ClientBinding, Code: pending.Code, IdempotencyKey: redeemKey})
 	if err != nil || expiredReplay.Encoded != credential.Encoded || expiredReplay.LookupID != credential.LookupID {
 		t.Fatalf("expired redemption retry=%#v err=%v", expiredReplay, err)
@@ -185,8 +193,8 @@ func testDeviceAuthIntegration(ctx context.Context, t *testing.T, app *Database,
 	var redeemedRows, redeemedGrantRows int
 	if err := ownerDB.QueryRowContext(ctx, `SELECT
         (SELECT count(*) FROM auth.pending_enrollments WHERE id = $1),
-        (SELECT count(*) FROM auth.pending_enrollment_grants WHERE enrollment_id = $1)`, pending.ID).Scan(&redeemedRows, &redeemedGrantRows); err != nil || redeemedRows != 0 || redeemedGrantRows != 0 {
-		t.Fatalf("expired redeemed enrollment rows=%d grants=%d err=%v, want pruned", redeemedRows, redeemedGrantRows, err)
+		(SELECT count(*) FROM auth.pending_enrollment_grants WHERE enrollment_id = $1)`, pending.ID).Scan(&redeemedRows, &redeemedGrantRows); err != nil || redeemedRows != 1 || redeemedGrantRows == 0 {
+		t.Fatalf("expired redeemed enrollment rows=%d grants=%d err=%v, want retained recovery", redeemedRows, redeemedGrantRows, err)
 	}
 	if _, err := ownerDB.ExecContext(ctx, `UPDATE auth.pending_enrollments SET created_at = statement_timestamp() - interval '2 seconds', expires_at = statement_timestamp() - interval '1 second' WHERE id = $1`, expiredPending.ID); err != nil {
 		t.Fatal(err)

--- a/internal/postgres/device_auth_store.go
+++ b/internal/postgres/device_auth_store.go
@@ -366,17 +366,20 @@ func (d *Database) redeemEnrollment(ctx context.Context, redeem RedeemEnrollment
 	}
 	var storedCode []byte
 	var storedBinding, label, issuer string
-	var usable bool
+	var unexpired, active bool
 	var redemptionKey, principalID, lookupID, requiredLegacy sql.NullString
 	var credentialTTL sql.NullInt64
 	err = tx.QueryRowContext(ctx, `SELECT code_digest, client_binding::text, label, issuer_principal_id::text,
-expires_at > statement_timestamp() AND invalidated_at IS NULL,
+expires_at > statement_timestamp(), invalidated_at IS NULL,
 redemption_key::text, redeemed_principal_id::text, credential_lookup_id::text, credential_ttl_seconds, legacy_principal_id::text
-FROM auth.pending_enrollments WHERE id = $1 FOR UPDATE`, redeem.EnrollmentID).Scan(&storedCode, &storedBinding, &label, &issuer, &usable, &redemptionKey, &principalID, &lookupID, &credentialTTL, &requiredLegacy)
+FROM auth.pending_enrollments WHERE id = $1 FOR UPDATE`, redeem.EnrollmentID).Scan(&storedCode, &storedBinding, &label, &issuer, &unexpired, &active, &redemptionKey, &principalID, &lookupID, &credentialTTL, &requiredLegacy)
 	if err != nil || storedBinding != redeem.ClientBinding || subtle.ConstantTimeCompare(storedCode, codeDigest[:]) != 1 || requiredLegacy.Valid != (legacyProof != nil) {
 		return DeviceCredential{}, ErrInvalidEnrollment
 	}
-	if !usable {
+	// Expiry prevents the first redemption, but a row already bound to this
+	// idempotency key must remain recoverable after a lost response. An
+	// invalidated enrollment remains unavailable in either state.
+	if !active || (!unexpired && !redemptionKey.Valid) {
 		return DeviceCredential{}, ErrInvalidEnrollment
 	}
 	if requiredLegacy.Valid {

--- a/internal/postgres/device_auth_store.go
+++ b/internal/postgres/device_auth_store.go
@@ -33,9 +33,6 @@ const (
 	enrollmentMutationLockKey int64 = 0x50756e61726f454e
 	maxPendingEnrollments           = 1000
 	lastUsedWriteInterval           = 5 * time.Minute
-	// enrollmentReplayRetention bounds the idempotent recovery record retained
-	// after a successful redemption whose response was lost by the client.
-	enrollmentReplayRetention = 24 * time.Hour
 )
 
 // Administration is a direct, host-local schema-owner connection. It is never
@@ -410,7 +407,13 @@ FROM auth.pending_enrollments WHERE id = $1 FOR UPDATE`, redeem.EnrollmentID).Sc
 		var storedDigest []byte
 		var generation int64
 		var expiresAt sql.NullTime
-		if err := tx.QueryRowContext(ctx, `SELECT secret_digest, generation, expires_at FROM auth.device_credentials WHERE lookup_id = $1 AND principal_id = $2`, lookupID.String, principalID.String).Scan(&storedDigest, &generation, &expiresAt); err != nil || subtle.ConstantTimeCompare(storedDigest, secretDigest[:]) != 1 {
+		if err := tx.QueryRowContext(ctx, `SELECT credential.secret_digest, credential.generation, credential.expires_at
+FROM auth.device_credentials AS credential
+JOIN auth.principals AS principal ON principal.id = credential.principal_id
+WHERE credential.lookup_id = $1 AND credential.principal_id = $2
+AND credential.revoked_at IS NULL
+AND (credential.expires_at IS NULL OR credential.expires_at > statement_timestamp())
+AND principal.disabled_at IS NULL`, lookupID.String, principalID.String).Scan(&storedDigest, &generation, &expiresAt); err != nil || subtle.ConstantTimeCompare(storedDigest, secretDigest[:]) != 1 {
 			return DeviceCredential{}, ErrInvalidEnrollment
 		}
 		return DeviceCredential{PrincipalID: principalID.String, LookupID: lookupID.String, Encoded: encodeDeviceCredential(lookupID.String, credentialSecret[:]), Generation: generation, ExpiresAt: expiresAt.Time}, nil
@@ -738,16 +741,25 @@ FOR SHARE OF principal`, principalID).Scan(&locked)
 func pruneExpiredEnrollments(ctx context.Context, tx *sql.Tx, limit int) error {
 	var pruned int64
 	err := tx.QueryRowContext(ctx, `WITH candidates AS (
-    SELECT id FROM auth.pending_enrollments
-    WHERE invalidated_at IS NOT NULL
-       OR (redeemed_at IS NULL AND expires_at <= statement_timestamp())
-       OR (redeemed_at IS NOT NULL AND redeemed_at <= statement_timestamp() - make_interval(secs => $2))
-    ORDER BY COALESCE(redeemed_at, expires_at), id LIMIT $1 FOR UPDATE SKIP LOCKED
+	SELECT enrollment.id FROM auth.pending_enrollments AS enrollment
+    WHERE enrollment.invalidated_at IS NOT NULL
+       OR (enrollment.redeemed_at IS NULL AND enrollment.expires_at <= statement_timestamp())
+       OR (enrollment.redeemed_at IS NOT NULL AND NOT EXISTS (
+           SELECT 1
+           FROM auth.device_credentials AS credential
+           JOIN auth.principals AS principal ON principal.id = credential.principal_id
+           WHERE credential.lookup_id = enrollment.credential_lookup_id
+           AND credential.principal_id = enrollment.redeemed_principal_id
+           AND credential.revoked_at IS NULL
+           AND (credential.expires_at IS NULL OR credential.expires_at > statement_timestamp())
+           AND principal.disabled_at IS NULL
+       ))
+    ORDER BY COALESCE(enrollment.redeemed_at, enrollment.expires_at), enrollment.id LIMIT $1 FOR UPDATE SKIP LOCKED
 ), deleted_enrollments AS (
     DELETE FROM auth.pending_enrollments AS enrollment USING candidates
     WHERE enrollment.id = candidates.id RETURNING enrollment.id
 )
-SELECT count(*) FROM deleted_enrollments`, limit, int64(enrollmentReplayRetention/time.Second)).Scan(&pruned)
+SELECT count(*) FROM deleted_enrollments`, limit).Scan(&pruned)
 	if err != nil {
 		return errors.New("expired enrollments could not be pruned")
 	}

--- a/internal/postgres/device_auth_store.go
+++ b/internal/postgres/device_auth_store.go
@@ -412,6 +412,7 @@ FROM auth.device_credentials AS credential
 JOIN auth.principals AS principal ON principal.id = credential.principal_id
 WHERE credential.lookup_id = $1 AND credential.principal_id = $2
 AND credential.revoked_at IS NULL
+AND credential.rotated_at IS NULL
 AND (credential.expires_at IS NULL OR credential.expires_at > statement_timestamp())
 AND principal.disabled_at IS NULL`, lookupID.String, principalID.String).Scan(&storedDigest, &generation, &expiresAt); err != nil || subtle.ConstantTimeCompare(storedDigest, secretDigest[:]) != 1 {
 			return DeviceCredential{}, ErrInvalidEnrollment
@@ -751,6 +752,7 @@ func pruneExpiredEnrollments(ctx context.Context, tx *sql.Tx, limit int) error {
            WHERE credential.lookup_id = enrollment.credential_lookup_id
            AND credential.principal_id = enrollment.redeemed_principal_id
            AND credential.revoked_at IS NULL
+           AND credential.rotated_at IS NULL
            AND (credential.expires_at IS NULL OR credential.expires_at > statement_timestamp())
            AND principal.disabled_at IS NULL
        ))

--- a/internal/postgres/device_auth_store.go
+++ b/internal/postgres/device_auth_store.go
@@ -33,6 +33,9 @@ const (
 	enrollmentMutationLockKey int64 = 0x50756e61726f454e
 	maxPendingEnrollments           = 1000
 	lastUsedWriteInterval           = 5 * time.Minute
+	// enrollmentReplayRetention bounds the idempotent recovery record retained
+	// after a successful redemption whose response was lost by the client.
+	enrollmentReplayRetention = 24 * time.Hour
 )
 
 // Administration is a direct, host-local schema-owner connection. It is never
@@ -736,14 +739,15 @@ func pruneExpiredEnrollments(ctx context.Context, tx *sql.Tx, limit int) error {
 	var pruned int64
 	err := tx.QueryRowContext(ctx, `WITH candidates AS (
     SELECT id FROM auth.pending_enrollments
-	WHERE invalidated_at IS NOT NULL
-	   OR (redeemed_at IS NULL AND expires_at <= statement_timestamp())
-    ORDER BY expires_at, id LIMIT $1 FOR UPDATE SKIP LOCKED
+    WHERE invalidated_at IS NOT NULL
+       OR (redeemed_at IS NULL AND expires_at <= statement_timestamp())
+       OR (redeemed_at IS NOT NULL AND redeemed_at <= statement_timestamp() - make_interval(secs => $2))
+    ORDER BY COALESCE(redeemed_at, expires_at), id LIMIT $1 FOR UPDATE SKIP LOCKED
 ), deleted_enrollments AS (
     DELETE FROM auth.pending_enrollments AS enrollment USING candidates
     WHERE enrollment.id = candidates.id RETURNING enrollment.id
 )
-SELECT count(*) FROM deleted_enrollments`, limit).Scan(&pruned)
+SELECT count(*) FROM deleted_enrollments`, limit, int64(enrollmentReplayRetention/time.Second)).Scan(&pruned)
 	if err != nil {
 		return errors.New("expired enrollments could not be pruned")
 	}

--- a/internal/postgres/device_auth_store.go
+++ b/internal/postgres/device_auth_store.go
@@ -736,7 +736,8 @@ func pruneExpiredEnrollments(ctx context.Context, tx *sql.Tx, limit int) error {
 	var pruned int64
 	err := tx.QueryRowContext(ctx, `WITH candidates AS (
     SELECT id FROM auth.pending_enrollments
-	WHERE expires_at <= statement_timestamp() OR invalidated_at IS NOT NULL
+	WHERE invalidated_at IS NOT NULL
+	   OR (redeemed_at IS NULL AND expires_at <= statement_timestamp())
     ORDER BY expires_at, id LIMIT $1 FOR UPDATE SKIP LOCKED
 ), deleted_enrollments AS (
     DELETE FROM auth.pending_enrollments AS enrollment USING candidates

--- a/scripts/install-adapter.sh
+++ b/scripts/install-adapter.sh
@@ -143,11 +143,13 @@ trap cleanup EXIT HUP INT TERM
 	go build -trimpath -buildvcs=true -o "$build_dir/punaro-adapter" ./cmd/punaro-adapter
 	go build -trimpath -buildvcs=true -o "$build_dir/punaro-trusted-attachment" ./cmd/punaro-trusted-attachment
 	go build -trimpath -buildvcs=true -o "$build_dir/punaro-memory" ./cmd/punaro-memory
+	go build -trimpath -buildvcs=true -o "$build_dir/punaro-enroll" ./cmd/punaro-enroll
 	go build -trimpath -buildvcs=true -o "$build_dir/punaro-keygen" ./cmd/punaro-keygen
 )
 install -m 700 "$build_dir/punaro-adapter" "$bin_dir/punaro-adapter"
 install -m 700 "$build_dir/punaro-trusted-attachment" "$bin_dir/punaro-trusted-attachment"
 install -m 700 "$build_dir/punaro-memory" "$bin_dir/punaro-memory"
+install -m 700 "$build_dir/punaro-enroll" "$bin_dir/punaro-enroll"
 
 if [ -e "$key_file" ] || [ -L "$key_file" ]; then
 	regular_private_file "$key_file" || fail 'existing machine key must be a non-symlink regular 0600 file'
@@ -251,6 +253,7 @@ cat "$enrollment_file"
 printf '%s\n' '' \
 	'Next: approve that record on the relay; create a distinct Cloudflare Access service token for this machine; add it to the owner-only adapter.env; bind and attach the desired agent aliases; then rerun this command with --enable.' \
 	'Trusted attachments: after device-credential enrollment, use punaro-trusted-attachment with an owner-protected credential file and configured safe download root.' \
+	'Device enrollment: run punaro-enroll prepare, have the server owner issue a grant for its printed public binding, then redeem a protected transfer file with punaro-enroll. It never accepts the code as an argument.' \
 	'Memory: after device-credential enrollment, use punaro-memory with the same fixed HTTPS origin and an owner-protected credential file; every project, idempotency key, and ETag remains explicit.' \
 	"Verify with: $service_hint"
 if [ -z "$agent_guidance_dir" ]; then

--- a/scripts/install-client.ps1
+++ b/scripts/install-client.ps1
@@ -135,6 +135,7 @@ $MailboxStateDir = Get-FullPath $MailboxStateDir
 
 Build-PunaroBinary -Package (Join-Path $repoDir 'cmd\punaro-adapter') -Output (Join-Path $binDir 'punaro-adapter.exe')
 Build-PunaroBinary -Package (Join-Path $repoDir 'cmd\punaro-trusted-attachment') -Output (Join-Path $binDir 'punaro-trusted-attachment.exe')
+Build-PunaroBinary -Package (Join-Path $repoDir 'cmd\punaro-enroll') -Output (Join-Path $binDir 'punaro-enroll.exe')
 Build-PunaroBinary -Package (Join-Path $repoDir 'cmd\punaro-keygen') -Output (Join-Path $binDir 'punaro-keygen.exe')
 foreach ($name in @('Run-PunaroAdapter.ps1', 'Import-PunaroEnvironment.ps1')) {
     $source = Join-Path $repoDir "deploy\windows\$name"
@@ -203,3 +204,4 @@ Write-Output 'Punaro Windows client installed. Approve this public machine enrol
 Get-Content -LiteralPath $enrollmentFile
 Write-Output 'Next: add this machine''s distinct Access token pair to adapter.env; bind and attach desired aliases; then rerun with -Enable.'
 Write-Output 'After device-credential enrollment, use punaro-trusted-attachment.exe with a protected credential file and safe download root.'
+Write-Output 'Run punaro-enroll.exe prepare before the server owner issues the one-time enrollment for this device; redeem only a protected enrollment-material file.'

--- a/scripts/test-install-adapter.sh
+++ b/scripts/test-install-adapter.sh
@@ -48,6 +48,7 @@ run_install >"$fixture_dir/first.out"
 adapter="$home/.local/bin/punaro-adapter"
 attachment="$home/.local/bin/punaro-trusted-attachment"
 memory="$home/.local/bin/punaro-memory"
+enroll="$home/.local/bin/punaro-enroll"
 config="$home/.config/punaro/adapter.env"
 key="$home/.config/punaro/machine.key"
 enrollment="$home/.config/punaro/enrollment.json"
@@ -64,6 +65,7 @@ file_mode() {
 [ -x "$adapter" ] || { printf '%s\n' 'adapter binary was not installed' >&2; exit 1; }
 [ -x "$attachment" ] || { printf '%s\n' 'attachment binary was not installed' >&2; exit 1; }
 [ -x "$memory" ] || { printf '%s\n' 'memory binary was not installed' >&2; exit 1; }
+[ -x "$enroll" ] || { printf '%s\n' 'enrollment binary was not installed' >&2; exit 1; }
 [ -f "$config" ] || { printf '%s\n' 'adapter environment was not installed' >&2; exit 1; }
 [ -f "$key" ] || { printf '%s\n' 'machine key was not installed' >&2; exit 1; }
 [ -f "$enrollment" ] || { printf '%s\n' 'public enrollment record was not retained' >&2; exit 1; }

--- a/scripts/test-install-client-windows.ps1
+++ b/scripts/test-install-client-windows.ps1
@@ -16,7 +16,7 @@ foreach ($path in $paths) {
 }
 
 $installer = [System.IO.File]::ReadAllText((Join-Path $repoDir 'scripts\install-client.ps1'))
-foreach ($expected in @('LogonType Interactive', 'ExecutionTimeLimit ([TimeSpan]::Zero)', 'SetAccessRuleProtection($true, $false)', '-ExecutionPolicy Bypass', 'ForEach-Object { $_.address }', 'punaro-trusted-attachment.exe', 'agent-mailbox', 'AgentGuidanceDir')) {
+foreach ($expected in @('LogonType Interactive', 'ExecutionTimeLimit ([TimeSpan]::Zero)', 'SetAccessRuleProtection($true, $false)', '-ExecutionPolicy Bypass', 'ForEach-Object { $_.address }', 'punaro-trusted-attachment.exe', 'punaro-enroll.exe', 'agent-mailbox', 'AgentGuidanceDir')) {
     if (-not $installer.Contains($expected)) { throw "Windows installer is missing required behavior: $expected" }
 }
 $allScripts = ($paths | ForEach-Object { [System.IO.File]::ReadAllText($_) }) -join "`n"
@@ -56,7 +56,7 @@ try {
     & (Join-Path $repoDir 'scripts\install-client.ps1') -RelayUrl 'https://relay.example.test' -MachineId 'windows-test' -AgentMailboxBin $mailbox -AgentGuidanceDir $project
     if ($LASTEXITCODE -ne 0) { throw 'Windows client installer failed' }
     $root = Join-Path $env:LOCALAPPDATA 'Punaro'
-    foreach ($path in @((Join-Path $root 'config\machine.key'), (Join-Path $root 'config\enrollment.json'), (Join-Path $root 'config\adapter.env'), (Join-Path $root 'bin\punaro-trusted-attachment.exe'), (Join-Path $project '.agents\skills\punaro-mailbox\SKILL.md'))) {
+    foreach ($path in @((Join-Path $root 'config\machine.key'), (Join-Path $root 'config\enrollment.json'), (Join-Path $root 'config\adapter.env'), (Join-Path $root 'bin\punaro-trusted-attachment.exe'), (Join-Path $root 'bin\punaro-enroll.exe'), (Join-Path $project '.agents\skills\punaro-mailbox\SKILL.md'))) {
         if (-not (Test-Path -LiteralPath $path -PathType Leaf)) { throw "Windows client installer did not create $path" }
     }
     foreach ($path in @((Join-Path $root 'bin\punaro-attachment.exe'), (Join-Path $root 'bin\punaro-directory.exe'), (Join-Path $root 'bin\punaro-dpapi.exe'), (Join-Path $root 'Run-PunaroAttachment.ps1'))) {

--- a/scripts/test-install-client-windows.sh
+++ b/scripts/test-install-client-windows.sh
@@ -17,6 +17,7 @@ for expected in \
 	'ExecutionTimeLimit ([TimeSpan]::Zero)' \
 	'SetAccessRuleProtection($true, $false)' \
 	'punaro-trusted-attachment.exe' \
+	'punaro-enroll.exe' \
 	'retired attachment artifact exists at' \
 	'agent-mailbox' \
 	'AgentGuidanceDir'; do


### PR DESCRIPTION
## Summary

Adds the supported `punaro-enroll` client flow for device-bound enrollment across macOS, Linux, and Windows.

- Creates and persists the fixed HTTPS origin plus opaque client binding without secret material.
- Redeems only protected enrollment files with strict schemas, binding validation, durable idempotent recovery, and safe rejected-enrollment remediation.
- Persists credentials behind validated POSIX or Windows protections and installs the command on all supported client platforms.
- Documents the server-controlled workflow and exercises it end-to-end against the real PostgreSQL device endpoint.

## Validation

- `make test`
- `make test-race`
- `make lint`
- `make security`
- Disposable PostgreSQL/TLS installed-client E2E
- Live Windows x64 DACL/private-file validation