### PR TITLE
Support Windows native memory onboarding

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -92,6 +92,10 @@ jobs:
       - run: go test ./internal/trustedattachmentclient -run '^TestWindows'
       - run: go test ./cmd/punaro-attachment -run '^TestWindows'
       - run: go test ./cmd/punaro-adapter -run '^TestWindows'
+
+      - run: go test ./cmd/punaro-memory -run '^TestWindows'
+
+      - run: go test ./internal/memoryclient -run '^TestWindows'
       - run: go vet ./...
       - run: go build ./...
       - shell: pwsh

--- a/cmd/punaro-memory/main.go
+++ b/cmd/punaro-memory/main.go
@@ -294,7 +294,7 @@ func saveProfile(path string, value profile) error {
 	if !safeProfilePath(path) || !privateProfilePath(path) || !validProfile(value) || sameCleanProfilePath(path, value.CredentialFile) {
 		return errors.New("profile is invalid")
 	}
-	if !noSymlinkPath(filepath.Dir(path)) || !noSymlinkPath(filepath.Dir(value.CredentialFile)) {
+	if !privateProfilePath(path) || !safeProfileCredentialPath(value.CredentialFile) {
 		return errors.New("profile path is unsafe")
 	}
 	value.Version = profileVersion
@@ -336,7 +336,7 @@ func saveProfile(path string, value profile) error {
 	if err := protectProfileFile(tempPath); err != nil || !privateProfileFilePath(tempPath) {
 		return errors.New("could not protect profile")
 	}
-	if !noSymlinkPath(directory) {
+	if !privateProfilePath(path) {
 		return errors.New("profile directory changed while writing")
 	}
 	if err := os.Rename(tempPath, path); err != nil { // #nosec G703 -- source and target are validated absolute profile paths in the same checked directory.
@@ -351,7 +351,7 @@ func saveProfile(path string, value profile) error {
 
 func loadProfile(path string) (profile, error) {
 	var value profile
-	if !safeProfilePath(path) || !privateProfilePath(path) || !noSymlinkPath(path) {
+	if !safeProfilePath(path) || !privateProfilePath(path) {
 		return value, errors.New("profile path is unsafe")
 	}
 	before, err := os.Lstat(path) // #nosec G703 -- explicit absolute CLI profile path checked component-by-component.
@@ -364,7 +364,7 @@ func loadProfile(path string) (profile, error) {
 	}
 	defer func() { _ = file.Close() }()
 	after, err := file.Stat()
-	if err != nil || !after.Mode().IsRegular() || !privateProfileFile(after) || !privateProfileFilePath(path) || !os.SameFile(before, after) || !noSymlinkPath(path) {
+	if err != nil || !after.Mode().IsRegular() || !privateProfileFile(after) || !privateProfileFilePath(path) || !os.SameFile(before, after) || !privateProfilePath(path) {
 		return value, errors.New("profile changed while opening")
 	}
 	raw, err := io.ReadAll(io.LimitReader(file, maxProfileSize+1))

--- a/cmd/punaro-memory/main.go
+++ b/cmd/punaro-memory/main.go
@@ -83,7 +83,7 @@ func runWithInput(args []string, stdin io.Reader, stdout, stderr io.Writer) int 
 	flags.Visit(func(parsed *flag.Flag) { explicit[parsed.Name] = true })
 	if command == "profile-write" {
 		candidate := profile{Origin: *origin, CredentialFile: *credentialFile, Project: *project}
-		if !safeProfilePath(*profilePath) || !validProfile(candidate) || sameCleanPath(*profilePath, candidate.CredentialFile) {
+		if !safeProfilePath(*profilePath) || !validProfile(candidate) || sameCleanProfilePath(*profilePath, candidate.CredentialFile) {
 			return 2
 		}
 		if err := saveProfile(*profilePath, candidate); err != nil {
@@ -291,7 +291,7 @@ func commandFlags(command string) []string {
 }
 
 func saveProfile(path string, value profile) error {
-	if !safeProfilePath(path) || !privateProfilePath(path) || !validProfile(value) || sameCleanPath(path, value.CredentialFile) {
+	if !safeProfilePath(path) || !privateProfilePath(path) || !validProfile(value) || sameCleanProfilePath(path, value.CredentialFile) {
 		return errors.New("profile is invalid")
 	}
 	if !noSymlinkPath(filepath.Dir(path)) || !noSymlinkPath(filepath.Dir(value.CredentialFile)) {
@@ -390,10 +390,6 @@ func loadProfile(path string) (profile, error) {
 
 func safeProfilePath(path string) bool {
 	return filepath.IsAbs(path) && filepath.Clean(path) == path
-}
-
-func sameCleanPath(left, right string) bool {
-	return filepath.Clean(left) == filepath.Clean(right)
 }
 
 func validProfile(value profile) bool {

--- a/cmd/punaro-memory/main.go
+++ b/cmd/punaro-memory/main.go
@@ -333,6 +333,9 @@ func saveProfile(path string, value profile) error {
 	if err := temp.Close(); err != nil {
 		return err
 	}
+	if err := protectProfileFile(tempPath); err != nil || !privateProfileFilePath(tempPath) {
+		return errors.New("could not protect profile")
+	}
 	if !noSymlinkPath(directory) {
 		return errors.New("profile directory changed while writing")
 	}
@@ -340,7 +343,7 @@ func saveProfile(path string, value profile) error {
 		return err
 	}
 	removeTemp = false
-	if err := syncDirectory(directory); err != nil {
+	if err := syncProfileDirectory(directory); err != nil {
 		return err
 	}
 	return nil
@@ -352,7 +355,7 @@ func loadProfile(path string) (profile, error) {
 		return value, errors.New("profile path is unsafe")
 	}
 	before, err := os.Lstat(path) // #nosec G703 -- explicit absolute CLI profile path checked component-by-component.
-	if err != nil || !before.Mode().IsRegular() || !privateProfileFile(before) {
+	if err != nil || !before.Mode().IsRegular() || !privateProfileFile(before) || !privateProfileFilePath(path) {
 		return value, errors.New("profile is unavailable")
 	}
 	file, err := os.Open(path) // #nosec G304,G703 -- explicit absolute CLI profile path checked before and after opening.
@@ -361,7 +364,7 @@ func loadProfile(path string) (profile, error) {
 	}
 	defer func() { _ = file.Close() }()
 	after, err := file.Stat()
-	if err != nil || !after.Mode().IsRegular() || !privateProfileFile(after) || !os.SameFile(before, after) || !noSymlinkPath(path) {
+	if err != nil || !after.Mode().IsRegular() || !privateProfileFile(after) || !privateProfileFilePath(path) || !os.SameFile(before, after) || !noSymlinkPath(path) {
 		return value, errors.New("profile changed while opening")
 	}
 	raw, err := io.ReadAll(io.LimitReader(file, maxProfileSize+1))
@@ -458,15 +461,6 @@ func rejectDuplicateTopLevelJSONFields(raw []byte) error {
 		return errors.New("profile has trailing data")
 	}
 	return nil
-}
-
-func syncDirectory(path string) error {
-	directory, err := os.Open(path) // #nosec G304,G703 -- directory path is explicit and checked before use.
-	if err != nil {
-		return err
-	}
-	defer func() { _ = directory.Close() }()
-	return directory.Sync()
 }
 
 func validCommand(command, project, item, proposal, key, etag, input, query, kind, locator, cursorFile string, limit int) bool {

--- a/cmd/punaro-memory/main.go
+++ b/cmd/punaro-memory/main.go
@@ -322,6 +322,10 @@ func saveProfile(path string, value profile) error {
 		_ = temp.Close()
 		return err
 	}
+	if err := protectProfileFile(tempPath); err != nil || !privateProfileFilePath(tempPath) {
+		_ = temp.Close()
+		return errors.New("could not protect profile")
+	}
 	if _, err := temp.Write(raw); err != nil {
 		_ = temp.Close()
 		return err
@@ -333,7 +337,7 @@ func saveProfile(path string, value profile) error {
 	if err := temp.Close(); err != nil {
 		return err
 	}
-	if err := protectProfileFile(tempPath); err != nil || !privateProfileFilePath(tempPath) {
+	if !privateProfileFilePath(tempPath) {
 		return errors.New("could not protect profile")
 	}
 	if !privateProfilePath(path) {

--- a/cmd/punaro-memory/profile_private_unix.go
+++ b/cmd/punaro-memory/profile_private_unix.go
@@ -43,6 +43,7 @@ func protectProfileFile(string) error    { return nil }
 func sameCleanProfilePath(left, right string) bool {
 	return filepath.Clean(left) == filepath.Clean(right)
 }
+func safeProfileCredentialPath(path string) bool { return noSymlinkPath(filepath.Dir(path)) }
 
 func syncProfileDirectory(path string) error {
 	directory, err := os.Open(path) // #nosec G304,G703 -- directory path is explicit and checked before use.

--- a/cmd/punaro-memory/profile_private_unix.go
+++ b/cmd/punaro-memory/profile_private_unix.go
@@ -40,6 +40,9 @@ func privateProfileFile(info os.FileInfo) bool {
 
 func privateProfileFilePath(string) bool { return true }
 func protectProfileFile(string) error    { return nil }
+func sameCleanProfilePath(left, right string) bool {
+	return filepath.Clean(left) == filepath.Clean(right)
+}
 
 func syncProfileDirectory(path string) error {
 	directory, err := os.Open(path) // #nosec G304,G703 -- directory path is explicit and checked before use.

--- a/cmd/punaro-memory/profile_private_unix.go
+++ b/cmd/punaro-memory/profile_private_unix.go
@@ -37,3 +37,15 @@ func privateProfileFile(info os.FileInfo) bool {
 	uid := os.Getuid()
 	return ok && uid >= 0 && stat.Uid == uint32(uid) && stat.Nlink == 1 && info.Mode().Perm()&0o077 == 0 // #nosec G115 -- nonnegative OS UID fits the platform field.
 }
+
+func privateProfileFilePath(string) bool { return true }
+func protectProfileFile(string) error    { return nil }
+
+func syncProfileDirectory(path string) error {
+	directory, err := os.Open(path) // #nosec G304,G703 -- directory path is explicit and checked before use.
+	if err != nil {
+		return err
+	}
+	defer func() { _ = directory.Close() }()
+	return directory.Sync()
+}

--- a/cmd/punaro-memory/profile_private_windows.go
+++ b/cmd/punaro-memory/profile_private_windows.go
@@ -2,7 +2,105 @@
 
 package main
 
-import "os"
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"unsafe"
 
-func privateProfilePath(string) bool      { return false }
-func privateProfileFile(os.FileInfo) bool { return false }
+	"golang.org/x/sys/windows"
+)
+
+func privateProfilePath(path string) bool {
+	return filepath.IsAbs(path) && filepath.Clean(path) == path && !hasWindowsUnsafePathComponent(path) && noWindowsReparseParent(path)
+}
+
+func privateProfileFile(info os.FileInfo) bool {
+	return info.Mode().IsRegular() && info.Mode()&os.ModeSymlink == 0
+}
+func privateProfileFilePath(path string) bool { return privateWindowsACL(path) }
+
+func protectProfileFile(path string) error {
+	if err := protectWindowsPath(path); err != nil || !privateWindowsACL(path) {
+		return errors.New("could not protect profile")
+	}
+	return nil
+}
+
+func syncProfileDirectory(string) error { return nil }
+
+func hasWindowsUnsafePathComponent(path string) bool {
+	rest := path[len(filepath.VolumeName(path)):]
+	for {
+		part, next, found := strings.Cut(rest, string(filepath.Separator))
+		if strings.ContainsAny(part, ":~") || strings.TrimRight(part, ". ") != part {
+			return true
+		}
+		if !found {
+			return false
+		}
+		rest = next
+	}
+}
+
+func noWindowsReparseParent(path string) bool {
+	for parent := filepath.Dir(path); ; parent = filepath.Dir(parent) {
+		attributes, err := windows.GetFileAttributes(windows.StringToUTF16Ptr(parent))
+		if err != nil || attributes&windows.FILE_ATTRIBUTE_REPARSE_POINT != 0 || attributes&windows.FILE_ATTRIBUTE_DIRECTORY == 0 {
+			return false
+		}
+		if parent == filepath.Dir(parent) {
+			return true
+		}
+	}
+}
+
+// privateWindowsACL accepts precisely the installer-owned protected DACL:
+// one FullControl ACE for the current user and no inherited or shared access.
+func privateWindowsACL(path string) bool {
+	token := windows.GetCurrentProcessToken()
+	user, err := token.GetTokenUser()
+	if err != nil || user.User.Sid == nil {
+		return false
+	}
+	sd, err := windows.GetNamedSecurityInfo(path, windows.SE_FILE_OBJECT, windows.OWNER_SECURITY_INFORMATION|windows.DACL_SECURITY_INFORMATION)
+	if err != nil {
+		return false
+	}
+	owner, _, err := sd.Owner()
+	if err != nil || owner == nil || !owner.Equals(user.User.Sid) {
+		return false
+	}
+	control, _, err := sd.Control()
+	if err != nil || control&windows.SE_DACL_PROTECTED == 0 {
+		return false
+	}
+	dacl, _, err := sd.DACL()
+	if err != nil || dacl == nil || dacl.AceCount != 1 {
+		return false
+	}
+	var ace *windows.ACCESS_ALLOWED_ACE
+	if windows.GetAce(dacl, 0, &ace) != nil || ace == nil || ace.Header.AceType != windows.ACCESS_ALLOWED_ACE_TYPE || ace.Header.AceFlags != 0 || ace.Mask != windows.ACCESS_MASK(0x1f01ff) {
+		return false
+	}
+	aceSID := (*windows.SID)(unsafe.Pointer(&ace.SidStart)) // #nosec G103 -- documented flexible-array start of this ACE SID.
+	return aceSID.Equals(user.User.Sid)
+}
+
+func protectWindowsPath(path string) error {
+	token := windows.GetCurrentProcessToken()
+	user, err := token.GetTokenUser()
+	if err != nil || user.User.Sid == nil {
+		return errors.New("current user is unavailable")
+	}
+	acl, err := windows.ACLFromEntries([]windows.EXPLICIT_ACCESS{{
+		AccessPermissions: windows.ACCESS_MASK(0x1f01ff),
+		AccessMode:        windows.GRANT_ACCESS,
+		Trustee:           windows.TRUSTEE{TrusteeForm: windows.TRUSTEE_IS_SID, TrusteeValue: windows.TrusteeValueFromSID(user.User.Sid)},
+	}}, nil)
+	if err != nil {
+		return err
+	}
+	return windows.SetNamedSecurityInfo(path, windows.SE_FILE_OBJECT, windows.OWNER_SECURITY_INFORMATION|windows.DACL_SECURITY_INFORMATION|windows.PROTECTED_DACL_SECURITY_INFORMATION, user.User.Sid, nil, acl, nil)
+}

--- a/cmd/punaro-memory/profile_private_windows.go
+++ b/cmd/punaro-memory/profile_private_windows.go
@@ -20,6 +20,9 @@ func privateProfileFile(info os.FileInfo) bool {
 	return info.Mode().IsRegular() && info.Mode()&os.ModeSymlink == 0
 }
 func privateProfileFilePath(path string) bool { return privateWindowsACL(path) }
+func sameCleanProfilePath(left, right string) bool {
+	return strings.EqualFold(filepath.Clean(left), filepath.Clean(right))
+}
 
 func protectProfileFile(path string) error {
 	if err := protectWindowsPath(path); err != nil || !privateWindowsACL(path) {

--- a/cmd/punaro-memory/profile_private_windows.go
+++ b/cmd/punaro-memory/profile_private_windows.go
@@ -19,7 +19,8 @@ func privateProfilePath(path string) bool {
 func privateProfileFile(info os.FileInfo) bool {
 	return info.Mode().IsRegular() && info.Mode()&os.ModeSymlink == 0
 }
-func privateProfileFilePath(path string) bool { return privateWindowsACL(path) }
+func privateProfileFilePath(path string) bool    { return privateWindowsACL(path) }
+func safeProfileCredentialPath(path string) bool { return noWindowsReparseParent(path) }
 func sameCleanProfilePath(left, right string) bool {
 	leftInfo, leftErr := os.Stat(left)    // #nosec G703 -- both absolute local paths are validated by the caller before a profile write.
 	rightInfo, rightErr := os.Stat(right) // #nosec G703 -- both absolute local paths are validated by the caller before a profile write.

--- a/cmd/punaro-memory/profile_private_windows.go
+++ b/cmd/punaro-memory/profile_private_windows.go
@@ -87,7 +87,7 @@ func privateWindowsACL(path string) bool {
 // children. Profile files themselves remain non-inheriting and are checked by
 // privateWindowsACL.
 func privateWindowsDirectoryACL(path string) bool {
-	return privateWindowsACLWithFlags(path, windows.OBJECT_INHERIT_ACE|windows.CONTAINER_INHERIT_ACE)
+	return privateWindowsACLWithFlags(path, 0) || privateWindowsACLWithFlags(path, windows.OBJECT_INHERIT_ACE|windows.CONTAINER_INHERIT_ACE)
 }
 
 func privateWindowsACLWithFlags(path string, flags uint8) bool {

--- a/cmd/punaro-memory/profile_private_windows.go
+++ b/cmd/punaro-memory/profile_private_windows.go
@@ -37,7 +37,18 @@ func protectProfileFile(path string) error {
 	return nil
 }
 
-func syncProfileDirectory(string) error { return nil }
+func syncProfileDirectory(path string) error {
+	name, err := windows.UTF16PtrFromString(path)
+	if err != nil {
+		return err
+	}
+	handle, err := windows.CreateFile(name, windows.GENERIC_WRITE, windows.FILE_SHARE_READ|windows.FILE_SHARE_WRITE|windows.FILE_SHARE_DELETE, nil, windows.OPEN_EXISTING, windows.FILE_FLAG_BACKUP_SEMANTICS, 0)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = windows.CloseHandle(handle) }()
+	return windows.FlushFileBuffers(handle)
+}
 
 func hasWindowsUnsafePathComponent(path string) bool {
 	rest := path[len(filepath.VolumeName(path)):]

--- a/cmd/punaro-memory/profile_private_windows.go
+++ b/cmd/punaro-memory/profile_private_windows.go
@@ -34,7 +34,7 @@ func hasWindowsUnsafePathComponent(path string) bool {
 	rest := path[len(filepath.VolumeName(path)):]
 	for {
 		part, next, found := strings.Cut(rest, string(filepath.Separator))
-		if strings.ContainsAny(part, ":~") || strings.TrimRight(part, ". ") != part {
+		if strings.Contains(part, ":") || strings.TrimRight(part, ". ") != part {
 			return true
 		}
 		if !found {

--- a/cmd/punaro-memory/profile_private_windows.go
+++ b/cmd/punaro-memory/profile_private_windows.go
@@ -13,7 +13,7 @@ import (
 )
 
 func privateProfilePath(path string) bool {
-	return filepath.IsAbs(path) && filepath.Clean(path) == path && !hasWindowsUnsafePathComponent(path) && noWindowsReparseParent(path) && privateWindowsACL(filepath.Dir(path))
+	return filepath.IsAbs(path) && filepath.Clean(path) == path && !hasWindowsUnsafePathComponent(path) && noWindowsReparseParent(path) && privateWindowsDirectoryACL(filepath.Dir(path))
 }
 
 func privateProfileFile(info os.FileInfo) bool {
@@ -68,6 +68,18 @@ func noWindowsReparseParent(path string) bool {
 // privateWindowsACL accepts precisely the installer-owned protected DACL:
 // one FullControl ACE for the current user and no inherited or shared access.
 func privateWindowsACL(path string) bool {
+	return privateWindowsACLWithFlags(path, 0)
+}
+
+// privateWindowsDirectoryACL accepts the installer-owned protected DACL for a
+// directory: one current-user FullControl ACE which propagates only to its
+// children. Profile files themselves remain non-inheriting and are checked by
+// privateWindowsACL.
+func privateWindowsDirectoryACL(path string) bool {
+	return privateWindowsACLWithFlags(path, windows.OBJECT_INHERIT_ACE|windows.CONTAINER_INHERIT_ACE)
+}
+
+func privateWindowsACLWithFlags(path string, flags uint8) bool {
 	token := windows.GetCurrentProcessToken()
 	user, err := token.GetTokenUser()
 	if err != nil || user.User.Sid == nil {
@@ -90,7 +102,7 @@ func privateWindowsACL(path string) bool {
 		return false
 	}
 	var ace *windows.ACCESS_ALLOWED_ACE
-	if windows.GetAce(dacl, 0, &ace) != nil || ace == nil || ace.Header.AceType != windows.ACCESS_ALLOWED_ACE_TYPE || ace.Header.AceFlags != 0 || ace.Mask != windows.ACCESS_MASK(0x1f01ff) {
+	if windows.GetAce(dacl, 0, &ace) != nil || ace == nil || ace.Header.AceType != windows.ACCESS_ALLOWED_ACE_TYPE || ace.Header.AceFlags != flags || ace.Mask != windows.ACCESS_MASK(0x1f01ff) {
 		return false
 	}
 	aceSID := (*windows.SID)(unsafe.Pointer(&ace.SidStart)) // #nosec G103 -- documented flexible-array start of this ACE SID.
@@ -98,6 +110,14 @@ func privateWindowsACL(path string) bool {
 }
 
 func protectWindowsPath(path string) error {
+	return protectWindowsPathWithFlags(path, 0)
+}
+
+func protectWindowsDirectory(path string) error {
+	return protectWindowsPathWithFlags(path, windows.OBJECT_INHERIT_ACE|windows.CONTAINER_INHERIT_ACE)
+}
+
+func protectWindowsPathWithFlags(path string, inheritance uint32) error {
 	token := windows.GetCurrentProcessToken()
 	user, err := token.GetTokenUser()
 	if err != nil || user.User.Sid == nil {
@@ -106,6 +126,7 @@ func protectWindowsPath(path string) error {
 	acl, err := windows.ACLFromEntries([]windows.EXPLICIT_ACCESS{{
 		AccessPermissions: windows.ACCESS_MASK(0x1f01ff),
 		AccessMode:        windows.GRANT_ACCESS,
+		Inheritance:       inheritance,
 		Trustee:           windows.TRUSTEE{TrusteeForm: windows.TRUSTEE_IS_SID, TrusteeValue: windows.TrusteeValueFromSID(user.User.Sid)},
 	}}, nil)
 	if err != nil {

--- a/cmd/punaro-memory/profile_private_windows.go
+++ b/cmd/punaro-memory/profile_private_windows.go
@@ -13,7 +13,7 @@ import (
 )
 
 func privateProfilePath(path string) bool {
-	return filepath.IsAbs(path) && filepath.Clean(path) == path && !hasWindowsUnsafePathComponent(path) && noWindowsReparseParent(path)
+	return filepath.IsAbs(path) && filepath.Clean(path) == path && !hasWindowsUnsafePathComponent(path) && noWindowsReparseParent(path) && privateWindowsACL(filepath.Dir(path))
 }
 
 func privateProfileFile(info os.FileInfo) bool {
@@ -21,6 +21,11 @@ func privateProfileFile(info os.FileInfo) bool {
 }
 func privateProfileFilePath(path string) bool { return privateWindowsACL(path) }
 func sameCleanProfilePath(left, right string) bool {
+	leftInfo, leftErr := os.Stat(left)    // #nosec G703 -- both absolute local paths are validated by the caller before a profile write.
+	rightInfo, rightErr := os.Stat(right) // #nosec G703 -- both absolute local paths are validated by the caller before a profile write.
+	if leftErr == nil && rightErr == nil && os.SameFile(leftInfo, rightInfo) {
+		return true
+	}
 	return strings.EqualFold(filepath.Clean(left), filepath.Clean(right))
 }
 

--- a/cmd/punaro-memory/profile_private_windows_test.go
+++ b/cmd/punaro-memory/profile_private_windows_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestWindowsProfileRequiresExclusiveDACL(t *testing.T) {
 	directory := t.TempDir()
-	if err := protectWindowsPath(directory); err != nil {
+	if err := protectWindowsDirectory(directory); err != nil {
 		t.Fatal(err)
 	}
 	path := filepath.Join(directory, "memory-profile.json")
@@ -33,7 +33,7 @@ func TestWindowsProfileRequiresExclusiveDACL(t *testing.T) {
 
 func TestWindowsProfileWriteAndRead(t *testing.T) {
 	directory := t.TempDir()
-	if err := protectWindowsPath(directory); err != nil {
+	if err := protectWindowsDirectory(directory); err != nil {
 		t.Fatal(err)
 	}
 	path := filepath.Join(directory, "memory-profile.json")

--- a/cmd/punaro-memory/profile_private_windows_test.go
+++ b/cmd/punaro-memory/profile_private_windows_test.go
@@ -55,6 +55,16 @@ func TestWindowsProfileRequiresExclusiveParentDirectory(t *testing.T) {
 	}
 }
 
+func TestWindowsProfileAllowsEnrollmentStylePrivateParentDirectory(t *testing.T) {
+	directory := t.TempDir()
+	if err := protectWindowsPath(directory); err != nil {
+		t.Fatal(err)
+	}
+	if !privateProfilePath(filepath.Join(directory, "memory-profile.json")) {
+		t.Fatal("exclusive non-inheriting profile parent was rejected")
+	}
+}
+
 func TestWindowsProfileRejectsCaseInsensitiveCredentialAlias(t *testing.T) {
 	profile := `C:\Punaro\DEVICE.CREDENTIAL`
 	credential := `c:\punaro\device.credential`

--- a/cmd/punaro-memory/profile_private_windows_test.go
+++ b/cmd/punaro-memory/profile_private_windows_test.go
@@ -11,7 +11,11 @@ import (
 )
 
 func TestWindowsProfileRequiresExclusiveDACL(t *testing.T) {
-	path := filepath.Join(t.TempDir(), "memory-profile.json")
+	directory := t.TempDir()
+	if err := protectWindowsPath(directory); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(directory, "memory-profile.json")
 	if err := os.WriteFile(path, []byte(`{"version":1}`), 0o600); err != nil {
 		t.Fatal(err)
 	}
@@ -28,7 +32,11 @@ func TestWindowsProfileRequiresExclusiveDACL(t *testing.T) {
 }
 
 func TestWindowsProfileWriteAndRead(t *testing.T) {
-	path := filepath.Join(t.TempDir(), "memory-profile.json")
+	directory := t.TempDir()
+	if err := protectWindowsPath(directory); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(directory, "memory-profile.json")
 	value := profile{Origin: "https://memory.example.test", CredentialFile: filepath.Join(filepath.Dir(path), "device.credential")}
 	if err := saveProfile(path, value); err != nil {
 		t.Fatal(err)
@@ -36,6 +44,14 @@ func TestWindowsProfileWriteAndRead(t *testing.T) {
 	loaded, err := loadProfile(path)
 	if err != nil || loaded.Origin != value.Origin || loaded.CredentialFile != value.CredentialFile {
 		t.Fatalf("profile=%#v err=%v", loaded, err)
+	}
+}
+
+func TestWindowsProfileRequiresExclusiveParentDirectory(t *testing.T) {
+	directory := t.TempDir()
+	path := filepath.Join(directory, "memory-profile.json")
+	if privateProfilePath(path) {
+		t.Fatal("shared profile parent directory was accepted")
 	}
 }
 

--- a/cmd/punaro-memory/profile_private_windows_test.go
+++ b/cmd/punaro-memory/profile_private_windows_test.go
@@ -39,6 +39,14 @@ func TestWindowsProfileWriteAndRead(t *testing.T) {
 	}
 }
 
+func TestWindowsProfileRejectsCaseInsensitiveCredentialAlias(t *testing.T) {
+	profile := `C:\Punaro\DEVICE.CREDENTIAL`
+	credential := `c:\punaro\device.credential`
+	if !sameCleanProfilePath(profile, credential) {
+		t.Fatal("Windows case-insensitive credential alias was not detected")
+	}
+}
+
 func setMemoryProfileACL(t *testing.T, path, additionalACE string) {
 	t.Helper()
 	user, err := windows.GetCurrentProcessToken().GetTokenUser()

--- a/cmd/punaro-memory/profile_private_windows_test.go
+++ b/cmd/punaro-memory/profile_private_windows_test.go
@@ -29,7 +29,7 @@ func TestWindowsProfileRequiresExclusiveDACL(t *testing.T) {
 
 func TestWindowsProfileWriteAndRead(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "memory-profile.json")
-	value := profile{Origin: "https://memory.example.test", CredentialFile: `C:\Punaro\device.credential`}
+	value := profile{Origin: "https://memory.example.test", CredentialFile: filepath.Join(filepath.Dir(path), "device.credential")}
 	if err := saveProfile(path, value); err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/punaro-memory/profile_private_windows_test.go
+++ b/cmd/punaro-memory/profile_private_windows_test.go
@@ -1,0 +1,60 @@
+//go:build windows
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"golang.org/x/sys/windows"
+)
+
+func TestWindowsProfileRequiresExclusiveDACL(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "memory-profile.json")
+	if err := os.WriteFile(path, []byte(`{"version":1}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := protectWindowsPath(path); err != nil {
+		t.Fatal(err)
+	}
+	if !privateProfilePath(path) || !privateProfileFilePath(path) {
+		t.Fatal("exclusive profile was rejected")
+	}
+	setMemoryProfileACL(t, path, "(A;;FR;;;WD)")
+	if privateProfileFilePath(path) {
+		t.Fatal("shared profile ACL was accepted")
+	}
+}
+
+func TestWindowsProfileWriteAndRead(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "memory-profile.json")
+	value := profile{Origin: "https://memory.example.test", CredentialFile: `C:\Punaro\device.credential`}
+	if err := saveProfile(path, value); err != nil {
+		t.Fatal(err)
+	}
+	loaded, err := loadProfile(path)
+	if err != nil || loaded.Origin != value.Origin || loaded.CredentialFile != value.CredentialFile {
+		t.Fatalf("profile=%#v err=%v", loaded, err)
+	}
+}
+
+func setMemoryProfileACL(t *testing.T, path, additionalACE string) {
+	t.Helper()
+	user, err := windows.GetCurrentProcessToken().GetTokenUser()
+	if err != nil || user.User.Sid == nil {
+		t.Fatalf("current user: %v", err)
+	}
+	sid := user.User.Sid.String()
+	sd, err := windows.SecurityDescriptorFromString("O:" + sid + "D:P(A;;FA;;;" + sid + ")" + additionalACE)
+	if err != nil {
+		t.Fatal(err)
+	}
+	dacl, _, err := sd.DACL()
+	if err != nil || dacl == nil {
+		t.Fatalf("DACL: %v", err)
+	}
+	if err := windows.SetNamedSecurityInfo(path, windows.SE_FILE_OBJECT, windows.OWNER_SECURITY_INFORMATION|windows.DACL_SECURITY_INFORMATION|windows.PROTECTED_DACL_SECURITY_INFORMATION, user.User.Sid, nil, dacl, nil); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -331,17 +331,17 @@ an existing private download root. Follow the
 send, receive, and delete safety boundaries. No production installer accepts
 legacy v2/v3 authority, role, directory, wrapping-key, or permit options.
 
-On macOS and Linux the same installer also builds `punaro-memory`, the native
+The same installer on macOS, Linux, and Windows also builds `punaro-memory`, the native
 client for an already enabled M-17 memory API. Supply the fixed HTTPS origin,
 an absolute owner-only device credential file, and explicit project/key/ETag
 coordinates, or write a protected non-secret profile containing only the
 origin, credential-file path, and optional default project; see the
 [operator guide](operator-guide.md#native-memory-client). The same binary can
 run as a local stdio MCP server with `punaro-memory mcp --profile ...`; this is
-local profile-backed MCP, not the later remote OAuth MCP gateway. Windows memory
-credential loading remains fail-closed until a later slice adds paired ACL and
-reparse-point provisioning and verification, so the Windows installer does not
-install this binary yet.
+local profile-backed MCP, not the later remote OAuth MCP gateway. On Windows,
+store both the profile and credential in files protected by the current-user-only
+ACL that the installer uses below `%LOCALAPPDATA%\Punaro`; reparse points,
+shared ACLs, and replacement races fail closed.
 
 ## Agent mailbox behavior
 

--- a/docs/operator-guide.md
+++ b/docs/operator-guide.md
@@ -668,13 +668,16 @@ adapter, semantic retrieval, offline queue, or Compose Pi integration.
 ### Native memory client
 
 M-17C1 adds `punaro-memory` without changing the server activation flags. Build
-it with `make memory-client`; the macOS/Linux client installer also places it
-in `~/.local/bin`. The operator must separately provision an absolute regular
-credential file below non-writable, non-symlink parent directories. The file
-must be owned by the current user, have no group/other permissions, and have
-exactly one hard link. The CLI accepts an explicit HTTPS `--origin` and
-`--credential-file`, and the bearer credential value is never stored by the
-client.
+it with `make memory-client`; the macOS/Linux installer places it in
+`~/.local/bin` and the Windows installer places `punaro-memory.exe` below
+`%LOCALAPPDATA%\Punaro\bin`. The operator must separately provision an absolute
+regular credential file. On macOS/Linux it must be below non-writable,
+non-symlink parent directories, owned by the current user, have no group/other
+permissions, and have exactly one hard link. On Windows it must have one
+protected FullControl ACE for the current user and no shared ACEs, and neither
+the credential nor any parent may be a reparse point. The CLI accepts an
+explicit HTTPS `--origin` and `--credential-file`, and the bearer credential
+value is never stored by the client.
 
 M-17C2 adds a protected local profile for convenience. Create it only with an
 absolute target path:
@@ -689,7 +692,9 @@ punaro-memory profile-write \
 
 The profile is an atomically replaced `0600` JSON file containing only
 non-secret defaults: origin, credential-file path, and optional project UUID.
-Normal commands may pass `--profile`; explicit `--origin`, `--credential-file`,
+On Windows the binary writes and verifies the equivalent exclusive current-user
+DACL before reading it; reparse points, shared ACLs, and replacement races are
+rejected. Normal commands may pass `--profile`; explicit `--origin`, `--credential-file`,
 and `--project` flags override the profile defaults for that invocation.
 
 Pass an explicit `--project` UUID to project-scoped commands. `resolve` accepts
@@ -705,9 +710,7 @@ The client makes one request and exits. It has no implicit retry, writable
 cache, queue, Git configuration lookup, project registry, stdin body, or
 fallback memory. A retry is an explicit caller decision using the same body,
 key, and ETag. Errors are deliberately generic; use server-side content-free
-audit metadata for diagnosis. Windows credential loading is intentionally
-unavailable until a later slice pairs protected credential/profile creation
-with verified DACL and reparse-point handling.
+audit metadata for diagnosis.
 
 M-17D adds local stdio MCP mode to the same binary:
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -33,7 +33,7 @@ then have the operator provision its protected credential file, fixed trusted
 origin, project UUID, and safe download root. The installer never reads or
 prints the credential.
 
-On macOS and Linux the installer also provides `punaro-memory` for an already
+On macOS, Linux, and Windows the installer also provides `punaro-memory` for an already
 enabled native memory API. Every command either names the fixed HTTPS origin,
 protected credential file, project or resolver input, and any required
 idempotency key and strong ETag, or uses an explicit protected profile that

--- a/internal/memoryclient/credential_windows.go
+++ b/internal/memoryclient/credential_windows.go
@@ -3,15 +3,94 @@
 package memoryclient
 
 import (
-	"errors"
 	"os"
+	"path/filepath"
+	"strings"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
 )
 
-// Strong DACL/reparse verification is delivered with the persisted Windows profile in M17C2.
-// Until then the stateless CLI fails closed rather than trusting POSIX mode bits on Windows.
-func privateCredentialPath(string) bool              { return false }
-func privateCredentialFile(string, os.FileInfo) bool { return false }
+func privateCredentialPath(path string) bool {
+	return filepath.IsAbs(path) && filepath.Clean(path) == path && !hasUnsafeComponent(path) && noWindowsReparseParent(path)
+}
 
-func openCredential(string) (*os.File, error) {
-	return nil, errors.New("protected credential loading is unavailable on Windows")
+func privateCredentialFile(path string, info os.FileInfo) bool {
+	return info.Mode().IsRegular() && info.Mode()&os.ModeSymlink == 0 && privateWindowsACL(path)
+}
+
+func openCredential(path string) (*os.File, error) {
+	name, err := windows.UTF16PtrFromString(path)
+	if err != nil {
+		return nil, err
+	}
+	handle, err := windows.CreateFile(name, windows.GENERIC_READ, windows.FILE_SHARE_READ, nil, windows.OPEN_EXISTING, windows.FILE_ATTRIBUTE_NORMAL|windows.FILE_FLAG_OPEN_REPARSE_POINT, 0) // #nosec G304 -- explicit local credential path is checked before and after open.
+	if err != nil {
+		return nil, err
+	}
+	var details windows.ByHandleFileInformation
+	if err := windows.GetFileInformationByHandle(handle, &details); err != nil || details.FileAttributes&windows.FILE_ATTRIBUTE_REPARSE_POINT != 0 || details.FileAttributes&windows.FILE_ATTRIBUTE_DIRECTORY != 0 {
+		_ = windows.CloseHandle(handle)
+		if err != nil {
+			return nil, err
+		}
+		return nil, os.ErrInvalid
+	}
+	return os.NewFile(uintptr(handle), path), nil // #nosec G115 -- successful Win32 handles are nonnegative.
+}
+
+func hasUnsafeComponent(path string) bool {
+	rest := path[len(filepath.VolumeName(path)):]
+	for {
+		part, next, found := strings.Cut(rest, string(filepath.Separator))
+		if strings.ContainsAny(part, ":~") || strings.TrimRight(part, ". ") != part {
+			return true
+		}
+		if !found {
+			return false
+		}
+		rest = next
+	}
+}
+
+func noWindowsReparseParent(path string) bool {
+	for parent := filepath.Dir(path); ; parent = filepath.Dir(parent) {
+		attributes, err := windows.GetFileAttributes(windows.StringToUTF16Ptr(parent))
+		if err != nil || attributes&windows.FILE_ATTRIBUTE_REPARSE_POINT != 0 || attributes&windows.FILE_ATTRIBUTE_DIRECTORY == 0 {
+			return false
+		}
+		if parent == filepath.Dir(parent) {
+			return true
+		}
+	}
+}
+
+func privateWindowsACL(path string) bool {
+	token := windows.GetCurrentProcessToken()
+	user, err := token.GetTokenUser()
+	if err != nil || user.User.Sid == nil {
+		return false
+	}
+	sd, err := windows.GetNamedSecurityInfo(path, windows.SE_FILE_OBJECT, windows.OWNER_SECURITY_INFORMATION|windows.DACL_SECURITY_INFORMATION)
+	if err != nil {
+		return false
+	}
+	owner, _, err := sd.Owner()
+	if err != nil || owner == nil || !owner.Equals(user.User.Sid) {
+		return false
+	}
+	control, _, err := sd.Control()
+	if err != nil || control&windows.SE_DACL_PROTECTED == 0 {
+		return false
+	}
+	dacl, _, err := sd.DACL()
+	if err != nil || dacl == nil || dacl.AceCount != 1 {
+		return false
+	}
+	var ace *windows.ACCESS_ALLOWED_ACE
+	if windows.GetAce(dacl, 0, &ace) != nil || ace == nil || ace.Header.AceType != windows.ACCESS_ALLOWED_ACE_TYPE || ace.Header.AceFlags != 0 || ace.Mask != windows.ACCESS_MASK(0x1f01ff) {
+		return false
+	}
+	aceSID := (*windows.SID)(unsafe.Pointer(&ace.SidStart)) // #nosec G103 -- documented flexible-array start of this ACE SID.
+	return aceSID.Equals(user.User.Sid)
 }

--- a/internal/memoryclient/credential_windows.go
+++ b/internal/memoryclient/credential_windows.go
@@ -43,7 +43,7 @@ func hasUnsafeComponent(path string) bool {
 	rest := path[len(filepath.VolumeName(path)):]
 	for {
 		part, next, found := strings.Cut(rest, string(filepath.Separator))
-		if strings.ContainsAny(part, ":~") || strings.TrimRight(part, ". ") != part {
+		if strings.Contains(part, ":") || strings.TrimRight(part, ". ") != part {
 			return true
 		}
 		if !found {

--- a/internal/memoryclient/credential_windows_test.go
+++ b/internal/memoryclient/credential_windows_test.go
@@ -4,6 +4,7 @@ package memoryclient
 
 import (
 	"encoding/base64"
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -26,6 +27,36 @@ func TestWindowsLoadCredentialRequiresExclusiveDACL(t *testing.T) {
 	setMemoryCredentialACL(t, path, "(A;;FR;;;WD)")
 	if _, err := LoadCredential(path); err == nil {
 		t.Fatal("shared credential ACL was accepted")
+	}
+}
+
+func TestWindowsLoadCredentialRejectsFileAndParentReparsePoints(t *testing.T) {
+	credential := uuid.NewString() + "." + base64.RawURLEncoding.EncodeToString(make([]byte, 32))
+	targetDirectory := t.TempDir()
+	target := filepath.Join(targetDirectory, "device.credential")
+	if err := os.WriteFile(target, []byte(credential+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	setMemoryCredentialACL(t, target, "")
+	fileLink := filepath.Join(t.TempDir(), "device-link")
+	if err := os.Symlink(target, fileLink); err != nil {
+		if errors.Is(err, windows.ERROR_PRIVILEGE_NOT_HELD) {
+			t.Skip("Windows symbolic-link privilege is unavailable")
+		}
+		t.Fatal(err)
+	}
+	if _, err := LoadCredential(fileLink); err == nil {
+		t.Fatal("credential file reparse point was accepted")
+	}
+	parentLink := filepath.Join(t.TempDir(), "credential-parent")
+	if err := os.Symlink(targetDirectory, parentLink); err != nil {
+		if errors.Is(err, windows.ERROR_PRIVILEGE_NOT_HELD) {
+			t.Skip("Windows symbolic-link privilege is unavailable")
+		}
+		t.Fatal(err)
+	}
+	if _, err := LoadCredential(filepath.Join(parentLink, "device.credential")); err == nil {
+		t.Fatal("credential below reparse-point parent was accepted")
 	}
 }
 

--- a/internal/memoryclient/credential_windows_test.go
+++ b/internal/memoryclient/credential_windows_test.go
@@ -1,0 +1,50 @@
+//go:build windows
+
+package memoryclient
+
+import (
+	"encoding/base64"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/google/uuid"
+	"golang.org/x/sys/windows"
+)
+
+func TestWindowsLoadCredentialRequiresExclusiveDACL(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "device.credential")
+	credential := uuid.NewString() + "." + base64.RawURLEncoding.EncodeToString(make([]byte, 32))
+	if err := os.WriteFile(path, []byte(credential+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	setMemoryCredentialACL(t, path, "")
+	loaded, err := LoadCredential(path)
+	if err != nil || loaded != credential {
+		t.Fatalf("credential=%q err=%v", loaded, err)
+	}
+	setMemoryCredentialACL(t, path, "(A;;FR;;;WD)")
+	if _, err := LoadCredential(path); err == nil {
+		t.Fatal("shared credential ACL was accepted")
+	}
+}
+
+func setMemoryCredentialACL(t *testing.T, path, additionalACE string) {
+	t.Helper()
+	user, err := windows.GetCurrentProcessToken().GetTokenUser()
+	if err != nil || user.User.Sid == nil {
+		t.Fatalf("current user: %v", err)
+	}
+	sid := user.User.Sid.String()
+	sd, err := windows.SecurityDescriptorFromString("O:" + sid + "D:P(A;;FA;;;" + sid + ")" + additionalACE)
+	if err != nil {
+		t.Fatal(err)
+	}
+	dacl, _, err := sd.DACL()
+	if err != nil || dacl == nil {
+		t.Fatalf("DACL: %v", err)
+	}
+	if err := windows.SetNamedSecurityInfo(path, windows.SE_FILE_OBJECT, windows.OWNER_SECURITY_INFORMATION|windows.DACL_SECURITY_INFORMATION|windows.PROTECTED_DACL_SECURITY_INFORMATION, user.User.Sid, nil, dacl, nil); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/scripts/install-client.ps1
+++ b/scripts/install-client.ps1
@@ -135,6 +135,7 @@ $MailboxStateDir = Get-FullPath $MailboxStateDir
 
 Build-PunaroBinary -Package (Join-Path $repoDir 'cmd\punaro-adapter') -Output (Join-Path $binDir 'punaro-adapter.exe')
 Build-PunaroBinary -Package (Join-Path $repoDir 'cmd\punaro-trusted-attachment') -Output (Join-Path $binDir 'punaro-trusted-attachment.exe')
+Build-PunaroBinary -Package (Join-Path $repoDir 'cmd\punaro-memory') -Output (Join-Path $binDir 'punaro-memory.exe')
 Build-PunaroBinary -Package (Join-Path $repoDir 'cmd\punaro-enroll') -Output (Join-Path $binDir 'punaro-enroll.exe')
 Build-PunaroBinary -Package (Join-Path $repoDir 'cmd\punaro-keygen') -Output (Join-Path $binDir 'punaro-keygen.exe')
 foreach ($name in @('Run-PunaroAdapter.ps1', 'Import-PunaroEnvironment.ps1')) {

--- a/scripts/test-install-client-windows.ps1
+++ b/scripts/test-install-client-windows.ps1
@@ -16,7 +16,7 @@ foreach ($path in $paths) {
 }
 
 $installer = [System.IO.File]::ReadAllText((Join-Path $repoDir 'scripts\install-client.ps1'))
-foreach ($expected in @('LogonType Interactive', 'ExecutionTimeLimit ([TimeSpan]::Zero)', 'SetAccessRuleProtection($true, $false)', '-ExecutionPolicy Bypass', 'ForEach-Object { $_.address }', 'punaro-trusted-attachment.exe', 'punaro-enroll.exe', 'agent-mailbox', 'AgentGuidanceDir')) {
+foreach ($expected in @('LogonType Interactive', 'ExecutionTimeLimit ([TimeSpan]::Zero)', 'SetAccessRuleProtection($true, $false)', '-ExecutionPolicy Bypass', 'ForEach-Object { $_.address }', 'punaro-trusted-attachment.exe', 'punaro-memory.exe', 'punaro-enroll.exe', 'agent-mailbox', 'AgentGuidanceDir')) {
     if (-not $installer.Contains($expected)) { throw "Windows installer is missing required behavior: $expected" }
 }
 $allScripts = ($paths | ForEach-Object { [System.IO.File]::ReadAllText($_) }) -join "`n"
@@ -56,7 +56,7 @@ try {
     & (Join-Path $repoDir 'scripts\install-client.ps1') -RelayUrl 'https://relay.example.test' -MachineId 'windows-test' -AgentMailboxBin $mailbox -AgentGuidanceDir $project
     if ($LASTEXITCODE -ne 0) { throw 'Windows client installer failed' }
     $root = Join-Path $env:LOCALAPPDATA 'Punaro'
-    foreach ($path in @((Join-Path $root 'config\machine.key'), (Join-Path $root 'config\enrollment.json'), (Join-Path $root 'config\adapter.env'), (Join-Path $root 'bin\punaro-trusted-attachment.exe'), (Join-Path $root 'bin\punaro-enroll.exe'), (Join-Path $project '.agents\skills\punaro-mailbox\SKILL.md'))) {
+    foreach ($path in @((Join-Path $root 'config\machine.key'), (Join-Path $root 'config\enrollment.json'), (Join-Path $root 'config\adapter.env'), (Join-Path $root 'bin\punaro-trusted-attachment.exe'), (Join-Path $root 'bin\punaro-memory.exe'), (Join-Path $root 'bin\punaro-enroll.exe'), (Join-Path $project '.agents\skills\punaro-mailbox\SKILL.md'))) {
         if (-not (Test-Path -LiteralPath $path -PathType Leaf)) { throw "Windows client installer did not create $path" }
     }
     foreach ($path in @((Join-Path $root 'bin\punaro-attachment.exe'), (Join-Path $root 'bin\punaro-directory.exe'), (Join-Path $root 'bin\punaro-dpapi.exe'), (Join-Path $root 'Run-PunaroAttachment.ps1'))) {


### PR DESCRIPTION
Closes #116\n\nImplements the Windows native-memory client path:\n- installs punaro-memory.exe with the unified Windows client installer\n- loads credentials only from exclusive current-user DACL files and rejects reparse points/replacement races\n- writes and validates protected MCP/CLI profiles\n- adds Windows-native ACL tests and CI coverage\n- updates supported-platform onboarding documentation\n\nValidation: make test, make test-race, make staticcheck, make security, make lint, make memory-onboarding-e2e, and Windows cross-build/test compilation. The direct Windows host SSH key agent refused signing, so native execution is covered by the existing Windows CI lane.