### PR TITLE
test: cover revoked relay client rejection

### DIFF
--- a/cmd/punaro-adapter/relay_lifecycle_e2e_test.go
+++ b/cmd/punaro-adapter/relay_lifecycle_e2e_test.go
@@ -147,7 +147,7 @@ func TestE2ERealTwoClientRelayLifecycle(t *testing.T) {
 	relayBinary := filepath.Join(fixture, "punarod")
 	e2eRun(t, root, e2eGoEnvironment(), "go", "build", "-trimpath", "-o", relayBinary, "./cmd/punarod")
 	machines := e2eEnrollmentSet(t, senderHome, receiverHome)
-	relayEnvironment := e2eEnvironment(e2eGoEnvironment(), map[string]string{
+	relaySettings := map[string]string{
 		"PUNARO_DATA_DIR":            filepath.Join(fixture, "relay-state"),
 		"PUNARO_RELAY_ENABLED":       "true",
 		"PUNARO_RELAY_MACHINES_JSON": machines,
@@ -159,7 +159,8 @@ func TestE2ERealTwoClientRelayLifecycle(t *testing.T) {
 		"PUNARO_ACCESS_JWKS_URL":     "",
 		"PUNARO_ACCESS_JWKS_FILE":    "",
 		"PUNARO_ENV_FILE":            "",
-	})
+	}
+	relayEnvironment := e2eEnvironment(e2eGoEnvironment(), relaySettings)
 	relay := e2eStartRelay(t, relayBinary, relayEnvironment)
 	t.Cleanup(func() { e2eStopProcess(relay) })
 	e2eEventually(t, 20*time.Second, func() bool { return e2eReady(healthAddress) }, "disposable central relay did not become ready")
@@ -208,6 +209,14 @@ func TestE2ERealTwoClientRelayLifecycle(t *testing.T) {
 	e2eEventually(t, 75*time.Second, func() bool { return proxy.retryAcknowledged.Load() }, "restarted receiver did not retry its relay acknowledgement")
 
 	e2eExpectMailboxTimeout(t, receiverMailboxState, receiverEndpoint)
+	e2eStopProcess(relay)
+	relaySettings["PUNARO_RELAY_MACHINES_JSON"] = e2eEnrollmentSet(t, receiverHome)
+	relay = e2eStartRelay(t, relayBinary, e2eEnvironment(e2eGoEnvironment(), relaySettings))
+	e2eEventually(t, 20*time.Second, func() bool { return e2eReady(healthAddress) }, "revocation relay did not become ready")
+	revokedOutput, revokedErr := e2eTryAdapterCommand(senderAdapter, senderProfile, "create", "--creator", senderEndpoint, "--member", senderEndpoint+":send,receive,admin", "--idempotency-key", "e2e-revoked-"+uuid.NewString())
+	if revokedErr == nil || !strings.Contains(string(revokedOutput), "relay rejected request with HTTP 401") {
+		t.Fatalf("revoked installed sender result error=%v output=%q, want actionable HTTP 401 rejection", revokedErr, revokedOutput)
+	}
 }
 
 type e2eClaimResult struct {
@@ -492,7 +501,7 @@ func e2eAdapterCommand(t *testing.T, binary, profile string, arguments ...string
 func e2eTryAdapterCommand(binary, profile string, arguments ...string) ([]byte, error) {
 	command := exec.Command(binary, arguments...)
 	command.Env = e2eEnvironment(e2eGoEnvironment(), map[string]string{adapterProfileFileEnv: profile})
-	return command.Output()
+	return command.CombinedOutput()
 }
 
 func e2eMailbox(t *testing.T, state string, arguments ...string) {


### PR DESCRIPTION
## Summary
- extend the real installed two-client relay lifecycle E2E with public-enrollment revocation
- restart the durable relay after removing the sender enrollment
- verify the installed revoked sender fails closed with an actionable HTTP 401 diagnostic

## Validation
- === RUN   TestE2ERealTwoClientRelayLifecycle
--- PASS: TestE2ERealTwoClientRelayLifecycle (77.97s)
PASS
ok  	github.com/rock3r/punaro/cmd/punaro-adapter	78.427s
- go test -covermode=atomic ./...
ok  	github.com/rock3r/punaro/cmd/punaro	(cached)	coverage: 40.1% of statements
ok  	github.com/rock3r/punaro/cmd/punaro-adapter	(cached)	coverage: 63.3% of statements
ok  	github.com/rock3r/punaro/cmd/punaro-admin	(cached)	coverage: 23.6% of statements
ok  	github.com/rock3r/punaro/cmd/punaro-attachment	(cached)	coverage: 19.8% of statements
ok  	github.com/rock3r/punaro/cmd/punaro-directory	(cached)	coverage: 56.2% of statements
	github.com/rock3r/punaro/cmd/punaro-dpapi		coverage: 0.0% of statements
ok  	github.com/rock3r/punaro/cmd/punaro-enroll	(cached)	coverage: 74.7% of statements
ok  	github.com/rock3r/punaro/cmd/punaro-keychain	(cached)	coverage: 38.9% of statements
ok  	github.com/rock3r/punaro/cmd/punaro-keygen	(cached)	coverage: 47.4% of statements
ok  	github.com/rock3r/punaro/cmd/punaro-memory	(cached)	coverage: 75.0% of statements
ok  	github.com/rock3r/punaro/cmd/punaro-migrate	(cached)	coverage: 96.7% of statements
ok  	github.com/rock3r/punaro/cmd/punaro-telegram	(cached)	coverage: 51.1% of statements
ok  	github.com/rock3r/punaro/cmd/punaro-trusted-attachment	(cached)	coverage: 69.2% of statements
ok  	github.com/rock3r/punaro/cmd/punarod	(cached)	coverage: 55.9% of statements
ok  	github.com/rock3r/punaro/internal/access	(cached)	coverage: 83.3% of statements
ok  	github.com/rock3r/punaro/internal/adapter	0.573s	coverage: 73.4% of statements
ok  	github.com/rock3r/punaro/internal/attachment	(cached)	coverage: 72.0% of statements
ok  	github.com/rock3r/punaro/internal/attachment/v2	(cached)	coverage: 70.0% of statements
ok  	github.com/rock3r/punaro/internal/attachment/v3	(cached)	coverage: 70.2% of statements
ok  	github.com/rock3r/punaro/internal/attachment/v3/controller	(cached)	coverage: 69.3% of statements
ok  	github.com/rock3r/punaro/internal/backup	(cached)	coverage: 76.7% of statements
ok  	github.com/rock3r/punaro/internal/clientidentity	(cached)	coverage: 86.8% of statements
ok  	github.com/rock3r/punaro/internal/config	(cached)	coverage: 85.2% of statements
ok  	github.com/rock3r/punaro/internal/cutover	(cached)	coverage: 69.6% of statements
ok  	github.com/rock3r/punaro/internal/devicehttp	(cached)	coverage: 81.0% of statements
ok  	github.com/rock3r/punaro/internal/embeddingprovider	(cached)	coverage: 89.7% of statements
ok  	github.com/rock3r/punaro/internal/ingress	(cached)	coverage: 82.5% of statements
ok  	github.com/rock3r/punaro/internal/listener	(cached)	coverage: 93.3% of statements
ok  	github.com/rock3r/punaro/internal/mcphttp	(cached)	coverage: 87.8% of statements
ok  	github.com/rock3r/punaro/internal/mcpoauth	(cached)	coverage: 77.5% of statements
ok  	github.com/rock3r/punaro/internal/memoryclient	(cached)	coverage: 79.3% of statements
ok  	github.com/rock3r/punaro/internal/memoryhttp	(cached)	coverage: 77.3% of statements
ok  	github.com/rock3r/punaro/internal/operator	(cached)	coverage: 75.6% of statements
ok  	github.com/rock3r/punaro/internal/postgres	(cached)	coverage: 14.1% of statements
ok  	github.com/rock3r/punaro/internal/relay	(cached)	coverage: 74.2% of statements
	github.com/rock3r/punaro/internal/relay/contracttest		coverage: 0.0% of statements
ok  	github.com/rock3r/punaro/internal/release	(cached)	coverage: 83.3% of statements
ok  	github.com/rock3r/punaro/internal/secretguard	(cached)	coverage: 98.6% of statements
ok  	github.com/rock3r/punaro/internal/telegram	(cached)	coverage: 76.8% of statements
ok  	github.com/rock3r/punaro/internal/trustedattachment	(cached)	coverage: 76.5% of statements
ok  	github.com/rock3r/punaro/internal/trustedattachmentclient	(cached)	coverage: 78.2% of statements
ok  	github.com/rock3r/punaro/internal/trustedattachmenthttp	(cached)	coverage: 81.5% of statements
PUNARO_REMOTE_MCP_E2E_LIVE= PUNARO_REMOTE_MCP_E2E_CONFIG= go test -tags=e2e ./internal/mcphttp
ok  	github.com/rock3r/punaro/internal/mcphttp	(cached)
- go test -race -count=1 ./...
ok  	github.com/rock3r/punaro/cmd/punaro	8.911s
ok  	github.com/rock3r/punaro/cmd/punaro-adapter	1.655s
ok  	github.com/rock3r/punaro/cmd/punaro-admin	2.043s
ok  	github.com/rock3r/punaro/cmd/punaro-attachment	2.437s
ok  	github.com/rock3r/punaro/cmd/punaro-directory	2.832s
?   	github.com/rock3r/punaro/cmd/punaro-dpapi	[no test files]
ok  	github.com/rock3r/punaro/cmd/punaro-enroll	3.971s
ok  	github.com/rock3r/punaro/cmd/punaro-keychain	3.398s
ok  	github.com/rock3r/punaro/cmd/punaro-keygen	3.786s
ok  	github.com/rock3r/punaro/cmd/punaro-memory	4.165s
ok  	github.com/rock3r/punaro/cmd/punaro-migrate	4.540s
ok  	github.com/rock3r/punaro/cmd/punaro-telegram	3.663s
ok  	github.com/rock3r/punaro/cmd/punaro-trusted-attachment	3.576s
ok  	github.com/rock3r/punaro/cmd/punarod	4.830s
ok  	github.com/rock3r/punaro/internal/access	3.693s
ok  	github.com/rock3r/punaro/internal/adapter	4.251s
ok  	github.com/rock3r/punaro/internal/attachment	4.354s
ok  	github.com/rock3r/punaro/internal/attachment/v2	4.461s
ok  	github.com/rock3r/punaro/internal/attachment/v3	7.559s
ok  	github.com/rock3r/punaro/internal/attachment/v3/controller	9.042s
ok  	github.com/rock3r/punaro/internal/backup	5.093s
ok  	github.com/rock3r/punaro/internal/clientidentity	3.733s
ok  	github.com/rock3r/punaro/internal/config	3.089s
ok  	github.com/rock3r/punaro/internal/cutover	2.486s
ok  	github.com/rock3r/punaro/internal/devicehttp	2.651s
ok  	github.com/rock3r/punaro/internal/embeddingprovider	2.610s
ok  	github.com/rock3r/punaro/internal/ingress	2.682s
ok  	github.com/rock3r/punaro/internal/listener	2.936s
ok  	github.com/rock3r/punaro/internal/mcphttp	2.450s
ok  	github.com/rock3r/punaro/internal/mcpoauth	2.612s
ok  	github.com/rock3r/punaro/internal/memoryclient	2.390s
ok  	github.com/rock3r/punaro/internal/memoryhttp	3.996s
ok  	github.com/rock3r/punaro/internal/operator	10.632s
ok  	github.com/rock3r/punaro/internal/postgres	3.183s
ok  	github.com/rock3r/punaro/internal/relay	15.081s
?   	github.com/rock3r/punaro/internal/relay/contracttest	[no test files]
ok  	github.com/rock3r/punaro/internal/release	3.455s
ok  	github.com/rock3r/punaro/internal/secretguard	3.527s
ok  	github.com/rock3r/punaro/internal/telegram	3.733s
ok  	github.com/rock3r/punaro/internal/trustedattachment	5.388s
ok  	github.com/rock3r/punaro/internal/trustedattachmentclient	9.016s
ok  	github.com/rock3r/punaro/internal/trustedattachmenthttp	3.085s
- go run honnef.co/go/tools/cmd/staticcheck@v0.6.1 ./...
- go run golang.org/x/vuln/cmd/govulncheck@v1.1.4 ./...
=== Symbol Results ===

No vulnerabilities found.

Your code is affected by 0 vulnerabilities.
This scan also found 1 vulnerability in packages you import and 1 vulnerability
in modules you require, but your code doesn't appear to call these
vulnerabilities.
Use '-show verbose' for more details.
CGO_ENABLED=0 go run github.com/securego/gosec/v2/cmd/gosec@v2.22.10 -exclude-generated ./...
Results:


Summary:
  Gosec  : dev
  Files  : 240
  Lines  : 63703
  Nosec  : 209
  Issues : 0

go run github.com/zricethezav/gitleaks/v8@v8.27.2 detect --source . --no-git
- go vet ./...
go run honnef.co/go/tools/cmd/staticcheck@v0.6.1 ./...
cmd/punaro-enroll/private_file_unix.go:272:13: Error return value of `unix.Sync` is not checked (errcheck)
			unix.Sync() // #nosec G104 -- unix.Sync has no return value to check. //nolint:errcheck
			         ^
cmd/punaro-enroll/private_file_unix.go:289:12: Error return value of `unix.Sync` is not checked (errcheck)
		unix.Sync() // #nosec G104 -- unix.Sync has no return value to check. //nolint:errcheck
		         ^
2 issues:
* errcheck: 2
0 issues.
0 issues.
GOOS=windows go build ./...
./scripts/verify-deployment-files.sh
install_adapter_tests_passed
install_server_tests_passed
attachment_v3_relay_retirement_tests_passed
Punaro agent guidance and project-local skills installed in /var/folders/10/534j41jj6_sg2tygjm9_crl80000gn/T/punaro-guidance-test.WT7dgDrF/project
Punaro agent guidance and project-local skills installed in /var/folders/10/534j41jj6_sg2tygjm9_crl80000gn/T/punaro-guidance-test.WT7dgDrF/project
install_agent_guidance_tests_passed
install_client_windows_tests_passed

Closes #114