### PR TITLE
Fix Developer ID import on macos-14

### DIFF
--- a/.github/workflows/macos-notarize.yml
+++ b/.github/workflows/macos-notarize.yml
@@ -26,6 +26,8 @@ jobs:
         env:
           MACOS_DEVELOPER_ID_APPLICATION_P12: ${{ secrets.MACOS_DEVELOPER_ID_APPLICATION_P12 }}
           MACOS_DEVELOPER_ID_APPLICATION_P12_PASSWORD: ${{ secrets.MACOS_DEVELOPER_ID_APPLICATION_P12_PASSWORD }}
+          MACOS_DEVELOPER_ID_APPLICATION_CER: ${{ secrets.MACOS_DEVELOPER_ID_APPLICATION_CER }}
+          MACOS_DEVELOPER_ID_APPLICATION_KEY: ${{ secrets.MACOS_DEVELOPER_ID_APPLICATION_KEY }}
           MACOS_KEYCHAIN_PATH: ${{ runner.temp }}/punaro-signing.keychain-db
           MACOS_KEYCHAIN_PASSWORD: ${{ github.run_id }}-${{ github.run_attempt }}
         run: ./scripts/import-macos-signing-cert.sh

--- a/scripts/import-macos-signing-cert.sh
+++ b/scripts/import-macos-signing-cert.sh
@@ -1,6 +1,10 @@
 #!/bin/sh
-# Import the Developer ID Application PKCS#12 into a throwaway keychain.
+# Import the Developer ID Application identity into a throwaway keychain.
 # Never prints certificate bytes or passwords.
+#
+# GitHub-hosted macOS rejects many modern PKCS#12 encodings as "Unknown format".
+# Rebuild a 3DES/SHA1 bag that security(1) will accept, from either the stored
+# p12 or the stored cer+key pair.
 set -eu
 
 fail() {
@@ -13,19 +17,71 @@ fail() {
 [ -n "${MACOS_KEYCHAIN_PATH:-}" ] || fail 'MACOS_KEYCHAIN_PATH is required'
 [ -n "${MACOS_KEYCHAIN_PASSWORD:-}" ] || fail 'MACOS_KEYCHAIN_PASSWORD is required'
 
-p12=$(mktemp)
-cleanup() { rm -f -- "$p12"; }
+work=$(mktemp -d "${TMPDIR:-/tmp}/punaro-signing-import.XXXXXXXX")
+cleanup() { rm -rf -- "$work"; }
 trap cleanup EXIT HUP INT TERM
 
-printf '%s' "$MACOS_DEVELOPER_ID_APPLICATION_P12" | python3 -c 'import base64,sys; sys.stdout.buffer.write(base64.standard_b64decode(sys.stdin.read()))' >"$p12"
-[ -s "$p12" ] || fail 'Developer ID PKCS#12 decoded to an empty file'
+decode_b64() {
+	python3 -c 'import base64,sys; sys.stdout.buffer.write(base64.standard_b64decode(sys.stdin.read()))'
+}
+
+printf '%s' "$MACOS_DEVELOPER_ID_APPLICATION_P12" | decode_b64 >"$work/source.p12"
+[ -s "$work/source.p12" ] || fail 'Developer ID PKCS#12 decoded to an empty file'
+file -b "$work/source.p12" >/dev/null
+
+export MACOS_DEVELOPER_ID_APPLICATION_P12_PASSWORD
+export MACOS_KEYCHAIN_PASSWORD
+
+# Prefer rebuilding from cer+key when present: that avoids an unreadable p12 bag.
+if [ -n "${MACOS_DEVELOPER_ID_APPLICATION_CER:-}" ] && [ -n "${MACOS_DEVELOPER_ID_APPLICATION_KEY:-}" ]; then
+	printf '%s' "$MACOS_DEVELOPER_ID_APPLICATION_CER" | decode_b64 >"$work/cert.bin"
+	printf '%s' "$MACOS_DEVELOPER_ID_APPLICATION_KEY" | decode_b64 >"$work/key.bin"
+	if grep -q -- '-----BEGIN' "$work/cert.bin"; then
+		cp "$work/cert.bin" "$work/cert.pem"
+	else
+		openssl x509 -inform DER -in "$work/cert.bin" -out "$work/cert.pem"
+	fi
+	if grep -q -- '-----BEGIN' "$work/key.bin"; then
+		cp "$work/key.bin" "$work/key.pem"
+	else
+		openssl pkcs8 -inform DER -in "$work/key.bin" -nocrypt -out "$work/key.pem" 2>/dev/null ||
+			openssl rsa -inform DER -in "$work/key.bin" -out "$work/key.pem"
+	fi
+	openssl pkcs12 -export \
+		-inkey "$work/key.pem" \
+		-in "$work/cert.pem" \
+		-out "$work/import.p12" \
+		-passout env:MACOS_KEYCHAIN_PASSWORD \
+		-keypbe PBE-SHA1-3DES \
+		-certpbe PBE-SHA1-3DES
+	import_pass=$MACOS_KEYCHAIN_PASSWORD
+else
+	# Convert the stored p12 into a bag security(1) accepts.
+	if ! openssl pkcs12 -in "$work/source.p12" -passin env:MACOS_DEVELOPER_ID_APPLICATION_P12_PASSWORD -nodes -out "$work/bundle.pem" 2>"$work/openssl.err"; then
+		fail 'could not read the stored Developer ID PKCS#12'
+	fi
+	openssl pkcs12 -export \
+		-in "$work/bundle.pem" \
+		-out "$work/import.p12" \
+		-passout env:MACOS_KEYCHAIN_PASSWORD \
+		-keypbe PBE-SHA1-3DES \
+		-certpbe PBE-SHA1-3DES
+	import_pass=$MACOS_KEYCHAIN_PASSWORD
+fi
 
 security create-keychain -p "$MACOS_KEYCHAIN_PASSWORD" "$MACOS_KEYCHAIN_PATH"
 security set-keychain-settings -lut 21600 "$MACOS_KEYCHAIN_PATH"
 security unlock-keychain -p "$MACOS_KEYCHAIN_PASSWORD" "$MACOS_KEYCHAIN_PATH"
-security import "$p12" -k "$MACOS_KEYCHAIN_PATH" -P "$MACOS_DEVELOPER_ID_APPLICATION_P12_PASSWORD" -T /usr/bin/codesign -T /usr/bin/security
+security import "$work/import.p12" -k "$MACOS_KEYCHAIN_PATH" -P "$import_pass" -T /usr/bin/codesign -T /usr/bin/security
 security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$MACOS_KEYCHAIN_PASSWORD" "$MACOS_KEYCHAIN_PATH" >/dev/null
-security list-keychains -d user -s "$MACOS_KEYCHAIN_PATH" $(security list-keychains -d user | sed 's/"//g')
+
+# Developer ID Application G2 intermediate, required for a valid identity chain.
+curl -fsS https://www.apple.com/certificateauthority/DeveloperIDG2CA.cer -o "$work/DeveloperIDG2CA.cer"
+security import "$work/DeveloperIDG2CA.cer" -k "$MACOS_KEYCHAIN_PATH" -T /usr/bin/codesign >/dev/null || true
+
+user_keychains=$(security list-keychains -d user | tr -d '"')
+# shellcheck disable=SC2086
+security list-keychains -d user -s "$MACOS_KEYCHAIN_PATH" $user_keychains
 
 if ! security find-identity -v -p codesigning "$MACOS_KEYCHAIN_PATH" | grep -Fq 'Developer ID Application:'; then
 	fail 'imported keychain has no Developer ID Application identity'


### PR DESCRIPTION
## Summary
- The first `macos-notarize` run failed at `security import` with `Unknown format in import`.
- Rebuild the stored p12 (or cer+key) into a 3DES bag that macOS `security` accepts, and import Apple's Developer ID G2 intermediate.

## Testing
- [x] `./scripts/test-sign-notarize-macos.sh`
- [ ] Live `macos-notarize` run on this branch: https://github.com/rock3r/punaro/actions/runs/31965884882

## Risks
- Import still depends on the 1Password-sourced cert/key material already stored as repo secrets.