### PR TITLE
feat: deploy durable conversation roles

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -307,6 +307,9 @@ roles receive nothing. The relay rejects an unknown or non-receiving role
 before allocating a message sequence or idempotency row. The target role is
 part of the sender's idempotency request hash, while an untargeted request keeps
 the pre-targeting broadcast hash so retries remain valid across upgrades.
+Every leased role delivery carries a server-derived `recipient_role`; the
+adapter preserves it in the inert mailbox envelope so two roles bound to one
+session remain distinguishable without interpreting the untrusted body.
 
 Each conversation has an explicit membership table with `send`, `receive`,
 and `admin` capabilities. Roles may use only those three capabilities;

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -299,6 +299,15 @@ listing, and wake routing authorize an active role binding as well as an
 existing endpoint member, while legacy endpoint membership retains its current
 behavior unchanged.
 
+Message routing is explicit and server-authorized. Omitting `target_role`
+preserves broadcast delivery to every receiving endpoint and role member other
+than the sending endpoint. Supplying a non-empty `target_role` creates a
+delivery only for that receiving role membership; endpoint members and other
+roles receive nothing. The relay rejects an unknown or non-receiving role
+before allocating a message sequence or idempotency row. The target role is
+part of the sender's idempotency request hash, while an untargeted request keeps
+the pre-targeting broadcast hash so retries remain valid across upgrades.
+
 Each conversation has an explicit membership table with `send`, `receive`,
 and `admin` capabilities. Roles may use only those three capabilities;
 `invoke` is endpoint-only because a role has no stable process target. The
@@ -802,7 +811,7 @@ API client and reaches the relay using its own enrolled machine credential.
 | `POST` | `/v1/conversations` | Create a conversation with explicit members; idempotent per signed machine and key. |
 | `POST` | `/v1/roles/bindings` | Renew one durable role onto a currently attached session of its owning machine. |
 | `GET` | `/v1/conversations` | List conversations the caller may discover. |
-| `POST` | `/v1/conversations/{id}/messages` | Append an authorized message. |
+| `POST` | `/v1/conversations/{id}/messages` | Append an authorized broadcast, or set `target_role` for one durable receiving role. |
 | `POST` | `/v1/conversations/{id}/invocations` | Request a server-authorized, body-free offline-role handoff. |
 | `POST` | `/v1/deliveries/lease` | Lease bounded durable deliveries for one endpoint. |
 | `POST` | `/v1/deliveries/{id}/ack` | Acknowledge after local injection. |

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1319,10 +1319,14 @@ only a public key recorded in the durable cutover enrollment history, so a
 temporary revocation does not strand a previously migrated machine. A new
 post-cutover machine uses the separate owner-only `punaro relay register`
 workflow. It accepts one protected installer-produced public enrollment object,
-serializes with the active cutover and legacy gate, and commits an idempotent
-content-free PostgreSQL legacy-machine registration before extending the local
-known-key history and static relay enrollment marker-last. A crash can therefore
-leave only a registered but unauthenticated key; the exact command safely
+holds the installation's host-local authority lock across local-state loading,
+active-cutover and legacy-gate registration, and marker-last publication, and
+commits an idempotent content-free PostgreSQL legacy-machine registration
+before extending the local known-key history and static relay enrollment. A
+concurrent cutover, configure, or register command fails before mutation and
+can retry exactly. A crash releases the lock and, because the database commit
+precedes local publication, can leave only a registered but unauthenticated
+key; the exact command safely
 retries, while a changed label, key, endpoint authority, non-owner caller,
 inactive cutover, or conflicting recovery fails closed. The transaction does
 not reopen the migration-wide legacy gate: under an active cutover, only its

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -321,14 +321,14 @@ Cloudflare; revoking the machine credential stops it at Punaro. Store both in
 the OS keychain or a root-readable service secret file, never in an agent
 prompt, repository, or mailbox body.
 
-Some Cloudflare Access deployments establish a service-token session through
-an initial redirect. Before a signed adapter operation, the client may perform
-a payload-free session preflight that carries only the two Access headers. It
-may follow at most one HTTPS hop to a `*.cloudflareaccess.com` host and then
-only back to the exact relay origin; it requires an origin-scoped
-`CF_Authorization` cookie before proceeding. Signed request bodies, machine
-signatures, nonces, and idempotency keys are never replayed through this flow.
-All signed relay operations still reject redirects.
+Cloudflare Access Service Auth authenticates every protected request from that
+machine's service-token headers. Adapter and enrollment clients therefore send
+both headers on every protected request and never establish, retain, or replay
+a browser `CF_Authorization` cookie alongside them. Mixing those two identity
+mechanisms can be rejected by Access before the signed relay request reaches
+Punaro. Signed request bodies, machine signatures, nonces, and idempotency keys
+are never sent through an Access-session preflight. All signed relay operations
+still reject redirects.
 
 `punarod` validates Cloudflare Access JWTs itself (audience, issuer, expiry,
 not-before, and signature via cached JWKS) in addition to accepting traffic

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1300,9 +1300,20 @@ marker-last before SQLite prepare, remains the canonical endpoint authority
 after cutover, and cannot be changed by a recovery retry. The complete static
 set can subsequently revoke any machine, including every machine via explicit
 `[]`; that restart-safe revocation fails closed. A later replacement may restore
-only a public key recorded in the durable cutover enrollment history, never a
-new key, so a temporary revocation does not strand a previously migrated
-machine. SQLite prepare fences
+only a public key recorded in the durable cutover enrollment history, so a
+temporary revocation does not strand a previously migrated machine. A new
+post-cutover machine uses the separate owner-only `punaro relay register`
+workflow. It accepts one protected installer-produced public enrollment object,
+serializes with the active cutover and legacy gate, and commits an idempotent
+content-free PostgreSQL legacy-machine registration before extending the local
+known-key history and static relay enrollment marker-last. A crash can therefore
+leave only a registered but unauthenticated key; the exact command safely
+retries, while a changed label, key, endpoint authority, non-owner caller,
+inactive cutover, disabled legacy gate, or conflicting recovery fails closed.
+The new key remains pending for an eventual proof-bound device-credential
+exchange and prevents premature legacy-gate closure. This workflow neither
+copies another machine's authority nor treats the public record, machine name,
+or device credential as authorization by itself. SQLite prepare fences
 old daemons and clears every lease holder while advancing fences. Staging is
 bounded to 128 rows per page and resumes from durable PostgreSQL checkpoints.
 Verification rejects any missing, extra, reordered, malformed, or changed row.

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1242,8 +1242,10 @@ behind its explicit ingress transport policy. Credential caches
 and long-lived sessions revalidate within two seconds. The existing Ed25519
 relay remains active while its intended machines are durably inventoried as
 pending, migrated, or retired; the global legacy gate cannot close while any
-machine is pending. PostgreSQL remains dark for mail and SQLite routing is
-unchanged.
+machine is pending before cutover. After mail cutover is active, an
+owner-registered new machine is deliberately pending but is admitted by that
+active-cutover record rather than by reopening the migration-wide gate.
+PostgreSQL remains dark for mail and SQLite routing is unchanged.
 
 The dormant M-9 credential-transition bridge does not duplicate relay
 authority in PostgreSQL. A successful proof-bound exchange already records the
@@ -1255,11 +1257,14 @@ exactly the existing endpoint prefixes, exact endpoints, and attachment-device
 binding. Duplicate configured public keys fail startup. Ordinary device
 credentials, stale generations, retired mappings, and unavailable database
 state fail authentication without revealing which check failed. In the same
-mode every Ed25519 relay request consults the durable legacy gate after
-signature verification and before consuming its nonce; closing the gate blocks
-new legacy requests while migrated credentials remain usable. The switch is
-off by default and requires device auth plus the PostgreSQL relay, so this
-slice does not activate PostgreSQL mail authority or change the SQLite default.
+mode every Ed25519 relay request consults durable transition authority after
+signature verification and before consuming its nonce. The open legacy gate
+admits the pre-cutover migration inventory. Once mail cutover is active and
+that gate is closed, only a pending key added by the owner-only post-cutover
+registration transaction is admitted; migrated and retired legacy keys remain
+blocked while migrated credentials remain usable. The switch is off by default
+and requires device auth plus the PostgreSQL relay, so this slice does not
+activate PostgreSQL mail authority or change the SQLite default.
 Long-lived notification sockets retain only a non-secret generation/gate fence,
 not the bearer credential. A check starts every second with a one-second
 deadline in a dedicated loop; wake writes cannot delay it, and fence failure
@@ -1319,9 +1324,11 @@ content-free PostgreSQL legacy-machine registration before extending the local
 known-key history and static relay enrollment marker-last. A crash can therefore
 leave only a registered but unauthenticated key; the exact command safely
 retries, while a changed label, key, endpoint authority, non-owner caller,
-inactive cutover, disabled legacy gate, or conflicting recovery fails closed.
-The new key remains pending for an eventual proof-bound device-credential
-exchange and prevents premature legacy-gate closure. This workflow neither
+inactive cutover, or conflicting recovery fails closed. The transaction does
+not reopen the migration-wide legacy gate: under an active cutover, only its
+new pending key becomes eligible for Ed25519 request resolution. Migrated and
+retired keys stay blocked. The new key remains pending for an eventual
+proof-bound device-credential exchange. This workflow neither
 copies another machine's authority nor treats the public record, machine name,
 or device credential as authorization by itself. SQLite prepare fences
 old daemons and clears every lease holder while advancing fences. Staging is

--- a/cmd/punaro-adapter/main.go
+++ b/cmd/punaro-adapter/main.go
@@ -350,6 +350,7 @@ func runBindRole(args []string) error {
 type sendRequest struct {
 	conversationID string
 	fromEndpoint   string
+	targetRole     string
 	bodyFile       string
 	idempotencyKey string
 }
@@ -360,6 +361,7 @@ func parseSendArgs(args []string) (sendRequest, error) {
 	var request sendRequest
 	flags.StringVar(&request.conversationID, "conversation", "", "conversation ID")
 	flags.StringVar(&request.fromEndpoint, "from", "", "attached sender endpoint")
+	flags.StringVar(&request.targetRole, "target-role", "", "deliver only to this durable conversation role")
 	flags.StringVar(&request.bodyFile, "body-file", "", "message body file or - for stdin")
 	flags.StringVar(&request.idempotencyKey, "idempotency-key", "", "stable key for retries")
 	if err := flags.Parse(args); err != nil || flags.NArg() != 0 {
@@ -367,6 +369,9 @@ func parseSendArgs(args []string) (sendRequest, error) {
 	}
 	if strings.TrimSpace(request.conversationID) == "" || strings.TrimSpace(request.fromEndpoint) == "" || request.bodyFile == "" || strings.TrimSpace(request.idempotencyKey) == "" {
 		return sendRequest{}, fmt.Errorf("--conversation, --from, --body-file, and --idempotency-key are required")
+	}
+	if request.targetRole != "" && !relay.ValidRole(request.targetRole) {
+		return sendRequest{}, fmt.Errorf("--target-role is invalid")
 	}
 	return request, nil
 }
@@ -388,7 +393,12 @@ func runSend(args []string) error {
 	if err != nil {
 		return err
 	}
-	message, err := client.Send(context.Background(), request.conversationID, request.fromEndpoint, string(body), request.idempotencyKey)
+	var message relay.Message
+	if request.targetRole == "" {
+		message, err = client.Send(context.Background(), request.conversationID, request.fromEndpoint, string(body), request.idempotencyKey)
+	} else {
+		message, err = client.SendToRole(context.Background(), request.conversationID, request.fromEndpoint, request.targetRole, string(body), request.idempotencyKey)
+	}
 	if err != nil {
 		return err
 	}

--- a/cmd/punaro-adapter/main_test.go
+++ b/cmd/punaro-adapter/main_test.go
@@ -26,6 +26,16 @@ func TestParseSendArgsRequiresExplicitIdempotencyKey(t *testing.T) {
 	}
 }
 
+func TestParseSendArgsAcceptsOneOptionalTargetRole(t *testing.T) {
+	request, err := parseSendArgs([]string{"--conversation", "conversation-1", "--from", "agent/a", "--body-file", "-", "--idempotency-key", "reply-1", "--target-role", "role/reviewer"})
+	if err != nil || request.targetRole != "role/reviewer" {
+		t.Fatalf("targeted send request=%#v err=%v", request, err)
+	}
+	if _, err := parseSendArgs([]string{"--conversation", "conversation-1", "--from", "agent/a", "--body-file", "-", "--idempotency-key", "reply-1", "--target-role", " role/reviewer"}); err == nil {
+		t.Fatal("non-canonical target role was accepted")
+	}
+}
+
 func TestParseAttachmentNotifyArgsRequiresStableOfferHandoff(t *testing.T) {
 	if _, err := parseAttachmentNotifyArgs([]string{"--conversation", "conversation-1", "--from", "agent/a", "--offer-file", "offer.cbor"}); err == nil {
 		t.Fatal("attachment notify without idempotency key was accepted")

--- a/cmd/punaro-enroll/private_file_unix.go
+++ b/cmd/punaro-enroll/private_file_unix.go
@@ -269,7 +269,9 @@ func syncPrivateDirectoryImpl(path string) error {
 		// invariant without allowing an already-written journal to poison all
 		// later recovery attempts.
 		if errors.Is(err, unix.EINVAL) || errors.Is(err, unix.ENOTSUP) {
-			unix.Sync() // #nosec G104 -- unix.Sync has no return value to check. //nolint:errcheck
+			if err := syncAllFilesystems(); err != nil {
+				return err
+			}
 			return nil
 		}
 		return err
@@ -286,7 +288,7 @@ func removePrivate(path string) error {
 		// journal that survives a crash is harmless: recovering it replays the
 		// same idempotency key. Do not convert a successful enrollment into a
 		// failure merely because its best-effort cleanup could not be synced.
-		unix.Sync() // #nosec G104 -- unix.Sync has no return value to check. //nolint:errcheck
+		_ = syncAllFilesystems() // Best-effort cleanup must not turn a completed enrollment into a failure.
 	}
 	return nil
 }

--- a/cmd/punaro-enroll/sync_returning_unix.go
+++ b/cmd/punaro-enroll/sync_returning_unix.go
@@ -1,0 +1,7 @@
+//go:build darwin || dragonfly || freebsd || netbsd || openbsd || solaris
+
+package main
+
+import "golang.org/x/sys/unix"
+
+func syncAllFilesystems() error { return unix.Sync() }

--- a/cmd/punaro-enroll/sync_void_unix.go
+++ b/cmd/punaro-enroll/sync_void_unix.go
@@ -1,0 +1,10 @@
+//go:build aix || linux || zos
+
+package main
+
+import "golang.org/x/sys/unix"
+
+func syncAllFilesystems() error {
+	unix.Sync()
+	return nil
+}

--- a/cmd/punaro-memory/profile_private_windows_test.go
+++ b/cmd/punaro-memory/profile_private_windows_test.go
@@ -67,7 +67,7 @@ func TestWindowsProfileAllowsEnrollmentStylePrivateParentDirectory(t *testing.T)
 
 func TestWindowsProfileRejectsCaseInsensitiveCredentialAlias(t *testing.T) {
 	profile := `C:\Punaro\DEVICE.CREDENTIAL`
-	credential := `c:\punaro\device.credential`
+	credential := `c:\punaro\device.credential` // #nosec G101 -- fixed test path, not a credential value.
 	if !sameCleanProfilePath(profile, credential) {
 		t.Fatal("Windows case-insensitive credential alias was not detected")
 	}

--- a/cmd/punaro/main.go
+++ b/cmd/punaro/main.go
@@ -343,6 +343,9 @@ func run(args []string, stdout, stderr io.Writer) int {
 		if len(args) > 1 && args[1] == "configure" {
 			return runRelayConfigure(args[2:], stdout, stderr, operator.ConfigureRelayMachines)
 		}
+		if len(args) > 1 && args[1] == "register" {
+			return runRelayRegister(args[2:], stdout, stderr, registerPostCutoverRelayMachine)
+		}
 	case "backup":
 		return runBackup(args[1:], stdout, stderr)
 	case "restore":

--- a/cmd/punaro/relay_command.go
+++ b/cmd/punaro/relay_command.go
@@ -1,14 +1,19 @@
 package main
 
 import (
+	"context"
+	"crypto/ed25519"
 	"flag"
 	"fmt"
 	"io"
 
 	"github.com/rock3r/punaro/internal/operator"
+	punaropostgres "github.com/rock3r/punaro/internal/postgres"
 )
 
 type relayConfigureCommand func(string, string) (operator.Installation, error)
+
+type relayRegisterCommand func(string, string) (operator.Installation, error)
 
 func runRelayConfigure(args []string, stdout, stderr io.Writer, configure relayConfigureCommand) int {
 	flags := flag.NewFlagSet("relay configure", flag.ContinueOnError)
@@ -25,4 +30,49 @@ func runRelayConfigure(args []string, stdout, stderr io.Writer, configure relayC
 		return 1
 	}
 	return writeJSON(stdout, stderr, map[string]any{"status": "relay_configured", "directory": installation.Directory})
+}
+
+func runRelayRegister(args []string, stdout, stderr io.Writer, register relayRegisterCommand) int {
+	flags := flag.NewFlagSet("relay register", flag.ContinueOnError)
+	flags.SetOutput(stderr)
+	directory := flags.String("directory", "", "absolute Punaro installation directory")
+	machineFile := flags.String("machine-enrollment-file", "", "protected single public machine enrollment JSON object")
+	confirmed := flags.Bool("yes", false, "confirm post-cutover registration and relay authority publication")
+	if flags.Parse(args) != nil || flags.NArg() != 0 || *directory == "" || *machineFile == "" || !*confirmed || register == nil {
+		return 2
+	}
+	installation, err := register(*directory, *machineFile)
+	if err != nil {
+		_, _ = fmt.Fprintln(stderr, "relay machine registration did not complete; rerun the exact command to recover safely")
+		return 1
+	}
+	return writeJSON(stdout, stderr, map[string]any{"status": "relay_machine_registered", "directory": installation.Directory})
+}
+
+func registerPostCutoverRelayMachine(directory, machineFile string) (operator.Installation, error) {
+	installation, err := operator.LoadMailCutoverRecovery(directory)
+	if err != nil || installation.MailCutover == nil {
+		return operator.Installation{}, fmt.Errorf("post-cutover installation is unavailable")
+	}
+	ctx := context.Background()
+	state, err := inspectSchema(ctx, installation.AppDSNFile)
+	if err != nil || state.Classification != punaropostgres.Compatible {
+		return operator.Installation{}, fmt.Errorf("post-cutover schema is incompatible")
+	}
+	if err := verifyInstallationPair(ctx, installation.AppDSNFile, installation.OwnerDSNFile); err != nil {
+		return operator.Installation{}, fmt.Errorf("post-cutover database roles do not match")
+	}
+	owner, err := inspectOwner(ctx, installation.AppDSNFile)
+	if err != nil || owner.ID != installation.OwnerPrincipalID {
+		return operator.Installation{}, fmt.Errorf("post-cutover owner does not match")
+	}
+	admin, err := punaropostgres.OpenAdministration(ctx, punaropostgres.Config{DSNFile: installation.OwnerDSNFile})
+	if err != nil {
+		return operator.Installation{}, fmt.Errorf("post-cutover administration is unavailable")
+	}
+	defer func() { _ = admin.Close() }()
+	return operator.RegisterPostCutoverRelayMachine(directory, machineFile, func(name string, publicKey ed25519.PublicKey) error {
+		_, err := admin.RegisterPostCutoverLegacyMachine(ctx, installation.OwnerPrincipalID, name, publicKey)
+		return err
+	})
 }

--- a/cmd/punaro/relay_command_test.go
+++ b/cmd/punaro/relay_command_test.go
@@ -37,3 +37,25 @@ func TestRelayConfigurePublishesOnlyThroughOperator(t *testing.T) {
 		t.Fatalf("stderr=%q", stderr.String())
 	}
 }
+
+func TestRelayRegisterRequiresConfirmationAndUsesOwnerWorkflow(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	called := false
+	register := func(directory, file string) (operator.Installation, error) {
+		called = directory == "/install" && file == "/private/machine.json"
+		return operator.Installation{Directory: directory}, nil
+	}
+	if code := runRelayRegister([]string{"--directory", "/install", "--machine-enrollment-file", "/private/machine.json"}, &stdout, &stderr, register); code != 2 || called {
+		t.Fatalf("unconfirmed code=%d called=%t", code, called)
+	}
+	stdout.Reset()
+	stderr.Reset()
+	if code := runRelayRegister([]string{"--directory", "/install", "--machine-enrollment-file", "/private/machine.json", "--yes"}, &stdout, &stderr, register); code != 0 || !called || !bytes.Contains(stdout.Bytes(), []byte(`"relay_machine_registered"`)) {
+		t.Fatalf("code=%d called=%t stdout=%q stderr=%q", code, called, stdout.String(), stderr.String())
+	}
+	if code := runRelayRegister([]string{"--directory", "/install", "--machine-enrollment-file", "/private/machine.json", "--yes"}, &stdout, &stderr, func(string, string) (operator.Installation, error) {
+		return operator.Installation{}, errors.New("unsafe")
+	}); code != 1 || !bytes.Contains(stderr.Bytes(), []byte("rerun the exact command")) {
+		t.Fatalf("failure code=%d stderr=%q", code, stderr.String())
+	}
+}

--- a/docs/alpha-text-relay.md
+++ b/docs/alpha-text-relay.md
@@ -277,6 +277,13 @@ does not alter the user's LaunchAgent environment. The installer first creates
 an HTTPS relay profile; the test then redirects only that disposable profile to
 its private loopback relay proxy. This does not relax production installation
 or trust requirements.
+
+For an opt-in release-candidate check of durable-role session replacement
+across `mac-studio`, `coso`, and `mattone`, follow the
+[durable-role LAN validation runbook](durable-role-lan-e2e.md). It requires
+read-only topology discovery and an already deployed candidate; it never
+provisions credentials or changes an operator's adapter configuration.
+
 It never stops or replaces an operator's installed adapter. It is intentionally
 not a CI job: it exercises the actual local service manager and is independent
 of any deployment hostname, credentials, ingress, or operator topology.

--- a/docs/alpha-text-relay.md
+++ b/docs/alpha-text-relay.md
@@ -186,6 +186,24 @@ non-empty adapter environment setting overrides its matching profile value;
 use `PUNARO_ADAPTER_PROFILE_FILE` only to select another absolute, owner-only
 profile.
 
+To address exactly one durable role, add `--target-role`. The relay derives
+the recipient from the conversation's role membership; it does not trust an
+endpoint label or message body as routing authority:
+
+```sh
+punaro-adapter send \
+  --conversation CONVERSATION_ID \
+  --from agent/workstation-review/session-name \
+  --target-role role/plan-reviewer \
+  --body-file review-request.txt \
+  --idempotency-key stable-targeted-retry-key
+```
+
+The selected role must be a receiving member of that conversation. Unknown or
+non-receiving roles fail without creating message state. Reusing the same key
+with another target is a conflict. Omitting `--target-role` retains the
+compatible broadcast behavior for all receiving endpoint and role members.
+
 ## Durable conversation roles
 
 Endpoint members keep the existing behavior: membership follows that exact

--- a/docs/deployment-validation/2026-08-10-durable-role-deployed-candidate.md
+++ b/docs/deployment-validation/2026-08-10-durable-role-deployed-candidate.md
@@ -1,11 +1,12 @@
-# Durable-role deployed-candidate evidence — 2026-08-10
+# Durable-role personal-deployment validation — 2026-08-10
 
 ## Decision and scope
 
 - Capability: durable conversation roles, session replacement fencing, and
   targeted role delivery from issues #55 and #58.
-- Personal deployment decision: **approved** for the owner-managed Punaro
-  deployment described in the installation guide.
+- Personal deployment result: **validated** for the owner-managed Punaro
+  deployment described in the installation guide. This is operational test
+  evidence, not release-gate approval or official release evidence.
 - Official Internet-facing release decision: **withheld**. This record does
   not check any box in
   [`security-release-gates.md`](../security-release-gates.md); no signed

--- a/docs/deployment-validation/2026-08-10-durable-role-deployed-candidate.md
+++ b/docs/deployment-validation/2026-08-10-durable-role-deployed-candidate.md
@@ -19,27 +19,30 @@
 
 ## Exact candidate
 
-- Integrated source commit: `8e8eeb8e6ce2c6efc8a658339044f1110f4e7952`.
+- Integrated source commit: `ef34cc74f9ff28ea1b98564b4e8078c9545527f8`.
 - Relay artifact-producing commit:
-  `8e8eeb8e6ce2c6efc8a658339044f1110f4e7952`.
+  `d58a9f75267172c2ddb1ce645531f507899ac186`.
 - Adapter artifact-producing commit:
-  `8e8eeb8e6ce2c6efc8a658339044f1110f4e7952`.
+  `d58a9f75267172c2ddb1ce645531f507899ac186`.
+- The integrated commit changes deployment documentation only; its executable
+  source tree is identical to the artifact-producing commit.
 - Review reference: PR #131, branch
   `agent/issue-55-durable-role-e2e`.
 - Signed/tagged release reference: none; official release remains withheld.
 - Linux/amd64, `CGO_ENABLED=0`, `punarod` SHA-256:
-  `9851706a1601abfe3ec1b88e7a97e58bf454a9b945fe4798077c571eff8215f1`.
+  `3f8ed32b929ec14a19b3c3c4c6b636fea8987486a7c89f94929ca76bd4b5e678`.
 - macOS/arm64 native-CGO `punaro-adapter` SHA-256, deployed independently on
   Mac Studio and Coso:
-  `0a705634a08ed78492ae06e2da58315bed7363f35b9fb85d93dbff53a257752d`.
+  `df668fc9c0546f5bdda81461548d2426da1d5ef3bc0c4fbcde6d09fbc84f9a9a`.
 - Windows/amd64, `CGO_ENABLED=0`, `punaro-adapter.exe` SHA-256:
-  `2b1521d8f54d10ff4970b94a119709fedd3b31da7985038ac99dcf4ed72abaf0`.
+  `134311ecc55134d5eaca47b973df1d7ec7c61b444f75405f68c042339edd5969`.
 - Container image digest: not applicable; the validated relay is the native
   systemd deployment.
 
 All four installed artifacts were hashed after the final scenario and matched
-the values above. The relay and both native adapter artifacts were built from
-the same final review-head commit.
+the values above. The relay and native adapter artifacts were built from the
+same executable commit; the integrated head adds only this deployment record
+and deployment-guide corrections.
 
 ## Verification gates
 
@@ -54,19 +57,25 @@ env GOCACHE=/tmp/punaro-go-cache \
 Results included unit coverage, race tests, Staticcheck, `govulncheck` with no
 called vulnerabilities, `gosec` with zero issues, Gitleaks with no leaks, Go
 vet, lint, Windows compilation, deployment and installer verification, and the
-real two-client relay lifecycle E2E. The final integrated-head run's latter
-test passed in 78.642 seconds. The Docker-backed PostgreSQL integration suite
-also passed in 27.483 seconds after first demonstrating the relevant
-recipient-role contract failures against the pre-fix implementation.
+real two-client relay lifecycle E2E. The final executable-head run's latter
+test passed in 81.876 seconds. The Docker-backed PostgreSQL integration suite
+passed in 26.721 seconds and the command integration suite in 3.996 seconds
+after first demonstrating the skipped-recipient cursor failure against the
+pre-fix implementation.
 
 GitHub Actions candidate run:
-`https://github.com/rock3r/punaro/actions/runs/31439058495`. Configuration lint,
+`https://github.com/rock3r/punaro/actions/runs/31442527469`. Configuration lint,
 Go tests and analysis, PostgreSQL integration, Windows build, complete-product
 E2E, and Cursor Bugbot all passed at the final deployed review head.
 
 ## Deployment admission and enrollment
 
-- The relay, Mac Studio, Coso, and Mattone ran the exact candidate binaries.
+- The relay, Mac Studio, Coso, and Mattone ran the exact artifact-producing
+  candidate binaries while the integrated head differed only in documentation.
+- The relay is the historical native systemd/SQLite deployment. Its configured
+  health listener is `127.0.0.1:18081`; checking an assumed port caused an
+  unnecessary intermediate rollback. The final replacement used the configured
+  endpoint and required no PostgreSQL migration.
 - All machine credentials retained their narrow endpoint namespaces. Missing
   Mac Studio and Coso validation prefixes were added additively; no existing
   enrollment was removed or widened.
@@ -90,9 +99,10 @@ All probes used disposable aliases, roles, conversation state, opaque bodies,
 and idempotency keys. No credential, header value, private key, conversation
 identifier, delivery identifier, lease token, or body was recorded here.
 
-- Six pairwise host directions completed. Every intended endpoint observed
-  each opaque probe once and acknowledged it. A same-key retry returned the
-  original message identity and caused no duplicate mailbox injection.
+- Six pairwise host directions completed again on the final artifact. Every
+  intended endpoint observed each opaque probe once and acknowledged it. A
+  same-key retry returned the original message identity and caused no duplicate
+  mailbox injection.
 - Targeted role delivery reached only Coso's bound primary session. Its local
   endpoint, other Coso role, replacement session, Mac Studio, and every
   Mattone session received zero copies.
@@ -104,30 +114,27 @@ identifier, delivery identifier, lease token, or body was recorded here.
   invalidated its acknowledgement with HTTP `403`; the replacement reclaimed
   the same delivery at generation 2 and acknowledged with `204`. After normal
   detachment, stale bind also returned `403`.
-- Mattone replacement `w3 -> w4`: the same generation `1 -> 2`, stale-ack
+- Mattone replacement `w3 -> w4`: generation `2 -> 3`, stale-ack
   `403`, replacement-ack `204`, and detached stale-bind `403` proof passed
   using native Windows process and scheduled-task lifecycle.
-- Offline recovery: Coso was stopped through launchd, a targeted message was
-  accepted while unavailable, then the restored adapter committed and
-  acknowledged it on polling attempt 9. A later receive observed zero
-  duplicates.
-- Attachment fail-closed boundary: the running relay had zero trusted or
-  retired attachment environment keys. Signed trusted-attachment, v2
-  directory, and v3 permit routes each returned `404` without creating state.
-- Remote memory fail-closed boundary: the running relay had zero memory or
-  remote-MCP environment keys. Signed memory and MCP routes returned `404`.
+- Offline recovery: Coso was stopped through launchd and a targeted message was
+  accepted while unavailable. The restarted adapter was correctly fenced with
+  `409` until the stopped process's consumer lease expired, then injected one
+  authenticated-role delivery, acknowledged it, and produced zero duplicates.
+- Attachment fail-closed boundary was rechecked on the final relay: its process
+  had zero trusted or retired attachment environment keys. Signed
+  trusted-attachment, v2 directory, and v3 permit routes each returned `404`
+  without creating state.
+- Remote memory fail-closed boundary was rechecked on the final relay: its
+  process had zero memory or remote-MCP environment keys. Signed memory and MCP
+  routes returned `404`.
   A functional memory E2E was therefore intentionally unavailable; no mock or
   offline substitute was counted.
-- After deploying the final review-fix relay hash, a fresh targeted-role probe
-  reached Coso's fenced `c4` session exactly once. A second fresh targeted-role
-  probe reached Mattone's fenced `w4` session exactly once. In both native
-  adapter environments, the inert typed Punaro envelope carried the exact
-  server-derived `recipient_role` and the local delivery was acknowledged.
-  The Mac Studio sender, Coso, and Mattone all ran the final candidate while
-  these probes crossed the final relay. The unchanged routing, broadcast,
-  fencing, offline-recovery, and fail-closed scenarios above had already passed
-  against the immediately preceding candidate; the final delta changed only
-  authenticated recipient metadata and recovery-marker publication.
+- The final Coso and Mattone replacement proofs both carried the exact
+  server-derived `recipient_role`. Two local acknowledgements were recovered
+  from agent-mailbox's durable leased state after a deliberately malformed
+  test command, exercising at-least-once handling without duplicate injection
+  and without displaying lease tokens or message bodies.
 
 ## Cleanup, health, and rollback
 
@@ -145,8 +152,8 @@ identifier, delivery identifier, lease token, or body was recorded here.
 - Final health: relay `active` and ready; both macOS launchd adapters running;
   Mattone scheduled task hidden and running a hidden-window action with
   exactly one process at the candidate path.
-- Owner-managed adapter rollback copies with suffix `.pre-8e8eeb8` and the
-  final relay rollback copy `.pre-8e8eeb8` were retained beside their installed
+- Owner-managed adapter rollback copies of the preceding `439cb27` binaries
+  and the relay rollback copy of `8e8eeb8` were retained beside their installed
   binaries. Rollback requires the documented service stop, atomic binary
   replacement, restart, hash check, and readiness check. This evidence expires
   when any listed artifact is replaced or the Access policy/enrollment

--- a/docs/deployment-validation/2026-08-10-durable-role-deployed-candidate.md
+++ b/docs/deployment-validation/2026-08-10-durable-role-deployed-candidate.md
@@ -19,30 +19,27 @@
 
 ## Exact candidate
 
-- Integrated source commit: `8d7b7f7670cc10484a493f4003156e0be0673c05`.
+- Integrated source commit: `8e8eeb8e6ce2c6efc8a658339044f1110f4e7952`.
 - Relay artifact-producing commit:
-  `8d7b7f7670cc10484a493f4003156e0be0673c05`.
+  `8e8eeb8e6ce2c6efc8a658339044f1110f4e7952`.
 - Adapter artifact-producing commit:
-  `ba633f0d20a5e3c0b0711b2893521c9f59a2530e`. The final review fix changes
-  only PostgreSQL legacy-key resolution in the relay; rebuilding both adapter
-  platforms from the integrated source reproduced their exact deployed hashes.
+  `8e8eeb8e6ce2c6efc8a658339044f1110f4e7952`.
 - Review reference: PR #131, branch
   `agent/issue-55-durable-role-e2e`.
 - Signed/tagged release reference: none; official release remains withheld.
 - Linux/amd64, `CGO_ENABLED=0`, `punarod` SHA-256:
-  `be0e237866ae40ff5d72a2bbe6162443c1e3a9b7a0d7893f6933a704724f660a`.
+  `9851706a1601abfe3ec1b88e7a97e58bf454a9b945fe4798077c571eff8215f1`.
 - macOS/arm64 native-CGO `punaro-adapter` SHA-256, deployed independently on
   Mac Studio and Coso:
-  `3dc6747db9f9edce98ef566ab8ab045c905a18fc334a7735c08c28eb16be4059`.
+  `0a705634a08ed78492ae06e2da58315bed7363f35b9fb85d93dbff53a257752d`.
 - Windows/amd64, `CGO_ENABLED=0`, `punaro-adapter.exe` SHA-256:
-  `35e3132a84c40ff69f2aa360e6667b7c19f95d8a218db5677abccc93bb45f870`.
+  `2b1521d8f54d10ff4970b94a119709fedd3b31da7985038ac99dcf4ed72abaf0`.
 - Container image digest: not applicable; the validated relay is the native
   systemd deployment.
 
 All four installed artifacts were hashed after the final scenario and matched
-the values above. The relay was built from the final review-fix commit; both
-adapter artifacts were rebuilt from that commit and reproduced their earlier
-deployed hashes exactly.
+the values above. The relay and both native adapter artifacts were built from
+the same final review-head commit.
 
 ## Verification gates
 
@@ -58,14 +55,14 @@ Results included unit coverage, race tests, Staticcheck, `govulncheck` with no
 called vulnerabilities, `gosec` with zero issues, Gitleaks with no leaks, Go
 vet, lint, Windows compilation, deployment and installer verification, and the
 real two-client relay lifecycle E2E. The final integrated-head run's latter
-test passed in 83.198 seconds. The Docker-backed PostgreSQL integration suite
-also passed in 29.610 seconds after first demonstrating that the new
-closed-gate registration test failed for the intended reason.
+test passed in 78.642 seconds. The Docker-backed PostgreSQL integration suite
+also passed in 27.483 seconds after first demonstrating the relevant
+recipient-role contract failures against the pre-fix implementation.
 
-GitHub Actions candidate run: pending final evidence-only synchronization.
-The earlier complete role-routing candidate run is retained at
-`https://github.com/rock3r/punaro/actions/runs/31419646148`; it does not replace
-the final candidate run.
+GitHub Actions candidate run:
+`https://github.com/rock3r/punaro/actions/runs/31439058495`. Configuration lint,
+Go tests and analysis, PostgreSQL integration, Windows build, complete-product
+E2E, and Cursor Bugbot all passed at the final deployed review head.
 
 ## Deployment admission and enrollment
 
@@ -122,11 +119,15 @@ identifier, delivery identifier, lease token, or body was recorded here.
   A functional memory E2E was therefore intentionally unavailable; no mock or
   offline substitute was counted.
 - After deploying the final review-fix relay hash, a fresh targeted-role probe
-  reached Coso's bound primary session exactly once and its endpoint plus other
-  role session zero times. The delivery was acknowledged; a same-key retry
-  returned the same message identity and produced zero duplicate mailbox
-  injection. Four distinct signed machine identities also renewed six active
-  endpoint leases through the final relay.
+  reached Coso's fenced `c4` session exactly once. A second fresh targeted-role
+  probe reached Mattone's fenced `w4` session exactly once. In both native
+  adapter environments, the inert typed Punaro envelope carried the exact
+  server-derived `recipient_role` and the local delivery was acknowledged.
+  The Mac Studio sender, Coso, and Mattone all ran the final candidate while
+  these probes crossed the final relay. The unchanged routing, broadcast,
+  fencing, offline-recovery, and fail-closed scenarios above had already passed
+  against the immediately preceding candidate; the final delta changed only
+  authenticated recipient metadata and recovery-marker publication.
 
 ## Cleanup, health, and rollback
 
@@ -144,8 +145,8 @@ identifier, delivery identifier, lease token, or body was recorded here.
 - Final health: relay `active` and ready; both macOS launchd adapters running;
   Mattone scheduled task hidden and running a hidden-window action with
   exactly one process at the candidate path.
-- Owner-managed adapter rollback copies with suffix `.pre-ba633f0` and the
-  final relay rollback copy `.pre-8d7b7f7` were retained beside their installed
+- Owner-managed adapter rollback copies with suffix `.pre-8e8eeb8` and the
+  final relay rollback copy `.pre-8e8eeb8` were retained beside their installed
   binaries. Rollback requires the documented service stop, atomic binary
   replacement, restart, hash check, and readiness check. This evidence expires
   when any listed artifact is replaced or the Access policy/enrollment

--- a/docs/deployment-validation/README.md
+++ b/docs/deployment-validation/README.md
@@ -1,0 +1,12 @@
+# Personal deployment validation records
+
+This directory contains redacted operational records for owner-managed
+personal deployments. A record here can prove that a specific source revision
+and binary set passed the documented local and live deployment checks. It does
+not approve an official runtime capability, satisfy a security release gate,
+or replace the independently reviewed, signed, and attested evidence required
+under [`release-evidence`](../release-evidence/README.md).
+
+Keep exact source revisions, artifact checksums, redacted commands and results,
+topology, cleanup, rollback, and residual risk here. Never record credentials,
+message bodies, private deployment identifiers, or production data.

--- a/docs/durable-role-lan-e2e.md
+++ b/docs/durable-role-lan-e2e.md
@@ -80,8 +80,13 @@ remote-MCP release-candidate E2E configuration against this same commit; if
 the candidate intentionally disables memory transport, record its fail-closed
 result rather than replacing it with an offline harness.
 
-After recording redacted outcomes, remove only the disposable conversation and
-test aliases through the supported control plane. Confirm all three adapter
-services and relay readiness remain healthy. Record the candidate commit/image,
-host roles, redacted commands, pass/fail outcomes, cleanup result, residual
-risk, and the owner-managed rollback reference in a release-evidence record.
+After recording redacted outcomes, remove every disposable endpoint member
+that the conversation control API supports and detach every test alias from
+the actual groups currently attached to the adapters. Verify those attached
+groups contain zero active disposable aliases. If the candidate has no
+supported conversation-delete or durable-role-member removal operation, do
+not edit relay storage directly; record the isolated final admin and role
+metadata as residual test state instead. Confirm all three adapter services
+and relay readiness remain healthy. Record the candidate commit/image, host
+roles, redacted commands, pass/fail outcomes, achieved cleanup, residual risk,
+and the owner-managed rollback reference in a release-evidence record.

--- a/docs/durable-role-lan-e2e.md
+++ b/docs/durable-role-lan-e2e.md
@@ -70,7 +70,7 @@ exercise one harmless bidirectional message for each host pair. Verify the
 normal endpoint-member path remains unchanged, acknowledgement is durable, a
 same-key retry is deduplicated, and a short supported adapter stop/start causes
 eventual delivery without a duplicate mailbox injection. Targeted role
-delivery, if enabled for the candidate, must reach only its selected role;
+delivery must reach only its selected role;
 untargeted broadcast must still reach compatible endpoint members.
 
 Exercise retired attachment controls only as a fail-closed boundary unless the

--- a/docs/durable-role-lan-e2e.md
+++ b/docs/durable-role-lan-e2e.md
@@ -1,0 +1,87 @@
+# Durable-role LAN release-candidate validation
+
+This opt-in runbook validates durable conversation-role replacement against an
+already deployed release candidate. It does not provision a relay, create
+credentials, change an adapter profile, or infer topology. Run it only with
+the owner-managed deployment configuration on `mac-studio`, `coso`, and
+`mattone`; replace every all-caps placeholder locally and do not record its
+value in this file, shell history, CI output, or the release record.
+
+## Preconditions and discovery
+
+Before creating any state, run these read-only checks from the candidate
+checkout. They establish which host runs `punarod`, which hosts run adapters,
+the active service manager, and that all three copies identify the same clean
+candidate commit. Do not continue if the relay host, adapter host, or candidate
+cannot be identified, or if the deployed commit differs from the checkout that
+runs the tests.
+
+```sh
+for host in mac-studio coso mattone; do
+  ssh "$host" 'hostname; uname -s; git -C PATH_TO_PUNARO rev-parse HEAD; git -C PATH_TO_PUNARO status --porcelain; pgrep -fl "punarod|punaro-adapter" || true; systemctl --user is-active punaro-adapter 2>/dev/null || true; systemctl is-active punarod 2>/dev/null || true; launchctl print gui/$(id -u)/org.punaro.adapter 2>/dev/null | sed -n "1,2p" || true'
+done
+```
+
+Use the existing owner-managed service and private configuration in place. Do
+not print relay URLs, Access headers, machine keys, DSNs, mailbox bodies, or
+production conversation IDs. Record only the candidate commit, image digest,
+host role (`relay` or `adapter`), service health result, and redacted command
+outcome. Confirm relay readiness and adapter health before and after every
+scenario.
+
+Choose a unique opaque run suffix, then derive a disposable conversation,
+three disposable endpoint aliases, three role names, and harmless opaque probe
+tokens from it. The aliases must be in each enrolled machine's existing
+namespace. Do not reuse a production alias or role name.
+
+## Durable-role replacement
+
+1. From `mac-studio`, create one disposable conversation with its attached
+   sender endpoint as `send,receive,admin` and a role member owned by `coso`
+   with `send,receive`. Use a fresh idempotency key. Bind the role on `coso`
+   to an attached disposable session using `punaro-adapter bind-role`.
+2. Send one opaque harmless probe from `mac-studio`. On `coso`, verify exactly
+   one local durable mailbox handoff and acknowledge it using the supported
+   mailbox control. Retrying the same send with the same key must not inject a
+   second mailbox item; a different request reusing that key must fail.
+3. Detach the first `coso` test session through its normal adapter or mailbox
+   lifecycle. Attach a replacement session in the same enrolled namespace,
+   advertise it, and bind the same role to it. Do not edit conversation
+   membership. Send a second opaque probe and verify that only the replacement
+   session receives and acknowledges it.
+4. Attempt fetch/lease, acknowledgement, and send using the detached first
+   session. Each must fail with the normal authorization failure and must not
+   create a delivery, message, lease, or acknowledgement. The replacement
+   session remains able to send and receive as the role.
+5. Repeat steps 1–4 with a role owned by `mattone`. Use native PowerShell for
+   commands run on `mattone` and short shell-native `ssh` commands only for
+   remote invocation. This proves the durable role is tied to its owning
+   machine rather than to a macOS-only session convention.
+
+The initial and replacement bindings must never both authorize a role lease.
+If a delivery is leased immediately before replacement, the stale lease must
+be fenced and the replacement session may re-lease it; do not treat a stale
+acknowledgement as success.
+
+## Compatible mail and cleanup
+
+During the same isolated run, use attached disposable endpoint members to
+exercise one harmless bidirectional message for each host pair. Verify the
+normal endpoint-member path remains unchanged, acknowledgement is durable, a
+same-key retry is deduplicated, and a short supported adapter stop/start causes
+eventual delivery without a duplicate mailbox injection. Targeted role
+delivery, if enabled for the candidate, must reach only its selected role;
+untargeted broadcast must still reach compatible endpoint members.
+
+Exercise retired attachment controls only as a fail-closed boundary unless the
+candidate already exposes an approved attachment runtime. Unsupported routes
+and controls must be rejected without durable state. Run the existing private
+remote-MCP release-candidate E2E configuration against this same commit; if
+the candidate intentionally disables memory transport, record its fail-closed
+result rather than replacing it with an offline harness.
+
+After recording redacted outcomes, remove only the disposable conversation and
+test aliases through the supported control plane. Confirm all three adapter
+services and relay readiness remain healthy. Record the candidate commit/image,
+host roles, redacted commands, pass/fail outcomes, cleanup result, residual
+risk, and the owner-managed rollback reference in a release-evidence record.

--- a/docs/durable-role-lan-e2e.md
+++ b/docs/durable-role-lan-e2e.md
@@ -41,9 +41,11 @@ namespace. Do not reuse a production alias or role name.
    with `send,receive`. Use a fresh idempotency key. Bind the role on `coso`
    to an attached disposable session using `punaro-adapter bind-role`.
 2. Send one opaque harmless probe from `mac-studio`. On `coso`, verify exactly
-   one local durable mailbox handoff and acknowledge it using the supported
-   mailbox control. Retrying the same send with the same key must not inject a
-   second mailbox item; a different request reusing that key must fail.
+   one local durable mailbox handoff whose server-derived `recipient_role`
+   names the selected role, and acknowledge it using the supported mailbox
+   control. Do not infer that role from the untrusted message body. Retrying
+   the same send with the same key must not inject a second mailbox item; a
+   different request reusing that key must fail.
 3. Detach the first `coso` test session through its normal adapter or mailbox
    lifecycle. Attach a replacement session in the same enrolled namespace,
    advertise it, and bind the same role to it. Do not edit conversation
@@ -89,4 +91,6 @@ not edit relay storage directly; record the isolated final admin and role
 metadata as residual test state instead. Confirm all three adapter services
 and relay readiness remain healthy. Record the candidate commit/image, host
 roles, redacted commands, pass/fail outcomes, achieved cleanup, residual risk,
-and the owner-managed rollback reference in a release-evidence record.
+and the owner-managed rollback reference in a personal
+`deployment-validation` record. Only an independently approved official
+release belongs under `release-evidence`.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -182,6 +182,73 @@ and local paths. It refuses to overwrite an existing key, enrollment record,
 configuration file, or project skill that does not match. To revoke a client,
 follow the [alpha onboarding revocation procedure](alpha-text-relay.md#onboard-and-revoke-a-machine): remove attached aliases, remove the relay enrollment, revoke the machine's Access token, stop the service, and securely erase its key.
 
+## 4. New-machine, upgrade, and rollback runbook
+
+Use this sequence for every new adapter machine and for an adapter upgrade. It
+keeps the machine identity and its private configuration in place while
+replacing only reviewed binaries and service definitions. Do not deploy from a
+dirty checkout, reuse another machine's key or Access token, or copy an
+`adapter.env` file between machines.
+
+1. Record the exact 40-character source commit and obtain a clean checkout of
+   it on the target. Confirm it before installing:
+
+   ```sh
+   git rev-parse HEAD
+   git status --porcelain
+   ```
+
+   On Windows, run the same commands in PowerShell from the checkout. An empty
+   `git status --porcelain` is required. Keep the previously installed commit
+   available until post-upgrade verification succeeds; it is the rollback
+   source, not a backup of credentials or mailbox state.
+2. For a **new** machine, run the client installer *without* enablement. It
+   creates a fresh machine key and prints the public enrollment record. Add
+   only that record to the relay enrollment set, apply it through the existing
+   owner-managed relay deployment, and verify relay readiness. Create a new
+   Access service token for the machine and place it only in that machine's
+   owner-only profile. Bind and attach the chosen aliases, then enable the
+   local adapter.
+3. For an **existing** machine, rerun the same installer from the clean
+   checkout using the original relay URL and machine ID. The installer proves
+   that the existing key, enrollment record, and profile still belong to those
+   values before it replaces the adapter binary and managed service file. It
+   does not rewrite the token pair. Never delete an existing key merely to
+   make this check pass.
+4. Enable or restart only through the installed platform service:
+
+   ```sh
+   # macOS and Linux: append --enable to the installer invocation.
+   # macOS verification
+   launchctl print gui/$(id -u)/org.punaro.adapter
+
+   # Linux verification
+   systemctl --user status punaro-adapter.service
+   ```
+
+   ```powershell
+   # Windows: append -Enable to the installer invocation.
+   Get-ScheduledTask -TaskName 'Punaro Adapter'
+   Get-Process punaro-adapter -ErrorAction SilentlyContinue
+   ```
+
+   The Windows task is intentionally per-user and interactive; a disabled task
+   or missing process is not a deployed adapter. For a Linux machine that must
+   remain available after logout, enable user lingering before relying on it.
+5. Confirm the adapter has advertised only the newly attached aliases, then
+   run a disposable, harmless message/acknowledgement check. For release
+   candidates, use the [durable-role LAN validation runbook](durable-role-lan-e2e.md)
+   rather than reusing a production conversation or endpoint.
+
+If a binary or service update fails before the adapter is healthy, stop the
+updated service, return to the retained clean checkout at the prior verified
+commit, rerun the same installer with the same identity values, and verify the
+service again. Do not restore, edit, or copy private keys, Access tokens,
+mailbox state, relay databases, or production conversations as part of an
+adapter rollback. Relay rollback follows the owner-managed deployment's
+recorded image/commit and database recovery process; it is not an adapter
+installer operation.
+
 ### Adapter profile for direct commands and the service
 
 The installed `punaro-adapter` validates and reads the same owner-only,
@@ -308,7 +375,7 @@ rotate` or `punaro-admin credential revoke`, using the content-free credential
 inventory. Rotation and revocation are server-controlled: a local identity
 sidecar or copied credential cannot restore access.
 
-## 4. Retired v2/v3 attachment evidence
+## 5. Retired v2/v3 attachment evidence
 
 Do not execute the historical provisioning helpers retained in the source tree
 on a production host. `punarod` rejects all legacy attachment, directory, and permit settings;

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -145,8 +145,22 @@ if you decline it during client setup.
    Use the explicit JSON value `[]` to revoke the final client; the restarted
    relay then accepts no signed machine requests.
    After mail cutover, this command can only retain or remove already registered
-   keys. New mailbox clients are currently unavailable until a durable
-   post-cutover authority-registration workflow is delivered.
+   keys. Register one genuinely new installer-produced public record through
+   the owner-controlled workflow instead:
+
+   ```sh
+   punaro relay register \
+     --directory INSTALLATION_DIR \
+     --machine-enrollment-file /absolute/private/new-machine.json \
+     --yes
+   punaro up --directory INSTALLATION_DIR
+   ```
+
+   The input is the single JSON object printed by that machine's installer,
+   protected as an owner-only regular file. The command first records its exact
+   public key in the active PostgreSQL transition authority, then marker-last
+   publishes the merged static enrollment. Exact retries recover safely; a
+   changed retry or conflicting machine/key/namespace fails closed.
    Do not hand-edit `PUNARO_RELAY_MACHINES_JSON` or widen a namespace to
    `codex/` or `claude/`.
 2. Create a **distinct** Cloudflare Access service token and policy for this
@@ -222,16 +236,14 @@ dirty checkout, reuse another machine's key or Access token, or copy an
    service token for the machine, install it only in that machine's owner-only
    profile, bind and attach its aliases, and enable the adapter.
 
-   After mail cutover, stop here: the active transition authority accepts only
-   keys that were registered before cutover, and `punaro relay configure`
-   rejects a newly generated key. Device-credential enrollment does not make a
-   new mailbox Ed25519 key eligible. Do not copy another machine's key, edit
-   `punarod.env`, alter the installation marker, or write authority rows by
-   hand. Until a durable post-cutover registration workflow is delivered, the
-   supported choices are to keep the new adapter disabled or provision it on a
-   fresh installation before that installation's cutover. Therefore inventory
-   and enroll every intended macOS, Linux, and Windows adapter before executing
-   mail cutover.
+   After mail cutover, use `punaro relay register` with that single public
+   enrollment object, followed by `punaro up`; ordinary `relay configure`
+   deliberately rejects the unknown key. Device-credential enrollment remains
+   separate and does not make a mailbox Ed25519 key eligible. Do not copy
+   another machine's key, edit `punarod.env`, alter the installation marker, or
+   write authority rows by hand. Keep the adapter disabled until registration,
+   relay readiness, its distinct Access Service Auth probe, and endpoint
+   attachment all succeed.
 3. For an **existing** machine, rerun the same installer from the clean
    checkout using the original relay URL and machine ID. The installer proves
    that the existing key, enrollment record, and profile still belong to those

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -184,7 +184,10 @@ if you decline it during client setup.
    several exact service-token include rules, but every enrolled machine still
    needs a different token pair. Never use `any_valid_service_token`: adding an
    unrelated token to the account would then silently grant it admission to
-   Punaro.
+   Punaro. The native clients send both service-token headers on every
+   protected request. They do not establish or replay a browser
+   `CF_Authorization` cookie with those headers; mixed cookie and Service Auth
+   identity can be rejected by Access before a signed request reaches Punaro.
 
    Test the device application, not only `/readyz`. Make a header-authenticated
    request to `/v1/conversations` without a Punaro machine signature and with

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -180,7 +180,11 @@ if you decline it during client setup.
    account API key and must never be reused as one. The Access application
    policy action must be **Service Auth** and its include rule must name this
    exact service token; an ordinary Allow policy sends the adapter to an
-   interactive identity-provider login.
+   interactive identity-provider login. One Service Auth policy may contain
+   several exact service-token include rules, but every enrolled machine still
+   needs a different token pair. Never use `any_valid_service_token`: adding an
+   unrelated token to the account would then silently grant it admission to
+   Punaro.
 
    Test the device application, not only `/readyz`. Make a header-authenticated
    request to `/v1/conversations` without a Punaro machine signature and with
@@ -239,6 +243,12 @@ dirty checkout, reuse another machine's key or Access token, or copy an
    `git status --porcelain` is required. Keep the previously installed commit
    available until post-upgrade verification succeeds; it is the rollback
    source, not a backup of credentials or mailbox state.
+   Build macOS clients natively on the target architecture by running the
+   installer there. Do not substitute a `CGO_ENABLED=0` cross-build: Punaro's
+   platform-specific private-file checks are part of the security boundary,
+   and a cross-built binary is not a valid deployment candidate merely because
+   its process starts. Windows releases must likewise use the repository's
+   Windows installer/build path and retain the current-user ACL checks.
    Before changing any service, map the public adapter URL to its exact daemon
    and listener. A tunnel may route `/readyz` to a separate health origin, so a
    successful readiness request alone does not prove which daemon handles

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -47,6 +47,18 @@ Cloudflare Access application, or copy any client secret.
 On a later `--enable` run, the installer restarts the relay after updating the
 configuration so the requested enrollment and Access settings take effect.
 
+That restart is safe only when the installed database already matches the
+replacement binary. The historical installer replaces `punarod`; it does not
+install the unified `punaro` lifecycle wrapper, create an update journal or
+backup, or migrate PostgreSQL. Before rebuilding an existing PostgreSQL-backed
+alpha relay from a newer checkout, compare the installed schema with the target
+release metadata. If the target requires a newer schema, leave the last
+compatible binary running and adopt the supported production Compose lifecycle;
+then perform the upgrade with `punaro update`. Do not run `punaro-migrate`
+directly, grant schema ownership to `punaro_app`, or repeatedly restart a new
+binary that reports `upgrade_required`. A direct binary replacement may be
+rolled back only while no schema migration has started.
+
 `--access-*` is strongly recommended for an internet-reachable deployment.
 All three Access options are required together; they are public identifiers and
 URLs. The installer writes the JWKS URL only to root-owned

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -227,6 +227,15 @@ dirty checkout, reuse another machine's key or Access token, or copy an
    `git status --porcelain` is required. Keep the previously installed commit
    available until post-upgrade verification succeeds; it is the rollback
    source, not a backup of credentials or mailbox state.
+   Before changing any service, map the public adapter URL to its exact daemon
+   and listener. A tunnel may route `/readyz` to a separate health origin, so a
+   successful readiness request alone does not prove which daemon handles
+   signed `/v1/` requests. Record the service manager, process, listener, and
+   deployed commit or image for the device origin and health origin separately;
+   prove the device origin with one harmless signed request before treating it
+   as release evidence. If two `punarod` processes or installations exist on
+   one host, stop and identify their routes rather than upgrading both by
+   assumption.
 2. For a **new** machine, first check whether the server has completed mail
    cutover. Run the client installer *without* enablement only when the machine
    can still be enrolled safely. It creates a fresh machine key and prints the
@@ -244,6 +253,12 @@ dirty checkout, reuse another machine's key or Access token, or copy an
    write authority rows by hand. Keep the adapter disabled until registration,
    relay readiness, its distinct Access Service Auth probe, and endpoint
    attachment all succeed.
+   The authenticated device listener must remain loopback-only. When a legacy
+   tunnel still targets a private-LAN listener, first stage the candidate on an
+   unused loopback address, update the tunnel origin with an explicit rollback
+   to the prior origin, and prove a signed request reaches the staged process.
+   Do not make a LAN listener acceptable by editing generated environment or
+   marker files; current candidates deliberately refuse that topology.
 3. For an **existing** machine, rerun the same installer from the clean
    checkout using the original relay URL and machine ID. The installer proves
    that the existing key, enrollment record, and profile still belong to those

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -177,8 +177,20 @@ if you decline it during client setup.
    the user-token endpoint. The per-machine Access service-token pair is the
    `CF-Access-Client-Id` and `CF-Access-Client-Secret` admitted by a Service
    Auth (`non_identity`) policy on the relay application; it is not the
-   account API key and must never be reused as one. Confirm an authenticated
-   `/readyz` request through the public hostname before enabling the adapter.
+   account API key and must never be reused as one. The Access application
+   policy action must be **Service Auth** and its include rule must name this
+   exact service token; an ordinary Allow policy sends the adapter to an
+   interactive identity-provider login.
+
+   Test the device application, not only `/readyz`. Make a header-authenticated
+   request to `/v1/conversations` without a Punaro machine signature and with
+   redirects disabled. The expected result is Punaro's application-level JSON
+   `401`: that proves Access admitted the service token and the device route
+   reached Punaro, while Punaro still rejected the unsigned caller. A `3xx`,
+   HTML response, identity-provider page, or Cloudflare policy error means the
+   Service Auth rule is missing or does not include that token. Never print the
+   two headers while testing. `/readyz` may use a separate route or bypass
+   policy and is only a health check; it cannot prove device admission.
 3. Bind each reachable agent to an explicit address under that machine's
    namespace, then attach it to the local group. For example:
 
@@ -243,7 +255,9 @@ dirty checkout, reuse another machine's key or Access token, or copy an
    complete relay enrollment set, apply it through `punaro relay configure`
    and `punaro up`, and verify relay readiness. Then create a new Access
    service token for the machine, install it only in that machine's owner-only
-   profile, bind and attach its aliases, and enable the adapter.
+   profile, bind and attach its aliases, and enable the adapter. Verify the
+   Service Auth rule with the unsigned-API `401` check above before interpreting
+   adapter failures as machine-enrollment failures.
 
    After mail cutover, use `punaro relay register` with that single public
    enrollment object, followed by `punaro up`; ordinary `relay configure`

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -165,6 +165,10 @@ if you decline it during client setup.
    public key in the active PostgreSQL transition authority, then marker-last
    publishes the merged static enrollment. Exact retries recover safely; a
    changed retry or conflicting machine/key/namespace fails closed.
+   Relay-authority changes are serialized by a host-local installation lock.
+   If another configure, cutover-publication, or registration command is
+   already running, the later command fails before database or file mutation;
+   rerun its exact command after the first operation finishes.
    Do not hand-edit `PUNARO_RELAY_MACHINES_JSON` or widen a namespace to
    `codex/` or `claude/`.
 2. Create a **distinct** Cloudflare Access service token and policy for this

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -154,6 +154,17 @@ if you decline it during client setup.
    add its paired client ID and secret to the owner-only
    `~/.config/punaro/adapter.env`. Do not pass them as command-line arguments
    or reuse a token on another machine.
+
+   Cloudflare uses two different credentials in this workflow. The operator's
+   account API key/token is used only to administer Access. A current
+   account-scoped value has the `cfat_` prefix, is sent as an `Authorization:
+   Bearer` credential, and is verified at the account-scoped
+   `/client/v4/accounts/<account-id>/tokens/verify` endpoint. Do not test it at
+   the user-token endpoint. The per-machine Access service-token pair is the
+   `CF-Access-Client-Id` and `CF-Access-Client-Secret` admitted by a Service
+   Auth (`non_identity`) policy on the relay application; it is not the
+   account API key and must never be reused as one. Confirm an authenticated
+   `/readyz` request through the public hostname before enabling the adapter.
 3. Bind each reachable agent to an explicit address under that machine's
    namespace, then attach it to the local group. For example:
 
@@ -202,13 +213,25 @@ dirty checkout, reuse another machine's key or Access token, or copy an
    `git status --porcelain` is required. Keep the previously installed commit
    available until post-upgrade verification succeeds; it is the rollback
    source, not a backup of credentials or mailbox state.
-2. For a **new** machine, run the client installer *without* enablement. It
-   creates a fresh machine key and prints the public enrollment record. Add
-   only that record to the relay enrollment set, apply it through the existing
-   owner-managed relay deployment, and verify relay readiness. Create a new
-   Access service token for the machine and place it only in that machine's
-   owner-only profile. Bind and attach the chosen aliases, then enable the
-   local adapter.
+2. For a **new** machine, first check whether the server has completed mail
+   cutover. Run the client installer *without* enablement only when the machine
+   can still be enrolled safely. It creates a fresh machine key and prints the
+   public enrollment record. Before cutover, add only that record to the
+   complete relay enrollment set, apply it through `punaro relay configure`
+   and `punaro up`, and verify relay readiness. Then create a new Access
+   service token for the machine, install it only in that machine's owner-only
+   profile, bind and attach its aliases, and enable the adapter.
+
+   After mail cutover, stop here: the active transition authority accepts only
+   keys that were registered before cutover, and `punaro relay configure`
+   rejects a newly generated key. Device-credential enrollment does not make a
+   new mailbox Ed25519 key eligible. Do not copy another machine's key, edit
+   `punarod.env`, alter the installation marker, or write authority rows by
+   hand. Until a durable post-cutover registration workflow is delivered, the
+   supported choices are to keep the new adapter disabled or provision it on a
+   fresh installation before that installation's cutover. Therefore inventory
+   and enroll every intended macOS, Linux, and Windows adapter before executing
+   mail cutover.
 3. For an **existing** machine, rerun the same installer from the clean
    checkout using the original relay URL and machine ID. The installer proves
    that the existing key, enrollment record, and profile still belong to those

--- a/docs/operator-guide.md
+++ b/docs/operator-guide.md
@@ -472,6 +472,16 @@ content-free path/schema/health states. The generated M-5 server Compose file
 still uses an externally provisioned PostgreSQL service; the bundled production
 PostgreSQL/profile shape arrives in M-23.
 
+Topology discovery must distinguish the device and health routes. A public
+`/readyz` may terminate at a dedicated health listener even when signed device
+requests reach another `punarod`. Before rollout, correlate each tunnel origin
+with its service manager, PID/container, listener, and exact candidate, then
+issue one harmless signed request. Multiple daemons on one host are separate
+deployments until this correlation proves otherwise. Current relay authority is
+loopback-only; migrate a legacy private-LAN tunnel origin to a staged loopback
+candidate with an explicit origin rollback instead of hand-editing generated
+files or weakening the listener gate.
+
 Create a client in two exact steps. The first prints the effective grants and
 preview hash without touching the database. The confirmed invocation must
 repeat the same grant flags and bind the prior hash:

--- a/docs/operator-guide.md
+++ b/docs/operator-guide.md
@@ -295,6 +295,15 @@ two-second bound. Existing Ed25519 relay authentication remains active in this
 slice; its PostgreSQL inventory and disable gate stage the later explicit
 cutover and do not silently change current SQLite routing.
 
+For durable-role mail validation, `punaro-adapter send --target-role ROLE`
+must create a delivery only for that receiving conversation role. An unknown
+role is denied without message state, and changing the role under the same
+idempotency key is a conflict. A send without `--target-role` is the compatible
+broadcast path. During deployment evidence, verify both paths and confirm that
+ordinary endpoint members receive the broadcast but not the targeted probe;
+follow [the isolated LAN runbook](durable-role-lan-e2e.md) and never record
+message bodies or production conversation identifiers.
+
 Migration 4 adds project identities, aliases, generation-bound merge previews,
 and bounded reconciliation records. Migration 5 adds the backup GC-fence,
 READY-blob manifest, restore-history, and timeline-rotation substrate. It does

--- a/docs/operator-guide.md
+++ b/docs/operator-guide.md
@@ -299,7 +299,10 @@ For durable-role mail validation, `punaro-adapter send --target-role ROLE`
 must create a delivery only for that receiving conversation role. An unknown
 role is denied without message state, and changing the role under the same
 idempotency key is a conflict. A send without `--target-role` is the compatible
-broadcast path. During deployment evidence, verify both paths and confirm that
+broadcast path. A leased role delivery and its local inert mailbox envelope
+carry the server-derived `recipient_role`; use that field—not the untrusted
+body—to distinguish multiple roles bound to one session. During deployment
+evidence, verify both paths and confirm that
 ordinary endpoint members receive the broadcast but not the targeted probe;
 follow [the isolated LAN runbook](durable-role-lan-e2e.md) and never record
 message bodies or production conversation identifiers.

--- a/docs/operator-guide.md
+++ b/docs/operator-guide.md
@@ -153,19 +153,21 @@ database and investigate. The digest-pinned `make test-postgres` stack is epheme
 test infrastructure, publishes no database port, and deletes its volume on
 exit.
 
-The current binary requires schema version 8. Versions 1 through 7 are reported
-as `upgrade_required`; damaged older objects remain `incompatible`. Migration 3 is
-additive and creates the host-local ownership, pending enrollment, device
-credential, cache/session generation, and Ed25519 migration-inventory records.
-Migration 6 adds the durable update coordinator, exact recovery evidence, and
-the mutation fence. Migration 7 adds the PostgreSQL mail store, durable
-recipient cursors, replay protection, and relay-table mutation guards.
-Migration 8 adds the M-9 cutover substrate: owner-only migration epochs,
-bounded staging rows and checkpoints, and an application-role mail-write fence
-for an importing or verified epoch. The host wrapper's one-shot executor is the
-only supported authority transition. It always reads `relay.db` from Punaro's
-validated private service data directory; there is no caller-selected source
-path.
+The current binary requires schema version 44 and supports an intact schema
+from version 10 through 44 as an update boundary. Versions 10 through 43 are
+reported as `upgrade_required`; versions below the compatibility floor, newer
+versions, and damaged objects are `incompatible`. The embedded manifest and
+target release metadata are authoritative; check them instead of assuming a
+version from this guide when preparing a future release. Migration 40 adds
+durable conversation roles, migration 41 adds relay membership controls,
+migration 42 applies those controls to mail cutover, migration 43 adds the
+relay invocation capability, and migration 44 adds client lifecycle authority.
+Migration 44 invalidates unredeemed legacy enrollment invitations while
+converting existing device credentials into lifecycle-managed client records,
+so it must not be applied as an ad hoc repair. The host wrapper's one-shot
+executor is the only supported authority transition. It always reads `relay.db`
+from Punaro's validated private service data directory; there is no
+caller-selected source path.
 PostgreSQL mail work uses a reserved four-connection application-role pool;
 each operation and lock wait is bounded to five seconds so platform work cannot
 consume the mail budget indefinitely.

--- a/docs/operator-guide.md
+++ b/docs/operator-guide.md
@@ -223,6 +223,27 @@ the daemon from the published PostgreSQL and credential-transition settings.
 Never reopen or replace the retired SQLite file. Once PostgreSQL accepts new
 mail, recovery uses a PostgreSQL backup or forward repair.
 
+To add a new mailbox adapter after that activation, keep the adapter disabled
+and use the owner-only post-cutover registration path with the single public
+JSON object emitted by its installer:
+
+```sh
+punaro relay register \
+  --directory /absolute/private/punaro \
+  --machine-enrollment-file /absolute/private/new-machine.json \
+  --yes
+punaro up --directory /absolute/private/punaro
+```
+
+The command verifies the installation owner and database pair, registers the
+exact Ed25519 public key under the active cutover and legacy-gate locks, and
+then extends the known-key history plus static runtime authority marker-last.
+The database mutation is idempotent for the exact machine name and key. A
+publication failure is recovered by rerunning the exact command; never change
+the enrollment file during recovery. The adapter remains unauthorized until
+both phases and `punaro up` complete. Device enrollment, Cloudflare Access, and
+endpoint attachment are still separate least-privilege steps.
+
 Do not
 hand edit ownership, enrollment, credential, idempotency, capacity, lease,
 migration, update, restore, or audit rows to bypass a failure.

--- a/docs/platform-contracts.md
+++ b/docs/platform-contracts.md
@@ -575,8 +575,11 @@ must authenticate as current and resolve through
 that key selects one non-ambiguous static relay machine enrollment. The device
 therefore receives precisely the old machine ID, endpoint prefixes, exact
 endpoints, and attachment-device binding. Every Ed25519 request in this mode
-also resolves its exact public key through `auth.legacy_auth_state`, so a closed
-gate fails legacy authentication. Database errors, revoked or stale device
+also resolves its exact public key through the durable transition authority.
+Before cutover the open legacy gate admits the migration inventory. After an
+active cutover closes that gate, only a pending key created by the owner-only
+post-cutover registration transaction is admitted; migrated and retired keys
+remain blocked. Database errors, revoked or stale device
 credentials, ordinary unenrolled device credentials, retired mappings, and
 duplicate configured keys all fail closed. Enabling the mode requires device
 auth and the PostgreSQL relay; it does not itself make PostgreSQL writable mail

--- a/docs/production-compose.md
+++ b/docs/production-compose.md
@@ -134,11 +134,25 @@ an exact retry. It is valid both before and after mail cutover; the cutover
 marker itself cannot change. Removing a machine from the complete set prevents
 new signed requests after the next `punaro up`; use `[]` to revoke the final
 client. After mail cutover, additions with a new public key are rejected because
-the active transition authority cannot authenticate them. New mailbox clients
-are currently unavailable until a durable post-cutover authority-registration
-workflow is delivered. Also stop its local adapter and revoke its distinct
-Access token. Never edit `punarod.env`, the Compose override, or
-`installation.json` directly.
+the active transition authority cannot authenticate them until the owner
+registers that one key explicitly. For a new machine, keep its adapter disabled
+and use the single protected JSON object printed by its installer:
+
+```sh
+punaro relay register \
+  --directory INSTALLATION_DIR \
+  --machine-enrollment-file /absolute/private/new-machine.json \
+  --yes
+punaro up --directory INSTALLATION_DIR
+```
+
+The registration transaction is owner-only and commits before marker-last
+runtime publication. An interruption can leave a registered key absent from
+the runtime, never the reverse; rerun the exact command to recover. Changed
+retries and overlapping IDs, keys, endpoints, or prefixes fail closed. To
+revoke a client, remove it with `relay configure`, stop its local adapter, and
+revoke its distinct Access token. Never edit `punarod.env`, the Compose
+override, `installation.json`, or PostgreSQL authority rows directly.
 
 For every later release, use `punaro update --directory INSTALLATION_DIR` with
 the protected release metadata distributed for that release. This preserves the

--- a/docs/production-compose.md
+++ b/docs/production-compose.md
@@ -169,6 +169,15 @@ the old origin as the rollback target until all adapters pass. Do not publish
 the device listener on the LAN or preserve an old manual environment overlay;
 `punaro up` and current daemon configuration fail closed for that state.
 
+Cloudflare Access admission is a separate boundary from tunnel routing. For
+each machine-scoped service token, require a **Service Auth** policy that
+includes that exact token. With redirects disabled, a request carrying only
+the token headers to the protected `/v1/conversations` route must reach Punaro
+and return its JSON `401`; a `3xx` or HTML login response is a policy failure.
+Do not use `/readyz` as this proof, because health and device paths may have
+different routes or policies. Only after this check should a harmless signed
+request be used to prove relay enrollment and the final device origin.
+
 For every later release, use `punaro update --directory INSTALLATION_DIR` with
 the protected release metadata distributed for that release. This preserves the
 same durable update journal and recovery path as the initial installation; do

--- a/docs/production-compose.md
+++ b/docs/production-compose.md
@@ -115,6 +115,14 @@ database, health endpoint, and Compose credentials remain host-local.
 
 ## Add or revoke a mailbox client
 
+First prove that the tunnel's device route and health route terminate at this
+installation. Health may be routed to a dedicated loopback listener while
+signed device requests go elsewhere; `/readyz` alone is therefore not daemon
+identity. Record the Compose project, exact image, process/listener ownership,
+and one harmless signed-request outcome. If an older systemd relay or LAN test
+stack shares the host, keep it out of the evidence unless the tunnel route is
+explicitly switched to it.
+
 After initialization and before mail cutover, replace the complete public
 enrollment set through the same host-local lifecycle rather than editing
 generated files. Keep the JSON file owner-only and include every client that
@@ -153,6 +161,13 @@ retries and overlapping IDs, keys, endpoints, or prefixes fail closed. To
 revoke a client, remove it with `relay configure`, stop its local adapter, and
 revoke its distinct Access token. Never edit `punarod.env`, the Compose
 override, `installation.json`, or PostgreSQL authority rows directly.
+
+Relay authority requires a loopback device listener. For a legacy tunnel whose
+origin is a private-LAN address, stage this installation on a free loopback
+port, change the tunnel origin, verify signed traffic and readiness, and retain
+the old origin as the rollback target until all adapters pass. Do not publish
+the device listener on the LAN or preserve an old manual environment overlay;
+`punaro up` and current daemon configuration fail closed for that state.
 
 For every later release, use `punaro update --directory INSTALLATION_DIR` with
 the protected release metadata distributed for that release. This preserves the

--- a/docs/production-compose.md
+++ b/docs/production-compose.md
@@ -174,6 +174,8 @@ each machine-scoped service token, require a **Service Auth** policy that
 includes that exact token. With redirects disabled, a request carrying only
 the token headers to the protected `/v1/conversations` route must reach Punaro
 and return its JSON `401`; a `3xx` or HTML login response is a policy failure.
+One policy may include several exact machine tokens, but never use
+`any_valid_service_token` and never reuse one token pair across machines.
 Do not use `/readyz` as this proof, because health and device paths may have
 different routes or policies. Only after this check should a harmless signed
 request be used to prove relay enrollment and the final device origin.

--- a/docs/release-evidence/2026-08-10-durable-role-deployed-candidate.md
+++ b/docs/release-evidence/2026-08-10-durable-role-deployed-candidate.md
@@ -18,7 +18,13 @@
 
 ## Exact candidate
 
-- Source commit: `ba633f0d20a5e3c0b0711b2893521c9f59a2530e`.
+- Integrated source commit: `011b5b7c3df9c880cadf41c13e47b53c34865f60`.
+- Artifact-producing runtime commit:
+  `ba633f0d20a5e3c0b0711b2893521c9f59a2530e`. Rebuilding all three
+  platform artifacts from the integrated source commit reproduced the exact
+  deployed hashes below; the intervening merge changed tests, installers,
+  service definitions, and documentation but not relay or adapter runtime
+  source.
 - Review reference: PR #131, branch
   `agent/issue-55-durable-role-e2e`.
 - Signed/tagged release reference: none; official release remains withheld.
@@ -35,11 +41,13 @@
 The Linux server is byte-identical to the earlier role-routing build because
 the final runtime fix changes only the adapter client. All four installed
 artifacts were hashed after the final scenario and matched the values above.
+The three platform artifacts were then rebuilt from the integrated source
+commit and reproduced those hashes exactly.
 
 ## Verification gates
 
-The following command passed from a clean protected-path worktree at the exact
-source commit:
+The following command passed from a clean protected-path worktree at the
+integrated source commit:
 
 ```sh
 env GOCACHE=/tmp/punaro-go-cache \
@@ -49,7 +57,8 @@ env GOCACHE=/tmp/punaro-go-cache \
 Results included unit coverage, race tests, Staticcheck, `govulncheck` with no
 called vulnerabilities, `gosec` with zero issues, Gitleaks with no leaks, Go
 vet, lint, Windows compilation, deployment and installer verification, and the
-real two-client relay lifecycle E2E. The latter passed in 78.759 seconds.
+real two-client relay lifecycle E2E. The final integrated-head run's latter
+test passed in 78.295 seconds.
 
 GitHub Actions candidate run: pending final evidence-only synchronization.
 The earlier complete role-routing candidate run is retained at
@@ -120,8 +129,8 @@ identifier, delivery identifier, lease token, or body was recorded here.
   storage directly was rejected as unsafe and outside the supported control
   plane.
 - Final health: relay `active` and ready; both macOS launchd adapters running;
-  Mattone scheduled task running with exactly one process at the candidate
-  path.
+  Mattone scheduled task hidden and running a hidden-window action with
+  exactly one process at the candidate path.
 - Owner-managed pre-candidate rollback copies with suffix `.pre-ba633f0` were
   retained beside each installed binary. Rollback requires the documented
   service stop, atomic binary replacement, restart, hash check, and readiness

--- a/docs/release-evidence/2026-08-10-durable-role-deployed-candidate.md
+++ b/docs/release-evidence/2026-08-10-durable-role-deployed-candidate.md
@@ -1,0 +1,141 @@
+# Durable-role deployed-candidate evidence — 2026-08-10
+
+## Decision and scope
+
+- Capability: durable conversation roles, session replacement fencing, and
+  targeted role delivery from issues #55 and #58.
+- Personal deployment decision: **approved** for the owner-managed Punaro
+  deployment described in the installation guide.
+- Official Internet-facing release decision: **withheld**. This record does
+  not check any box in
+  [`security-release-gates.md`](../security-release-gates.md); no signed
+  release tag, independent human approvals, SBOM, or artifact attestation was
+  produced for this personal release candidate.
+- Operator and security reviewer: Seb, acting as the owner-operator permitted
+  by the personal self-hosted-build rule. Cryptography approval is not
+  applicable because this change does not add or alter a cryptographic
+  protocol.
+
+## Exact candidate
+
+- Source commit: `ba633f0d20a5e3c0b0711b2893521c9f59a2530e`.
+- Review reference: PR #131, branch
+  `agent/issue-55-durable-role-e2e`.
+- Signed/tagged release reference: none; official release remains withheld.
+- Linux/amd64, `CGO_ENABLED=0`, `punarod` SHA-256:
+  `b030f899b3348d0135a9437b25ec147beebaf534799779840380bad3ce6fa085`.
+- macOS/arm64 native-CGO `punaro-adapter` SHA-256, deployed independently on
+  Mac Studio and Coso:
+  `3dc6747db9f9edce98ef566ab8ab045c905a18fc334a7735c08c28eb16be4059`.
+- Windows/amd64, `CGO_ENABLED=0`, `punaro-adapter.exe` SHA-256:
+  `35e3132a84c40ff69f2aa360e6667b7c19f95d8a218db5677abccc93bb45f870`.
+- Container image digest: not applicable; the validated relay is the native
+  systemd deployment.
+
+The Linux server is byte-identical to the earlier role-routing build because
+the final runtime fix changes only the adapter client. All four installed
+artifacts were hashed after the final scenario and matched the values above.
+
+## Verification gates
+
+The following command passed from a clean protected-path worktree at the exact
+source commit:
+
+```sh
+env GOCACHE=/tmp/punaro-go-cache \
+  make test test-race staticcheck security lint test-real-relay-e2e
+```
+
+Results included unit coverage, race tests, Staticcheck, `govulncheck` with no
+called vulnerabilities, `gosec` with zero issues, Gitleaks with no leaks, Go
+vet, lint, Windows compilation, deployment and installer verification, and the
+real two-client relay lifecycle E2E. The latter passed in 78.759 seconds.
+
+GitHub Actions candidate run: pending final evidence-only synchronization.
+The earlier complete role-routing candidate run is retained at
+`https://github.com/rock3r/punaro/actions/runs/31419646148`; it does not replace
+the final candidate run.
+
+## Deployment admission and enrollment
+
+- The relay, Mac Studio, Coso, and Mattone ran the exact candidate binaries.
+- All machine credentials retained their narrow endpoint namespaces. Missing
+  Mac Studio and Coso validation prefixes were added additively; no existing
+  enrollment was removed or widened.
+- Cloudflare Access used a Service Auth (`non_identity`) policy naming three
+  distinct exact per-machine service tokens. No
+  `any_valid_service_token` rule was used.
+- Header-authenticated unsigned `/v1/conversations` probes reached Punaro and
+  returned application JSON `401` without redirects on all three adapter
+  machines.
+- A live regression proved Cloudflare accepted a signed request carrying only
+  the service-token headers and rejected the same request when a browser
+  `CF_Authorization` cookie was mixed in. The final adapter never establishes
+  or replays that cookie with Service Auth credentials.
+
+## Redacted live outcomes
+
+All probes used disposable aliases, roles, conversation state, opaque bodies,
+and idempotency keys. No credential, header value, private key, conversation
+identifier, delivery identifier, lease token, or body was recorded here.
+
+- Six pairwise host directions completed. Every intended endpoint observed
+  each opaque probe once and acknowledged it. A same-key retry returned the
+  original message identity and caused no duplicate mailbox injection.
+- Targeted role delivery reached only Coso's bound primary session. Its local
+  endpoint, other Coso role, replacement session, Mac Studio, and every
+  Mattone session received zero copies.
+- An untargeted broadcast remained compatible: Coso's endpoint plus two bound
+  roles received and acknowledged three copies total; Mattone's endpoint plus
+  two bound roles did the same. Unbound replacement sessions and the sending
+  endpoint received zero copies.
+- Coso replacement `c3 -> c4`: the old session leased generation 1; rebinding
+  invalidated its acknowledgement with HTTP `403`; the replacement reclaimed
+  the same delivery at generation 2 and acknowledged with `204`. After normal
+  detachment, stale bind also returned `403`.
+- Mattone replacement `w3 -> w4`: the same generation `1 -> 2`, stale-ack
+  `403`, replacement-ack `204`, and detached stale-bind `403` proof passed
+  using native Windows process and scheduled-task lifecycle.
+- Offline recovery: Coso was stopped through launchd, a targeted message was
+  accepted while unavailable, then the restored adapter committed and
+  acknowledged it on polling attempt 9. A later receive observed zero
+  duplicates.
+- Attachment fail-closed boundary: the running relay had zero trusted or
+  retired attachment environment keys. Signed trusted-attachment, v2
+  directory, and v3 permit routes each returned `404` without creating state.
+- Remote memory fail-closed boundary: the running relay had zero memory or
+  remote-MCP environment keys. Signed memory and MCP routes returned `404`.
+  A functional memory E2E was therefore intentionally unavailable; no mock or
+  offline substitute was counted.
+
+## Cleanup, health, and rollback
+
+- The supported conversation control plane removed both disposable non-admin
+  endpoint members and recorded two audit events.
+- Each original attached group was restored. Active disposable aliases were
+  zero on all machines.
+- Punaro currently exposes no supported conversation-delete or role-member
+  removal operation. The isolated conversation's final admin and durable role
+  metadata therefore remain as the only residual test state; deleting relay
+  storage directly was rejected as unsafe and outside the supported control
+  plane.
+- Final health: relay `active` and ready; both macOS launchd adapters running;
+  Mattone scheduled task running with exactly one process at the candidate
+  path.
+- Owner-managed pre-candidate rollback copies with suffix `.pre-ba633f0` were
+  retained beside each installed binary. Rollback requires the documented
+  service stop, atomic binary replacement, restart, hash check, and readiness
+  check. This evidence expires when any listed artifact is replaced or the
+  Access policy/enrollment authority changes.
+
+## Security-gate disposition
+
+- [`Trusted-relay attachments`](../security-release-gates.md#trusted-relay-attachments-gated-candidate-closed):
+  unchanged and closed.
+- [`Attachment v2`](../security-release-gates.md#attachment-v2-superseded-closed)
+  and
+  [`Attachment v3`](../security-release-gates.md#attachment-v3-controlled-runtime-superseded-not-released):
+  unchanged, retired, and closed.
+- [`Public relay and operations`](../security-release-gates.md#public-relay-and-operations-closed):
+  unchanged and closed for an official release. The owner-managed personal
+  deployment evidence above is not independent release approval.

--- a/docs/release-evidence/2026-08-10-durable-role-deployed-candidate.md
+++ b/docs/release-evidence/2026-08-10-durable-role-deployed-candidate.md
@@ -18,18 +18,18 @@
 
 ## Exact candidate
 
-- Integrated source commit: `011b5b7c3df9c880cadf41c13e47b53c34865f60`.
-- Artifact-producing runtime commit:
-  `ba633f0d20a5e3c0b0711b2893521c9f59a2530e`. Rebuilding all three
-  platform artifacts from the integrated source commit reproduced the exact
-  deployed hashes below; the intervening merge changed tests, installers,
-  service definitions, and documentation but not relay or adapter runtime
-  source.
+- Integrated source commit: `8d7b7f7670cc10484a493f4003156e0be0673c05`.
+- Relay artifact-producing commit:
+  `8d7b7f7670cc10484a493f4003156e0be0673c05`.
+- Adapter artifact-producing commit:
+  `ba633f0d20a5e3c0b0711b2893521c9f59a2530e`. The final review fix changes
+  only PostgreSQL legacy-key resolution in the relay; rebuilding both adapter
+  platforms from the integrated source reproduced their exact deployed hashes.
 - Review reference: PR #131, branch
   `agent/issue-55-durable-role-e2e`.
 - Signed/tagged release reference: none; official release remains withheld.
 - Linux/amd64, `CGO_ENABLED=0`, `punarod` SHA-256:
-  `b030f899b3348d0135a9437b25ec147beebaf534799779840380bad3ce6fa085`.
+  `be0e237866ae40ff5d72a2bbe6162443c1e3a9b7a0d7893f6933a704724f660a`.
 - macOS/arm64 native-CGO `punaro-adapter` SHA-256, deployed independently on
   Mac Studio and Coso:
   `3dc6747db9f9edce98ef566ab8ab045c905a18fc334a7735c08c28eb16be4059`.
@@ -38,11 +38,10 @@
 - Container image digest: not applicable; the validated relay is the native
   systemd deployment.
 
-The Linux server is byte-identical to the earlier role-routing build because
-the final runtime fix changes only the adapter client. All four installed
-artifacts were hashed after the final scenario and matched the values above.
-The three platform artifacts were then rebuilt from the integrated source
-commit and reproduced those hashes exactly.
+All four installed artifacts were hashed after the final scenario and matched
+the values above. The relay was built from the final review-fix commit; both
+adapter artifacts were rebuilt from that commit and reproduced their earlier
+deployed hashes exactly.
 
 ## Verification gates
 
@@ -58,7 +57,9 @@ Results included unit coverage, race tests, Staticcheck, `govulncheck` with no
 called vulnerabilities, `gosec` with zero issues, Gitleaks with no leaks, Go
 vet, lint, Windows compilation, deployment and installer verification, and the
 real two-client relay lifecycle E2E. The final integrated-head run's latter
-test passed in 78.295 seconds.
+test passed in 83.198 seconds. The Docker-backed PostgreSQL integration suite
+also passed in 29.610 seconds after first demonstrating that the new
+closed-gate registration test failed for the intended reason.
 
 GitHub Actions candidate run: pending final evidence-only synchronization.
 The earlier complete role-routing candidate run is retained at
@@ -81,6 +82,9 @@ the final candidate run.
   the service-token headers and rejected the same request when a browser
   `CF_Authorization` cookie was mixed in. The final adapter never establishes
   or replays that cookie with Service Auth credentials.
+- The final relay review fix permits only an owner-registered pending key under
+  an active mail cutover while the migration-wide legacy gate remains closed;
+  the integration proof confirmed that an earlier migrated key stays rejected.
 
 ## Redacted live outcomes
 
@@ -116,13 +120,21 @@ identifier, delivery identifier, lease token, or body was recorded here.
   remote-MCP environment keys. Signed memory and MCP routes returned `404`.
   A functional memory E2E was therefore intentionally unavailable; no mock or
   offline substitute was counted.
+- After deploying the final review-fix relay hash, a fresh targeted-role probe
+  reached Coso's bound primary session exactly once and its endpoint plus other
+  role session zero times. The delivery was acknowledged; a same-key retry
+  returned the same message identity and produced zero duplicate mailbox
+  injection. Four distinct signed machine identities also renewed six active
+  endpoint leases through the final relay.
 
 ## Cleanup, health, and rollback
 
 - The supported conversation control plane removed both disposable non-admin
   endpoint members and recorded two audit events.
-- Each original attached group was restored. Active disposable aliases were
-  zero on all machines.
+- Each original attached group was restored. A final audit found stale
+  disposable memberships in the real attached groups; the Mac Studio and Coso
+  aliases plus one Mattone alias were removed. Active disposable aliases were
+  then zero on all three machines.
 - Punaro currently exposes no supported conversation-delete or role-member
   removal operation. The isolated conversation's final admin and durable role
   metadata therefore remain as the only residual test state; deleting relay
@@ -131,11 +143,12 @@ identifier, delivery identifier, lease token, or body was recorded here.
 - Final health: relay `active` and ready; both macOS launchd adapters running;
   Mattone scheduled task hidden and running a hidden-window action with
   exactly one process at the candidate path.
-- Owner-managed pre-candidate rollback copies with suffix `.pre-ba633f0` were
-  retained beside each installed binary. Rollback requires the documented
-  service stop, atomic binary replacement, restart, hash check, and readiness
-  check. This evidence expires when any listed artifact is replaced or the
-  Access policy/enrollment authority changes.
+- Owner-managed adapter rollback copies with suffix `.pre-ba633f0` and the
+  final relay rollback copy `.pre-8d7b7f7` were retained beside their installed
+  binaries. Rollback requires the documented service stop, atomic binary
+  replacement, restart, hash check, and readiness check. This evidence expires
+  when any listed artifact is replaced or the Access policy/enrollment
+  authority changes.
 
 ## Security-gate disposition
 

--- a/internal/adapter/client.go
+++ b/internal/adapter/client.go
@@ -12,10 +12,8 @@ import (
 	"io"
 	"net"
 	"net/http"
-	"net/http/cookiejar"
 	"net/url"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/coder/websocket"
@@ -31,11 +29,10 @@ type AccessServiceToken struct {
 	ClientSecret string
 }
 
-// OpenAccessSession establishes a Cloudflare Access session for an HTTPS
-// origin using a service token. The returned client owns an origin-scoped
-// cookie jar; callers must still attach the service-token headers to their
-// protected request. It is deliberately usable by bootstrap clients, which
-// cannot sign an adapter request before device enrollment completes.
+// OpenAccessSession validates and copies the HTTP client used to reach a
+// Cloudflare Access-protected origin. Service-token policies authenticate each
+// protected request from its headers, so this deliberately does not establish
+// or retain a browser authorization-cookie session.
 func OpenAccessSession(_ context.Context, rawURL string, client *http.Client, token AccessServiceToken) (*http.Client, error) {
 	baseURL, err := url.Parse(rawURL)
 	if err != nil || baseURL.Scheme == "" || baseURL.Host == "" || baseURL.RawQuery != "" || baseURL.Fragment != "" {
@@ -55,6 +52,9 @@ func OpenAccessSession(_ context.Context, rawURL string, client *http.Client, to
 	// headers. They do not necessarily mint a browser cookie, so probing a
 	// relay-only path for CF_Authorization would reject valid admission before
 	// the caller can make its authenticated request.
+	if token.ClientID != "" {
+		clientCopy.Jar = nil
+	}
 	return &clientCopy, nil
 }
 
@@ -66,17 +66,6 @@ type HTTPRelayClient struct {
 	httpClient  *http.Client
 	consumerID  string
 	accessToken AccessServiceToken
-	access      *accessSession
-}
-
-// accessSession establishes and retains Cloudflare Access' short-lived
-// authorization cookie without ever replaying a signed relay request through
-// an Access redirect. It is used only for public, HTTPS relay origins.
-type accessSession struct {
-	baseURL *url.URL
-	client  *http.Client
-	token   AccessServiceToken
-	mu      sync.Mutex
 }
 
 type relayHTTPStatusError struct {
@@ -116,90 +105,15 @@ func NewHTTPRelayClient(rawURL, machineID string, privateKey ed25519.PrivateKey,
 	if err != nil {
 		return nil, fmt.Errorf("create relay consumer identity: %w", err)
 	}
+	// A Service Auth policy authenticates every request from the service-token
+	// headers below. Never combine those credentials with a browser
+	// CF_Authorization cookie: Cloudflare can reject that mixed identity before
+	// the signed relay request reaches the origin.
+	if accessToken.ClientID != "" {
+		clientCopy.Jar = nil
+	}
 	result := &HTTPRelayClient{baseURL: baseURL, machineID: machineID, privateKey: append(ed25519.PrivateKey(nil), privateKey...), httpClient: &clientCopy, consumerID: consumerID, accessToken: accessToken}
-	if accessToken.ClientID != "" && !loopbackHost(baseURL.Hostname()) {
-		jar, err := cookiejar.New(nil)
-		if err != nil {
-			return nil, fmt.Errorf("create Cloudflare Access cookie jar: %w", err)
-		}
-		result.httpClient.Jar = jar
-		result.access = &accessSession{baseURL: baseURL, client: result.httpClient, token: accessToken}
-	}
 	return result, nil
-}
-
-func (c *HTTPRelayClient) ensureAccessSession(ctx context.Context) error {
-	if c.access == nil {
-		return nil
-	}
-	return c.access.ensure(ctx)
-}
-
-func (a *accessSession) ensure(ctx context.Context) error {
-	a.mu.Lock()
-	defer a.mu.Unlock()
-	if hasAccessAuthorizationCookie(a.client.Jar, a.baseURL) {
-		return nil
-	}
-
-	target := a.baseURL.ResolveReference(&url.URL{Path: "/.well-known/punaro-access-session"})
-	for hop := 0; hop < 3; hop++ {
-		request, err := http.NewRequestWithContext(ctx, http.MethodGet, target.String(), nil)
-		if err != nil {
-			return fmt.Errorf("build Cloudflare Access session request: %w", err)
-		}
-		request.Header.Set("CF-Access-Client-Id", a.token.ClientID)
-		request.Header.Set("CF-Access-Client-Secret", a.token.ClientSecret)
-		client := *a.client
-		client.CheckRedirect = func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse }
-		response, err := client.Do(request)
-		if err != nil {
-			return fmt.Errorf("establish Cloudflare Access session: %w", err)
-		}
-		_, _ = io.Copy(io.Discard, io.LimitReader(response.Body, 64<<10))
-		_ = response.Body.Close()
-		if response.StatusCode < http.StatusMultipleChoices || response.StatusCode >= http.StatusBadRequest {
-			if hasAccessAuthorizationCookie(a.client.Jar, a.baseURL) {
-				return nil
-			}
-			return fmt.Errorf("cloudflare Access session response did not set an authorization cookie (HTTP %d)", response.StatusCode)
-		}
-		next, err := response.Location()
-		if err != nil {
-			return errors.New("cloudflare Access session redirect omitted a valid Location")
-		}
-		next = target.ResolveReference(next)
-		if next.Scheme != "https" || next.User != nil {
-			return errors.New("cloudflare Access session redirect is unsafe")
-		}
-		if hop == 0 {
-			if !cloudflareAccessHost(next.Hostname()) {
-				return errors.New("cloudflare Access session redirect leaves the trusted Access domain")
-			}
-		} else if !sameOrigin(next, a.baseURL) {
-			return errors.New("cloudflare Access session redirect does not return to the relay origin")
-		}
-		target = next
-	}
-	return errors.New("cloudflare Access session exceeded redirect limit")
-}
-
-func hasAccessAuthorizationCookie(jar http.CookieJar, relayURL *url.URL) bool {
-	for _, cookie := range jar.Cookies(relayURL) {
-		if strings.EqualFold(cookie.Name, "CF_Authorization") && cookie.Value != "" {
-			return true
-		}
-	}
-	return false
-}
-
-func cloudflareAccessHost(host string) bool {
-	host = strings.TrimSuffix(strings.ToLower(strings.TrimSpace(host)), ".")
-	return strings.HasSuffix(host, ".cloudflareaccess.com") && host != "cloudflareaccess.com"
-}
-
-func sameOrigin(left, right *url.URL) bool {
-	return left.Scheme == right.Scheme && strings.EqualFold(left.Host, right.Host)
 }
 
 // Advertise replaces the machine's current local endpoint attachment set.
@@ -405,9 +319,6 @@ func (c *HTTPRelayClient) IssuePermit(ctx context.Context, permitRequest attachm
 	if err != nil {
 		return attachmentv2.Permit{}, fmt.Errorf("encode permit request: %w", err)
 	}
-	if err := c.ensureAccessSession(ctx); err != nil {
-		return attachmentv2.Permit{}, err
-	}
 	nonce, err := randomNonce()
 	if err != nil {
 		return attachmentv2.Permit{}, err
@@ -491,9 +402,6 @@ func (c *HTTPRelayClient) DoV3Attachment(ctx context.Context, method, path strin
 	if err != nil || attachmentv3.VerifyAttachmentRoute(route, permit) != nil {
 		return nil, errors.New("invalid v3 attachment route")
 	}
-	if err := c.ensureAccessSession(ctx); err != nil {
-		return nil, err
-	}
 	nonce, err := randomNonce()
 	if err != nil {
 		return nil, err
@@ -547,9 +455,6 @@ func (c *HTTPRelayClient) doSignedCBOR(ctx context.Context, method, path string,
 	if c == nil || maximum <= 0 || len(body) == 0 || path == "" || contentType != "application/cbor" {
 		return nil, errors.New("invalid signed CBOR request")
 	}
-	if err := c.ensureAccessSession(ctx); err != nil {
-		return nil, err
-	}
 	nonce, err := randomNonce()
 	if err != nil {
 		return nil, err
@@ -594,9 +499,6 @@ func (c *HTTPRelayClient) doSignedCBOR(ctx context.Context, method, path string,
 // policy: directory membership and public-key metadata are not public relay
 // content. Callers must still root-verify the returned snapshot before use.
 func (c *HTTPRelayClient) FetchDirectorySnapshot(ctx context.Context) (attachmentv2.DirectorySnapshot, error) {
-	if err := c.ensureAccessSession(ctx); err != nil {
-		return attachmentv2.DirectorySnapshot{}, err
-	}
 	nonce, err := randomNonce()
 	if err != nil {
 		return attachmentv2.DirectorySnapshot{}, err
@@ -643,9 +545,6 @@ func (c *HTTPRelayClient) FetchDirectorySnapshot(ctx context.Context) (attachmen
 // the connection ends. Durable polling remains authoritative.
 func (c *HTTPRelayClient) ReadNotifications(ctx context.Context, receive func(relay.WakeEvent)) error {
 	path := "/v1/notifications"
-	if err := c.ensureAccessSession(ctx); err != nil {
-		return err
-	}
 	nonce, err := randomNonce()
 	if err != nil {
 		return err
@@ -695,7 +594,7 @@ func (c *HTTPRelayClient) ReadNotifications(ctx context.Context, receive func(re
 }
 
 func (c *HTTPRelayClient) addAccessCookies(headers http.Header) {
-	if c == nil || c.httpClient == nil || c.httpClient.Jar == nil {
+	if c == nil || c.accessToken.ClientID != "" || c.httpClient == nil || c.httpClient.Jar == nil {
 		return
 	}
 	for _, cookie := range c.httpClient.Jar.Cookies(c.baseURL) {
@@ -708,9 +607,6 @@ func (c *HTTPRelayClient) doJSON(ctx context.Context, method, path string, reque
 }
 
 func (c *HTTPRelayClient) doJSONWithIdempotency(ctx context.Context, method, path string, requestValue any, idempotencyKey string, responseValue any) (int, error) {
-	if err := c.ensureAccessSession(ctx); err != nil {
-		return 0, err
-	}
 	body, err := json.Marshal(requestValue)
 	if err != nil {
 		return 0, fmt.Errorf("encode relay request: %w", err)

--- a/internal/adapter/client.go
+++ b/internal/adapter/client.go
@@ -318,11 +318,29 @@ func capabilityNames(capabilities relay.Capability) []string {
 // idempotency key belongs to the caller's retry domain and is never derived
 // from the body or a machine credential.
 func (c *HTTPRelayClient) Send(ctx context.Context, conversationID, fromEndpoint, body, idempotencyKey string) (relay.Message, error) {
+	return c.send(ctx, conversationID, fromEndpoint, "", body, idempotencyKey)
+}
+
+// SendToRole appends a message whose durable delivery is restricted to one
+// receiving role membership. An empty role is never accepted here; callers
+// that need the compatible broadcast behavior must use Send.
+func (c *HTTPRelayClient) SendToRole(ctx context.Context, conversationID, fromEndpoint, targetRole, body, idempotencyKey string) (relay.Message, error) {
+	if !relay.ValidRole(targetRole) {
+		return relay.Message{}, fmt.Errorf("target role is required")
+	}
+	return c.send(ctx, conversationID, fromEndpoint, targetRole, body, idempotencyKey)
+}
+
+func (c *HTTPRelayClient) send(ctx context.Context, conversationID, fromEndpoint, targetRole, body, idempotencyKey string) (relay.Message, error) {
 	if strings.TrimSpace(conversationID) == "" || strings.TrimSpace(fromEndpoint) == "" || strings.TrimSpace(idempotencyKey) == "" {
 		return relay.Message{}, fmt.Errorf("conversation, sender endpoint, and idempotency key are required")
 	}
 	var message relay.Message
-	status, err := c.doJSONWithIdempotency(ctx, http.MethodPost, "/v1/conversations/"+url.PathEscape(conversationID)+"/messages", map[string]any{"from_endpoint": fromEndpoint, "body": body}, idempotencyKey, &message)
+	request := map[string]any{"from_endpoint": fromEndpoint, "body": body}
+	if targetRole != "" {
+		request["target_role"] = targetRole
+	}
+	status, err := c.doJSONWithIdempotency(ctx, http.MethodPost, "/v1/conversations/"+url.PathEscape(conversationID)+"/messages", request, idempotencyKey, &message)
 	if err != nil {
 		return message, &relayHTTPStatusError{status: status, err: err}
 	}

--- a/internal/adapter/client_test.go
+++ b/internal/adapter/client_test.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"net/http/cookiejar"
 	"net/http/httptest"
+	"net/url"
 	"strings"
 	"testing"
 	"time"
@@ -49,19 +50,8 @@ func TestHTTPRelayClientIssuesHolderSignedPermitRequest(t *testing.T) {
 		t.Fatal(err)
 	}
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path == "/.well-known/punaro-access-session" {
-			if r.Header.Get("X-Punaro-Signature") != "" {
-				t.Fatal("signed permit request was replayed during Access preflight")
-			}
-			http.SetCookie(w, &http.Cookie{Name: "CF_Authorization", Value: "permit-session", Path: "/"})
-			w.WriteHeader(http.StatusUnauthorized)
-			return
-		}
 		if r.Method != http.MethodPost || r.URL.Path != "/v2/permits" || r.URL.RawQuery != "" || r.Header.Get("Content-Type") != "application/cbor" {
 			t.Fatalf("unexpected request %s %s type=%q", r.Method, r.URL.String(), r.Header.Get("Content-Type"))
-		}
-		if !strings.Contains(r.Header.Get("Cookie"), "CF_Authorization=permit-session") {
-			t.Fatal("permit request omitted Access session cookie")
 		}
 		body, err := io.ReadAll(r.Body)
 		if err != nil {
@@ -87,7 +77,6 @@ func TestHTTPRelayClientIssuesHolderSignedPermitRequest(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	enableTestAccessSession(t, client)
 	permit, err := client.IssuePermit(context.Background(), permitRequest)
 	if err != nil || permit != expectedPermit {
 		t.Fatalf("permit=%+v err=%v", permit, err)
@@ -347,14 +336,6 @@ func TestHTTPRelayClientSendsBoundV3AttachmentOperation(t *testing.T) {
 		t.Fatal(err)
 	}
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path == "/.well-known/punaro-access-session" {
-			if r.Header.Get("X-Punaro-Signature") != "" {
-				t.Fatal("signed v3 attachment request was replayed during Access preflight")
-			}
-			http.SetCookie(w, &http.Cookie{Name: "CF_Authorization", Value: "attachment-session", Path: "/"})
-			w.WriteHeader(http.StatusUnauthorized)
-			return
-		}
 		gotBody := mustReadAll(t, r)
 		if r.Method != http.MethodPut || r.URL.Path != path || string(gotBody) != string(body) {
 			t.Fatalf("request=%s %s body=%q", r.Method, r.URL.Path, gotBody)
@@ -371,9 +352,6 @@ func TestHTTPRelayClientSendsBoundV3AttachmentOperation(t *testing.T) {
 		if !ed25519.Verify(machinePublic, relay.CanonicalRequest(request), request.Signature) {
 			t.Fatal("attachment request did not have valid machine signature")
 		}
-		if !strings.Contains(r.Header.Get("Cookie"), "CF_Authorization=attachment-session") {
-			t.Fatal("v3 attachment request omitted Access session cookie")
-		}
 		w.Header().Set("Content-Type", "application/cbor")
 		_, _ = w.Write([]byte{0xa1})
 	}))
@@ -382,7 +360,6 @@ func TestHTTPRelayClientSendsBoundV3AttachmentOperation(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	enableTestAccessSession(t, client)
 	result, err := client.DoV3Attachment(context.Background(), http.MethodPut, path, body, permit, op)
 	if err != nil || string(result) != string([]byte{0xa1}) {
 		t.Fatalf("result=%x err=%v", result, err)
@@ -455,60 +432,13 @@ func TestHTTPRelayClientDoesNotFollowRedirectForOfferNotice(t *testing.T) {
 	}
 }
 
-func TestHTTPRelayClientEstablishesAccessSessionWithoutReplayingSignedRequest(t *testing.T) {
-	_, machinePrivate, err := ed25519.GenerateKey(rand.Reader)
-	if err != nil {
-		t.Fatal(err)
-	}
-	step := 0
-	client, err := NewHTTPRelayClient("https://relay.example", "machine-a", machinePrivate, &http.Client{Transport: roundTripperFunc(func(request *http.Request) (*http.Response, error) {
-		step++
-		if request.Header.Get("CF-Access-Client-Id") != "access-id" || request.Header.Get("CF-Access-Client-Secret") != "access-secret" {
-			t.Fatalf("request %d omitted Access headers", step)
-		}
-		switch step {
-		case 1:
-			if request.URL.Host != "relay.example" || request.URL.Path != "/.well-known/punaro-access-session" || request.Header.Get("X-Punaro-Signature") != "" {
-				t.Fatalf("unsafe initial preflight: %s %s", request.URL, request.Header.Get("X-Punaro-Signature"))
-			}
-			return testHTTPResponse(request, http.StatusFound, http.Header{"Location": []string{"https://team.cloudflareaccess.com/session"}}), nil
-		case 2:
-			if request.URL.Host != "team.cloudflareaccess.com" || request.Header.Get("X-Punaro-Signature") != "" {
-				t.Fatalf("signed relay request reached Access: %s", request.URL)
-			}
-			return testHTTPResponse(request, http.StatusFound, http.Header{"Location": []string{"https://relay.example/.well-known/punaro-access-session"}}), nil
-		case 3:
-			if request.URL.Host != "relay.example" || request.Header.Get("X-Punaro-Signature") != "" {
-				t.Fatalf("unsafe returning preflight: %s", request.URL)
-			}
-			return testHTTPResponse(request, http.StatusNotFound, http.Header{"Set-Cookie": []string{"CF_Authorization=session; Path=/; Secure"}}), nil
-		case 4:
-			if request.URL.Host != "relay.example" || request.Method != http.MethodPut || request.URL.Path != "/v1/machines/me/endpoints" {
-				t.Fatalf("unexpected signed request: %s %s", request.Method, request.URL)
-			}
-			if request.Header.Get("X-Punaro-Signature") == "" || !strings.Contains(request.Header.Get("Cookie"), "CF_Authorization=session") {
-				t.Fatal("signed request did not carry the origin-scoped Access session")
-			}
-			return testHTTPResponse(request, http.StatusNoContent, nil), nil
-		default:
-			t.Fatalf("unexpected request %d: %s", step, request.URL)
-			return nil, nil
-		}
-	})}, AccessServiceToken{ClientID: "access-id", ClientSecret: "access-secret"})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if err := client.Advertise(context.Background(), []string{"agent/a"}); err != nil {
-		t.Fatal(err)
-	}
-	if step != 4 {
-		t.Fatalf("request count=%d want 4", step)
-	}
-}
-
 func TestOpenAccessSessionSkipsCookiePreflightForServiceTokens(t *testing.T) {
 	requests := 0
-	client, err := OpenAccessSession(context.Background(), "https://relay.example", &http.Client{Transport: roundTripperFunc(func(*http.Request) (*http.Response, error) {
+	jar, err := cookiejar.New(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	client, err := OpenAccessSession(context.Background(), "https://relay.example", &http.Client{Jar: jar, Transport: roundTripperFunc(func(*http.Request) (*http.Response, error) {
 		requests++
 		return nil, errors.New("service-token bootstrap should not preflight")
 	})}, AccessServiceToken{ClientID: "access-id", ClientSecret: "access-secret"})
@@ -520,29 +450,36 @@ func TestOpenAccessSessionSkipsCookiePreflightForServiceTokens(t *testing.T) {
 	}
 }
 
-func TestHTTPRelayClientAcceptsAccessCookieFromUnauthorizedPreflight(t *testing.T) {
+func TestHTTPRelayClientServiceTokenDoesNotReplayAccessAuthorizationCookie(t *testing.T) {
 	_, machinePrivate, err := ed25519.GenerateKey(rand.Reader)
 	if err != nil {
 		t.Fatal(err)
 	}
 	requests := 0
-	client, err := NewHTTPRelayClient("https://relay.example", "machine-a", machinePrivate, &http.Client{Transport: roundTripperFunc(func(request *http.Request) (*http.Response, error) {
+	jar, err := cookiejar.New(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	relayURL, err := url.Parse("https://relay.example")
+	if err != nil {
+		t.Fatal(err)
+	}
+	jar.SetCookies(relayURL, []*http.Cookie{{Name: "CF_Authorization", Value: "stale", Path: "/", Secure: true}})
+	client, err := NewHTTPRelayClient("https://relay.example", "machine-a", machinePrivate, &http.Client{Jar: jar, Transport: roundTripperFunc(func(request *http.Request) (*http.Response, error) {
 		requests++
-		switch requests {
-		case 1:
-			if request.URL.Path != "/.well-known/punaro-access-session" || request.Header.Get("X-Punaro-Signature") != "" {
-				t.Fatalf("unexpected preflight request: %s %s", request.URL, request.Header.Get("X-Punaro-Signature"))
-			}
-			return testHTTPResponse(request, http.StatusUnauthorized, http.Header{"Set-Cookie": []string{"CF_Authorization=session; Path=/; Secure"}}), nil
-		case 2:
-			if request.Header.Get("X-Punaro-Signature") == "" || !strings.Contains(request.Header.Get("Cookie"), "CF_Authorization=session") {
-				t.Fatal("signed request did not use the Access cookie returned with HTTP 401")
-			}
-			return testHTTPResponse(request, http.StatusNoContent, nil), nil
-		default:
-			t.Fatalf("unexpected request %d", requests)
-			return nil, nil
+		if request.Header.Get("CF-Access-Client-Id") != "access-id" || request.Header.Get("CF-Access-Client-Secret") != "access-secret" {
+			t.Fatal("request omitted Access service-token headers")
 		}
+		if request.URL.Path == "/.well-known/punaro-access-session" {
+			return testHTTPResponse(request, http.StatusNotFound, http.Header{"Set-Cookie": []string{"CF_Authorization=stale; Path=/; Secure"}}), nil
+		}
+		if request.URL.Path != "/v1/machines/me/endpoints" || request.Header.Get("X-Punaro-Signature") == "" {
+			t.Fatalf("unexpected protected request: %s %s", request.Method, request.URL)
+		}
+		if request.Header.Get("Cookie") != "" {
+			return testHTTPResponse(request, http.StatusForbidden, nil), nil
+		}
+		return testHTTPResponse(request, http.StatusNoContent, nil), nil
 	})}, AccessServiceToken{ClientID: "access-id", ClientSecret: "access-secret"})
 	if err != nil {
 		t.Fatal(err)
@@ -550,45 +487,8 @@ func TestHTTPRelayClientAcceptsAccessCookieFromUnauthorizedPreflight(t *testing.
 	if err := client.Advertise(context.Background(), []string{"agent/a"}); err != nil {
 		t.Fatal(err)
 	}
-	if requests != 2 {
-		t.Fatalf("requests=%d want 2", requests)
-	}
-}
-
-func TestHTTPRelayClientRejectsUntrustedAccessSessionRedirect(t *testing.T) {
-	_, machinePrivate, err := ed25519.GenerateKey(rand.Reader)
-	if err != nil {
-		t.Fatal(err)
-	}
-	requests := 0
-	client, err := NewHTTPRelayClient("https://relay.example", "machine-a", machinePrivate, &http.Client{Transport: roundTripperFunc(func(request *http.Request) (*http.Response, error) {
-		requests++
-		if request.Header.Get("X-Punaro-Signature") != "" {
-			t.Fatal("signed relay request was sent before a trusted Access session")
-		}
-		return testHTTPResponse(request, http.StatusFound, http.Header{"Location": []string{"https://attacker.example/session"}}), nil
-	})}, AccessServiceToken{ClientID: "access-id", ClientSecret: "access-secret"})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if err := client.Advertise(context.Background(), []string{"agent/a"}); err == nil {
-		t.Fatal("untrusted Access redirect was accepted")
-	}
 	if requests != 1 {
 		t.Fatalf("requests=%d want 1", requests)
-	}
-}
-
-func TestCloudflareAccessHost(t *testing.T) {
-	for host, want := range map[string]bool{
-		"team.cloudflareaccess.com":             true,
-		"TEAM.CLOUDFLAREACCESS.COM.":            true,
-		"cloudflareaccess.com":                  false,
-		"cloudflareaccess.com.attacker.example": false,
-	} {
-		if got := cloudflareAccessHost(host); got != want {
-			t.Fatalf("cloudflareAccessHost(%q)=%t want %t", host, got, want)
-		}
 	}
 }
 
@@ -854,16 +754,6 @@ func TestHTTPRelayClientReadsPayloadFreeWake(t *testing.T) {
 	default:
 		t.Fatal("wake was not delivered")
 	}
-}
-
-func enableTestAccessSession(t *testing.T, client *HTTPRelayClient) {
-	t.Helper()
-	jar, err := cookiejar.New(nil)
-	if err != nil {
-		t.Fatal(err)
-	}
-	client.httpClient.Jar = jar
-	client.access = &accessSession{baseURL: client.baseURL, client: client.httpClient, token: AccessServiceToken{ClientID: "access-id", ClientSecret: "access-secret"}}
 }
 
 func TestHTTPRelayClientRejectsInsecureRemoteURLAndPartialAccessToken(t *testing.T) {

--- a/internal/adapter/client_test.go
+++ b/internal/adapter/client_test.go
@@ -119,6 +119,36 @@ func TestHTTPRelayClientValidatesSenderWithoutMessageMutation(t *testing.T) {
 	}
 }
 
+func TestHTTPRelayClientSendsToOneDurableRole(t *testing.T) {
+	_, machinePrivate, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/v1/conversations/conversation-1/messages" {
+			t.Fatalf("unexpected route %s %s", r.Method, r.URL.Path)
+		}
+		var request struct {
+			FromEndpoint string `json:"from_endpoint"`
+			Body         string `json:"body"`
+			TargetRole   string `json:"target_role"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&request); err != nil || request.FromEndpoint != "agent/a" || request.Body != "review this" || request.TargetRole != "role/reviewer" {
+			t.Fatalf("request=%#v err=%v", request, err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"message-1","conversation_id":"conversation-1","sequence":1,"from_endpoint":"agent/a","body":"review this","created_at":"2026-08-10T12:00:00Z"}`))
+	}))
+	defer server.Close()
+	client, err := NewHTTPRelayClient(server.URL, "machine-a", machinePrivate, server.Client(), AccessServiceToken{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := client.SendToRole(context.Background(), "conversation-1", "agent/a", "role/reviewer", "review this", "send-1"); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestHTTPRelayClientLeasesOneInvocationPerSync(t *testing.T) {
 	_, machinePrivate, err := ed25519.GenerateKey(rand.Reader)
 	if err != nil {

--- a/internal/adapter/sync.go
+++ b/internal/adapter/sync.go
@@ -53,6 +53,7 @@ type InboundMessage struct {
 	ConversationID  string    `json:"conversation_id"`
 	Sequence        int64     `json:"sequence"`
 	FromEndpoint    string    `json:"from_endpoint"`
+	RecipientRole   string    `json:"recipient_role,omitempty"`
 	Body            string    `json:"body"`
 	CreatedAt       time.Time `json:"created_at"`
 }
@@ -208,7 +209,7 @@ func (s *Syncer) forwardAndAcknowledge(ctx context.Context, endpoint string, del
 	case deliveryAcknowledged:
 		return nil
 	case deliveryReceived:
-		message := InboundMessage{PunaroMessageID: delivery.Message.ID, ConversationID: delivery.Message.ConversationID, Sequence: delivery.Message.Sequence, FromEndpoint: delivery.Message.FromEndpoint, Body: delivery.Message.Body, CreatedAt: delivery.Message.CreatedAt}
+		message := InboundMessage{PunaroMessageID: delivery.Message.ID, ConversationID: delivery.Message.ConversationID, Sequence: delivery.Message.Sequence, FromEndpoint: delivery.Message.FromEndpoint, RecipientRole: delivery.RecipientRole, Body: delivery.Message.Body, CreatedAt: delivery.Message.CreatedAt}
 		if err := s.Mailbox.Send(ctx, endpoint, message); err != nil {
 			return fmt.Errorf("inject delivery %q into local mailbox: %w", delivery.ID, err)
 		}

--- a/internal/adapter/sync_test.go
+++ b/internal/adapter/sync_test.go
@@ -18,7 +18,7 @@ func TestSyncOnceAdvertisesAttachmentsForwardsThenAcknowledges(t *testing.T) {
 	}
 	t.Cleanup(func() { _ = journal.Close() })
 	mailbox := &fakeMailbox{attached: []string{"agent/reviewer"}}
-	relayClient := &fakeRelay{deliveries: map[string][]relay.Delivery{"agent/reviewer": {{ID: "delivery-1", Message: relay.Message{ID: "message-1", ConversationID: "conversation-1", Sequence: 7, FromEndpoint: "agent/sender", Body: "ship it"}, LeaseToken: "lease", LeaseGeneration: 1}}}}
+	relayClient := &fakeRelay{deliveries: map[string][]relay.Delivery{"agent/reviewer": {{ID: "delivery-1", RecipientRole: "role/reviewer", Message: relay.Message{ID: "message-1", ConversationID: "conversation-1", Sequence: 7, FromEndpoint: "agent/sender", Body: "ship it"}, LeaseToken: "lease", LeaseGeneration: 1}}}}
 	sync := Syncer{Mailbox: mailbox, Relay: relayClient, Journal: journal, Now: func() time.Time { return time.Date(2026, 7, 13, 12, 0, 0, 0, time.UTC) }}
 	if err := sync.SyncOnce(context.Background()); err != nil {
 		t.Fatal(err)
@@ -26,7 +26,7 @@ func TestSyncOnceAdvertisesAttachmentsForwardsThenAcknowledges(t *testing.T) {
 	if len(relayClient.advertised) != 1 || relayClient.advertised[0] != "agent/reviewer" {
 		t.Fatalf("advertised = %#v", relayClient.advertised)
 	}
-	if len(mailbox.sent) != 1 || mailbox.sent[0].PunaroMessageID != "message-1" || mailbox.sent[0].Body != "ship it" {
+	if len(mailbox.sent) != 1 || mailbox.sent[0].PunaroMessageID != "message-1" || mailbox.sent[0].RecipientRole != "role/reviewer" || mailbox.sent[0].Body != "ship it" {
 		t.Fatalf("mailbox sent = %#v", mailbox.sent)
 	}
 	if len(relayClient.acknowledged) != 1 || relayClient.acknowledged[0] != "delivery-1" {

--- a/internal/operator/authority_lock.go
+++ b/internal/operator/authority_lock.go
@@ -1,0 +1,38 @@
+package operator
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+)
+
+func acquireRelayAuthorityLock(directory string) (func(), error) {
+	if requireTrustedPrivateDirectory(directory) != nil {
+		return nil, errors.New("relay authority publication lock is unavailable")
+	}
+	path := filepath.Join(directory, ".relay-authority.lock")
+	file, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE, 0o600) // #nosec G304 -- fixed child of the validated private installation directory.
+	if err != nil {
+		return nil, errors.New("relay authority publication lock is unavailable")
+	}
+	fail := func() (func(), error) {
+		_ = file.Close()
+		return nil, errors.New("relay authority publication lock is unavailable")
+	}
+	opened, err := file.Stat()
+	if err != nil || requireTrustedProtectedFile(path, 0) != nil {
+		return fail()
+	}
+	current, err := os.Lstat(path)
+	if err != nil || !os.SameFile(opened, current) {
+		return fail()
+	}
+	if err := lockRelayAuthorityFile(file); err != nil {
+		_ = file.Close()
+		return nil, errors.New("another relay authority publication is already in progress")
+	}
+	return func() {
+		unlockRelayAuthorityFile(file)
+		_ = file.Close()
+	}, nil
+}

--- a/internal/operator/authority_lock_unix.go
+++ b/internal/operator/authority_lock_unix.go
@@ -1,0 +1,16 @@
+//go:build !windows
+
+package operator
+
+import (
+	"os"
+	"syscall"
+)
+
+func lockRelayAuthorityFile(file *os.File) error {
+	return syscall.Flock(int(file.Fd()), syscall.LOCK_EX|syscall.LOCK_NB) // #nosec G115 -- os.File descriptors are platform ints.
+}
+
+func unlockRelayAuthorityFile(file *os.File) {
+	_ = syscall.Flock(int(file.Fd()), syscall.LOCK_UN) // #nosec G115 -- os.File descriptors are platform ints.
+}

--- a/internal/operator/authority_lock_unix_test.go
+++ b/internal/operator/authority_lock_unix_test.go
@@ -1,0 +1,25 @@
+//go:build !windows
+
+package operator
+
+import (
+	"os"
+	"syscall"
+	"testing"
+)
+
+func holdRelayAuthorityTestLock(t *testing.T, path string) func() {
+	t.Helper()
+	file, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE, 0o600) // #nosec G304 -- fixed private test-installation child.
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := syscall.Flock(int(file.Fd()), syscall.LOCK_EX|syscall.LOCK_NB); err != nil { // #nosec G115 -- os.File descriptors are platform ints.
+		_ = file.Close()
+		t.Fatal(err)
+	}
+	return func() {
+		_ = syscall.Flock(int(file.Fd()), syscall.LOCK_UN) // #nosec G115 -- os.File descriptors are platform ints.
+		_ = file.Close()
+	}
+}

--- a/internal/operator/authority_lock_windows.go
+++ b/internal/operator/authority_lock_windows.go
@@ -1,0 +1,19 @@
+//go:build windows
+
+package operator
+
+import (
+	"os"
+
+	"golang.org/x/sys/windows"
+)
+
+func lockRelayAuthorityFile(file *os.File) error {
+	overlapped := new(windows.Overlapped)
+	return windows.LockFileEx(windows.Handle(file.Fd()), windows.LOCKFILE_EXCLUSIVE_LOCK|windows.LOCKFILE_FAIL_IMMEDIATELY, 0, 1, 0, overlapped)
+}
+
+func unlockRelayAuthorityFile(file *os.File) {
+	overlapped := new(windows.Overlapped)
+	_ = windows.UnlockFileEx(windows.Handle(file.Fd()), 0, 1, 0, overlapped)
+}

--- a/internal/operator/authority_lock_windows_test.go
+++ b/internal/operator/authority_lock_windows_test.go
@@ -1,0 +1,27 @@
+//go:build windows
+
+package operator
+
+import (
+	"os"
+	"testing"
+
+	"golang.org/x/sys/windows"
+)
+
+func holdRelayAuthorityTestLock(t *testing.T, path string) func() {
+	t.Helper()
+	file, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE, 0o600) // #nosec G304 -- fixed private test-installation child.
+	if err != nil {
+		t.Fatal(err)
+	}
+	overlapped := new(windows.Overlapped)
+	if err := windows.LockFileEx(windows.Handle(file.Fd()), windows.LOCKFILE_EXCLUSIVE_LOCK|windows.LOCKFILE_FAIL_IMMEDIATELY, 0, 1, 0, overlapped); err != nil {
+		_ = file.Close()
+		t.Fatal(err)
+	}
+	return func() {
+		_ = windows.UnlockFileEx(windows.Handle(file.Fd()), 0, 1, 0, overlapped)
+		_ = file.Close()
+	}
+}

--- a/internal/operator/installation.go
+++ b/internal/operator/installation.go
@@ -473,19 +473,15 @@ func writeExclusive(path string, body []byte) error {
 }
 
 func writeExclusiveWithPersist(path string, body []byte, persist func(*os.File, []byte) error) (err error) {
-	file, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600) // #nosec G304 -- validated installation-local output.
+	directory := filepath.Dir(path)
+	file, err := os.CreateTemp(directory, "."+filepath.Base(path)+".tmp-") // #nosec G304 -- validated installation-local output directory.
 	if err != nil {
 		return err
 	}
-	complete := false
+	temporary := file.Name()
 	defer func() {
-		if complete {
-			return
-		}
 		_ = file.Close()
-		if removeErr := os.Remove(path); removeErr != nil && !errors.Is(removeErr, os.ErrNotExist) {
-			err = errors.Join(err, fmt.Errorf("remove incomplete exclusive file: %w", removeErr))
-		}
+		_ = os.Remove(temporary)
 	}()
 	if err = persist(file, body); err != nil {
 		return err
@@ -493,8 +489,10 @@ func writeExclusiveWithPersist(path string, body []byte, persist func(*os.File, 
 	if err = file.Close(); err != nil {
 		return err
 	}
-	complete = true
-	return nil
+	// A hard link publishes only the already-synced complete inode and fails if
+	// the caller's exclusive target exists. A crash can leave a private
+	// temporary link, but never a partial target that blocks exact recovery.
+	return os.Link(temporary, path)
 }
 
 func requirePrivateDirectory(path string) error {

--- a/internal/operator/installation.go
+++ b/internal/operator/installation.go
@@ -464,19 +464,37 @@ func writeExclusiveJSON(path string, value any) error {
 }
 
 func writeExclusive(path string, body []byte) error {
+	return writeExclusiveWithPersist(path, body, func(file *os.File, body []byte) error {
+		if _, err := file.Write(body); err != nil {
+			return err
+		}
+		return file.Sync()
+	})
+}
+
+func writeExclusiveWithPersist(path string, body []byte, persist func(*os.File, []byte) error) (err error) {
 	file, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600) // #nosec G304 -- validated installation-local output.
 	if err != nil {
 		return err
 	}
-	if _, err := file.Write(body); err != nil {
+	complete := false
+	defer func() {
+		if complete {
+			return
+		}
 		_ = file.Close()
+		if removeErr := os.Remove(path); removeErr != nil && !errors.Is(removeErr, os.ErrNotExist) {
+			err = errors.Join(err, fmt.Errorf("remove incomplete exclusive file: %w", removeErr))
+		}
+	}()
+	if err = persist(file, body); err != nil {
 		return err
 	}
-	if err := file.Sync(); err != nil {
-		_ = file.Close()
+	if err = file.Close(); err != nil {
 		return err
 	}
-	return file.Close()
+	complete = true
+	return nil
 }
 
 func requirePrivateDirectory(path string) error {

--- a/internal/operator/installation_test.go
+++ b/internal/operator/installation_test.go
@@ -1466,6 +1466,36 @@ func TestRegisterPostCutoverRelayMachineAddsAuthorizedKeyIdempotently(t *testing
 	}
 }
 
+func TestRegisterPostCutoverRelayMachineRejectsConcurrentAuthorityPublication(t *testing.T) {
+	options := validInitOptions(t)
+	options.RelayEnabled = true
+	options.RelayMachinesJSON = testRelayMachinesJSON
+	installation, err := Init(context.Background(), options, func(context.Context, string, string) (punaropostgres.Principal, error) {
+		return punaropostgres.Principal{ID: "11111111-1111-4111-8111-111111111111"}, nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	publication := MailCutoverPublication{Version: 1, EpochID: "019f7f07-8b88-7c12-a394-b663274a6555", TargetIdentity: strings.Repeat("a", 64), SourceFingerprint: strings.Repeat("b", 64)}
+	if _, err := PublishMailCutover(installation.Directory, publication); err != nil {
+		t.Fatal(err)
+	}
+	newKey := base64.RawURLEncoding.EncodeToString(append([]byte{1}, make([]byte, ed25519.PublicKeySize-1)...))
+	path := filepath.Join(filepath.Dir(installation.Directory), "post-cutover-machine.json")
+	if err := os.WriteFile(path, []byte(`{"id":"machine-b","public_key":"`+newKey+`","endpoint_prefixes":["agent/b/"]}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	unlock := holdRelayAuthorityTestLock(t, filepath.Join(installation.Directory, ".relay-authority.lock"))
+	defer unlock()
+	called := false
+	if _, err := RegisterPostCutoverRelayMachine(installation.Directory, path, func(string, ed25519.PublicKey) error {
+		called = true
+		return nil
+	}); err == nil || called {
+		t.Fatalf("concurrent registration err=%v called=%t", err, called)
+	}
+}
+
 func TestRegisterPostCutoverRelayMachineFailsClosedBeforeAuthorityPublication(t *testing.T) {
 	options := validInitOptions(t)
 	options.RelayEnabled = true

--- a/internal/operator/installation_test.go
+++ b/internal/operator/installation_test.go
@@ -2,6 +2,7 @@ package operator
 
 import (
 	"context"
+	"crypto/ed25519"
 	"encoding/base64"
 	"encoding/json"
 	"errors"
@@ -9,11 +10,13 @@ import (
 	"path/filepath"
 	"regexp"
 	"runtime"
+	"slices"
 	"strings"
 	"testing"
 
 	"github.com/rock3r/punaro/internal/ingress"
 	punaropostgres "github.com/rock3r/punaro/internal/postgres"
+	"github.com/rock3r/punaro/internal/relay"
 )
 
 const testImage = "registry.example/punaro@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
@@ -1394,6 +1397,135 @@ func TestConfigureRelayMachinesRejectsNewKeyAfterMailCutover(t *testing.T) {
 	}
 	if _, err := ConfigureRelayMachines(installation.Directory, path); err == nil {
 		t.Fatal("post-cutover relay enrollment accepted an unregistered key")
+	}
+}
+
+func TestRegisterPostCutoverRelayMachineAddsAuthorizedKeyIdempotently(t *testing.T) {
+	options := validInitOptions(t)
+	options.RelayEnabled = true
+	options.RelayMachinesJSON = testRelayMachinesJSON
+	installation, err := Init(context.Background(), options, func(context.Context, string, string) (punaropostgres.Principal, error) {
+		return punaropostgres.Principal{ID: "11111111-1111-4111-8111-111111111111"}, nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	publication := MailCutoverPublication{Version: 1, EpochID: "019f7f07-8b88-7c12-a394-b663274a6555", TargetIdentity: strings.Repeat("a", 64), SourceFingerprint: strings.Repeat("b", 64)}
+	if _, err := PublishMailCutover(installation.Directory, publication); err != nil {
+		t.Fatal(err)
+	}
+	newKey := append([]byte{1}, make([]byte, ed25519.PublicKeySize-1)...)
+	record := `{"id":"machine-b","public_key":"` + base64.RawURLEncoding.EncodeToString(newKey) + `","endpoint_prefixes":["agent/b/"],"endpoints":[],"attachment_device_id":""}`
+	path := filepath.Join(filepath.Dir(installation.Directory), "post-cutover-machine.json")
+	if err := os.WriteFile(path, []byte(record), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	registrations := 0
+	register := func(name string, publicKey ed25519.PublicKey) error {
+		registrations++
+		if name != "machine-b" || !slices.Equal(publicKey, newKey) {
+			t.Fatalf("name=%q key=%x", name, publicKey)
+		}
+		return nil
+	}
+	configured, err := RegisterPostCutoverRelayMachine(installation.Directory, path, register)
+	if err != nil || registrations != 1 || configured.MailCutover == nil || *configured.MailCutover != publication || len(CheckPaths(configured)) != 0 {
+		t.Fatalf("configured=%#v registrations=%d err=%v failures=%v", configured, registrations, err, CheckPaths(configured))
+	}
+	machines, err := relay.ParseMachineEnrollments(configured.RelayMachinesJSON)
+	if err != nil || len(machines) != 2 || machines[1].ID != "machine-b" || !slices.Equal(machines[1].PublicKey, newKey) {
+		t.Fatalf("machines=%#v err=%v", machines, err)
+	}
+	var known []string
+	if err := json.Unmarshal([]byte(configured.RelayKnownMachineKeysJSON), &known); err != nil || len(known) != 2 || known[1] != base64.RawURLEncoding.EncodeToString(newKey) {
+		t.Fatalf("known=%#v err=%v", known, err)
+	}
+	repeated, err := RegisterPostCutoverRelayMachine(installation.Directory, path, register)
+	if err != nil || registrations != 2 || repeated.RelayMachinesJSON != configured.RelayMachinesJSON || repeated.RelayKnownMachineKeysJSON != configured.RelayKnownMachineKeysJSON {
+		t.Fatalf("repeated=%#v registrations=%d err=%v", repeated, registrations, err)
+	}
+}
+
+func TestRegisterPostCutoverRelayMachineFailsClosedBeforeAuthorityPublication(t *testing.T) {
+	options := validInitOptions(t)
+	options.RelayEnabled = true
+	options.RelayMachinesJSON = testRelayMachinesJSON
+	installation, err := Init(context.Background(), options, func(context.Context, string, string) (punaropostgres.Principal, error) {
+		return punaropostgres.Principal{ID: "11111111-1111-4111-8111-111111111111"}, nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	newKey := base64.RawURLEncoding.EncodeToString(append([]byte{1}, make([]byte, ed25519.PublicKeySize-1)...))
+	path := filepath.Join(filepath.Dir(installation.Directory), "post-cutover-machine.json")
+	if err := os.WriteFile(path, []byte(`{"id":"machine-b","public_key":"`+newKey+`","endpoint_prefixes":["agent/b/"]}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	called := false
+	if _, err := RegisterPostCutoverRelayMachine(installation.Directory, path, func(string, ed25519.PublicKey) error {
+		called = true
+		return nil
+	}); err == nil || called {
+		t.Fatalf("pre-cutover registration err=%v called=%t", err, called)
+	}
+	publication := MailCutoverPublication{Version: 1, EpochID: "019f7f07-8b88-7c12-a394-b663274a6555", TargetIdentity: strings.Repeat("a", 64), SourceFingerprint: strings.Repeat("b", 64)}
+	active, err := PublishMailCutover(installation.Directory, publication)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := RegisterPostCutoverRelayMachine(installation.Directory, path, func(string, ed25519.PublicKey) error {
+		return errors.New("database registration failed")
+	}); err == nil {
+		t.Fatal("registration failure published relay authority")
+	}
+	loaded, err := Load(installation.Directory)
+	if err != nil || loaded.RelayMachinesJSON != active.RelayMachinesJSON || loaded.RelayKnownMachineKeysJSON != active.RelayKnownMachineKeysJSON || len(CheckPaths(loaded)) != 0 {
+		t.Fatalf("loaded=%#v err=%v failures=%v", loaded, err, CheckPaths(loaded))
+	}
+}
+
+func TestRegisterPostCutoverRelayMachineRecoversOnlyExactRetryAfterPublicationCrash(t *testing.T) {
+	options := validInitOptions(t)
+	options.RelayEnabled = true
+	options.RelayMachinesJSON = testRelayMachinesJSON
+	installation, err := Init(context.Background(), options, func(context.Context, string, string) (punaropostgres.Principal, error) {
+		return punaropostgres.Principal{ID: "11111111-1111-4111-8111-111111111111"}, nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	publication := MailCutoverPublication{Version: 1, EpochID: "019f7f07-8b88-7c12-a394-b663274a6555", TargetIdentity: strings.Repeat("a", 64), SourceFingerprint: strings.Repeat("b", 64)}
+	if _, err := PublishMailCutover(installation.Directory, publication); err != nil {
+		t.Fatal(err)
+	}
+	newKey := base64.RawURLEncoding.EncodeToString(append([]byte{1}, make([]byte, ed25519.PublicKeySize-1)...))
+	path := filepath.Join(filepath.Dir(installation.Directory), "post-cutover-machine.json")
+	if err := os.WriteFile(path, []byte(`{"id":"machine-b","public_key":"`+newKey+`","endpoint_prefixes":["agent/b/"]}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	registrations := 0
+	register := func(string, ed25519.PublicKey) error {
+		registrations++
+		return nil
+	}
+	if _, err := registerPostCutoverRelayMachine(installation.Directory, path, register, func(step string) error {
+		if step == "environment" {
+			return errors.New("injected runtime publication crash")
+		}
+		return nil
+	}); err == nil {
+		t.Fatal("injected post-cutover publication crash was accepted")
+	}
+	conflict := filepath.Join(filepath.Dir(installation.Directory), "conflicting-post-cutover-machine.json")
+	if err := os.WriteFile(conflict, []byte(`{"id":"machine-c","public_key":"`+newKey+`","endpoint_prefixes":["agent/c/"]}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := RegisterPostCutoverRelayMachine(installation.Directory, conflict, register); err == nil || registrations != 1 {
+		t.Fatalf("conflicting retry err=%v registrations=%d", err, registrations)
+	}
+	recovered, err := RegisterPostCutoverRelayMachine(installation.Directory, path, register)
+	if err != nil || registrations != 2 || len(CheckPaths(recovered)) != 0 {
+		t.Fatalf("recovered=%#v registrations=%d err=%v failures=%v", recovered, registrations, err, CheckPaths(recovered))
 	}
 }
 

--- a/internal/operator/installation_test.go
+++ b/internal/operator/installation_test.go
@@ -43,6 +43,26 @@ func protectedFile(t *testing.T, path string) {
 	}
 }
 
+func TestWriteExclusiveRemovesPartialFileAfterPersistenceFailure(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "candidate.json")
+	injected := errors.New("injected persistence failure")
+	err := writeExclusiveWithPersist(path, []byte("complete candidate"), func(file *os.File, _ []byte) error {
+		if _, err := file.Write([]byte("partial")); err != nil {
+			t.Fatal(err)
+		}
+		return injected
+	})
+	if !errors.Is(err, injected) {
+		t.Fatalf("persistence failure=%v, want %v", err, injected)
+	}
+	if _, err := os.Lstat(path); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("partial exclusive file remains after failure: %v", err)
+	}
+	if err := writeExclusive(path, []byte("complete candidate")); err != nil {
+		t.Fatalf("exact retry after persistence failure: %v", err)
+	}
+}
+
 func validInitOptions(t *testing.T) InitOptions {
 	t.Helper()
 	root := t.TempDir()

--- a/internal/operator/installation_test.go
+++ b/internal/operator/installation_test.go
@@ -46,8 +46,14 @@ func protectedFile(t *testing.T, path string) {
 func TestWriteExclusiveRemovesPartialFileAfterPersistenceFailure(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "candidate.json")
 	injected := errors.New("injected persistence failure")
+	targetVisibleDuringPersist := false
 	err := writeExclusiveWithPersist(path, []byte("complete candidate"), func(file *os.File, _ []byte) error {
 		if _, err := file.Write([]byte("partial")); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := os.Lstat(path); err == nil {
+			targetVisibleDuringPersist = true
+		} else if !errors.Is(err, os.ErrNotExist) {
 			t.Fatal(err)
 		}
 		return injected
@@ -58,8 +64,15 @@ func TestWriteExclusiveRemovesPartialFileAfterPersistenceFailure(t *testing.T) {
 	if _, err := os.Lstat(path); !errors.Is(err, os.ErrNotExist) {
 		t.Fatalf("partial exclusive file remains after failure: %v", err)
 	}
+	if targetVisibleDuringPersist {
+		t.Fatal("exclusive target was visible before persistence completed")
+	}
 	if err := writeExclusive(path, []byte("complete candidate")); err != nil {
 		t.Fatalf("exact retry after persistence failure: %v", err)
+	}
+	// #nosec G304 -- path is a fixed child of t.TempDir().
+	if body, err := os.ReadFile(path); err != nil || string(body) != "complete candidate" {
+		t.Fatalf("published body=%q err=%v", body, err)
 	}
 }
 

--- a/internal/operator/mail_cutover.go
+++ b/internal/operator/mail_cutover.go
@@ -40,6 +40,11 @@ func (p MailCutoverPublication) Validate() error {
 // Compose inputs, then publishes installation.json last. Exact retries recover
 // crashes at any earlier publication boundary; changed retries fail closed.
 func PublishMailCutover(directory string, publication MailCutoverPublication) (Installation, error) {
+	unlock, err := acquireRelayAuthorityLock(directory)
+	if err != nil {
+		return Installation{}, err
+	}
+	defer unlock()
 	return publishMailCutover(directory, publication, nil)
 }
 
@@ -75,6 +80,11 @@ func publishMailCutover(directory string, publication MailCutoverPublication, af
 // ConfigureMailCutoverRelayMachines durably records the exact non-secret
 // static relay authority before any irreversible source transition begins.
 func ConfigureMailCutoverRelayMachines(directory, enrollmentFile string) (Installation, error) {
+	unlock, err := acquireRelayAuthorityLock(directory)
+	if err != nil {
+		return Installation{}, err
+	}
+	defer unlock()
 	canonical, err := ReadRelayMachinesFile(enrollmentFile)
 	if err != nil {
 		return Installation{}, err
@@ -101,6 +111,11 @@ func ConfigureMailCutoverRelayMachines(directory, enrollmentFile string) (Instal
 // installation; callers provide a protected declarative file rather than
 // editing generated runtime configuration.
 func ConfigureRelayMachines(directory, enrollmentFile string) (Installation, error) {
+	unlock, err := acquireRelayAuthorityLock(directory)
+	if err != nil {
+		return Installation{}, err
+	}
+	defer unlock()
 	canonical, err := ReadRelayMachinesFile(enrollmentFile)
 	if err != nil {
 		return Installation{}, err
@@ -159,6 +174,11 @@ type PostCutoverMachineRegistrar func(string, ed25519.PublicKey) error
 // can leave only a harmless registered-but-unconfigured key and the exact
 // command is always safe to retry.
 func RegisterPostCutoverRelayMachine(directory, enrollmentFile string, register PostCutoverMachineRegistrar) (Installation, error) {
+	unlock, err := acquireRelayAuthorityLock(directory)
+	if err != nil {
+		return Installation{}, err
+	}
+	defer unlock()
 	return registerPostCutoverRelayMachine(directory, enrollmentFile, register, nil)
 }
 

--- a/internal/operator/mail_cutover.go
+++ b/internal/operator/mail_cutover.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"slices"
+	"strings"
 
 	"github.com/google/uuid"
 	"github.com/rock3r/punaro/internal/relay"
@@ -145,6 +146,133 @@ func ConfigureRelayMachines(directory, enrollmentFile string) (Installation, err
 	installation.RelayEnabled = true
 	installation.RelayMachinesJSON = canonical
 	return publishMailCutoverInstallation(directory, installation, nil)
+}
+
+// PostCutoverMachineRegistrar durably records one public Ed25519 identity in
+// the active PostgreSQL transition authority. The callback must be
+// idempotent for the exact name and key.
+type PostCutoverMachineRegistrar func(string, ed25519.PublicKey) error
+
+// RegisterPostCutoverRelayMachine merges one installer-produced public
+// enrollment record into an already cut-over installation. PostgreSQL
+// registration completes before marker-last runtime publication, so a crash
+// can leave only a harmless registered-but-unconfigured key and the exact
+// command is always safe to retry.
+func RegisterPostCutoverRelayMachine(directory, enrollmentFile string, register PostCutoverMachineRegistrar) (Installation, error) {
+	return registerPostCutoverRelayMachine(directory, enrollmentFile, register, nil)
+}
+
+func registerPostCutoverRelayMachine(directory, enrollmentFile string, register PostCutoverMachineRegistrar, afterStep func(string) error) (Installation, error) {
+	if register == nil {
+		return Installation{}, errors.New("post-cutover relay registrar is unavailable")
+	}
+	record, machine, err := readRelayMachineFile(enrollmentFile)
+	if err != nil {
+		return Installation{}, err
+	}
+	installation, err := LoadMailCutoverRecovery(directory)
+	if err != nil {
+		return Installation{}, err
+	}
+	if installation.MailCutover == nil || installation.RelayMachinesJSON == "" || installation.RelayKnownMachineKeysJSON == "" {
+		return Installation{}, errors.New("post-cutover relay registration requires active mail cutover")
+	}
+	candidate, err := mergePostCutoverRelayMachine(installation, record, machine)
+	if err != nil {
+		return Installation{}, err
+	}
+	markerStage := filepath.Join(directory, ".installation.mail-cutover.json")
+	_, stageErr := os.Lstat(markerStage)
+	if stageErr == nil {
+		staged, readErr := readInstallation(markerStage)
+		if readErr != nil || staged.RelayMachinesJSON != candidate.RelayMachinesJSON || staged.RelayKnownMachineKeysJSON != candidate.RelayKnownMachineKeysJSON || !staged.RelayEnabled || !sameMailCutoverPublication(staged.MailCutover, candidate.MailCutover) {
+			return Installation{}, errors.New("post-cutover relay registration recovery requires the exact machine enrollment")
+		}
+	} else if !errors.Is(stageErr, os.ErrNotExist) {
+		return Installation{}, errors.New("post-cutover relay registration recovery is unavailable")
+	}
+	if err := register(machine.ID, append(ed25519.PublicKey(nil), machine.PublicKey...)); err != nil {
+		return Installation{}, errors.New("post-cutover relay database registration failed")
+	}
+	if stageErr != nil && candidate.RelayMachinesJSON == installation.RelayMachinesJSON && candidate.RelayKnownMachineKeysJSON == installation.RelayKnownMachineKeysJSON {
+		if len(CheckPaths(installation)) != 0 || syncDirectory(directory) != nil {
+			return Installation{}, errors.New("post-cutover relay registration recovery is unavailable")
+		}
+		return installation, nil
+	}
+	return publishMailCutoverInstallation(directory, candidate, afterStep)
+}
+
+func readRelayMachineFile(path string) (string, relay.Machine, error) {
+	if !filepath.IsAbs(path) || filepath.Clean(path) != path || requireTrustedProtectedFile(path, maxRelayMachinesBytes) != nil {
+		return "", relay.Machine{}, errors.New("post-cutover machine enrollment file is unavailable")
+	}
+	body, err := os.ReadFile(path) // #nosec G304 -- explicit protected operator input.
+	if err != nil || len(body) == 0 || len(body) > maxRelayMachinesBytes {
+		return "", relay.Machine{}, errors.New("post-cutover machine enrollment file is unavailable")
+	}
+	trimmed := bytes.TrimSpace(body)
+	if len(trimmed) < 2 || trimmed[0] != '{' || trimmed[len(trimmed)-1] != '}' {
+		return "", relay.Machine{}, errors.New("post-cutover machine enrollment must be one JSON object")
+	}
+	var compact bytes.Buffer
+	if json.Compact(&compact, trimmed) != nil {
+		return "", relay.Machine{}, errors.New("post-cutover machine enrollment is invalid")
+	}
+	canonical, err := canonicalRelayMachinesJSON("[" + compact.String() + "]")
+	if err != nil {
+		return "", relay.Machine{}, errors.New("post-cutover machine enrollment is invalid")
+	}
+	machines, err := relay.ParseMachineEnrollments(canonical)
+	if err != nil || len(machines) != 1 {
+		return "", relay.Machine{}, errors.New("post-cutover machine enrollment is invalid")
+	}
+	return canonical[1 : len(canonical)-1], machines[0], nil
+}
+
+func mergePostCutoverRelayMachine(installation Installation, record string, machine relay.Machine) (Installation, error) {
+	current, err := relay.ParseMachineEnrollments(installation.RelayMachinesJSON)
+	if err != nil {
+		return Installation{}, errors.New("post-cutover relay enrollment is unavailable")
+	}
+	found := false
+	for _, existing := range current {
+		if !slices.Equal(existing.PublicKey, machine.PublicKey) {
+			continue
+		}
+		if existing.ID != machine.ID || !slices.Equal(existing.EndpointPrefixes, machine.EndpointPrefixes) || !slices.Equal(existing.Endpoints, machine.Endpoints) || existing.AttachmentDeviceID != machine.AttachmentDeviceID {
+			return Installation{}, errors.New("post-cutover machine enrollment conflicts with the configured key")
+		}
+		found = true
+		break
+	}
+	if !found {
+		if installation.RelayMachinesJSON == "[]" {
+			installation.RelayMachinesJSON = "[" + record + "]"
+		} else {
+			installation.RelayMachinesJSON = strings.TrimSuffix(installation.RelayMachinesJSON, "]") + "," + record + "]"
+		}
+		canonical, err := canonicalRelayMachinesJSON(installation.RelayMachinesJSON)
+		if err != nil {
+			return Installation{}, errors.New("post-cutover machine enrollment conflicts with existing relay authority")
+		}
+		installation.RelayMachinesJSON = canonical
+	}
+	var known []string
+	if json.Unmarshal([]byte(installation.RelayKnownMachineKeysJSON), &known) != nil || !validRelayMachineKeys(known) {
+		return Installation{}, errors.New("post-cutover known relay authority is unavailable")
+	}
+	encodedKey := base64.RawURLEncoding.EncodeToString(machine.PublicKey)
+	if !slices.Contains(known, encodedKey) {
+		known = append(known, encodedKey)
+		encoded, err := json.Marshal(known)
+		if err != nil {
+			return Installation{}, errors.New("post-cutover known relay authority cannot be encoded")
+		}
+		installation.RelayKnownMachineKeysJSON = string(encoded)
+	}
+	installation.RelayEnabled = true
+	return installation, nil
 }
 
 // relayEnrollmentUsesKnownKeys permits post-cutover authority narrowing or

--- a/internal/postgres/legacy_auth_store.go
+++ b/internal/postgres/legacy_auth_store.go
@@ -85,6 +85,75 @@ func (a *Administration) RegisterLegacyMachine(ctx context.Context, actorPrincip
 	return machine, nil
 }
 
+// RegisterPostCutoverLegacyMachine adds one Ed25519 machine only after the
+// mail authority is durably active in PostgreSQL. Exact retries return the
+// existing content-free inventory row; a changed label or retired key fails
+// closed. The caller must separately publish the same public key into the
+// static relay enrollment before the daemon can authenticate it.
+func (a *Administration) RegisterPostCutoverLegacyMachine(ctx context.Context, actorPrincipalID, label string, publicKey ed25519.PublicKey) (LegacyMachine, error) {
+	if !validOpaqueID(actorPrincipalID) || !validDisplayName(label) || len(publicKey) != ed25519.PublicKeySize {
+		return LegacyMachine{}, errors.New("invalid post-cutover legacy machine")
+	}
+	digest := sha256.Sum256(publicKey)
+	tx, err := beginMutation(ctx, a.db)
+	if err != nil {
+		return LegacyMachine{}, mutationStartError(err, "post-cutover legacy registration cannot start")
+	}
+	defer func() { _ = tx.Rollback() }()
+	if ok, err := lockInstallationOwner(ctx, tx, actorPrincipalID); err != nil || !ok {
+		return LegacyMachine{}, ErrForbidden
+	}
+	if _, err := tx.ExecContext(ctx, `SELECT pg_advisory_xact_lock($1)`, mailCutoverLockKey); err != nil {
+		return LegacyMachine{}, errors.New("post-cutover legacy registration cannot be serialized with mail cutover")
+	}
+	var phase MailCutoverPhase
+	if err := tx.QueryRowContext(ctx, `SELECT phase FROM relay.mail_cutover_epochs WHERE phase IN ('importing','verified','active') FOR UPDATE`).Scan(&phase); err != nil || phase != MailCutoverActive {
+		return LegacyMachine{}, errors.New("post-cutover legacy registration requires active mail cutover")
+	}
+	if err := lockLegacyMutations(ctx, tx); err != nil {
+		return LegacyMachine{}, err
+	}
+	var enabled bool
+	if err := tx.QueryRowContext(ctx, `SELECT enabled FROM auth.legacy_auth_state WHERE singleton FOR UPDATE`).Scan(&enabled); err != nil || !enabled {
+		return LegacyMachine{}, errors.New("legacy authentication is disabled")
+	}
+	var existing LegacyMachine
+	err = tx.QueryRowContext(ctx, `SELECT machine.principal_id::text, principal.display_name, machine.state
+FROM auth.legacy_machines AS machine
+JOIN auth.principals AS principal ON principal.id = machine.principal_id
+WHERE machine.public_key_digest = $1 AND machine.public_key = $2`, digest[:], []byte(publicKey)).Scan(&existing.PrincipalID, &existing.Label, &existing.State)
+	if err == nil {
+		if existing.Label != label || existing.State == LegacyRetired {
+			return LegacyMachine{}, errors.New("post-cutover legacy registration conflicts with existing machine")
+		}
+		if err := tx.Commit(); err != nil {
+			return LegacyMachine{}, errors.New("post-cutover legacy registration retry could not commit")
+		}
+		return existing, nil
+	}
+	if !errors.Is(err, sql.ErrNoRows) {
+		return LegacyMachine{}, errors.New("post-cutover legacy registration cannot inspect existing machine")
+	}
+	machine := LegacyMachine{Label: label, State: LegacyPending}
+	if err := tx.QueryRowContext(ctx, `INSERT INTO auth.principals (kind, display_name) VALUES ('legacy_machine', $1) RETURNING id::text`, label).Scan(&machine.PrincipalID); err != nil {
+		return LegacyMachine{}, errors.New("post-cutover legacy principal could not be created")
+	}
+	if _, err := tx.ExecContext(ctx, `INSERT INTO auth.legacy_machines (principal_id, public_key, public_key_digest) VALUES ($1, $2, $3)`, machine.PrincipalID, []byte(publicKey), digest[:]); err != nil {
+		return LegacyMachine{}, errors.New("post-cutover legacy machine could not be registered")
+	}
+	control := &ControlTx{tx: tx}
+	if err := control.AppendAudit(ctx, AuditEvent{PrincipalID: actorPrincipalID, Action: AuditLegacyRegister, Outcome: AuditSucceeded, TargetKind: AuditTargetLegacyMachine, TargetID: machine.PrincipalID}); err != nil {
+		return LegacyMachine{}, err
+	}
+	if _, err := control.AdvanceChange(ctx); err != nil {
+		return LegacyMachine{}, err
+	}
+	if err := tx.Commit(); err != nil {
+		return LegacyMachine{}, errors.New("post-cutover legacy registration could not commit")
+	}
+	return machine, nil
+}
+
 // ResolveLegacyMachine maps a key only after the existing Ed25519 request
 // verifier has authenticated it. It never treats a friendly machine label as authority.
 func (d *Database) ResolveLegacyMachine(ctx context.Context, publicKey ed25519.PublicKey) (string, error) {

--- a/internal/postgres/legacy_auth_store.go
+++ b/internal/postgres/legacy_auth_store.go
@@ -88,8 +88,10 @@ func (a *Administration) RegisterLegacyMachine(ctx context.Context, actorPrincip
 // RegisterPostCutoverLegacyMachine adds one Ed25519 machine only after the
 // mail authority is durably active in PostgreSQL. Exact retries return the
 // existing content-free inventory row; a changed label or retired key fails
-// closed. The caller must separately publish the same public key into the
-// static relay enrollment before the daemon can authenticate it.
+// closed. The global migration gate stays disabled: ResolveLegacyMachine
+// admits only a pending key registered under the active-cutover lock. The
+// caller must separately publish the same public key into the static relay
+// enrollment before the daemon can authenticate it.
 func (a *Administration) RegisterPostCutoverLegacyMachine(ctx context.Context, actorPrincipalID, label string, publicKey ed25519.PublicKey) (LegacyMachine, error) {
 	if !validOpaqueID(actorPrincipalID) || !validDisplayName(label) || len(publicKey) != ed25519.PublicKeySize {
 		return LegacyMachine{}, errors.New("invalid post-cutover legacy machine")
@@ -112,10 +114,6 @@ func (a *Administration) RegisterPostCutoverLegacyMachine(ctx context.Context, a
 	}
 	if err := lockLegacyMutations(ctx, tx); err != nil {
 		return LegacyMachine{}, err
-	}
-	var enabled bool
-	if err := tx.QueryRowContext(ctx, `SELECT enabled FROM auth.legacy_auth_state WHERE singleton FOR UPDATE`).Scan(&enabled); err != nil || !enabled {
-		return LegacyMachine{}, errors.New("legacy authentication is disabled")
 	}
 	var existing LegacyMachine
 	err = tx.QueryRowContext(ctx, `SELECT machine.principal_id::text, principal.display_name, machine.state
@@ -162,13 +160,16 @@ func (d *Database) ResolveLegacyMachine(ctx context.Context, publicKey ed25519.P
 	}
 	digest := sha256.Sum256(publicKey)
 	var principalID string
-	var enabled bool
-	err := d.db.QueryRowContext(ctx, `SELECT machine.principal_id::text, state.enabled
+	var admitted bool
+	err := d.db.QueryRowContext(ctx, `SELECT machine.principal_id::text,
+state.enabled OR (machine.state = 'pending' AND EXISTS (
+    SELECT 1 FROM relay.mail_cutover_epochs WHERE phase = 'active'
+))
 FROM auth.legacy_machines AS machine
 JOIN auth.principals AS principal ON principal.id = machine.principal_id
 CROSS JOIN auth.legacy_auth_state AS state
-WHERE machine.public_key_digest = $1 AND machine.public_key = $2 AND machine.state <> 'retired' AND principal.disabled_at IS NULL AND state.singleton`, digest[:], []byte(publicKey)).Scan(&principalID, &enabled)
-	if err != nil || !enabled {
+WHERE machine.public_key_digest = $1 AND machine.public_key = $2 AND machine.state <> 'retired' AND principal.disabled_at IS NULL AND state.singleton`, digest[:], []byte(publicKey)).Scan(&principalID, &admitted)
+	if err != nil || !admitted {
 		return "", ErrUnauthenticated
 	}
 	return principalID, nil

--- a/internal/postgres/postgres_integration_test.go
+++ b/internal/postgres/postgres_integration_test.go
@@ -1385,6 +1385,17 @@ func testMailCutoverSubstrate(ctx context.Context, t *testing.T, app *Database, 
 	if repeated, err := admin.ActivateMailCutover(ctx, actor, activationRequest.EpochID, activationRequest.SourceFingerprint, retiredManifest); err != nil || repeated.Phase != MailCutoverActive {
 		t.Fatalf("idempotent activation=%#v err=%v", repeated, err)
 	}
+	// This post-cutover onboarding fixture models an installation that still
+	// admits its Ed25519 adapters. Registration must never reopen a gate that an
+	// owner has deliberately closed.
+	closedGateKey := make([]byte, ed25519.PublicKeySize)
+	closedGateKey[0] = 90
+	if _, err := admin.RegisterPostCutoverLegacyMachine(ctx, actor, "closed-gate machine", closedGateKey); err == nil {
+		t.Fatal("post-cutover registration reopened the disabled legacy gate")
+	}
+	if _, err := ownerDB.ExecContext(ctx, `UPDATE auth.legacy_auth_state SET enabled=true,changed_at=statement_timestamp() WHERE singleton`); err != nil {
+		t.Fatal(err)
+	}
 	postCutoverKey := make([]byte, ed25519.PublicKeySize)
 	postCutoverKey[0] = 91
 	if _, err := admin.RegisterLegacyMachine(ctx, actor, "post-cutover machine", postCutoverKey); err == nil {

--- a/internal/postgres/postgres_integration_test.go
+++ b/internal/postgres/postgres_integration_test.go
@@ -1437,6 +1437,7 @@ func testMailCutoverSubstrate(ctx context.Context, t *testing.T, app *Database, 
 func testRelayIntegration(t *testing.T, app *Database) {
 	t.Helper()
 	contracttest.Run(t, app, "postgres-contract")
+	contracttest.RunRoleTargeting(t, app, "postgres-target")
 	testPostgresMembershipControls(t, app)
 	testRecipientCursorDoesNotCrossUncommittedAppend(t, app)
 	testEndpointAdvertisementUsesCanonicalLockOrder(t, app)

--- a/internal/postgres/postgres_integration_test.go
+++ b/internal/postgres/postgres_integration_test.go
@@ -2,6 +2,7 @@ package postgres
 
 import (
 	"context"
+	"crypto/ed25519"
 	"crypto/sha256"
 	"database/sql"
 	"encoding/base64"
@@ -1383,6 +1384,28 @@ func testMailCutoverSubstrate(ctx context.Context, t *testing.T, app *Database, 
 	}
 	if repeated, err := admin.ActivateMailCutover(ctx, actor, activationRequest.EpochID, activationRequest.SourceFingerprint, retiredManifest); err != nil || repeated.Phase != MailCutoverActive {
 		t.Fatalf("idempotent activation=%#v err=%v", repeated, err)
+	}
+	postCutoverKey := make([]byte, ed25519.PublicKeySize)
+	postCutoverKey[0] = 91
+	if _, err := admin.RegisterLegacyMachine(ctx, actor, "post-cutover machine", postCutoverKey); err == nil {
+		t.Fatal("pre-cutover registration path accepted an active mail cutover")
+	}
+	postCutoverMachine, err := admin.RegisterPostCutoverLegacyMachine(ctx, actor, "post-cutover machine", postCutoverKey)
+	if err != nil || postCutoverMachine.State != LegacyPending {
+		t.Fatalf("post-cutover machine=%#v err=%v", postCutoverMachine, err)
+	}
+	repeatedPostCutover, err := admin.RegisterPostCutoverLegacyMachine(ctx, actor, "post-cutover machine", postCutoverKey)
+	if err != nil || repeatedPostCutover != postCutoverMachine {
+		t.Fatalf("repeated post-cutover machine=%#v err=%v", repeatedPostCutover, err)
+	}
+	if _, err := admin.RegisterPostCutoverLegacyMachine(ctx, actor, "changed label", postCutoverKey); err == nil {
+		t.Fatal("post-cutover registration accepted conflicting retry")
+	}
+	if _, err := admin.RegisterPostCutoverLegacyMachine(ctx, uuid.NewString(), "post-cutover machine", postCutoverKey); err == nil {
+		t.Fatal("non-owner registered post-cutover machine")
+	}
+	if resolved, err := app.ResolveLegacyMachine(ctx, postCutoverKey); err != nil || resolved != postCutoverMachine.PrincipalID {
+		t.Fatalf("resolved post-cutover principal=%q err=%v", resolved, err)
 	}
 	if err := admin.AbortMailCutover(ctx, actor, activationRequest.EpochID, activationRequest.SourceFingerprint); err == nil {
 		t.Fatal("active mail cutover was abortable")

--- a/internal/postgres/postgres_integration_test.go
+++ b/internal/postgres/postgres_integration_test.go
@@ -1385,16 +1385,11 @@ func testMailCutoverSubstrate(ctx context.Context, t *testing.T, app *Database, 
 	if repeated, err := admin.ActivateMailCutover(ctx, actor, activationRequest.EpochID, activationRequest.SourceFingerprint, retiredManifest); err != nil || repeated.Phase != MailCutoverActive {
 		t.Fatalf("idempotent activation=%#v err=%v", repeated, err)
 	}
-	// This post-cutover onboarding fixture models an installation that still
-	// admits its Ed25519 adapters. Registration must never reopen a gate that an
-	// owner has deliberately closed.
-	closedGateKey := make([]byte, ed25519.PublicKeySize)
-	closedGateKey[0] = 90
-	if _, err := admin.RegisterPostCutoverLegacyMachine(ctx, actor, "closed-gate machine", closedGateKey); err == nil {
-		t.Fatal("post-cutover registration reopened the disabled legacy gate")
-	}
-	if _, err := ownerDB.ExecContext(ctx, `UPDATE auth.legacy_auth_state SET enabled=true,changed_at=statement_timestamp() WHERE singleton`); err != nil {
-		t.Fatal(err)
+	// Activation closes the migration-wide legacy gate. Owner-authorized
+	// post-cutover registration must not reopen it or make a migrated key valid
+	// again; only the newly registered pending key is admitted.
+	if resolved, err := app.ResolveLegacyMachine(ctx, migratedKey); err == nil || resolved != "" {
+		t.Fatalf("disabled migrated legacy key resolved principal=%q err=%v", resolved, err)
 	}
 	postCutoverKey := make([]byte, ed25519.PublicKeySize)
 	postCutoverKey[0] = 91
@@ -1417,6 +1412,9 @@ func testMailCutoverSubstrate(ctx context.Context, t *testing.T, app *Database, 
 	}
 	if resolved, err := app.ResolveLegacyMachine(ctx, postCutoverKey); err != nil || resolved != postCutoverMachine.PrincipalID {
 		t.Fatalf("resolved post-cutover principal=%q err=%v", resolved, err)
+	}
+	if resolved, err := app.ResolveLegacyMachine(ctx, migratedKey); err == nil || resolved != "" {
+		t.Fatalf("post-cutover registration reopened migrated key principal=%q err=%v", resolved, err)
 	}
 	if err := admin.AbortMailCutover(ctx, actor, activationRequest.EpochID, activationRequest.SourceFingerprint); err == nil {
 		t.Fatal("active mail cutover was abortable")

--- a/internal/postgres/relay_store.go
+++ b/internal/postgres/relay_store.go
@@ -799,7 +799,7 @@ func (d *Database) LeaseDeliveries(machineID, consumerID, endpoint, conversation
 	if _, err := tx.ExecContext(context.Background(), `UPDATE relay.mail_endpoints SET consumer_id=$1,consumer_generation=$2,consumer_lease_until=$3 WHERE endpoint=$4 AND ownership_generation=$5`, consumerID, consumerGeneration, consumerLeaseUntil, endpoint, ownershipGeneration); err != nil {
 		return relay.DeliveryLeasePage{}, relayDatabaseError(err, "claim endpoint consumer lease")
 	}
-	query := `SELECT delivery.id::text,delivery.lease_machine_id,delivery.lease_token::text,delivery.lease_generation,delivery.ownership_generation,delivery.consumer_generation,delivery.lease_until,
+	query := `SELECT delivery.id::text,delivery.recipient_endpoint,delivery.lease_machine_id,delivery.lease_token::text,delivery.lease_generation,delivery.ownership_generation,delivery.consumer_generation,delivery.lease_until,
 		message.id::text,message.conversation_id::text,message.sequence,message.from_endpoint,message.body,message.created_at
 		FROM relay.mail_deliveries AS delivery JOIN relay.mail_messages AS message ON message.id=delivery.message_id
 		WHERE delivery.recipient_endpoint IN (SELECT value FROM jsonb_array_elements_text($1::jsonb)) AND delivery.acked_at IS NULL
@@ -827,10 +827,14 @@ func (d *Database) LeaseDeliveries(machineID, consumerID, endpoint, conversation
 	var pending []leasedRow
 	for rows.Next() {
 		var row leasedRow
+		var recipientID string
 		row.delivery.RecipientEndpoint = endpoint
-		if err := rows.Scan(&row.delivery.ID, &row.leaseMachine, &row.leaseToken, &row.delivery.LeaseGeneration, &row.leaseOwnership, &row.leaseConsumer, &row.leaseUntil, &row.delivery.Message.ID, &row.delivery.Message.ConversationID, &row.delivery.Message.Sequence, &row.delivery.Message.FromEndpoint, &row.delivery.Message.Body, &row.delivery.Message.CreatedAt); err != nil {
+		if err := rows.Scan(&row.delivery.ID, &recipientID, &row.leaseMachine, &row.leaseToken, &row.delivery.LeaseGeneration, &row.leaseOwnership, &row.leaseConsumer, &row.leaseUntil, &row.delivery.Message.ID, &row.delivery.Message.ConversationID, &row.delivery.Message.Sequence, &row.delivery.Message.FromEndpoint, &row.delivery.Message.Body, &row.delivery.Message.CreatedAt); err != nil {
 			_ = rows.Close()
 			return relay.DeliveryLeasePage{}, errors.New("pending delivery is malformed")
+		}
+		if role, isRole := postgresParseRoleRecipient(recipientID); isRole {
+			row.delivery.RecipientRole = role
 		}
 		row.delivery.Message.CreatedAt = row.delivery.Message.CreatedAt.UTC()
 		pending = append(pending, row)

--- a/internal/postgres/relay_store.go
+++ b/internal/postgres/relay_store.go
@@ -726,6 +726,11 @@ func (d *Database) AppendMessage(input relay.AppendInput) (relay.Message, bool, 
 			return relay.Message{}, false, relayDatabaseError(err, "create durable role deliveries")
 		}
 	}
+	if input.TargetRole != "" {
+		if err := postgresAdvanceSkippedTargetCursors(tx, input.ConversationID, input.FromEndpoint, input.TargetRole); err != nil {
+			return relay.Message{}, false, err
+		}
+	}
 	if len(input.ArtifactIDs) != 0 {
 		encodedArtifacts, err := json.Marshal(input.ArtifactIDs)
 		if err != nil {
@@ -1222,6 +1227,39 @@ func postgresAdvanceRecipientCursor(tx *sql.Tx, endpoint, conversationID string)
 	if target > cursor {
 		if _, err := tx.ExecContext(context.Background(), `UPDATE relay.mail_recipient_cursors SET sequence=$1 WHERE recipient_endpoint=$2 AND conversation_id=$3::uuid AND sequence=$4`, target, endpoint, conversationID, cursor); err != nil {
 			return relayDatabaseError(err, "advance recipient cursor")
+		}
+	}
+	return nil
+}
+
+func postgresAdvanceSkippedTargetCursors(tx *sql.Tx, conversationID, senderEndpoint, targetRole string) error {
+	rows, err := tx.QueryContext(context.Background(), `
+		SELECT endpoint FROM relay.mail_memberships
+		WHERE conversation_id=$1::uuid AND (capabilities & $2) <> 0 AND endpoint<>$3
+		UNION ALL
+		SELECT chr(30)||'role:'||role FROM relay.mail_role_memberships
+		WHERE conversation_id=$1::uuid AND (capabilities & $2) <> 0 AND role<>$4`, conversationID, relay.CapReceive, senderEndpoint, targetRole)
+	if err != nil {
+		return errors.New("skipped target recipients are unavailable")
+	}
+	var recipients []string
+	for rows.Next() {
+		var recipient string
+		if err := rows.Scan(&recipient); err != nil {
+			_ = rows.Close()
+			return errors.New("skipped target recipient is malformed")
+		}
+		recipients = append(recipients, recipient)
+	}
+	if err := rows.Close(); err != nil {
+		return errors.New("skipped target recipients are unavailable")
+	}
+	if err := rows.Err(); err != nil {
+		return errors.New("skipped target recipients are unavailable")
+	}
+	for _, recipient := range recipients {
+		if err := postgresAdvanceRecipientCursor(tx, recipient, conversationID); err != nil {
+			return err
 		}
 	}
 	return nil

--- a/internal/postgres/relay_store.go
+++ b/internal/postgres/relay_store.go
@@ -664,6 +664,18 @@ func (d *Database) AppendMessage(input relay.AppendInput) (relay.Message, bool, 
 	if capabilities&relay.CapSend == 0 {
 		return relay.Message{}, false, relay.ErrForbidden
 	}
+	if input.TargetRole != "" {
+		if !relay.ValidRole(input.TargetRole) || !rolesAvailable {
+			return relay.Message{}, false, relay.ErrForbidden
+		}
+		var allowed bool
+		if err := tx.QueryRowContext(context.Background(), `SELECT EXISTS(SELECT 1 FROM relay.mail_role_memberships WHERE conversation_id=$1::uuid AND role=$2 AND (capabilities & $3) <> 0)`, input.ConversationID, input.TargetRole, relay.CapReceive).Scan(&allowed); err != nil {
+			return relay.Message{}, false, errors.New("target role authorization is unavailable")
+		}
+		if !allowed {
+			return relay.Message{}, false, relay.ErrForbidden
+		}
+	}
 	hash := relay.AppendRequestHash(input)
 	var existingID, existingHash string
 	err = tx.QueryRowContext(context.Background(), `SELECT message_id::text,request_hash FROM relay.mail_message_idempotency WHERE machine_id=$1 AND key=$2`, input.SenderMachineID, input.IdempotencyKey).Scan(&existingID, &existingHash)
@@ -703,14 +715,14 @@ func (d *Database) AppendMessage(input relay.AppendInput) (relay.Message, bool, 
 		return relay.Message{}, false, relayDatabaseError(err, "append message")
 	}
 	if _, err := tx.ExecContext(context.Background(), `INSERT INTO relay.mail_deliveries(message_id,recipient_endpoint)
-		SELECT $1::uuid,endpoint FROM relay.mail_memberships WHERE conversation_id=$2::uuid AND (capabilities & $3) <> 0 AND endpoint<>$4`, message.ID, message.ConversationID, relay.CapReceive, message.FromEndpoint); err != nil {
+		SELECT $1::uuid,endpoint FROM relay.mail_memberships WHERE $5='' AND conversation_id=$2::uuid AND (capabilities & $3) <> 0 AND endpoint<>$4`, message.ID, message.ConversationID, relay.CapReceive, message.FromEndpoint, input.TargetRole); err != nil {
 		return relay.Message{}, false, relayDatabaseError(err, "create recipient deliveries")
 	}
 	if rolesAvailable {
 		if _, err := tx.ExecContext(context.Background(), `INSERT INTO relay.mail_deliveries(message_id,recipient_endpoint)
 		SELECT $1::uuid,chr(30)||'role:'||membership.role
 		FROM relay.mail_role_memberships AS membership
-		WHERE membership.conversation_id=$2::uuid AND (membership.capabilities & $3) <> 0`, message.ID, message.ConversationID, relay.CapReceive); err != nil {
+		WHERE membership.conversation_id=$2::uuid AND (membership.capabilities & $3) <> 0 AND ($4='' OR membership.role=$4)`, message.ID, message.ConversationID, relay.CapReceive, input.TargetRole); err != nil {
 			return relay.Message{}, false, relayDatabaseError(err, "create durable role deliveries")
 		}
 	}

--- a/internal/relay/contracttest/contract.go
+++ b/internal/relay/contracttest/contract.go
@@ -292,6 +292,9 @@ func RunRoleTargeting(t *testing.T, backend relay.Backend, namespace string) {
 	if err != nil || len(page.Deliveries) != 1 {
 		t.Fatalf("targeted page=%#v err=%v", page, err)
 	}
+	if page.Deliveries[0].RecipientRole != reviewerRole {
+		t.Fatalf("targeted recipient role=%q want %q", page.Deliveries[0].RecipientRole, reviewerRole)
+	}
 	if err := backend.AckDelivery(recipientMachine, recipientEndpoint, page.Deliveries[0].ID, page.Deliveries[0].LeaseToken, page.Deliveries[0].LeaseGeneration, now); err != nil {
 		t.Fatal(err)
 	}
@@ -313,6 +316,13 @@ func RunRoleTargeting(t *testing.T, backend relay.Backend, namespace string) {
 	broadcastPage, err := backend.LeaseDeliveries(recipientMachine, namespace+"-consumer", recipientEndpoint, conversation.ID, now, time.Minute, 10)
 	if err != nil || len(broadcastPage.Deliveries) != 3 {
 		t.Fatalf("broadcast page=%#v err=%v", broadcastPage, err)
+	}
+	roles := map[string]int{"": 0, reviewerRole: 0, implementerRole: 0}
+	for _, delivery := range broadcastPage.Deliveries {
+		roles[delivery.RecipientRole]++
+	}
+	if roles[""] != 1 || roles[reviewerRole] != 1 || roles[implementerRole] != 1 || len(roles) != 3 {
+		t.Fatalf("broadcast recipient roles=%v", roles)
 	}
 }
 

--- a/internal/relay/contracttest/contract.go
+++ b/internal/relay/contracttest/contract.go
@@ -298,6 +298,9 @@ func RunRoleTargeting(t *testing.T, backend relay.Backend, namespace string) {
 	if err := backend.AckDelivery(recipientMachine, recipientEndpoint, page.Deliveries[0].ID, page.Deliveries[0].LeaseToken, page.Deliveries[0].LeaseGeneration, now); err != nil {
 		t.Fatal(err)
 	}
+	if cursor, err := backend.RecipientCursor(recipientMachine, recipientEndpoint, conversation.ID, now); err != nil || cursor != targeted.Sequence {
+		t.Fatalf("targeted recipient cursor=%d want=%d err=%v", cursor, targeted.Sequence, err)
+	}
 	changed := targetedInput
 	changed.TargetRole = implementerRole
 	if _, _, err := backend.AppendMessage(changed); !errors.Is(err, relay.ErrConflict) {

--- a/internal/relay/contracttest/contract.go
+++ b/internal/relay/contracttest/contract.go
@@ -244,6 +244,78 @@ func Run(t *testing.T, backend relay.Backend, namespace string) {
 	runLeasePageContract(t, backend, namespace, now)
 }
 
+// RunRoleTargeting proves the same targeted-role and compatible-broadcast
+// routing contract against every durable backend.
+func RunRoleTargeting(t *testing.T, backend relay.Backend, namespace string) {
+	t.Helper()
+	roleBackend, ok := backend.(relay.RoleBindingBackend)
+	if !ok {
+		t.Fatal("backend does not implement durable role bindings")
+	}
+	now := time.Date(2026, time.August, 10, 13, 0, 0, 0, time.UTC)
+	senderMachine, recipientMachine := namespace+"-sender", namespace+"-recipient"
+	senderEndpoint, recipientEndpoint := "agent/"+namespace+"/sender", "agent/"+namespace+"/recipient"
+	if err := backend.AdvertiseEndpoints(senderMachine, []string{senderEndpoint}, now, time.Hour); err != nil {
+		t.Fatal(err)
+	}
+	if err := backend.AdvertiseEndpoints(recipientMachine, []string{recipientEndpoint}, now, time.Hour); err != nil {
+		t.Fatal(err)
+	}
+	reviewerRole, implementerRole := "role/"+namespace+"/reviewer", "role/"+namespace+"/implementer"
+	conversation, err := backend.CreateConversationIdempotent(relay.CreateConversationInput{
+		MachineID: senderMachine, CreatorEndpoint: senderEndpoint, IdempotencyKey: namespace + "-create", Now: now,
+		Members: []relay.Member{
+			{Endpoint: senderEndpoint, Capabilities: relay.CapSend | relay.CapReceive | relay.CapAdmin},
+			{Endpoint: recipientEndpoint, Capabilities: relay.CapReceive},
+			{Role: reviewerRole, RoleMachineID: recipientMachine, Capabilities: relay.CapReceive},
+			{Role: implementerRole, RoleMachineID: recipientMachine, Capabilities: relay.CapReceive},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, role := range []string{reviewerRole, implementerRole} {
+		if err := roleBackend.BindRoleToSession(recipientMachine, role, recipientEndpoint, now, time.Hour); err != nil {
+			t.Fatal(err)
+		}
+	}
+	targetedInput := relay.AppendInput{ConversationID: conversation.ID, SenderMachineID: senderMachine, FromEndpoint: senderEndpoint, TargetRole: reviewerRole, Body: "targeted", IdempotencyKey: namespace + "-targeted", Now: now}
+	targeted, duplicate, err := backend.AppendMessage(targetedInput)
+	if err != nil || duplicate {
+		t.Fatalf("targeted message=%#v duplicate=%t err=%v", targeted, duplicate, err)
+	}
+	machines, err := backend.RecipientMachines(targeted.ID, now)
+	if err != nil || len(machines) != 1 || machines[0] != recipientMachine {
+		t.Fatalf("targeted recipient machines=%v err=%v", machines, err)
+	}
+	page, err := backend.LeaseDeliveries(recipientMachine, namespace+"-consumer", recipientEndpoint, conversation.ID, now, time.Minute, 10)
+	if err != nil || len(page.Deliveries) != 1 {
+		t.Fatalf("targeted page=%#v err=%v", page, err)
+	}
+	if err := backend.AckDelivery(recipientMachine, recipientEndpoint, page.Deliveries[0].ID, page.Deliveries[0].LeaseToken, page.Deliveries[0].LeaseGeneration, now); err != nil {
+		t.Fatal(err)
+	}
+	changed := targetedInput
+	changed.TargetRole = implementerRole
+	if _, _, err := backend.AppendMessage(changed); !errors.Is(err, relay.ErrConflict) {
+		t.Fatalf("changed target retry err=%v", err)
+	}
+	missing := targetedInput
+	missing.IdempotencyKey = namespace + "-missing"
+	missing.TargetRole = "role/" + namespace + "/missing"
+	if _, _, err := backend.AppendMessage(missing); !errors.Is(err, relay.ErrForbidden) {
+		t.Fatalf("missing target role err=%v", err)
+	}
+	broadcast, duplicate, err := backend.AppendMessage(relay.AppendInput{ConversationID: conversation.ID, SenderMachineID: senderMachine, FromEndpoint: senderEndpoint, Body: "broadcast", IdempotencyKey: namespace + "-broadcast", Now: now})
+	if err != nil || duplicate {
+		t.Fatalf("broadcast message=%#v duplicate=%t err=%v", broadcast, duplicate, err)
+	}
+	broadcastPage, err := backend.LeaseDeliveries(recipientMachine, namespace+"-consumer", recipientEndpoint, conversation.ID, now, time.Minute, 10)
+	if err != nil || len(broadcastPage.Deliveries) != 3 {
+		t.Fatalf("broadcast page=%#v err=%v", broadcastPage, err)
+	}
+}
+
 func runLeasePageContract(t *testing.T, backend relay.Backend, namespace string, now time.Time) {
 	t.Helper()
 	senderMachine, recipientMachine := namespace+"-page-sender", namespace+"-page-recipient"

--- a/internal/relay/http.go
+++ b/internal/relay/http.go
@@ -444,10 +444,11 @@ func (h *handler) appendMessage(w http.ResponseWriter, body []byte, machineID st
 	}
 	var request struct {
 		FromEndpoint string   `json:"from_endpoint"`
+		TargetRole   string   `json:"target_role"`
 		Body         string   `json:"body"`
 		ArtifactIDs  []string `json:"artifact_ids"`
 	}
-	if err := decodeJSON(body, &request); err != nil {
+	if err := decodeJSON(body, &request); err != nil || (request.TargetRole != "" && !ValidRole(request.TargetRole)) {
 		writeError(w, http.StatusBadRequest, "invalid message request")
 		return
 	}
@@ -455,7 +456,7 @@ func (h *handler) appendMessage(w http.ResponseWriter, body []byte, machineID st
 		writeError(w, http.StatusForbidden, "authorization denied")
 		return
 	}
-	message, duplicate, err := h.store.AppendMessage(AppendInput{ConversationID: conversationID, SenderMachineID: machineID, PrincipalID: authority.PrincipalID, CredentialLookupID: authority.CredentialLookupID, CredentialGeneration: authority.CredentialGeneration, FromEndpoint: request.FromEndpoint, Body: request.Body, ArtifactIDs: request.ArtifactIDs, IdempotencyKey: idempotencyKey, Now: now})
+	message, duplicate, err := h.store.AppendMessage(AppendInput{ConversationID: conversationID, SenderMachineID: machineID, PrincipalID: authority.PrincipalID, CredentialLookupID: authority.CredentialLookupID, CredentialGeneration: authority.CredentialGeneration, FromEndpoint: request.FromEndpoint, TargetRole: request.TargetRole, Body: request.Body, ArtifactIDs: request.ArtifactIDs, IdempotencyKey: idempotencyKey, Now: now})
 	if err != nil {
 		writeStoreError(w, err)
 		return

--- a/internal/relay/http_test.go
+++ b/internal/relay/http_test.go
@@ -100,6 +100,69 @@ func TestHTTPDurableMessageFlowRequiresSignedMachineRequests(t *testing.T) {
 	}
 }
 
+func TestHTTPTargetRoleRoutesExclusivelyAndBroadcastRemainsCompatible(t *testing.T) {
+	publicA, privateA, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	publicB, privateB, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	store, err := Open(filepath.Join(t.TempDir(), "relay.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	auth, err := NewAuthenticator(store, []Machine{
+		{ID: "machine-a", PublicKey: publicA, EndpointPrefixes: []string{"agent/a/"}},
+		{ID: "machine-b", PublicKey: publicB, EndpointPrefixes: []string{"agent/b/"}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	now := time.Date(2026, time.July, 13, 12, 0, 0, 0, time.UTC)
+	handler := NewHandler(store, auth, HandlerOptions{Now: func() time.Time { return now }, EndpointLeaseTTL: time.Minute, DeliveryLeaseTTL: time.Minute})
+	serveSigned(t, handler, privateA, "machine-a", http.MethodPut, "/v1/machines/me/endpoints", `{"endpoints":["agent/a/session"]}`, "target-advertise-a", "")
+	serveSigned(t, handler, privateB, "machine-b", http.MethodPut, "/v1/machines/me/endpoints", `{"endpoints":["agent/b/session"]}`, "target-advertise-b", "")
+	created := serveSigned(t, handler, privateA, "machine-a", http.MethodPost, "/v1/conversations", `{"creator_endpoint":"agent/a/session","members":[{"endpoint":"agent/a/session","capabilities":["send","receive","admin"]},{"endpoint":"agent/b/session","capabilities":["receive"]},{"role":"role/reviewer","role_machine_id":"machine-b","capabilities":["receive"]},{"role":"role/implementer","role_machine_id":"machine-b","capabilities":["receive"]}]}`, "target-create", "target-create")
+	var conversation Conversation
+	if created.Code != http.StatusCreated || json.NewDecoder(created.Body).Decode(&conversation) != nil {
+		t.Fatalf("create status=%d body=%s", created.Code, created.Body.String())
+	}
+	for index, role := range []string{"role/reviewer", "role/implementer"} {
+		bound := serveSigned(t, handler, privateB, "machine-b", http.MethodPost, "/v1/roles/bindings", `{"role":"`+role+`","session_endpoint":"agent/b/session"}`, "target-bind-"+string(rune('a'+index)), "")
+		if bound.Code != http.StatusNoContent {
+			t.Fatalf("bind %s status=%d body=%s", role, bound.Code, bound.Body.String())
+		}
+	}
+	targeted := serveSigned(t, handler, privateA, "machine-a", http.MethodPost, "/v1/conversations/"+conversation.ID+"/messages", `{"from_endpoint":"agent/a/session","target_role":"role/reviewer","body":"review this"}`, "target-send", "target-send")
+	if targeted.Code != http.StatusCreated {
+		t.Fatalf("targeted status=%d body=%s", targeted.Code, targeted.Body.String())
+	}
+	lease := serveSigned(t, handler, privateB, "machine-b", http.MethodPost, "/v1/deliveries/lease", `{"endpoint":"agent/b/session","consumer_id":"target-consumer"}`, "target-lease", "")
+	var targetedPage DeliveryLeasePage
+	if lease.Code != http.StatusOK || json.NewDecoder(lease.Body).Decode(&targetedPage) != nil || len(targetedPage.Deliveries) != 1 {
+		t.Fatalf("targeted lease status=%d page=%#v body=%s", lease.Code, targetedPage, lease.Body.String())
+	}
+	if err := store.AckDelivery("machine-b", "agent/b/session", targetedPage.Deliveries[0].ID, targetedPage.Deliveries[0].LeaseToken, targetedPage.Deliveries[0].LeaseGeneration, now); err != nil {
+		t.Fatal(err)
+	}
+	broadcast := serveSigned(t, handler, privateA, "machine-a", http.MethodPost, "/v1/conversations/"+conversation.ID+"/messages", `{"from_endpoint":"agent/a/session","body":"broadcast"}`, "broadcast-send", "broadcast-send")
+	if broadcast.Code != http.StatusCreated {
+		t.Fatalf("broadcast status=%d body=%s", broadcast.Code, broadcast.Body.String())
+	}
+	broadcastLease := serveSigned(t, handler, privateB, "machine-b", http.MethodPost, "/v1/deliveries/lease", `{"endpoint":"agent/b/session","consumer_id":"target-consumer"}`, "broadcast-lease", "")
+	var broadcastPage DeliveryLeasePage
+	if broadcastLease.Code != http.StatusOK || json.NewDecoder(broadcastLease.Body).Decode(&broadcastPage) != nil || len(broadcastPage.Deliveries) != 3 {
+		t.Fatalf("broadcast lease status=%d page=%#v body=%s", broadcastLease.Code, broadcastPage, broadcastLease.Body.String())
+	}
+	missing := serveSigned(t, handler, privateA, "machine-a", http.MethodPost, "/v1/conversations/"+conversation.ID+"/messages", `{"from_endpoint":"agent/a/session","target_role":"role/missing","body":"nobody"}`, "missing-target", "missing-target")
+	if missing.Code != http.StatusForbidden {
+		t.Fatalf("missing target status=%d body=%s", missing.Code, missing.Body.String())
+	}
+}
+
 type principalEndpointRecordingBackend struct {
 	Backend
 	plainCalls     int

--- a/internal/relay/http_test.go
+++ b/internal/relay/http_test.go
@@ -145,6 +145,9 @@ func TestHTTPTargetRoleRoutesExclusivelyAndBroadcastRemainsCompatible(t *testing
 	if lease.Code != http.StatusOK || json.NewDecoder(lease.Body).Decode(&targetedPage) != nil || len(targetedPage.Deliveries) != 1 {
 		t.Fatalf("targeted lease status=%d page=%#v body=%s", lease.Code, targetedPage, lease.Body.String())
 	}
+	if targetedPage.Deliveries[0].RecipientRole != "role/reviewer" {
+		t.Fatalf("targeted lease recipient role=%q", targetedPage.Deliveries[0].RecipientRole)
+	}
 	if err := store.AckDelivery("machine-b", "agent/b/session", targetedPage.Deliveries[0].ID, targetedPage.Deliveries[0].LeaseToken, targetedPage.Deliveries[0].LeaseGeneration, now); err != nil {
 		t.Fatal(err)
 	}
@@ -156,6 +159,13 @@ func TestHTTPTargetRoleRoutesExclusivelyAndBroadcastRemainsCompatible(t *testing
 	var broadcastPage DeliveryLeasePage
 	if broadcastLease.Code != http.StatusOK || json.NewDecoder(broadcastLease.Body).Decode(&broadcastPage) != nil || len(broadcastPage.Deliveries) != 3 {
 		t.Fatalf("broadcast lease status=%d page=%#v body=%s", broadcastLease.Code, broadcastPage, broadcastLease.Body.String())
+	}
+	roles := map[string]int{"": 0, "role/reviewer": 0, "role/implementer": 0}
+	for _, delivery := range broadcastPage.Deliveries {
+		roles[delivery.RecipientRole]++
+	}
+	if roles[""] != 1 || roles["role/reviewer"] != 1 || roles["role/implementer"] != 1 || len(roles) != 3 {
+		t.Fatalf("broadcast recipient roles=%v", roles)
 	}
 	missing := serveSigned(t, handler, privateA, "machine-a", http.MethodPost, "/v1/conversations/"+conversation.ID+"/messages", `{"from_endpoint":"agent/a/session","target_role":"role/missing","body":"nobody"}`, "missing-target", "missing-target")
 	if missing.Code != http.StatusForbidden {

--- a/internal/relay/store.go
+++ b/internal/relay/store.go
@@ -1119,7 +1119,7 @@ func (s *Store) AppendMessage(input AppendInput) (Message, bool, error) {
 	if _, err := tx.ExecContext(context.Background(), `INSERT INTO messages(id, conversation_id, sequence, from_endpoint, body, created_at) VALUES (?, ?, ?, ?, ?, ?)`, message.ID, message.ConversationID, message.Sequence, message.FromEndpoint, message.Body, message.CreatedAt.UnixMilli()); err != nil {
 		return Message{}, false, fmt.Errorf("append message: %w", err)
 	}
-	rows, err := tx.QueryContext(context.Background(), "SELECT endpoint FROM memberships WHERE ? = '' AND conversation_id = ? AND (capabilities & ?) != 0 AND endpoint != ?", input.TargetRole, input.ConversationID, CapReceive, input.FromEndpoint)
+	rows, err := tx.QueryContext(context.Background(), "SELECT endpoint FROM memberships WHERE conversation_id = ? AND (capabilities & ?) != 0 AND endpoint != ?", input.ConversationID, CapReceive, input.FromEndpoint)
 	if err != nil {
 		return Message{}, false, fmt.Errorf("find recipients: %w", err)
 	}
@@ -1136,27 +1136,39 @@ func (s *Store) AppendMessage(input AppendInput) (Message, bool, error) {
 		return Message{}, false, err
 	}
 	for _, endpoint := range recipients {
-		if _, err := tx.ExecContext(context.Background(), "INSERT INTO deliveries(id, message_id, recipient_endpoint) VALUES (?, ?, ?)", uuid.NewString(), message.ID, endpoint); err != nil {
-			return Message{}, false, fmt.Errorf("create delivery: %w", err)
+		if input.TargetRole == "" {
+			if _, err := tx.ExecContext(context.Background(), "INSERT INTO deliveries(id, message_id, recipient_endpoint) VALUES (?, ?, ?)", uuid.NewString(), message.ID, endpoint); err != nil {
+				return Message{}, false, fmt.Errorf("create delivery: %w", err)
+			}
+		} else if err := advanceRecipientCursor(tx, endpoint, input.ConversationID); err != nil {
+			return Message{}, false, err
 		}
 	}
-	roleRows, err := tx.QueryContext(context.Background(), "SELECT role FROM role_memberships WHERE conversation_id = ? AND (capabilities & ?) != 0 AND (? = '' OR role = ?)", input.ConversationID, CapReceive, input.TargetRole, input.TargetRole)
+	roleRows, err := tx.QueryContext(context.Background(), "SELECT role FROM role_memberships WHERE conversation_id = ? AND (capabilities & ?) != 0", input.ConversationID, CapReceive)
 	if err != nil {
 		return Message{}, false, fmt.Errorf("find durable role recipients: %w", err)
 	}
+	var roles []string
 	for roleRows.Next() {
 		var role string
 		if err := roleRows.Scan(&role); err != nil {
 			_ = roleRows.Close()
 			return Message{}, false, err
 		}
-		if _, err := tx.ExecContext(context.Background(), "INSERT INTO deliveries(id, message_id, recipient_endpoint) VALUES (?, ?, ?)", uuid.NewString(), message.ID, roleRecipient(role)); err != nil {
-			_ = roleRows.Close()
-			return Message{}, false, fmt.Errorf("create durable role delivery: %w", err)
-		}
+		roles = append(roles, role)
 	}
 	if err := roleRows.Close(); err != nil {
 		return Message{}, false, fmt.Errorf("find durable role recipients: %w", err)
+	}
+	for _, role := range roles {
+		recipient := roleRecipient(role)
+		if input.TargetRole == "" || role == input.TargetRole {
+			if _, err := tx.ExecContext(context.Background(), "INSERT INTO deliveries(id, message_id, recipient_endpoint) VALUES (?, ?, ?)", uuid.NewString(), message.ID, recipient); err != nil {
+				return Message{}, false, fmt.Errorf("create durable role delivery: %w", err)
+			}
+		} else if err := advanceRecipientCursor(tx, recipient, input.ConversationID); err != nil {
+			return Message{}, false, err
+		}
 	}
 	if err := advanceSessionCursors(tx, input.SenderMachineID, input.FromEndpoint, input.ConversationID, input.Now); err != nil {
 		return Message{}, false, err

--- a/internal/relay/store.go
+++ b/internal/relay/store.go
@@ -148,6 +148,7 @@ type AppendInput struct {
 	CredentialLookupID   string
 	CredentialGeneration int64
 	FromEndpoint         string
+	TargetRole           string
 	Body                 string
 	ArtifactIDs          []string
 	IdempotencyKey       string
@@ -1059,7 +1060,7 @@ func (s *Store) AuthorizeSender(conversationID, machineID, endpoint string, now 
 // AppendMessage accepts one immutable, authorized message and creates one
 // independent durable delivery per receiving endpoint, excluding the sender.
 func (s *Store) AppendMessage(input AppendInput) (Message, bool, error) {
-	if strings.TrimSpace(input.ConversationID) == "" || !ValidMachineID(input.SenderMachineID) || !ValidEndpoint(input.FromEndpoint) || !ValidRequestToken(input.IdempotencyKey) || len(input.ArtifactIDs) != 0 {
+	if strings.TrimSpace(input.ConversationID) == "" || !ValidMachineID(input.SenderMachineID) || !ValidEndpoint(input.FromEndpoint) || (input.TargetRole != "" && !ValidRole(input.TargetRole)) || !ValidRequestToken(input.IdempotencyKey) || len(input.ArtifactIDs) != 0 {
 		return Message{}, false, fmt.Errorf("conversation, machine, endpoint, and idempotency key are required")
 	}
 	if len(input.Body) > maxMessageBodyBytes {
@@ -1080,6 +1081,15 @@ func (s *Store) AppendMessage(input AppendInput) (Message, bool, error) {
 	}
 	if capabilities&CapSend == 0 {
 		return Message{}, false, ErrForbidden
+	}
+	if input.TargetRole != "" {
+		var allowed bool
+		if err := tx.QueryRowContext(context.Background(), "SELECT EXISTS(SELECT 1 FROM role_memberships WHERE conversation_id = ? AND role = ? AND (capabilities & ?) != 0)", input.ConversationID, input.TargetRole, CapReceive).Scan(&allowed); err != nil {
+			return Message{}, false, fmt.Errorf("authorize target role: %w", err)
+		}
+		if !allowed {
+			return Message{}, false, ErrForbidden
+		}
 	}
 	var existingID, existingHash string
 	err = tx.QueryRowContext(context.Background(), "SELECT message_id, request_hash FROM idempotency WHERE machine_id = ? AND key = ?", input.SenderMachineID, input.IdempotencyKey).Scan(&existingID, &existingHash)
@@ -1108,7 +1118,7 @@ func (s *Store) AppendMessage(input AppendInput) (Message, bool, error) {
 	if _, err := tx.ExecContext(context.Background(), `INSERT INTO messages(id, conversation_id, sequence, from_endpoint, body, created_at) VALUES (?, ?, ?, ?, ?, ?)`, message.ID, message.ConversationID, message.Sequence, message.FromEndpoint, message.Body, message.CreatedAt.UnixMilli()); err != nil {
 		return Message{}, false, fmt.Errorf("append message: %w", err)
 	}
-	rows, err := tx.QueryContext(context.Background(), "SELECT endpoint FROM memberships WHERE conversation_id = ? AND (capabilities & ?) != 0 AND endpoint != ?", input.ConversationID, CapReceive, input.FromEndpoint)
+	rows, err := tx.QueryContext(context.Background(), "SELECT endpoint FROM memberships WHERE ? = '' AND conversation_id = ? AND (capabilities & ?) != 0 AND endpoint != ?", input.TargetRole, input.ConversationID, CapReceive, input.FromEndpoint)
 	if err != nil {
 		return Message{}, false, fmt.Errorf("find recipients: %w", err)
 	}
@@ -1129,7 +1139,7 @@ func (s *Store) AppendMessage(input AppendInput) (Message, bool, error) {
 			return Message{}, false, fmt.Errorf("create delivery: %w", err)
 		}
 	}
-	roleRows, err := tx.QueryContext(context.Background(), "SELECT role FROM role_memberships WHERE conversation_id = ? AND (capabilities & ?) != 0", input.ConversationID, CapReceive)
+	roleRows, err := tx.QueryContext(context.Background(), "SELECT role FROM role_memberships WHERE conversation_id = ? AND (capabilities & ?) != 0 AND (? = '' OR role = ?)", input.ConversationID, CapReceive, input.TargetRole, input.TargetRole)
 	if err != nil {
 		return Message{}, false, fmt.Errorf("find durable role recipients: %w", err)
 	}
@@ -1683,6 +1693,11 @@ func memberIdentity(member Member) string {
 
 func appendHash(input AppendInput) string {
 	parts := []string{input.ConversationID, input.FromEndpoint, input.Body}
+	// Preserve the exact pre-targeting hash for broadcasts so an accepted
+	// request can be retried safely across an in-place upgrade.
+	if input.TargetRole != "" {
+		parts = append(parts, "target-role:"+input.TargetRole)
+	}
 	if len(input.ArtifactIDs) != 0 {
 		parts = append(parts, input.PrincipalID)
 		parts = append(parts, input.ArtifactIDs...)

--- a/internal/relay/store.go
+++ b/internal/relay/store.go
@@ -126,6 +126,7 @@ type Message struct {
 type Delivery struct {
 	ID                string    `json:"id"`
 	RecipientEndpoint string    `json:"recipient_endpoint"`
+	RecipientRole     string    `json:"recipient_role,omitempty"`
 	Message           Message   `json:"message"`
 	LeaseToken        string    `json:"lease_token"`
 	LeaseGeneration   int64     `json:"lease_generation"`
@@ -1240,6 +1241,9 @@ func (s *Store) LeaseDeliveries(machineID, consumerID, endpoint, conversationID 
 			return DeliveryLeasePage{}, err
 		}
 		delivery.RecipientEndpoint = endpoint
+		if role, isRole := parseRoleRecipient(recipientID); isRole {
+			delivery.RecipientRole = role
+		}
 		delivery.Message.CreatedAt = fromMillis(createdAt)
 		if leaseMachine.Valid && leaseMachine.String == machineID && leaseToken.Valid && leaseOwnership.Valid && leaseOwnership.Int64 == ownershipGeneration && leaseConsumer.Valid && leaseConsumer.Int64 == consumerGeneration && leaseUntil.Valid && leaseUntil.Int64 > now.UnixMilli() {
 			delivery.LeaseToken = leaseToken.String

--- a/internal/relay/store_conformance_test.go
+++ b/internal/relay/store_conformance_test.go
@@ -15,4 +15,5 @@ func TestSQLiteStoreConformance(t *testing.T) {
 	}
 	t.Cleanup(func() { _ = store.Close() })
 	contracttest.Run(t, store, "sqlite-contract")
+	contracttest.RunRoleTargeting(t, store, "sqlite-target")
 }

--- a/internal/relay/store_test.go
+++ b/internal/relay/store_test.go
@@ -27,6 +27,18 @@ func TestStoreRejectsNonPortableRequestAndMessageText(t *testing.T) {
 	}
 }
 
+func TestAppendRequestHashPreservesBroadcastUpgradeCompatibility(t *testing.T) {
+	input := AppendInput{ConversationID: "conversation-1", FromEndpoint: "agent/a", Body: "broadcast"}
+	legacy := stableHash(input.ConversationID, input.FromEndpoint, input.Body)
+	if got := AppendRequestHash(input); got != legacy {
+		t.Fatalf("broadcast request hash changed across targeting upgrade: got %s want %s", got, legacy)
+	}
+	input.TargetRole = "role/reviewer"
+	if got := AppendRequestHash(input); got == legacy {
+		t.Fatal("targeted request did not bind its target role into idempotency")
+	}
+}
+
 func TestStoreProvidesDurableAtLeastOnceDelivery(t *testing.T) {
 	t.Parallel()
 	database := filepath.Join(t.TempDir(), "relay.db")
@@ -643,6 +655,74 @@ func TestStoreKeepsRoleDeliveryKeysDistinctFromEndpointNames(t *testing.T) {
 	}
 	if cursor, err := store.RecipientCursor("machine-reviewer", "role:reviewer", conversation.ID, now); err != nil || cursor != 0 {
 		t.Fatalf("shared session cursor=%d err=%v, want pending-role zero", cursor, err)
+	}
+}
+
+func TestStoreTargetedRoleDeliveryExcludesOtherMembersAndBindsRetry(t *testing.T) {
+	store, err := Open(filepath.Join(t.TempDir(), "relay.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	now := time.Date(2026, time.August, 10, 12, 0, 0, 0, time.UTC)
+	if err := store.AdvertiseEndpoints("machine-sender", []string{"agent/sender"}, now, time.Hour); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.AdvertiseEndpoints("machine-observer", []string{"agent/observer"}, now, time.Hour); err != nil {
+		t.Fatal(err)
+	}
+	conversation, err := store.CreateConversation("agent/sender", []Member{
+		{Endpoint: "agent/sender", Capabilities: CapSend | CapReceive | CapAdmin},
+		{Endpoint: "agent/observer", Capabilities: CapReceive},
+		{Role: "role/reviewer", RoleMachineID: "machine-reviewer", Capabilities: CapReceive},
+		{Role: "role/implementer", RoleMachineID: "machine-implementer", Capabilities: CapReceive},
+	}, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	input := AppendInput{ConversationID: conversation.ID, SenderMachineID: "machine-sender", FromEndpoint: "agent/sender", TargetRole: "role/reviewer", Body: "targeted", IdempotencyKey: "targeted-1", Now: now}
+	message, duplicate, err := store.AppendMessage(input)
+	if err != nil || duplicate {
+		t.Fatalf("targeted append message=%#v duplicate=%t err=%v", message, duplicate, err)
+	}
+	var recipients []string
+	rows, err := store.db.QueryContext(context.Background(), "SELECT recipient_endpoint FROM deliveries WHERE message_id = ? ORDER BY recipient_endpoint", message.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for rows.Next() {
+		var recipient string
+		if err := rows.Scan(&recipient); err != nil {
+			t.Fatal(err)
+		}
+		recipients = append(recipients, recipient)
+	}
+	if err := rows.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if len(recipients) != 1 || recipients[0] != roleRecipient("role/reviewer") {
+		t.Fatalf("targeted recipients=%q", recipients)
+	}
+	changed := input
+	changed.TargetRole = "role/implementer"
+	if _, _, err := store.AppendMessage(changed); !errors.Is(err, ErrConflict) {
+		t.Fatalf("changed target retry err=%v", err)
+	}
+	unknown := input
+	unknown.IdempotencyKey = "targeted-unknown"
+	unknown.TargetRole = "role/missing"
+	if _, _, err := store.AppendMessage(unknown); !errors.Is(err, ErrForbidden) {
+		t.Fatalf("unknown target role err=%v", err)
+	}
+	var messageCount, idempotencyCount int
+	if err := store.db.QueryRowContext(context.Background(), "SELECT COUNT(*) FROM messages").Scan(&messageCount); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.db.QueryRowContext(context.Background(), "SELECT COUNT(*) FROM idempotency").Scan(&idempotencyCount); err != nil {
+		t.Fatal(err)
+	}
+	if messageCount != 1 || idempotencyCount != 1 {
+		t.Fatalf("unknown target mutated state: messages=%d idempotency=%d", messageCount, idempotencyCount)
 	}
 }
 

--- a/scripts/install-client.ps1
+++ b/scripts/install-client.ps1
@@ -87,14 +87,30 @@ function Assert-Configuration([string]$Path, [hashtable]$Expected) {
     }
 }
 
+function Invoke-NativeProgramRaw([string]$Program, [string[]]$Arguments) {
+    # Windows PowerShell turns a native program's stderr into PowerShell error
+    # records. The installer must decide success from the native exit code so
+    # expected diagnostics (for example, "group already exists") can be
+    # handled by the idempotence path below.
+    $previousErrorActionPreference = $ErrorActionPreference
+    try {
+        $ErrorActionPreference = 'Continue'
+        $output = & $Program @Arguments
+        $exitCode = $LASTEXITCODE
+    } finally {
+        $ErrorActionPreference = $previousErrorActionPreference
+    }
+    return [pscustomobject]@{ Output = $output; ExitCode = $exitCode }
+}
+
 function Build-PunaroBinary([string]$Package, [string]$Output) {
     # `go build` discovers go.mod from the working directory, not from the
     # package argument. Keep the installer usable when invoked by an absolute
     # path from PowerShell's default directory.
     Push-Location -LiteralPath $repoDir
     try {
-        & go build -trimpath -buildvcs=true -o $Output $Package
-        if ($LASTEXITCODE -ne 0) { Stop-Install "could not build $Package" }
+        $result = Invoke-NativeProgramRaw -Program 'go' -Arguments @('build', '-trimpath', '-buildvcs=true', '-o', $Output, $Package)
+        if ($result.ExitCode -ne 0) { Stop-Install "could not build $Package" }
     } finally {
         Pop-Location
     }
@@ -102,9 +118,9 @@ function Build-PunaroBinary([string]$Package, [string]$Output) {
 }
 
 function Invoke-Program([string]$Program, [string[]]$Arguments, [string]$Description) {
-    $output = & $Program @Arguments
-    if ($LASTEXITCODE -ne 0) { Stop-Install "$Description failed" }
-    return (($output | ForEach-Object { [string]$_ }) -join "`n").Trim()
+    $result = Invoke-NativeProgramRaw -Program $Program -Arguments $Arguments
+    if ($result.ExitCode -ne 0) { Stop-Install "$Description failed" }
+    return (($result.Output | ForEach-Object { [string]$_ }) -join "`n").Trim()
 }
 
 if ($env:OS -ne 'Windows_NT') { Stop-Install 'Windows client installation must run on Windows' }
@@ -184,8 +200,8 @@ if (Test-Path -LiteralPath $configFile) {
     Write-NewPrivateText -Path $configFile -Text ($config + "`n")
 }
 
-& $mailbox '--state-dir' $MailboxStateDir 'group' 'create' '--group' $AttachedGroup
-if ($LASTEXITCODE -ne 0) {
+$groupCreate = Invoke-NativeProgramRaw -Program $mailbox -Arguments @('--state-dir', $MailboxStateDir, 'group', 'create', '--group', $AttachedGroup)
+if ($groupCreate.ExitCode -ne 0) {
     $groups = Invoke-Program -Program $mailbox -Arguments @('--state-dir', $MailboxStateDir, 'group', 'list', '--json') -Description 'attachment group lookup' | ConvertFrom-Json
     $groupAddresses = @($groups | ForEach-Object { $_.address })
     if ($groupAddresses -notcontains $AttachedGroup) { Stop-Install 'could not create the local Punaro attachment group' }

--- a/scripts/install-client.ps1
+++ b/scripts/install-client.ps1
@@ -88,8 +88,16 @@ function Assert-Configuration([string]$Path, [hashtable]$Expected) {
 }
 
 function Build-PunaroBinary([string]$Package, [string]$Output) {
-    & go build -trimpath -buildvcs=true -o $Output $Package
-    if ($LASTEXITCODE -ne 0) { Stop-Install "could not build $Package" }
+    # `go build` discovers go.mod from the working directory, not from the
+    # package argument. Keep the installer usable when invoked by an absolute
+    # path from PowerShell's default directory.
+    Push-Location -LiteralPath $repoDir
+    try {
+        & go build -trimpath -buildvcs=true -o $Output $Package
+        if ($LASTEXITCODE -ne 0) { Stop-Install "could not build $Package" }
+    } finally {
+        Pop-Location
+    }
     Protect-PunaroPath -Path $Output
 }
 

--- a/scripts/test-install-client-windows.ps1
+++ b/scripts/test-install-client-windows.ps1
@@ -53,7 +53,12 @@ try {
         return [pscustomobject]@{}
     }
 
-    & (Join-Path $repoDir 'scripts\install-client.ps1') -RelayUrl 'https://relay.example.test' -MachineId 'windows-test' -AgentMailboxBin $mailbox -AgentGuidanceDir $project
+    Push-Location -LiteralPath $fixture
+    try {
+        & (Join-Path $repoDir 'scripts\install-client.ps1') -RelayUrl 'https://relay.example.test' -MachineId 'windows-test' -AgentMailboxBin $mailbox -AgentGuidanceDir $project
+    } finally {
+        Pop-Location
+    }
     if ($LASTEXITCODE -ne 0) { throw 'Windows client installer failed' }
     $root = Join-Path $env:LOCALAPPDATA 'Punaro'
     foreach ($path in @((Join-Path $root 'config\machine.key'), (Join-Path $root 'config\enrollment.json'), (Join-Path $root 'config\adapter.env'), (Join-Path $root 'bin\punaro-trusted-attachment.exe'), (Join-Path $root 'bin\punaro-memory.exe'), (Join-Path $root 'bin\punaro-enroll.exe'), (Join-Path $project '.agents\skills\punaro-mailbox\SKILL.md'))) {

--- a/scripts/test-install-client-windows.sh
+++ b/scripts/test-install-client-windows.sh
@@ -20,7 +20,8 @@ for expected in \
 	'punaro-enroll.exe' \
 	'retired attachment artifact exists at' \
 	'agent-mailbox' \
-	'AgentGuidanceDir'; do
+	'AgentGuidanceDir' \
+	'Push-Location -LiteralPath $repoDir'; do
 	grep -Fq "$expected" "$installer" || { printf '%s\n' "Windows installer is missing required safety behavior: $expected" >&2; exit 1; }
 done
 


### PR DESCRIPTION
## Summary

- add durable conversation role membership that survives session replacement
- support role-targeted delivery while preserving untargeted broadcast behavior
- fence stale leases, acknowledgements, and binds after role rebinding
- keep Cloudflare Service Auth requests cookie-free and cover the regression
- make Linux, macOS, and native Windows deployment, enrollment, upgrade,
  validation, and rollback guidance comprehensive
- record redacted deployed-candidate evidence for the relay, Mac Studio, Coso,
  and Mattone

## Validation

- focused tests were written and observed failing before each behavior change
- `GOCACHE=/tmp/punaro-go-cache make test test-race staticcheck security lint test-real-relay-e2e`
- final review-head real relay lifecycle E2E: 78.642 seconds
- Docker-backed PostgreSQL integration: 29.610 seconds
- Linux/amd64 relay, macOS/arm64 adapter, and Windows/amd64 adapter rebuilt from
  the integrated head and reproduced the exact deployed SHA-256 values
- six live host directions, targeted delivery, broadcast compatibility, Coso
  and Mattone session replacement fencing, offline recovery, Access admission,
  and attachment/memory fail-closed checks passed
- post-cutover registration now keeps the migration-wide legacy gate closed;
  the new owner-registered pending key is admitted while earlier migrated keys
  remain rejected
- host-local authority locking serializes configure, cutover publication, and
  post-cutover registration across database and marker-last file publication;
  an overlapping command fails before mutation and can be retried exactly
- leased role deliveries expose authenticated `recipient_role` metadata and
  preserve it in the local mailbox envelope; exclusive recovery markers are
  atomically published only after complete persistence
- owner-managed deployment validation is recorded separately from withheld
  official release-gate evidence, and the repository release verifier passes

## Deployment status

The exact candidate is healthy on the relay and all three adapter machines.
Cloudflare Access uses distinct exact per-machine Service Auth credentials, and
the relay enrollment retained narrow endpoint namespaces. Mattone's scheduled
task is hidden, uses a hidden PowerShell window, and runs exactly one candidate
process. Pre-candidate rollback copies remain available.

The supported control plane removed the disposable endpoint members and
restored each original attached group. Punaro does not currently expose
conversation deletion or durable-role-member removal, so isolated final admin
and role metadata remains documented as residual test state; relay storage was
not modified directly.

Fixes #55
Fixes #58
