### PR TITLE
Add server client lifecycle authority

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1291,6 +1291,20 @@ cross-origin, unavailable, expired, already-used, or revoked enrollment fails
 closed; only the server owner can issue a replacement, rotate a credential, or
 revoke it.
 
+Schema version 44 adds the first server-side named-release lifecycle
+foundation. Every newly redeemed bearer credential atomically owns one
+immutable, unique machine ID, opaque client installation, and derived exclusive
+`agent/<machine-id>/` endpoint namespace. First-release credentials are
+non-expiring; rotation and either owner or targetless self-revocation advance
+the credential, client, principal, and endpoint-authority fences together.
+`punaro client list` exposes only bounded lifecycle metadata, while `punaro
+client revoke` is host-local, permanent, and idempotent. The public self-revoke
+route accepts no body or target and permits an already-revoked credential only
+for the exact committed self-revocation key. Authentication and session checks
+fail closed unless every lifecycle generation agrees. This sub-slice does not
+yet replace static relay endpoint authority, import exact legacy enrollments,
+or implement the new invitation, hello, updater, fleet, or recovery protocols.
+
 The supported cutover action is `punaro mail cutover`. Its dry-run reads the
 service-owned `relay.db` from the installation data directory and prints the
 source fingerprint, exact counts, and PostgreSQL target identity without a

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ wake-up hints containing an opaque conversation ID and sequence only.
 Read the [accepted platform and Big Brain plan](docs/big-brain-plan.md),
 [architecture and security design](DESIGN.md),
 [platform compatibility contracts](docs/platform-contracts.md),
+[proposed client lifecycle, compatibility, and recovery RFC](docs/client-lifecycle-compatibility-recovery-rfc.md),
 [user guide](docs/user-guide.md), [operator guide](docs/operator-guide.md),
 [installation guide](docs/installation.md),
 [alpha text-relay onboarding](docs/alpha-text-relay.md),

--- a/cmd/punaro-admin/main.go
+++ b/cmd/punaro-admin/main.go
@@ -22,6 +22,8 @@ type adminDatabase interface {
 	Close() error
 	BootstrapOwner(context.Context, string) (punaropostgres.Principal, error)
 	CreateEnrollment(context.Context, string, punaropostgres.EnrollmentRequest, string) (punaropostgres.PendingEnrollment, error)
+	ListClients(context.Context, string, int) ([]punaropostgres.ClientMetadata, error)
+	RevokeClient(context.Context, string, string, string) error
 	ListDeviceCredentials(context.Context, string, int) ([]punaropostgres.DeviceCredentialMetadata, error)
 	BeginDeviceCredentialRotation(context.Context, string, string, int64) (punaropostgres.PendingCredentialRotation, error)
 	RotateDeviceCredential(context.Context, string, punaropostgres.RotateCredential) (punaropostgres.DeviceCredential, error)
@@ -47,8 +49,14 @@ func run(args []string, stdout, stderr io.Writer) int {
 	case "init":
 		return runInit(args[1:], stdout, stderr)
 	case "client":
-		if len(args) > 1 && args[1] == "add" {
+		if len(args) > 1 && (args[1] == "invite" || args[1] == "add") {
 			return runClientAdd(args[2:], stdout, stderr)
+		}
+		if len(args) > 1 && args[1] == "list" {
+			return runClientList(args[2:], stdout, stderr)
+		}
+		if len(args) > 1 && args[1] == "revoke" {
+			return runClientRevoke(args[2:], stderr)
 		}
 	case "credential":
 		if len(args) > 1 && args[1] == "list" {
@@ -112,15 +120,15 @@ func runClientAdd(args []string, stdout, stderr io.Writer) int {
 	dsnFile := flags.String("owner-dsn-file", "", "protected schema-owner DSN file")
 	actor := flags.String("actor-principal-id", "", "installation owner principal ID")
 	name := flags.String("name", "", "client display name")
+	machineID := flags.String("machine-id", "", "unique lowercase client machine ID")
 	binding := flags.String("client-binding", "", "client-generated opaque binding UUID")
 	allProjects := flags.Bool("all-projects", false, "grant dynamic current and future project access")
 	ttl := flags.Duration("ttl", 10*time.Minute, "single-use enrollment lifetime")
-	credentialTTL := flags.Duration("credential-ttl", 0, "optional credential lifetime")
 	legacyPrincipal := flags.String("legacy-principal-id", "", "operator-approved legacy machine principal for exchange")
 	confirmed := flags.Bool("yes", false, "confirm the printed exact grant expansion")
 	var projects stringList
 	flags.Var(&projects, "project", "selected opaque project UUID (repeatable)")
-	if flags.Parse(args) != nil || *actor == "" || *name == "" || *binding == "" || flags.NArg() != 0 {
+	if flags.Parse(args) != nil || *actor == "" || *name == "" || *machineID == "" || *binding == "" || flags.NArg() != 0 {
 		return 2
 	}
 	grants, previewHash, err := punaropostgres.PreviewTrustedAgentEnrollment(projects, *allProjects)
@@ -148,11 +156,53 @@ func runClientAdd(args []string, stdout, stderr io.Writer) int {
 		return adminError(stderr, err)
 	}
 	defer func() { _ = admin.Close() }()
-	pending, err := admin.CreateEnrollment(context.Background(), *actor, punaropostgres.EnrollmentRequest{ClientBinding: *binding, Label: *name, ProjectIDs: projects, AllProjects: *allProjects, LegacyPrincipalID: *legacyPrincipal, TTL: *ttl, CredentialTTL: *credentialTTL}, previewHash)
+	pending, err := admin.CreateEnrollment(context.Background(), *actor, punaropostgres.EnrollmentRequest{ClientBinding: *binding, MachineID: *machineID, Label: *name, ProjectIDs: projects, AllProjects: *allProjects, LegacyPrincipalID: *legacyPrincipal, TTL: *ttl}, previewHash)
 	if err != nil {
 		return adminError(stderr, err)
 	}
 	return writeJSON(stdout, stderr, pending)
+}
+
+func runClientList(args []string, stdout, stderr io.Writer) int {
+	flags := flag.NewFlagSet("client list", flag.ContinueOnError)
+	flags.SetOutput(stderr)
+	dsnFile := flags.String("owner-dsn-file", "", "protected schema-owner DSN file")
+	actor := flags.String("actor-principal-id", "", "installation owner principal ID")
+	limit := flags.Int("limit", 100, "maximum rows (1-1000)")
+	if flags.Parse(args) != nil || *dsnFile == "" || *actor == "" || *limit < 1 || *limit > 1000 || flags.NArg() != 0 {
+		return 2
+	}
+	admin, err := openAdminDatabase(context.Background(), punaropostgres.Config{DSNFile: *dsnFile})
+	if err != nil {
+		return adminError(stderr, err)
+	}
+	defer func() { _ = admin.Close() }()
+	clients, err := admin.ListClients(context.Background(), *actor, *limit)
+	if err != nil {
+		return adminError(stderr, err)
+	}
+	return writeJSON(stdout, stderr, map[string]any{"clients": clients})
+}
+
+func runClientRevoke(args []string, stderr io.Writer) int {
+	flags := flag.NewFlagSet("client revoke", flag.ContinueOnError)
+	flags.SetOutput(stderr)
+	dsnFile := flags.String("owner-dsn-file", "", "protected schema-owner DSN file")
+	actor := flags.String("actor-principal-id", "", "installation owner principal ID")
+	clientID := flags.String("client", "", "opaque client UUID")
+	reason := flags.String("reason", "", "lost, retired, compromised, or replaced")
+	if flags.Parse(args) != nil || *dsnFile == "" || *actor == "" || *clientID == "" || *reason == "" || flags.NArg() != 0 {
+		return 2
+	}
+	admin, err := openAdminDatabase(context.Background(), punaropostgres.Config{DSNFile: *dsnFile})
+	if err != nil {
+		return adminError(stderr, err)
+	}
+	defer func() { _ = admin.Close() }()
+	if err := admin.RevokeClient(context.Background(), *actor, *clientID, *reason); err != nil {
+		return adminError(stderr, err)
+	}
+	return 0
 }
 
 func runCredentialList(args []string, stdout, stderr io.Writer) int {

--- a/cmd/punaro-admin/main_test.go
+++ b/cmd/punaro-admin/main_test.go
@@ -12,6 +12,26 @@ import (
 	postgres "github.com/rock3r/punaro/internal/postgres"
 )
 
+type lifecycleAdminDouble struct {
+	adminDatabase
+	clients []postgres.ClientMetadata
+	revoked bool
+}
+
+func (d *lifecycleAdminDouble) Close() error { return nil }
+
+func (d *lifecycleAdminDouble) ListClients(context.Context, string, int) ([]postgres.ClientMetadata, error) {
+	return d.clients, nil
+}
+
+func (d *lifecycleAdminDouble) RevokeClient(_ context.Context, _, clientID, reason string) error {
+	if clientID != "22222222-2222-4222-8222-222222222222" || reason != "retired" {
+		return context.Canceled
+	}
+	d.revoked = true
+	return nil
+}
+
 func TestClientAddPrintsExactPreviewBeforeOpeningAdministration(t *testing.T) {
 	original := openAdminDatabase
 	t.Cleanup(func() { openAdminDatabase = original })
@@ -20,9 +40,30 @@ func TestClientAddPrintsExactPreviewBeforeOpeningAdministration(t *testing.T) {
 		return nil, nil
 	}
 	var stdout, stderr bytes.Buffer
-	code := run([]string{"client", "add", "--actor-principal-id", "11111111-1111-4111-8111-111111111111", "--name", "laptop", "--client-binding", "22222222-2222-4222-8222-222222222222", "--all-projects"}, &stdout, &stderr)
+	code := run([]string{"client", "add", "--actor-principal-id", "11111111-1111-4111-8111-111111111111", "--name", "laptop", "--machine-id", "laptop", "--client-binding", "22222222-2222-4222-8222-222222222222", "--all-projects"}, &stdout, &stderr)
 	if code != 3 || !strings.Contains(stdout.String(), `"template": "trusted-agent"`) || !strings.Contains(stdout.String(), `"preview_hash"`) || !strings.Contains(stderr.String(), "rerun with --yes") {
 		t.Fatalf("code=%d stdout=%q stderr=%q", code, stdout.String(), stderr.String())
+	}
+}
+
+func TestClientInviteAliasAndLifecycleCommands(t *testing.T) {
+	original := openAdminDatabase
+	t.Cleanup(func() { openAdminDatabase = original })
+	double := &lifecycleAdminDouble{clients: []postgres.ClientMetadata{{ClientID: "22222222-2222-4222-8222-222222222222", MachineID: "laptop", LifecycleState: "active"}}}
+	openAdminDatabase = func(context.Context, postgres.Config) (adminDatabase, error) { return double, nil }
+	var stdout, stderr bytes.Buffer
+	if code := run([]string{"client", "invite", "--actor-principal-id", "11111111-1111-4111-8111-111111111111", "--name", "laptop", "--machine-id", "laptop", "--client-binding", "22222222-2222-4222-8222-222222222222", "--all-projects"}, &stdout, &stderr); code != 3 {
+		t.Fatalf("invite code=%d stdout=%q stderr=%q", code, stdout.String(), stderr.String())
+	}
+	stdout.Reset()
+	stderr.Reset()
+	if code := run([]string{"client", "list", "--owner-dsn-file", "/protected/owner.dsn", "--actor-principal-id", "11111111-1111-4111-8111-111111111111"}, &stdout, &stderr); code != 0 || !strings.Contains(stdout.String(), "22222222-2222-4222-8222-222222222222") {
+		t.Fatalf("list code=%d stdout=%q stderr=%q", code, stdout.String(), stderr.String())
+	}
+	stdout.Reset()
+	stderr.Reset()
+	if code := run([]string{"client", "revoke", "--owner-dsn-file", "/protected/owner.dsn", "--actor-principal-id", "11111111-1111-4111-8111-111111111111", "--client", "22222222-2222-4222-8222-222222222222", "--reason", "retired"}, &stdout, &stderr); code != 0 || stdout.Len() != 0 || stderr.Len() != 0 || !double.revoked {
+		t.Fatalf("revoke code=%d revoked=%t stdout=%q stderr=%q", code, double.revoked, stdout.String(), stderr.String())
 	}
 }
 
@@ -58,7 +99,7 @@ func TestRotationCodeFileIsExclusiveAndProtected(t *testing.T) {
 
 func TestClientAddRejectsAmbiguousProjectScope(t *testing.T) {
 	var stdout, stderr bytes.Buffer
-	code := run([]string{"client", "add", "--actor-principal-id", "11111111-1111-4111-8111-111111111111", "--name", "laptop", "--client-binding", "22222222-2222-4222-8222-222222222222", "--project", "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa", "--all-projects"}, &stdout, &stderr)
+	code := run([]string{"client", "add", "--actor-principal-id", "11111111-1111-4111-8111-111111111111", "--name", "laptop", "--machine-id", "laptop", "--client-binding", "22222222-2222-4222-8222-222222222222", "--project", "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa", "--all-projects"}, &stdout, &stderr)
 	if code != 1 || stdout.Len() != 0 || strings.Contains(stderr.String(), "aaaaaaaa") {
 		t.Fatalf("code=%d stdout=%q stderr=%q", code, stdout.String(), stderr.String())
 	}

--- a/cmd/punaro-enroll/main.go
+++ b/cmd/punaro-enroll/main.go
@@ -29,7 +29,7 @@ const (
 	redemptionLockName    = "redemption-recovery.lock"
 	maxEnrollmentFile     = 4096
 	// maxEnrollmentMaterial bounds the two JSON records emitted by
-	// `punaro-admin client add --yes` at its 100-project limit.
+	// `punaro-admin client invite --machine-id ID --yes` at its 100-project limit.
 	maxEnrollmentMaterial = 512 * 1024
 )
 
@@ -93,11 +93,14 @@ type redemptionRequest struct {
 }
 
 type redemptionResponse struct {
-	PrincipalID string    `json:"principal_id"`
-	LookupID    string    `json:"lookup_id"`
-	Credential  string    `json:"credential"`
-	Generation  int64     `json:"generation"`
-	ExpiresAt   time.Time `json:"expires_at"`
+	ClientID       string    `json:"client_id"`
+	MachineID      string    `json:"machine_id"`
+	EndpointPrefix string    `json:"endpoint_prefix"`
+	PrincipalID    string    `json:"principal_id"`
+	LookupID       string    `json:"lookup_id"`
+	Credential     string    `json:"credential"`
+	Generation     int64     `json:"generation"`
+	ExpiresAt      time.Time `json:"expires_at"`
 }
 
 func main() { os.Exit(run(os.Args[1:], os.Stdout, os.Stderr)) }
@@ -569,10 +572,33 @@ func decodeFields(raw []byte, target any, required, optional []string) error {
 
 func decodeRedemptionResponse(raw []byte) (redemptionResponse, error) {
 	var value redemptionResponse
-	if err := decodeFields(raw, &value, []string{"principal_id", "lookup_id", "credential", "generation"}, []string{"expires_at"}); err != nil || !validUUID(value.PrincipalID) || !validUUID(value.LookupID) || !validCredential(value.Credential, value.LookupID) || value.Generation < 1 {
+	if err := decodeFields(raw, &value, []string{"principal_id", "lookup_id", "credential", "generation"}, []string{"client_id", "machine_id", "endpoint_prefix", "expires_at"}); err != nil || !validUUID(value.PrincipalID) || !validUUID(value.LookupID) || !validCredential(value.Credential, value.LookupID) || value.Generation < 1 || !validLifecycleResponse(value) {
 		return redemptionResponse{}, errors.New("invalid redemption response")
 	}
 	return value, nil
+}
+
+func validLifecycleResponse(value redemptionResponse) bool {
+	if value.ClientID == "" && value.MachineID == "" && value.EndpointPrefix == "" {
+		return true
+	}
+	return validUUID(value.ClientID) && validLifecycleMachineID(value.MachineID) && value.EndpointPrefix == "agent/"+value.MachineID+"/"
+}
+
+func validLifecycleMachineID(value string) bool {
+	if len(value) < 1 || len(value) > 64 {
+		return false
+	}
+	for index, character := range []byte(value) {
+		if character >= 'a' && character <= 'z' || character >= '0' && character <= '9' {
+			continue
+		}
+		if index > 0 && index < len(value)-1 && (character == '.' || character == '_' || character == '-') {
+			continue
+		}
+		return false
+	}
+	return true
 }
 
 type redemptionResult uint8

--- a/cmd/punaro-enroll/main_test.go
+++ b/cmd/punaro-enroll/main_test.go
@@ -477,6 +477,18 @@ func TestRedemptionResponseAcceptsOptionalExpiryWithoutRelaxingItsSchema(t *test
 	if _, err := decodeRedemptionResponse([]byte(`{"principal_id":"11111111-1111-4111-8111-111111111111","lookup_id":"22222222-2222-4222-822222222222","credential":"punaro_device_credential","generation":1,"expires_at":"invalid"}`)); err == nil {
 		t.Fatal("invalid expiry was accepted")
 	}
+	response, err = decodeRedemptionResponse([]byte(`{"client_id":"33333333-3333-4333-8333-333333333333","machine_id":"laptop-a","endpoint_prefix":"agent/laptop-a/","principal_id":"11111111-1111-4111-8111-111111111111","lookup_id":"22222222-2222-4222-8222-222222222222","credential":"22222222-2222-4222-8222-222222222222.` + strings.Repeat("A", 43) + `","generation":1}`))
+	if err != nil || response.ClientID == "" || response.MachineID != "laptop-a" || response.EndpointPrefix != "agent/laptop-a/" {
+		t.Fatalf("lifecycle response err=%v response=%#v", err, response)
+	}
+	for _, malformed := range []string{
+		`{"client_id":"33333333-3333-4333-8333-333333333333","principal_id":"11111111-1111-4111-8111-111111111111","lookup_id":"22222222-2222-4222-8222-222222222222","credential":"22222222-2222-4222-8222-222222222222.` + strings.Repeat("A", 43) + `","generation":1}`,
+		`{"client_id":"33333333-3333-4333-8333-333333333333","machine_id":"Laptop","endpoint_prefix":"agent/Laptop/","principal_id":"11111111-1111-4111-8111-111111111111","lookup_id":"22222222-2222-4222-8222-222222222222","credential":"22222222-2222-4222-8222-222222222222.` + strings.Repeat("A", 43) + `","generation":1}`,
+	} {
+		if _, err := decodeRedemptionResponse([]byte(malformed)); err == nil {
+			t.Fatalf("malformed lifecycle response was accepted: %s", malformed)
+		}
+	}
 }
 
 func TestRejectedEnrollmentClearsRecoverySoReplacementCanProceed(t *testing.T) {

--- a/cmd/punaro-enroll/private_file_unix.go
+++ b/cmd/punaro-enroll/private_file_unix.go
@@ -269,7 +269,8 @@ func syncPrivateDirectoryImpl(path string) error {
 		// invariant without allowing an already-written journal to poison all
 		// later recovery attempts.
 		if errors.Is(err, unix.EINVAL) || errors.Is(err, unix.ENOTSUP) {
-			unix.Sync() // #nosec G104 -- unix.Sync has no return value to check. //nolint:errcheck
+			//nolint:errcheck // Sync has no return value on supported Unix platforms.
+			unix.Sync() // #nosec G104 -- no error value exists to handle.
 			return nil
 		}
 		return err
@@ -286,7 +287,8 @@ func removePrivate(path string) error {
 		// journal that survives a crash is harmless: recovering it replays the
 		// same idempotency key. Do not convert a successful enrollment into a
 		// failure merely because its best-effort cleanup could not be synced.
-		unix.Sync() // #nosec G104 -- unix.Sync has no return value to check. //nolint:errcheck
+		//nolint:errcheck // Sync has no return value on supported Unix platforms.
+		unix.Sync() // #nosec G104 -- no error value exists to handle.
 	}
 	return nil
 }

--- a/cmd/punaro-memory/onboarding_e2e_test.go
+++ b/cmd/punaro-memory/onboarding_e2e_test.go
@@ -196,7 +196,7 @@ func TestInstalledMemoryClientOnboardingE2E(t *testing.T) {
 	if err != nil {
 		t.Fatal("enrollment preview setup failed")
 	}
-	pending, err := admin.CreateEnrollment(ctx, owner.ID, punaropostgres.EnrollmentRequest{ClientBinding: prepared.ClientBinding, Label: "memory E2E client", ProjectIDs: []string{project.ProjectID}, TTL: time.Minute}, previewHash)
+	pending, err := admin.CreateEnrollment(ctx, owner.ID, punaropostgres.EnrollmentRequest{ClientBinding: prepared.ClientBinding, MachineID: "memory-e2e", Label: "memory E2E client", ProjectIDs: []string{project.ProjectID}, TTL: time.Minute}, previewHash)
 	if err != nil {
 		t.Fatal("disposable enrollment setup failed")
 	}
@@ -332,7 +332,7 @@ func TestInstalledCompleteProductE2E(t *testing.T) {
 	if err != nil {
 		t.Fatal("product enrollment preview setup failed")
 	}
-	pending, err := admin.CreateEnrollment(ctx, owner.ID, punaropostgres.EnrollmentRequest{ClientBinding: prepared.ClientBinding, Label: "complete product E2E client", ProjectIDs: []string{project.ProjectID}, TTL: time.Minute}, previewHash)
+	pending, err := admin.CreateEnrollment(ctx, owner.ID, punaropostgres.EnrollmentRequest{ClientBinding: prepared.ClientBinding, MachineID: "complete-product-e2e", Label: "complete product E2E client", ProjectIDs: []string{project.ProjectID}, TTL: time.Minute}, previewHash)
 	if err != nil {
 		t.Fatal("product enrollment setup failed")
 	}

--- a/cmd/punaro-memory/profile_private_windows_test.go
+++ b/cmd/punaro-memory/profile_private_windows_test.go
@@ -67,7 +67,7 @@ func TestWindowsProfileAllowsEnrollmentStylePrivateParentDirectory(t *testing.T)
 
 func TestWindowsProfileRejectsCaseInsensitiveCredentialAlias(t *testing.T) {
 	profile := `C:\Punaro\DEVICE.CREDENTIAL`
-	credential := `c:\punaro\device.credential`
+	credential := `c:\punaro\device.credential` // #nosec G101 -- public test path, not a credential value.
 	if !sameCleanProfilePath(profile, credential) {
 		t.Fatal("Windows case-insensitive credential alias was not detected")
 	}

--- a/cmd/punaro/main.go
+++ b/cmd/punaro/main.go
@@ -24,6 +24,8 @@ import (
 	punaropostgres "github.com/rock3r/punaro/internal/postgres"
 )
 
+const minimumClientLifecycleSchema int64 = 44
+
 var (
 	inspectSchema = func(ctx context.Context, dsnFile string) (punaropostgres.SchemaState, error) {
 		database, err := punaropostgres.OpenApplication(ctx, punaropostgres.Config{DSNFile: dsnFile})
@@ -122,6 +124,22 @@ var (
 		}
 		defer func() { _ = admin.Close() }()
 		return admin.CreateEnrollment(ctx, installation.OwnerPrincipalID, request, previewHash)
+	}
+	listClients = func(ctx context.Context, installation operator.Installation, limit int) ([]punaropostgres.ClientMetadata, error) {
+		admin, err := punaropostgres.OpenAdministration(ctx, punaropostgres.Config{DSNFile: installation.OwnerDSNFile})
+		if err != nil {
+			return nil, err
+		}
+		defer func() { _ = admin.Close() }()
+		return admin.ListClients(ctx, installation.OwnerPrincipalID, limit)
+	}
+	revokeClient = func(ctx context.Context, installation operator.Installation, clientID, reason string) error {
+		admin, err := punaropostgres.OpenAdministration(ctx, punaropostgres.Config{DSNFile: installation.OwnerDSNFile})
+		if err != nil {
+			return err
+		}
+		defer func() { _ = admin.Close() }()
+		return admin.RevokeClient(ctx, installation.OwnerPrincipalID, clientID, reason)
 	}
 	startServices = func(ctx context.Context, installation operator.Installation) error {
 		command, err := composeUpCommand(ctx, installation)
@@ -332,8 +350,14 @@ func run(args []string, stdout, stderr io.Writer) int {
 	case "doctor":
 		return runStatus(args[1:], stdout, stderr, true)
 	case "client":
-		if len(args) > 1 && args[1] == "add" {
+		if len(args) > 1 && (args[1] == "invite" || args[1] == "add") {
 			return runClientAdd(args[2:], stdout, stderr)
+		}
+		if len(args) > 1 && args[1] == "list" {
+			return runClientList(args[2:], stdout, stderr)
+		}
+		if len(args) > 1 && args[1] == "revoke" {
+			return runClientRevoke(args[2:], stderr)
 		}
 	case "mail":
 		if len(args) > 1 && args[1] == "cutover" {
@@ -580,14 +604,14 @@ func runClientAdd(args []string, stdout, stderr io.Writer) int {
 	flags.SetOutput(stderr)
 	directory := flags.String("directory", "", "absolute installation directory")
 	name := flags.String("name", "", "client display name")
+	machineID := flags.String("machine-id", "", "unique lowercase client machine ID")
 	allProjects := flags.Bool("all-projects", false, "grant current and future project access")
 	confirmed := flags.Bool("yes", false, "confirm the exact printed grants")
 	confirmedHash := flags.String("confirm-preview-hash", "", "exact preview hash printed by the prior preview-only run")
 	ttl := flags.Duration("ttl", 10*time.Minute, "single-use code lifetime")
-	credentialTTL := flags.Duration("credential-ttl", 0, "optional credential lifetime")
 	var projects stringList
 	flags.Var(&projects, "project", "selected opaque project UUID (repeatable)")
-	if flags.Parse(args) != nil || flags.NArg() != 0 || *directory == "" || *name == "" {
+	if flags.Parse(args) != nil || flags.NArg() != 0 || *directory == "" || *name == "" || *machineID == "" {
 		return 2
 	}
 	installation, err := operator.Load(*directory)
@@ -620,7 +644,7 @@ func runClientAdd(args []string, stdout, stderr io.Writer) int {
 		return 1
 	}
 	state, err := inspectSchema(context.Background(), installation.AppDSNFile)
-	if err != nil || state.Classification != punaropostgres.Compatible {
+	if err != nil || state.Classification != punaropostgres.Compatible || state.Version < minimumClientLifecycleSchema {
 		_, _ = fmt.Fprintln(stderr, "client enrollment refused: database schema is not compatible")
 		return 1
 	}
@@ -633,12 +657,73 @@ func runClientAdd(args []string, stdout, stderr io.Writer) int {
 		_, _ = fmt.Fprintln(stderr, "client enrollment refused: database owner does not match the installation configuration")
 		return 1
 	}
-	pending, err := issueEnrollment(context.Background(), installation, punaropostgres.EnrollmentRequest{ClientBinding: uuid.NewString(), Label: *name, ProjectIDs: projects, AllProjects: *allProjects, TTL: *ttl, CredentialTTL: *credentialTTL}, previewHash)
+	pending, err := issueEnrollment(context.Background(), installation, punaropostgres.EnrollmentRequest{ClientBinding: uuid.NewString(), MachineID: *machineID, Label: *name, ProjectIDs: projects, AllProjects: *allProjects, TTL: *ttl}, previewHash)
 	if err != nil {
 		_, _ = fmt.Fprintln(stderr, "client enrollment failed")
 		return 1
 	}
 	return writeJSON(stdout, stderr, pending)
+}
+
+func runClientList(args []string, stdout, stderr io.Writer) int {
+	flags := flag.NewFlagSet("client list", flag.ContinueOnError)
+	flags.SetOutput(stderr)
+	directory := flags.String("directory", "", "absolute installation directory")
+	limit := flags.Int("limit", 100, "maximum rows (1-1000)")
+	if flags.Parse(args) != nil || flags.NArg() != 0 || *directory == "" || *limit < 1 || *limit > 1000 {
+		return 2
+	}
+	installation, err := loadClientAdministration(*directory)
+	if err != nil {
+		_, _ = fmt.Fprintln(stderr, "client inventory refused: installation is unavailable or unsafe")
+		return 1
+	}
+	clients, err := listClients(context.Background(), installation, *limit)
+	if err != nil {
+		_, _ = fmt.Fprintln(stderr, "client inventory failed")
+		return 1
+	}
+	return writeJSON(stdout, stderr, map[string]any{"clients": clients})
+}
+
+func runClientRevoke(args []string, stderr io.Writer) int {
+	flags := flag.NewFlagSet("client revoke", flag.ContinueOnError)
+	flags.SetOutput(stderr)
+	directory := flags.String("directory", "", "absolute installation directory")
+	clientID := flags.String("client", "", "opaque client UUID")
+	reason := flags.String("reason", "", "lost, retired, compromised, or replaced")
+	if flags.Parse(args) != nil || flags.NArg() != 0 || *directory == "" || *clientID == "" || *reason == "" {
+		return 2
+	}
+	installation, err := loadClientAdministration(*directory)
+	if err != nil {
+		_, _ = fmt.Fprintln(stderr, "client revocation refused: installation is unavailable or unsafe")
+		return 1
+	}
+	if err := revokeClient(context.Background(), installation, *clientID, *reason); err != nil {
+		_, _ = fmt.Fprintln(stderr, "client revocation failed")
+		return 1
+	}
+	return 0
+}
+
+func loadClientAdministration(directory string) (operator.Installation, error) {
+	installation, err := operator.Load(directory)
+	if err != nil || len(operator.CheckPaths(installation)) != 0 {
+		return operator.Installation{}, errors.New("installation is unavailable")
+	}
+	state, err := inspectSchema(context.Background(), installation.AppDSNFile)
+	if err != nil || state.Classification != punaropostgres.Compatible || state.Version < minimumClientLifecycleSchema {
+		return operator.Installation{}, errors.New("database schema is not compatible")
+	}
+	if err := verifyInstallationPair(context.Background(), installation.AppDSNFile, installation.OwnerDSNFile); err != nil {
+		return operator.Installation{}, err
+	}
+	owner, err := inspectOwner(context.Background(), installation.AppDSNFile)
+	if err != nil || owner.ID != installation.OwnerPrincipalID {
+		return operator.Installation{}, errors.New("database owner does not match installation")
+	}
+	return installation, nil
 }
 
 func runBackup(args []string, stdout, stderr io.Writer) int {

--- a/cmd/punaro/main_test.go
+++ b/cmd/punaro/main_test.go
@@ -433,7 +433,7 @@ func preserveDependencies(t *testing.T) {
 	originalInspect, originalOwner, originalMigrate, originalMaintenance := inspectSchema, inspectOwner, migratePristinePair, maintenanceActive
 	originalCreate, originalRecover := createOwner, recoverInstallationOwner
 	originalVerify := verifyInstallationPair
-	originalStart, originalProbe, originalIssue := startServices, probe, issueEnrollment
+	originalStart, originalProbe, originalIssue, originalListClients, originalRevokeClient := startServices, probe, issueEnrollment, listClients, revokeClient
 	originalBackup, originalListBackups, originalVerifyBackup, originalRestore := createOperatorBackup, listOperatorBackups, verifyOperatorBackup, restoreOperatorBackup
 	t.Cleanup(func() {
 		inspectSchema, inspectOwner, migratePristinePair, maintenanceActive = originalInspect, originalOwner, originalMigrate, originalMaintenance
@@ -441,6 +441,7 @@ func preserveDependencies(t *testing.T) {
 		verifyInstallationPair = originalVerify
 		startServices, probe = originalStart, originalProbe
 		issueEnrollment = originalIssue
+		listClients, revokeClient = originalListClients, originalRevokeClient
 		createOperatorBackup, listOperatorBackups, verifyOperatorBackup, restoreOperatorBackup = originalBackup, originalListBackups, originalVerifyBackup, originalRestore
 	})
 	inspectOwner = func(context.Context, string) (punaropostgres.Principal, error) {
@@ -778,7 +779,7 @@ func TestUpRefusesMismatchedInstallationPairBeforeStart(t *testing.T) {
 	preserveDependencies(t)
 	directory := testInstallation(t)
 	inspectSchema = func(context.Context, string) (punaropostgres.SchemaState, error) {
-		return punaropostgres.SchemaState{Classification: punaropostgres.Compatible, Version: 5}, nil
+		return punaropostgres.SchemaState{Classification: punaropostgres.Compatible, Version: 44}, nil
 	}
 	verifyInstallationPair = func(context.Context, string, string) error {
 		return errors.New("different installation")
@@ -986,15 +987,55 @@ func TestInitResumeRecoversUncertainOwnerOutcome(t *testing.T) {
 func TestClientAddPrintsPreviewWithoutDatabaseMutation(t *testing.T) {
 	directory := testInstallation(t)
 	var stdout, stderr bytes.Buffer
-	if code := run([]string{"client", "add", "--directory", directory, "--name", "laptop", "--all-projects"}, &stdout, &stderr); code != 3 || !strings.Contains(stdout.String(), "trusted-agent") || !strings.Contains(stderr.String(), "rerun with --yes") {
+	if code := run([]string{"client", "add", "--directory", directory, "--name", "laptop", "--machine-id", "laptop", "--all-projects"}, &stdout, &stderr); code != 3 || !strings.Contains(stdout.String(), "trusted-agent") || !strings.Contains(stderr.String(), "rerun with --yes") {
 		t.Fatalf("code=%d stdout=%q stderr=%q", code, stdout.String(), stderr.String())
+	}
+}
+
+func TestClientInviteAliasPrintsPreviewWithoutDatabaseMutation(t *testing.T) {
+	directory := testInstallation(t)
+	var stdout, stderr bytes.Buffer
+	if code := run([]string{"client", "invite", "--directory", directory, "--name", "laptop", "--machine-id", "laptop", "--all-projects"}, &stdout, &stderr); code != 3 || !strings.Contains(stdout.String(), "trusted-agent") || !strings.Contains(stderr.String(), "rerun with --yes") {
+		t.Fatalf("code=%d stdout=%q stderr=%q", code, stdout.String(), stderr.String())
+	}
+}
+
+func TestClientInventoryAndRevocationUseHostLocalInstallationAuthority(t *testing.T) {
+	preserveDependencies(t)
+	directory := testInstallation(t)
+	inspectSchema = func(context.Context, string) (punaropostgres.SchemaState, error) {
+		return punaropostgres.SchemaState{Classification: punaropostgres.Compatible, Version: 44}, nil
+	}
+	clientID := "22222222-2222-4222-8222-222222222222"
+	listClients = func(_ context.Context, installation operator.Installation, limit int) ([]punaropostgres.ClientMetadata, error) {
+		if installation.Directory != directory || limit != 7 {
+			t.Fatalf("list installation=%#v limit=%d", installation, limit)
+		}
+		return []punaropostgres.ClientMetadata{{ClientID: clientID, MachineID: "laptop", EndpointPrefix: "agent/laptop/", LifecycleState: "active"}}, nil
+	}
+	var stdout, stderr bytes.Buffer
+	if code := run([]string{"client", "list", "--directory", directory, "--limit", "7"}, &stdout, &stderr); code != 0 || stderr.Len() != 0 || !strings.Contains(stdout.String(), clientID) || strings.Contains(stdout.String(), "credential\"") {
+		t.Fatalf("list code=%d stdout=%q stderr=%q", code, stdout.String(), stderr.String())
+	}
+	revoked := false
+	revokeClient = func(_ context.Context, installation operator.Installation, gotClientID, reason string) error {
+		if installation.Directory != directory || gotClientID != clientID || reason != "retired" {
+			t.Fatalf("revoke installation=%#v client=%q reason=%q", installation, gotClientID, reason)
+		}
+		revoked = true
+		return nil
+	}
+	stdout.Reset()
+	stderr.Reset()
+	if code := run([]string{"client", "revoke", "--directory", directory, "--client", clientID, "--reason", "retired"}, &stdout, &stderr); code != 0 || stdout.Len() != 0 || stderr.Len() != 0 || !revoked {
+		t.Fatalf("revoke code=%d revoked=%t stdout=%q stderr=%q", code, revoked, stdout.String(), stderr.String())
 	}
 }
 
 func TestClientAddRefusesYesWithoutPriorExactPreviewHash(t *testing.T) {
 	directory := testInstallation(t)
 	var stdout, stderr bytes.Buffer
-	if code := run([]string{"client", "add", "--directory", directory, "--name", "laptop", "--all-projects", "--yes", "--confirm-preview-hash", "stale"}, &stdout, &stderr); code != 3 || !strings.Contains(stderr.String(), "does not match") {
+	if code := run([]string{"client", "add", "--directory", directory, "--name", "laptop", "--machine-id", "laptop", "--all-projects", "--yes", "--confirm-preview-hash", "stale"}, &stdout, &stderr); code != 3 || !strings.Contains(stderr.String(), "does not match") {
 		t.Fatalf("code=%d stdout=%q stderr=%q", code, stdout.String(), stderr.String())
 	}
 }
@@ -1006,16 +1047,33 @@ func TestClientAddRefusesMutationWhenDatabaseRolesDiffer(t *testing.T) {
 		return errors.New("different installation")
 	}
 	inspectSchema = func(context.Context, string) (punaropostgres.SchemaState, error) {
-		return punaropostgres.SchemaState{Classification: punaropostgres.Compatible, Version: 5}, nil
+		return punaropostgres.SchemaState{Classification: punaropostgres.Compatible, Version: 44}, nil
 	}
 	var stdout, stderr bytes.Buffer
 	_, previewHash, err := punaropostgres.PreviewTrustedAgentEnrollment(nil, true)
 	if err != nil {
 		t.Fatal(err)
 	}
-	args := []string{"client", "add", "--directory", directory, "--name", "laptop", "--all-projects", "--yes", "--confirm-preview-hash", previewHash}
+	args := []string{"client", "add", "--directory", directory, "--name", "laptop", "--machine-id", "laptop", "--all-projects", "--yes", "--confirm-preview-hash", previewHash}
 	if code := run(args, &stdout, &stderr); code != 1 || !strings.Contains(stderr.String(), "database roles") {
 		t.Fatalf("code=%d stdout=%q stderr=%q", code, stdout.String(), stderr.String())
+	}
+}
+
+func TestClientLifecycleCommandsRefuseCompatibleHistoricalSchema(t *testing.T) {
+	preserveDependencies(t)
+	directory := testInstallation(t)
+	inspectSchema = func(context.Context, string) (punaropostgres.SchemaState, error) {
+		return punaropostgres.SchemaState{Classification: punaropostgres.Compatible, Version: 43}, nil
+	}
+	listed := false
+	listClients = func(context.Context, operator.Installation, int) ([]punaropostgres.ClientMetadata, error) {
+		listed = true
+		return nil, nil
+	}
+	var stdout, stderr bytes.Buffer
+	if code := run([]string{"client", "list", "--directory", directory}, &stdout, &stderr); code != 1 || listed || !strings.Contains(stderr.String(), "refused") {
+		t.Fatalf("code=%d listed=%t stdout=%q stderr=%q", code, listed, stdout.String(), stderr.String())
 	}
 }
 
@@ -1044,7 +1102,7 @@ func TestClientAddRevalidatesPathsAndOwnerBeforeMutation(t *testing.T) {
 			preserveDependencies(t)
 			directory := testInstallation(t)
 			inspectSchema = func(context.Context, string) (punaropostgres.SchemaState, error) {
-				return punaropostgres.SchemaState{Classification: punaropostgres.Compatible, Version: 5}, nil
+				return punaropostgres.SchemaState{Classification: punaropostgres.Compatible, Version: 44}, nil
 			}
 			test.mutate(t, directory)
 			issued := false
@@ -1057,7 +1115,7 @@ func TestClientAddRevalidatesPathsAndOwnerBeforeMutation(t *testing.T) {
 				t.Fatal(err)
 			}
 			var stdout, stderr bytes.Buffer
-			args := []string{"client", "add", "--directory", directory, "--name", "laptop", "--all-projects", "--yes", "--confirm-preview-hash", previewHash}
+			args := []string{"client", "add", "--directory", directory, "--name", "laptop", "--machine-id", "laptop", "--all-projects", "--yes", "--confirm-preview-hash", previewHash}
 			if code := run(args, &stdout, &stderr); code != 1 || issued {
 				t.Fatalf("code=%d issued=%t stdout=%q stderr=%q", code, issued, stdout.String(), stderr.String())
 			}
@@ -1069,7 +1127,7 @@ func TestConfirmedClientAddEmitsOnlyEnrollmentJSON(t *testing.T) {
 	preserveDependencies(t)
 	directory := testInstallation(t)
 	inspectSchema = func(context.Context, string) (punaropostgres.SchemaState, error) {
-		return punaropostgres.SchemaState{Classification: punaropostgres.Compatible, Version: 5}, nil
+		return punaropostgres.SchemaState{Classification: punaropostgres.Compatible, Version: 44}, nil
 	}
 	issueEnrollment = func(_ context.Context, _ operator.Installation, request punaropostgres.EnrollmentRequest, previewHash string) (punaropostgres.PendingEnrollment, error) {
 		return punaropostgres.PendingEnrollment{ID: "22222222-2222-4222-8222-222222222222", ClientBinding: request.ClientBinding, Code: "one-time-code", PreviewHash: previewHash}, nil
@@ -1079,7 +1137,7 @@ func TestConfirmedClientAddEmitsOnlyEnrollmentJSON(t *testing.T) {
 		t.Fatal(err)
 	}
 	var stdout, stderr bytes.Buffer
-	args := []string{"client", "add", "--directory", directory, "--name", "laptop", "--all-projects", "--yes", "--confirm-preview-hash", previewHash}
+	args := []string{"client", "add", "--directory", directory, "--name", "laptop", "--machine-id", "laptop", "--all-projects", "--yes", "--confirm-preview-hash", previewHash}
 	if code := run(args, &stdout, &stderr); code != 0 {
 		t.Fatalf("code=%d stdout=%q stderr=%q", code, stdout.String(), stderr.String())
 	}

--- a/cmd/punarod/main.go
+++ b/cmd/punarod/main.go
@@ -50,8 +50,10 @@ type platformDatabase interface {
 }
 
 type deviceDatabase interface {
+	ClientLifecycleRuntimeReady(context.Context) error
 	RedeemEnrollment(context.Context, punaropostgres.RedeemEnrollment) (punaropostgres.DeviceCredential, error)
 	AuthenticateDevice(context.Context, string) (punaropostgres.AuthenticatedDevice, error)
+	SelfRevokeDevice(context.Context, string, string) (punaropostgres.DeviceRevocation, error)
 }
 
 type trustedAttachmentDatabase interface {
@@ -243,6 +245,13 @@ func run(args []string, stderr io.Writer) int {
 		database, ok := platformDB.(deviceDatabase)
 		if !ok {
 			_, _ = fmt.Fprintln(stderr, "punarod device ingress error: PostgreSQL device store is unavailable")
+			return 2
+		}
+		lifecycleCtx, lifecycleCancel := context.WithTimeout(context.Background(), 30*time.Second)
+		lifecycleErr := database.ClientLifecycleRuntimeReady(lifecycleCtx)
+		lifecycleCancel()
+		if lifecycleErr != nil {
+			_, _ = fmt.Fprintln(stderr, "punarod device ingress error: PostgreSQL client lifecycle schema is unavailable")
 			return 2
 		}
 		policy := &ingress.Policy{Mode: ingress.Mode(cfg.IngressMode), ListenAddr: cfg.ListenAddr, PublicURL: cfg.PublicURL, TrustedLAN: cfg.TrustedLANCIDR, AllowPlaintext: cfg.TrustedLANHTTP}

--- a/cmd/punarod/main.go
+++ b/cmd/punarod/main.go
@@ -260,8 +260,7 @@ func run(args []string, stderr io.Writer) int {
 			return 2
 		}
 		deviceHandler := devicehttp.New(database, policy)
-		mux.Handle("/v1/enrollments/redeem", deviceHandler)
-		mux.Handle("/v1/device/session", deviceHandler)
+		registerDeviceRoutes(mux, deviceHandler)
 	}
 	registerProductionRoutes(mux, memoryHandler, trustedAttachmentHandler, relayHandler, remoteMCPMetadataHandler)
 	server := configuredServer(cfg.ListenAddr, securityHeaders(mux))
@@ -317,6 +316,15 @@ func run(args []string, stderr io.Writer) int {
 		}
 		return 0
 	}
+}
+
+func registerDeviceRoutes(mux *http.ServeMux, deviceHandler http.Handler) {
+	if deviceHandler == nil {
+		return
+	}
+	mux.Handle("/v1/enrollments/redeem", deviceHandler)
+	mux.Handle("/v1/device/session", deviceHandler)
+	mux.Handle("/v1/device/session/revoke", deviceHandler)
 }
 
 func registerProductionRoutes(mux *http.ServeMux, memoryHandler http.Handler, trustedAttachmentHandler *trustedAttachmentRuntime, relayHandler http.Handler, remoteMCPMetadataHandler http.Handler) {

--- a/cmd/punarod/main.go
+++ b/cmd/punarod/main.go
@@ -183,6 +183,7 @@ func run(args []string, stderr io.Writer) int {
 		}
 	}
 	accessReadiness := func() error { return nil }
+	lifecycleReadiness := func() error { return nil }
 	if cfg.AccessIssuer != "" {
 		verifier, err := newAccessVerifier(cfg)
 		if err != nil {
@@ -234,7 +235,7 @@ func run(args []string, stderr io.Writer) int {
 	healthMux := http.NewServeMux()
 	healthMux.HandleFunc("GET /healthz", func(w http.ResponseWriter, _ *http.Request) { _, _ = w.Write([]byte(`{"status":"ok"}\n`)) })
 	healthMux.HandleFunc("GET /readyz", func(w http.ResponseWriter, _ *http.Request) {
-		if postgresReadiness() != nil || accessReadiness() != nil || (trustedAttachmentHandler != nil && trustedAttachmentHandler.Ready() != nil) {
+		if !runtimeReady(postgresReadiness, lifecycleReadiness, accessReadiness, trustedAttachmentHandler) {
 			http.Error(w, `{"status":"not_ready"}`, http.StatusServiceUnavailable)
 			return
 		}
@@ -247,10 +248,8 @@ func run(args []string, stderr io.Writer) int {
 			_, _ = fmt.Fprintln(stderr, "punarod device ingress error: PostgreSQL device store is unavailable")
 			return 2
 		}
-		lifecycleCtx, lifecycleCancel := context.WithTimeout(context.Background(), 30*time.Second)
-		lifecycleErr := database.ClientLifecycleRuntimeReady(lifecycleCtx)
-		lifecycleCancel()
-		if lifecycleErr != nil {
+		lifecycleReadiness = clientLifecycleReadiness(database)
+		if err := lifecycleReadiness(); err != nil {
 			_, _ = fmt.Fprintln(stderr, "punarod device ingress error: PostgreSQL client lifecycle schema is unavailable")
 			return 2
 		}
@@ -316,6 +315,19 @@ func run(args []string, stderr io.Writer) int {
 		}
 		return 0
 	}
+}
+
+func clientLifecycleReadiness(database deviceDatabase) func() error {
+	return func() error {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		return database.ClientLifecycleRuntimeReady(ctx)
+	}
+}
+
+func runtimeReady(postgresReadiness, lifecycleReadiness, accessReadiness func() error, trustedAttachmentHandler *trustedAttachmentRuntime) bool {
+	return postgresReadiness() == nil && lifecycleReadiness() == nil && accessReadiness() == nil &&
+		(trustedAttachmentHandler == nil || trustedAttachmentHandler.Ready() == nil)
 }
 
 func registerDeviceRoutes(mux *http.ServeMux, deviceHandler http.Handler) {

--- a/cmd/punarod/main_test.go
+++ b/cmd/punarod/main_test.go
@@ -61,6 +61,25 @@ func TestProductionRoutesOmitRetiredAttachments(t *testing.T) {
 	}
 }
 
+func TestDeviceSelfRevokeRouteWinsOverRelayCatchAll(t *testing.T) {
+	mux := http.NewServeMux()
+	device := http.HandlerFunc(func(response http.ResponseWriter, _ *http.Request) {
+		response.WriteHeader(http.StatusNoContent)
+	})
+	relay := http.HandlerFunc(func(response http.ResponseWriter, _ *http.Request) {
+		response.WriteHeader(http.StatusTeapot)
+	})
+	registerDeviceRoutes(mux, device)
+	registerProductionRoutes(mux, nil, nil, relay, nil)
+
+	request := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/v1/device/session/revoke", nil)
+	response := httptest.NewRecorder()
+	mux.ServeHTTP(response, request)
+	if response.Code != http.StatusNoContent {
+		t.Fatalf("self-revoke route status=%d, want device handler status", response.Code)
+	}
+}
+
 func TestBuildMemoryHandlerIsDarkByDefaultAndRequiresCompleteAuthority(t *testing.T) {
 	handler, err := buildMemoryHandler(config.Config{}, &refusingPlatformDatabase{})
 	if err != nil || handler != nil {

--- a/cmd/punarod/main_test.go
+++ b/cmd/punarod/main_test.go
@@ -80,6 +80,19 @@ func TestDeviceSelfRevokeRouteWinsOverRelayCatchAll(t *testing.T) {
 	}
 }
 
+func TestRuntimeReadinessRechecksClientLifecycle(t *testing.T) {
+	database := &transitionDatabaseDouble{}
+	lifecycleReadiness := clientLifecycleReadiness(database)
+	alwaysReady := func() error { return nil }
+	if !runtimeReady(alwaysReady, lifecycleReadiness, alwaysReady, nil) {
+		t.Fatal("current lifecycle schema reported not ready")
+	}
+	database.err = errors.New("recovered database is schema 43")
+	if runtimeReady(alwaysReady, lifecycleReadiness, alwaysReady, nil) {
+		t.Fatal("recurring readiness accepted recovered historical lifecycle schema")
+	}
+}
+
 func TestBuildMemoryHandlerIsDarkByDefaultAndRequiresCompleteAuthority(t *testing.T) {
 	handler, err := buildMemoryHandler(config.Config{}, &refusingPlatformDatabase{})
 	if err != nil || handler != nil {

--- a/cmd/punarod/relay_test.go
+++ b/cmd/punarod/relay_test.go
@@ -28,6 +28,8 @@ type transitionDatabaseDouble struct {
 	err        error
 }
 
+func (d *transitionDatabaseDouble) ClientLifecycleRuntimeReady(context.Context) error { return d.err }
+
 func (d *transitionDatabaseDouble) RedeemEnrollment(context.Context, punaropostgres.RedeemEnrollment) (punaropostgres.DeviceCredential, error) {
 	return punaropostgres.DeviceCredential{}, errors.New("not used")
 }
@@ -37,6 +39,10 @@ func (d *transitionDatabaseDouble) AuthenticateDevice(_ context.Context, credent
 		return punaropostgres.AuthenticatedDevice{}, punaropostgres.ErrUnauthenticated
 	}
 	return d.device, nil
+}
+
+func (d *transitionDatabaseDouble) SelfRevokeDevice(context.Context, string, string) (punaropostgres.DeviceRevocation, error) {
+	return punaropostgres.DeviceRevocation{}, errors.New("not used")
 }
 
 func (d *transitionDatabaseDouble) DeviceSessionCurrent(_ context.Context, authenticated punaropostgres.AuthenticatedDevice) (bool, error) {

--- a/docs/big-brain-plan.md
+++ b/docs/big-brain-plan.md
@@ -228,8 +228,9 @@ happy paths:
   existing schema that needs migration and directs the operator to
   `punaro update`; raw `docker compose up` never migrates either, and
   `punarod` fails readiness on schema mismatch.
-- `punaro client add --name NAME`: show the proposed effective grants, then
-  issue one single-use enrollment code after confirmation.
+- `punaro client invite --name NAME --machine-id ID`: show the proposed
+  effective grants, then issue one single-use enrollment code after
+  confirmation. `client add` remains a transitional alias.
 - `punaro status` / `punaro doctor`: report core and optional capabilities.
 
 Internet mode fails closed without TLS at the ingress. LAN-only plaintext HTTP

--- a/docs/client-lifecycle-compatibility-recovery-rfc.md
+++ b/docs/client-lifecycle-compatibility-recovery-rfc.md
@@ -1,0 +1,792 @@
+# Client lifecycle, compatibility, and recovery RFC
+
+Status: proposed design for the first named release (2026-08-10). It is not an
+implemented or released security boundary. Acceptance requires corresponding
+updates to `DESIGN.md`, tests, release gates, and operator documentation.
+
+Implementation is intentionally incremental. Database schema 44 and the first
+server-side bearer-client lifecycle sub-slice implement authoritative client
+records, derived endpoint namespaces, owner inventory/revocation, and narrow
+self-revocation. Supported invitation consumption, exact legacy authority
+import, protocol negotiation, updates, and recovery remain outstanding.
+
+In this RFC, **gateway** means the central Punaro installation and `punarod`
+service. The optional Telegram bridge remains a separately enrolled client.
+
+## Decisions
+
+1. The host-local installation owner may invite, inspect, and revoke any
+   client without a second authentication system. There is no remote admin
+   enrollment API.
+2. Client enrollment uses the existing short-lived, single-use, high-entropy
+   code. Punaro does not add a shared installation password or a custom
+   password challenge protocol.
+3. A client may revoke only the credential authenticating that request. It
+   cannot name, invite, update, or revoke another client.
+4. Product release, wire protocol, release-metadata schema, bootstrap protocol,
+   and database schema are separate version axes.
+5. Every normal client performs an authenticated hello and supplies the
+   selected wire protocol on later requests. No compatible protocol means a
+   fail-closed `426 Upgrade Required`, not a legacy fallback.
+6. Client updates are pull-based. The gateway selects a signed release; it
+   never supplies an arbitrary executable, command, or download URL.
+7. A gateway upgrade first moves every active client onto a bridge release
+   compatible with both the old and new gateway protocols.
+8. A small `punaro-bootstrap` executable owns signed-artifact verification,
+   release slots, child-process health, rollback, and recovery. It does not
+   read Punaro content, authorize messages, open PostgreSQL, or run migrations.
+9. Critically outdated software enters a recovery-only mode. The recovery
+   surface exposes signed public release metadata and no Punaro data or
+   control-plane mutation.
+10. Every named release publishes an offline recovery bundle. Online recovery
+    is a convenience, not the only path back to a supported version.
+11. First-release device credentials do not expire automatically. Compromise,
+    loss, and retirement use permanent revocation followed by a fresh
+    invitation; expiring credentials and online renewal are deferred.
+
+## Existing foundation
+
+This design extends current contracts rather than creating parallel ones:
+
+- `punaro client add` already creates a bounded, preview-confirmed enrollment
+  with a ten-minute default lifetime.
+- Redemption already derives one retry-recoverable device credential from a
+  256-bit one-time code and stores only its digest.
+- Credentials already carry a generation fence; generation changes and owner
+  revocation invalidate cached and long-lived sessions within two seconds.
+- The host-local owner can list content-free credential metadata.
+- Gateway release metadata already binds an immutable OCI digest, database
+  compatibility range, rollback floor, Compose digest, and migration-manifest
+  digest.
+- `punaro update` already owns the database maintenance fence, verified backup,
+  migration authorization, candidate readiness, and compatible-image or
+  restore recovery boundary.
+
+The missing pieces are the supported client-side enrollment UX, self-revocation,
+wire negotiation, signed native artifacts, fleet rollout coordination, and an
+update path that survives normal-protocol incompatibility.
+
+## Goals
+
+- Onboard and revoke macOS, Linux, Windows, and Telegram clients without
+  editing gateway configuration by hand.
+- Ensure one compromised client credential cannot manage any other client.
+- Detect version skew before normal operations begin and return an actionable,
+  machine-readable result.
+- Move all active clients through a compatible bridge before changing the
+  gateway protocol. An active client has an enabled installation and at least
+  one current, non-revoked credential.
+- Recover a client whose normal protocol no longer overlaps the gateway.
+- Recover a gateway whose current operator or image is too old to reach the
+  desired release directly.
+- Preserve credentials, client queues, deduplication state, and gateway data
+  across software replacement.
+- Keep the release trust and recovery plane small enough to audit and exercise.
+
+## Non-goals
+
+- Remote gateway administration, an enrollment web console, or enrollment by
+  Telegram message.
+- Automatic creation or revocation of Cloudflare Access service tokens.
+- Transparent rolling upgrades or zero downtime for a single-node gateway.
+- Remote attestation that proves an honest client is running particular bytes.
+- Keeping every historical messaging protocol enabled forever.
+- A general package manager or arbitrary plugin updater.
+- Password-authenticated key exchange, mTLS PKI, or a full TUF implementation
+  for the first named release.
+
+## Trust boundaries
+
+| Actor | Authority |
+| --- | --- |
+| Host-local owner | Invite, list, revoke, plan fleet rollouts, and run the existing gateway update transaction. Compromise is installation compromise. |
+| Gateway daemon | Redeem stored invitations, authenticate devices, negotiate protocols, publish desired signed releases, and record content-free fleet status. It cannot sign releases. |
+| Client credential | Exercise only its granted Punaro capabilities, report its own runtime state, and revoke itself. |
+| `punaro-bootstrap` | Install only signed Punaro artifacts from fixed sources or an explicit local bundle, switch local slots, launch children, and roll back. |
+| Release signing key | Authorize exact public release catalogs, manifests, and artifacts. Compromise permits malicious Punaro code until the operator completes out-of-band re-key recovery; it does not directly authorize Punaro data access. |
+| Cloudflare Access | Optional ingress admission only; it remains independent of Punaro enrollment and revocation. |
+
+A compromised gateway may deny service or withhold updates, but it must not be
+able to make an honest bootstrap execute unsigned bytes. A compromised client
+may impersonate that client until revocation; it must not be able to create an
+invitation, alter a rollout, or revoke another credential.
+
+A compromised release-signing key is a fleet code-execution incident, not an
+ordinary rotation. An attacker holding it can authorize malicious Punaro bytes,
+including an apparently valid transition bootstrap. Automatic recovery cannot
+distinguish that from an honest release. Recovery therefore requires an
+independently obtained bootstrap digest and host-local or OS-level replacement;
+systems that already executed malicious signed bytes may require full host
+reinstallation and fresh enrollment of every potentially exposed client.
+
+## Client lifecycle
+
+### Invitation
+
+The supported owner command becomes conceptually:
+
+```text
+punaro client invite --name NAME --machine-id ID
+                     (--project ID ... | --all-projects)
+                     [--ttl 10m]
+                     [--output PROTECTED_FILE]
+```
+
+The existing grant preview and exact preview-hash confirmation remain. Host
+ownership is the administrator authentication boundary; the confirmation is a
+safety check, not a second identity factor.
+
+The invitation document is versioned and contains only:
+
+```json
+{
+  "schema": 1,
+  "origin": "https://punaro.example",
+  "enrollment_id": "uuid",
+  "client_binding": "uuid",
+  "code": "base64url-256-bit-secret",
+  "expires_at": "RFC3339 timestamp"
+}
+```
+
+The gateway remains authoritative for the label, machine ID, derived exclusive
+`agent/<machine-id>/` endpoint namespace, and grants. Exact legacy endpoints
+require a separate explicit owner option and never imply a prefix. The client
+cannot supply or widen any of these at redemption. The code is shown once,
+stored only as a digest by the gateway, and never accepted in a command-line
+argument. The CLI may write a new `0600`/exclusive-ACL file or print to an
+interactive terminal; automation uses a protected file or standard input.
+
+The full invitation is the magic link. A shorter human transcription code may
+be added later only if it still provides at least 128 bits of entropy. A
+six-digit OTP would require a separate tightly rate-limited exchange and is not
+part of the first release.
+
+The resulting device credential has no automatic expiry in the first named
+release. It remains current until permanent owner or client self-revocation.
+This intentionally avoids a credential-expiry state from which an offline or
+protocol-stranded client could neither authenticate nor recover. Routine online
+credential renewal is deferred until it can be specified and tested with
+lost-response recovery; suspected exposure uses revoke and fresh enrollment.
+
+### Client redemption
+
+```text
+punaro-bootstrap enroll --invite-file FILE
+punaro-bootstrap enroll --invite-file -
+```
+
+The bootstrap validates the fixed HTTPS origin, invitation schema, expiry, and
+local destination before calling the existing strict
+`POST /v1/enrollments/redeem` route. It chooses one UUID idempotency key and
+retains it until the response is durably committed. An exact retry must recover
+the same credential after a lost response.
+
+The credential is written atomically beneath the platform's existing protected
+client directory. The invitation secret is removed only after the credential
+and installed identity metadata are durable. Installation does not enable the
+adapter until an authenticated hello succeeds.
+
+No remote request can create an invitation. A client can redeem only an
+already approved invitation, and redemption always creates the principal bound
+to that credential; it cannot name an existing or different client.
+
+Redemption also atomically creates the server-authoritative client installation
+record. That record binds one opaque client ID and device principal to the
+unique machine ID, endpoint prefix, optional exact endpoints, and lifecycle
+state. Runtime endpoint authorization comes from that record under the same
+current credential-generation fence; a friendly machine ID or client-supplied
+prefix is never authority. PostgreSQL replaces `PUNARO_RELAY_MACHINES_JSON` as
+the named-release authority after the legacy migration below is complete.
+
+### Inventory and owner revocation
+
+```text
+punaro client list
+punaro client revoke --client UUID
+                     --reason lost|retired|compromised|replaced
+```
+
+Inventory is bounded and content-free: client ID, machine ID, assigned endpoint
+namespace, principal ID, credential lookup ID, label, generation, release,
+protocol range, selected protocol, platform, bootstrap version, last successful
+hello, last credential use, rollout state, and revocation timestamp. It
+contains no live endpoint inventory, bodies, credential digest, Access token,
+or private host detail.
+
+One client installation has exactly one current credential in the first named
+release. Owner revocation is permanent and idempotent. It revokes the client
+installation and credential together, advances the credential and principal
+fences, closes long-lived sessions within the existing two-second bound, and
+retains the principal, audit event, and rollout history. Rejoining uses a fresh
+invitation, client ID, and credential; revocation is never cleared in place.
+Cloudflare token revocation remains a separate operator action.
+
+### Client self-revocation
+
+An authenticated client receives one narrow route:
+
+```text
+POST /v1/device/session/revoke
+Authorization: Bearer <current credential>
+Idempotency-Key: <uuid>
+Content-Length: 0
+```
+
+The request contains no target identifier. The server obtains the client,
+credential lookup ID, and generation only from authentication and atomically
+revokes that exact client installation and credential. The transaction advances
+the same client, credential, principal, and endpoint-authority fences as owner
+revocation and closes long-lived sessions within the existing two-second bound.
+
+The credential row retains a bounded revocation idempotency key. The narrow
+route may verify an already-revoked credential only to return the exact prior
+successful self-revocation result for the same key; it grants no normal API
+access and discloses no credential state. This makes a lost success response
+recoverable without creating a temporary post-revocation session.
+
+This revoked-credential verification is scoped to this handler and can never
+create or populate a normal authenticated request context. The first committed
+revocation wins. If owner revocation won the race, the credential has no prior
+self-revocation result and a later self-revocation attempt fails uniformly as
+unauthenticated. It does not replace the owner reason or write a second audit
+event. If self-revocation won, only its exact idempotency-key retry succeeds.
+
+After confirmed revocation, the bootstrap stops managed processes, retires the
+local credential, and preserves queues as operator-recoverable local data. It
+does not silently delete unsent messages or mailbox state.
+
+### Legacy Ed25519 migration
+
+Existing adapters are authenticated by an Ed25519 key whose static gateway
+enrollment also owns their machine ID and endpoint namespace. The first named
+release must not silently reinterpret or discard that authority.
+
+The migration imports each reviewed static enrollment into a disabled
+server-authoritative client installation record and links it to the existing
+legacy principal/public-key digest. The owner then issues an enrollment for
+that exact legacy client. Redemption requires both the one-time code and the
+existing proof-of-possession exchange; it creates the bearer credential and
+activates the imported client record without changing its machine ID, prefixes,
+exact endpoints, or grants.
+
+During the bridge window, the global legacy gate permits either the existing
+signed request or its exactly linked replacement credential to select that one
+client record. New clients receive bearer credentials only. Inventory reports
+each legacy record as `pending`, `migrated`, or `retired`. After every record is
+migrated or explicitly retired, the owner runs the existing one-way legacy
+disable operation. The gateway then removes the static JSON authority and
+refuses any Ed25519 request permanently. Reopening that gate requires restore
+of an earlier verified installation, not a configuration toggle.
+
+### Persistent model
+
+The implementation adds bounded records equivalent to:
+
+- `auth.client_installations`: opaque client ID, immutable machine ID and
+  label, device principal, lifecycle state, created/revoked timestamps, and
+  revocation reason code;
+- `relay.client_endpoint_authority`: client ID, the one derived endpoint
+  prefix, optional bounded exact endpoints, and authority generation;
+- the existing `auth.device_credentials`, extended with a unique current-client
+  binding and bounded self-revocation idempotency result;
+- `jobs.client_runtime_status`: latest content-free hello/update report keyed
+  by client ID and current credential generation;
+- `jobs.fleet_rollouts`: immutable plan hash, signed source/bridge/target
+  release identities, state, and timestamps; and
+- `jobs.fleet_rollout_clients`: rollout/client/generation snapshot and one
+  bounded reported state.
+
+Machine ID uniqueness makes the derived `agent/<machine-id>/` namespaces
+disjoint. Exact endpoint uniqueness is checked while the same bounded authority
+mutation lock is held. Activated machine IDs, prefixes, client IDs, and
+principal bindings are immutable; changing one means revoking and enrolling a
+new client rather than retargeting existing authority.
+
+Enrollment creates the principal, credential, client record, endpoint
+authority, grants, audit event, and change sequence atomically. Revocation
+locks and advances the same client, credential, principal, and endpoint
+authority generations before committing one content-free audit event. The
+application role reaches these tables only through bounded store transactions
+and column-exact grants; ordinary client status reports cannot mutate identity
+or endpoint authority.
+
+## Version model
+
+| Axis | Example | Meaning |
+| --- | --- | --- |
+| Product release | `v0.2.0` | Human-facing gateway/client bundle release. |
+| Wire protocol | `2` | HTTP and WebSocket semantics shared by gateway and clients. |
+| Release metadata | `1` | Strict signed manifest and signature-envelope schema. |
+| Recovery/bootstrap | `1` | Frozen minimal recovery descriptor understood by the bootstrap. |
+| Database schema | `44` | Client-lifecycle PostgreSQL migration/compatibility boundary. |
+
+SemVer never determines wire or database compatibility. Compatibility comes
+only from the signed release manifest and the gateway's implemented protocol
+range.
+
+Within one wire protocol, changes must be additive: optional response fields,
+new optional capabilities, or new routes that old clients do not use. Changing
+the meaning or required shape of an existing operation requires a new protocol
+integer. A gateway supports at least the current and immediately previous
+protocol until the fleet has crossed the corresponding bridge release.
+
+## Authenticated hello
+
+Before normal HTTP work and before opening a notification WebSocket, a client
+sends a bounded strict request:
+
+```text
+POST /v1/hello
+Authorization: Bearer <device credential>
+Content-Type: application/json
+```
+
+```json
+{
+  "schema": 1,
+  "client_kind": "adapter",
+  "client_release": "v0.2.0",
+  "protocol": {"min": 1, "max": 2},
+  "capabilities": ["fleet-update-v1", "websocket-hello-v1"],
+  "platform": {"os": "darwin", "arch": "arm64"},
+  "bootstrap": {"release": "v0.1.0", "recovery_protocol": 1},
+  "artifact_sha256": "hex-sha256"
+}
+```
+
+The gateway selects the highest overlap and replies:
+
+```json
+{
+  "schema": 1,
+  "gateway_release": "v0.3.0",
+  "gateway_protocol": {"min": 2, "max": 3},
+  "selected_protocol": 2,
+  "required_capabilities": ["websocket-hello-v1"],
+  "update": {
+    "policy": "required",
+    "release": "v0.3.0-bridge.1",
+    "sequence": 18,
+    "manifest_sha256": "hex-sha256"
+  },
+  "recovery_path": "/.well-known/punaro-recovery/v1"
+}
+```
+
+`update.policy` is the closed enum `none`, `optional`, or `required`. For
+`none`, the update object contains only `policy`. For `optional` and `required`,
+`release`, `sequence`, and `manifest_sha256` are all required. An optional
+update does not block normal operations. A required update closes normal
+operations after hello and permits only the bounded update-status and
+self-revocation routes until the selected signed release becomes healthy.
+
+The client must implement every returned `required_capabilities` value before
+normal operations or a notification WebSocket begin. A missing capability fails
+closed with the same structured upgrade response; unknown required capability
+strings are never ignored.
+
+The hello body is at most 8 KiB. It has at most 64 unique capability strings,
+each at most 64 ASCII characters. OS, architecture, and client kind are closed
+enums. Unknown fields, duplicate fields, invalid ranges, and noncanonical
+release or digest values are rejected.
+
+Every later HTTP request carries `Punaro-Protocol: N`. The first WebSocket
+client frame repeats the hello schema and the server must acknowledge the
+selected protocol before sending hints. Missing or unsupported protocol values
+fail before request-body processing.
+
+If there is no overlap, or the signed release policy marks the reported release
+critically outdated, the gateway returns `426 Upgrade Required` with a fixed
+problem code, its protocol range, and the fixed relative recovery path. Normal
+operations remain closed. Claimed client release and artifact hashes are
+operational evidence only; the server never relaxes authorization because a
+client claims a newer version.
+
+A client without protocol overlap cannot use the authenticated self-revocation
+route because hello precedes normal authenticated work. The host-local owner
+revocation command is the deliberate revocation path for such a stranded client;
+recovery does not create a legacy authentication exception.
+
+## Signed release contract
+
+Each named release publishes an exact detached-signature pair:
+
+- `punaro-release.json`
+- `punaro-release.sig`
+
+Each Ed25519 signature covers the exact manifest bytes. The strict signature
+envelope has schema `1`, a bounded key ID, and at most four unique signatures,
+which permits a dual-signed key transition. Verification occurs before manifest
+JSON parsing. Parsing then rejects duplicate and unknown fields. There is no
+JSON reserialization or home-grown canonicalization step.
+
+The immutable release manifest contains:
+
+- metadata schema, monotonically increasing release sequence, release name,
+  and publication time;
+- gateway and client wire-protocol ranges;
+- minimum recovery protocol and bootstrap release;
+- the existing database schema minimum, maximum, target, rollback floor,
+  PostgreSQL major, image digest, Compose digest, and migration-manifest digest;
+- a bounded artifact list with component, OS, architecture, relative path,
+  byte length, mode, and SHA-256;
+- the releases from which a direct update is supported; and
+- an optional signed stepping-stone sequence for older supported installations.
+
+A separately signed, short-lived release catalog lists the current release
+manifests, minimum safe sequences, and critical-release blocks. It has no key
+delegation. Online update and automatic recovery require a fresh catalog. This
+lets Punaro retire a vulnerable release without making the immutable manifest
+itself unverifiable years later.
+
+Artifact paths are relative names beneath a fixed configured release origin.
+They cannot contain a scheme, host, credentials, query, fragment, empty path
+component, or `..`. The gateway may select a release and mirror its signed
+bytes, but cannot change the origin or authorize a URL.
+
+A bootstrap honors a gateway-selected release only when a fresh verified
+catalog contains the exact release sequence and manifest digest and does not
+critically block it. A signed manifest by itself proves artifact identity, not
+that the release is still allowed for an automatic update.
+
+The first release uses one offline Ed25519 release key whose public key and key
+ID are embedded in the bootstrap. The catalog and every release manifest are
+signed independently by that same key. A bootstrap accepts each document only
+when at least one envelope signature verifies against a public key embedded in
+that bootstrap; catalog contents never grant manifest-signing authority.
+
+Routine key rotation requires a transition bootstrap plus catalog and manifest
+envelopes signed by both old and new keys. An old bootstrap verifies the old
+signature, the transition installs a bootstrap embedding the new key, and later
+releases may be new-key-only. Rotation is not an ordinary gateway setting. The
+private key is not committed or placed in an ordinary CI secret. The approved
+release process signs the final catalog and manifest after CI has produced the
+exact artifact hashes, then publishes the catalog, manifest, signatures,
+artifacts, SBOM, provenance, and release evidence together.
+
+Key-compromise recovery never trusts a transition authorized only by the
+compromised key. The operator obtains an emergency offline bundle and expected
+bootstrap SHA-256 through independent official channels, stops Punaro, and runs
+the host-local `punaro-bootstrap recover rekey --bundle FILE
+--expected-bootstrap-sha256 HEX` flow. That flow verifies the typed digest before
+installing a bootstrap containing the replacement key, records a content-free
+re-key event, and then verifies the bundled catalog, manifests, and artifacts
+only with the replacement key. It is never gateway-triggered or automatic. If
+the current bootstrap or host may already have executed attacker-signed code,
+the safe procedure is OS-level reinstall followed by credential replacement,
+not in-place recovery.
+
+The bootstrap durably records the highest accepted release and catalog
+sequences. Normal gateway-directed updates cannot move backward. A signed
+downgrade is available only through an explicit host-local recovery command
+and still must satisfy the current wire/database compatibility boundary.
+
+## Bootstrap and client slots
+
+Platform services launch `punaro-bootstrap run`, not a versioned adapter binary
+directly. The bootstrap has a deliberately narrow standard-library-oriented
+surface:
+
+- verify signed release manifests and exact artifact length/digest;
+- stage only a closed list of Punaro component filenames;
+- maintain `current`, `candidate`, and `previous` release records under the
+  existing private client directory;
+- write a crash-recoverable content-free update journal;
+- start the selected child with the existing protected configuration;
+- wait for a bounded local healthy/handshake signal; and
+- atomically publish or roll back a slot.
+
+Slot records are private regular files published with atomic rename and parent
+directory synchronization; symlinks, junctions, reparse points, hard-linked
+credentials, and writable ancestors are rejected. No slot contains a device
+credential, Access token, mailbox database, queue, or deduplication journal.
+At most two completed release slots plus one bounded candidate are retained.
+
+The bootstrap never accepts a shell command, installer script, environment
+assignment, arbitrary filename, or post-install hook from release metadata.
+Platform-specific service definitions are fixed bootstrap-owned templates. A
+candidate must report a successful authenticated hello within 60 seconds and
+remain alive for the configured health window before publication. Failure
+restores the previous slot once only when the fresh signed catalog still allows
+that release and its protocol overlaps the observed gateway. Otherwise, or
+after repeated failure, the bootstrap enters recovery-only mode rather than a
+restart loop.
+
+Self-update of the bootstrap uses the frozen recovery protocol and a separately
+identified bootstrap artifact. The old bootstrap verifies and stages the new
+binary before a small platform-specific handoff. If it cannot understand the
+required recovery protocol, it stops with the exact offline-bundle instruction.
+
+## Fleet rollout
+
+The gateway stores only content-free rollout coordination:
+
+- desired signed release, sequence, and manifest digest;
+- target gateway release and protocol range;
+- each active credential lookup ID and generation in the rollout cohort;
+- reported client release, protocol range, selected protocol, bootstrap
+  release, artifact digest, and last hello time; and
+- one bounded state: `pending`, `offered`, `downloading`, `staged`,
+  `restarting`, `healthy`, `failed`, `offline`, or `revoked`.
+
+Client status updates are authenticated, strict, idempotent, and may update only
+the caller's row. They are operational reports, not authorization or remote
+attestation.
+
+The owner workflow is:
+
+```text
+punaro client rollout plan --gateway-release RELEASE
+punaro client rollout start --plan-hash SHA256
+punaro client rollout status --rollout UUID
+```
+
+Planning loads signed metadata for the current gateway, target gateway, and
+available client releases. It must find a bridge client whose protocol range
+overlaps both gateways. If none exists, planning fails before changing desired
+state.
+
+Starting snapshots every active credential. A client enrolled during an active
+rollout inherits the desired bridge release and joins the cohort. Gateway
+publication rechecks all current active credentials, not only the original
+snapshot, so a concurrent enrollment cannot create a compatibility hole.
+
+The gateway update remains blocked until every cohort member is `healthy`, has
+a fresh authenticated hello, and overlaps the target gateway protocol. An
+offline client remains visibly pending; timeout never silently excludes or
+revokes it. The operator may wait or explicitly revoke a retired/lost client.
+
+The final cohort evaluation is part of the existing maintenance-fence and
+gateway-update transaction, not a check performed before it. That transaction
+locks a monotonically increasing client-registry epoch, re-reads every active
+credential, and refuses publication unless each row satisfies the gate.
+Enrollment redemption may prepare records while the fence is held, but client
+activation and any credential-generation change serialize on the same epoch and
+cannot commit between the final check and gateway publication. Failure releases
+the fence without publishing either the gateway or a partial cohort decision.
+
+The rollout sequence is:
+
+```mermaid
+flowchart LR
+    A["Plan signed target"] --> B["Select old/new bridge client"]
+    B --> C["Clients pull, verify, and become healthy"]
+    C --> D["Recheck every active client"]
+    D --> E["Run existing backup-gated gateway update"]
+    E --> F["Clients negotiate the new protocol"]
+    F --> G["Optionally converge clients to the preferred release"]
+```
+
+Before an incompatible database migration, the gateway may return to the old
+image and every bridge client must still work. After that boundary, the
+existing fenced compatible-image or verified-backup recovery rules remain
+authoritative. Fleet coordination cannot bypass or clear the database update
+fence.
+
+## Recovery-only mode
+
+### Frozen public recovery surface
+
+Every gateway release serves:
+
+```text
+GET /.well-known/punaro-recovery/v1
+```
+
+This route requires no Punaro credential, is cacheable for a short bounded
+period, and is content-free. Optional outer Cloudflare admission and origin
+isolation remain in force; upstream and offline recovery remain available when
+that admission path is unavailable. The route returns either the signed
+release manifest bytes or a fixed descriptor containing only the gateway
+release, gateway protocol range, release sequence, manifest digest, and fixed
+same-origin manifest path. It contains no client inventory, installation ID,
+database schema, desired per-client policy, hostname inventory, credential
+material, or arbitrary URL.
+
+Public recovery makes an incompatible client repairable when normal device
+authentication or wire semantics have changed. It grants no normal route and
+is bounded and rate-limited. Artifacts normally come from the fixed release
+origin; an optional gateway mirror serves only exact signed artifacts with
+declared size ceilings.
+
+### Critically outdated client
+
+On `426`, repeated candidate failure, a corrupt current slot, or a critical
+signed release block, the bootstrap:
+
+1. disables normal child restart loops;
+2. loads the frozen recovery descriptor from the gateway, configured release
+   origin, or explicit offline bundle;
+3. verifies the signed catalog and chooses the newest bridge release that
+   overlaps the observed gateway protocol;
+4. verifies and stages exact platform artifacts;
+5. starts the candidate and requires an authenticated hello; and
+6. publishes it or returns to recovery-only mode with a content-free error.
+
+If no signed bridge supports the observed gateway, client recovery stops and
+reports that the gateway requires host-local recovery. It never enables an
+obsolete unauthenticated messaging protocol merely to regain connectivity.
+Revoked credentials cannot enter this flow; the owner must issue a fresh
+invitation after recovery if the installation is meant to rejoin.
+
+### Critically outdated gateway
+
+Gateway recovery does not require `punarod` to be running:
+
+```text
+punaro-bootstrap recover gateway --directory DIR --release RELEASE
+punaro-bootstrap recover gateway --directory DIR --bundle FILE
+```
+
+The bootstrap validates protected installation metadata and signed release
+metadata, then selects a signed `punaro` operator binary capable of the current
+release/database boundary. If the target cannot be reached directly, it
+constructs an acyclic stepping-stone plan of at most 16 releases from signed
+manifests. Ambiguous edges, cycles, gaps, or a longer path are a hard refusal.
+
+For each step, the selected `punaro` operator—not the bootstrap—runs the
+existing preflight, maintenance fence, verified backup, one-shot migration,
+candidate readiness, doctor, publication, and recovery transaction. The
+bootstrap records only which signed operator step is active and resumes that
+exact step after a crash. It never opens PostgreSQL, edits a migration record,
+guesses that a failed external action succeeded, or starts an obsolete writer
+against newer state.
+
+Corrupt or incompatible database state is not repaired by installing a newer
+binary. Recovery remains fenced and follows the existing verified-backup
+restore workflow into safe paths.
+
+### Offline recovery bundle
+
+Every named release publishes one signed bundle containing:
+
+- the frozen recovery descriptor;
+- the current release catalog and detached signature;
+- release manifest and detached signature;
+- bootstrap artifacts for the declared platform matrix;
+- client artifacts;
+- gateway/operator artifacts or exact OCI digest declarations;
+- Compose and migration-manifest hashes;
+- the finite supported stepping-stone manifests; and
+- a human-readable recovery summary with no secrets.
+
+The bundle contains no installation configuration, credential, database,
+message, backup, or mutable URL. Extraction validates every path before writing
+and verifies exact size and SHA-256 before publication. An offline exercise
+must succeed with network access disabled. Because a bundled catalog may have
+expired after publication, offline use requires the explicit host-local
+`--allow-stale-catalog` acknowledgement already defined below; staleness never
+relaxes catalog/manifest signatures, release-sequence checks, artifact bounds,
+or artifact digests.
+
+## Failure and security rules
+
+- Invitation, hello, status, manifest, and recovery decoders reject unknown and
+  duplicate fields and enforce explicit body, list, string, and concurrency
+  bounds.
+- Enrollment and self-revocation are idempotent across lost responses and
+  restart boundaries.
+- Revoked or superseded generations cannot report status, receive desired
+  releases, or retain WebSocket sessions beyond the existing revalidation
+  bound.
+- No Telegram or agent message body can invite, revoke, update, recover, or
+  select a release.
+- The gateway never returns a bearer credential, invitation code, Access token,
+  release private key, message body, or raw update failure in logs or status.
+- Catalog expiry prevents an untrusted mirror from indefinitely replaying an
+  old signed policy. Clock failure produces an explicit recovery diagnostic;
+  it does not disable signature or sequence checks. Explicit offline recovery
+  may accept an expired signed catalog only with a host-local
+  `--allow-stale-catalog` acknowledgement; it never disables artifact signature
+  or digest verification, and a sequence downgrade needs a separate explicit
+  acknowledgement.
+- A gateway may require an update from an honest client, but claimed version
+  metadata never substitutes for server-side authorization or input validation.
+- Local downgrade and restore commands are explicit, host-local, and preserve
+  the current database compatibility and backup fences.
+- Suspected release-key compromise stops automatic updates. Recovery requires
+  the independently verified host-local re-key procedure or an OS-level
+  reinstall; a gateway-selected or old-key-only transition is refused.
+
+## Implementation slices
+
+Each slice is independently reviewable and follows the repository's test-first
+and full-quality-gate requirements.
+
+1. **Lifecycle completion:** server-authoritative client/endpoint records,
+   supported invitation consumption, bounded owner inventory/revoke CLI,
+   self-revocation route/store, exact legacy import/exchange/disablement, and
+   Unix/Windows failure tests. No updater yet.
+2. **Wire contract:** strict hello, `Punaro-Protocol` enforcement, WebSocket
+   hello/ack, structured `426`, content-free runtime inventory, and mixed-range
+   contract tests.
+3. **Release trust:** extend current release metadata into the detached-signed
+   manifest, offline signing/publishing tooling, native artifact matrix, strict
+   parser/fuzz corpus, sequence/expiry checks, SBOM/provenance binding, and
+   routine key-rotation plus compromised-key out-of-band recovery drills.
+4. **Client bootstrap:** private slot/journal format, download bounds, digest
+   verification, platform service handoff, candidate health, crash recovery,
+   and one-slot rollback on macOS, Linux, and Windows.
+5. **Fleet bridge rollout:** desired release/status stores, plan hash, cohort
+   fencing, new-enrollment behavior, offline/revoked handling, and a real
+   multi-client old-gateway/bridge/new-gateway E2E.
+6. **Disaster recovery:** frozen public recovery surface, critical-client
+   recovery, signed stepping-stone planner, gateway operator handoff, and
+   network-disabled offline-bundle drills.
+7. **Named-release gates:** fresh enrollment, self- and owner revocation,
+   protocol incompatibility, bridge rollout, failed client candidate rollback,
+   critically outdated client, critically outdated gateway, database recovery,
+   routine signing-key transition, compromised-key recovery, and
+   supported-platform evidence.
+
+## Rejected alternatives
+
+- **Shared gateway enrollment password:** easy to explain, but every client and
+  every copied configuration becomes authority to enroll more clients. A
+  single-use invitation has a smaller blast radius and already exists.
+- **Custom password challenge/response:** adds cryptographic protocol and
+  dependency risk without improving a high-entropy one-time token sent over
+  validated TLS.
+- **Gateway-pushed binaries or commands:** makes gateway compromise a remote
+  code-execution signing authority. The gateway may choose only a separately
+  signed release identity.
+- **Update gateway first and hope clients follow:** strands sleeping or offline
+  clients. A bridge release keeps rollback and reconnect deterministic.
+- **Silently ignore offline clients:** makes `update-all` untrue and creates
+  latent incompatibility. The operator must wait or explicitly revoke them.
+- **Keep every old protocol enabled:** expands the permanent attack surface and
+  prevents retiring known-bad implementations. The frozen recovery plane is
+  the long-lived compatibility contract instead.
+- **Put database migration logic in the bootstrap:** duplicates the existing
+  durable updater and makes the supposedly stable rescue component understand
+  every schema. The bootstrap selects a signed compatible operator; the
+  operator owns database safety.
+
+## First named release exit criteria
+
+The first named release is withheld until reviewable evidence proves:
+
+- invitation redemption, lost-response retry, owner revocation, self-revocation,
+  owner/self race replay, cache/session closure, and fresh re-enrollment;
+- exact static-enrollment import, legacy proof-bound exchange, unchanged
+  endpoint authority, explicit retirement, and irreversible legacy-gate
+  disablement;
+- strict protocol negotiation, closed update-policy decoding, missing-required-
+  capability refusal, and fail-closed normal operations with no overlap;
+- signed artifact rejection for wrong key, altered bytes, wrong platform,
+  rollback sequence, expiry, path traversal, truncation, and oversized input;
+- client candidate crash/restart recovery and previous-slot rollback on every
+  supported platform;
+- a bridge rollout across at least two real clients, including one temporarily
+  offline client and one revoked client;
+- gateway update refusal until every active client is compatible, including an
+  enrollment racing the final fenced cohort check;
+- critically outdated client recovery through the frozen endpoint;
+- critically outdated gateway recovery through at least one stepping stone;
+- network-disabled offline recovery for both one client and one gateway using
+  the bundled signed catalog, including explicit stale-catalog handling;
+- routine dual-signed key transition and independently verified compromised-key
+  re-key recovery; and
+- the existing backup, migration, restore, SBOM, scan, signed-tag, and release
+  evidence gates for the exact candidate artifacts.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -249,8 +249,9 @@ punaro-enroll prepare \
 
 The command prints only the canonical origin and an opaque `client_binding`.
 Give that public value to the server owner. The owner previews and creates the
-least-privilege grant with `punaro-admin client add`; the owner chooses the
-projects and cannot be overridden by the client. With `--yes`, that command
+least-privilege grant with `punaro-admin client invite --machine-id ID`; the
+owner chooses the unique machine ID and projects, and neither can be overridden
+by the client. With `--yes`, that command
 prints the confirmed preview followed by the pending enrollment object. Treat
 the complete exact output as short-lived enrollment material: transfer it
 unchanged through an approved protected channel into a current-user-only regular
@@ -298,19 +299,20 @@ the same `redeem` command; if the transfer file is gone, use `punaro-enroll
 recover` with the state and credential paths, and include the same
 `--access-file` when the origin is Access-protected. The retry has the same
 idempotency key, so it cannot mint a second device credential. The server retains that
-recovery record while its credential and principal remain active; after either
-expires, is revoked, or is disabled, request a new enrollment. A rejected
-(including
-expired, already-used, or revoked) enrollment fails closed and tells the user
+recovery record while its non-expiring credential and principal remain active;
+after revocation or disablement, request a new enrollment. A rejected (including
+expired-first-use, already-used, or revoked) enrollment fails closed and tells the user
 to request a new enrollment; its private recovery journal is removed so the
 replacement material is not blocked. After success, remove the transferred material
 through its approved secret-handling process; the identity sidecar remains
 non-secret and the recovery journal is removed.
 
-The server owner rotates or revokes a device with `punaro-admin credential
-rotate` or `punaro-admin credential revoke`, using the content-free credential
-inventory. Rotation and revocation are server-controlled: a local identity
-sidecar or copied credential cannot restore access.
+The server owner lists and permanently revokes installed clients with
+`punaro-admin client list` and `punaro-admin client revoke`, using only
+content-free lifecycle inventory. Credential rotation remains available through
+`punaro-admin credential rotate`; the old credential revoke command delegates
+to whole-client revocation. A local identity sidecar or copied credential cannot
+restore access.
 
 ## 4. Retired v2/v3 attachment evidence
 

--- a/docs/operator-guide.md
+++ b/docs/operator-guide.md
@@ -243,8 +243,9 @@ both. The command exits with status 3 after printing the preview until `--yes`
 is supplied:
 
 ```sh
-punaro-admin client add -owner-dsn-file /absolute/private/owner.dsn \
-  -actor-principal-id OWNER_UUID -name laptop -client-binding CLIENT_UUID \
+punaro-admin client invite -owner-dsn-file /absolute/private/owner.dsn \
+  -actor-principal-id OWNER_UUID -name laptop -machine-id laptop \
+  -client-binding CLIENT_UUID \
   -project PROJECT_UUID
 ```
 
@@ -255,11 +256,15 @@ opaque client value, generates the 256-bit
 credential secret by domain-separated derivation from the internally generated
 256-bit code, and stores only an indexed SHA-256 digest. An exact retry with the
 same code, client binding, and idempotency UUID returns the same result without
-retaining plaintext while the original short enrollment lifetime remains
-unexpired; any changed, expired, or ordinary replay fails. Never put an
+retaining plaintext while the resulting credential and principal remain active,
+even after the invitation expires. A first attempt after expiry, any changed
+retry, or an ordinary replay fails. The resulting first-release credential does
+not expire automatically. Never put an
 enrollment code or device secret in
 logs, shell history, audit fields, or an environment variable.
 
+List client lifecycle metadata with `client list`; permanently revoke one exact
+client with `client revoke --client UUID --reason lost|retired|compromised|replaced`.
 List credential metadata with `credential list`. Rotation requires the current
 generation and two host-local steps. First run `credential rotate` with an
 absolute new `--code-output` path; the command stages a short-lived random code
@@ -273,6 +278,12 @@ and other processes/sessions force reauthentication within the documented
 two-second bound. Existing Ed25519 relay authentication remains active in this
 slice; its PostgreSQL inventory and disable gate stage the later explicit
 cutover and do not silently change current SQLite routing.
+
+Applying schema 44 invalidates every still-unredeemed older invitation because
+those rows have no owner-approved machine ID; issue a replacement invitation
+after migration. It also converts every active device credential to the
+first-release non-expiring policy. Revoked credentials and their history are
+unchanged.
 
 Migration 4 adds project identities, aliases, generation-bound merge previews,
 and bounded reconciliation records. Migration 5 adds the backup GC-fence,
@@ -456,19 +467,21 @@ preview hash without touching the database. The confirmed invocation must
 repeat the same grant flags and bind the prior hash:
 
 ```sh
-punaro client add --directory /absolute/private/punaro-installation \
-  --name laptop --project PROJECT_UUID
-punaro client add --directory /absolute/private/punaro-installation \
-  --name laptop --project PROJECT_UUID --yes \
+punaro client invite --directory /absolute/private/punaro-installation \
+  --name laptop --machine-id laptop --project PROJECT_UUID
+punaro client invite --directory /absolute/private/punaro-installation \
+  --name laptop --machine-id laptop --project PROJECT_UUID --yes \
   --confirm-preview-hash HASH_FROM_THE_PRIOR_OUTPUT
 ```
 
 The second response contains the generated client binding, enrollment ID, and
 single-use code. Send the exact four-field JSON object to
-`POST /v1/enrollments/redeem`; retain the returned bearer credential only in
-protected client storage. `GET /v1/device/session` is the bounded authentication
-check. Forwarded headers never qualify a direct request for TLS or trusted-LAN
-admission.
+`POST /v1/enrollments/redeem`; retain the returned non-expiring bearer
+credential only in protected client storage. `GET /v1/device/session` is the
+bounded authentication check. `POST /v1/device/session/revoke` permanently
+revokes only its authenticating client and accepts no target. Forwarded headers
+never qualify a direct request for TLS or trusted-LAN admission. The older
+`client add` spelling remains an alias during the transition.
 
 ### Consistent backup and clean-stack restore
 

--- a/docs/operator-guide.md
+++ b/docs/operator-guide.md
@@ -282,8 +282,9 @@ cutover and do not silently change current SQLite routing.
 Applying schema 44 invalidates every still-unredeemed older invitation because
 those rows have no owner-approved machine ID; issue a replacement invitation
 after migration. It also converts every active device credential to the
-first-release non-expiring policy. Revoked credentials and their history are
-unchanged.
+first-release non-expiring policy. A credential already expired when the
+migration begins is permanently revoked and generation-fenced; previously
+revoked credentials and their history are unchanged.
 
 Migration 4 adds project identities, aliases, generation-bound merge previews,
 and bounded reconciliation records. Migration 5 adds the backup GC-fence,

--- a/docs/platform-contracts.md
+++ b/docs/platform-contracts.md
@@ -568,6 +568,14 @@ server-constrained defaults, and coalesce `last_used_at`; it cannot rotate or
 revoke credentials. Host-local administration uses a direct `punaro_owner`
 connection and is not exposed as an HTTP route.
 
+Version 44 adds one server-authoritative client installation and one derived
+endpoint-authority record per device credential. New credentials do not expire
+automatically. The application role has only the column grants needed to create
+those records, update their shared generation fences, and record permanent
+self-revocation; readiness verifies the tables, constraints, indexes, ownership,
+and exact grants. Static relay enrollment remains authoritative until the later
+explicit legacy migration.
+
 The M-9 credential transition is a separate, off-by-default relay mode. It
 does not copy endpoint scopes into the auth schema. A replacement credential
 must authenticate as current and resolve through
@@ -603,12 +611,15 @@ epochs and retired SQLite sources are permanently non-abortable. A begin that
 failed before epoch insertion is aborted by durably reserving the exact epoch
 as terminal before SQLite reopens, fencing every delayed retry of that begin.
 
-M-5 mounts only `POST /v1/enrollments/redeem` and authenticated
-`GET /v1/device/session`. Redemption requires exact `application/json`, a
+M-5 mounts `POST /v1/enrollments/redeem`, authenticated
+`GET /v1/device/session`, and targetless `POST /v1/device/session/revoke`.
+Redemption requires exact `application/json`, a
 bounded object with four unique string fields, and the store's exact enrollment
 binding. Device bearer failures are uniform and content-free. A fixed
 concurrency ceiling and per-operation database deadline bound public work.
-Both routes admit credentials only over TLS, same-host loopback, or the
+The self-revoke route requires an empty body and one canonical idempotency UUID;
+only an exact retry of a committed self-revocation can verify the revoked
+credential. All routes admit credentials only over TLS, same-host loopback, or the
 explicitly configured trusted-LAN HTTP exception. `X-Forwarded-For` and
 `X-Forwarded-Proto` are never transport evidence.
 

--- a/internal/devicehttp/handler.go
+++ b/internal/devicehttp/handler.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/rock3r/punaro/internal/ingress"
 	punaropostgres "github.com/rock3r/punaro/internal/postgres"
 )
@@ -26,6 +27,7 @@ const (
 type store interface {
 	RedeemEnrollment(context.Context, punaropostgres.RedeemEnrollment) (punaropostgres.DeviceCredential, error)
 	AuthenticateDevice(context.Context, string) (punaropostgres.AuthenticatedDevice, error)
+	SelfRevokeDevice(context.Context, string, string) (punaropostgres.DeviceRevocation, error)
 }
 
 type handler struct {
@@ -48,6 +50,7 @@ func newHandler(database store, policy *ingress.Policy, concurrency int, timeout
 	h := &handler{store: database, policy: policy, mux: http.NewServeMux(), slots: make(chan struct{}, concurrency), timeout: timeout}
 	h.mux.HandleFunc("POST /v1/enrollments/redeem", h.redeem)
 	h.mux.Handle("GET /v1/device/session", h.authenticate(http.HandlerFunc(h.session)))
+	h.mux.HandleFunc("POST /v1/device/session/revoke", h.selfRevoke)
 	return h
 }
 
@@ -188,6 +191,53 @@ func (h *handler) session(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	writeJSON(w, http.StatusOK, map[string]string{"status": "authenticated"})
+}
+
+func (h *handler) selfRevoke(w http.ResponseWriter, r *http.Request) {
+	if r.ContentLength > 0 {
+		writeError(w, http.StatusBadRequest, "request is malformed")
+		return
+	}
+	body, err := io.ReadAll(io.LimitReader(r.Body, 1))
+	if err != nil || len(body) != 0 || len(r.Header.Values("Idempotency-Key")) != 1 {
+		writeError(w, http.StatusBadRequest, "request is malformed")
+		return
+	}
+	idempotencyKey := r.Header.Get("Idempotency-Key")
+	parsedKey, err := uuid.Parse(idempotencyKey)
+	if err != nil || parsedKey == uuid.Nil || parsedKey.String() != idempotencyKey {
+		writeError(w, http.StatusBadRequest, "request is malformed")
+		return
+	}
+	credential, ok := bearerCredential(r)
+	if !ok {
+		unauthenticated(w)
+		return
+	}
+	operationCtx, cancel := context.WithTimeout(r.Context(), h.timeout)
+	defer cancel()
+	result, err := h.store.SelfRevokeDevice(operationCtx, credential, idempotencyKey)
+	if err != nil {
+		if errors.Is(err, punaropostgres.ErrUnauthenticated) {
+			unauthenticated(w)
+			return
+		}
+		writeError(w, http.StatusServiceUnavailable, "revocation service is unavailable")
+		return
+	}
+	writeJSON(w, http.StatusOK, result)
+}
+
+func bearerCredential(r *http.Request) (string, bool) {
+	if len(r.Header.Values("Authorization")) != 1 {
+		return "", false
+	}
+	authorization := r.Header.Get("Authorization")
+	if !strings.HasPrefix(authorization, "Bearer ") {
+		return "", false
+	}
+	credential := strings.TrimPrefix(authorization, "Bearer ")
+	return credential, credential != "" && !strings.ContainsAny(credential, " \t\r\n")
 }
 
 func unauthenticated(w http.ResponseWriter) {

--- a/internal/devicehttp/handler_test.go
+++ b/internal/devicehttp/handler_test.go
@@ -15,10 +15,12 @@ import (
 )
 
 type fakeStore struct {
-	redeem     punaropostgres.RedeemEnrollment
-	credential punaropostgres.DeviceCredential
-	auth       punaropostgres.AuthenticatedDevice
-	err        error
+	redeem               punaropostgres.RedeemEnrollment
+	credential           punaropostgres.DeviceCredential
+	auth                 punaropostgres.AuthenticatedDevice
+	selfRevokeCredential string
+	selfRevokeKey        string
+	err                  error
 }
 
 type blockingStore struct{ started chan struct{} }
@@ -33,6 +35,12 @@ func (b *blockingStore) AuthenticateDevice(ctx context.Context, _ string) (punar
 	close(b.started)
 	<-ctx.Done()
 	return punaropostgres.AuthenticatedDevice{}, ctx.Err()
+}
+
+func (b *blockingStore) SelfRevokeDevice(ctx context.Context, _, _ string) (punaropostgres.DeviceRevocation, error) {
+	close(b.started)
+	<-ctx.Done()
+	return punaropostgres.DeviceRevocation{}, ctx.Err()
 }
 
 func (f *fakeStore) RedeemEnrollment(_ context.Context, redeem punaropostgres.RedeemEnrollment) (punaropostgres.DeviceCredential, error) {
@@ -51,6 +59,15 @@ func (f *fakeStore) AuthenticateDevice(_ context.Context, _ string) (punaropostg
 		return punaropostgres.AuthenticatedDevice{}, f.err
 	}
 	return f.auth, nil
+}
+
+func (f *fakeStore) SelfRevokeDevice(_ context.Context, credential, idempotencyKey string) (punaropostgres.DeviceRevocation, error) {
+	f.selfRevokeCredential = credential
+	f.selfRevokeKey = idempotencyKey
+	if f.err != nil {
+		return punaropostgres.DeviceRevocation{}, f.err
+	}
+	return punaropostgres.DeviceRevocation{Status: "revoked"}, nil
 }
 
 func testPolicy(t *testing.T) *ingress.Policy {
@@ -150,6 +167,52 @@ func TestCredentialRoutesEnforceTransportAndUniformAuthentication(t *testing.T) 
 	handler.ServeHTTP(w, duplicate)
 	if w.Code != http.StatusUnauthorized {
 		t.Fatalf("duplicate Authorization status=%d", w.Code)
+	}
+}
+
+func TestSelfRevocationIsTargetlessStrictAndRetryBound(t *testing.T) {
+	store := &fakeStore{}
+	handler := New(store, testPolicy(t))
+	key := "33333333-3333-4333-8333-333333333333"
+	request := func(body string, authorization string, keys ...string) *httptest.ResponseRecorder {
+		r := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/v1/device/session/revoke", strings.NewReader(body))
+		r.RemoteAddr = "192.168.1.20:1234"
+		if authorization != "" {
+			r.Header.Set("Authorization", authorization)
+		}
+		for _, value := range keys {
+			r.Header.Add("Idempotency-Key", value)
+		}
+		w := httptest.NewRecorder()
+		handler.ServeHTTP(w, r)
+		return w
+	}
+	response := request("", "Bearer opaque-device-credential", key)
+	if response.Code != http.StatusOK || response.Body.String() != "{\"status\":\"revoked\"}\n" || store.selfRevokeCredential != "opaque-device-credential" || store.selfRevokeKey != key {
+		t.Fatalf("status=%d body=%q credential=%q key=%q", response.Code, response.Body.String(), store.selfRevokeCredential, store.selfRevokeKey)
+	}
+	for name, response := range map[string]*httptest.ResponseRecorder{
+		"body":          request(`{"client_id":"11111111-1111-4111-8111-111111111111"}`, "Bearer opaque-device-credential", key),
+		"missing key":   request("", "Bearer opaque-device-credential"),
+		"duplicate key": request("", "Bearer opaque-device-credential", key, key),
+		"invalid key":   request("", "Bearer opaque-device-credential", "friendly-retry"),
+		"missing auth":  request("", "", key),
+	} {
+		wantStatus := http.StatusBadRequest
+		if name == "missing auth" {
+			wantStatus = http.StatusUnauthorized
+		}
+		if response.Code != wantStatus {
+			t.Fatalf("%s status=%d body=%q", name, response.Code, response.Body.String())
+		}
+	}
+	store.err = punaropostgres.ErrUnauthenticated
+	if got := request("", "Bearer revoked", key); got.Code != http.StatusUnauthorized {
+		t.Fatalf("revoked unseen retry status=%d body=%q", got.Code, got.Body.String())
+	}
+	store.err = errors.New("database unavailable")
+	if got := request("", "Bearer opaque-device-credential", key); got.Code != http.StatusServiceUnavailable || strings.Contains(got.Body.String(), "database") {
+		t.Fatalf("store failure status=%d body=%q", got.Code, got.Body.String())
 	}
 }
 

--- a/internal/postgres/db.go
+++ b/internal/postgres/db.go
@@ -690,23 +690,28 @@ SELECT
     AND has_column_privilege('punaro_app', credentials_oid, 'principal_id', 'INSERT')
     AND has_column_privilege('punaro_app', credentials_oid, 'label', 'INSERT')
     AND has_column_privilege('punaro_app', credentials_oid, 'secret_digest', 'INSERT')
-    AND has_column_privilege('punaro_app', credentials_oid, 'expires_at', 'INSERT')
+    AND (($1 < 44 AND has_column_privilege('punaro_app', credentials_oid, 'expires_at', 'INSERT'))
+         OR ($1 >= 44 AND NOT has_column_privilege('punaro_app', credentials_oid, 'expires_at', 'INSERT')))
     AND NOT has_column_privilege('punaro_app', credentials_oid, 'generation', 'INSERT')
     AND NOT has_column_privilege('punaro_app', credentials_oid, 'revoked_at', 'INSERT')
     AND has_column_privilege('punaro_app', credentials_oid, 'last_used_at', 'UPDATE')
     AND NOT has_column_privilege('punaro_app', credentials_oid, 'secret_digest', 'UPDATE')
-    AND NOT has_column_privilege('punaro_app', credentials_oid, 'generation', 'UPDATE')
-    AND NOT has_column_privilege('punaro_app', credentials_oid, 'revoked_at', 'UPDATE')
+    AND (($1 < 44 AND NOT has_column_privilege('punaro_app', credentials_oid, 'generation', 'UPDATE'))
+         OR ($1 >= 44 AND has_column_privilege('punaro_app', credentials_oid, 'generation', 'UPDATE')))
+    AND (($1 < 44 AND NOT has_column_privilege('punaro_app', credentials_oid, 'revoked_at', 'UPDATE'))
+         OR ($1 >= 44 AND has_column_privilege('punaro_app', credentials_oid, 'revoked_at', 'UPDATE')))
     AND NOT EXISTS (
         SELECT 1 FROM pg_attribute
         WHERE attrelid = credentials_oid AND attnum > 0 AND NOT attisdropped
-          AND attname <> ALL (ARRAY['lookup_id', 'principal_id', 'label', 'secret_digest', 'expires_at'])
+          AND (($1 < 44 AND attname <> ALL (ARRAY['lookup_id', 'principal_id', 'label', 'secret_digest', 'expires_at']))
+               OR ($1 >= 44 AND attname <> ALL (ARRAY['lookup_id', 'principal_id', 'label', 'secret_digest'])))
           AND has_column_privilege('punaro_app', credentials_oid, attname, 'INSERT')
     )
     AND NOT EXISTS (
         SELECT 1 FROM pg_attribute
         WHERE attrelid = credentials_oid AND attnum > 0 AND NOT attisdropped
-          AND attname <> 'last_used_at'
+          AND (($1 < 44 AND attname <> 'last_used_at')
+               OR ($1 >= 44 AND attname <> ALL (ARRAY['last_used_at', 'generation', 'revoked_at'])))
           AND has_column_privilege('punaro_app', credentials_oid, attname, 'UPDATE')
     )
     AND NOT has_any_column_privilege('punaro_app', credentials_oid, 'REFERENCES')
@@ -1235,7 +1240,112 @@ FROM objects, table_ownership, routine_safety, routine_acl, table_acl, schema_ac
 		}
 		snapshot.CurrentObjectsPresent = controlObjectsPresent
 	}
+	if snapshot.CurrentObjectsPresent && len(snapshot.Records) > 0 && snapshot.Records[len(snapshot.Records)-1].Version >= 44 {
+		lifecycleObjectsPresent, err := clientLifecycleObjectsAvailable(ctx, q)
+		if err != nil {
+			return Snapshot{}, errors.New("PostgreSQL client lifecycle schema cannot be inspected")
+		}
+		snapshot.CurrentObjectsPresent = lifecycleObjectsPresent
+	}
 	return snapshot, nil
+}
+
+func clientLifecycleObjectsAvailable(ctx context.Context, q queryer) (bool, error) {
+	var available bool
+	err := q.QueryRowContext(ctx, `
+WITH objects AS (
+    SELECT to_regclass('auth.pending_enrollments') AS enrollments_oid,
+           to_regclass('auth.pending_enrollments_active_machine') AS pending_machine_oid,
+           to_regclass('auth.client_installations') AS clients_oid,
+           to_regclass('relay.client_endpoint_authority') AS authority_oid
+), ownership AS (
+    SELECT count(*) = 3 AND bool_and(pg_get_userbyid(relowner) = 'punaro_owner') AS owned
+    FROM pg_class, objects
+    WHERE oid = ANY(ARRAY[pending_machine_oid, clients_oid, authority_oid])
+)
+SELECT enrollments_oid IS NOT NULL AND pending_machine_oid IS NOT NULL
+   AND clients_oid IS NOT NULL AND authority_oid IS NOT NULL AND ownership.owned
+   AND EXISTS (
+       SELECT 1 FROM pg_attribute
+       WHERE attrelid = enrollments_oid AND attname = 'machine_id' AND NOT attisdropped
+         AND atttypid = 'text'::regtype AND NOT attnotnull
+   )
+   AND EXISTS (
+       SELECT 1 FROM pg_constraint
+       WHERE conrelid = enrollments_oid AND conname = 'pending_enrollments_machine_id_check'
+         AND contype = 'c' AND convalidated
+         AND pg_get_constraintdef(oid) = 'CHECK (((machine_id IS NULL) OR (machine_id ~ ''^[a-z0-9]([a-z0-9._-]{0,62}[a-z0-9])?$''::text)))'
+   )
+   AND EXISTS (
+       SELECT 1 FROM pg_index
+       WHERE indexrelid = pending_machine_oid AND indrelid = enrollments_oid
+         AND indisunique AND indisvalid AND indisready AND indnkeyatts = 1
+         AND pg_get_expr(indpred, indrelid) = '((redeemed_at IS NULL) AND (invalidated_at IS NULL))'
+   )
+   AND EXISTS (SELECT 1 FROM pg_constraint WHERE conrelid = clients_oid AND contype = 'p' AND conkey = ARRAY[1]::smallint[] AND convalidated)
+   AND EXISTS (SELECT 1 FROM pg_constraint WHERE conrelid = clients_oid AND contype = 'u' AND conkey = ARRAY[2]::smallint[] AND convalidated)
+   AND EXISTS (SELECT 1 FROM pg_constraint WHERE conrelid = clients_oid AND contype = 'u' AND conkey = ARRAY[4]::smallint[] AND convalidated)
+   AND EXISTS (SELECT 1 FROM pg_constraint WHERE conrelid = clients_oid AND contype = 'u' AND conkey = ARRAY[5]::smallint[] AND convalidated)
+   AND EXISTS (SELECT 1 FROM pg_constraint WHERE conrelid = clients_oid AND contype = 'u' AND conkey = ARRAY[11]::smallint[] AND convalidated)
+   AND EXISTS (SELECT 1 FROM pg_constraint WHERE conrelid = clients_oid AND contype = 'f' AND conkey = ARRAY[4]::smallint[] AND confrelid = 'auth.principals'::regclass AND convalidated)
+   AND EXISTS (SELECT 1 FROM pg_constraint WHERE conrelid = clients_oid AND contype = 'f' AND conkey = ARRAY[5]::smallint[] AND confrelid = 'auth.device_credentials'::regclass AND convalidated)
+   AND EXISTS (SELECT 1 FROM pg_constraint WHERE conrelid = authority_oid AND contype = 'p' AND conkey = ARRAY[1]::smallint[] AND convalidated)
+   AND EXISTS (SELECT 1 FROM pg_constraint WHERE conrelid = authority_oid AND contype = 'f' AND conkey = ARRAY[1]::smallint[] AND confrelid = clients_oid AND convalidated)
+   AND EXISTS (SELECT 1 FROM pg_constraint WHERE conrelid = authority_oid AND contype = 'u' AND conkey = ARRAY[2]::smallint[] AND convalidated)
+   AND has_table_privilege('punaro_app', clients_oid, 'SELECT')
+   AND NOT has_table_privilege('punaro_app', clients_oid, 'INSERT')
+   AND NOT has_table_privilege('punaro_app', clients_oid, 'UPDATE')
+   AND NOT has_table_privilege('punaro_app', clients_oid, 'DELETE')
+   AND NOT has_table_privilege('punaro_app', clients_oid, 'TRUNCATE')
+   AND NOT has_table_privilege('punaro_app', clients_oid, 'REFERENCES')
+   AND NOT has_table_privilege('punaro_app', clients_oid, 'TRIGGER')
+   AND NOT EXISTS (
+       SELECT 1 FROM pg_attribute
+       WHERE attrelid = clients_oid AND attnum > 0 AND NOT attisdropped
+         AND attname <> ALL (ARRAY['machine_id', 'label', 'principal_id', 'credential_lookup_id'])
+         AND has_column_privilege('punaro_app', clients_oid, attname, 'INSERT')
+   )
+   AND NOT EXISTS (
+       SELECT 1 FROM pg_attribute
+       WHERE attrelid = clients_oid AND attnum > 0 AND NOT attisdropped
+         AND attname <> ALL (ARRAY['generation', 'lifecycle_state', 'revoked_at', 'revocation_reason', 'self_revoke_idempotency'])
+         AND has_column_privilege('punaro_app', clients_oid, attname, 'UPDATE')
+   )
+   AND NOT has_any_column_privilege('punaro_app', clients_oid, 'REFERENCES')
+   AND has_column_privilege('punaro_app', clients_oid, 'machine_id', 'INSERT')
+   AND has_column_privilege('punaro_app', clients_oid, 'label', 'INSERT')
+   AND has_column_privilege('punaro_app', clients_oid, 'principal_id', 'INSERT')
+   AND has_column_privilege('punaro_app', clients_oid, 'credential_lookup_id', 'INSERT')
+   AND has_column_privilege('punaro_app', clients_oid, 'generation', 'UPDATE')
+   AND has_column_privilege('punaro_app', clients_oid, 'lifecycle_state', 'UPDATE')
+   AND has_column_privilege('punaro_app', clients_oid, 'revoked_at', 'UPDATE')
+   AND has_column_privilege('punaro_app', clients_oid, 'revocation_reason', 'UPDATE')
+   AND has_column_privilege('punaro_app', clients_oid, 'self_revoke_idempotency', 'UPDATE')
+   AND has_table_privilege('punaro_app', authority_oid, 'SELECT')
+   AND NOT has_table_privilege('punaro_app', authority_oid, 'INSERT')
+   AND NOT has_table_privilege('punaro_app', authority_oid, 'UPDATE')
+   AND NOT has_table_privilege('punaro_app', authority_oid, 'DELETE')
+   AND NOT has_table_privilege('punaro_app', authority_oid, 'TRUNCATE')
+   AND NOT has_table_privilege('punaro_app', authority_oid, 'REFERENCES')
+   AND NOT has_table_privilege('punaro_app', authority_oid, 'TRIGGER')
+   AND has_column_privilege('punaro_app', authority_oid, 'client_id', 'INSERT')
+   AND has_column_privilege('punaro_app', authority_oid, 'endpoint_prefix', 'INSERT')
+   AND has_column_privilege('punaro_app', authority_oid, 'generation', 'UPDATE')
+   AND NOT EXISTS (
+       SELECT 1 FROM pg_attribute
+       WHERE attrelid = authority_oid AND attnum > 0 AND NOT attisdropped
+         AND attname <> ALL (ARRAY['client_id', 'endpoint_prefix'])
+         AND has_column_privilege('punaro_app', authority_oid, attname, 'INSERT')
+   )
+   AND NOT EXISTS (
+       SELECT 1 FROM pg_attribute
+       WHERE attrelid = authority_oid AND attnum > 0 AND NOT attisdropped
+         AND attname <> 'generation'
+         AND has_column_privilege('punaro_app', authority_oid, attname, 'UPDATE')
+   )
+   AND NOT has_any_column_privilege('punaro_app', authority_oid, 'REFERENCES')
+FROM objects, ownership`).Scan(&available)
+	return available, err
 }
 
 func verifyApplicationRole(ctx context.Context, db queryer) error {

--- a/internal/postgres/db.go
+++ b/internal/postgres/db.go
@@ -1286,7 +1286,7 @@ SELECT enrollments_oid IS NOT NULL AND pending_machine_oid IS NOT NULL
    AND EXISTS (SELECT 1 FROM pg_constraint WHERE conrelid = clients_oid AND contype = 'u' AND conkey = ARRAY[2]::smallint[] AND convalidated)
    AND EXISTS (SELECT 1 FROM pg_constraint WHERE conrelid = clients_oid AND contype = 'u' AND conkey = ARRAY[4]::smallint[] AND convalidated)
    AND EXISTS (SELECT 1 FROM pg_constraint WHERE conrelid = clients_oid AND contype = 'u' AND conkey = ARRAY[5]::smallint[] AND convalidated)
-   AND EXISTS (SELECT 1 FROM pg_constraint WHERE conrelid = clients_oid AND contype = 'u' AND conkey = ARRAY[11]::smallint[] AND convalidated)
+   AND NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conrelid = clients_oid AND contype = 'u' AND conkey = ARRAY[11]::smallint[])
    AND EXISTS (SELECT 1 FROM pg_constraint WHERE conrelid = clients_oid AND contype = 'f' AND conkey = ARRAY[4]::smallint[] AND confrelid = 'auth.principals'::regclass AND convalidated)
    AND EXISTS (SELECT 1 FROM pg_constraint WHERE conrelid = clients_oid AND contype = 'f' AND conkey = ARRAY[5]::smallint[] AND confrelid = 'auth.device_credentials'::regclass AND convalidated)
    AND EXISTS (SELECT 1 FROM pg_constraint WHERE conrelid = authority_oid AND contype = 'p' AND conkey = ARRAY[1]::smallint[] AND convalidated)

--- a/internal/postgres/db.go
+++ b/internal/postgres/db.go
@@ -1292,6 +1292,72 @@ SELECT enrollments_oid IS NOT NULL AND pending_machine_oid IS NOT NULL
    AND EXISTS (SELECT 1 FROM pg_constraint WHERE conrelid = authority_oid AND contype = 'p' AND conkey = ARRAY[1]::smallint[] AND convalidated)
    AND EXISTS (SELECT 1 FROM pg_constraint WHERE conrelid = authority_oid AND contype = 'f' AND conkey = ARRAY[1]::smallint[] AND confrelid = clients_oid AND convalidated)
    AND EXISTS (SELECT 1 FROM pg_constraint WHERE conrelid = authority_oid AND contype = 'u' AND conkey = ARRAY[2]::smallint[] AND convalidated)
+   AND ARRAY(
+       SELECT attname || '|' || format_type(atttypid, atttypmod) || '|' || attnotnull::text || '|' || COALESCE(pg_get_expr(adbin, adrelid), '')
+       FROM pg_attribute
+       LEFT JOIN pg_attrdef ON adrelid = attrelid AND adnum = attnum
+       WHERE attrelid = clients_oid AND attnum > 0 AND NOT attisdropped
+       ORDER BY attnum
+   ) = ARRAY[
+       'id|uuid|true|gen_random_uuid()',
+       'machine_id|text|true|',
+       'label|text|true|',
+       'principal_id|uuid|true|',
+       'credential_lookup_id|uuid|true|',
+       'generation|bigint|true|1',
+       'lifecycle_state|text|true|''active''::text',
+       'created_at|timestamp with time zone|true|statement_timestamp()',
+       'revoked_at|timestamp with time zone|false|',
+       'revocation_reason|text|false|',
+       'self_revoke_idempotency|uuid|false|'
+   ]
+   AND ARRAY(
+       SELECT conname::text
+       FROM pg_constraint
+       WHERE conrelid = clients_oid AND contype = 'c' AND convalidated
+       ORDER BY conname
+   ) = ARRAY[
+       'client_installations_check',
+       'client_installations_generation_check',
+       'client_installations_label_check',
+       'client_installations_lifecycle_state_check',
+       'client_installations_machine_id_check',
+       'client_installations_revocation_reason_check'
+   ]
+   AND EXISTS (SELECT 1 FROM pg_constraint WHERE conrelid = clients_oid AND conname = 'client_installations_check' AND pg_get_constraintdef(oid) = 'CHECK ((((lifecycle_state = ''active''::text) AND (revoked_at IS NULL) AND (revocation_reason IS NULL) AND (self_revoke_idempotency IS NULL)) OR ((lifecycle_state = ''revoked''::text) AND (revoked_at IS NOT NULL) AND (revocation_reason IS NOT NULL))))')
+   AND EXISTS (SELECT 1 FROM pg_constraint WHERE conrelid = clients_oid AND conname = 'client_installations_generation_check' AND pg_get_constraintdef(oid) = 'CHECK ((generation >= 1))')
+   AND EXISTS (
+       SELECT 1 FROM pg_constraint
+       WHERE conrelid = clients_oid AND conname = 'client_installations_label_check'
+         AND pg_get_constraintdef(oid) IN (
+             'CHECK ((((char_length(label) >= 1) AND (char_length(label) <= 128)) AND (octet_length(label) <= 512) AND (label !~ ''[[:cntrl:]]''::text)))',
+             'CHECK (((char_length(label) >= 1) AND (char_length(label) <= 128) AND (octet_length(label) <= 512) AND (label !~ ''[[:cntrl:]]''::text)))'
+         )
+   )
+   AND EXISTS (SELECT 1 FROM pg_constraint WHERE conrelid = clients_oid AND conname = 'client_installations_lifecycle_state_check' AND pg_get_constraintdef(oid) = 'CHECK ((lifecycle_state = ANY (ARRAY[''active''::text, ''revoked''::text])))')
+   AND EXISTS (SELECT 1 FROM pg_constraint WHERE conrelid = clients_oid AND conname = 'client_installations_machine_id_check' AND pg_get_constraintdef(oid) = 'CHECK ((machine_id ~ ''^[a-z0-9]([a-z0-9._-]{0,62}[a-z0-9])?$''::text))')
+   AND EXISTS (SELECT 1 FROM pg_constraint WHERE conrelid = clients_oid AND conname = 'client_installations_revocation_reason_check' AND pg_get_constraintdef(oid) = 'CHECK ((revocation_reason = ANY (ARRAY[''lost''::text, ''retired''::text, ''compromised''::text, ''replaced''::text, ''self''::text])))')
+   AND ARRAY(
+       SELECT attname || '|' || format_type(atttypid, atttypmod) || '|' || attnotnull::text || '|' || COALESCE(pg_get_expr(adbin, adrelid), '')
+       FROM pg_attribute
+       LEFT JOIN pg_attrdef ON adrelid = attrelid AND adnum = attnum
+       WHERE attrelid = authority_oid AND attnum > 0 AND NOT attisdropped
+       ORDER BY attnum
+   ) = ARRAY[
+       'client_id|uuid|true|',
+       'endpoint_prefix|text|true|',
+       'generation|bigint|true|1',
+       'created_at|timestamp with time zone|true|statement_timestamp()'
+   ]
+   AND ARRAY(
+       SELECT conname || '|' || pg_get_constraintdef(oid)
+       FROM pg_constraint
+       WHERE conrelid = authority_oid AND contype = 'c' AND convalidated
+       ORDER BY conname
+   ) = ARRAY[
+       'client_endpoint_authority_endpoint_prefix_check|CHECK ((endpoint_prefix ~ ''^agent/[a-z0-9]([a-z0-9._-]{0,62}[a-z0-9])?/$''::text))',
+       'client_endpoint_authority_generation_check|CHECK ((generation >= 1))'
+   ]
    AND has_table_privilege('punaro_app', clients_oid, 'SELECT')
    AND NOT has_table_privilege('punaro_app', clients_oid, 'INSERT')
    AND NOT has_table_privilege('punaro_app', clients_oid, 'UPDATE')

--- a/internal/postgres/db.go
+++ b/internal/postgres/db.go
@@ -1279,7 +1279,12 @@ SELECT enrollments_oid IS NOT NULL AND pending_machine_oid IS NOT NULL
    AND EXISTS (
        SELECT 1 FROM pg_index
        WHERE indexrelid = pending_machine_oid AND indrelid = enrollments_oid
-         AND indisunique AND indisvalid AND indisready AND indnkeyatts = 1
+         AND indisunique AND indisvalid AND indisready AND indnkeyatts = 1 AND indnatts = 1
+         AND indkey[0] = (
+             SELECT attnum FROM pg_attribute
+             WHERE attrelid = enrollments_oid AND attname = 'machine_id' AND NOT attisdropped
+         )
+         AND indexprs IS NULL
          AND pg_get_expr(indpred, indrelid) = '((redeemed_at IS NULL) AND (invalidated_at IS NULL))'
    )
    AND EXISTS (SELECT 1 FROM pg_constraint WHERE conrelid = clients_oid AND contype = 'p' AND conkey = ARRAY[1]::smallint[] AND convalidated)

--- a/internal/postgres/device_auth.go
+++ b/internal/postgres/device_auth.go
@@ -18,7 +18,6 @@ const (
 	maxEnrollmentProjects = 100
 	minEnrollmentTTL      = time.Minute
 	maxEnrollmentTTL      = 24 * time.Hour
-	maxCredentialTTL      = 365 * 24 * time.Hour
 )
 
 // GrantSpec is one principal-independent grant displayed before enrollment.
@@ -95,6 +94,7 @@ func PreviewTrustedAgentEnrollment(projectIDs []string, allProjects bool) ([]Gra
 // EnrollmentRequest is a bounded host-local request to create one pending client.
 type EnrollmentRequest struct {
 	ClientBinding     string
+	MachineID         string
 	Label             string
 	ProjectIDs        []string
 	AllProjects       bool
@@ -106,11 +106,34 @@ type EnrollmentRequest struct {
 
 // Validate rejects ambiguous grants, friendly client bindings, and unsafe lifetimes.
 func (r EnrollmentRequest) Validate() error {
-	if !validOpaqueID(r.ClientBinding) || !validDisplayName(r.Label) || len(r.ProjectIDs) > maxEnrollmentProjects || r.TTL < minEnrollmentTTL || r.TTL > maxEnrollmentTTL || r.CredentialTTL < 0 || r.CredentialTTL > maxCredentialTTL || (r.CredentialTTL > 0 && r.CredentialTTL < minEnrollmentTTL) || !r.ExpiresAt.IsZero() || (r.LegacyPrincipalID != "" && !validOpaqueID(r.LegacyPrincipalID)) {
+	if !validOpaqueID(r.ClientBinding) || !validLifecycleMachineID(r.MachineID) || !validDisplayName(r.Label) || len(r.ProjectIDs) > maxEnrollmentProjects || r.TTL < minEnrollmentTTL || r.TTL > maxEnrollmentTTL || r.CredentialTTL != 0 || !r.ExpiresAt.IsZero() || (r.LegacyPrincipalID != "" && !validOpaqueID(r.LegacyPrincipalID)) {
 		return errors.New("invalid enrollment request")
 	}
 	_, err := TrustedAgentGrantPreview(r.ProjectIDs, r.AllProjects)
 	return err
+}
+
+func validLifecycleMachineID(value string) bool {
+	if len(value) < 1 || len(value) > 64 {
+		return false
+	}
+	first := value[0]
+	switch {
+	case first >= 'a' && first <= 'z':
+	case first >= '0' && first <= '9':
+	default:
+		return false
+	}
+	for index, character := range []byte(value) {
+		if character >= 'a' && character <= 'z' || character >= '0' && character <= '9' {
+			continue
+		}
+		if index > 0 && index < len(value)-1 && (character == '.' || character == '_' || character == '-') {
+			continue
+		}
+		return false
+	}
+	return true
 }
 
 func newDeviceCredential() (encoded, lookupID string, digest [sha256.Size]byte, err error) {

--- a/internal/postgres/device_auth_integration_test.go
+++ b/internal/postgres/device_auth_integration_test.go
@@ -76,6 +76,32 @@ func testDeviceAuthIntegration(ctx context.Context, t *testing.T, app *Database,
 	if err != nil || len(preview) == 0 || previewHash == "" {
 		t.Fatalf("preview=%#v hash=%q err=%v", preview, previewHash, err)
 	}
+	const boundedPruneMachineID = "bounded-prune-reissue"
+	if _, err := ownerDB.ExecContext(ctx, `INSERT INTO auth.pending_enrollments
+(issuer_principal_id, client_binding, machine_id, label, code_digest, preview_hash, created_at, expires_at)
+SELECT $1, gen_random_uuid(), 'older-stale-' || ordinal::text, 'older stale enrollment',
+       sha256(convert_to('older-code-' || ordinal::text, 'UTF8')),
+       sha256(convert_to('older-preview-' || ordinal::text, 'UTF8')),
+       statement_timestamp() - interval '4 hours', statement_timestamp() - interval '3 hours'
+FROM generate_series(1, 100) AS ordinal`, owner.ID); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ownerDB.ExecContext(ctx, `INSERT INTO auth.pending_enrollments
+(issuer_principal_id, client_binding, machine_id, label, code_digest, preview_hash, created_at, expires_at)
+VALUES ($1, gen_random_uuid(), $2, 'bounded prune target',
+        sha256(convert_to('bounded-prune-code', 'UTF8')),
+        sha256(convert_to('bounded-prune-preview', 'UTF8')),
+        statement_timestamp() - interval '2 hours', statement_timestamp() - interval '1 hour')`, owner.ID, boundedPruneMachineID); err != nil {
+		t.Fatal(err)
+	}
+	reissueRequest := EnrollmentRequest{ClientBinding: uuid.NewString(), MachineID: boundedPruneMachineID, Label: "bounded prune reissue", AllProjects: true, TTL: time.Minute}
+	_, reissuePreviewHash, err := PreviewTrustedAgentEnrollment(nil, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := admin.CreateEnrollment(ctx, owner.ID, reissueRequest, reissuePreviewHash); err != nil {
+		t.Fatalf("reissue after bounded stale prune: %v", err)
+	}
 	pending, err := admin.CreateEnrollment(ctx, owner.ID, request, previewHash)
 	if err != nil {
 		t.Fatal(err)

--- a/internal/postgres/device_auth_integration_test.go
+++ b/internal/postgres/device_auth_integration_test.go
@@ -87,6 +87,16 @@ FROM generate_series(1, 100) AS ordinal`, owner.ID); err != nil {
 		t.Fatal(err)
 	}
 	if _, err := ownerDB.ExecContext(ctx, `INSERT INTO auth.pending_enrollments
+(issuer_principal_id, client_binding, machine_id, label, code_digest, preview_hash, created_at, expires_at, invalidated_at)
+SELECT $1, gen_random_uuid(), $2, 'invalidated same-machine enrollment',
+       sha256(convert_to('invalidated-code-' || ordinal::text, 'UTF8')),
+       sha256(convert_to('invalidated-preview-' || ordinal::text, 'UTF8')),
+       statement_timestamp() - interval '2 hours', statement_timestamp() - interval '1 hour',
+       statement_timestamp() - interval '30 minutes'
+FROM generate_series(1, 2) AS ordinal`, owner.ID, boundedPruneMachineID); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ownerDB.ExecContext(ctx, `INSERT INTO auth.pending_enrollments
 (issuer_principal_id, client_binding, machine_id, label, code_digest, preview_hash, created_at, expires_at)
 VALUES ($1, gen_random_uuid(), $2, 'bounded prune target',
         sha256(convert_to('bounded-prune-code', 'UTF8')),

--- a/internal/postgres/device_auth_integration_test.go
+++ b/internal/postgres/device_auth_integration_test.go
@@ -267,6 +267,18 @@ VALUES ($1, gen_random_uuid(), $2, 'bounded prune target',
 	if err != nil || len(clients) != 2 || clients[1].LifecycleState != "revoked" || clients[1].RevocationReason != "self" || clients[1].Generation != selfCredential.Generation+1 {
 		t.Fatalf("self-revoked client inventory=%#v err=%v", clients, err)
 	}
+	duplicateKeyRequest := EnrollmentRequest{ClientBinding: uuid.NewString(), MachineID: "duplicate-self-key-client", Label: "duplicate self key client", AllProjects: true, TTL: time.Minute}
+	duplicateKeyPending, err := admin.CreateEnrollment(ctx, owner.ID, duplicateKeyRequest, selfPreviewHash)
+	if err != nil {
+		t.Fatal(err)
+	}
+	duplicateKeyCredential, err := app.RedeemEnrollment(ctx, RedeemEnrollment{EnrollmentID: duplicateKeyPending.ID, ClientBinding: duplicateKeyRequest.ClientBinding, Code: duplicateKeyPending.Code, IdempotencyKey: uuid.NewString()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result, err := app.SelfRevokeDevice(ctx, duplicateKeyCredential.Encoded, selfKey); err != nil || result.Status != "revoked" {
+		t.Fatalf("second client self revocation with reused key result=%#v err=%v", result, err)
+	}
 
 	raceRequest := EnrollmentRequest{ClientBinding: uuid.NewString(), MachineID: "revocation-race-client", Label: "revocation race client", AllProjects: true, TTL: time.Minute}
 	racePending, err := admin.CreateEnrollment(ctx, owner.ID, raceRequest, selfPreviewHash)

--- a/internal/postgres/device_auth_integration_test.go
+++ b/internal/postgres/device_auth_integration_test.go
@@ -71,7 +71,7 @@ func testDeviceAuthIntegration(ctx context.Context, t *testing.T, app *Database,
 	if err != nil {
 		t.Fatal(err)
 	}
-	request := EnrollmentRequest{ClientBinding: uuid.NewString(), Label: "laptop", ProjectIDs: []string{project.ProjectID}, TTL: 10 * time.Minute, CredentialTTL: time.Minute}
+	request := EnrollmentRequest{ClientBinding: uuid.NewString(), MachineID: "laptop", Label: "laptop", ProjectIDs: []string{project.ProjectID}, TTL: 10 * time.Minute}
 	preview, previewHash, err := PreviewTrustedAgentEnrollment(request.ProjectIDs, request.AllProjects)
 	if err != nil || len(preview) == 0 || previewHash == "" {
 		t.Fatalf("preview=%#v hash=%q err=%v", preview, previewHash, err)
@@ -102,8 +102,15 @@ func testDeviceAuthIntegration(ctx context.Context, t *testing.T, app *Database,
 	if err != nil {
 		t.Fatal(err)
 	}
-	if time.Until(credential.ExpiresAt) < 50*time.Second {
-		t.Fatalf("credential TTL was anchored to enrollment issuance: expires_at=%s", credential.ExpiresAt)
+	if credential.ClientID == "" || credential.MachineID != request.MachineID || credential.EndpointPrefix != "agent/"+request.MachineID+"/" {
+		t.Fatalf("redemption lifecycle metadata=%#v", credential)
+	}
+	if !credential.ExpiresAt.IsZero() {
+		t.Fatalf("first-release credential unexpectedly expires: expires_at=%s", credential.ExpiresAt)
+	}
+	clients, err := admin.ListClients(ctx, owner.ID, 100)
+	if err != nil || len(clients) != 1 || clients[0].ClientID != credential.ClientID || clients[0].LifecycleState != "active" || clients[0].Generation != credential.Generation {
+		t.Fatalf("initial client inventory=%#v err=%v", clients, err)
 	}
 	replayed, err := app.RedeemEnrollment(ctx, RedeemEnrollment{EnrollmentID: pending.ID, ClientBinding: request.ClientBinding, Code: pending.Code, IdempotencyKey: redeemKey})
 	if err != nil || replayed.Encoded != credential.Encoded || replayed.LookupID != credential.LookupID {
@@ -112,7 +119,7 @@ func testDeviceAuthIntegration(ctx context.Context, t *testing.T, app *Database,
 	if _, err := ownerDB.ExecContext(ctx, `UPDATE auth.pending_enrollments SET expires_at = statement_timestamp() - interval '1 second' WHERE id = $1`, pending.ID); err != nil {
 		t.Fatal(err)
 	}
-	pruneTrigger := EnrollmentRequest{ClientBinding: uuid.NewString(), Label: "prune trigger", AllProjects: true, TTL: time.Minute}
+	pruneTrigger := EnrollmentRequest{ClientBinding: uuid.NewString(), MachineID: "prune-trigger", Label: "prune trigger", AllProjects: true, TTL: time.Minute}
 	_, pruneHash, err := PreviewTrustedAgentEnrollment(nil, true)
 	if err != nil {
 		t.Fatal(err)
@@ -155,6 +162,9 @@ func testDeviceAuthIntegration(ctx context.Context, t *testing.T, app *Database,
 	if err != nil {
 		t.Fatal(err)
 	}
+	if rotated.ClientID != credential.ClientID || rotated.MachineID != credential.MachineID || rotated.EndpointPrefix != credential.EndpointPrefix || rotated.Generation != credential.Generation+1 {
+		t.Fatalf("rotated lifecycle metadata=%#v", rotated)
+	}
 	rotationRetry, err := admin.RotateDeviceCredential(ctx, owner.ID, rotation)
 	if err != nil || rotationRetry.Encoded != rotated.Encoded || rotationRetry.Generation != rotated.Generation {
 		t.Fatalf("exact rotation retry=%#v err=%v", rotationRetry, err)
@@ -177,10 +187,93 @@ func testDeviceAuthIntegration(ctx context.Context, t *testing.T, app *Database,
 	if err := admin.RevokeDeviceCredential(ctx, owner.ID, rotated.LookupID); err != nil {
 		t.Fatal(err)
 	}
+	if err := admin.RevokeClient(ctx, owner.ID, credential.ClientID, "compromised"); err != nil {
+		t.Fatalf("owner revocation retry: %v", err)
+	}
 	if _, err := app.AuthenticateDevice(ctx, rotated.Encoded); !errors.Is(err, ErrUnauthenticated) {
 		t.Fatalf("revoked credential error=%v", err)
 	}
-	recoveryRequest := EnrollmentRequest{ClientBinding: uuid.NewString(), Label: "recoverable client", AllProjects: true, TTL: time.Minute, CredentialTTL: time.Minute}
+	clients, err = admin.ListClients(ctx, owner.ID, 100)
+	if err != nil || len(clients) != 1 || clients[0].LifecycleState != "revoked" || clients[0].RevocationReason != "replaced" || clients[0].Generation != rotated.Generation+1 {
+		t.Fatalf("owner-revoked client inventory=%#v err=%v", clients, err)
+	}
+
+	selfRequest := EnrollmentRequest{ClientBinding: uuid.NewString(), MachineID: "self-revoking-client", Label: "self revoking client", AllProjects: true, TTL: time.Minute}
+	_, selfPreviewHash, err := PreviewTrustedAgentEnrollment(nil, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	selfPending, err := admin.CreateEnrollment(ctx, owner.ID, selfRequest, selfPreviewHash)
+	if err != nil {
+		t.Fatal(err)
+	}
+	selfCredential, err := app.RedeemEnrollment(ctx, RedeemEnrollment{EnrollmentID: selfPending.ID, ClientBinding: selfRequest.ClientBinding, Code: selfPending.Code, IdempotencyKey: uuid.NewString()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	selfKey := uuid.NewString()
+	if result, err := app.SelfRevokeDevice(ctx, selfCredential.Encoded, selfKey); err != nil || result.Status != "revoked" {
+		t.Fatalf("self revocation result=%#v err=%v", result, err)
+	}
+	if result, err := app.SelfRevokeDevice(ctx, selfCredential.Encoded, selfKey); err != nil || result.Status != "revoked" {
+		t.Fatalf("self revocation retry result=%#v err=%v", result, err)
+	}
+	if _, err := app.SelfRevokeDevice(ctx, selfCredential.Encoded, uuid.NewString()); !errors.Is(err, ErrUnauthenticated) {
+		t.Fatalf("self revocation accepted a different retry key: %v", err)
+	}
+	if _, err := app.AuthenticateDevice(ctx, selfCredential.Encoded); !errors.Is(err, ErrUnauthenticated) {
+		t.Fatalf("self-revoked credential error=%v", err)
+	}
+	if err := admin.RevokeClient(ctx, owner.ID, selfCredential.ClientID, "retired"); err != nil {
+		t.Fatalf("owner retry of self-revoked client: %v", err)
+	}
+	clients, err = admin.ListClients(ctx, owner.ID, 100)
+	if err != nil || len(clients) != 2 || clients[1].LifecycleState != "revoked" || clients[1].RevocationReason != "self" || clients[1].Generation != selfCredential.Generation+1 {
+		t.Fatalf("self-revoked client inventory=%#v err=%v", clients, err)
+	}
+
+	raceRequest := EnrollmentRequest{ClientBinding: uuid.NewString(), MachineID: "revocation-race-client", Label: "revocation race client", AllProjects: true, TTL: time.Minute}
+	racePending, err := admin.CreateEnrollment(ctx, owner.ID, raceRequest, selfPreviewHash)
+	if err != nil {
+		t.Fatal(err)
+	}
+	raceCredential, err := app.RedeemEnrollment(ctx, RedeemEnrollment{EnrollmentID: racePending.ID, ClientBinding: raceRequest.ClientBinding, Code: racePending.Code, IdempotencyKey: uuid.NewString()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	raceSelfKey := uuid.NewString()
+	selfResult := make(chan error, 1)
+	ownerResult := make(chan error, 1)
+	go func() {
+		_, revokeErr := app.SelfRevokeDevice(ctx, raceCredential.Encoded, raceSelfKey)
+		selfResult <- revokeErr
+	}()
+	go func() { ownerResult <- admin.RevokeClient(ctx, owner.ID, raceCredential.ClientID, "lost") }()
+	selfErr, ownerErr := <-selfResult, <-ownerResult
+	if ownerErr != nil || (selfErr != nil && !errors.Is(selfErr, ErrUnauthenticated)) {
+		t.Fatalf("owner/self revocation race self=%v owner=%v", selfErr, ownerErr)
+	}
+	clients, err = admin.ListClients(ctx, owner.ID, 100)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var raced ClientMetadata
+	for _, client := range clients {
+		if client.ClientID == raceCredential.ClientID {
+			raced = client
+		}
+	}
+	if raced.LifecycleState != "revoked" || (raced.RevocationReason != "self" && raced.RevocationReason != "lost") {
+		t.Fatalf("owner/self revocation race inventory=%#v", raced)
+	}
+	_, retryErr := app.SelfRevokeDevice(ctx, raceCredential.Encoded, raceSelfKey)
+	if raced.RevocationReason == "self" && retryErr != nil {
+		t.Fatalf("self-winning race was not retryable: %v", retryErr)
+	}
+	if raced.RevocationReason == "lost" && !errors.Is(retryErr, ErrUnauthenticated) {
+		t.Fatalf("owner-winning race accepted self retry: %v", retryErr)
+	}
+	recoveryRequest := EnrollmentRequest{ClientBinding: uuid.NewString(), MachineID: "recoverable-client", Label: "recoverable client", AllProjects: true, TTL: time.Minute}
 	recoveryPending, err := admin.CreateEnrollment(ctx, owner.ID, recoveryRequest, pruneHash)
 	if err != nil {
 		t.Fatal(err)
@@ -199,7 +292,7 @@ func testDeviceAuthIntegration(ctx context.Context, t *testing.T, app *Database,
 	if _, err := ownerDB.ExecContext(ctx, `UPDATE auth.pending_enrollments SET created_at = statement_timestamp() - interval '2 seconds', expires_at = statement_timestamp() - interval '1 second' WHERE id = $1`, recoveryPending.ID); err != nil {
 		t.Fatal(err)
 	}
-	activePruneTrigger := EnrollmentRequest{ClientBinding: uuid.NewString(), Label: "active credential prune trigger", AllProjects: true, TTL: time.Minute}
+	activePruneTrigger := EnrollmentRequest{ClientBinding: uuid.NewString(), MachineID: "active-prune-trigger", Label: "active credential prune trigger", AllProjects: true, TTL: time.Minute}
 	if _, err := admin.CreateEnrollment(ctx, owner.ID, activePruneTrigger, pruneHash); err != nil {
 		t.Fatalf("create enrollment after expired recovery enrollment: %v", err)
 	}
@@ -215,7 +308,7 @@ func testDeviceAuthIntegration(ctx context.Context, t *testing.T, app *Database,
 	if _, err := ownerDB.ExecContext(ctx, `UPDATE auth.device_credentials SET created_at = statement_timestamp() - interval '2 seconds', expires_at = statement_timestamp() - interval '1 second' WHERE lookup_id = $1`, recoveryCredential.LookupID); err != nil {
 		t.Fatal(err)
 	}
-	latePruneTrigger := EnrollmentRequest{ClientBinding: uuid.NewString(), Label: "expired credential prune trigger", AllProjects: true, TTL: time.Minute}
+	latePruneTrigger := EnrollmentRequest{ClientBinding: uuid.NewString(), MachineID: "expired-credential-trigger", Label: "expired credential prune trigger", AllProjects: true, TTL: time.Minute}
 	if _, err := admin.CreateEnrollment(ctx, owner.ID, latePruneTrigger, pruneHash); err != nil {
 		t.Fatalf("create enrollment after credential expiry: %v", err)
 	}
@@ -227,7 +320,7 @@ func testDeviceAuthIntegration(ctx context.Context, t *testing.T, app *Database,
         (SELECT count(*) FROM auth.pending_enrollment_grants WHERE enrollment_id = $1)`, recoveryPending.ID).Scan(&redeemedRows, &redeemedGrantRows); err != nil || redeemedRows != 0 || redeemedGrantRows != 0 {
 		t.Fatalf("expired credential recovery rows=%d grants=%d err=%v, want pruned", redeemedRows, redeemedGrantRows, err)
 	}
-	expiredRequest := EnrollmentRequest{ClientBinding: uuid.NewString(), Label: "expired client", AllProjects: true, TTL: time.Minute}
+	expiredRequest := EnrollmentRequest{ClientBinding: uuid.NewString(), MachineID: "expired-client", Label: "expired client", AllProjects: true, TTL: time.Minute}
 	_, expiredHash, err := PreviewTrustedAgentEnrollment(nil, true)
 	if err != nil {
 		t.Fatal(err)
@@ -243,7 +336,7 @@ func testDeviceAuthIntegration(ctx context.Context, t *testing.T, app *Database,
 		t.Fatalf("expired enrollment error=%v", err)
 	}
 
-	concurrentRequest := EnrollmentRequest{ClientBinding: uuid.NewString(), Label: "desktop", AllProjects: true, TTL: 10 * time.Minute}
+	concurrentRequest := EnrollmentRequest{ClientBinding: uuid.NewString(), MachineID: "desktop", Label: "desktop", AllProjects: true, TTL: 10 * time.Minute}
 	_, concurrentHash, err := PreviewTrustedAgentEnrollment(nil, true)
 	if err != nil {
 		t.Fatal(err)
@@ -291,7 +384,7 @@ func testDeviceAuthIntegration(ctx context.Context, t *testing.T, app *Database,
 	if err := admin.DisableLegacyAuthentication(ctx, owner.ID); err == nil {
 		t.Fatal("legacy authentication disabled with a pending intended machine")
 	}
-	legacyRequest := EnrollmentRequest{ClientBinding: uuid.NewString(), Label: "legacy replacement", AllProjects: true, LegacyPrincipalID: legacy.PrincipalID, TTL: 10 * time.Minute}
+	legacyRequest := EnrollmentRequest{ClientBinding: uuid.NewString(), MachineID: "legacy-replacement", Label: "legacy replacement", AllProjects: true, LegacyPrincipalID: legacy.PrincipalID, TTL: 10 * time.Minute}
 	legacyPending, err := admin.CreateEnrollment(ctx, owner.ID, legacyRequest, concurrentHash)
 	if err != nil {
 		t.Fatal(err)

--- a/internal/postgres/device_auth_store.go
+++ b/internal/postgres/device_auth_store.go
@@ -1063,7 +1063,8 @@ SELECT count(*) FROM deleted_enrollments`, limit).Scan(&pruned)
 
 func pruneExpiredMachineEnrollment(ctx context.Context, tx *sql.Tx, machineID string) error {
 	result, err := tx.ExecContext(ctx, `DELETE FROM auth.pending_enrollments
-WHERE machine_id = $1 AND redeemed_at IS NULL AND expires_at <= statement_timestamp()`, machineID)
+WHERE machine_id = $1 AND redeemed_at IS NULL AND invalidated_at IS NULL
+AND expires_at <= statement_timestamp()`, machineID)
 	if err != nil {
 		return errors.New("expired machine enrollment could not be pruned")
 	}

--- a/internal/postgres/device_auth_store.go
+++ b/internal/postgres/device_auth_store.go
@@ -320,6 +320,9 @@ func (a *Administration) CreateEnrollment(ctx context.Context, actorPrincipalID 
 	if err := lockEnrollmentMutations(ctx, tx); err != nil {
 		return PendingEnrollment{}, err
 	}
+	if err := pruneExpiredMachineEnrollment(ctx, tx, request.MachineID); err != nil {
+		return PendingEnrollment{}, err
+	}
 	if err := pruneExpiredEnrollments(ctx, tx, 100); err != nil {
 		return PendingEnrollment{}, err
 	}
@@ -1054,6 +1057,18 @@ func pruneExpiredEnrollments(ctx context.Context, tx *sql.Tx, limit int) error {
 SELECT count(*) FROM deleted_enrollments`, limit).Scan(&pruned)
 	if err != nil {
 		return errors.New("expired enrollments could not be pruned")
+	}
+	return nil
+}
+
+func pruneExpiredMachineEnrollment(ctx context.Context, tx *sql.Tx, machineID string) error {
+	result, err := tx.ExecContext(ctx, `DELETE FROM auth.pending_enrollments
+WHERE machine_id = $1 AND redeemed_at IS NULL AND expires_at <= statement_timestamp()`, machineID)
+	if err != nil {
+		return errors.New("expired machine enrollment could not be pruned")
+	}
+	if count, err := result.RowsAffected(); err != nil || count > 1 {
+		return errors.New("expired machine enrollment prune is inconsistent")
 	}
 	return nil
 }

--- a/internal/postgres/device_auth_store.go
+++ b/internal/postgres/device_auth_store.go
@@ -29,10 +29,11 @@ var (
 )
 
 const (
-	bootstrapLockKey          int64 = 0x50756e61726f4f57
-	enrollmentMutationLockKey int64 = 0x50756e61726f454e
-	maxPendingEnrollments           = 1000
-	lastUsedWriteInterval           = 5 * time.Minute
+	bootstrapLockKey             int64 = 0x50756e61726f4f57
+	enrollmentMutationLockKey    int64 = 0x50756e61726f454e
+	maxPendingEnrollments              = 1000
+	lastUsedWriteInterval              = 5 * time.Minute
+	clientLifecycleSchemaVersion       = 44
 )
 
 // Administration is a direct, host-local schema-owner connection. It is never
@@ -88,6 +89,28 @@ func OpenAdministration(ctx context.Context, cfg Config) (*Administration, error
 // Close releases the host-local owner connection pool.
 func (a *Administration) Close() error { return a.db.Close() }
 
+// ClientLifecycleRuntimeReady rejects compatible historical schemas before a
+// daemon exposes lifecycle-dependent authentication or enrollment routes.
+func (d *Database) ClientLifecycleRuntimeReady(ctx context.Context) error {
+	state, err := d.SchemaState(ctx)
+	if err != nil || state.Classification != Compatible || state.Version < clientLifecycleSchemaVersion {
+		return errors.New("PostgreSQL client lifecycle schema is unavailable")
+	}
+	return nil
+}
+
+func (a *Administration) requireClientLifecycleSchema(ctx context.Context) error {
+	var version int64
+	if err := a.db.QueryRowContext(ctx, `SELECT COALESCE(max(version), 0) FROM jobs.schema_migrations WHERE status = 'applied'`).Scan(&version); err != nil || version < clientLifecycleSchemaVersion {
+		return errors.New("client lifecycle schema is unavailable")
+	}
+	available, err := clientLifecycleObjectsAvailable(ctx, a.db)
+	if err != nil || !available {
+		return errors.New("client lifecycle schema is unavailable")
+	}
+	return nil
+}
+
 // InstallationOwner returns the existing singleton owner for host-local
 // initialization recovery. It exposes no network route and no secret material.
 func (a *Administration) InstallationOwner(ctx context.Context) (Principal, error) {
@@ -130,11 +153,19 @@ type PendingEnrollment struct {
 // DeviceCredential is returned once at redemption/rotation. Encoded is the
 // canonical lookup-id plus caller-retained 256-bit secret.
 type DeviceCredential struct {
-	PrincipalID string    `json:"principal_id"`
-	LookupID    string    `json:"lookup_id"`
-	Encoded     string    `json:"credential"`
-	Generation  int64     `json:"generation"`
-	ExpiresAt   time.Time `json:"expires_at,omitzero"`
+	ClientID       string    `json:"client_id,omitempty"`
+	MachineID      string    `json:"machine_id,omitempty"`
+	EndpointPrefix string    `json:"endpoint_prefix,omitempty"`
+	PrincipalID    string    `json:"principal_id"`
+	LookupID       string    `json:"lookup_id"`
+	Encoded        string    `json:"credential"`
+	Generation     int64     `json:"generation"`
+	ExpiresAt      time.Time `json:"expires_at,omitzero"`
+}
+
+// DeviceRevocation is the fixed content-free result of a successful self-revocation.
+type DeviceRevocation struct {
+	Status string `json:"status"`
 }
 
 // AuthenticatedDevice is the generation fence carried by caches and sessions.
@@ -155,6 +186,22 @@ type DeviceCredentialMetadata struct {
 	ExpiresAt   time.Time `json:"expires_at,omitzero"`
 	RotatedAt   time.Time `json:"rotated_at,omitzero"`
 	RevokedAt   time.Time `json:"revoked_at,omitzero"`
+}
+
+// ClientMetadata is the bounded content-free owner inventory for one installed client.
+type ClientMetadata struct {
+	ClientID           string    `json:"client_id"`
+	MachineID          string    `json:"machine_id"`
+	EndpointPrefix     string    `json:"endpoint_prefix"`
+	PrincipalID        string    `json:"principal_id"`
+	CredentialLookupID string    `json:"credential_lookup_id"`
+	Label              string    `json:"label"`
+	Generation         int64     `json:"generation"`
+	LifecycleState     string    `json:"lifecycle_state"`
+	CreatedAt          time.Time `json:"created_at"`
+	LastUsedAt         time.Time `json:"last_used_at,omitzero"`
+	RevokedAt          time.Time `json:"revoked_at,omitzero"`
+	RevocationReason   string    `json:"revocation_reason,omitempty"`
 }
 
 // RedeemEnrollment binds a one-time code to the exact approved client.
@@ -245,6 +292,9 @@ func (a *Administration) CreateEnrollment(ctx context.Context, actorPrincipalID 
 	if !validOpaqueID(actorPrincipalID) || request.Validate() != nil {
 		return PendingEnrollment{}, errors.New("invalid enrollment")
 	}
+	if err := a.requireClientLifecycleSchema(ctx); err != nil {
+		return PendingEnrollment{}, err
+	}
 	grants, previewHash, err := PreviewTrustedAgentEnrollment(request.ProjectIDs, request.AllProjects)
 	if err != nil || subtle.ConstantTimeCompare([]byte(previewHash), []byte(confirmedPreviewHash)) != 1 {
 		return PendingEnrollment{}, errors.New("enrollment preview was not confirmed")
@@ -281,6 +331,12 @@ func (a *Administration) CreateEnrollment(ctx context.Context, actorPrincipalID 
 	if err := tx.QueryRowContext(ctx, `SELECT EXISTS (SELECT 1 FROM auth.pending_enrollments WHERE client_binding = $1 AND redeemed_at IS NULL AND invalidated_at IS NULL AND expires_at > statement_timestamp())`, request.ClientBinding).Scan(&bindingExists); err != nil || bindingExists {
 		return PendingEnrollment{}, errors.New("client already has a pending enrollment")
 	}
+	var machineExists bool
+	if err := tx.QueryRowContext(ctx, `SELECT
+EXISTS (SELECT 1 FROM auth.client_installations WHERE machine_id = $1)
+OR EXISTS (SELECT 1 FROM auth.pending_enrollments WHERE machine_id = $1 AND redeemed_at IS NULL AND invalidated_at IS NULL AND expires_at > statement_timestamp())`, request.MachineID).Scan(&machineExists); err != nil || machineExists {
+		return PendingEnrollment{}, errors.New("machine already has an enrollment")
+	}
 	projectIDs := append([]string(nil), request.ProjectIDs...)
 	sort.Strings(projectIDs)
 	for _, projectID := range projectIDs {
@@ -302,15 +358,11 @@ func (a *Administration) CreateEnrollment(ctx context.Context, actorPrincipalID 
 			return PendingEnrollment{}, errors.New("legacy machine is not eligible for exchange")
 		}
 	}
-	var credentialTTL any
-	if request.CredentialTTL > 0 {
-		credentialTTL = int64(request.CredentialTTL / time.Second)
-	}
 	if err := tx.QueryRowContext(ctx, `INSERT INTO auth.pending_enrollments
-(issuer_principal_id, client_binding, label, code_digest, preview_hash, expires_at, credential_ttl_seconds, legacy_principal_id)
-VALUES ($1, $2, $3, $4, $5, statement_timestamp() + make_interval(secs => $6),
-$7, $8)
-RETURNING id::text, expires_at`, actorPrincipalID, request.ClientBinding, request.Label, codeDigest[:], previewDigest, int64(request.TTL/time.Second), credentialTTL, nullableID(request.LegacyPrincipalID)).Scan(&pending.ID, &pending.ExpiresAt); err != nil {
+(issuer_principal_id, client_binding, machine_id, label, code_digest, preview_hash, expires_at, credential_ttl_seconds, legacy_principal_id)
+VALUES ($1, $2, $3, $4, $5, $6, statement_timestamp() + make_interval(secs => $7),
+NULL, $8)
+RETURNING id::text, expires_at`, actorPrincipalID, request.ClientBinding, request.MachineID, request.Label, codeDigest[:], previewDigest, int64(request.TTL/time.Second), nullableID(request.LegacyPrincipalID)).Scan(&pending.ID, &pending.ExpiresAt); err != nil {
 		return PendingEnrollment{}, errors.New("pending enrollment could not be created")
 	}
 	for ordinal, grant := range grants {
@@ -365,14 +417,13 @@ func (d *Database) redeemEnrollment(ctx context.Context, redeem RedeemEnrollment
 		return DeviceCredential{}, err
 	}
 	var storedCode []byte
-	var storedBinding, label, issuer string
+	var storedBinding, machineID, label, issuer string
 	var unexpired, active bool
 	var redemptionKey, principalID, lookupID, requiredLegacy sql.NullString
-	var credentialTTL sql.NullInt64
 	err = tx.QueryRowContext(ctx, `SELECT code_digest, client_binding::text, label, issuer_principal_id::text,
 expires_at > statement_timestamp(), invalidated_at IS NULL,
-redemption_key::text, redeemed_principal_id::text, credential_lookup_id::text, credential_ttl_seconds, legacy_principal_id::text
-FROM auth.pending_enrollments WHERE id = $1 FOR UPDATE`, redeem.EnrollmentID).Scan(&storedCode, &storedBinding, &label, &issuer, &unexpired, &active, &redemptionKey, &principalID, &lookupID, &credentialTTL, &requiredLegacy)
+redemption_key::text, redeemed_principal_id::text, credential_lookup_id::text, legacy_principal_id::text, machine_id
+FROM auth.pending_enrollments WHERE id = $1 FOR UPDATE`, redeem.EnrollmentID).Scan(&storedCode, &storedBinding, &label, &issuer, &unexpired, &active, &redemptionKey, &principalID, &lookupID, &requiredLegacy, &machineID)
 	if err != nil || storedBinding != redeem.ClientBinding || subtle.ConstantTimeCompare(storedCode, codeDigest[:]) != 1 || requiredLegacy.Valid != (legacyProof != nil) {
 		return DeviceCredential{}, ErrInvalidEnrollment
 	}
@@ -407,17 +458,20 @@ FROM auth.pending_enrollments WHERE id = $1 FOR UPDATE`, redeem.EnrollmentID).Sc
 		var storedDigest []byte
 		var generation int64
 		var expiresAt sql.NullTime
-		if err := tx.QueryRowContext(ctx, `SELECT credential.secret_digest, credential.generation, credential.expires_at
+		var clientID, installedMachineID, endpointPrefix string
+		if err := tx.QueryRowContext(ctx, `SELECT credential.secret_digest, credential.generation, credential.expires_at,
+client.id::text, client.machine_id, authority.endpoint_prefix
 FROM auth.device_credentials AS credential
 JOIN auth.principals AS principal ON principal.id = credential.principal_id
+JOIN auth.client_installations AS client ON client.credential_lookup_id = credential.lookup_id
+JOIN relay.client_endpoint_authority AS authority ON authority.client_id = client.id
 WHERE credential.lookup_id = $1 AND credential.principal_id = $2
 AND credential.revoked_at IS NULL
-AND credential.rotated_at IS NULL
 AND (credential.expires_at IS NULL OR credential.expires_at > statement_timestamp())
-AND principal.disabled_at IS NULL`, lookupID.String, principalID.String).Scan(&storedDigest, &generation, &expiresAt); err != nil || subtle.ConstantTimeCompare(storedDigest, secretDigest[:]) != 1 {
+AND principal.disabled_at IS NULL AND client.lifecycle_state = 'active'`, lookupID.String, principalID.String).Scan(&storedDigest, &generation, &expiresAt, &clientID, &installedMachineID, &endpointPrefix); err != nil || subtle.ConstantTimeCompare(storedDigest, secretDigest[:]) != 1 {
 			return DeviceCredential{}, ErrInvalidEnrollment
 		}
-		return DeviceCredential{PrincipalID: principalID.String, LookupID: lookupID.String, Encoded: encodeDeviceCredential(lookupID.String, credentialSecret[:]), Generation: generation, ExpiresAt: expiresAt.Time}, nil
+		return DeviceCredential{ClientID: clientID, MachineID: installedMachineID, EndpointPrefix: endpointPrefix, PrincipalID: principalID.String, LookupID: lookupID.String, Encoded: encodeDeviceCredential(lookupID.String, credentialSecret[:]), Generation: generation, ExpiresAt: expiresAt.Time}, nil
 	}
 	projectIDs, allProjects, err := lockPendingEnrollmentGrantTargets(ctx, tx, redeem.EnrollmentID)
 	if err != nil {
@@ -436,11 +490,18 @@ AND principal.disabled_at IS NULL`, lookupID.String, principalID.String).Scan(&s
 		return DeviceCredential{}, errors.New("device principal could not be created")
 	}
 	principalID.Valid = true
-	var credentialExpiresAt sql.NullTime
-	if err := tx.QueryRowContext(ctx, `INSERT INTO auth.device_credentials (lookup_id, principal_id, label, secret_digest, expires_at)
-VALUES ($1, $2, $3, $4, CASE WHEN $5::bigint IS NULL THEN NULL ELSE statement_timestamp() + make_interval(secs => $5) END)
-RETURNING expires_at`, lookup, principalID.String, label, secretDigest[:], nullableInt64(credentialTTL)).Scan(&credentialExpiresAt); err != nil {
+	if _, err := tx.ExecContext(ctx, `INSERT INTO auth.device_credentials (lookup_id, principal_id, label, secret_digest)
+VALUES ($1, $2, $3, $4)`, lookup, principalID.String, label, secretDigest[:]); err != nil {
 		return DeviceCredential{}, errors.New("device credential could not be created")
+	}
+	var clientID string
+	if err := tx.QueryRowContext(ctx, `INSERT INTO auth.client_installations (machine_id, label, principal_id, credential_lookup_id)
+VALUES ($1, $2, $3, $4) RETURNING id::text`, machineID, label, principalID.String, lookup).Scan(&clientID); err != nil {
+		return DeviceCredential{}, errors.New("client installation could not be created")
+	}
+	endpointPrefix := "agent/" + machineID + "/"
+	if _, err := tx.ExecContext(ctx, `INSERT INTO relay.client_endpoint_authority (client_id, endpoint_prefix) VALUES ($1, $2)`, clientID, endpointPrefix); err != nil {
+		return DeviceCredential{}, errors.New("client endpoint authority could not be created")
 	}
 	if _, err := tx.ExecContext(ctx, `INSERT INTO auth.capability_grants (principal_id, scope, project_id, capability)
 SELECT $2, scope, project_id, capability FROM auth.pending_enrollment_grants WHERE enrollment_id = $1 ORDER BY ordinal`, redeem.EnrollmentID, principalID.String); err != nil {
@@ -484,7 +545,7 @@ SELECT $2, scope, project_id, capability FROM auth.pending_enrollment_grants WHE
 	if err := tx.Commit(); err != nil {
 		return DeviceCredential{}, errors.New("enrollment redemption could not commit")
 	}
-	return DeviceCredential{PrincipalID: principalID.String, LookupID: lookup, Encoded: encodedCredential, Generation: 1, ExpiresAt: credentialExpiresAt.Time}, nil
+	return DeviceCredential{ClientID: clientID, MachineID: machineID, EndpointPrefix: endpointPrefix, PrincipalID: principalID.String, LookupID: lookup, Encoded: encodedCredential, Generation: 1}, nil
 }
 
 // AuthenticateDevice validates one bearer credential without distinguishing failure causes.
@@ -499,8 +560,13 @@ func (d *Database) AuthenticateDevice(ctx context.Context, encoded string) (Auth
 	var generation int64
 	var active bool
 	err = d.db.QueryRowContext(ctx, `SELECT credential.secret_digest, credential.principal_id::text, credential.generation,
-credential.revoked_at IS NULL AND (credential.expires_at IS NULL OR credential.expires_at > statement_timestamp()) AND principal.disabled_at IS NULL
-FROM auth.device_credentials AS credential JOIN auth.principals AS principal ON principal.id = credential.principal_id
+credential.revoked_at IS NULL AND (credential.expires_at IS NULL OR credential.expires_at > statement_timestamp())
+AND principal.disabled_at IS NULL AND client.lifecycle_state = 'active'
+AND client.generation = credential.generation AND authority.generation = credential.generation
+FROM auth.device_credentials AS credential
+JOIN auth.principals AS principal ON principal.id = credential.principal_id
+JOIN auth.client_installations AS client ON client.credential_lookup_id = credential.lookup_id
+JOIN relay.client_endpoint_authority AS authority ON authority.client_id = client.id
 WHERE credential.lookup_id = $1`, lookupID).Scan(&stored, &principalID, &generation, &active)
 	if err != nil || !active || subtle.ConstantTimeCompare(stored, digest[:]) != 1 {
 		return AuthenticatedDevice{}, ErrUnauthenticated
@@ -517,13 +583,108 @@ func (d *Database) DeviceSessionCurrent(ctx context.Context, authenticated Authe
 	}
 	var current bool
 	err := d.db.QueryRowContext(ctx, `SELECT EXISTS (
-SELECT 1 FROM auth.device_credentials AS credential JOIN auth.principals AS principal ON principal.id = credential.principal_id
+SELECT 1 FROM auth.device_credentials AS credential
+JOIN auth.principals AS principal ON principal.id = credential.principal_id
+JOIN auth.client_installations AS client ON client.credential_lookup_id = credential.lookup_id
+JOIN relay.client_endpoint_authority AS authority ON authority.client_id = client.id
 WHERE credential.lookup_id = $1 AND credential.principal_id = $2 AND credential.generation = $3
-AND credential.revoked_at IS NULL AND (credential.expires_at IS NULL OR credential.expires_at > statement_timestamp()) AND principal.disabled_at IS NULL)`, authenticated.LookupID, authenticated.PrincipalID, authenticated.Generation).Scan(&current)
+AND credential.revoked_at IS NULL AND (credential.expires_at IS NULL OR credential.expires_at > statement_timestamp())
+AND principal.disabled_at IS NULL AND client.lifecycle_state = 'active'
+AND client.generation = credential.generation AND authority.generation = credential.generation)`, authenticated.LookupID, authenticated.PrincipalID, authenticated.Generation).Scan(&current)
 	if err != nil {
 		return false, errors.New("device session could not be revalidated")
 	}
 	return current, nil
+}
+
+// SelfRevokeDevice permanently revokes only the client authenticated by the
+// supplied bearer credential. An already-revoked credential is accepted only
+// for an exact retry of a self-revocation that previously committed.
+func (d *Database) SelfRevokeDevice(ctx context.Context, encoded, idempotencyKey string) (DeviceRevocation, error) {
+	lookupID, secret, err := parseDeviceCredential(encoded)
+	if err != nil || !validOpaqueID(idempotencyKey) {
+		return DeviceRevocation{}, ErrUnauthenticated
+	}
+	digest := sha256.Sum256(secret)
+	tx, err := beginMutation(ctx, d.db)
+	if err != nil {
+		return DeviceRevocation{}, mutationStartError(err, "self-revocation cannot start")
+	}
+	defer func() { _ = tx.Rollback() }()
+	if err := lockEnrollmentMutations(ctx, tx); err != nil {
+		return DeviceRevocation{}, err
+	}
+	var storedDigest []byte
+	var principalID, clientID, lifecycleState string
+	var credentialRevoked, principalDisabled bool
+	var credentialUnexpired bool
+	var credentialGeneration, clientGeneration, authorityGeneration int64
+	var priorKey sql.NullString
+	err = tx.QueryRowContext(ctx, `SELECT credential.secret_digest, credential.principal_id::text,
+credential.revoked_at IS NOT NULL, principal.disabled_at IS NOT NULL,
+credential.expires_at IS NULL OR credential.expires_at > statement_timestamp(),
+credential.generation, client.generation, authority.generation,
+client.id::text, client.lifecycle_state, client.self_revoke_idempotency::text
+FROM auth.device_credentials AS credential
+JOIN auth.principals AS principal ON principal.id = credential.principal_id
+JOIN auth.client_installations AS client ON client.credential_lookup_id = credential.lookup_id
+JOIN relay.client_endpoint_authority AS authority ON authority.client_id = client.id
+WHERE credential.lookup_id = $1
+FOR UPDATE OF credential, principal, client, authority`, lookupID).Scan(&storedDigest, &principalID, &credentialRevoked, &principalDisabled, &credentialUnexpired, &credentialGeneration, &clientGeneration, &authorityGeneration, &clientID, &lifecycleState, &priorKey)
+	if err != nil || subtle.ConstantTimeCompare(storedDigest, digest[:]) != 1 {
+		return DeviceRevocation{}, ErrUnauthenticated
+	}
+	generationCurrent := credentialGeneration == clientGeneration && clientGeneration == authorityGeneration
+	if credentialRevoked || lifecycleState == "revoked" || principalDisabled {
+		if credentialRevoked && lifecycleState == "revoked" && generationCurrent && priorKey.Valid && priorKey.String == idempotencyKey {
+			if err := tx.Commit(); err != nil {
+				return DeviceRevocation{}, errors.New("self-revocation replay cannot commit")
+			}
+			return DeviceRevocation{Status: "revoked"}, nil
+		}
+		return DeviceRevocation{}, ErrUnauthenticated
+	}
+	if !credentialUnexpired || !generationCurrent {
+		return DeviceRevocation{}, ErrUnauthenticated
+	}
+	result, err := tx.ExecContext(ctx, `UPDATE auth.device_credentials
+SET revoked_at = statement_timestamp(), generation = generation + 1
+WHERE lookup_id = $1 AND revoked_at IS NULL`, lookupID)
+	if err != nil {
+		return DeviceRevocation{}, errors.New("credential could not be self-revoked")
+	}
+	if count, err := result.RowsAffected(); err != nil || count != 1 {
+		return DeviceRevocation{}, ErrUnauthenticated
+	}
+	if _, err := tx.ExecContext(ctx, `UPDATE auth.principals SET auth_generation = auth_generation + 1 WHERE id = $1`, principalID); err != nil {
+		return DeviceRevocation{}, errors.New("self-revocation principal fence could not be advanced")
+	}
+	result, err = tx.ExecContext(ctx, `UPDATE auth.client_installations
+SET lifecycle_state = 'revoked', revoked_at = statement_timestamp(), revocation_reason = 'self',
+    self_revoke_idempotency = $2, generation = generation + 1
+WHERE id = $1 AND lifecycle_state = 'active'`, clientID, idempotencyKey)
+	if err != nil {
+		return DeviceRevocation{}, errors.New("client could not be self-revoked")
+	}
+	if count, err := result.RowsAffected(); err != nil || count != 1 {
+		return DeviceRevocation{}, ErrUnauthenticated
+	}
+	if update, err := tx.ExecContext(ctx, `UPDATE relay.client_endpoint_authority SET generation = generation + 1 WHERE client_id = $1`, clientID); err != nil {
+		return DeviceRevocation{}, errors.New("self-revocation endpoint fence could not be advanced")
+	} else if count, countErr := update.RowsAffected(); countErr != nil || count != 1 {
+		return DeviceRevocation{}, errors.New("self-revocation endpoint authority is unavailable")
+	}
+	control := &ControlTx{tx: tx}
+	if err := control.AppendAudit(ctx, AuditEvent{PrincipalID: principalID, Action: AuditCredentialRevoke, Outcome: AuditSucceeded, TargetKind: AuditTargetCredential, TargetID: lookupID}); err != nil {
+		return DeviceRevocation{}, err
+	}
+	if _, err := control.AdvanceChange(ctx); err != nil {
+		return DeviceRevocation{}, err
+	}
+	if err := tx.Commit(); err != nil {
+		return DeviceRevocation{}, errors.New("self-revocation could not commit")
+	}
+	return DeviceRevocation{Status: "revoked"}, nil
 }
 
 // BeginDeviceCredentialRotation creates or replaces a pending rotation while
@@ -531,6 +692,9 @@ AND credential.revoked_at IS NULL AND (credential.expires_at IS NULL OR credenti
 func (a *Administration) BeginDeviceCredentialRotation(ctx context.Context, actorPrincipalID, lookupID string, expectedGeneration int64) (PendingCredentialRotation, error) {
 	if !validOpaqueID(actorPrincipalID) || !validOpaqueID(lookupID) || expectedGeneration < 1 {
 		return PendingCredentialRotation{}, errors.New("invalid credential rotation")
+	}
+	if err := a.requireClientLifecycleSchema(ctx); err != nil {
+		return PendingCredentialRotation{}, err
 	}
 	codeBytes := make([]byte, 32)
 	if _, err := rand.Read(codeBytes); err != nil {
@@ -574,6 +738,9 @@ func (a *Administration) RotateDeviceCredential(ctx context.Context, actorPrinci
 	if err != nil || len(codeBytes) != 32 || base64.RawURLEncoding.EncodeToString(codeBytes) != rotate.Code {
 		return DeviceCredential{}, errors.New("invalid credential rotation")
 	}
+	if err := a.requireClientLifecycleSchema(ctx); err != nil {
+		return DeviceCredential{}, err
+	}
 	codeDigest := sha256.Sum256(codeBytes)
 	secret := deriveRotationCredentialSecret(rotate, codeBytes)
 	digest := sha256.Sum256(secret[:])
@@ -585,6 +752,9 @@ func (a *Administration) RotateDeviceCredential(ctx context.Context, actorPrinci
 	if ok, err := lockInstallationOwner(ctx, tx, actorPrincipalID); err != nil || !ok {
 		return DeviceCredential{}, ErrForbidden
 	}
+	if err := lockEnrollmentMutations(ctx, tx); err != nil {
+		return DeviceCredential{}, err
+	}
 	var result DeviceCredential
 	result.LookupID = rotate.LookupID
 	var expiry sql.NullTime
@@ -594,9 +764,15 @@ func (a *Administration) RotateDeviceCredential(ctx context.Context, actorPrinci
 	var rotationUsable bool
 	var completed bool
 	var revoked bool
-	err = tx.QueryRowContext(ctx, `SELECT principal_id::text, generation, rotation_code_digest, rotation_expected_generation,
-COALESCE(rotation_expires_at > statement_timestamp(), false), rotation_completed_at IS NOT NULL, revoked_at IS NOT NULL, expires_at
-FROM auth.device_credentials WHERE lookup_id = $1 FOR UPDATE`, rotate.LookupID).Scan(&result.PrincipalID, &currentGeneration, &storedCode, &storedExpected, &rotationUsable, &completed, &revoked, &expiry)
+	var clientGeneration, authorityGeneration int64
+	err = tx.QueryRowContext(ctx, `SELECT credential.principal_id::text, credential.generation, credential.rotation_code_digest, credential.rotation_expected_generation,
+COALESCE(rotation_expires_at > statement_timestamp(), false), rotation_completed_at IS NOT NULL, credential.revoked_at IS NOT NULL, credential.expires_at,
+client.id::text, client.machine_id, authority.endpoint_prefix, client.generation, authority.generation
+FROM auth.device_credentials AS credential
+JOIN auth.client_installations AS client ON client.credential_lookup_id = credential.lookup_id
+JOIN relay.client_endpoint_authority AS authority ON authority.client_id = client.id
+WHERE credential.lookup_id = $1 AND client.lifecycle_state = 'active'
+FOR UPDATE OF credential, client, authority`, rotate.LookupID).Scan(&result.PrincipalID, &currentGeneration, &storedCode, &storedExpected, &rotationUsable, &completed, &revoked, &expiry, &result.ClientID, &result.MachineID, &result.EndpointPrefix, &clientGeneration, &authorityGeneration)
 	if errors.Is(err, sql.ErrNoRows) {
 		return DeviceCredential{}, ErrNotFound
 	}
@@ -604,7 +780,7 @@ FROM auth.device_credentials WHERE lookup_id = $1 FOR UPDATE`, rotate.LookupID).
 		return DeviceCredential{}, errors.New("credential could not be locked")
 	}
 	result.ExpiresAt = expiry.Time
-	if revoked || !storedExpected.Valid || storedExpected.Int64 != rotate.ExpectedGeneration || subtle.ConstantTimeCompare(storedCode, codeDigest[:]) != 1 {
+	if revoked || clientGeneration != currentGeneration || authorityGeneration != currentGeneration || !storedExpected.Valid || storedExpected.Int64 != rotate.ExpectedGeneration || subtle.ConstantTimeCompare(storedCode, codeDigest[:]) != 1 {
 		return DeviceCredential{}, ErrCredentialChanged
 	}
 	if !rotationUsable {
@@ -635,6 +811,16 @@ RETURNING generation`, rotate.LookupID, digest[:], rotate.ExpectedGeneration).Sc
 	if _, err := tx.ExecContext(ctx, `UPDATE auth.principals SET auth_generation = auth_generation + 1 WHERE id = $1`, result.PrincipalID); err != nil {
 		return DeviceCredential{}, errors.New("credential fence could not be advanced")
 	}
+	if update, err := tx.ExecContext(ctx, `UPDATE auth.client_installations SET generation = $2 WHERE id = $1 AND generation = $3 AND lifecycle_state = 'active'`, result.ClientID, result.Generation, rotate.ExpectedGeneration); err != nil {
+		return DeviceCredential{}, errors.New("client fence could not be advanced")
+	} else if count, countErr := update.RowsAffected(); countErr != nil || count != 1 {
+		return DeviceCredential{}, ErrCredentialChanged
+	}
+	if update, err := tx.ExecContext(ctx, `UPDATE relay.client_endpoint_authority SET generation = $2 WHERE client_id = $1 AND generation = $3`, result.ClientID, result.Generation, rotate.ExpectedGeneration); err != nil {
+		return DeviceCredential{}, errors.New("client endpoint fence could not be advanced")
+	} else if count, countErr := update.RowsAffected(); countErr != nil || count != 1 {
+		return DeviceCredential{}, ErrCredentialChanged
+	}
 	control := &ControlTx{tx: tx}
 	if err := control.AppendAudit(ctx, AuditEvent{PrincipalID: actorPrincipalID, Action: AuditCredentialRotate, Outcome: AuditSucceeded, TargetKind: AuditTargetCredential, TargetID: rotate.LookupID}); err != nil {
 		return DeviceCredential{}, err
@@ -653,37 +839,18 @@ func (a *Administration) RevokeDeviceCredential(ctx context.Context, actorPrinci
 	if !validOpaqueID(actorPrincipalID) || !validOpaqueID(lookupID) {
 		return errors.New("invalid credential revocation")
 	}
-	tx, err := beginMutation(ctx, a.db)
-	if err != nil {
-		return mutationStartError(err, "credential revocation cannot start")
+	if err := a.requireClientLifecycleSchema(ctx); err != nil {
+		return err
 	}
-	defer func() { _ = tx.Rollback() }()
-	if ok, err := lockInstallationOwner(ctx, tx, actorPrincipalID); err != nil || !ok {
-		return ErrForbidden
-	}
-	var principalID string
-	err = tx.QueryRowContext(ctx, `UPDATE auth.device_credentials SET revoked_at = statement_timestamp(), generation = generation + 1
-WHERE lookup_id = $1 AND revoked_at IS NULL RETURNING principal_id::text`, lookupID).Scan(&principalID)
+	var clientID string
+	err := a.db.QueryRowContext(ctx, `SELECT id::text FROM auth.client_installations WHERE credential_lookup_id = $1`, lookupID).Scan(&clientID)
 	if errors.Is(err, sql.ErrNoRows) {
 		return ErrNotFound
 	}
 	if err != nil {
-		return errors.New("credential could not be revoked")
+		return errors.New("credential client could not be resolved")
 	}
-	if _, err := tx.ExecContext(ctx, `UPDATE auth.principals SET auth_generation = auth_generation + 1 WHERE id = $1`, principalID); err != nil {
-		return errors.New("credential fence could not be advanced")
-	}
-	control := &ControlTx{tx: tx}
-	if err := control.AppendAudit(ctx, AuditEvent{PrincipalID: actorPrincipalID, Action: AuditCredentialRevoke, Outcome: AuditSucceeded, TargetKind: AuditTargetCredential, TargetID: lookupID}); err != nil {
-		return err
-	}
-	if _, err := control.AdvanceChange(ctx); err != nil {
-		return err
-	}
-	if err := tx.Commit(); err != nil {
-		return errors.New("credential revocation could not commit")
-	}
-	return nil
+	return a.RevokeClient(ctx, actorPrincipalID, clientID, "replaced")
 }
 
 // ListDeviceCredentials returns bounded metadata without secrets or digests.
@@ -722,6 +889,129 @@ FROM auth.device_credentials ORDER BY created_at, lookup_id LIMIT $1`, limit)
 		return nil, errors.New("credential inventory cannot commit")
 	}
 	return credentials, nil
+}
+
+// ListClients returns bounded server-authoritative client inventory without
+// endpoint discovery, credential digests, or other content.
+func (a *Administration) ListClients(ctx context.Context, actorPrincipalID string, limit int) ([]ClientMetadata, error) {
+	if !validOpaqueID(actorPrincipalID) || limit < 1 || limit > 1000 {
+		return nil, errors.New("invalid client inventory request")
+	}
+	if err := a.requireClientLifecycleSchema(ctx); err != nil {
+		return nil, err
+	}
+	tx, err := a.db.BeginTx(ctx, &sql.TxOptions{Isolation: sql.LevelRepeatableRead})
+	if err != nil {
+		return nil, errors.New("client inventory cannot start")
+	}
+	defer func() { _ = tx.Rollback() }()
+	if ok, err := lockInstallationOwner(ctx, tx, actorPrincipalID); err != nil || !ok {
+		return nil, ErrForbidden
+	}
+	rows, err := tx.QueryContext(ctx, `SELECT client.id::text, client.machine_id, authority.endpoint_prefix,
+client.principal_id::text, client.credential_lookup_id::text, client.label, client.generation,
+client.lifecycle_state, client.created_at, credential.last_used_at, client.revoked_at, client.revocation_reason
+FROM auth.client_installations AS client
+JOIN relay.client_endpoint_authority AS authority ON authority.client_id = client.id
+JOIN auth.device_credentials AS credential ON credential.lookup_id = client.credential_lookup_id
+ORDER BY client.created_at, client.id LIMIT $1`, limit)
+	if err != nil {
+		return nil, errors.New("client inventory is unavailable")
+	}
+	defer func() { _ = rows.Close() }()
+	var clients []ClientMetadata
+	for rows.Next() {
+		var item ClientMetadata
+		var lastUsed, revoked sql.NullTime
+		var reason sql.NullString
+		if err := rows.Scan(&item.ClientID, &item.MachineID, &item.EndpointPrefix, &item.PrincipalID, &item.CredentialLookupID, &item.Label, &item.Generation, &item.LifecycleState, &item.CreatedAt, &lastUsed, &revoked, &reason); err != nil {
+			return nil, errors.New("client inventory is malformed")
+		}
+		item.LastUsedAt, item.RevokedAt, item.RevocationReason = lastUsed.Time, revoked.Time, reason.String
+		clients = append(clients, item)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, errors.New("client inventory is unavailable")
+	}
+	if err := tx.Commit(); err != nil {
+		return nil, errors.New("client inventory cannot commit")
+	}
+	return clients, nil
+}
+
+// RevokeClient permanently revokes one exact client and all of its current
+// authority. Repeating an already-committed owner revocation is a no-op.
+func (a *Administration) RevokeClient(ctx context.Context, actorPrincipalID, clientID, reason string) error {
+	if !validOpaqueID(actorPrincipalID) || !validOpaqueID(clientID) || !validOwnerRevocationReason(reason) {
+		return errors.New("invalid client revocation")
+	}
+	if err := a.requireClientLifecycleSchema(ctx); err != nil {
+		return err
+	}
+	tx, err := beginMutation(ctx, a.db)
+	if err != nil {
+		return mutationStartError(err, "client revocation cannot start")
+	}
+	defer func() { _ = tx.Rollback() }()
+	if ok, err := lockInstallationOwner(ctx, tx, actorPrincipalID); err != nil || !ok {
+		return ErrForbidden
+	}
+	if err := lockEnrollmentMutations(ctx, tx); err != nil {
+		return err
+	}
+	var principalID, lookupID, state string
+	err = tx.QueryRowContext(ctx, `SELECT principal_id::text, credential_lookup_id::text, lifecycle_state
+FROM auth.client_installations WHERE id = $1 FOR UPDATE`, clientID).Scan(&principalID, &lookupID, &state)
+	if errors.Is(err, sql.ErrNoRows) {
+		return ErrNotFound
+	}
+	if err != nil {
+		return errors.New("client could not be locked")
+	}
+	if state == "revoked" {
+		if err := tx.Commit(); err != nil {
+			return errors.New("client revocation replay cannot commit")
+		}
+		return nil
+	}
+	if update, err := tx.ExecContext(ctx, `UPDATE auth.device_credentials
+SET revoked_at = COALESCE(revoked_at, statement_timestamp()), generation = generation + CASE WHEN revoked_at IS NULL THEN 1 ELSE 0 END
+WHERE lookup_id = $1`, lookupID); err != nil {
+		return errors.New("client credential could not be revoked")
+	} else if count, countErr := update.RowsAffected(); countErr != nil || count != 1 {
+		return errors.New("client credential is unavailable")
+	}
+	if _, err := tx.ExecContext(ctx, `UPDATE auth.principals SET auth_generation = auth_generation + 1 WHERE id = $1`, principalID); err != nil {
+		return errors.New("client principal fence could not be advanced")
+	}
+	if update, err := tx.ExecContext(ctx, `UPDATE auth.client_installations
+SET lifecycle_state = 'revoked', revoked_at = statement_timestamp(), revocation_reason = $2,
+    self_revoke_idempotency = NULL, generation = generation + 1
+WHERE id = $1 AND lifecycle_state = 'active'`, clientID, reason); err != nil {
+		return errors.New("client could not be revoked")
+	} else if count, countErr := update.RowsAffected(); countErr != nil || count != 1 {
+		return errors.New("client state changed during revocation")
+	}
+	if update, err := tx.ExecContext(ctx, `UPDATE relay.client_endpoint_authority SET generation = generation + 1 WHERE client_id = $1`, clientID); err != nil {
+		return errors.New("client endpoint fence could not be advanced")
+	} else if count, countErr := update.RowsAffected(); countErr != nil || count != 1 {
+		return errors.New("client endpoint authority is unavailable")
+	}
+	control := &ControlTx{tx: tx}
+	if err := control.AppendAudit(ctx, AuditEvent{PrincipalID: actorPrincipalID, Action: AuditCredentialRevoke, Outcome: AuditSucceeded, TargetKind: AuditTargetCredential, TargetID: lookupID}); err != nil {
+		return err
+	}
+	if _, err := control.AdvanceChange(ctx); err != nil {
+		return err
+	}
+	if err := tx.Commit(); err != nil {
+		return errors.New("client revocation could not commit")
+	}
+	return nil
+}
+
+func validOwnerRevocationReason(reason string) bool {
+	return reason == "lost" || reason == "retired" || reason == "compromised" || reason == "replaced"
 }
 
 func lockInstallationOwner(ctx context.Context, tx *sql.Tx, principalID string) (bool, error) {
@@ -777,13 +1067,6 @@ func lockEnrollmentMutations(ctx context.Context, tx *sql.Tx) error {
 
 func encodeDeviceCredential(lookupID string, secret []byte) string {
 	return lookupID + "." + base64.RawURLEncoding.EncodeToString(secret)
-}
-
-func nullableInt64(value sql.NullInt64) any {
-	if value.Valid {
-		return value.Int64
-	}
-	return nil
 }
 
 func legacyExchangeTranscript(redeem RedeemEnrollment, codeDigest [sha256.Size]byte) []byte {

--- a/internal/postgres/device_auth_test.go
+++ b/internal/postgres/device_auth_test.go
@@ -70,16 +70,18 @@ func TestDeviceCredentialEncodingHasOpaqueLookupAnd256BitSecret(t *testing.T) {
 }
 
 func TestEnrollmentAndCredentialBounds(t *testing.T) {
-	valid := EnrollmentRequest{ClientBinding: testPrincipalB, Label: "laptop", ProjectIDs: []string{testProjectA}, TTL: 10 * time.Minute}
+	valid := EnrollmentRequest{ClientBinding: testPrincipalB, MachineID: "laptop-a", Label: "laptop", ProjectIDs: []string{testProjectA}, TTL: 10 * time.Minute}
 	if err := valid.Validate(); err != nil {
 		t.Fatal(err)
 	}
 	for name, request := range map[string]EnrollmentRequest{
-		"binding": {ClientBinding: "laptop", Label: valid.Label, ProjectIDs: valid.ProjectIDs, TTL: valid.TTL},
-		"label":   {ClientBinding: valid.ClientBinding, Label: "", ProjectIDs: valid.ProjectIDs, TTL: valid.TTL},
-		"ttl":     {ClientBinding: valid.ClientBinding, Label: valid.Label, ProjectIDs: valid.ProjectIDs, TTL: 25 * time.Hour},
+		"binding":    {ClientBinding: "laptop", MachineID: valid.MachineID, Label: valid.Label, ProjectIDs: valid.ProjectIDs, TTL: valid.TTL},
+		"machine":    {ClientBinding: valid.ClientBinding, MachineID: "", Label: valid.Label, ProjectIDs: valid.ProjectIDs, TTL: valid.TTL},
+		"label":      {ClientBinding: valid.ClientBinding, MachineID: valid.MachineID, Label: "", ProjectIDs: valid.ProjectIDs, TTL: valid.TTL},
+		"ttl":        {ClientBinding: valid.ClientBinding, MachineID: valid.MachineID, Label: valid.Label, ProjectIDs: valid.ProjectIDs, TTL: 25 * time.Hour},
+		"credential": {ClientBinding: valid.ClientBinding, MachineID: valid.MachineID, Label: valid.Label, ProjectIDs: valid.ProjectIDs, TTL: valid.TTL, CredentialTTL: time.Hour},
 		"projects": {ClientBinding: valid.ClientBinding, Label: valid.Label,
-			ProjectIDs: append(make([]string, maxEnrollmentProjects), testProjectA), TTL: valid.TTL},
+			MachineID: valid.MachineID, ProjectIDs: append(make([]string, maxEnrollmentProjects), testProjectA), TTL: valid.TTL},
 	} {
 		t.Run(name, func(t *testing.T) {
 			if err := request.Validate(); err == nil {

--- a/internal/postgres/migrate.go
+++ b/internal/postgres/migrate.go
@@ -76,6 +76,7 @@ var migrationCompatibilityFloors = map[int64]int64{
 	41: 10,
 	42: 10,
 	43: 10,
+	44: 10,
 }
 
 // CurrentManifest returns the immutable migrations embedded in this binary.

--- a/internal/postgres/migrations/044_client_lifecycle.sql
+++ b/internal/postgres/migrations/044_client_lifecycle.sql
@@ -31,7 +31,7 @@ CREATE TABLE auth.client_installations (
     created_at timestamptz NOT NULL DEFAULT statement_timestamp(),
     revoked_at timestamptz,
     revocation_reason text CHECK (revocation_reason IN ('lost', 'retired', 'compromised', 'replaced', 'self')),
-    self_revoke_idempotency uuid UNIQUE,
+    self_revoke_idempotency uuid,
     CHECK (
         (lifecycle_state = 'active' AND revoked_at IS NULL AND revocation_reason IS NULL AND self_revoke_idempotency IS NULL)
         OR
@@ -47,6 +47,17 @@ CREATE TABLE relay.client_endpoint_authority (
     generation bigint NOT NULL DEFAULT 1 CHECK (generation >= 1),
     created_at timestamptz NOT NULL DEFAULT statement_timestamp()
 );
+
+WITH expired_credentials AS (
+    UPDATE auth.device_credentials
+    SET revoked_at = statement_timestamp(), generation = generation + 1
+    WHERE revoked_at IS NULL AND expires_at <= statement_timestamp()
+    RETURNING principal_id
+)
+UPDATE auth.principals AS principal
+SET auth_generation = auth_generation + 1
+FROM expired_credentials AS expired
+WHERE principal.id = expired.principal_id;
 
 INSERT INTO auth.client_installations
 (machine_id, label, principal_id, credential_lookup_id, generation, lifecycle_state, created_at, revoked_at, revocation_reason)

--- a/internal/postgres/migrations/044_client_lifecycle.sql
+++ b/internal/postgres/migrations/044_client_lifecycle.sql
@@ -1,0 +1,88 @@
+ALTER TABLE auth.pending_enrollments
+ADD COLUMN machine_id text;
+
+UPDATE auth.pending_enrollments
+SET invalidated_at = COALESCE(invalidated_at, statement_timestamp())
+WHERE redeemed_at IS NULL;
+
+ALTER TABLE auth.pending_enrollments
+ADD CONSTRAINT pending_enrollments_machine_id_check CHECK (
+    machine_id IS NULL OR machine_id ~ '^[a-z0-9]([a-z0-9._-]{0,62}[a-z0-9])?$'
+);
+
+CREATE UNIQUE INDEX pending_enrollments_active_machine
+ON auth.pending_enrollments (machine_id)
+WHERE redeemed_at IS NULL AND invalidated_at IS NULL;
+
+CREATE TABLE auth.client_installations (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    machine_id text NOT NULL UNIQUE CHECK (
+        machine_id ~ '^[a-z0-9]([a-z0-9._-]{0,62}[a-z0-9])?$'
+    ),
+    label text NOT NULL CHECK (
+        char_length(label) BETWEEN 1 AND 128
+        AND octet_length(label) <= 512
+        AND label !~ '[[:cntrl:]]'
+    ),
+    principal_id uuid NOT NULL UNIQUE REFERENCES auth.principals(id),
+    credential_lookup_id uuid NOT NULL UNIQUE REFERENCES auth.device_credentials(lookup_id),
+    generation bigint NOT NULL DEFAULT 1 CHECK (generation >= 1),
+    lifecycle_state text NOT NULL DEFAULT 'active' CHECK (lifecycle_state IN ('active', 'revoked')),
+    created_at timestamptz NOT NULL DEFAULT statement_timestamp(),
+    revoked_at timestamptz,
+    revocation_reason text CHECK (revocation_reason IN ('lost', 'retired', 'compromised', 'replaced', 'self')),
+    self_revoke_idempotency uuid UNIQUE,
+    CHECK (
+        (lifecycle_state = 'active' AND revoked_at IS NULL AND revocation_reason IS NULL AND self_revoke_idempotency IS NULL)
+        OR
+        (lifecycle_state = 'revoked' AND revoked_at IS NOT NULL AND revocation_reason IS NOT NULL)
+    )
+);
+
+CREATE TABLE relay.client_endpoint_authority (
+    client_id uuid PRIMARY KEY REFERENCES auth.client_installations(id),
+    endpoint_prefix text NOT NULL UNIQUE CHECK (
+        endpoint_prefix ~ '^agent/[a-z0-9]([a-z0-9._-]{0,62}[a-z0-9])?/$'
+    ),
+    generation bigint NOT NULL DEFAULT 1 CHECK (generation >= 1),
+    created_at timestamptz NOT NULL DEFAULT statement_timestamp()
+);
+
+INSERT INTO auth.client_installations
+(machine_id, label, principal_id, credential_lookup_id, generation, lifecycle_state, created_at, revoked_at, revocation_reason)
+SELECT 'device-' || credential.lookup_id::text,
+       credential.label,
+       credential.principal_id,
+       credential.lookup_id,
+       credential.generation,
+       CASE WHEN credential.revoked_at IS NULL THEN 'active' ELSE 'revoked' END,
+       credential.created_at,
+       credential.revoked_at,
+       CASE WHEN credential.revoked_at IS NULL THEN NULL ELSE 'replaced' END
+FROM auth.device_credentials AS credential;
+
+INSERT INTO relay.client_endpoint_authority (client_id, endpoint_prefix, generation, created_at)
+SELECT client.id, 'agent/' || client.machine_id || '/', client.generation, client.created_at
+FROM auth.client_installations AS client;
+
+UPDATE auth.pending_enrollments AS enrollment
+SET machine_id = client.machine_id
+FROM auth.client_installations AS client
+WHERE enrollment.credential_lookup_id = client.credential_lookup_id;
+
+UPDATE auth.device_credentials
+SET expires_at = NULL
+WHERE revoked_at IS NULL;
+
+GRANT SELECT ON auth.client_installations TO punaro_app;
+GRANT INSERT (machine_id, label, principal_id, credential_lookup_id) ON auth.client_installations TO punaro_app;
+GRANT UPDATE (generation, lifecycle_state, revoked_at, revocation_reason, self_revoke_idempotency) ON auth.client_installations TO punaro_app;
+REVOKE DELETE, TRUNCATE, REFERENCES, TRIGGER ON auth.client_installations FROM punaro_app;
+
+GRANT SELECT ON relay.client_endpoint_authority TO punaro_app;
+GRANT INSERT (client_id, endpoint_prefix) ON relay.client_endpoint_authority TO punaro_app;
+GRANT UPDATE (generation) ON relay.client_endpoint_authority TO punaro_app;
+REVOKE DELETE, TRUNCATE, REFERENCES, TRIGGER ON relay.client_endpoint_authority FROM punaro_app;
+
+GRANT UPDATE (generation, revoked_at) ON auth.device_credentials TO punaro_app;
+REVOKE INSERT (expires_at) ON auth.device_credentials FROM punaro_app;

--- a/internal/postgres/postgres_integration_test.go
+++ b/internal/postgres/postgres_integration_test.go
@@ -808,6 +808,26 @@ func testClientLifecycleSchemaDriftIntegration(ctx context.Context, t *testing.T
 	if _, err := ownerDB.ExecContext(ctx, `REVOKE UPDATE (machine_id) ON auth.client_installations FROM punaro_app`); err != nil {
 		t.Fatal(err)
 	}
+	if _, err := ownerDB.ExecContext(ctx, `DROP INDEX auth.pending_enrollments_active_machine`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ownerDB.ExecContext(ctx, `CREATE UNIQUE INDEX pending_enrollments_active_machine ON auth.pending_enrollments (id) WHERE redeemed_at IS NULL AND invalidated_at IS NULL`); err != nil {
+		t.Fatal(err)
+	}
+	assertDrift("wrong pending machine index key")
+	if _, err := ownerDB.ExecContext(ctx, `DROP INDEX auth.pending_enrollments_active_machine`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ownerDB.ExecContext(ctx, `CREATE UNIQUE INDEX pending_enrollments_active_machine ON auth.pending_enrollments ((lower(machine_id))) WHERE redeemed_at IS NULL AND invalidated_at IS NULL`); err != nil {
+		t.Fatal(err)
+	}
+	assertDrift("expression pending machine index")
+	if _, err := ownerDB.ExecContext(ctx, `DROP INDEX auth.pending_enrollments_active_machine`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ownerDB.ExecContext(ctx, `CREATE UNIQUE INDEX pending_enrollments_active_machine ON auth.pending_enrollments (machine_id) WHERE redeemed_at IS NULL AND invalidated_at IS NULL`); err != nil {
+		t.Fatal(err)
+	}
 	if _, err := ownerDB.ExecContext(ctx, `ALTER TABLE auth.client_installations DROP CONSTRAINT client_installations_generation_check`); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/postgres/postgres_integration_test.go
+++ b/internal/postgres/postgres_integration_test.go
@@ -789,23 +789,41 @@ AS $function$ BEGIN RETURN NEW; END $function$`); err != nil {
 
 func testClientLifecycleSchemaDriftIntegration(ctx context.Context, t *testing.T, app *Database, ownerDB *sql.DB) {
 	t.Helper()
+	assertDrift := func(detail string) {
+		t.Helper()
+		if drifted, err := app.SchemaState(ctx); err != nil || drifted.Classification != Incompatible {
+			t.Fatalf("%s state=%#v err=%v", detail, drifted, err)
+		}
+		if err := app.ClientLifecycleRuntimeReady(ctx); err == nil {
+			t.Fatalf("client lifecycle runtime accepted %s", detail)
+		}
+	}
 	if err := app.ClientLifecycleRuntimeReady(ctx); err != nil {
 		t.Fatalf("current client lifecycle runtime is unavailable: %v", err)
 	}
 	if _, err := ownerDB.ExecContext(ctx, `GRANT UPDATE (machine_id) ON auth.client_installations TO punaro_app`); err != nil {
 		t.Fatal(err)
 	}
-	if drifted, err := app.SchemaState(ctx); err != nil || drifted.Classification != Incompatible {
-		t.Fatalf("permissive client lifecycle grant state=%#v err=%v", drifted, err)
-	}
-	if err := app.ClientLifecycleRuntimeReady(ctx); err == nil {
-		t.Fatal("client lifecycle runtime accepted schema drift")
-	}
+	assertDrift("permissive client lifecycle grant")
 	if _, err := ownerDB.ExecContext(ctx, `REVOKE UPDATE (machine_id) ON auth.client_installations FROM punaro_app`); err != nil {
 		t.Fatal(err)
 	}
+	if _, err := ownerDB.ExecContext(ctx, `ALTER TABLE auth.client_installations DROP CONSTRAINT client_installations_generation_check`); err != nil {
+		t.Fatal(err)
+	}
+	assertDrift("missing client generation constraint")
+	if _, err := ownerDB.ExecContext(ctx, `ALTER TABLE auth.client_installations ADD CONSTRAINT client_installations_generation_check CHECK (generation >= 1)`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ownerDB.ExecContext(ctx, `ALTER TABLE relay.client_endpoint_authority ALTER COLUMN endpoint_prefix DROP NOT NULL`); err != nil {
+		t.Fatal(err)
+	}
+	assertDrift("nullable endpoint prefix")
+	if _, err := ownerDB.ExecContext(ctx, `ALTER TABLE relay.client_endpoint_authority ALTER COLUMN endpoint_prefix SET NOT NULL`); err != nil {
+		t.Fatal(err)
+	}
 	if err := app.Ready(ctx); err != nil {
-		t.Fatalf("client lifecycle grant restoration did not recover readiness: %v", err)
+		t.Fatalf("client lifecycle schema restoration did not recover readiness: %v", err)
 	}
 	if err := app.ClientLifecycleRuntimeReady(ctx); err != nil {
 		t.Fatalf("client lifecycle runtime did not recover readiness: %v", err)

--- a/internal/postgres/postgres_integration_test.go
+++ b/internal/postgres/postgres_integration_test.go
@@ -77,6 +77,18 @@ func TestPostgresPlatformSubstrateIntegration(t *testing.T) {
 		t.Fatal(err)
 	}
 	testV33ConsolidationSourcesUpgradeIntegration(ctx, t, pairOwnerDSN)
+	pairDB, err = open(ctx, pairOwnerDSN)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := pairDB.ExecContext(ctx, `DROP SCHEMA auth, relay, attachment, brain, jobs, audit CASCADE; REVOKE CONNECT ON DATABASE punaro_pair FROM punaro_app; REVOKE CONNECT ON DATABASE punaro_other FROM punaro_app`); err != nil {
+		_ = pairDB.Close()
+		t.Fatalf("auxiliary pair cleanup after v33 upgrade test failed: %v", err)
+	}
+	if err := pairDB.Close(); err != nil {
+		t.Fatal(err)
+	}
+	testV43ClientLifecycleUpgradeIntegration(ctx, t, pairOwnerDSN)
 
 	app, err := OpenApplication(ctx, Config{DSNFile: appFile})
 	if err != nil {
@@ -926,6 +938,76 @@ func testV33ConsolidationSourcesUpgradeIntegration(ctx context.Context, t *testi
 	var checkpointSequence int64
 	if err := ownerDB.QueryRowContext(ctx, `SELECT timeline_id::text,change_sequence FROM brain.memory_consolidation_checkpoints WHERE scope_id=$1`, scopeID).Scan(&checkpointTimeline, &checkpointSequence); err != nil || checkpointTimeline != rootTimeline || checkpointTimeline == restoredTimeline || checkpointSequence != 0 {
 		t.Fatalf("v33 restored checkpoint rebase timeline=%q sequence=%d root=%q restored=%q err=%v", checkpointTimeline, checkpointSequence, rootTimeline, restoredTimeline, err)
+	}
+}
+
+func testV43ClientLifecycleUpgradeIntegration(ctx context.Context, t *testing.T, ownerDSN string) {
+	t.Helper()
+	ownerDB, err := open(ctx, ownerDSN)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = ownerDB.Close() }()
+	current := CurrentManifest()
+	v43 := Manifest{MinSupported: 10, MaxSupported: 43, Migrations: append([]Migration(nil), current.Migrations[:43]...)}
+	if state, err := migrate(ctx, ownerDB, v43); err != nil || state.Classification != Compatible || state.Version != 43 {
+		t.Fatalf("v43 client lifecycle setup state=%#v err=%v", state, err)
+	}
+	expiredLookup, currentLookup := uuid.NewString(), uuid.NewString()
+	expiredSecret := sha256.Sum256([]byte("expired-v43-credential"))
+	currentSecret := sha256.Sum256([]byte("current-v43-credential"))
+	expiredDigest := sha256.Sum256(expiredSecret[:])
+	currentDigest := sha256.Sum256(currentSecret[:])
+	var expiredPrincipal, currentPrincipal string
+	if err := ownerDB.QueryRowContext(ctx, `INSERT INTO auth.principals(kind, display_name) VALUES ('device', 'expired v43 device') RETURNING id::text`).Scan(&expiredPrincipal); err != nil {
+		t.Fatal(err)
+	}
+	if err := ownerDB.QueryRowContext(ctx, `INSERT INTO auth.principals(kind, display_name) VALUES ('device', 'current v43 device') RETURNING id::text`).Scan(&currentPrincipal); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ownerDB.ExecContext(ctx, `INSERT INTO auth.device_credentials
+(lookup_id, principal_id, label, secret_digest, created_at, expires_at)
+VALUES ($1, $2, 'expired v43 device', $3, statement_timestamp() - interval '2 hours', statement_timestamp() - interval '1 hour'),
+       ($4, $5, 'current v43 device', $6, statement_timestamp() - interval '1 hour', statement_timestamp() + interval '1 hour')`,
+		expiredLookup, expiredPrincipal, expiredDigest[:], currentLookup, currentPrincipal, currentDigest[:]); err != nil {
+		t.Fatal(err)
+	}
+	conn := mustConn(ctx, t, ownerDB)
+	defer func() { _ = conn.Close() }()
+	if state, err := migrateConnExpectedAppRole(ctx, conn, current, "punaro_app", true); err != nil || state.Classification != Compatible || state.Version != current.MaxSupported {
+		t.Fatalf("v43 client lifecycle bridge state=%#v err=%v", state, err)
+	}
+	var credentialRevoked, expiryRetained, clientRevoked bool
+	var credentialGeneration, principalGeneration int64
+	var lifecycleState string
+	if err := ownerDB.QueryRowContext(ctx, `SELECT credential.revoked_at IS NOT NULL, credential.expires_at IS NOT NULL,
+credential.generation, principal.auth_generation, client.lifecycle_state, client.revoked_at IS NOT NULL
+FROM auth.device_credentials AS credential
+JOIN auth.principals AS principal ON principal.id = credential.principal_id
+JOIN auth.client_installations AS client ON client.credential_lookup_id = credential.lookup_id
+WHERE credential.lookup_id = $1`, expiredLookup).Scan(&credentialRevoked, &expiryRetained, &credentialGeneration, &principalGeneration, &lifecycleState, &clientRevoked); err != nil {
+		t.Fatal(err)
+	}
+	if !credentialRevoked || !expiryRetained || credentialGeneration != 2 || principalGeneration != 1 || lifecycleState != "revoked" || !clientRevoked {
+		t.Fatalf("expired v43 credential was not permanently fenced revoked=%t expiry_retained=%t credential_generation=%d principal_generation=%d lifecycle=%q client_revoked=%t", credentialRevoked, expiryRetained, credentialGeneration, principalGeneration, lifecycleState, clientRevoked)
+	}
+	var credentialCurrent, expiryCleared, clientActive bool
+	if err := ownerDB.QueryRowContext(ctx, `SELECT credential.revoked_at IS NULL, credential.expires_at IS NULL,
+client.lifecycle_state = 'active'
+FROM auth.device_credentials AS credential
+JOIN auth.client_installations AS client ON client.credential_lookup_id = credential.lookup_id
+WHERE credential.lookup_id = $1`, currentLookup).Scan(&credentialCurrent, &expiryCleared, &clientActive); err != nil {
+		t.Fatal(err)
+	}
+	if !credentialCurrent || !expiryCleared || !clientActive {
+		t.Fatalf("current v43 credential conversion current=%t expiry_cleared=%t client_active=%t", credentialCurrent, expiryCleared, clientActive)
+	}
+	database := &Database{db: ownerDB}
+	if _, err := database.AuthenticateDevice(ctx, encodeDeviceCredential(expiredLookup, expiredSecret[:])); !errors.Is(err, ErrUnauthenticated) {
+		t.Fatalf("expired v43 credential was reactivated: %v", err)
+	}
+	if _, err := database.AuthenticateDevice(ctx, encodeDeviceCredential(currentLookup, currentSecret[:])); err != nil {
+		t.Fatalf("current v43 credential did not survive migration: %v", err)
 	}
 }
 

--- a/internal/postgres/postgres_integration_test.go
+++ b/internal/postgres/postgres_integration_test.go
@@ -452,6 +452,7 @@ RETURNS boolean LANGUAGE plpgsql SECURITY DEFINER SET search_path=pg_catalog AS 
 		t.Fatal("application role opened host-local administration")
 	}
 	testDeviceAuthIntegration(ctx, t, app, ownerDB)
+	testClientLifecycleSchemaDriftIntegration(ctx, t, app, ownerDB)
 	testTrustedAttachmentIntegration(ctx, t, app, ownerDB)
 	testProjectIdentityIntegration(ctx, t, app, ownerDB)
 	testCanonicalBrainSchemaDriftIntegration(ctx, t, app, ownerDB)
@@ -771,6 +772,31 @@ AS $function$ BEGIN RETURN NEW; END $function$`); err != nil {
 	var trackerExists bool
 	if err := ownerDB.QueryRowContext(ctx, `SELECT to_regclass('jobs.schema_migrations') IS NOT NULL`).Scan(&trackerExists); err != nil || trackerExists {
 		t.Fatalf("missing-role refusal mutated schema: tracker_exists=%t err=%v", trackerExists, err)
+	}
+}
+
+func testClientLifecycleSchemaDriftIntegration(ctx context.Context, t *testing.T, app *Database, ownerDB *sql.DB) {
+	t.Helper()
+	if err := app.ClientLifecycleRuntimeReady(ctx); err != nil {
+		t.Fatalf("current client lifecycle runtime is unavailable: %v", err)
+	}
+	if _, err := ownerDB.ExecContext(ctx, `GRANT UPDATE (machine_id) ON auth.client_installations TO punaro_app`); err != nil {
+		t.Fatal(err)
+	}
+	if drifted, err := app.SchemaState(ctx); err != nil || drifted.Classification != Incompatible {
+		t.Fatalf("permissive client lifecycle grant state=%#v err=%v", drifted, err)
+	}
+	if err := app.ClientLifecycleRuntimeReady(ctx); err == nil {
+		t.Fatal("client lifecycle runtime accepted schema drift")
+	}
+	if _, err := ownerDB.ExecContext(ctx, `REVOKE UPDATE (machine_id) ON auth.client_installations FROM punaro_app`); err != nil {
+		t.Fatal(err)
+	}
+	if err := app.Ready(ctx); err != nil {
+		t.Fatalf("client lifecycle grant restoration did not recover readiness: %v", err)
+	}
+	if err := app.ClientLifecycleRuntimeReady(ctx); err != nil {
+		t.Fatalf("client lifecycle runtime did not recover readiness: %v", err)
 	}
 }
 

--- a/internal/postgres/project_identity_integration_test.go
+++ b/internal/postgres/project_identity_integration_test.go
@@ -533,7 +533,7 @@ FROM generate_series(1, 101) AS value`, actor.ID, reenrollmentBinding); err != n
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, err := (&Administration{db: ownerDB}).CreateEnrollment(ctx, ownerPrincipalID, EnrollmentRequest{ClientBinding: reenrollmentBinding, Label: "replacement enrollment", AllProjects: true, TTL: time.Minute}, reenrollmentHash); err != nil {
+	if _, err := (&Administration{db: ownerDB}).CreateEnrollment(ctx, ownerPrincipalID, EnrollmentRequest{ClientBinding: reenrollmentBinding, MachineID: "replacement-enrollment", Label: "replacement enrollment", AllProjects: true, TTL: time.Minute}, reenrollmentHash); err != nil {
 		t.Fatalf("invalidated binding blocked replacement after bounded prune: %v", err)
 	}
 	if _, err := app.AttachProjectIdentity(ctx, ProjectIdentityAttachRequest{ActorPrincipalID: actor.ID, ProjectID: source.ProjectID, IdempotencyKey: "88888888-8888-4888-8888-888888888888", Kind: ProjectIdentityOperatorAlias, Locator: "stale source"}); !errors.Is(err, ErrMergedProject) {

--- a/internal/postgres/state_test.go
+++ b/internal/postgres/state_test.go
@@ -69,8 +69,8 @@ func TestManifestValidationRejectsMutableOrNonContiguousHistory(t *testing.T) {
 
 func TestCurrentManifestRequiresControlPlaneSchema(t *testing.T) {
 	manifest := CurrentManifest()
-	if manifest.MinSupported != 10 || manifest.MaxSupported != 43 || len(manifest.Migrations) != 43 {
-		t.Fatalf("manifest=%#v, want exact v43 compatibility window", manifest)
+	if manifest.MinSupported != 10 || manifest.MaxSupported != 44 || len(manifest.Migrations) != 44 {
+		t.Fatalf("manifest=%#v, want exact v44 compatibility window", manifest)
 	}
 	embedding := manifest.Migrations[23]
 	if embedding.Version != 24 || embedding.Name != "024_memory_embedding_worker_control" ||
@@ -88,7 +88,7 @@ func TestCurrentManifestRequiresControlPlaneSchema(t *testing.T) {
 			want = 10
 		case 12, 13:
 			want = 10
-		case 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43:
+		case 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44:
 			want = 10
 		}
 		if migration.CompatibilityFloor != want {
@@ -210,7 +210,10 @@ func TestCompatibleSchemaCanStillHavePendingMigrations(t *testing.T) {
 	if !migrationPending(SchemaState{Classification: Compatible, Version: 42}, manifest) {
 		t.Fatal("compatible v42 schema must still apply the pending v43 migration")
 	}
-	if migrationPending(SchemaState{Classification: Compatible, Version: 43}, manifest) {
-		t.Fatal("current v43 schema reported a pending migration")
+	if !migrationPending(SchemaState{Classification: Compatible, Version: 43}, manifest) {
+		t.Fatal("compatible v43 schema must still apply the pending v44 migration")
+	}
+	if migrationPending(SchemaState{Classification: Compatible, Version: 44}, manifest) {
+		t.Fatal("current v44 schema reported a pending migration")
 	}
 }


### PR DESCRIPTION
## Summary

- add schema 44 server-authoritative client installations and derived endpoint namespaces
- add host-owner client inventory/revocation plus exact self-revocation with generation fencing and retry safety
- require the lifecycle schema before exposing device ingress and document the wider compatibility/update/recovery design

## Migration impact

- active device credentials become non-expiring and are imported as client installations
- unredeemed pre-schema-44 enrollment invitations are invalidated
- new invitations require a machine ID

## Validation

- make test
- make test-race
- make staticcheck
- make security
- make lint
- make test-postgres
- git diff --check