### PR TITLE
fix: hide adapter service launches

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -966,8 +966,9 @@ creates encrypted artifacts only after a local private artifact store has
 reserved file-key, salt, and nonce tuples; the file key is wrapped by the
 machine Keychain, Windows DPAPI CurrentUser boundary, or a private systemd
 credential and is never placed in that journal. The prototype Windows harness uses an
-exclusive current-user ACL and an interactive per-user Scheduled Task; it does
-not expose the wrapping key through an environment variable or task argument.
+exclusive current-user ACL and a hidden interactive per-user Scheduled Task; it
+does not expose the wrapping key through an environment variable or task
+argument.
 On Unix, attachment journals, keys, snapshots, and durable stores additionally
 require owner-only permission bits. On Windows, those same paths must remain
 regular, non-reparse files below the installer-managed ACL: Go's `FileMode`

--- a/deploy/systemd/user/punaro-adapter.service
+++ b/deploy/systemd/user/punaro-adapter.service
@@ -4,6 +4,9 @@ Description=Punaro machine mailbox adapter
 [Service]
 Type=exec
 ExecStart=%h/.local/bin/punaro-adapter
+StandardInput=null
+StandardOutput=journal
+StandardError=journal
 Restart=on-failure
 RestartSec=3
 NoNewPrivileges=yes

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -87,7 +87,9 @@ The machine ID must be unique. The script derives the exclusive endpoint
 namespace `agent/laptop-review/`, builds `punaro-adapter`, creates the local
 `group/punaro-attached` group, writes owner-only local state, installs the
 launchd (macOS) or user-systemd (Linux) service definition, and prints a
-public enrollment JSON record. It does not start the adapter yet.
+public enrollment JSON record. launchd declares it as a background process;
+systemd disables terminal input and sends output only to the journal. It does
+not start the adapter yet.
 
 ### Windows 10/11 client
 
@@ -103,11 +105,13 @@ powershell -NoProfile -File .\scripts\install-client.ps1 `
 ```
 
 The installer writes private state below `%LOCALAPPDATA%\Punaro`, applies an
-exclusive ACL for the current user, and registers the **Punaro Adapter** task
-to run only in that user's interactive session. It does not weaken PowerShell
-execution policy, accept Access secrets as arguments, or run as a Windows
-service. Add that machine's distinct Access token pair manually to
-`%LOCALAPPDATA%\Punaro\config\adapter.env`, then rerun with `-Enable` and
+exclusive ACL for the current user, and registers the hidden **Punaro Adapter**
+task to start at that user's sign-in without showing a PowerShell console. It
+runs in that user's interactive security context because the adapter must
+access that user's mailbox and private credentials; it is not a privileged
+Windows service. It does not weaken PowerShell execution policy or accept
+Access secrets as arguments. Add that machine's distinct Access token pair
+manually to `%LOCALAPPDATA%\Punaro\config\adapter.env`, then rerun with `-Enable` and
 verify with:
 
 ```powershell

--- a/scripts/install-client.ps1
+++ b/scripts/install-client.ps1
@@ -189,10 +189,10 @@ try {
     $windowsPowerShell = if (-not [string]::IsNullOrWhiteSpace($powerShellCommand.Path)) { $powerShellCommand.Path } else { $powerShellCommand.Source }
     if ([string]::IsNullOrWhiteSpace($windowsPowerShell)) { Stop-Install 'Windows PowerShell is required to register the adapter task' }
 } catch { Stop-Install 'Windows PowerShell is required to register the adapter task' }
-$action = New-ScheduledTaskAction -Execute $windowsPowerShell -Argument ('-NoProfile -NonInteractive -ExecutionPolicy Bypass -File "{0}"' -f $runner)
+$action = New-ScheduledTaskAction -Execute $windowsPowerShell -Argument ('-NoProfile -NonInteractive -WindowStyle Hidden -ExecutionPolicy Bypass -File "{0}"' -f $runner)
 $trigger = New-ScheduledTaskTrigger -AtLogOn -User $user
 $principal = New-ScheduledTaskPrincipal -UserId $user -LogonType Interactive -RunLevel Limited
-$settings = New-ScheduledTaskSettingsSet -AllowStartIfOnBatteries -DontStopIfGoingOnBatteries -ExecutionTimeLimit ([TimeSpan]::Zero)
+$settings = New-ScheduledTaskSettingsSet -AllowStartIfOnBatteries -DontStopIfGoingOnBatteries -Hidden -ExecutionTimeLimit ([TimeSpan]::Zero)
 Register-ScheduledTask -TaskName 'Punaro Adapter' -Action $action -Trigger $trigger -Principal $principal -Settings $settings -Description 'Punaro local mailbox adapter' -Force | Out-Null
 if ($Enable) { Start-ScheduledTask -TaskName 'Punaro Adapter' }
 

--- a/scripts/test-install-client-windows.ps1
+++ b/scripts/test-install-client-windows.ps1
@@ -16,7 +16,7 @@ foreach ($path in $paths) {
 }
 
 $installer = [System.IO.File]::ReadAllText((Join-Path $repoDir 'scripts\install-client.ps1'))
-foreach ($expected in @('LogonType Interactive', 'ExecutionTimeLimit ([TimeSpan]::Zero)', 'SetAccessRuleProtection($true, $false)', '-ExecutionPolicy Bypass', 'ForEach-Object { $_.address }', 'punaro-trusted-attachment.exe', 'punaro-memory.exe', 'punaro-enroll.exe', 'agent-mailbox', 'AgentGuidanceDir')) {
+foreach ($expected in @('LogonType Interactive', 'ExecutionTimeLimit ([TimeSpan]::Zero)', '-WindowStyle Hidden', '-Hidden', 'SetAccessRuleProtection($true, $false)', '-ExecutionPolicy Bypass', 'ForEach-Object { $_.address }', 'punaro-trusted-attachment.exe', 'punaro-memory.exe', 'punaro-enroll.exe', 'agent-mailbox', 'AgentGuidanceDir')) {
     if (-not $installer.Contains($expected)) { throw "Windows installer is missing required behavior: $expected" }
 }
 $allScripts = ($paths | ForEach-Object { [System.IO.File]::ReadAllText($_) }) -join "`n"
@@ -44,7 +44,7 @@ try {
     function New-ScheduledTaskAction { param([string]$Execute, [string]$Argument) return [pscustomobject]@{ Execute = $Execute; Argument = $Argument } }
     function New-ScheduledTaskTrigger { param([switch]$AtLogOn, [string]$User) return [pscustomobject]@{ User = $User } }
     function New-ScheduledTaskPrincipal { param([string]$UserId, [string]$LogonType, [string]$RunLevel) return [pscustomobject]@{ UserId = $UserId } }
-    function New-ScheduledTaskSettingsSet { param([switch]$AllowStartIfOnBatteries, [switch]$DontStopIfGoingOnBatteries, [TimeSpan]$ExecutionTimeLimit) return [pscustomobject]@{ ExecutionTimeLimit = $ExecutionTimeLimit } }
+    function New-ScheduledTaskSettingsSet { param([switch]$AllowStartIfOnBatteries, [switch]$DontStopIfGoingOnBatteries, [switch]$Hidden, [TimeSpan]$ExecutionTimeLimit) return [pscustomobject]@{ ExecutionTimeLimit = $ExecutionTimeLimit; Hidden = $Hidden } }
     function Register-ScheduledTask {
         param([string]$TaskName, $Action, $Trigger, $Principal, $Settings, [string]$Description, [switch]$Force)
         $global:punaroRegisteredTask = $TaskName
@@ -64,7 +64,9 @@ try {
     }
     if ($global:punaroRegisteredTask -ne 'Punaro Adapter') { throw 'Windows client installer did not register the expected per-user task' }
     if ($global:punaroRegisteredSettings.ExecutionTimeLimit -ne [TimeSpan]::Zero) { throw 'Windows client adapter task must have no execution time limit' }
+    if (-not $global:punaroRegisteredSettings.Hidden) { throw 'Windows client adapter task must be hidden from the task scheduler UI' }
     if (-not ([string]$global:punaroRegisteredAction.Argument -match '(^|\s)-ExecutionPolicy\s+Bypass(\s|$)')) { throw 'Windows client adapter task must use only process-scoped ExecutionPolicy Bypass' }
+    if (-not ([string]$global:punaroRegisteredAction.Argument -match '(^|\s)-WindowStyle\s+Hidden(\s|$)')) { throw 'Windows client adapter task must hide its PowerShell console window' }
     $existingGroupMailbox = @'
 @echo off
 echo %* | findstr /C:"group create" >nul

--- a/scripts/test-install-client-windows.sh
+++ b/scripts/test-install-client-windows.sh
@@ -15,13 +15,15 @@ done
 for expected in \
 	'LogonType Interactive' \
 	'ExecutionTimeLimit ([TimeSpan]::Zero)' \
+	'-WindowStyle Hidden' \
+	'-Hidden' \
 	'SetAccessRuleProtection($true, $false)' \
 	'punaro-trusted-attachment.exe' \
 	'punaro-enroll.exe' \
 	'retired attachment artifact exists at' \
 	'agent-mailbox' \
 	'AgentGuidanceDir'; do
-	grep -Fq "$expected" "$installer" || { printf '%s\n' "Windows installer is missing required safety behavior: $expected" >&2; exit 1; }
+	grep -Fq -- "$expected" "$installer" || { printf '%s\n' "Windows installer is missing required safety behavior: $expected" >&2; exit 1; }
 done
 
 for retired_package in 'cmd\punaro-dpapi' 'cmd\punaro-directory' 'cmd\punaro-attachment' 'cmd\punaro-keychain'; do

--- a/scripts/verify-deployment-files.sh
+++ b/scripts/verify-deployment-files.sh
@@ -42,6 +42,8 @@ for expected in \
 	'<string>org.punaro.adapter</string>' \
 	'<key>KeepAlive</key>' \
 	'<true/>' \
+	'<key>ProcessType</key>' \
+	'<string>Background</string>' \
 	'<string>exec "$HOME/.local/bin/punaro-adapter"</string>'; do
 	if ! grep -Fq "$expected" "$launch_agent"; then
 		printf '%s\n' "adapter LaunchAgent is missing required setting: $expected" >&2
@@ -72,6 +74,9 @@ for expected in \
 	'ProtectSystem=strict' \
 	'PrivateTmp=yes' \
 	'PrivateDevices=yes' \
+	'StandardInput=null' \
+	'StandardOutput=journal' \
+	'StandardError=journal' \
 	'CapabilityBoundingSet=' \
 	'UMask=0077'; do
 	if ! grep -Fqx "$expected" "$unit"; then


### PR DESCRIPTION
## Summary

Makes the local Punaro adapter run invisibly on every supported platform.

- Hides the Windows Task Scheduler entry and PowerShell console while retaining the user-scoped security context required for mailbox and credential access.
- Makes Linux terminal I/O and journald logging explicit.
- Verifies the macOS LaunchAgent background contract and adds Windows task-visibility regression coverage.

## Root cause

The Windows scheduled task launched `powershell.exe` in the interactive user session without a hidden window style, allowing a console window to appear at sign-in.

## Validation

- `make test`
- `make test-race`
- `make staticcheck`
- `make security`
- `make lint`
- `make deployment-lint`

The Windows configuration is regression-tested and cross-compiled; no live Windows desktop session was available for an end-to-end visual check.