### PR TITLE
Support relay enrollment lifecycle

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1297,7 +1297,12 @@ mutation. Execution accepts no arbitrary source path and requires a caller
 chosen epoch UUID, the dry-run fingerprint, `--yes`, and a complete validated
 public static relay enrollment on first execution. That enrollment is published
 marker-last before SQLite prepare, remains the canonical endpoint authority
-after cutover, and cannot be changed by a recovery retry. SQLite prepare fences
+after cutover, and cannot be changed by a recovery retry. The complete static
+set can subsequently revoke any machine, including every machine via explicit
+`[]`; that restart-safe revocation fails closed. A later replacement may restore
+only a public key recorded in the durable cutover enrollment history, never a
+new key, so a temporary revocation does not strand a previously migrated
+machine. SQLite prepare fences
 old daemons and clears every lease holder while advancing fences. Staging is
 bounded to 128 rows per page and resumes from durable PostgreSQL checkpoints.
 Verification rejects any missing, extra, reordered, malformed, or changed row.

--- a/cmd/punaro/mail_cutover_command.go
+++ b/cmd/punaro/mail_cutover_command.go
@@ -44,6 +44,15 @@ func runMailCutover(args []string, stdout, stderr io.Writer, execute mailCutover
 	var installation operator.Installation
 	var err error
 	if !*dryRun && !*abort {
+		// A supplied enrollment is also the exact authority needed to finish an
+		// interrupted initial enrollment publication. Recover it before checking
+		// whether any remaining staged update may enter irreversible cutover.
+		if *relayMachinesFile != "" {
+			if _, err := operator.ConfigureMailCutoverRelayMachines(*directory, *relayMachinesFile); err != nil {
+				_, _ = fmt.Fprintln(stderr, "mail cutover relay enrollment is unavailable")
+				return 1
+			}
+		}
 		installation, err = operator.LoadMailCutoverExecution(*directory)
 	} else {
 		installation, err = operator.Load(*directory)
@@ -53,13 +62,6 @@ func runMailCutover(args []string, stdout, stderr io.Writer, execute mailCutover
 		return 1
 	}
 	if !*dryRun && !*abort {
-		if *relayMachinesFile != "" {
-			installation, err = operator.ConfigureMailCutoverRelayMachines(*directory, *relayMachinesFile)
-			if err != nil {
-				_, _ = fmt.Fprintln(stderr, "mail cutover relay enrollment is unavailable")
-				return 1
-			}
-		}
 		if installation.RelayMachinesJSON == "" {
 			_, _ = fmt.Fprintln(stderr, "mail cutover execution requires --relay-machines-file")
 			return 2

--- a/cmd/punaro/mail_cutover_command.go
+++ b/cmd/punaro/mail_cutover_command.go
@@ -44,7 +44,7 @@ func runMailCutover(args []string, stdout, stderr io.Writer, execute mailCutover
 	var installation operator.Installation
 	var err error
 	if !*dryRun && !*abort {
-		installation, err = operator.LoadMailCutoverRecovery(*directory)
+		installation, err = operator.LoadMailCutoverExecution(*directory)
 	} else {
 		installation, err = operator.Load(*directory)
 	}

--- a/cmd/punaro/mail_cutover_command_test.go
+++ b/cmd/punaro/mail_cutover_command_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
@@ -55,6 +56,42 @@ func TestMailCutoverCommandPassesExactIrreversibleAuthorization(t *testing.T) {
 	args := []string{"--directory", directory, "--relay-machines-file", relayMachines, "--epoch-id", epoch, "--expected-source-fingerprint", fingerprint, "--yes"}
 	if code := runMailCutover(args, &stdout, &stderr, execute); code != 0 || !strings.Contains(stdout.String(), `"phase": "active"`) {
 		t.Fatalf("code=%d stdout=%q stderr=%q", code, stdout.String(), stderr.String())
+	}
+}
+
+func TestMailCutoverCommandRecoversStagedInitialRelayEnrollment(t *testing.T) {
+	directory := testInstallation(t)
+	relayMachines := filepath.Join(filepath.Dir(directory), "relay-machines.json")
+	const relayMachinesJSON = `[{"id":"machine-a","public_key":"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA","endpoint_prefixes":["agent/a/"],"endpoints":[],"attachment_device_id":""}]`
+	if err := os.WriteFile(relayMachines, []byte(relayMachinesJSON), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	installation, err := operator.Load(directory)
+	if err != nil {
+		t.Fatal(err)
+	}
+	installation.RelayMachinesJSON = relayMachinesJSON
+	staged, err := json.Marshal(installation)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(directory, ".installation.mail-cutover.json"), staged, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	epoch := "019f7f07-8b88-7c12-a394-b663274a6555"
+	fingerprint := strings.Repeat("a", 64)
+	called := false
+	execute := func(_ context.Context, installation operator.Installation, dryRun, abort bool, request cutover.Request) (any, error) {
+		called = true
+		if dryRun || abort || installation.RelayMachinesJSON != relayMachinesJSON || request.EpochID != epoch || request.ExpectedSourceFingerprint != fingerprint {
+			t.Fatalf("installation=%#v request=%#v dry=%t abort=%t", installation, request, dryRun, abort)
+		}
+		return cutover.Result{EpochID: epoch, SourceFingerprint: fingerprint, SourcePhase: relay.MigrationSourceRetired, Phase: postgres.MailCutoverActive}, nil
+	}
+	var stdout, stderr bytes.Buffer
+	args := []string{"--directory", directory, "--relay-machines-file", relayMachines, "--epoch-id", epoch, "--expected-source-fingerprint", fingerprint, "--yes"}
+	if code := runMailCutover(args, &stdout, &stderr, execute); code != 0 || !called {
+		t.Fatalf("code=%d called=%t stdout=%q stderr=%q", code, called, stdout.String(), stderr.String())
 	}
 }
 

--- a/cmd/punaro/main.go
+++ b/cmd/punaro/main.go
@@ -319,7 +319,7 @@ func main() { os.Exit(run(os.Args[1:], os.Stdout, os.Stderr)) }
 
 func run(args []string, stdout, stderr io.Writer) int {
 	if len(args) == 0 {
-		_, _ = fmt.Fprintln(stderr, "usage: punaro init|up|status|doctor|client|mail|backup|restore|update")
+		_, _ = fmt.Fprintln(stderr, "usage: punaro init|up|status|doctor|client|relay|mail|backup|restore|update")
 		return 2
 	}
 	switch args[0] {
@@ -338,6 +338,10 @@ func run(args []string, stdout, stderr io.Writer) int {
 	case "mail":
 		if len(args) > 1 && args[1] == "cutover" {
 			return runMailCutover(args[2:], stdout, stderr, executeMailCutover)
+		}
+	case "relay":
+		if len(args) > 1 && args[1] == "configure" {
+			return runRelayConfigure(args[2:], stdout, stderr, operator.ConfigureRelayMachines)
 		}
 	case "backup":
 		return runBackup(args[1:], stdout, stderr)

--- a/cmd/punaro/relay_command.go
+++ b/cmd/punaro/relay_command.go
@@ -21,7 +21,7 @@ func runRelayConfigure(args []string, stdout, stderr io.Writer, configure relayC
 	}
 	installation, err := configure(*directory, *machinesFile)
 	if err != nil {
-		_, _ = fmt.Fprintln(stderr, "relay configuration failed; generated configuration was not changed")
+		_, _ = fmt.Fprintln(stderr, "relay configuration did not complete; rerun the exact command to recover safely")
 		return 1
 	}
 	return writeJSON(stdout, stderr, map[string]any{"status": "relay_configured", "directory": installation.Directory})

--- a/cmd/punaro/relay_command.go
+++ b/cmd/punaro/relay_command.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io"
+
+	"github.com/rock3r/punaro/internal/operator"
+)
+
+type relayConfigureCommand func(string, string) (operator.Installation, error)
+
+func runRelayConfigure(args []string, stdout, stderr io.Writer, configure relayConfigureCommand) int {
+	flags := flag.NewFlagSet("relay configure", flag.ContinueOnError)
+	flags.SetOutput(stderr)
+	directory := flags.String("directory", "", "absolute Punaro installation directory")
+	machinesFile := flags.String("relay-machines-file", "", "protected complete public relay machine enrollment JSON file")
+	confirmed := flags.Bool("yes", false, "confirm replacing the complete relay machine enrollment set")
+	if flags.Parse(args) != nil || flags.NArg() != 0 || *directory == "" || *machinesFile == "" || !*confirmed || configure == nil {
+		return 2
+	}
+	installation, err := configure(*directory, *machinesFile)
+	if err != nil {
+		_, _ = fmt.Fprintln(stderr, "relay configuration failed; generated configuration was not changed")
+		return 1
+	}
+	return writeJSON(stdout, stderr, map[string]any{"status": "relay_configured", "directory": installation.Directory})
+}

--- a/cmd/punaro/relay_command_test.go
+++ b/cmd/punaro/relay_command_test.go
@@ -33,4 +33,7 @@ func TestRelayConfigurePublishesOnlyThroughOperator(t *testing.T) {
 	}); code != 1 {
 		t.Fatalf("code=%d", code)
 	}
+	if !bytes.Contains(stderr.Bytes(), []byte("rerun the exact command")) {
+		t.Fatalf("stderr=%q", stderr.String())
+	}
 }

--- a/cmd/punaro/relay_command_test.go
+++ b/cmd/punaro/relay_command_test.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"bytes"
+	"errors"
+	"testing"
+
+	"github.com/rock3r/punaro/internal/operator"
+)
+
+func TestRelayConfigureRequiresExplicitProtectedInputAndConfirmation(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	if code := runRelayConfigure([]string{"--directory", "/install", "--relay-machines-file", "/private/machines.json"}, &stdout, &stderr, func(string, string) (operator.Installation, error) {
+		t.Fatal("configure called without confirmation")
+		return operator.Installation{}, nil
+	}); code != 2 {
+		t.Fatalf("code=%d", code)
+	}
+}
+
+func TestRelayConfigurePublishesOnlyThroughOperator(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	called := false
+	configure := func(directory, file string) (operator.Installation, error) {
+		called = directory == "/install" && file == "/private/machines.json"
+		return operator.Installation{Directory: directory}, nil
+	}
+	if code := runRelayConfigure([]string{"--directory", "/install", "--relay-machines-file", "/private/machines.json", "--yes"}, &stdout, &stderr, configure); code != 0 || !called || !bytes.Contains(stdout.Bytes(), []byte(`"relay_configured"`)) {
+		t.Fatalf("code=%d called=%t stdout=%q stderr=%q", code, called, stdout.String(), stderr.String())
+	}
+	if code := runRelayConfigure([]string{"--directory", "/install", "--relay-machines-file", "/private/machines.json", "--yes"}, &stdout, &stderr, func(string, string) (operator.Installation, error) {
+		return operator.Installation{}, errors.New("unsafe")
+	}); code != 1 {
+		t.Fatalf("code=%d", code)
+	}
+}

--- a/cmd/punarod/relay_test.go
+++ b/cmd/punarod/relay_test.go
@@ -67,6 +67,52 @@ func TestBuildRelayHandlerRejectsInvalidEnrollment(t *testing.T) {
 	}
 }
 
+func TestBuildRelayHandlerRevokedEnrollmentFailsClosedAfterRestart(t *testing.T) {
+	public, private, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	machines := `[{"id":"machine-a","public_key":"` + base64.RawURLEncoding.EncodeToString(public) + `","endpoint_prefixes":["agent/a/"]}]`
+	dataDir := t.TempDir()
+	first, firstStore, err := buildRelayHandler(config.Config{DataDir: dataDir, RelayEnabled: true, RelayMachinesJSON: machines})
+	if err != nil {
+		t.Fatal(err)
+	}
+	request := signedRelayRequest(t, private, "machine-a", "first-request")
+	response := httptest.NewRecorder()
+	first.ServeHTTP(response, request)
+	if response.Code != http.StatusOK {
+		t.Fatalf("initial status=%d body=%s", response.Code, response.Body.String())
+	}
+	if err := firstStore.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	restarted, restartedStore, err := buildRelayHandler(config.Config{DataDir: dataDir, RelayEnabled: true, RelayMachinesJSON: `[]`})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = restartedStore.Close() })
+	request = signedRelayRequest(t, private, "machine-a", "revoked-request")
+	response = httptest.NewRecorder()
+	restarted.ServeHTTP(response, request)
+	if response.Code != http.StatusUnauthorized {
+		t.Fatalf("revoked status=%d body=%s", response.Code, response.Body.String())
+	}
+}
+
+func signedRelayRequest(t *testing.T, private ed25519.PrivateKey, machineID, nonce string) *http.Request {
+	t.Helper()
+	request := httptest.NewRequestWithContext(t.Context(), http.MethodPut, "/v1/machines/me/endpoints", bytes.NewBufferString(`{"endpoints":["agent/a/session"]}`))
+	signed := relay.SignedRequest{MachineID: machineID, Method: request.Method, Path: request.URL.Path, Body: []byte(`{"endpoints":["agent/a/session"]}`), Timestamp: time.Now().UTC(), Nonce: nonce}
+	signed.Signature = ed25519.Sign(private, relay.CanonicalRequest(signed))
+	request.Header.Set("X-Punaro-Machine", signed.MachineID)
+	request.Header.Set("X-Punaro-Timestamp", signed.Timestamp.Format(time.RFC3339Nano))
+	request.Header.Set("X-Punaro-Nonce", signed.Nonce)
+	request.Header.Set("X-Punaro-Signature", base64.RawURLEncoding.EncodeToString(signed.Signature))
+	return request
+}
+
 func TestBuildRelayCanSelectPostgresBackendWithoutOpeningSQLite(t *testing.T) {
 	backend, err := relay.Open(filepath.Join(t.TempDir(), "postgres-backend-double.db"))
 	if err != nil {

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -139,11 +139,13 @@ if you decline it during client setup.
 
 1. For a new unified server, add the printed JSON record to the protected
    relay-machine file before the initial `punaro init --relay-machines-file`.
-   To add or revoke a client later, replace that complete protected file and
+   Before mail cutover, to add or revoke a client later, replace that complete protected file and
    run `punaro relay configure --directory INSTALLATION_DIR
    --relay-machines-file RELAY_MACHINES_FILE --yes`, followed by `punaro up`.
    Use the explicit JSON value `[]` to revoke the final client; the restarted
    relay then accepts no signed machine requests.
+   After mail cutover, this command can only retain or remove already registered
+   keys; use the supported client-enrollment workflow for any new client.
    Do not hand-edit `PUNARO_RELAY_MACHINES_JSON` or widen a namespace to
    `codex/` or `claude/`.
 2. Create a **distinct** Cloudflare Access service token and policy for this

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -145,7 +145,8 @@ if you decline it during client setup.
    Use the explicit JSON value `[]` to revoke the final client; the restarted
    relay then accepts no signed machine requests.
    After mail cutover, this command can only retain or remove already registered
-   keys; use the supported client-enrollment workflow for any new client.
+   keys. New mailbox clients are currently unavailable until a durable
+   post-cutover authority-registration workflow is delivered.
    Do not hand-edit `PUNARO_RELAY_MACHINES_JSON` or widen a namespace to
    `codex/` or `claude/`.
 2. Create a **distinct** Cloudflare Access service token and policy for this

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -139,6 +139,9 @@ if you decline it during client setup.
 
 1. For a new unified server, add the printed JSON record to the protected
    relay-machine file before the initial `punaro init --relay-machines-file`.
+   To add or revoke a client later, replace that complete protected file and
+   run `punaro relay configure --directory INSTALLATION_DIR
+   --relay-machines-file RELAY_MACHINES_FILE --yes`, followed by `punaro up`.
    Do not hand-edit `PUNARO_RELAY_MACHINES_JSON` or widen a namespace to
    `codex/` or `claude/`.
 2. Create a **distinct** Cloudflare Access service token and policy for this

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -142,6 +142,8 @@ if you decline it during client setup.
    To add or revoke a client later, replace that complete protected file and
    run `punaro relay configure --directory INSTALLATION_DIR
    --relay-machines-file RELAY_MACHINES_FILE --yes`, followed by `punaro up`.
+   Use the explicit JSON value `[]` to revoke the final client; the restarted
+   relay then accepts no signed machine requests.
    Do not hand-edit `PUNARO_RELAY_MACHINES_JSON` or widen a namespace to
    `codex/` or `claude/`.
 2. Create a **distinct** Cloudflare Access service token and policy for this

--- a/docs/production-compose.md
+++ b/docs/production-compose.md
@@ -110,6 +110,28 @@ contradictory opt-in fails before listeners start. The generated runtime uses
 PostgreSQL relay authority and device authentication, while its daemon,
 database, health endpoint, and Compose credentials remain host-local.
 
+## Add or revoke a mailbox client
+
+After initialization, replace the complete public enrollment set through the
+same host-local lifecycle rather than editing generated files. Keep the JSON
+file owner-only and include every client that should remain authorized:
+
+```sh
+punaro relay configure \
+  --directory INSTALLATION_DIR \
+  --relay-machines-file RELAY_MACHINES_FILE \
+  --yes
+punaro up --directory INSTALLATION_DIR
+```
+
+The command validates the exact non-secret set, atomically publishes the
+daemon environment and Compose inputs, and preserves an interrupted update for
+an exact retry. It is valid both before and after mail cutover; the cutover
+marker itself cannot change. Removing a machine from the complete set prevents
+new signed requests after the next `punaro up`; also stop its local adapter and
+revoke its distinct Access token. Never edit `punarod.env`, the Compose
+override, or `installation.json` directly.
+
 For every later release, use `punaro update --directory INSTALLATION_DIR` with
 the protected release metadata distributed for that release. This preserves the
 same durable update journal and recovery path as the initial installation; do

--- a/docs/production-compose.md
+++ b/docs/production-compose.md
@@ -128,9 +128,9 @@ The command validates the exact non-secret set, atomically publishes the
 daemon environment and Compose inputs, and preserves an interrupted update for
 an exact retry. It is valid both before and after mail cutover; the cutover
 marker itself cannot change. Removing a machine from the complete set prevents
-new signed requests after the next `punaro up`; also stop its local adapter and
-revoke its distinct Access token. Never edit `punarod.env`, the Compose
-override, or `installation.json` directly.
+new signed requests after the next `punaro up`; use `[]` to revoke the final
+client. Also stop its local adapter and revoke its distinct Access token. Never
+edit `punarod.env`, the Compose override, or `installation.json` directly.
 
 For every later release, use `punaro update --directory INSTALLATION_DIR` with
 the protected release metadata distributed for that release. This preserves the

--- a/docs/production-compose.md
+++ b/docs/production-compose.md
@@ -112,9 +112,10 @@ database, health endpoint, and Compose credentials remain host-local.
 
 ## Add or revoke a mailbox client
 
-After initialization, replace the complete public enrollment set through the
-same host-local lifecycle rather than editing generated files. Keep the JSON
-file owner-only and include every client that should remain authorized:
+After initialization and before mail cutover, replace the complete public
+enrollment set through the same host-local lifecycle rather than editing
+generated files. Keep the JSON file owner-only and include every client that
+should remain authorized:
 
 ```sh
 punaro relay configure \
@@ -129,8 +130,11 @@ daemon environment and Compose inputs, and preserves an interrupted update for
 an exact retry. It is valid both before and after mail cutover; the cutover
 marker itself cannot change. Removing a machine from the complete set prevents
 new signed requests after the next `punaro up`; use `[]` to revoke the final
-client. Also stop its local adapter and revoke its distinct Access token. Never
-edit `punarod.env`, the Compose override, or `installation.json` directly.
+client. After mail cutover, additions with a new public key are rejected because
+the active transition authority cannot authenticate them; use the supported
+client-enrollment workflow instead. Also stop its local adapter and revoke its
+distinct Access token. Never edit `punarod.env`, the Compose override, or
+`installation.json` directly.
 
 For every later release, use `punaro update --directory INSTALLATION_DIR` with
 the protected release metadata distributed for that release. This preserves the

--- a/docs/production-compose.md
+++ b/docs/production-compose.md
@@ -131,9 +131,10 @@ an exact retry. It is valid both before and after mail cutover; the cutover
 marker itself cannot change. Removing a machine from the complete set prevents
 new signed requests after the next `punaro up`; use `[]` to revoke the final
 client. After mail cutover, additions with a new public key are rejected because
-the active transition authority cannot authenticate them; use the supported
-client-enrollment workflow instead. Also stop its local adapter and revoke its
-distinct Access token. Never edit `punarod.env`, the Compose override, or
+the active transition authority cannot authenticate them. New mailbox clients
+are currently unavailable until a durable post-cutover authority-registration
+workflow is delivered. Also stop its local adapter and revoke its distinct
+Access token. Never edit `punarod.env`, the Compose override, or
 `installation.json` directly.
 
 For every later release, use `punaro update --directory INSTALLATION_DIR` with

--- a/internal/operator/installation.go
+++ b/internal/operator/installation.go
@@ -97,6 +97,7 @@ type Installation struct {
 	TrustedAttachmentBlobDir  string                  `json:"trusted_attachment_blob_dir,omitempty"`
 	RelayEnabled              bool                    `json:"relay_enabled"`
 	RelayMachinesJSON         string                  `json:"relay_machines_json,omitempty"`
+	RelayKnownMachineKeysJSON string                  `json:"relay_known_machine_keys_json,omitempty"`
 	MailCutover               *MailCutoverPublication `json:"mail_cutover,omitempty"`
 }
 
@@ -400,6 +401,12 @@ func Load(directory string) (Installation, error) {
 		if err := validateRelayMachinesJSON(installation.RelayMachinesJSON); err != nil {
 			return Installation{}, errors.New("published installation relay enrollment is invalid")
 		}
+	}
+	if installation.RelayKnownMachineKeysJSON != "" && !validRelayMachineKeysJSON(installation.RelayKnownMachineKeysJSON) {
+		return Installation{}, errors.New("published installation relay key history is invalid")
+	}
+	if installation.MailCutover != nil && installation.RelayKnownMachineKeysJSON != "" && !relayMachineKeysContain(installation.RelayKnownMachineKeysJSON, installation.RelayMachinesJSON) {
+		return Installation{}, errors.New("published installation relay key history is incomplete")
 	}
 	if installation.RelayEnabled && installation.RelayMachinesJSON == "" {
 		return Installation{}, errors.New("published installation relay configuration is invalid")

--- a/internal/operator/installation_test.go
+++ b/internal/operator/installation_test.go
@@ -2,6 +2,7 @@ package operator
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"os"
@@ -1318,6 +1319,30 @@ func TestConfigureRelayMachinesReplacesPostCutoverEnrollment(t *testing.T) {
 	configured, err := ConfigureRelayMachines(installation.Directory, path)
 	if err != nil || configured.RelayMachinesJSON != replacement || configured.MailCutover == nil || *configured.MailCutover != publication || len(CheckPaths(configured)) != 0 {
 		t.Fatalf("configured=%#v err=%v failures=%v", configured, err, CheckPaths(configured))
+	}
+}
+
+func TestConfigureRelayMachinesRejectsNewKeyAfterMailCutover(t *testing.T) {
+	options := validInitOptions(t)
+	options.RelayEnabled = true
+	options.RelayMachinesJSON = testRelayMachinesJSON
+	installation, err := Init(context.Background(), options, func(context.Context, string, string) (punaropostgres.Principal, error) {
+		return punaropostgres.Principal{ID: "11111111-1111-4111-8111-111111111111"}, nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	publication := MailCutoverPublication{Version: 1, EpochID: "019f7f07-8b88-7c12-a394-b663274a6555", TargetIdentity: strings.Repeat("a", 64), SourceFingerprint: strings.Repeat("b", 64)}
+	if _, err := PublishMailCutover(installation.Directory, publication); err != nil {
+		t.Fatal(err)
+	}
+	newKey := base64.RawURLEncoding.EncodeToString(append([]byte{1}, make([]byte, 31)...))
+	path := filepath.Join(filepath.Dir(installation.Directory), "unregistered-relay-machines.json")
+	if err := os.WriteFile(path, []byte(`[{"id":"machine-b","public_key":"`+newKey+`","endpoint_prefixes":["agent/b/"]}]`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ConfigureRelayMachines(installation.Directory, path); err == nil {
+		t.Fatal("post-cutover relay enrollment accepted an unregistered key")
 	}
 }
 

--- a/internal/operator/installation_test.go
+++ b/internal/operator/installation_test.go
@@ -1131,6 +1131,120 @@ func TestMailCutoverRelayConfigurationQuotesDotenvMetacharacters(t *testing.T) {
 	}
 }
 
+func TestConfigureRelayMachinesReplacesPreCutoverEnrollment(t *testing.T) {
+	options := validInitOptions(t)
+	options.RelayEnabled = true
+	options.RelayMachinesJSON = testRelayMachinesJSON
+	installation, err := Init(context.Background(), options, func(context.Context, string, string) (punaropostgres.Principal, error) {
+		return punaropostgres.Principal{ID: "11111111-1111-4111-8111-111111111111"}, nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	replacement := `[{"id":"machine-b","public_key":"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA","endpoint_prefixes":["agent/b/"],"endpoints":[],"attachment_device_id":""}]`
+	path := filepath.Join(filepath.Dir(installation.Directory), "replacement-relay-machines.json")
+	if err := os.WriteFile(path, []byte(replacement), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	configured, err := ConfigureRelayMachines(installation.Directory, path)
+	if err != nil || configured.RelayMachinesJSON != replacement || !configured.RelayEnabled || len(CheckPaths(configured)) != 0 {
+		t.Fatalf("configured=%#v err=%v failures=%v", configured, err, CheckPaths(configured))
+	}
+}
+
+func TestRelayEnrollmentReplacementRecoversAfterRuntimePublication(t *testing.T) {
+	options := validInitOptions(t)
+	options.RelayEnabled = true
+	options.RelayMachinesJSON = testRelayMachinesJSON
+	installation, err := Init(context.Background(), options, func(context.Context, string, string) (punaropostgres.Principal, error) {
+		return punaropostgres.Principal{ID: "11111111-1111-4111-8111-111111111111"}, nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	replacement := `[{"id":"machine-b","public_key":"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA","endpoint_prefixes":["agent/b/"],"endpoints":[],"attachment_device_id":""}]`
+	candidate := installation
+	candidate.RelayMachinesJSON = replacement
+	if _, err := publishMailCutoverInstallation(installation.Directory, candidate, func(step string) error {
+		if step == "environment" {
+			return errors.New("injected publication crash")
+		}
+		return nil
+	}); err == nil {
+		t.Fatal("injected relay enrollment publication crash was accepted")
+	}
+	path := filepath.Join(filepath.Dir(installation.Directory), "replacement-relay-machines.json")
+	if err := os.WriteFile(path, []byte(replacement), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	configured, err := ConfigureRelayMachines(installation.Directory, path)
+	if err != nil || configured.RelayMachinesJSON != replacement || len(CheckPaths(configured)) != 0 {
+		t.Fatalf("configured=%#v err=%v failures=%v", configured, err, CheckPaths(configured))
+	}
+}
+
+func TestConfigureRelayMachinesReplacesPostCutoverEnrollment(t *testing.T) {
+	options := validInitOptions(t)
+	options.RelayEnabled = true
+	options.RelayMachinesJSON = testRelayMachinesJSON
+	installation, err := Init(context.Background(), options, func(context.Context, string, string) (punaropostgres.Principal, error) {
+		return punaropostgres.Principal{ID: "11111111-1111-4111-8111-111111111111"}, nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	publication := MailCutoverPublication{Version: 1, EpochID: "019f7f07-8b88-7c12-a394-b663274a6555", TargetIdentity: strings.Repeat("a", 64), SourceFingerprint: strings.Repeat("b", 64)}
+	installation, err = PublishMailCutover(installation.Directory, publication)
+	if err != nil {
+		t.Fatal(err)
+	}
+	replacement := `[{"id":"machine-b","public_key":"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA","endpoint_prefixes":["agent/b/"],"endpoints":[],"attachment_device_id":""}]`
+	path := filepath.Join(filepath.Dir(installation.Directory), "post-cutover-relay-machines.json")
+	if err := os.WriteFile(path, []byte(replacement), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	configured, err := ConfigureRelayMachines(installation.Directory, path)
+	if err != nil || configured.RelayMachinesJSON != replacement || configured.MailCutover == nil || *configured.MailCutover != publication || len(CheckPaths(configured)) != 0 {
+		t.Fatalf("configured=%#v err=%v failures=%v", configured, err, CheckPaths(configured))
+	}
+}
+
+func TestPostCutoverRelayEnrollmentReplacementRecoversAfterRuntimePublication(t *testing.T) {
+	options := validInitOptions(t)
+	options.RelayEnabled = true
+	options.RelayMachinesJSON = testRelayMachinesJSON
+	installation, err := Init(context.Background(), options, func(context.Context, string, string) (punaropostgres.Principal, error) {
+		return punaropostgres.Principal{ID: "11111111-1111-4111-8111-111111111111"}, nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	publication := MailCutoverPublication{Version: 1, EpochID: "019f7f07-8b88-7c12-a394-b663274a6555", TargetIdentity: strings.Repeat("a", 64), SourceFingerprint: strings.Repeat("b", 64)}
+	installation, err = PublishMailCutover(installation.Directory, publication)
+	if err != nil {
+		t.Fatal(err)
+	}
+	replacement := `[{"id":"machine-b","public_key":"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA","endpoint_prefixes":["agent/b/"],"endpoints":[],"attachment_device_id":""}]`
+	candidate := installation
+	candidate.RelayMachinesJSON = replacement
+	if _, err := publishMailCutoverInstallation(installation.Directory, candidate, func(step string) error {
+		if step == "environment" {
+			return errors.New("injected publication crash")
+		}
+		return nil
+	}); err == nil {
+		t.Fatal("injected post-cutover relay enrollment publication crash was accepted")
+	}
+	path := filepath.Join(filepath.Dir(installation.Directory), "post-cutover-replacement-relay-machines.json")
+	if err := os.WriteFile(path, []byte(replacement), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	configured, err := ConfigureRelayMachines(installation.Directory, path)
+	if err != nil || configured.RelayMachinesJSON != replacement || configured.MailCutover == nil || *configured.MailCutover != publication || len(CheckPaths(configured)) != 0 {
+		t.Fatalf("configured=%#v err=%v failures=%v", configured, err, CheckPaths(configured))
+	}
+}
+
 func TestInitRejectsInvalidOrAliasingHealthListener(t *testing.T) {
 	for _, address := range []string{"127.0.0.1:0", "127.0.0.1:", "127.0.0.1:http", "127.0.0.1:65536", "127.0.0.1:08080"} {
 		t.Run(address, func(t *testing.T) {

--- a/internal/operator/installation_test.go
+++ b/internal/operator/installation_test.go
@@ -1397,6 +1397,39 @@ func TestConfigureRelayMachinesRejectsNewKeyAfterMailCutover(t *testing.T) {
 	}
 }
 
+func TestConfigureRelayMachinesRestoresKnownKeyAfterPostCutoverRevocation(t *testing.T) {
+	options := validInitOptions(t)
+	options.RelayEnabled = true
+	secondKey := base64.RawURLEncoding.EncodeToString(append([]byte{1}, make([]byte, 31)...))
+	options.RelayMachinesJSON = `[{"id":"machine-a","public_key":"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA","endpoint_prefixes":["agent/a/"]},{"id":"machine-b","public_key":"` + secondKey + `","endpoint_prefixes":["agent/b/"]}]`
+	installation, err := Init(context.Background(), options, func(context.Context, string, string) (punaropostgres.Principal, error) {
+		return punaropostgres.Principal{ID: "11111111-1111-4111-8111-111111111111"}, nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	publication := MailCutoverPublication{Version: 1, EpochID: "019f7f07-8b88-7c12-a394-b663274a6555", TargetIdentity: strings.Repeat("a", 64), SourceFingerprint: strings.Repeat("b", 64)}
+	if _, err := PublishMailCutover(installation.Directory, publication); err != nil {
+		t.Fatal(err)
+	}
+	revoked := filepath.Join(filepath.Dir(installation.Directory), "revoked-relay-machines.json")
+	if err := os.WriteFile(revoked, []byte(`[]`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ConfigureRelayMachines(installation.Directory, revoked); err != nil {
+		t.Fatal(err)
+	}
+	restored := filepath.Join(filepath.Dir(installation.Directory), "restored-relay-machines.json")
+	restoredJSON := `[{"id":"machine-b","public_key":"` + secondKey + `","endpoint_prefixes":["agent/b/"]}]`
+	if err := os.WriteFile(restored, []byte(restoredJSON), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	configured, err := ConfigureRelayMachines(installation.Directory, restored)
+	if err != nil || configured.RelayMachinesJSON != restoredJSON || len(CheckPaths(configured)) != 0 {
+		t.Fatalf("configured=%#v err=%v failures=%v", configured, err, CheckPaths(configured))
+	}
+}
+
 func TestPostCutoverRelayEnrollmentReplacementRecoversAfterRuntimePublication(t *testing.T) {
 	options := validInitOptions(t)
 	options.RelayEnabled = true

--- a/internal/operator/installation_test.go
+++ b/internal/operator/installation_test.go
@@ -1242,6 +1242,35 @@ func TestRelayEnrollmentRecoveryRejectsDifferentRetry(t *testing.T) {
 	}
 }
 
+func TestRelayEnrollmentRecoveryRejectsStagedMailCutover(t *testing.T) {
+	options := validInitOptions(t)
+	options.RelayEnabled = true
+	options.RelayMachinesJSON = testRelayMachinesJSON
+	installation, err := Init(context.Background(), options, func(context.Context, string, string) (punaropostgres.Principal, error) {
+		return punaropostgres.Principal{ID: "11111111-1111-4111-8111-111111111111"}, nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	candidate := installation
+	candidate.MailCutover = &MailCutoverPublication{Version: 1, EpochID: "019f7f07-8b88-7c12-a394-b663274a6555", TargetIdentity: strings.Repeat("a", 64), SourceFingerprint: strings.Repeat("b", 64)}
+	if _, err := publishMailCutoverInstallation(installation.Directory, candidate, func(step string) error {
+		if step == "candidate" {
+			return errors.New("injected mail cutover staging crash")
+		}
+		return nil
+	}); err == nil {
+		t.Fatal("injected mail cutover staging crash was accepted")
+	}
+	path := filepath.Join(filepath.Dir(installation.Directory), "relay-machines.json")
+	if err := os.WriteFile(path, []byte(testRelayMachinesJSON), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ConfigureRelayMachines(installation.Directory, path); err == nil {
+		t.Fatal("relay enrollment resumed a staged mail cutover")
+	}
+}
+
 func TestConfigureRelayMachinesReplacesPostCutoverEnrollment(t *testing.T) {
 	options := validInitOptions(t)
 	options.RelayEnabled = true

--- a/internal/operator/installation_test.go
+++ b/internal/operator/installation_test.go
@@ -1265,6 +1265,29 @@ func TestRelayEnableRecoversExistingDarkEnrollmentAfterRuntimePublication(t *tes
 	}
 }
 
+func TestMailCutoverExecutionRejectsStagedDarkRelayEnable(t *testing.T) {
+	installation, err := Init(context.Background(), validInitOptions(t), func(context.Context, string, string) (punaropostgres.Principal, error) {
+		return punaropostgres.Principal{ID: "11111111-1111-4111-8111-111111111111"}, nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	installation = configureTestRelayMachines(t, installation)
+	candidate := installation
+	candidate.RelayEnabled = true
+	if _, err := publishMailCutoverInstallation(installation.Directory, candidate, func(step string) error {
+		if step == "environment" {
+			return errors.New("injected dark relay enable publication crash")
+		}
+		return nil
+	}); err == nil {
+		t.Fatal("injected dark relay enable publication crash was accepted")
+	}
+	if _, err := LoadMailCutoverExecution(installation.Directory); err == nil {
+		t.Fatal("mail cutover execution accepted staged relay enablement")
+	}
+}
+
 func TestRelayEnrollmentRecoveryRejectsDifferentRetry(t *testing.T) {
 	options := validInitOptions(t)
 	options.RelayEnabled = true

--- a/internal/operator/installation_test.go
+++ b/internal/operator/installation_test.go
@@ -1237,6 +1237,34 @@ func TestRelayEnableRecoversAfterRuntimePublication(t *testing.T) {
 	}
 }
 
+func TestRelayEnableRecoversExistingDarkEnrollmentAfterRuntimePublication(t *testing.T) {
+	installation, err := Init(context.Background(), validInitOptions(t), func(context.Context, string, string) (punaropostgres.Principal, error) {
+		return punaropostgres.Principal{ID: "11111111-1111-4111-8111-111111111111"}, nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	installation = configureTestRelayMachines(t, installation)
+	candidate := installation
+	candidate.RelayEnabled = true
+	if _, err := publishMailCutoverInstallation(installation.Directory, candidate, func(step string) error {
+		if step == "environment" {
+			return errors.New("injected dark relay enable publication crash")
+		}
+		return nil
+	}); err == nil {
+		t.Fatal("injected dark relay enable publication crash was accepted")
+	}
+	path := filepath.Join(filepath.Dir(installation.Directory), "dark-relay-enable-machines.json")
+	if err := os.WriteFile(path, []byte(testRelayMachinesJSON), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	configured, err := ConfigureRelayMachines(installation.Directory, path)
+	if err != nil || !configured.RelayEnabled || configured.RelayMachinesJSON != testRelayMachinesJSON || len(CheckPaths(configured)) != 0 {
+		t.Fatalf("configured=%#v err=%v failures=%v", configured, err, CheckPaths(configured))
+	}
+}
+
 func TestRelayEnrollmentRecoveryRejectsDifferentRetry(t *testing.T) {
 	options := validInitOptions(t)
 	options.RelayEnabled = true

--- a/internal/operator/installation_test.go
+++ b/internal/operator/installation_test.go
@@ -1152,6 +1152,30 @@ func TestConfigureRelayMachinesReplacesPreCutoverEnrollment(t *testing.T) {
 	}
 }
 
+func TestConfigureRelayMachinesRevokesFinalEnrollment(t *testing.T) {
+	options := validInitOptions(t)
+	options.RelayEnabled = true
+	options.RelayMachinesJSON = testRelayMachinesJSON
+	installation, err := Init(context.Background(), options, func(context.Context, string, string) (punaropostgres.Principal, error) {
+		return punaropostgres.Principal{ID: "11111111-1111-4111-8111-111111111111"}, nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(filepath.Dir(installation.Directory), "relay-machines.json")
+	if err := os.WriteFile(path, []byte(`[]`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	configured, err := ConfigureRelayMachines(installation.Directory, path)
+	if err != nil || !configured.RelayEnabled || configured.RelayMachinesJSON != "[]" || len(CheckPaths(configured)) != 0 {
+		t.Fatalf("configured=%#v err=%v failures=%v", configured, err, CheckPaths(configured))
+	}
+	loaded, err := Load(installation.Directory)
+	if err != nil || !loaded.RelayEnabled || loaded.RelayMachinesJSON != "[]" {
+		t.Fatalf("loaded=%#v err=%v", loaded, err)
+	}
+}
+
 func TestRelayEnrollmentReplacementRecoversAfterRuntimePublication(t *testing.T) {
 	options := validInitOptions(t)
 	options.RelayEnabled = true

--- a/internal/operator/installation_test.go
+++ b/internal/operator/installation_test.go
@@ -1183,6 +1183,65 @@ func TestRelayEnrollmentReplacementRecoversAfterRuntimePublication(t *testing.T)
 	}
 }
 
+func TestRelayEnableRecoversAfterRuntimePublication(t *testing.T) {
+	installation, err := Init(context.Background(), validInitOptions(t), func(context.Context, string, string) (punaropostgres.Principal, error) {
+		return punaropostgres.Principal{ID: "11111111-1111-4111-8111-111111111111"}, nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	replacement := `[{"id":"machine-b","public_key":"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA","endpoint_prefixes":["agent/b/"],"endpoints":[],"attachment_device_id":""}]`
+	candidate := installation
+	candidate.RelayEnabled = true
+	candidate.RelayMachinesJSON = replacement
+	if _, err := publishMailCutoverInstallation(installation.Directory, candidate, func(step string) error {
+		if step == "environment" {
+			return errors.New("injected relay enable publication crash")
+		}
+		return nil
+	}); err == nil {
+		t.Fatal("injected relay enable publication crash was accepted")
+	}
+	path := filepath.Join(filepath.Dir(installation.Directory), "relay-enable-machines.json")
+	if err := os.WriteFile(path, []byte(replacement), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	configured, err := ConfigureRelayMachines(installation.Directory, path)
+	if err != nil || !configured.RelayEnabled || configured.RelayMachinesJSON != replacement || len(CheckPaths(configured)) != 0 {
+		t.Fatalf("configured=%#v err=%v failures=%v", configured, err, CheckPaths(configured))
+	}
+}
+
+func TestRelayEnrollmentRecoveryRejectsDifferentRetry(t *testing.T) {
+	options := validInitOptions(t)
+	options.RelayEnabled = true
+	options.RelayMachinesJSON = testRelayMachinesJSON
+	installation, err := Init(context.Background(), options, func(context.Context, string, string) (punaropostgres.Principal, error) {
+		return punaropostgres.Principal{ID: "11111111-1111-4111-8111-111111111111"}, nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	replacement := `[{"id":"machine-b","public_key":"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA","endpoint_prefixes":["agent/b/"],"endpoints":[],"attachment_device_id":""}]`
+	candidate := installation
+	candidate.RelayMachinesJSON = replacement
+	if _, err := publishMailCutoverInstallation(installation.Directory, candidate, func(step string) error {
+		if step == "candidate" {
+			return errors.New("injected relay enrollment staging crash")
+		}
+		return nil
+	}); err == nil {
+		t.Fatal("injected relay enrollment staging crash was accepted")
+	}
+	path := filepath.Join(filepath.Dir(installation.Directory), "old-relay-machines.json")
+	if err := os.WriteFile(path, []byte(testRelayMachinesJSON), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ConfigureRelayMachines(installation.Directory, path); err == nil {
+		t.Fatal("conflicting relay enrollment retry was accepted")
+	}
+}
+
 func TestConfigureRelayMachinesReplacesPostCutoverEnrollment(t *testing.T) {
 	options := validInitOptions(t)
 	options.RelayEnabled = true

--- a/internal/operator/mail_cutover.go
+++ b/internal/operator/mail_cutover.go
@@ -87,6 +87,30 @@ func ConfigureMailCutoverRelayMachines(directory, enrollmentFile string) (Instal
 	return publishMailCutoverInstallation(directory, installation, nil)
 }
 
+// ConfigureRelayMachines replaces the complete public relay enrollment set.
+// It is the supported authority for adding or revoking a client from a unified
+// installation; callers provide a protected declarative file rather than
+// editing generated runtime configuration.
+func ConfigureRelayMachines(directory, enrollmentFile string) (Installation, error) {
+	canonical, err := ReadRelayMachinesFile(enrollmentFile)
+	if err != nil {
+		return Installation{}, err
+	}
+	installation, err := LoadMailCutoverRecovery(directory)
+	if err != nil {
+		return Installation{}, err
+	}
+	if installation.RelayEnabled && installation.RelayMachinesJSON == canonical {
+		return installation, nil
+	}
+	if _, err := validateStatic(InitOptions{Directory: directory, DataDir: installation.DataDir, BackupDir: installation.BackupDir, Image: installation.Image, OwnerDSNFile: installation.OwnerDSNFile, AppDSNFile: installation.AppDSNFile, OwnerName: installation.OwnerName, Ingress: installation.Ingress, HealthListenAddr: installation.HealthListenAddr, MemoryAPIEnabled: installation.MemoryAPIEnabled, MemoryMutationsEnabled: installation.MemoryMutationsEnabled, TrustedAttachmentsEnabled: installation.TrustedAttachmentsEnabled, TrustedAttachmentBlobDir: installation.TrustedAttachmentBlobDir, RelayEnabled: true, RelayMachinesJSON: canonical}); err != nil {
+		return Installation{}, errors.New("relay enrollment is incompatible with the installation")
+	}
+	installation.RelayEnabled = true
+	installation.RelayMachinesJSON = canonical
+	return publishMailCutoverInstallation(directory, installation, nil)
+}
+
 // ReadRelayMachinesFile loads a protected, bounded relay enrollment file for
 // either initial installation or an explicit mail-cutover transition.
 func ReadRelayMachinesFile(enrollmentFile string) (string, error) {
@@ -234,8 +258,12 @@ func LoadMailCutoverRecovery(directory string) (Installation, error) {
 		return Installation{}, errors.New("mail cutover recovery marker does not match the installation")
 	}
 	cutoverAdvance := base.MailCutover == nil && candidate.MailCutover != nil && base.RelayMachinesJSON == candidate.RelayMachinesJSON
-	enrollmentAdvance := base.MailCutover == nil && candidate.MailCutover == nil && base.RelayMachinesJSON == "" && candidate.RelayMachinesJSON != ""
-	if !cutoverAdvance && !enrollmentAdvance {
+	initialEnrollmentAdvance := base.MailCutover == nil && candidate.MailCutover == nil && base.RelayMachinesJSON == "" && candidate.RelayMachinesJSON != ""
+	// A live unified relay may change only its complete public enrollment set
+	// before mail cutover. The staged candidate still has to match every other
+	// installation invariant, so a crash can recover only this exact update.
+	relayEnrollmentAdvance := base.RelayEnabled && candidate.RelayEnabled && base.RelayMachinesJSON != candidate.RelayMachinesJSON && sameMailCutoverPublication(base.MailCutover, candidate.MailCutover)
+	if !cutoverAdvance && !initialEnrollmentAdvance && !relayEnrollmentAdvance {
 		return Installation{}, errors.New("mail cutover recovery marker transition is invalid")
 	}
 	for _, file := range []struct {
@@ -283,4 +311,11 @@ func LoadMailCutoverRecovery(directory string) (Installation, error) {
 		}
 	}
 	return base, nil
+}
+
+func sameMailCutoverPublication(left, right *MailCutoverPublication) bool {
+	if left == nil || right == nil {
+		return left == right
+	}
+	return *left == *right
 }

--- a/internal/operator/mail_cutover.go
+++ b/internal/operator/mail_cutover.go
@@ -2,6 +2,8 @@ package operator
 
 import (
 	"bytes"
+	"crypto/ed25519"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"os"
@@ -60,6 +62,11 @@ func publishMailCutover(directory string, publication MailCutoverPublication, af
 	if installation.RelayMachinesJSON == "" {
 		return Installation{}, errors.New("mail cutover relay enrollment is unavailable")
 	}
+	knownKeys, err := relayMachinePublicKeysJSON(installation.RelayMachinesJSON)
+	if err != nil {
+		return Installation{}, errors.New("mail cutover relay enrollment is unavailable")
+	}
+	installation.RelayKnownMachineKeysJSON = knownKeys
 	installation.MailCutover = &publication
 	return publishMailCutoverInstallation(directory, installation, afterStep)
 }
@@ -118,8 +125,19 @@ func ConfigureRelayMachines(directory, enrollmentFile string) (Installation, err
 		}
 		return installation, nil
 	}
-	if installation.MailCutover != nil && !relayEnrollmentUsesKnownKeys(installation.RelayMachinesJSON, canonical) {
-		return Installation{}, errors.New("post-cutover relay enrollment cannot add an unregistered machine key")
+	if installation.MailCutover != nil {
+		knownKeys := installation.RelayKnownMachineKeysJSON
+		if knownKeys == "" {
+			var err error
+			knownKeys, err = relayMachinePublicKeysJSON(installation.RelayMachinesJSON)
+			if err != nil {
+				return Installation{}, errors.New("post-cutover relay enrollment is unavailable")
+			}
+		}
+		if !relayEnrollmentUsesKnownKeys(knownKeys, canonical) {
+			return Installation{}, errors.New("post-cutover relay enrollment cannot add an unregistered machine key")
+		}
+		installation.RelayKnownMachineKeysJSON = knownKeys
 	}
 	if _, err := validateStatic(InitOptions{Directory: directory, DataDir: installation.DataDir, BackupDir: installation.BackupDir, Image: installation.Image, OwnerDSNFile: installation.OwnerDSNFile, AppDSNFile: installation.AppDSNFile, OwnerName: installation.OwnerName, Ingress: installation.Ingress, HealthListenAddr: installation.HealthListenAddr, MemoryAPIEnabled: installation.MemoryAPIEnabled, MemoryMutationsEnabled: installation.MemoryMutationsEnabled, TrustedAttachmentsEnabled: installation.TrustedAttachmentsEnabled, TrustedAttachmentBlobDir: installation.TrustedAttachmentBlobDir, RelayEnabled: true, RelayMachinesJSON: canonical}); err != nil {
 		return Installation{}, errors.New("relay enrollment is incompatible with the installation")
@@ -131,25 +149,80 @@ func ConfigureRelayMachines(directory, enrollmentFile string) (Installation, err
 
 // relayEnrollmentUsesKnownKeys permits post-cutover authority narrowing or
 // metadata changes only for keys the active transition runtime can resolve.
-func relayEnrollmentUsesKnownKeys(current, replacement string) bool {
-	currentMachines, err := relay.ParseMachineEnrollments(current)
-	if err != nil {
+func relayEnrollmentUsesKnownKeys(knownKeysJSON, replacement string) bool {
+	var knownKeys []string
+	if json.Unmarshal([]byte(knownKeysJSON), &knownKeys) != nil || !validRelayMachineKeys(knownKeys) {
 		return false
 	}
-	known := make(map[string]struct{}, len(currentMachines))
-	for _, machine := range currentMachines {
-		known[string(machine.PublicKey)] = struct{}{}
+	known := make(map[string]struct{}, len(knownKeys))
+	for _, key := range knownKeys {
+		known[key] = struct{}{}
 	}
 	replacementMachines, err := relay.ParseMachineEnrollments(replacement)
 	if err != nil {
 		return false
 	}
 	for _, machine := range replacementMachines {
-		if _, found := known[string(machine.PublicKey)]; !found {
+		if _, found := known[base64.RawURLEncoding.EncodeToString(machine.PublicKey)]; !found {
 			return false
 		}
 	}
 	return true
+}
+
+func relayMachinePublicKeys(enrollment string) ([]string, error) {
+	machines, err := relay.ParseMachineEnrollments(enrollment)
+	if err != nil {
+		return nil, err
+	}
+	keys := make([]string, 0, len(machines))
+	for _, machine := range machines {
+		keys = append(keys, base64.RawURLEncoding.EncodeToString(machine.PublicKey))
+	}
+	return keys, nil
+}
+
+func relayMachinePublicKeysJSON(enrollment string) (string, error) {
+	keys, err := relayMachinePublicKeys(enrollment)
+	if err != nil {
+		return "", err
+	}
+	encoded, err := json.Marshal(keys)
+	if err != nil {
+		return "", err
+	}
+	return string(encoded), nil
+}
+
+func validRelayMachineKeys(keys []string) bool {
+	seen := make(map[string]struct{}, len(keys))
+	for _, key := range keys {
+		decoded, err := base64.RawURLEncoding.DecodeString(key)
+		if err != nil || len(decoded) != ed25519.PublicKeySize || base64.RawURLEncoding.EncodeToString(decoded) != key {
+			return false
+		}
+		if _, duplicate := seen[key]; duplicate {
+			return false
+		}
+		seen[key] = struct{}{}
+	}
+	return true
+}
+
+func validRelayMachineKeysJSON(raw string) bool {
+	var keys []string
+	if json.Unmarshal([]byte(raw), &keys) != nil || !validRelayMachineKeys(keys) {
+		return false
+	}
+	encoded, err := json.Marshal(keys)
+	return err == nil && string(encoded) == raw
+}
+
+func relayMachineKeysContain(keysJSON, enrollment string) bool {
+	if !validRelayMachineKeysJSON(keysJSON) {
+		return false
+	}
+	return relayEnrollmentUsesKnownKeys(keysJSON, enrollment)
 }
 
 // ReadRelayMachinesFile loads a protected, bounded relay enrollment file for
@@ -292,13 +365,14 @@ func LoadMailCutoverRecovery(directory string) (Installation, error) {
 		}
 	}
 	candidate, err := readInstallation(markerStage)
-	if err != nil || candidate.MailCutover != nil && candidate.MailCutover.Validate() != nil || candidate.RelayMachinesJSON != "" && validateRelayMachinesJSON(candidate.RelayMachinesJSON) != nil {
+	if err != nil || candidate.MailCutover != nil && candidate.MailCutover.Validate() != nil || candidate.RelayMachinesJSON != "" && validateRelayMachinesJSON(candidate.RelayMachinesJSON) != nil || candidate.RelayKnownMachineKeysJSON != "" && !validRelayMachineKeysJSON(candidate.RelayKnownMachineKeysJSON) || candidate.MailCutover != nil && candidate.RelayKnownMachineKeysJSON != "" && !relayMachineKeysContain(candidate.RelayKnownMachineKeysJSON, candidate.RelayMachinesJSON) {
 		return Installation{}, errors.New("mail cutover recovery marker is unavailable")
 	}
 	candidate.Directory = directory
 	baseComparable, candidateComparable := base, candidate
 	baseComparable.MailCutover, candidateComparable.MailCutover = nil, nil
 	baseComparable.RelayMachinesJSON, candidateComparable.RelayMachinesJSON = "", ""
+	baseComparable.RelayKnownMachineKeysJSON, candidateComparable.RelayKnownMachineKeysJSON = "", ""
 	baseComparable.RelayEnabled, candidateComparable.RelayEnabled = false, false
 	if baseComparable != candidateComparable {
 		return Installation{}, errors.New("mail cutover recovery marker does not match the installation")

--- a/internal/operator/mail_cutover.go
+++ b/internal/operator/mail_cutover.go
@@ -103,7 +103,7 @@ func ConfigureRelayMachines(directory, enrollmentFile string) (Installation, err
 	markerStage := filepath.Join(directory, ".installation.mail-cutover.json")
 	if _, err := os.Lstat(markerStage); err == nil {
 		candidate, err := readInstallation(markerStage)
-		if err != nil || !candidate.RelayEnabled || candidate.RelayMachinesJSON != canonical {
+		if err != nil || !candidate.RelayEnabled || candidate.RelayMachinesJSON != canonical || !sameMailCutoverPublication(candidate.MailCutover, installation.MailCutover) {
 			return Installation{}, errors.New("relay enrollment recovery requires the exact requested enrollment")
 		}
 		candidate.Directory = directory
@@ -112,6 +112,9 @@ func ConfigureRelayMachines(directory, enrollmentFile string) (Installation, err
 		return Installation{}, errors.New("relay enrollment recovery is unavailable")
 	}
 	if installation.RelayEnabled && installation.RelayMachinesJSON == canonical {
+		if len(CheckPaths(installation)) != 0 || syncDirectory(directory) != nil {
+			return Installation{}, errors.New("relay enrollment recovery is unavailable")
+		}
 		return installation, nil
 	}
 	if _, err := validateStatic(InitOptions{Directory: directory, DataDir: installation.DataDir, BackupDir: installation.BackupDir, Image: installation.Image, OwnerDSNFile: installation.OwnerDSNFile, AppDSNFile: installation.AppDSNFile, OwnerName: installation.OwnerName, Ingress: installation.Ingress, HealthListenAddr: installation.HealthListenAddr, MemoryAPIEnabled: installation.MemoryAPIEnabled, MemoryMutationsEnabled: installation.MemoryMutationsEnabled, TrustedAttachmentsEnabled: installation.TrustedAttachmentsEnabled, TrustedAttachmentBlobDir: installation.TrustedAttachmentBlobDir, RelayEnabled: true, RelayMachinesJSON: canonical}); err != nil {

--- a/internal/operator/mail_cutover.go
+++ b/internal/operator/mail_cutover.go
@@ -100,6 +100,17 @@ func ConfigureRelayMachines(directory, enrollmentFile string) (Installation, err
 	if err != nil {
 		return Installation{}, err
 	}
+	markerStage := filepath.Join(directory, ".installation.mail-cutover.json")
+	if _, err := os.Lstat(markerStage); err == nil {
+		candidate, err := readInstallation(markerStage)
+		if err != nil || !candidate.RelayEnabled || candidate.RelayMachinesJSON != canonical {
+			return Installation{}, errors.New("relay enrollment recovery requires the exact requested enrollment")
+		}
+		candidate.Directory = directory
+		return publishMailCutoverInstallation(directory, candidate, nil)
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return Installation{}, errors.New("relay enrollment recovery is unavailable")
+	}
 	if installation.RelayEnabled && installation.RelayMachinesJSON == canonical {
 		return installation, nil
 	}
@@ -235,8 +246,13 @@ func LoadMailCutoverRecovery(directory string) (Installation, error) {
 	if err != nil {
 		return Installation{}, err
 	}
+	markerStage := filepath.Join(directory, ".installation.mail-cutover.json")
+	_, stageErr := os.Lstat(markerStage)
+	if stageErr != nil && !errors.Is(stageErr, os.ErrNotExist) {
+		return Installation{}, errors.New("mail cutover recovery marker is unavailable")
+	}
 	failures := CheckPaths(base)
-	if len(failures) == 0 {
+	if len(failures) == 0 && errors.Is(stageErr, os.ErrNotExist) {
 		return base, nil
 	}
 	allowed := []string{"generated Compose override does not match installation configuration", "generated daemon environment does not match installation configuration"}
@@ -245,7 +261,6 @@ func LoadMailCutoverRecovery(directory string) (Installation, error) {
 			return Installation{}, errors.New("mail cutover recovery paths are not safe")
 		}
 	}
-	markerStage := filepath.Join(directory, ".installation.mail-cutover.json")
 	candidate, err := readInstallation(markerStage)
 	if err != nil || candidate.MailCutover != nil && candidate.MailCutover.Validate() != nil || candidate.RelayMachinesJSON != "" && validateRelayMachinesJSON(candidate.RelayMachinesJSON) != nil {
 		return Installation{}, errors.New("mail cutover recovery marker is unavailable")
@@ -254,16 +269,18 @@ func LoadMailCutoverRecovery(directory string) (Installation, error) {
 	baseComparable, candidateComparable := base, candidate
 	baseComparable.MailCutover, candidateComparable.MailCutover = nil, nil
 	baseComparable.RelayMachinesJSON, candidateComparable.RelayMachinesJSON = "", ""
+	baseComparable.RelayEnabled, candidateComparable.RelayEnabled = false, false
 	if baseComparable != candidateComparable {
 		return Installation{}, errors.New("mail cutover recovery marker does not match the installation")
 	}
 	cutoverAdvance := base.MailCutover == nil && candidate.MailCutover != nil && base.RelayMachinesJSON == candidate.RelayMachinesJSON
 	initialEnrollmentAdvance := base.MailCutover == nil && candidate.MailCutover == nil && base.RelayMachinesJSON == "" && candidate.RelayMachinesJSON != ""
+	relayEnableAdvance := !base.RelayEnabled && candidate.RelayEnabled && base.RelayMachinesJSON == "" && candidate.RelayMachinesJSON != "" && sameMailCutoverPublication(base.MailCutover, candidate.MailCutover)
 	// A live unified relay may change only its complete public enrollment set
 	// before mail cutover. The staged candidate still has to match every other
 	// installation invariant, so a crash can recover only this exact update.
 	relayEnrollmentAdvance := base.RelayEnabled && candidate.RelayEnabled && base.RelayMachinesJSON != candidate.RelayMachinesJSON && sameMailCutoverPublication(base.MailCutover, candidate.MailCutover)
-	if !cutoverAdvance && !initialEnrollmentAdvance && !relayEnrollmentAdvance {
+	if !cutoverAdvance && !initialEnrollmentAdvance && !relayEnableAdvance && !relayEnrollmentAdvance {
 		return Installation{}, errors.New("mail cutover recovery marker transition is invalid")
 	}
 	for _, file := range []struct {

--- a/internal/operator/mail_cutover.go
+++ b/internal/operator/mail_cutover.go
@@ -305,7 +305,7 @@ func LoadMailCutoverRecovery(directory string) (Installation, error) {
 	}
 	cutoverAdvance := base.MailCutover == nil && candidate.MailCutover != nil && base.RelayMachinesJSON == candidate.RelayMachinesJSON
 	initialEnrollmentAdvance := base.MailCutover == nil && candidate.MailCutover == nil && base.RelayMachinesJSON == "" && candidate.RelayMachinesJSON != ""
-	relayEnableAdvance := !base.RelayEnabled && candidate.RelayEnabled && base.RelayMachinesJSON == "" && candidate.RelayMachinesJSON != "" && sameMailCutoverPublication(base.MailCutover, candidate.MailCutover)
+	relayEnableAdvance := !base.RelayEnabled && candidate.RelayEnabled && candidate.RelayMachinesJSON != "" && sameMailCutoverPublication(base.MailCutover, candidate.MailCutover)
 	// A live unified relay may change only its complete public enrollment set
 	// before mail cutover. The staged candidate still has to match every other
 	// installation invariant, so a crash can recover only this exact update.

--- a/internal/operator/mail_cutover.go
+++ b/internal/operator/mail_cutover.go
@@ -360,6 +360,28 @@ func LoadMailCutoverRecovery(directory string) (Installation, error) {
 	return base, nil
 }
 
+// LoadMailCutoverExecution accepts only a completed installation or an
+// interrupted execution of the same mail-cutover publication. It deliberately
+// refuses a staged relay-only change: that change must be recovered through its
+// own explicit lifecycle before an irreversible source transition can begin.
+func LoadMailCutoverExecution(directory string) (Installation, error) {
+	installation, err := LoadMailCutoverRecovery(directory)
+	if err != nil {
+		return Installation{}, err
+	}
+	markerStage := filepath.Join(directory, ".installation.mail-cutover.json")
+	if _, err := os.Lstat(markerStage); errors.Is(err, os.ErrNotExist) {
+		return installation, nil
+	} else if err != nil {
+		return Installation{}, errors.New("mail cutover recovery marker is unavailable")
+	}
+	candidate, err := readInstallation(markerStage)
+	if err != nil || candidate.MailCutover == nil {
+		return Installation{}, errors.New("mail cutover execution conflicts with a staged relay update")
+	}
+	return installation, nil
+}
+
 func sameMailCutoverPublication(left, right *MailCutoverPublication) bool {
 	if left == nil || right == nil {
 		return left == right

--- a/internal/operator/mail_cutover.go
+++ b/internal/operator/mail_cutover.go
@@ -10,6 +10,7 @@ import (
 	"slices"
 
 	"github.com/google/uuid"
+	"github.com/rock3r/punaro/internal/relay"
 )
 
 var mailCutoverPublicationDigest = regexp.MustCompile(`^[0-9a-f]{64}$`)
@@ -117,12 +118,38 @@ func ConfigureRelayMachines(directory, enrollmentFile string) (Installation, err
 		}
 		return installation, nil
 	}
+	if installation.MailCutover != nil && !relayEnrollmentUsesKnownKeys(installation.RelayMachinesJSON, canonical) {
+		return Installation{}, errors.New("post-cutover relay enrollment cannot add an unregistered machine key")
+	}
 	if _, err := validateStatic(InitOptions{Directory: directory, DataDir: installation.DataDir, BackupDir: installation.BackupDir, Image: installation.Image, OwnerDSNFile: installation.OwnerDSNFile, AppDSNFile: installation.AppDSNFile, OwnerName: installation.OwnerName, Ingress: installation.Ingress, HealthListenAddr: installation.HealthListenAddr, MemoryAPIEnabled: installation.MemoryAPIEnabled, MemoryMutationsEnabled: installation.MemoryMutationsEnabled, TrustedAttachmentsEnabled: installation.TrustedAttachmentsEnabled, TrustedAttachmentBlobDir: installation.TrustedAttachmentBlobDir, RelayEnabled: true, RelayMachinesJSON: canonical}); err != nil {
 		return Installation{}, errors.New("relay enrollment is incompatible with the installation")
 	}
 	installation.RelayEnabled = true
 	installation.RelayMachinesJSON = canonical
 	return publishMailCutoverInstallation(directory, installation, nil)
+}
+
+// relayEnrollmentUsesKnownKeys permits post-cutover authority narrowing or
+// metadata changes only for keys the active transition runtime can resolve.
+func relayEnrollmentUsesKnownKeys(current, replacement string) bool {
+	currentMachines, err := relay.ParseMachineEnrollments(current)
+	if err != nil {
+		return false
+	}
+	known := make(map[string]struct{}, len(currentMachines))
+	for _, machine := range currentMachines {
+		known[string(machine.PublicKey)] = struct{}{}
+	}
+	replacementMachines, err := relay.ParseMachineEnrollments(replacement)
+	if err != nil {
+		return false
+	}
+	for _, machine := range replacementMachines {
+		if _, found := known[string(machine.PublicKey)]; !found {
+			return false
+		}
+	}
+	return true
 }
 
 // ReadRelayMachinesFile loads a protected, bounded relay enrollment file for

--- a/internal/relay/auth.go
+++ b/internal/relay/auth.go
@@ -136,8 +136,8 @@ func NewTransitionAuthenticator(store NonceStore, machines []Machine, transition
 }
 
 func newAuthenticator(store NonceStore, machines []Machine, transition TransitionAuthority) (*Authenticator, error) {
-	if store == nil || len(machines) == 0 {
-		return nil, fmt.Errorf("relay authenticator requires enrolled machines")
+	if store == nil {
+		return nil, fmt.Errorf("relay authenticator requires a nonce store")
 	}
 	configured := make(map[string]Machine, len(machines))
 	attachmentDevices := make(map[[16]byte]string, len(machines))

--- a/internal/relay/enrollment.go
+++ b/internal/relay/enrollment.go
@@ -47,6 +47,9 @@ func machineEnrollmentAuthenticator(raw string) (*Authenticator, []Machine, erro
 // keys only; an adapter's private key must never be supplied to or persisted by
 // the relay.
 func ParseMachineEnrollments(raw string) ([]Machine, error) {
+	if !strings.HasPrefix(strings.TrimSpace(raw), "[") {
+		return nil, fmt.Errorf("parse machine enrollment: expected array")
+	}
 	decoder := json.NewDecoder(strings.NewReader(raw))
 	decoder.DisallowUnknownFields()
 	var records []struct {

--- a/internal/relay/enrollment.go
+++ b/internal/relay/enrollment.go
@@ -42,9 +42,10 @@ func machineEnrollmentAuthenticator(raw string) (*Authenticator, []Machine, erro
 	return authenticator, machines, nil
 }
 
-// ParseMachineEnrollments parses the non-secret daemon enrollment setting. It
-// deliberately accepts public keys only; an adapter's private key must never
-// be supplied to or persisted by the relay.
+// ParseMachineEnrollments parses the non-secret daemon enrollment setting. An
+// explicit empty array revokes all machines. It deliberately accepts public
+// keys only; an adapter's private key must never be supplied to or persisted by
+// the relay.
 func ParseMachineEnrollments(raw string) ([]Machine, error) {
 	decoder := json.NewDecoder(strings.NewReader(raw))
 	decoder.DisallowUnknownFields()
@@ -60,9 +61,6 @@ func ParseMachineEnrollments(raw string) ([]Machine, error) {
 	}
 	if err := decoder.Decode(&struct{}{}); err != io.EOF {
 		return nil, fmt.Errorf("parse machine enrollment: trailing JSON")
-	}
-	if len(records) == 0 {
-		return nil, fmt.Errorf("machine enrollment is empty")
 	}
 	machines := make([]Machine, 0, len(records))
 	for _, record := range records {

--- a/internal/relay/enrollment_test.go
+++ b/internal/relay/enrollment_test.go
@@ -24,6 +24,12 @@ func TestParseMachineEnrollmentsAcceptsEmptySetForExplicitRevocation(t *testing.
 	}
 }
 
+func TestParseMachineEnrollmentsRejectsNullInsteadOfRevoking(t *testing.T) {
+	if _, err := ParseMachineEnrollments(`null`); err == nil {
+		t.Fatal("null enrollment was accepted as a revocation")
+	}
+}
+
 func TestParseMachineEnrollmentsAcceptsExactEndpoints(t *testing.T) {
 	publicKey := make([]byte, 32)
 	publicKey[0] = 1

--- a/internal/relay/enrollment_test.go
+++ b/internal/relay/enrollment_test.go
@@ -17,6 +17,13 @@ func TestParseMachineEnrollmentsAcceptsPublicKeysOnly(t *testing.T) {
 	}
 }
 
+func TestParseMachineEnrollmentsAcceptsEmptySetForExplicitRevocation(t *testing.T) {
+	machines, err := ParseMachineEnrollments(`[]`)
+	if err != nil || len(machines) != 0 {
+		t.Fatalf("machines=%#v err=%v", machines, err)
+	}
+}
+
 func TestParseMachineEnrollmentsAcceptsExactEndpoints(t *testing.T) {
 	publicKey := make([]byte, 32)
 	publicKey[0] = 1

--- a/scripts/test-production-compose-bootstrap.sh
+++ b/scripts/test-production-compose-bootstrap.sh
@@ -230,6 +230,12 @@ if grep -F 'agent/a/' "$installation_dir/punarod.env" >/dev/null; then
 	echo 'relay configuration retained a removed enrollment' >&2
 	exit 1
 fi
+printf '%s\n' '[]' >"$relay_machines"
+(cd "$root" && go run ./cmd/punaro relay configure \
+	--directory "$installation_dir" \
+	--relay-machines-file "$relay_machines" \
+	--yes)
+grep -Fxq "PUNARO_RELAY_MACHINES_JSON='[]'" "$installation_dir/punarod.env"
 docker compose --project-name "$project" --file "$root/deploy/compose/production.yaml" run --rm --no-deps --entrypoint psql -e PGPASSWORD='production-app-password' postgres-bootstrap --host 127.0.0.1 --username punaro_app --dbname punaro --tuples-only --no-align --command 'SELECT 1 FROM auth.installation_owner LIMIT 1' | grep -Fxq 1
 docker compose --project-name "$project" --file "$root/deploy/compose/production.yaml" run --rm --no-deps --entrypoint psql -e PGPASSWORD='production-app-password' postgres-bootstrap --host 127.0.0.1 --username punaro_app --dbname punaro --command 'SELECT 1 FROM relay.projects LIMIT 1'
 docker compose --project-name "$project" --file "$root/deploy/compose/production.yaml" run --rm --no-deps --entrypoint psql -e PGPASSWORD='production-owner-password' postgres-bootstrap --host 127.0.0.1 --username punaro_owner --dbname punaro --command 'GRANT TRUNCATE ON relay.projects TO punaro_app'

--- a/scripts/test-production-compose-bootstrap.sh
+++ b/scripts/test-production-compose-bootstrap.sh
@@ -195,6 +195,13 @@ if docker compose --project-name "$project" --file "$root/deploy/compose/product
 	exit 1
 fi
 docker compose --project-name "$project" --file "$root/deploy/compose/production.yaml" run --rm --no-deps --entrypoint psql -e PGPASSWORD='production-owner-password' postgres-bootstrap --host 127.0.0.1 --username punaro_owner --dbname postgres --command 'DROP DATABASE punaro_bootstrap_other WITH (FORCE)'
+# The preceding bootstrap hardening probes deliberately mutate the production
+# database. Recreate it before the independent fresh-init phase: `punaro init`
+# must prove that it can migrate a genuinely pristine target, not a selectively
+# cleaned test fixture.
+docker compose --project-name "$project" --file "$root/deploy/compose/production.yaml" run --rm --no-deps --entrypoint psql -e PGPASSWORD='production-owner-password' postgres-bootstrap --host 127.0.0.1 --username punaro_owner --dbname postgres --command 'DROP DATABASE punaro WITH (FORCE)'
+docker compose --project-name "$project" --file "$root/deploy/compose/production.yaml" run --rm --no-deps --entrypoint psql -e PGPASSWORD='production-owner-password' postgres-bootstrap --host 127.0.0.1 --username punaro_owner --dbname postgres --command 'CREATE DATABASE punaro OWNER punaro_owner'
+docker compose --project-name "$project" --file "$root/deploy/compose/production.yaml" run --rm --no-deps postgres-bootstrap
 (cd "$root" && go run ./cmd/punaro init \
 	--directory "$installation_dir" \
 	--data-dir "$data_dir" \
@@ -213,6 +220,16 @@ grep -Fxq 'PUNARO_RELAY_ENABLED=true' "$installation_dir/punarod.env"
 grep -Fxq 'PUNARO_RELAY_STORE=postgres' "$installation_dir/punarod.env"
 grep -Fxq 'PUNARO_TRUSTED_ATTACHMENTS_ENABLED=true' "$installation_dir/punarod.env"
 grep -Fxq 'PUNARO_TRUSTED_ATTACHMENT_BLOB_DIR=/var/lib/punaro/attachments' "$installation_dir/punarod.env"
+printf '%s\n' '[{"id":"machine-b","public_key":"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA","endpoint_prefixes":["agent/b/"],"endpoints":[],"attachment_device_id":""}]' >"$relay_machines"
+(cd "$root" && go run ./cmd/punaro relay configure \
+	--directory "$installation_dir" \
+	--relay-machines-file "$relay_machines" \
+	--yes)
+grep -Fqx "PUNARO_RELAY_MACHINES_JSON='[{\"id\":\"machine-b\",\"public_key\":\"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\",\"endpoint_prefixes\":[\"agent/b/\"],\"endpoints\":[],\"attachment_device_id\":\"\"}]'" "$installation_dir/punarod.env"
+if grep -F 'agent/a/' "$installation_dir/punarod.env" >/dev/null; then
+	echo 'relay configuration retained a removed enrollment' >&2
+	exit 1
+fi
 docker compose --project-name "$project" --file "$root/deploy/compose/production.yaml" run --rm --no-deps --entrypoint psql -e PGPASSWORD='production-app-password' postgres-bootstrap --host 127.0.0.1 --username punaro_app --dbname punaro --tuples-only --no-align --command 'SELECT 1 FROM auth.installation_owner LIMIT 1' | grep -Fxq 1
 docker compose --project-name "$project" --file "$root/deploy/compose/production.yaml" run --rm --no-deps --entrypoint psql -e PGPASSWORD='production-app-password' postgres-bootstrap --host 127.0.0.1 --username punaro_app --dbname punaro --command 'SELECT 1 FROM relay.projects LIMIT 1'
 docker compose --project-name "$project" --file "$root/deploy/compose/production.yaml" run --rm --no-deps --entrypoint psql -e PGPASSWORD='production-owner-password' postgres-bootstrap --host 127.0.0.1 --username punaro_owner --dbname punaro --command 'GRANT TRUNCATE ON relay.projects TO punaro_app'


### PR DESCRIPTION
Implements the first independently mergeable slice of #114.

- add `punaro relay configure` for protected, complete public enrollment replacement
- atomically publish/recover configuration changes before and after mail cutover
- document add/revoke plus restart flow
- exercise fresh production Compose initialization and enrollment replacement

Validation:
- `make test`
- `make test-race`
- `make staticcheck`
- `make security`
- `make lint`
- `PUNARO_TEST_TMPDIR=<worktree> ./scripts/test-production-compose-bootstrap.sh`