### PR TITLE
Refresh JWKS before verifier expiry

### DIFF
--- a/deploy/systemd/punaro-jwks-refresh.timer
+++ b/deploy/systemd/punaro-jwks-refresh.timer
@@ -1,9 +1,10 @@
 [Unit]
-Description=Refresh Punaro's Cloudflare Access JWKS snapshot every five minutes
+Description=Refresh Punaro's Cloudflare Access JWKS snapshot before expiry
 
 [Timer]
 OnBootSec=15s
-OnUnitActiveSec=5m
+OnUnitActiveSec=4m
+AccuracySec=10s
 Persistent=true
 Unit=punaro-jwks-refresh.service
 

--- a/scripts/test-install-server.sh
+++ b/scripts/test-install-server.sh
@@ -27,6 +27,8 @@ grep -Fqx 'PUNARO_ACCESS_AUDIENCE=punaro-relay' "$stage/etc/punaro/punaro.env"
 grep -Fqx 'PUNARO_ACCESS_JWKS_FILE=/etc/punaro/jwks/current.json' "$stage/etc/punaro/punaro.env"
 [ -f "$stage/etc/systemd/system/punaro-jwks-refresh.service" ] || { printf '%s\n' 'JWKS refresh service was not installed' >&2; exit 1; }
 [ -f "$stage/etc/systemd/system/punaro-jwks-refresh.timer" ] || { printf '%s\n' 'JWKS refresh timer was not installed' >&2; exit 1; }
+grep -Fqx 'OnUnitActiveSec=4m' "$stage/etc/systemd/system/punaro-jwks-refresh.timer"
+grep -Fqx 'AccuracySec=10s' "$stage/etc/systemd/system/punaro-jwks-refresh.timer"
 [ -x "$stage/usr/local/libexec/punaro/refresh-jwks" ] || { printf '%s\n' 'JWKS refresh helper was not installed' >&2; exit 1; }
 [ -f "$stage/etc/punaro/jwks-refresh.env" ] || { printf '%s\n' 'JWKS refresh environment was not installed' >&2; exit 1; }
 grep -Fqx 'PUNARO_ACCESS_JWKS_URL=https://team.cloudflareaccess.example/cdn-cgi/access/certs' "$stage/etc/punaro/jwks-refresh.env"


### PR DESCRIPTION
## What changed

- refresh the Cloudflare Access JWKS snapshot every four minutes instead of five
- bound systemd timer scheduling accuracy to ten seconds
- assert both timer settings in the server installer test

## Why

Punaro's verifier accepts the local JWKS snapshot for at most five minutes. The old timer also ran every five minutes, and systemd's default scheduling accuracy could delay it past that boundary. That produced a brief recurring 403 window for the Telegram gateway and maintained adapter.

## Impact

The relay refreshes its authentication material with headroom before verifier expiry, removing the periodic authorization gap without changing credentials or message routing.

## Validation

- `make test`
- `make test-race`
- `make staticcheck`
- `make security`
- `make lint`
- focused installer test demonstrated failure before the timer change and passed afterward
- deployed timer passed `systemd-analyze verify` and refreshed successfully across repeated live cycles
