### PR TITLE
Add punaro-bootstrap signed GitHub Releases pull

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1498,7 +1498,9 @@ The implementation is not internet-exposure-ready until these cases pass:
 - Client updates pull signed artifacts from the fixed GitHub Releases origin
   `https://github.com/rock3r/punaro/releases/download`. The gateway names a
   signed release; it never supplies a URL, command, or unsigned `latest`
-  pointer. `punaro-bootstrap` is not implemented yet.
+  pointer. `punaro-bootstrap update` verifies catalog/manifest signatures and
+  exact artifact digests, then publishes `current`/`previous` slots.
+  `punaro-bootstrap run`, health, and enrollment are not implemented yet.
 - PostgreSQL is the sole authoritative server database after cutover; SQLite is
   retained for client recovery, migration evidence, and parity tests only.
 - HTTP fetch/ack is authoritative; WebSocket carries topic ID and sequence only.

--- a/cmd/punaro-bootstrap/main.go
+++ b/cmd/punaro-bootstrap/main.go
@@ -1,0 +1,124 @@
+// punaro-bootstrap installs signed Punaro artifacts from GitHub Releases.
+// It verifies catalog and manifest signatures and exact artifact digests.
+package main
+
+import (
+	"crypto/ed25519"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/rock3r/punaro/internal/bootstrap"
+	punarorelease "github.com/rock3r/punaro/internal/release"
+)
+
+func main() {
+	if err := run(os.Args[1:]); err != nil {
+		fmt.Fprintln(os.Stderr, err.Error())
+		os.Exit(2)
+	}
+}
+
+func run(args []string) error {
+	if len(args) == 0 {
+		return errors.New("usage: punaro-bootstrap update|status|rollback")
+	}
+	switch args[0] {
+	case "update":
+		return runUpdate(args[1:])
+	case "status":
+		return runStatus(args[1:])
+	case "rollback":
+		return runRollback(args[1:])
+	default:
+		return errors.New("usage: punaro-bootstrap update|status|rollback")
+	}
+}
+
+func runUpdate(args []string) error {
+	flags := flag.NewFlagSet("punaro-bootstrap update", flag.ContinueOnError)
+	flags.SetOutput(io.Discard)
+	directory := flags.String("directory", "", "absolute private bootstrap directory")
+	keysFile := flags.String("keys-file", "", "release public key set")
+	origin := flags.String("origin", punarorelease.GitHubReleaseOrigin, "fixed HTTPS release origin")
+	releaseName := flags.String("release", "", "catalog-listed release to install")
+	if err := flags.Parse(args); err != nil {
+		return errors.New("bootstrap update is invalid")
+	}
+	if flags.NArg() != 0 || *directory == "" || *keysFile == "" {
+		return errors.New("bootstrap update is invalid")
+	}
+	keys, err := loadKeys(*keysFile)
+	if err != nil {
+		return err
+	}
+	result, err := bootstrap.Update(bootstrap.Request{
+		Directory: *directory,
+		Origin:    strings.TrimSpace(*origin),
+		Keys:      keys,
+		Release:   *releaseName,
+	})
+	if err != nil {
+		return err
+	}
+	fmt.Printf("installed %s sequence %d\n", result.Release, result.Sequence)
+	return nil
+}
+
+func runStatus(args []string) error {
+	flags := flag.NewFlagSet("punaro-bootstrap status", flag.ContinueOnError)
+	flags.SetOutput(io.Discard)
+	directory := flags.String("directory", "", "absolute private bootstrap directory")
+	if err := flags.Parse(args); err != nil {
+		return errors.New("bootstrap status is invalid")
+	}
+	if flags.NArg() != 0 || *directory == "" {
+		return errors.New("bootstrap status is invalid")
+	}
+	state, err := bootstrap.Status(*directory)
+	if err != nil {
+		return err
+	}
+	if state.Current == "" {
+		fmt.Println("current none")
+		return nil
+	}
+	fmt.Printf("current %s sequence %d\n", state.Current, state.CurrentSequence)
+	if state.Previous != "" {
+		fmt.Printf("previous %s sequence %d\n", state.Previous, state.PreviousSequence)
+	}
+	return nil
+}
+
+func runRollback(args []string) error {
+	flags := flag.NewFlagSet("punaro-bootstrap rollback", flag.ContinueOnError)
+	flags.SetOutput(io.Discard)
+	directory := flags.String("directory", "", "absolute private bootstrap directory")
+	if err := flags.Parse(args); err != nil {
+		return errors.New("bootstrap rollback is invalid")
+	}
+	if flags.NArg() != 0 || *directory == "" {
+		return errors.New("bootstrap rollback is invalid")
+	}
+	result, err := bootstrap.Rollback(*directory)
+	if err != nil {
+		return err
+	}
+	fmt.Printf("rolled back to %s sequence %d\n", result.Release, result.Sequence)
+	return nil
+}
+
+func loadKeys(path string) (map[string]ed25519.PublicKey, error) {
+	if !filepath.IsAbs(path) {
+		return nil, errors.New("bootstrap keys file is invalid")
+	}
+	body, err := os.ReadFile(path) // #nosec G304 -- operator-selected public key set.
+	if err != nil {
+		return nil, errors.New("bootstrap keys file is invalid")
+	}
+	return punarorelease.ParsePublicKeys(body)
+}

--- a/cmd/punaro-bootstrap/main_test.go
+++ b/cmd/punaro-bootstrap/main_test.go
@@ -1,0 +1,137 @@
+package main
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	punarorelease "github.com/rock3r/punaro/internal/release"
+)
+
+func TestBootstrapCLIRequiresAbsoluteDirectoryAndKeys(t *testing.T) {
+	if err := run(nil); err == nil {
+		t.Fatal("empty args accepted")
+	}
+	if err := run([]string{"update"}); err == nil {
+		t.Fatal("update without flags accepted")
+	}
+	if err := run([]string{"status", "--directory", "relative-state"}); err == nil {
+		t.Fatal("relative status directory accepted")
+	}
+	if err := run([]string{"rollback", "--directory", "relative-state"}); err == nil {
+		t.Fatal("relative rollback directory accepted")
+	}
+	dir := t.TempDir()
+	abs := filepath.Join(dir, "state")
+	if err := os.Mkdir(abs, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := run([]string{"status", "--directory", abs}); err != nil {
+		t.Fatal(err)
+	}
+	if err := run([]string{"update", "--directory", abs, "--keys-file", "keys.json"}); err == nil {
+		t.Fatal("relative keys file accepted")
+	}
+}
+
+func TestBootstrapCLIUpdateInstallsSignedRelease(t *testing.T) {
+	dir := t.TempDir()
+	state := filepath.Join(dir, "state")
+	if err := os.Mkdir(state, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	origin, keysPath := newCLIOrigin(t, dir)
+	if err := run([]string{"update", "--directory", state, "--keys-file", keysPath, "--origin", origin}); err != nil {
+		t.Fatal(err)
+	}
+	if err := run([]string{"status", "--directory", state}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func newCLIOrigin(t *testing.T, dir string) (string, string) {
+	t.Helper()
+	build := filepath.Join(dir, "build")
+	if err := os.Mkdir(build, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	name := "punaro-adapter-" + runtime.GOOS + "-" + runtime.GOARCH
+	if runtime.GOOS == "windows" {
+		name += ".exe"
+	}
+	if err := os.WriteFile(filepath.Join(build, name), []byte("cli-adapter"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	assembled, err := punarorelease.Assemble(punarorelease.AssembleRequest{
+		Directory:               build,
+		Release:                 "v0.1.0",
+		Sequence:                1,
+		PublishedAt:             time.Date(2026, 8, 16, 12, 0, 0, 0, time.UTC),
+		ExpiresAt:               time.Date(2026, 8, 23, 12, 0, 0, 0, time.UTC),
+		MinimumSafeSequence:     1,
+		CatalogSequence:         1,
+		ComposeSHA256:           strings.Repeat("a", 64),
+		MigrationManifestSHA256: strings.Repeat("b", 64),
+		Database:                punarorelease.SchemaRange{Min: 10, Max: 44, Target: 44, RollbackFloor: 10},
+		PostgreSQLMajor:         18,
+		GatewayProtocol:         punarorelease.ProtocolRange{Min: 1, Max: 1},
+		ClientProtocol:          punarorelease.ProtocolRange{Min: 1, Max: 1},
+		MinimumRecoveryProtocol: 1,
+		MinimumBootstrapRelease: "v0.1.0",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	catalogSig, err := punarorelease.Sign(assembled.CatalogJSON, "punaro-release-1", priv)
+	if err != nil {
+		t.Fatal(err)
+	}
+	catalogSigJSON, err := punarorelease.EncodeEnvelope(catalogSig)
+	if err != nil {
+		t.Fatal(err)
+	}
+	manifestSig, err := punarorelease.Sign(assembled.ManifestJSON, "punaro-release-1", priv)
+	if err != nil {
+		t.Fatal(err)
+	}
+	manifestSigJSON, err := punarorelease.EncodeEnvelope(manifestSig)
+	if err != nil {
+		t.Fatal(err)
+	}
+	files := map[string][]byte{
+		punarorelease.CatalogReleaseName + "/" + punarorelease.CatalogFile:          assembled.CatalogJSON,
+		punarorelease.CatalogReleaseName + "/" + punarorelease.CatalogSignatureFile: catalogSigJSON,
+		"v0.1.0/" + punarorelease.ReleaseManifestFile:                               assembled.ManifestJSON,
+		"v0.1.0/" + punarorelease.ReleaseSignatureFile:                              manifestSigJSON,
+		"v0.1.0/" + name: []byte("cli-adapter"),
+	}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, ok := files[strings.TrimPrefix(r.URL.Path, "/")]
+		if !ok {
+			http.NotFound(w, r)
+			return
+		}
+		_, _ = w.Write(body)
+	}))
+	t.Cleanup(server.Close)
+	keys, err := punarorelease.EncodePublicKeys("punaro-release-1", pub)
+	if err != nil {
+		t.Fatal(err)
+	}
+	keysPath := filepath.Join(dir, "release.pub")
+	if err := os.WriteFile(keysPath, keys, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return server.URL, keysPath
+}

--- a/docs/github-releases.md
+++ b/docs/github-releases.md
@@ -1,12 +1,12 @@
 # GitHub Releases origin
 
 Punaro's public artifact origin is GitHub Releases. This is the fixed source
-`punaro-bootstrap` will pull from. The gateway may name a signed release; it
+`punaro-bootstrap` pulls from. The gateway may name a signed release; it
 never supplies a download URL, installer script, or unsigned `latest` pointer.
 
 This is the release-trust slice of
 [`client-lifecycle-compatibility-recovery-rfc.md`](client-lifecycle-compatibility-recovery-rfc.md).
-It is not yet a signed official release and does not implement bootstrap,
+It is not yet a signed official release and does not implement `run`/health,
 fleet rollout, or the recovery HTTP surface.
 
 ## Fixed origin
@@ -51,9 +51,9 @@ gh workflow run macos-notarize.yml --repo rock3r/punaro --ref <branch>
 
 The `release` workflow dispatch builds:
 
-- `punaro-adapter`, `punaro-trusted-attachment`, `punaro-memory`, and
-  `punaro-enroll` for `darwin/arm64`, `linux/amd64`, `linux/arm64`, and
-  `windows/amd64`
+- `punaro-adapter`, `punaro-trusted-attachment`, `punaro-memory`,
+  `punaro-enroll`, and `punaro-bootstrap` for `darwin/arm64`, `linux/amd64`,
+  `linux/arm64`, and `windows/amd64`
 - `punaro` and `punaro-telegram` for Linux
 
 Darwin adapter builds use `CGO_ENABLED=1` so the supported ACL path is compiled
@@ -105,8 +105,9 @@ the origin path stays stable. Replacing it does not make the catalog trusted.
    ```
 
 6. Upload the two `.sig` files to the versioned release and
-   `punaro-catalog.sig` to the `catalog` prerelease. Commit the public key set
-   into the bootstrap when that binary exists.
+   `punaro-catalog.sig` to the `catalog` prerelease. Pass that public key set
+   to `punaro-bootstrap update --keys-file`. Do not embed a production key
+   until the first official signed release exists.
 7. An official maintained release still requires the
    [security release gates](security-release-gates.md) and a
    [release-evidence record](release-evidence/README.md). This origin does not
@@ -128,9 +129,29 @@ go run ./cmd/punaro-release validate --dir ./dist
 manifest. A digest-pinned gateway image is optional until GHCR publication
 exists; when present it must be `@sha256:` and `release_sha256` must match.
 
+## Bootstrap pull
+
+`punaro-bootstrap` fetches only two-component paths beneath the fixed origin,
+verifies the catalog and manifest signatures, checks exact length/digest, and
+publishes `current` / `previous` slots. It does not run children, enroll, or
+open PostgreSQL. HTTPS is required except for loopback test origins.
+
+```sh
+punaro-bootstrap update \
+  --directory /absolute/private/bootstrap \
+  --keys-file /absolute/punaro-release.pub
+punaro-bootstrap status --directory /absolute/private/bootstrap
+punaro-bootstrap rollback --directory /absolute/private/bootstrap
+```
+
+`--release` may name a catalog-listed release. Automatic update refuses a
+stale catalog, an unsigned or digest-mismatched document, a sequence
+downgrade, a critical block, and a path outside the origin. Rollback swaps
+the two published slots and does not lower the highest accepted sequences.
+
 ## Still outstanding
 
-- `punaro-bootstrap` download, slot, health, and rollback
+- `punaro-bootstrap run`, candidate health, and platform service handoff
 - embedding the production public key in that bootstrap
 - GHCR image publication and a required `image` digest
 - SBOM, provenance attestations, and offline recovery bundles

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -11,9 +11,9 @@ installers:
 
 The scripts build from the source checkout you run them from. Use a reviewed,
 pinned checkout or a verified release artifact; do not pipe a network download
-into a shell. The future `punaro-bootstrap` pull origin is GitHub Releases,
-documented in [github-releases.md](github-releases.md). Until that bootstrap
-exists and a catalog/manifest pair is signed, install from a reviewed checkout. Neither installer accepts or prints secret values. For the
+into a shell. `punaro-bootstrap` pulls from GitHub Releases, documented in
+[github-releases.md](github-releases.md). Until a catalog/manifest pair is
+signed, install from a reviewed checkout. Neither installer accepts or prints secret values. For the
 supported fresh server path, follow the [production Compose lifecycle](production-compose.md#first-installation).
 It is the sole path that configures relay authority, device authentication,
 trusted attachment storage, memory APIs, ingress, and lifecycle recovery

--- a/docs/operator-guide.md
+++ b/docs/operator-guide.md
@@ -12,8 +12,9 @@ loopback systemd relay and its owner-controlled configuration; Cloudflare
 Tunnel, Access, machine enrollment, and attachment release gates remain
 explicit operator actions. Published native artifacts and the unsigned
 catalog/manifest pair live on GitHub Releases; see
-[github-releases.md](github-releases.md). `punaro-bootstrap` is not
-implemented yet, and unsigned draft assets are not an automatic update source.
+[github-releases.md](github-releases.md). `punaro-bootstrap` installs only
+signed catalog/manifest pairs; unsigned draft assets are not an automatic
+update source.
 
 ## Run locally
 

--- a/internal/bootstrap/fetch.go
+++ b/internal/bootstrap/fetch.go
@@ -1,0 +1,100 @@
+package bootstrap
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	punarorelease "github.com/rock3r/punaro/internal/release"
+)
+
+type fetcher interface {
+	Get(relative string, limit int64) ([]byte, error)
+}
+
+type httpFetcher struct {
+	origin *url.URL
+	client *http.Client
+}
+
+func newFetcher(origin string) (*httpFetcher, error) {
+	parsed, err := url.Parse(origin)
+	if err != nil || parsed.Scheme == "" || parsed.Host == "" || parsed.User != nil || parsed.RawQuery != "" || parsed.Fragment != "" {
+		return nil, errors.New("release origin is invalid")
+	}
+	if strings.Contains(parsed.Path, "..") || strings.Contains(origin, "..") {
+		return nil, errors.New("release origin is invalid")
+	}
+	switch parsed.Scheme {
+	case "https":
+	case "http":
+		if !localhostHost(parsed.Hostname()) {
+			return nil, errors.New("release origin is invalid")
+		}
+	default:
+		return nil, errors.New("release origin is invalid")
+	}
+	return &httpFetcher{
+		origin: parsed,
+		client: &http.Client{
+			Timeout:       60 * time.Second,
+			CheckRedirect: boundedHTTPSRedirects,
+		},
+	}, nil
+}
+
+func (transport *httpFetcher) Get(relative string, limit int64) ([]byte, error) {
+	if err := punarorelease.ValidateRelativePath(relative); err != nil {
+		return nil, err
+	}
+	if limit < 1 {
+		return nil, errors.New("release download is invalid")
+	}
+	target := strings.TrimRight(transport.origin.String(), "/") + "/" + relative
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, target, nil)
+	if err != nil {
+		return nil, errors.New("release download failed")
+	}
+	response, err := transport.client.Do(request) // #nosec G107 -- target is origin plus a validated relative path.
+	if err != nil {
+		return nil, errors.New("release download failed")
+	}
+	defer func() { _ = response.Body.Close() }()
+	if response.StatusCode != http.StatusOK {
+		return nil, errors.New("release download failed")
+	}
+	if response.ContentLength > limit {
+		return nil, errors.New("release download exceeds bound")
+	}
+	body, err := io.ReadAll(io.LimitReader(response.Body, limit+1))
+	if err != nil {
+		return nil, errors.New("release download failed")
+	}
+	if int64(len(body)) > limit {
+		return nil, errors.New("release download exceeds bound")
+	}
+	return body, nil
+}
+
+func boundedHTTPSRedirects(req *http.Request, via []*http.Request) error {
+	if len(via) >= 5 {
+		return errors.New("release download failed")
+	}
+	if req.URL.Scheme == "https" {
+		return nil
+	}
+	if req.URL.Scheme == "http" && localhostHost(req.URL.Hostname()) {
+		return nil
+	}
+	return errors.New("release download failed")
+}
+
+func localhostHost(host string) bool {
+	return host == "127.0.0.1" || host == "localhost" || host == "::1"
+}

--- a/internal/bootstrap/fetch_test.go
+++ b/internal/bootstrap/fetch_test.go
@@ -1,0 +1,97 @@
+package bootstrap
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	punarorelease "github.com/rock3r/punaro/internal/release"
+)
+
+func TestNewFetcherRejectsNonLocalHTTP(t *testing.T) {
+	if _, err := newFetcher("http://example.com/releases"); err == nil {
+		t.Fatal("cleartext remote origin accepted")
+	}
+}
+
+func TestNewFetcherRejectsUserinfoQueryAndParent(t *testing.T) {
+	for _, origin := range []string{
+		"https://user:pass@github.com/rock3r/punaro/releases/download",
+		"https://github.com/rock3r/punaro/releases/download?x=1",
+		"https://github.com/rock3r/punaro/releases/download#frag",
+		"https://github.com/rock3r/punaro/releases/download/../evil",
+		"ftp://127.0.0.1/releases",
+	} {
+		if _, err := newFetcher(origin); err == nil {
+			t.Fatalf("invalid origin accepted: %s", origin)
+		}
+	}
+}
+
+func TestHTTPFetcherRejectsOversizedBody(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("0123456789"))
+	}))
+	t.Cleanup(server.Close)
+	client, err := newFetcher(server.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := client.Get(punarorelease.CatalogReleaseName+"/"+punarorelease.CatalogFile, 4); err == nil {
+		t.Fatal("oversized body accepted")
+	}
+}
+
+func TestHTTPFetcherRejectsInvalidRelativePath(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		t.Fatal("invalid relative path was fetched")
+	}))
+	t.Cleanup(server.Close)
+	client, err := newFetcher(server.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := client.Get("../evil/punaro-catalog.json", 64); err == nil {
+		t.Fatal("parent relative path accepted")
+	}
+	if _, err := client.Get("latest/punaro-release.json", 64); err == nil {
+		t.Fatal("latest pointer accepted")
+	}
+}
+
+func TestHTTPFetcherRejectsNonLocalHTTPRedirect(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, "http://example.com/steal", http.StatusFound)
+	}))
+	t.Cleanup(server.Close)
+	client, err := newFetcher(server.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := client.Get(punarorelease.CatalogReleaseName+"/"+punarorelease.CatalogFile, 64); err == nil {
+		t.Fatal("non-local HTTP redirect accepted")
+	}
+}
+
+func TestHTTPFetcherFollowsLocalhostRedirect(t *testing.T) {
+	final := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	t.Cleanup(final.Close)
+	origin := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, strings.TrimRight(final.URL, "/")+"/"+punarorelease.CatalogReleaseName+"/"+punarorelease.CatalogFile, http.StatusFound)
+	}))
+	t.Cleanup(origin.Close)
+	client, err := newFetcher(origin.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	body, err := client.Get(punarorelease.CatalogReleaseName+"/"+punarorelease.CatalogFile, 64)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(body) != `{"ok":true}` {
+		t.Fatalf("body=%q", body)
+	}
+}

--- a/internal/bootstrap/lock.go
+++ b/internal/bootstrap/lock.go
@@ -1,0 +1,26 @@
+package bootstrap
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+)
+
+func lockDirectory(directory string) (func(), error) {
+	if err := requireRealDir(directory); err != nil {
+		return nil, errors.New("bootstrap directory is invalid")
+	}
+	path := filepath.Join(directory, lockFile)
+	file, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE, 0o600) // #nosec G304 -- fixed lock child of the bootstrap directory.
+	if err != nil {
+		return nil, errors.New("bootstrap directory is busy")
+	}
+	if err := lockDirectoryFile(file); err != nil {
+		_ = file.Close()
+		return nil, errors.New("bootstrap directory is busy")
+	}
+	return func() {
+		unlockDirectoryFile(file)
+		_ = file.Close()
+	}, nil
+}

--- a/internal/bootstrap/lock.go
+++ b/internal/bootstrap/lock.go
@@ -11,7 +11,7 @@ func lockDirectory(directory string) (func(), error) {
 		return nil, errors.New("bootstrap directory is invalid")
 	}
 	path := filepath.Join(directory, lockFile)
-	file, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE, 0o600) // #nosec G304 -- fixed lock child of the bootstrap directory.
+	file, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE, 0o600) // #nosec G304,G703 -- fixed lock child of the bootstrap directory.
 	if err != nil {
 		return nil, errors.New("bootstrap directory is busy")
 	}

--- a/internal/bootstrap/lock_test.go
+++ b/internal/bootstrap/lock_test.go
@@ -2,6 +2,7 @@ package bootstrap
 
 import (
 	"bufio"
+	"context"
 	"os"
 	"os/exec"
 	"testing"
@@ -19,7 +20,7 @@ func TestLockDirectoryRejectsSecondProcess(t *testing.T) {
 		os.Exit(0)
 	}
 	dir := t.TempDir()
-	helper := exec.Command(os.Args[0], "-test.run=^TestLockDirectoryRejectsSecondProcess$") // #nosec G204,G702 -- same test binary.
+	helper := exec.CommandContext(context.Background(), os.Args[0], "-test.run=^TestLockDirectoryRejectsSecondProcess$") // #nosec G204,G702 -- same test binary.
 	helper.Env = append(os.Environ(), "PUNARO_BOOTSTRAP_LOCK_DIR="+dir)
 	stdin, err := helper.StdinPipe()
 	if err != nil {

--- a/internal/bootstrap/lock_test.go
+++ b/internal/bootstrap/lock_test.go
@@ -1,0 +1,46 @@
+package bootstrap
+
+import (
+	"bufio"
+	"os"
+	"os/exec"
+	"testing"
+)
+
+func TestLockDirectoryRejectsSecondProcess(t *testing.T) {
+	if dir := os.Getenv("PUNARO_BOOTSTRAP_LOCK_DIR"); dir != "" {
+		unlock, err := lockDirectory(dir)
+		if err != nil {
+			os.Exit(2)
+		}
+		_, _ = os.Stdout.WriteString("locked\n")
+		_, _ = os.Stdin.Read(make([]byte, 1))
+		unlock()
+		os.Exit(0)
+	}
+	dir := t.TempDir()
+	helper := exec.Command(os.Args[0], "-test.run=^TestLockDirectoryRejectsSecondProcess$") // #nosec G204 -- same test binary.
+	helper.Env = append(os.Environ(), "PUNARO_BOOTSTRAP_LOCK_DIR="+dir)
+	stdin, err := helper.StdinPipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	stdout, err := helper.StdoutPipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := helper.Start(); err != nil {
+		t.Fatal(err)
+	}
+	line, err := bufio.NewReader(stdout).ReadString('\n')
+	if err != nil || line != "locked\n" {
+		t.Fatalf("helper lock=%q err=%v", line, err)
+	}
+	if _, err := lockDirectory(dir); err == nil {
+		t.Fatal("second process lock accepted")
+	}
+	_ = stdin.Close()
+	if err := helper.Wait(); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/bootstrap/lock_test.go
+++ b/internal/bootstrap/lock_test.go
@@ -19,7 +19,7 @@ func TestLockDirectoryRejectsSecondProcess(t *testing.T) {
 		os.Exit(0)
 	}
 	dir := t.TempDir()
-	helper := exec.Command(os.Args[0], "-test.run=^TestLockDirectoryRejectsSecondProcess$") // #nosec G204 -- same test binary.
+	helper := exec.Command(os.Args[0], "-test.run=^TestLockDirectoryRejectsSecondProcess$") // #nosec G204,G702 -- same test binary.
 	helper.Env = append(os.Environ(), "PUNARO_BOOTSTRAP_LOCK_DIR="+dir)
 	stdin, err := helper.StdinPipe()
 	if err != nil {

--- a/internal/bootstrap/lock_unix.go
+++ b/internal/bootstrap/lock_unix.go
@@ -1,0 +1,16 @@
+//go:build !windows
+
+package bootstrap
+
+import (
+	"os"
+	"syscall"
+)
+
+func lockDirectoryFile(file *os.File) error {
+	return syscall.Flock(int(file.Fd()), syscall.LOCK_EX|syscall.LOCK_NB) // #nosec G115 -- os.File descriptors are platform ints.
+}
+
+func unlockDirectoryFile(file *os.File) {
+	_ = syscall.Flock(int(file.Fd()), syscall.LOCK_UN) // #nosec G115 -- os.File descriptors are platform ints.
+}

--- a/internal/bootstrap/lock_windows.go
+++ b/internal/bootstrap/lock_windows.go
@@ -1,0 +1,19 @@
+//go:build windows
+
+package bootstrap
+
+import (
+	"os"
+
+	"golang.org/x/sys/windows"
+)
+
+func lockDirectoryFile(file *os.File) error {
+	overlapped := new(windows.Overlapped)
+	return windows.LockFileEx(windows.Handle(file.Fd()), windows.LOCKFILE_EXCLUSIVE_LOCK|windows.LOCKFILE_FAIL_IMMEDIATELY, 0, 1, 0, overlapped)
+}
+
+func unlockDirectoryFile(file *os.File) {
+	overlapped := new(windows.Overlapped)
+	_ = windows.UnlockFileEx(windows.Handle(file.Fd()), 0, 1, 0, overlapped)
+}

--- a/internal/bootstrap/path_unix.go
+++ b/internal/bootstrap/path_unix.go
@@ -1,0 +1,86 @@
+//go:build !windows
+
+package bootstrap
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"syscall"
+)
+
+func requireTrustedBootstrapDirectory(path string) error {
+	info, err := os.Lstat(path) // #nosec G703 -- operator-selected absolute bootstrap directory.
+	if err != nil || !info.IsDir() || info.Mode()&os.ModeSymlink != 0 || info.Mode().Perm()&0o077 != 0 {
+		return errors.New("bootstrap directory is invalid")
+	}
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	if !ok || int(stat.Uid) != os.Getuid() {
+		return errors.New("bootstrap directory is invalid")
+	}
+	return requireTrustedAncestors(filepath.Dir(filepath.Clean(path)))
+}
+
+func requireTrustedAncestors(path string) error {
+	current := filepath.Clean(path)
+	for {
+		info, err := os.Lstat(current) // #nosec G703 -- ancestor of the operator-selected bootstrap directory.
+		if err != nil {
+			return errors.New("bootstrap directory is invalid")
+		}
+		if info.Mode()&os.ModeSymlink != 0 {
+			stat, ok := info.Sys().(*syscall.Stat_t)
+			if !ok || stat.Uid != 0 {
+				return errors.New("bootstrap directory is invalid")
+			}
+			if err := requireTrustedAncestors(filepath.Dir(current)); err != nil {
+				return err
+			}
+			resolved, err := filepath.EvalSymlinks(path)
+			if err != nil {
+				return errors.New("bootstrap directory is invalid")
+			}
+			return requireResolvedAncestors(resolved)
+		}
+		if err := requireTrustedAncestorDir(info); err != nil {
+			return err
+		}
+		parent := filepath.Dir(current)
+		if parent == current {
+			return nil
+		}
+		current = parent
+	}
+}
+
+func requireResolvedAncestors(path string) error {
+	current := filepath.Clean(path)
+	for {
+		info, err := os.Lstat(current) // #nosec G703 -- resolved ancestor of the bootstrap directory.
+		if err != nil || info.Mode()&os.ModeSymlink != 0 {
+			return errors.New("bootstrap directory is invalid")
+		}
+		if err := requireTrustedAncestorDir(info); err != nil {
+			return err
+		}
+		parent := filepath.Dir(current)
+		if parent == current {
+			return nil
+		}
+		current = parent
+	}
+}
+
+func requireTrustedAncestorDir(info os.FileInfo) error {
+	if !info.IsDir() {
+		return errors.New("bootstrap directory is invalid")
+	}
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	if !ok || (int(stat.Uid) != 0 && int(stat.Uid) != os.Getuid()) {
+		return errors.New("bootstrap directory is invalid")
+	}
+	if info.Mode().Perm()&0o022 != 0 && info.Mode()&os.ModeSticky == 0 {
+		return errors.New("bootstrap directory is invalid")
+	}
+	return nil
+}

--- a/internal/bootstrap/path_unix.go
+++ b/internal/bootstrap/path_unix.go
@@ -9,6 +9,10 @@ import (
 	"syscall"
 )
 
+func requireTrustedExistingAncestor(path string) error {
+	return requireTrustedAncestors(path)
+}
+
 func requireTrustedBootstrapDirectory(path string) error {
 	info, err := os.Lstat(path) // #nosec G703 -- operator-selected absolute bootstrap directory.
 	if err != nil || !info.IsDir() || info.Mode()&os.ModeSymlink != 0 || info.Mode().Perm()&0o077 != 0 {

--- a/internal/bootstrap/path_unix.go
+++ b/internal/bootstrap/path_unix.go
@@ -10,7 +10,21 @@ import (
 )
 
 func requireTrustedExistingAncestor(path string) error {
-	return requireTrustedAncestors(path)
+	current := filepath.Clean(path)
+	for {
+		_, err := os.Lstat(current) // #nosec G703 -- ancestor of the operator-selected bootstrap directory.
+		if err == nil {
+			return requireTrustedAncestors(current)
+		}
+		if !os.IsNotExist(err) {
+			return errors.New("bootstrap directory is invalid")
+		}
+		parent := filepath.Dir(current)
+		if parent == current {
+			return errors.New("bootstrap directory is invalid")
+		}
+		current = parent
+	}
 }
 
 func requireTrustedBootstrapDirectory(path string) error {

--- a/internal/bootstrap/path_windows.go
+++ b/internal/bootstrap/path_windows.go
@@ -17,7 +17,21 @@ const (
 )
 
 func requireTrustedExistingAncestor(path string) error {
-	return walkTrustedWindowsAncestors(path)
+	current := filepath.Clean(path)
+	for {
+		_, err := os.Lstat(current) // #nosec G703 -- ancestor of the operator-selected bootstrap directory.
+		if err == nil {
+			return walkTrustedWindowsAncestors(current)
+		}
+		if !os.IsNotExist(err) {
+			return errors.New("bootstrap directory is invalid")
+		}
+		parent := filepath.Dir(current)
+		if parent == current {
+			return errors.New("bootstrap directory is invalid")
+		}
+		current = parent
+	}
 }
 
 func requireTrustedBootstrapDirectory(path string) error {

--- a/internal/bootstrap/path_windows.go
+++ b/internal/bootstrap/path_windows.go
@@ -11,7 +11,7 @@ import (
 	"golang.org/x/sys/windows"
 )
 
-const windowsAncestorWriteMask = windows.FILE_WRITE_DATA | windows.FILE_APPEND_DATA | windows.DELETE
+const windowsAncestorWriteMask = windows.FILE_WRITE_DATA | windows.FILE_APPEND_DATA | windows.DELETE | windows.WRITE_DAC | windows.WRITE_OWNER | windows.GENERIC_ALL | windows.GENERIC_WRITE
 
 func requireTrustedBootstrapDirectory(path string) error {
 	info, err := os.Lstat(path) // #nosec G703 -- operator-selected absolute bootstrap directory.

--- a/internal/bootstrap/path_windows.go
+++ b/internal/bootstrap/path_windows.go
@@ -6,13 +6,24 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"unsafe"
 
 	"golang.org/x/sys/windows"
 )
 
+const windowsAncestorWriteMask = windows.FILE_WRITE_DATA | windows.FILE_APPEND_DATA | windows.DELETE
+
 func requireTrustedBootstrapDirectory(path string) error {
 	info, err := os.Lstat(path) // #nosec G703 -- operator-selected absolute bootstrap directory.
 	if err != nil || !info.IsDir() {
+		return errors.New("bootstrap directory is invalid")
+	}
+	world, err := windows.CreateWellKnownSid(windows.WinWorldSid)
+	if err != nil {
+		return errors.New("bootstrap directory is invalid")
+	}
+	authenticated, err := windows.CreateWellKnownSid(windows.WinAuthenticatedUserSid)
+	if err != nil {
 		return errors.New("bootstrap directory is invalid")
 	}
 	current := filepath.Clean(path)
@@ -21,10 +32,38 @@ func requireTrustedBootstrapDirectory(path string) error {
 		if err != nil || attributes&windows.FILE_ATTRIBUTE_REPARSE_POINT != 0 || attributes&windows.FILE_ATTRIBUTE_DIRECTORY == 0 {
 			return errors.New("bootstrap directory is invalid")
 		}
+		if ancestorWritableByBroadSID(current, world, authenticated) {
+			return errors.New("bootstrap directory is invalid")
+		}
 		parent := filepath.Dir(current)
 		if parent == current {
 			return nil
 		}
 		current = parent
 	}
+}
+
+func ancestorWritableByBroadSID(path string, world, authenticated *windows.SID) bool {
+	sd, err := windows.GetNamedSecurityInfo(path, windows.SE_FILE_OBJECT, windows.DACL_SECURITY_INFORMATION)
+	if err != nil {
+		return true
+	}
+	dacl, _, err := sd.DACL()
+	if err != nil || dacl == nil {
+		return true
+	}
+	for i := uint32(0); i < uint32(dacl.AceCount); i++ {
+		var ace *windows.ACCESS_ALLOWED_ACE
+		if windows.GetAce(dacl, i, &ace) != nil || ace == nil || ace.Header.AceType != windows.ACCESS_ALLOWED_ACE_TYPE {
+			continue
+		}
+		if ace.Mask&windows.ACCESS_MASK(windowsAncestorWriteMask) == 0 {
+			continue
+		}
+		sid := (*windows.SID)(unsafe.Pointer(&ace.SidStart)) // #nosec G103 -- documented flexible-array start of this ACE SID.
+		if sid.Equals(world) || sid.Equals(authenticated) {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/bootstrap/path_windows.go
+++ b/internal/bootstrap/path_windows.go
@@ -1,0 +1,16 @@
+//go:build windows
+
+package bootstrap
+
+import (
+	"errors"
+	"os"
+)
+
+func requireTrustedBootstrapDirectory(path string) error {
+	info, err := os.Lstat(path) // #nosec G703 -- operator-selected absolute bootstrap directory.
+	if err != nil || !info.IsDir() {
+		return errors.New("bootstrap directory is invalid")
+	}
+	return nil
+}

--- a/internal/bootstrap/path_windows.go
+++ b/internal/bootstrap/path_windows.go
@@ -11,7 +11,10 @@ import (
 	"golang.org/x/sys/windows"
 )
 
-const windowsAncestorWriteMask = windows.FILE_WRITE_DATA | windows.FILE_APPEND_DATA | windows.DELETE | windows.WRITE_DAC | windows.WRITE_OWNER | windows.GENERIC_ALL | windows.GENERIC_WRITE
+const (
+	fileDeleteChild          = 0x0040
+	windowsAncestorWriteMask = windows.FILE_WRITE_DATA | windows.FILE_APPEND_DATA | windows.DELETE | fileDeleteChild | windows.WRITE_DAC | windows.WRITE_OWNER | windows.GENERIC_ALL | windows.GENERIC_WRITE
+)
 
 func requireTrustedBootstrapDirectory(path string) error {
 	info, err := os.Lstat(path) // #nosec G703 -- operator-selected absolute bootstrap directory.

--- a/internal/bootstrap/path_windows.go
+++ b/internal/bootstrap/path_windows.go
@@ -57,6 +57,9 @@ func ancestorWritableByBroadSID(path string, world, authenticated *windows.SID) 
 		if windows.GetAce(dacl, i, &ace) != nil || ace == nil || ace.Header.AceType != windows.ACCESS_ALLOWED_ACE_TYPE {
 			continue
 		}
+		if ace.Header.AceFlags&windows.INHERIT_ONLY_ACE != 0 {
+			continue
+		}
 		if ace.Mask&windows.ACCESS_MASK(windowsAncestorWriteMask) == 0 {
 			continue
 		}

--- a/internal/bootstrap/path_windows.go
+++ b/internal/bootstrap/path_windows.go
@@ -16,11 +16,19 @@ const (
 	windowsAncestorWriteMask = windows.FILE_WRITE_DATA | windows.FILE_APPEND_DATA | windows.DELETE | fileDeleteChild | windows.WRITE_DAC | windows.WRITE_OWNER | windows.GENERIC_ALL | windows.GENERIC_WRITE
 )
 
+func requireTrustedExistingAncestor(path string) error {
+	return walkTrustedWindowsAncestors(path)
+}
+
 func requireTrustedBootstrapDirectory(path string) error {
 	info, err := os.Lstat(path) // #nosec G703 -- operator-selected absolute bootstrap directory.
 	if err != nil || !info.IsDir() {
 		return errors.New("bootstrap directory is invalid")
 	}
+	return walkTrustedWindowsAncestors(path)
+}
+
+func walkTrustedWindowsAncestors(path string) error {
 	world, err := windows.CreateWellKnownSid(windows.WinWorldSid)
 	if err != nil {
 		return errors.New("bootstrap directory is invalid")

--- a/internal/bootstrap/path_windows.go
+++ b/internal/bootstrap/path_windows.go
@@ -5,6 +5,9 @@ package bootstrap
 import (
 	"errors"
 	"os"
+	"path/filepath"
+
+	"golang.org/x/sys/windows"
 )
 
 func requireTrustedBootstrapDirectory(path string) error {
@@ -12,5 +15,16 @@ func requireTrustedBootstrapDirectory(path string) error {
 	if err != nil || !info.IsDir() {
 		return errors.New("bootstrap directory is invalid")
 	}
-	return nil
+	current := filepath.Clean(path)
+	for {
+		attributes, err := windows.GetFileAttributes(windows.StringToUTF16Ptr(current))
+		if err != nil || attributes&windows.FILE_ATTRIBUTE_REPARSE_POINT != 0 || attributes&windows.FILE_ATTRIBUTE_DIRECTORY == 0 {
+			return errors.New("bootstrap directory is invalid")
+		}
+		parent := filepath.Dir(current)
+		if parent == current {
+			return nil
+		}
+		current = parent
+	}
 }

--- a/internal/bootstrap/slots.go
+++ b/internal/bootstrap/slots.go
@@ -343,7 +343,7 @@ func readSlot(directory string) (slotState, error) {
 }
 
 func requireRealDir(path string) error {
-	info, err := os.Lstat(path)
+	info, err := os.Lstat(path) // #nosec G703 -- path is a bootstrap-owned slot or the operator-selected absolute directory.
 	if err != nil {
 		return err
 	}
@@ -354,7 +354,7 @@ func requireRealDir(path string) error {
 }
 
 func existsRealDir(path string) (bool, error) {
-	info, err := os.Lstat(path)
+	info, err := os.Lstat(path) // #nosec G703 -- path is a bootstrap-owned slot or the operator-selected absolute directory.
 	if os.IsNotExist(err) {
 		return false, nil
 	}

--- a/internal/bootstrap/slots.go
+++ b/internal/bootstrap/slots.go
@@ -294,8 +294,21 @@ func loadAccepted(directory string) (acceptedState, error) {
 	if err != nil {
 		return acceptedState{}, err
 	}
+	accepted, err := parseAccepted(body)
+	if err != nil {
+		return acceptedState{}, err
+	}
+	return accepted, nil
+}
+
+func parseAccepted(body []byte) (acceptedState, error) {
+	decoder := json.NewDecoder(strings.NewReader(string(body)))
+	decoder.DisallowUnknownFields()
 	var accepted acceptedState
-	if err := json.Unmarshal(body, &accepted); err != nil || accepted.Schema != 1 {
+	if err := decoder.Decode(&accepted); err != nil {
+		return acceptedState{}, errors.New("bootstrap accepted state is invalid")
+	}
+	if accepted.Schema != 1 || accepted.Release == "" || accepted.ReleaseSequence < 1 || accepted.CatalogSequence < 1 || !validManifestDigest(accepted.ManifestSHA256) {
 		return acceptedState{}, errors.New("bootstrap accepted state is invalid")
 	}
 	return accepted, nil
@@ -313,6 +326,17 @@ func saveAccepted(directory string, accepted acceptedState) error {
 func Status(directory string) (State, error) {
 	if directory == "" || !filepath.IsAbs(directory) {
 		return State{}, errors.New("bootstrap directory is invalid")
+	}
+	if _, err := os.Lstat(directory); os.IsNotExist(err) {
+		return State{}, nil
+	}
+	unlock, err := lockDirectory(directory)
+	if err != nil {
+		return State{}, err
+	}
+	defer unlock()
+	if err := recoverJournal(directory); err != nil {
+		return State{}, err
 	}
 	accepted, err := loadAccepted(directory)
 	if err != nil {

--- a/internal/bootstrap/slots.go
+++ b/internal/bootstrap/slots.go
@@ -41,12 +41,13 @@ func prepareDirectory(directory string) error {
 		if err := os.MkdirAll(directory, 0o700); err != nil {
 			return errors.New("bootstrap directory is invalid")
 		}
-		return nil
-	}
-	if !info.IsDir() {
+	} else if !info.IsDir() {
 		return errors.New("bootstrap directory is invalid")
 	}
-	return nil
+	if err := os.Chmod(directory, 0o700); err != nil {
+		return errors.New("bootstrap directory is invalid")
+	}
+	return requireTrustedBootstrapDirectory(directory)
 }
 
 func publishSlot(directory, release string, sequence int64, manifestSHA256 string) error {
@@ -316,8 +317,14 @@ func Status(directory string) (State, error) {
 	if err != nil {
 		return State{}, err
 	}
-	current, _ := readSlot(filepath.Join(directory, currentSlot))
-	previous, _ := readSlot(filepath.Join(directory, previousSlot))
+	current, err := readOptionalSlot(filepath.Join(directory, currentSlot))
+	if err != nil {
+		return State{}, err
+	}
+	previous, err := readOptionalSlot(filepath.Join(directory, previousSlot))
+	if err != nil {
+		return State{}, err
+	}
 	return State{
 		Current:          current.Release,
 		CurrentSequence:  current.Sequence,
@@ -325,6 +332,17 @@ func Status(directory string) (State, error) {
 		PreviousSequence: previous.Sequence,
 		CatalogSequence:  accepted.CatalogSequence,
 	}, nil
+}
+
+func readOptionalSlot(directory string) (slotState, error) {
+	_, err := os.Lstat(directory) // #nosec G703 -- slot is a fixed child of the bootstrap directory.
+	if os.IsNotExist(err) {
+		return slotState{}, nil
+	}
+	if err != nil {
+		return slotState{}, err
+	}
+	return readSlot(directory)
 }
 
 func readSlot(directory string) (slotState, error) {

--- a/internal/bootstrap/slots.go
+++ b/internal/bootstrap/slots.go
@@ -42,11 +42,11 @@ func prepareDirectory(directory string) error {
 		if err := os.MkdirAll(directory, 0o700); err != nil {
 			return errors.New("bootstrap directory is invalid")
 		}
+		// #nosec G302 -- newly created bootstrap directories are 0700, not 0600 files.
+		if err := os.Chmod(directory, 0o700); err != nil {
+			return errors.New("bootstrap directory is invalid")
+		}
 	} else if !info.IsDir() {
-		return errors.New("bootstrap directory is invalid")
-	}
-	// #nosec G302 -- bootstrap directories are 0700, not 0600 files.
-	if err := os.Chmod(directory, 0o700); err != nil {
 		return errors.New("bootstrap directory is invalid")
 	}
 	return requireTrustedBootstrapDirectory(directory)
@@ -309,8 +309,21 @@ func readJournal(directory string) (journal, error) {
 	if err != nil {
 		return journal{}, err
 	}
+	return parseJournal(body)
+}
+
+func parseJournal(body []byte) (journal, error) {
+	if err := rejectDuplicateJSONFields(body); err != nil {
+		return journal{}, errors.New("bootstrap journal is invalid")
+	}
+	decoder := json.NewDecoder(strings.NewReader(string(body)))
+	decoder.DisallowUnknownFields()
 	var record journal
-	if err := json.Unmarshal(body, &record); err != nil {
+	if err := decoder.Decode(&record); err != nil {
+		return journal{}, errors.New("bootstrap journal is invalid")
+	}
+	var trailing any
+	if err := decoder.Decode(&trailing); !errors.Is(err, io.EOF) {
 		return journal{}, errors.New("bootstrap journal is invalid")
 	}
 	return record, nil

--- a/internal/bootstrap/slots.go
+++ b/internal/bootstrap/slots.go
@@ -3,6 +3,7 @@ package bootstrap
 import (
 	"encoding/json"
 	"errors"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -308,6 +309,10 @@ func parseAccepted(body []byte) (acceptedState, error) {
 	if err := decoder.Decode(&accepted); err != nil {
 		return acceptedState{}, errors.New("bootstrap accepted state is invalid")
 	}
+	var trailing any
+	if err := decoder.Decode(&trailing); !errors.Is(err, io.EOF) {
+		return acceptedState{}, errors.New("bootstrap accepted state is invalid")
+	}
 	if accepted.Schema != 1 || accepted.Release == "" || accepted.ReleaseSequence < 1 || accepted.CatalogSequence < 1 || !validManifestDigest(accepted.ManifestSHA256) {
 		return acceptedState{}, errors.New("bootstrap accepted state is invalid")
 	}
@@ -393,6 +398,10 @@ func parseSlot(body []byte) (slotState, error) {
 	decoder.DisallowUnknownFields()
 	var slot slotState
 	if err := decoder.Decode(&slot); err != nil {
+		return slotState{}, errors.New("bootstrap slot is invalid")
+	}
+	var trailing any
+	if err := decoder.Decode(&trailing); !errors.Is(err, io.EOF) {
 		return slotState{}, errors.New("bootstrap slot is invalid")
 	}
 	if slot.Schema != 1 || slot.Release == "" || slot.Sequence < 1 || !validManifestDigest(slot.ManifestSHA256) {

--- a/internal/bootstrap/slots.go
+++ b/internal/bootstrap/slots.go
@@ -1,0 +1,322 @@
+package bootstrap
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+)
+
+type acceptedState struct {
+	Schema          int64  `json:"schema"`
+	Release         string `json:"release"`
+	ReleaseSequence int64  `json:"release_sequence"`
+	CatalogSequence int64  `json:"catalog_sequence"`
+	ManifestSHA256  string `json:"manifest_sha256"`
+}
+
+type slotState struct {
+	Schema         int64  `json:"schema"`
+	Release        string `json:"release"`
+	Sequence       int64  `json:"sequence"`
+	ManifestSHA256 string `json:"manifest_sha256"`
+}
+
+type journal struct {
+	Schema         int64  `json:"schema"`
+	Phase          string `json:"phase"`
+	Release        string `json:"release"`
+	Sequence       int64  `json:"sequence"`
+	ManifestSHA256 string `json:"manifest_sha256,omitempty"`
+}
+
+func prepareDirectory(directory string) error {
+	info, err := os.Lstat(directory)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			return errors.New("bootstrap directory is invalid")
+		}
+		if err := os.MkdirAll(directory, 0o700); err != nil {
+			return errors.New("bootstrap directory is invalid")
+		}
+		return nil
+	}
+	if !info.IsDir() {
+		return errors.New("bootstrap directory is invalid")
+	}
+	return nil
+}
+
+func publishSlot(directory, release string, sequence int64, manifestSHA256 string) error {
+	candidate := filepath.Join(directory, candidateSlot)
+	current := filepath.Join(directory, currentSlot)
+	previous := filepath.Join(directory, previousSlot)
+	if err := requireRealDir(candidate); err != nil {
+		return err
+	}
+	record, err := json.Marshal(slotState{Schema: 1, Release: release, Sequence: sequence, ManifestSHA256: manifestSHA256})
+	if err != nil {
+		return err
+	}
+	if err := writeAtomic(filepath.Join(candidate, slotRecord), record, 0o600); err != nil {
+		return err
+	}
+	currentExists, err := existsRealDir(current)
+	if err != nil {
+		return err
+	}
+	if currentExists {
+		if err := os.RemoveAll(previous); err != nil {
+			return err
+		}
+		if err := os.Rename(current, previous); err != nil {
+			return err
+		}
+	}
+	return os.Rename(candidate, current)
+}
+
+// Rollback swaps the published current and previous slots. It does not lower
+// the highest accepted sequences, so a later automatic update still cannot
+// move backward.
+func Rollback(directory string) (Result, error) {
+	if directory == "" || !filepath.IsAbs(directory) {
+		return Result{}, errors.New("bootstrap directory is invalid")
+	}
+	if err := recoverJournal(directory); err != nil {
+		return Result{}, err
+	}
+	current := filepath.Join(directory, currentSlot)
+	previous := filepath.Join(directory, previousSlot)
+	if err := requireRealDir(current); err != nil {
+		return Result{}, errors.New("bootstrap has no current slot")
+	}
+	if err := requireRealDir(previous); err != nil {
+		return Result{}, errors.New("bootstrap has no previous slot")
+	}
+	if err := writeJournal(directory, journal{Schema: 1, Phase: "rolling-back"}); err != nil {
+		return Result{}, err
+	}
+	if err := completeRollback(directory); err != nil {
+		return Result{}, err
+	}
+	if err := clearJournal(directory); err != nil {
+		return Result{}, err
+	}
+	slot, err := readSlot(current)
+	if err != nil {
+		return Result{}, err
+	}
+	return Result{Release: slot.Release, Sequence: slot.Sequence, Manifest: slot.ManifestSHA256}, nil
+}
+
+func recoverJournal(directory string) error {
+	record, err := readJournal(directory)
+	if err != nil {
+		return err
+	}
+	switch record.Phase {
+	case "", "staging":
+		return os.RemoveAll(filepath.Join(directory, candidateSlot))
+	case "publishing":
+		exists, err := existsRealDir(filepath.Join(directory, candidateSlot))
+		if err != nil {
+			return err
+		}
+		if exists {
+			return publishSlot(directory, record.Release, record.Sequence, record.ManifestSHA256)
+		}
+		return clearJournal(directory)
+	case "rolling-back":
+		if err := completeRollback(directory); err != nil {
+			return err
+		}
+		return clearJournal(directory)
+	default:
+		return errors.New("bootstrap journal is invalid")
+	}
+}
+
+func completeRollback(directory string) error {
+	current := filepath.Join(directory, currentSlot)
+	previous := filepath.Join(directory, previousSlot)
+	swap := filepath.Join(directory, swapSlot)
+	currentExists, err := existsRealDir(current)
+	if err != nil {
+		return err
+	}
+	previousExists, err := existsRealDir(previous)
+	if err != nil {
+		return err
+	}
+	swapExists, err := existsRealDir(swap)
+	if err != nil {
+		return err
+	}
+	if currentExists && previousExists && !swapExists {
+		if err := os.Rename(current, swap); err != nil {
+			return err
+		}
+		currentExists = false
+		swapExists = true
+	}
+	if swapExists && previousExists && !currentExists {
+		if err := os.Rename(previous, current); err != nil {
+			return err
+		}
+		previousExists = false
+		currentExists = true
+	}
+	if swapExists && currentExists && !previousExists {
+		return os.Rename(swap, previous)
+	}
+	if !swapExists && currentExists && previousExists {
+		return nil
+	}
+	return errors.New("bootstrap rollback is incomplete")
+}
+
+func writeJournal(directory string, record journal) error {
+	body, err := json.Marshal(record)
+	if err != nil {
+		return err
+	}
+	return writeAtomic(filepath.Join(directory, journalFile), body, 0o600)
+}
+
+func clearJournal(directory string) error {
+	err := os.Remove(filepath.Join(directory, journalFile))
+	if err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	return nil
+}
+
+func readJournal(directory string) (journal, error) {
+	body, err := os.ReadFile(filepath.Join(directory, journalFile)) // #nosec G304 -- journal is a fixed child of the bootstrap directory.
+	if os.IsNotExist(err) {
+		return journal{}, nil
+	}
+	if err != nil {
+		return journal{}, err
+	}
+	var record journal
+	if err := json.Unmarshal(body, &record); err != nil {
+		return journal{}, errors.New("bootstrap journal is invalid")
+	}
+	return record, nil
+}
+
+func loadAccepted(directory string) (acceptedState, error) {
+	body, err := os.ReadFile(filepath.Join(directory, acceptedFile)) // #nosec G304 -- accepted record is a fixed child of the bootstrap directory.
+	if os.IsNotExist(err) {
+		return acceptedState{}, nil
+	}
+	if err != nil {
+		return acceptedState{}, err
+	}
+	var accepted acceptedState
+	if err := json.Unmarshal(body, &accepted); err != nil || accepted.Schema != 1 {
+		return acceptedState{}, errors.New("bootstrap accepted state is invalid")
+	}
+	return accepted, nil
+}
+
+func saveAccepted(directory string, accepted acceptedState) error {
+	body, err := json.Marshal(accepted)
+	if err != nil {
+		return err
+	}
+	return writeAtomic(filepath.Join(directory, acceptedFile), body, 0o600)
+}
+
+// Status reports the published slots without contacting the origin.
+func Status(directory string) (State, error) {
+	if directory == "" || !filepath.IsAbs(directory) {
+		return State{}, errors.New("bootstrap directory is invalid")
+	}
+	accepted, err := loadAccepted(directory)
+	if err != nil {
+		return State{}, err
+	}
+	current, _ := readSlot(filepath.Join(directory, currentSlot))
+	previous, _ := readSlot(filepath.Join(directory, previousSlot))
+	return State{
+		Current:          current.Release,
+		CurrentSequence:  current.Sequence,
+		Previous:         previous.Release,
+		PreviousSequence: previous.Sequence,
+		CatalogSequence:  accepted.CatalogSequence,
+	}, nil
+}
+
+func readSlot(directory string) (slotState, error) {
+	if err := requireRealDir(directory); err != nil {
+		return slotState{}, err
+	}
+	body, err := os.ReadFile(filepath.Join(directory, slotRecord)) // #nosec G304 -- slot record is a fixed child.
+	if err != nil {
+		return slotState{}, err
+	}
+	var slot slotState
+	if err := json.Unmarshal(body, &slot); err != nil {
+		return slotState{}, err
+	}
+	return slot, nil
+}
+
+func requireRealDir(path string) error {
+	info, err := os.Lstat(path)
+	if err != nil {
+		return err
+	}
+	if !info.IsDir() {
+		return errors.New("bootstrap directory is invalid")
+	}
+	return nil
+}
+
+func existsRealDir(path string) (bool, error) {
+	info, err := os.Lstat(path)
+	if os.IsNotExist(err) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	if !info.IsDir() {
+		return false, errors.New("bootstrap directory is invalid")
+	}
+	return true, nil
+}
+
+func writeAtomic(path string, body []byte, mode os.FileMode) error {
+	tmp := path + ".tmp"
+	file, err := os.OpenFile(tmp, os.O_WRONLY|os.O_CREATE|os.O_EXCL, mode) // #nosec G304,G302 -- tmp is a sibling of a bootstrap-owned path; mode comes from the signed manifest.
+	if err != nil {
+		return err
+	}
+	if _, err := file.Write(body); err != nil {
+		_ = file.Close()
+		_ = os.Remove(tmp)
+		return err
+	}
+	if err := file.Sync(); err != nil {
+		_ = file.Close()
+		_ = os.Remove(tmp)
+		return err
+	}
+	if err := file.Close(); err != nil {
+		_ = os.Remove(tmp)
+		return err
+	}
+	if err := os.Chmod(tmp, mode); err != nil {
+		_ = os.Remove(tmp)
+		return err
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		_ = os.Remove(tmp)
+		return err
+	}
+	return nil
+}

--- a/internal/bootstrap/slots.go
+++ b/internal/bootstrap/slots.go
@@ -163,11 +163,14 @@ func recoverJournal(directory string) error {
 	if err != nil {
 		return err
 	}
+	if record.Phase != "" && record.Schema != 1 {
+		return errors.New("bootstrap journal is invalid")
+	}
 	switch record.Phase {
 	case "", "staging":
 		return os.RemoveAll(filepath.Join(directory, candidateSlot))
 	case "publishing", "repairing":
-		if record.Release == "" || record.Sequence < 1 || record.CatalogSequence < 1 || record.ManifestSHA256 == "" {
+		if record.Release == "" || record.Sequence < 1 || record.CatalogSequence < 1 || !validManifestDigest(record.ManifestSHA256) {
 			return errors.New("bootstrap journal is invalid")
 		}
 		exists, err := existsRealDir(filepath.Join(directory, candidateSlot))
@@ -191,7 +194,7 @@ func recoverJournal(directory string) error {
 			ManifestSHA256:  record.ManifestSHA256,
 		})
 	case "rolling-back":
-		if record.Release == "" || record.Sequence < 1 {
+		if record.Release == "" || record.Sequence < 1 || !validManifestDigest(record.ManifestSHA256) {
 			return errors.New("bootstrap journal is invalid")
 		}
 		if err := completeRollback(directory, slotState{Release: record.Release, Sequence: record.Sequence, ManifestSHA256: record.ManifestSHA256}); err != nil {
@@ -329,6 +332,9 @@ func loadAccepted(directory string) (acceptedState, error) {
 }
 
 func parseAccepted(body []byte) (acceptedState, error) {
+	if err := rejectDuplicateJSONFields(body); err != nil {
+		return acceptedState{}, errors.New("bootstrap accepted state is invalid")
+	}
 	decoder := json.NewDecoder(strings.NewReader(string(body)))
 	decoder.DisallowUnknownFields()
 	var accepted acceptedState
@@ -408,7 +414,12 @@ func readSlot(directory string) (slotState, error) {
 	if err := requireRealDir(directory); err != nil {
 		return slotState{}, err
 	}
-	body, err := os.ReadFile(filepath.Join(directory, slotRecord)) // #nosec G304 -- slot record is a fixed child.
+	recordPath := filepath.Join(directory, slotRecord)
+	info, err := os.Lstat(recordPath) // #nosec G703 -- slot record is a fixed child.
+	if err != nil || !info.Mode().IsRegular() {
+		return slotState{}, errors.New("bootstrap slot is invalid")
+	}
+	body, err := os.ReadFile(recordPath) // #nosec G304 -- slot record is a fixed child.
 	if err != nil {
 		return slotState{}, err
 	}
@@ -420,6 +431,9 @@ func readSlot(directory string) (slotState, error) {
 }
 
 func parseSlot(body []byte) (slotState, error) {
+	if err := rejectDuplicateJSONFields(body); err != nil {
+		return slotState{}, errors.New("bootstrap slot is invalid")
+	}
 	decoder := json.NewDecoder(strings.NewReader(string(body)))
 	decoder.DisallowUnknownFields()
 	var slot slotState
@@ -434,6 +448,38 @@ func parseSlot(body []byte) (slotState, error) {
 		return slotState{}, errors.New("bootstrap slot is invalid")
 	}
 	return slot, nil
+}
+
+func rejectDuplicateJSONFields(body []byte) error {
+	decoder := json.NewDecoder(strings.NewReader(string(body)))
+	token, err := decoder.Token()
+	if err != nil {
+		return err
+	}
+	delim, ok := token.(json.Delim)
+	if !ok || delim != '{' {
+		return errors.New("bootstrap document is invalid")
+	}
+	seen := map[string]struct{}{}
+	for decoder.More() {
+		key, err := decoder.Token()
+		if err != nil {
+			return err
+		}
+		name, ok := key.(string)
+		if !ok {
+			return errors.New("bootstrap document is invalid")
+		}
+		if _, exists := seen[name]; exists {
+			return errors.New("bootstrap document is invalid")
+		}
+		seen[name] = struct{}{}
+		var value any
+		if err := decoder.Decode(&value); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func validManifestDigest(value string) bool {

--- a/internal/bootstrap/slots.go
+++ b/internal/bootstrap/slots.go
@@ -87,6 +87,28 @@ func publishSlot(directory, release string, sequence int64, manifestSHA256 strin
 	return syncDir(directory)
 }
 
+func replaceCurrent(directory, release string, sequence int64, manifestSHA256 string) error {
+	candidate := filepath.Join(directory, candidateSlot)
+	current := filepath.Join(directory, currentSlot)
+	if err := requireRealDir(candidate); err != nil {
+		return err
+	}
+	record, err := json.Marshal(slotState{Schema: 1, Release: release, Sequence: sequence, ManifestSHA256: manifestSHA256})
+	if err != nil {
+		return err
+	}
+	if err := writeAtomic(filepath.Join(candidate, slotRecord), record, 0o600); err != nil {
+		return err
+	}
+	if err := os.RemoveAll(current); err != nil {
+		return err
+	}
+	if err := os.Rename(candidate, current); err != nil {
+		return err
+	}
+	return syncDir(directory)
+}
+
 // Rollback swaps the published current and previous slots. It does not lower
 // the highest accepted sequences, so a later automatic update still cannot
 // move backward.
@@ -144,7 +166,7 @@ func recoverJournal(directory string) error {
 	switch record.Phase {
 	case "", "staging":
 		return os.RemoveAll(filepath.Join(directory, candidateSlot))
-	case "publishing":
+	case "publishing", "repairing":
 		if record.Release == "" || record.Sequence < 1 || record.CatalogSequence < 1 || record.ManifestSHA256 == "" {
 			return errors.New("bootstrap journal is invalid")
 		}
@@ -153,7 +175,11 @@ func recoverJournal(directory string) error {
 			return err
 		}
 		if exists {
-			if err := publishSlot(directory, record.Release, record.Sequence, record.ManifestSHA256); err != nil {
+			if record.Phase == "repairing" {
+				if err := replaceCurrent(directory, record.Release, record.Sequence, record.ManifestSHA256); err != nil {
+					return err
+				}
+			} else if err := publishSlot(directory, record.Release, record.Sequence, record.ManifestSHA256); err != nil {
 				return err
 			}
 		}

--- a/internal/bootstrap/slots.go
+++ b/internal/bootstrap/slots.go
@@ -39,6 +39,9 @@ func prepareDirectory(directory string) error {
 		if !os.IsNotExist(err) {
 			return errors.New("bootstrap directory is invalid")
 		}
+		if err := requireTrustedExistingAncestor(filepath.Dir(filepath.Clean(directory))); err != nil {
+			return err
+		}
 		if err := os.MkdirAll(directory, 0o700); err != nil {
 			return errors.New("bootstrap directory is invalid")
 		}

--- a/internal/bootstrap/slots.go
+++ b/internal/bootstrap/slots.go
@@ -206,7 +206,7 @@ func completeRollback(directory string, target slotState) error {
 		if err != nil {
 			return err
 		}
-		if currentSlotState.Release == target.Release && currentSlotState.Sequence == target.Sequence {
+		if currentSlotState.Release == target.Release && currentSlotState.Sequence == target.Sequence && currentSlotState.ManifestSHA256 == target.ManifestSHA256 {
 			if swapExists && !previousExists {
 				if err := os.Rename(swap, previous); err != nil {
 					return err
@@ -353,11 +353,36 @@ func readSlot(directory string) (slotState, error) {
 	if err != nil {
 		return slotState{}, err
 	}
-	var slot slotState
-	if err := json.Unmarshal(body, &slot); err != nil {
+	slot, err := parseSlot(body)
+	if err != nil {
 		return slotState{}, err
 	}
 	return slot, nil
+}
+
+func parseSlot(body []byte) (slotState, error) {
+	decoder := json.NewDecoder(strings.NewReader(string(body)))
+	decoder.DisallowUnknownFields()
+	var slot slotState
+	if err := decoder.Decode(&slot); err != nil {
+		return slotState{}, errors.New("bootstrap slot is invalid")
+	}
+	if slot.Schema != 1 || slot.Release == "" || slot.Sequence < 1 || !validManifestDigest(slot.ManifestSHA256) {
+		return slotState{}, errors.New("bootstrap slot is invalid")
+	}
+	return slot, nil
+}
+
+func validManifestDigest(value string) bool {
+	if len(value) != 64 {
+		return false
+	}
+	for _, r := range value {
+		if r < '0' || r > '9' && (r < 'a' || r > 'f') {
+			return false
+		}
+	}
+	return true
 }
 
 func requireRealDir(path string) error {
@@ -413,16 +438,17 @@ func writeAtomic(path string, body []byte, mode os.FileMode) error {
 		_ = os.Remove(tmp)
 		return err
 	}
+	if err := os.Chmod(tmp, mode); err != nil {
+		_ = file.Close()
+		_ = os.Remove(tmp)
+		return err
+	}
 	if err := file.Sync(); err != nil {
 		_ = file.Close()
 		_ = os.Remove(tmp)
 		return err
 	}
 	if err := file.Close(); err != nil {
-		_ = os.Remove(tmp)
-		return err
-	}
-	if err := os.Chmod(tmp, mode); err != nil {
 		_ = os.Remove(tmp)
 		return err
 	}

--- a/internal/bootstrap/slots.go
+++ b/internal/bootstrap/slots.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 )
 
 type acceptedState struct {
@@ -23,11 +24,12 @@ type slotState struct {
 }
 
 type journal struct {
-	Schema         int64  `json:"schema"`
-	Phase          string `json:"phase"`
-	Release        string `json:"release"`
-	Sequence       int64  `json:"sequence"`
-	ManifestSHA256 string `json:"manifest_sha256,omitempty"`
+	Schema          int64  `json:"schema"`
+	Phase           string `json:"phase"`
+	Release         string `json:"release"`
+	Sequence        int64  `json:"sequence"`
+	CatalogSequence int64  `json:"catalog_sequence,omitempty"`
+	ManifestSHA256  string `json:"manifest_sha256,omitempty"`
 }
 
 func prepareDirectory(directory string) error {
@@ -72,8 +74,14 @@ func publishSlot(directory, release string, sequence int64, manifestSHA256 strin
 		if err := os.Rename(current, previous); err != nil {
 			return err
 		}
+		if err := syncDir(directory); err != nil {
+			return err
+		}
 	}
-	return os.Rename(candidate, current)
+	if err := os.Rename(candidate, current); err != nil {
+		return err
+	}
+	return syncDir(directory)
 }
 
 // Rollback swaps the published current and previous slots. It does not lower
@@ -83,6 +91,14 @@ func Rollback(directory string) (Result, error) {
 	if directory == "" || !filepath.IsAbs(directory) {
 		return Result{}, errors.New("bootstrap directory is invalid")
 	}
+	if err := prepareDirectory(directory); err != nil {
+		return Result{}, err
+	}
+	unlock, err := lockDirectory(directory)
+	if err != nil {
+		return Result{}, err
+	}
+	defer unlock()
 	if err := recoverJournal(directory); err != nil {
 		return Result{}, err
 	}
@@ -94,10 +110,14 @@ func Rollback(directory string) (Result, error) {
 	if err := requireRealDir(previous); err != nil {
 		return Result{}, errors.New("bootstrap has no previous slot")
 	}
-	if err := writeJournal(directory, journal{Schema: 1, Phase: "rolling-back"}); err != nil {
+	target, err := readSlot(previous)
+	if err != nil {
 		return Result{}, err
 	}
-	if err := completeRollback(directory); err != nil {
+	if err := writeJournal(directory, journal{Schema: 1, Phase: "rolling-back", Release: target.Release, Sequence: target.Sequence, ManifestSHA256: target.ManifestSHA256}); err != nil {
+		return Result{}, err
+	}
+	if err := completeRollback(directory, target); err != nil {
 		return Result{}, err
 	}
 	if err := clearJournal(directory); err != nil {
@@ -111,6 +131,9 @@ func Rollback(directory string) (Result, error) {
 }
 
 func recoverJournal(directory string) error {
+	if err := removeAbandonedTemps(directory); err != nil {
+		return err
+	}
 	record, err := readJournal(directory)
 	if err != nil {
 		return err
@@ -119,16 +142,30 @@ func recoverJournal(directory string) error {
 	case "", "staging":
 		return os.RemoveAll(filepath.Join(directory, candidateSlot))
 	case "publishing":
+		if record.Release == "" || record.Sequence < 1 || record.CatalogSequence < 1 || record.ManifestSHA256 == "" {
+			return errors.New("bootstrap journal is invalid")
+		}
 		exists, err := existsRealDir(filepath.Join(directory, candidateSlot))
 		if err != nil {
 			return err
 		}
 		if exists {
-			return publishSlot(directory, record.Release, record.Sequence, record.ManifestSHA256)
+			if err := publishSlot(directory, record.Release, record.Sequence, record.ManifestSHA256); err != nil {
+				return err
+			}
 		}
-		return clearJournal(directory)
+		return finishPublication(directory, acceptedState{
+			Schema:          1,
+			Release:         record.Release,
+			ReleaseSequence: record.Sequence,
+			CatalogSequence: record.CatalogSequence,
+			ManifestSHA256:  record.ManifestSHA256,
+		})
 	case "rolling-back":
-		if err := completeRollback(directory); err != nil {
+		if record.Release == "" || record.Sequence < 1 {
+			return errors.New("bootstrap journal is invalid")
+		}
+		if err := completeRollback(directory, slotState{Release: record.Release, Sequence: record.Sequence, ManifestSHA256: record.ManifestSHA256}); err != nil {
 			return err
 		}
 		return clearJournal(directory)
@@ -137,7 +174,17 @@ func recoverJournal(directory string) error {
 	}
 }
 
-func completeRollback(directory string) error {
+func finishPublication(directory string, accepted acceptedState) error {
+	if accepted.Schema != 1 || accepted.Release == "" || accepted.ReleaseSequence < 1 || accepted.CatalogSequence < 1 || accepted.ManifestSHA256 == "" {
+		return errors.New("bootstrap journal is invalid")
+	}
+	if err := saveAccepted(directory, accepted); err != nil {
+		return err
+	}
+	return clearJournal(directory)
+}
+
+func completeRollback(directory string, target slotState) error {
 	current := filepath.Join(directory, currentSlot)
 	previous := filepath.Join(directory, previousSlot)
 	swap := filepath.Join(directory, swapSlot)
@@ -153,8 +200,32 @@ func completeRollback(directory string) error {
 	if err != nil {
 		return err
 	}
+	if currentExists {
+		currentSlotState, err := readSlot(current)
+		if err != nil {
+			return err
+		}
+		if currentSlotState.Release == target.Release && currentSlotState.Sequence == target.Sequence {
+			if swapExists && !previousExists {
+				if err := os.Rename(swap, previous); err != nil {
+					return err
+				}
+				return syncDir(directory)
+			}
+			if !swapExists {
+				return nil
+			}
+			if err := os.RemoveAll(swap); err != nil {
+				return err
+			}
+			return syncDir(directory)
+		}
+	}
 	if currentExists && previousExists && !swapExists {
 		if err := os.Rename(current, swap); err != nil {
+			return err
+		}
+		if err := syncDir(directory); err != nil {
 			return err
 		}
 		currentExists = false
@@ -164,11 +235,17 @@ func completeRollback(directory string) error {
 		if err := os.Rename(previous, current); err != nil {
 			return err
 		}
+		if err := syncDir(directory); err != nil {
+			return err
+		}
 		previousExists = false
 		currentExists = true
 	}
 	if swapExists && currentExists && !previousExists {
-		return os.Rename(swap, previous)
+		if err := os.Rename(swap, previous); err != nil {
+			return err
+		}
+		return syncDir(directory)
 	}
 	if !swapExists && currentExists && previousExists {
 		return nil
@@ -189,7 +266,7 @@ func clearJournal(directory string) error {
 	if err != nil && !os.IsNotExist(err) {
 		return err
 	}
-	return nil
+	return syncDir(directory)
 }
 
 func readJournal(directory string) (journal, error) {
@@ -290,12 +367,29 @@ func existsRealDir(path string) (bool, error) {
 	return true, nil
 }
 
-func writeAtomic(path string, body []byte, mode os.FileMode) error {
-	tmp := path + ".tmp"
-	file, err := os.OpenFile(tmp, os.O_WRONLY|os.O_CREATE|os.O_EXCL, mode) // #nosec G304,G302 -- tmp is a sibling of a bootstrap-owned path; mode comes from the signed manifest.
+func removeAbandonedTemps(directory string) error {
+	entries, err := os.ReadDir(directory)
 	if err != nil {
 		return err
 	}
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".tmp") {
+			continue
+		}
+		if err := os.Remove(filepath.Join(directory, entry.Name())); err != nil && !os.IsNotExist(err) {
+			return err
+		}
+	}
+	return nil
+}
+
+func writeAtomic(path string, body []byte, mode os.FileMode) error {
+	dir := filepath.Dir(path)
+	file, err := os.CreateTemp(dir, "."+filepath.Base(path)+"-*.tmp")
+	if err != nil {
+		return err
+	}
+	tmp := file.Name()
 	if _, err := file.Write(body); err != nil {
 		_ = file.Close()
 		_ = os.Remove(tmp)
@@ -318,5 +412,5 @@ func writeAtomic(path string, body []byte, mode os.FileMode) error {
 		_ = os.Remove(tmp)
 		return err
 	}
-	return nil
+	return syncDir(dir)
 }

--- a/internal/bootstrap/slots.go
+++ b/internal/bootstrap/slots.go
@@ -44,7 +44,7 @@ func prepareDirectory(directory string) error {
 	} else if !info.IsDir() {
 		return errors.New("bootstrap directory is invalid")
 	}
-	if err := os.Chmod(directory, 0o700); err != nil {
+	if err := os.Chmod(directory, 0o700); err != nil { // #nosec G302 -- bootstrap directories are 0700, not 0600 files.
 		return errors.New("bootstrap directory is invalid")
 	}
 	return requireTrustedBootstrapDirectory(directory)

--- a/internal/bootstrap/slots.go
+++ b/internal/bootstrap/slots.go
@@ -44,7 +44,8 @@ func prepareDirectory(directory string) error {
 	} else if !info.IsDir() {
 		return errors.New("bootstrap directory is invalid")
 	}
-	if err := os.Chmod(directory, 0o700); err != nil { // #nosec G302 -- bootstrap directories are 0700, not 0600 files.
+	// #nosec G302 -- bootstrap directories are 0700, not 0600 files.
+	if err := os.Chmod(directory, 0o700); err != nil {
 		return errors.New("bootstrap directory is invalid")
 	}
 	return requireTrustedBootstrapDirectory(directory)

--- a/internal/bootstrap/slots.go
+++ b/internal/bootstrap/slots.go
@@ -330,6 +330,9 @@ func Status(directory string) (State, error) {
 	if _, err := os.Lstat(directory); os.IsNotExist(err) {
 		return State{}, nil
 	}
+	if err := prepareDirectory(directory); err != nil {
+		return State{}, err
+	}
 	unlock, err := lockDirectory(directory)
 	if err != nil {
 		return State{}, err

--- a/internal/bootstrap/slots_test.go
+++ b/internal/bootstrap/slots_test.go
@@ -28,6 +28,9 @@ func TestRecoverJournalDiscardsStagingCandidate(t *testing.T) {
 
 func TestRecoverJournalCompletesPublishAfterCurrentMoved(t *testing.T) {
 	dir := t.TempDir()
+	if err := saveAccepted(dir, acceptedState{Schema: 1, Release: "v0.1.0", ReleaseSequence: 1, CatalogSequence: 1, ManifestSHA256: repeatC()}); err != nil {
+		t.Fatal(err)
+	}
 	previous := filepath.Join(dir, previousSlot)
 	if err := os.Mkdir(previous, 0o700); err != nil {
 		t.Fatal(err)
@@ -45,7 +48,7 @@ func TestRecoverJournalCompletesPublishAfterCurrentMoved(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(candidate, "new-current"), []byte("new"), 0o600); err != nil {
 		t.Fatal(err)
 	}
-	if err := writeJournal(dir, journal{Schema: 1, Phase: "publishing", Release: "v0.2.0", Sequence: 2, ManifestSHA256: repeatC()}); err != nil {
+	if err := writeJournal(dir, journal{Schema: 1, Phase: "publishing", Release: "v0.2.0", Sequence: 2, CatalogSequence: 2, ManifestSHA256: repeatC()}); err != nil {
 		t.Fatal(err)
 	}
 	if err := recoverJournal(dir); err != nil {
@@ -62,8 +65,45 @@ func TestRecoverJournalCompletesPublishAfterCurrentMoved(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if status.Current != "v0.2.0" || status.Previous != "v0.1.0" {
+	if status.Current != "v0.2.0" || status.Previous != "v0.1.0" || status.CatalogSequence != 2 {
 		t.Fatalf("status=%#v", status)
+	}
+	accepted, err := loadAccepted(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if accepted.ReleaseSequence != 2 || accepted.CatalogSequence != 2 {
+		t.Fatalf("accepted=%#v", accepted)
+	}
+}
+
+func TestRecoverJournalPersistsAcceptedAfterPublishWithoutCandidate(t *testing.T) {
+	dir := t.TempDir()
+	current := filepath.Join(dir, currentSlot)
+	if err := os.Mkdir(current, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeAtomic(filepath.Join(current, slotRecord), []byte(`{"schema":1,"release":"v0.2.0","sequence":2,"manifest_sha256":"`+repeatC()+`"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := saveAccepted(dir, acceptedState{Schema: 1, Release: "v0.1.0", ReleaseSequence: 1, CatalogSequence: 1, ManifestSHA256: repeatC()}); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeJournal(dir, journal{Schema: 1, Phase: "publishing", Release: "v0.2.0", Sequence: 2, CatalogSequence: 2, ManifestSHA256: repeatC()}); err != nil {
+		t.Fatal(err)
+	}
+	if err := recoverJournal(dir); err != nil {
+		t.Fatal(err)
+	}
+	accepted, err := loadAccepted(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if accepted.Release != "v0.2.0" || accepted.ReleaseSequence != 2 || accepted.CatalogSequence != 2 {
+		t.Fatalf("accepted=%#v", accepted)
+	}
+	if _, err := os.Lstat(filepath.Join(dir, journalFile)); !os.IsNotExist(err) {
+		t.Fatal("publishing journal retained after accepted recovery")
 	}
 }
 
@@ -83,7 +123,7 @@ func TestRecoverJournalCompletesInterruptedRollback(t *testing.T) {
 	if err := writeAtomic(filepath.Join(swap, slotRecord), []byte(`{"schema":1,"release":"v0.2.0","sequence":2,"manifest_sha256":"`+repeatC()+`"}`), 0o600); err != nil {
 		t.Fatal(err)
 	}
-	if err := writeJournal(dir, journal{Schema: 1, Phase: "rolling-back"}); err != nil {
+	if err := writeJournal(dir, journal{Schema: 1, Phase: "rolling-back", Release: "v0.1.0", Sequence: 1, ManifestSHA256: repeatC()}); err != nil {
 		t.Fatal(err)
 	}
 	if err := recoverJournal(dir); err != nil {
@@ -95,6 +135,56 @@ func TestRecoverJournalCompletesInterruptedRollback(t *testing.T) {
 	}
 	if status.Current != "v0.1.0" || status.Previous != "v0.2.0" {
 		t.Fatalf("status=%#v", status)
+	}
+}
+
+func TestRecoverJournalDoesNotReswapCompletedRollback(t *testing.T) {
+	dir := t.TempDir()
+	current := filepath.Join(dir, currentSlot)
+	previous := filepath.Join(dir, previousSlot)
+	if err := os.Mkdir(current, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(previous, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeAtomic(filepath.Join(current, slotRecord), []byte(`{"schema":1,"release":"v0.1.0","sequence":1,"manifest_sha256":"`+repeatC()+`"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeAtomic(filepath.Join(previous, slotRecord), []byte(`{"schema":1,"release":"v0.2.0","sequence":2,"manifest_sha256":"`+repeatC()+`"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeJournal(dir, journal{Schema: 1, Phase: "rolling-back", Release: "v0.1.0", Sequence: 1, ManifestSHA256: repeatC()}); err != nil {
+		t.Fatal(err)
+	}
+	if err := recoverJournal(dir); err != nil {
+		t.Fatal(err)
+	}
+	status, err := Status(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if status.Current != "v0.1.0" || status.Previous != "v0.2.0" {
+		t.Fatalf("status=%#v", status)
+	}
+}
+
+func TestRecoverJournalRemovesAbandonedTempFiles(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "journal.json.tmp"), []byte("stale"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, ".accepted.json-old.tmp"), []byte("stale"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := recoverJournal(dir); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Lstat(filepath.Join(dir, "journal.json.tmp")); !os.IsNotExist(err) {
+		t.Fatal("fixed temporary journal retained")
+	}
+	if _, err := os.Lstat(filepath.Join(dir, ".accepted.json-old.tmp")); !os.IsNotExist(err) {
+		t.Fatal("unique temporary file retained")
 	}
 }
 

--- a/internal/bootstrap/slots_test.go
+++ b/internal/bootstrap/slots_test.go
@@ -1,0 +1,103 @@
+package bootstrap
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestRecoverJournalDiscardsStagingCandidate(t *testing.T) {
+	dir := t.TempDir()
+	candidate := filepath.Join(dir, candidateSlot)
+	if err := os.Mkdir(candidate, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(candidate, "punaro-adapter-linux-amd64"), []byte("partial"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeJournal(dir, journal{Schema: 1, Phase: "staging", Release: "v0.2.0", Sequence: 2}); err != nil {
+		t.Fatal(err)
+	}
+	if err := recoverJournal(dir); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Lstat(candidate); !os.IsNotExist(err) {
+		t.Fatalf("staging candidate retained: %v", err)
+	}
+}
+
+func TestRecoverJournalCompletesPublishAfterCurrentMoved(t *testing.T) {
+	dir := t.TempDir()
+	previous := filepath.Join(dir, previousSlot)
+	if err := os.Mkdir(previous, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(previous, "old-current"), []byte("keep-me"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeAtomic(filepath.Join(previous, slotRecord), []byte(`{"schema":1,"release":"v0.1.0","sequence":1,"manifest_sha256":"`+repeatC()+`"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	candidate := filepath.Join(dir, candidateSlot)
+	if err := os.Mkdir(candidate, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(candidate, "new-current"), []byte("new"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeJournal(dir, journal{Schema: 1, Phase: "publishing", Release: "v0.2.0", Sequence: 2, ManifestSHA256: repeatC()}); err != nil {
+		t.Fatal(err)
+	}
+	if err := recoverJournal(dir); err != nil {
+		t.Fatal(err)
+	}
+	kept, err := os.ReadFile(filepath.Join(dir, previousSlot, "old-current")) // #nosec G304 -- path is under t.TempDir.
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(kept) != "keep-me" {
+		t.Fatalf("previous slot was discarded during publish recovery: %q", kept)
+	}
+	status, err := Status(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if status.Current != "v0.2.0" || status.Previous != "v0.1.0" {
+		t.Fatalf("status=%#v", status)
+	}
+}
+
+func TestRecoverJournalCompletesInterruptedRollback(t *testing.T) {
+	dir := t.TempDir()
+	previous := filepath.Join(dir, previousSlot)
+	swap := filepath.Join(dir, swapSlot)
+	if err := os.Mkdir(previous, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(swap, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeAtomic(filepath.Join(previous, slotRecord), []byte(`{"schema":1,"release":"v0.1.0","sequence":1,"manifest_sha256":"`+repeatC()+`"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeAtomic(filepath.Join(swap, slotRecord), []byte(`{"schema":1,"release":"v0.2.0","sequence":2,"manifest_sha256":"`+repeatC()+`"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeJournal(dir, journal{Schema: 1, Phase: "rolling-back"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := recoverJournal(dir); err != nil {
+		t.Fatal(err)
+	}
+	status, err := Status(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if status.Current != "v0.1.0" || status.Previous != "v0.2.0" {
+		t.Fatalf("status=%#v", status)
+	}
+}
+
+func repeatC() string {
+	return "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+}

--- a/internal/bootstrap/slots_test.go
+++ b/internal/bootstrap/slots_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestRecoverJournalDiscardsStagingCandidate(t *testing.T) {
-	dir := t.TempDir()
+	dir := privateDir(t)
 	candidate := filepath.Join(dir, candidateSlot)
 	if err := os.Mkdir(candidate, 0o700); err != nil {
 		t.Fatal(err)
@@ -27,7 +27,7 @@ func TestRecoverJournalDiscardsStagingCandidate(t *testing.T) {
 }
 
 func TestRecoverJournalCompletesPublishAfterCurrentMoved(t *testing.T) {
-	dir := t.TempDir()
+	dir := privateDir(t)
 	if err := saveAccepted(dir, acceptedState{Schema: 1, Release: "v0.1.0", ReleaseSequence: 1, CatalogSequence: 1, ManifestSHA256: repeatC()}); err != nil {
 		t.Fatal(err)
 	}
@@ -78,7 +78,7 @@ func TestRecoverJournalCompletesPublishAfterCurrentMoved(t *testing.T) {
 }
 
 func TestRecoverJournalPersistsAcceptedAfterPublishWithoutCandidate(t *testing.T) {
-	dir := t.TempDir()
+	dir := privateDir(t)
 	current := filepath.Join(dir, currentSlot)
 	if err := os.Mkdir(current, 0o700); err != nil {
 		t.Fatal(err)
@@ -108,7 +108,7 @@ func TestRecoverJournalPersistsAcceptedAfterPublishWithoutCandidate(t *testing.T
 }
 
 func TestRecoverJournalCompletesInterruptedRollback(t *testing.T) {
-	dir := t.TempDir()
+	dir := privateDir(t)
 	previous := filepath.Join(dir, previousSlot)
 	swap := filepath.Join(dir, swapSlot)
 	if err := os.Mkdir(previous, 0o700); err != nil {
@@ -139,7 +139,7 @@ func TestRecoverJournalCompletesInterruptedRollback(t *testing.T) {
 }
 
 func TestRecoverJournalDoesNotReswapCompletedRollback(t *testing.T) {
-	dir := t.TempDir()
+	dir := privateDir(t)
 	current := filepath.Join(dir, currentSlot)
 	previous := filepath.Join(dir, previousSlot)
 	if err := os.Mkdir(current, 0o700); err != nil {
@@ -176,7 +176,7 @@ func TestParseSlotRejectsEmptyRecord(t *testing.T) {
 }
 
 func TestRecoverJournalRemovesAbandonedTempFiles(t *testing.T) {
-	dir := t.TempDir()
+	dir := privateDir(t)
 	if err := os.WriteFile(filepath.Join(dir, "journal.json.tmp"), []byte("stale"), 0o600); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/bootstrap/slots_test.go
+++ b/internal/bootstrap/slots_test.go
@@ -169,6 +169,12 @@ func TestRecoverJournalDoesNotReswapCompletedRollback(t *testing.T) {
 	}
 }
 
+func TestParseSlotRejectsEmptyRecord(t *testing.T) {
+	if _, err := parseSlot([]byte(`{}`)); err == nil {
+		t.Fatal("empty slot record accepted")
+	}
+}
+
 func TestRecoverJournalRemovesAbandonedTempFiles(t *testing.T) {
 	dir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(dir, "journal.json.tmp"), []byte("stale"), 0o600); err != nil {

--- a/internal/bootstrap/sync_unix.go
+++ b/internal/bootstrap/sync_unix.go
@@ -1,0 +1,14 @@
+//go:build !windows
+
+package bootstrap
+
+import "os"
+
+func syncDir(path string) error {
+	dir, err := os.Open(path) // #nosec G304 -- parent of a bootstrap-owned path.
+	if err != nil {
+		return err
+	}
+	defer func() { _ = dir.Close() }()
+	return dir.Sync()
+}

--- a/internal/bootstrap/sync_windows.go
+++ b/internal/bootstrap/sync_windows.go
@@ -1,0 +1,7 @@
+//go:build windows
+
+package bootstrap
+
+func syncDir(string) error {
+	return nil
+}

--- a/internal/bootstrap/update.go
+++ b/internal/bootstrap/update.go
@@ -78,6 +78,15 @@ func Update(request Request) (Result, error) {
 	if err != nil {
 		return Result{}, err
 	}
+	if accepted.ReleaseSequence < 1 {
+		exists, slotErr := existsRealDir(filepath.Join(request.Directory, currentSlot))
+		if slotErr != nil {
+			return Result{}, slotErr
+		}
+		if exists {
+			return Result{}, errors.New("bootstrap accepted state is invalid")
+		}
+	}
 	client := request.HTTP
 	if client == nil {
 		transport, err := newFetcher(request.Origin)

--- a/internal/bootstrap/update.go
+++ b/internal/bootstrap/update.go
@@ -25,6 +25,7 @@ const (
 	swapSlot      = "swap"
 	slotRecord    = "slot.json"
 	journalFile   = "journal.json"
+	lockFile      = "bootstrap.lock"
 )
 
 // Request is one host-local update from a fixed origin.
@@ -65,6 +66,11 @@ func Update(request Request) (Result, error) {
 	if err := prepareDirectory(request.Directory); err != nil {
 		return Result{}, err
 	}
+	unlock, err := lockDirectory(request.Directory)
+	if err != nil {
+		return Result{}, err
+	}
+	defer unlock()
 	if err := recoverJournal(request.Directory); err != nil {
 		return Result{}, err
 	}
@@ -187,22 +193,27 @@ func Update(request Request) (Result, error) {
 		}
 		installed = append(installed, name)
 	}
-	if err := writeJournal(request.Directory, journal{Schema: 1, Phase: "publishing", Release: manifest.Release, Sequence: manifest.Sequence, ManifestSHA256: listed.ManifestSHA256}); err != nil {
-		return Result{}, err
-	}
-	if err := publishSlot(request.Directory, manifest.Release, manifest.Sequence, listed.ManifestSHA256); err != nil {
-		return Result{}, err
-	}
-	if err := saveAccepted(request.Directory, acceptedState{
+	published := acceptedState{
 		Schema:          1,
 		Release:         manifest.Release,
 		ReleaseSequence: manifest.Sequence,
 		CatalogSequence: catalog.Sequence,
 		ManifestSHA256:  listed.ManifestSHA256,
+	}
+	if err := writeJournal(request.Directory, journal{
+		Schema:          1,
+		Phase:           "publishing",
+		Release:         published.Release,
+		Sequence:        published.ReleaseSequence,
+		CatalogSequence: published.CatalogSequence,
+		ManifestSHA256:  published.ManifestSHA256,
 	}); err != nil {
 		return Result{}, err
 	}
-	if err := clearJournal(request.Directory); err != nil {
+	if err := publishSlot(request.Directory, published.Release, published.ReleaseSequence, published.ManifestSHA256); err != nil {
+		return Result{}, err
+	}
+	if err := finishPublication(request.Directory, published); err != nil {
 		return Result{}, err
 	}
 	return Result{Release: manifest.Release, Sequence: manifest.Sequence, Manifest: listed.ManifestSHA256, Installed: installed}, nil

--- a/internal/bootstrap/update.go
+++ b/internal/bootstrap/update.go
@@ -167,19 +167,19 @@ func Update(request Request) (Result, error) {
 		CatalogSequence: catalog.Sequence,
 		ManifestSHA256:  listed.ManifestSHA256,
 	}
+	artifacts := platformArtifacts(manifest.Artifacts, request.GOOS, request.GOARCH)
+	if len(artifacts) == 0 {
+		return Result{}, errors.New("release has no artifacts for this platform")
+	}
 	current, err := readOptionalSlot(filepath.Join(request.Directory, currentSlot))
 	if err != nil {
 		return Result{}, err
 	}
-	if current.Release == published.Release && current.Sequence == published.ReleaseSequence && current.ManifestSHA256 == published.ManifestSHA256 {
+	if current.Release == published.Release && current.Sequence == published.ReleaseSequence && current.ManifestSHA256 == published.ManifestSHA256 && currentSlotMatches(request.Directory, artifacts) {
 		if err := finishPublication(request.Directory, published); err != nil {
 			return Result{}, err
 		}
 		return Result{Release: published.Release, Sequence: published.ReleaseSequence, Manifest: published.ManifestSHA256}, nil
-	}
-	artifacts := platformArtifacts(manifest.Artifacts, request.GOOS, request.GOARCH)
-	if len(artifacts) == 0 {
-		return Result{}, errors.New("release has no artifacts for this platform")
 	}
 	candidate := filepath.Join(request.Directory, candidateSlot)
 	if err := os.RemoveAll(candidate); err != nil {
@@ -260,6 +260,24 @@ func verifyDocument(document, signature []byte, keys map[string]ed25519.PublicKe
 		return err
 	}
 	return punarorelease.Verify(document, envelope, keys)
+}
+
+func currentSlotMatches(directory string, artifacts []punarorelease.Artifact) bool {
+	for _, artifact := range artifacts {
+		name := filepath.Base(artifact.Path)
+		if name != artifactName(artifact.Component, artifact.OS, artifact.Arch) {
+			return false
+		}
+		body, err := os.ReadFile(filepath.Join(directory, currentSlot, name)) // #nosec G304 -- name is a verified platform artifact filename.
+		if err != nil || int64(len(body)) != artifact.Length {
+			return false
+		}
+		digest := sha256.Sum256(body)
+		if hex.EncodeToString(digest[:]) != artifact.SHA256 {
+			return false
+		}
+	}
+	return len(artifacts) > 0
 }
 
 func platformArtifacts(artifacts []punarorelease.Artifact, goos, goarch string) []punarorelease.Artifact {

--- a/internal/bootstrap/update.go
+++ b/internal/bootstrap/update.go
@@ -157,6 +157,26 @@ func Update(request Request) (Result, error) {
 	if accepted.ReleaseSequence > 0 && manifest.Sequence < accepted.ReleaseSequence {
 		return Result{}, errors.New("release sequence downgrade")
 	}
+	if accepted.ReleaseSequence == manifest.Sequence && accepted.ManifestSHA256 != "" && accepted.ManifestSHA256 != listed.ManifestSHA256 {
+		return Result{}, errors.New("release identity mismatch")
+	}
+	published := acceptedState{
+		Schema:          1,
+		Release:         manifest.Release,
+		ReleaseSequence: manifest.Sequence,
+		CatalogSequence: catalog.Sequence,
+		ManifestSHA256:  listed.ManifestSHA256,
+	}
+	current, err := readOptionalSlot(filepath.Join(request.Directory, currentSlot))
+	if err != nil {
+		return Result{}, err
+	}
+	if current.Release == published.Release && current.Sequence == published.ReleaseSequence && current.ManifestSHA256 == published.ManifestSHA256 {
+		if err := finishPublication(request.Directory, published); err != nil {
+			return Result{}, err
+		}
+		return Result{Release: published.Release, Sequence: published.ReleaseSequence, Manifest: published.ManifestSHA256}, nil
+	}
 	artifacts := platformArtifacts(manifest.Artifacts, request.GOOS, request.GOARCH)
 	if len(artifacts) == 0 {
 		return Result{}, errors.New("release has no artifacts for this platform")
@@ -192,13 +212,6 @@ func Update(request Request) (Result, error) {
 			return Result{}, err
 		}
 		installed = append(installed, name)
-	}
-	published := acceptedState{
-		Schema:          1,
-		Release:         manifest.Release,
-		ReleaseSequence: manifest.Sequence,
-		CatalogSequence: catalog.Sequence,
-		ManifestSHA256:  listed.ManifestSHA256,
 	}
 	if err := writeJournal(request.Directory, journal{
 		Schema:          1,

--- a/internal/bootstrap/update.go
+++ b/internal/bootstrap/update.go
@@ -175,7 +175,8 @@ func Update(request Request) (Result, error) {
 	if err != nil {
 		return Result{}, err
 	}
-	if current.Release == published.Release && current.Sequence == published.ReleaseSequence && current.ManifestSHA256 == published.ManifestSHA256 && currentSlotMatches(request.Directory, artifacts) {
+	sameIdentity := current.Release == published.Release && current.Sequence == published.ReleaseSequence && current.ManifestSHA256 == published.ManifestSHA256
+	if sameIdentity && currentSlotMatches(request.Directory, artifacts) {
 		if err := finishPublication(request.Directory, published); err != nil {
 			return Result{}, err
 		}
@@ -213,9 +214,13 @@ func Update(request Request) (Result, error) {
 		}
 		installed = append(installed, name)
 	}
+	phase := "publishing"
+	if sameIdentity {
+		phase = "repairing"
+	}
 	if err := writeJournal(request.Directory, journal{
 		Schema:          1,
-		Phase:           "publishing",
+		Phase:           phase,
 		Release:         published.Release,
 		Sequence:        published.ReleaseSequence,
 		CatalogSequence: published.CatalogSequence,
@@ -223,7 +228,11 @@ func Update(request Request) (Result, error) {
 	}); err != nil {
 		return Result{}, err
 	}
-	if err := publishSlot(request.Directory, published.Release, published.ReleaseSequence, published.ManifestSHA256); err != nil {
+	if sameIdentity {
+		if err := replaceCurrent(request.Directory, published.Release, published.ReleaseSequence, published.ManifestSHA256); err != nil {
+			return Result{}, err
+		}
+	} else if err := publishSlot(request.Directory, published.Release, published.ReleaseSequence, published.ManifestSHA256); err != nil {
 		return Result{}, err
 	}
 	if err := finishPublication(request.Directory, published); err != nil {

--- a/internal/bootstrap/update.go
+++ b/internal/bootstrap/update.go
@@ -268,7 +268,12 @@ func currentSlotMatches(directory string, artifacts []punarorelease.Artifact) bo
 		if name != artifactName(artifact.Component, artifact.OS, artifact.Arch) {
 			return false
 		}
-		body, err := os.ReadFile(filepath.Join(directory, currentSlot, name)) // #nosec G304 -- name is a verified platform artifact filename.
+		path := filepath.Join(directory, currentSlot, name)
+		info, err := os.Lstat(path) // #nosec G703 -- name is a verified platform artifact filename.
+		if err != nil || !info.Mode().IsRegular() || (runtime.GOOS != "windows" && info.Mode().Perm() != 0o755) {
+			return false
+		}
+		body, err := os.ReadFile(path) // #nosec G304 -- name is a verified platform artifact filename.
 		if err != nil || int64(len(body)) != artifact.Length {
 			return false
 		}

--- a/internal/bootstrap/update.go
+++ b/internal/bootstrap/update.go
@@ -1,0 +1,257 @@
+// Package bootstrap installs signed Punaro client artifacts from the fixed
+// GitHub Releases origin. It verifies catalog and manifest signatures and
+// exact artifact length/digest. It does not run children, open PostgreSQL, or
+// read Punaro message content.
+package bootstrap
+
+import (
+	"crypto/ed25519"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"os"
+	"path/filepath"
+	"runtime"
+	"time"
+
+	punarorelease "github.com/rock3r/punaro/internal/release"
+)
+
+const (
+	acceptedFile  = "accepted.json"
+	currentSlot   = "current"
+	previousSlot  = "previous"
+	candidateSlot = "candidate"
+	swapSlot      = "swap"
+	slotRecord    = "slot.json"
+	journalFile   = "journal.json"
+)
+
+// Request is one host-local update from a fixed origin.
+type Request struct {
+	Directory string
+	Origin    string
+	Keys      map[string]ed25519.PublicKey
+	Release   string
+	GOOS      string
+	GOARCH    string
+	Now       time.Time
+	HTTP      fetcher
+}
+
+// Result is the published slot after a successful update.
+type Result struct {
+	Release   string
+	Sequence  int64
+	Manifest  string
+	Installed []string
+}
+
+// State is the content-free view of local slots.
+type State struct {
+	Current          string
+	CurrentSequence  int64
+	Previous         string
+	PreviousSequence int64
+	CatalogSequence  int64
+}
+
+// Update fetches the signed catalog, honors only a listed release, and
+// publishes matching platform artifacts into the current slot.
+func Update(request Request) (Result, error) {
+	if err := request.normalize(); err != nil {
+		return Result{}, err
+	}
+	if err := prepareDirectory(request.Directory); err != nil {
+		return Result{}, err
+	}
+	if err := recoverJournal(request.Directory); err != nil {
+		return Result{}, err
+	}
+	accepted, err := loadAccepted(request.Directory)
+	if err != nil {
+		return Result{}, err
+	}
+	client := request.HTTP
+	if client == nil {
+		transport, err := newFetcher(request.Origin)
+		if err != nil {
+			return Result{}, err
+		}
+		client = transport
+	}
+	catalogBody, err := client.Get(punarorelease.CatalogReleaseName+"/"+punarorelease.CatalogFile, punarorelease.MaximumManifestBytes)
+	if err != nil {
+		return Result{}, err
+	}
+	catalogSig, err := client.Get(punarorelease.CatalogReleaseName+"/"+punarorelease.CatalogSignatureFile, punarorelease.MaximumEnvelopeBytes)
+	if err != nil {
+		return Result{}, err
+	}
+	if err := verifyDocument(catalogBody, catalogSig, request.Keys); err != nil {
+		return Result{}, err
+	}
+	catalog, err := punarorelease.ParseCatalog(catalogBody)
+	if err != nil {
+		return Result{}, err
+	}
+	if !catalog.Fresh(request.Now) {
+		return Result{}, errors.New("release catalog is stale")
+	}
+	if accepted.CatalogSequence > 0 && catalog.Sequence < accepted.CatalogSequence {
+		return Result{}, errors.New("release catalog sequence downgrade")
+	}
+	wanted := request.Release
+	if wanted == "" {
+		wanted = catalog.CurrentRelease
+	}
+	var listed punarorelease.CatalogRelease
+	found := false
+	for _, entry := range catalog.Releases {
+		if entry.Release == wanted {
+			listed = entry
+			found = true
+			break
+		}
+	}
+	if !found {
+		return Result{}, errors.New("requested release is not in the catalog")
+	}
+	if !catalog.Allows(listed.Release, listed.Sequence, listed.ManifestSHA256) {
+		return Result{}, errors.New("catalog does not allow the release")
+	}
+	if err := writeJournal(request.Directory, journal{Schema: 1, Phase: "staging", Release: listed.Release, Sequence: listed.Sequence, ManifestSHA256: listed.ManifestSHA256}); err != nil {
+		return Result{}, err
+	}
+	manifestBody, err := client.Get(listed.ManifestPath, listed.ManifestLength)
+	if err != nil {
+		return Result{}, err
+	}
+	if int64(len(manifestBody)) != listed.ManifestLength {
+		return Result{}, errors.New("release manifest length mismatch")
+	}
+	sum := sha256.Sum256(manifestBody)
+	if hex.EncodeToString(sum[:]) != listed.ManifestSHA256 {
+		return Result{}, errors.New("release manifest digest mismatch")
+	}
+	manifestSig, err := client.Get(listed.Release+"/"+punarorelease.ReleaseSignatureFile, punarorelease.MaximumEnvelopeBytes)
+	if err != nil {
+		return Result{}, err
+	}
+	if err := verifyDocument(manifestBody, manifestSig, request.Keys); err != nil {
+		return Result{}, err
+	}
+	manifest, err := punarorelease.ParseReleaseManifest(manifestBody)
+	if err != nil {
+		return Result{}, err
+	}
+	if !catalog.Allows(manifest.Release, manifest.Sequence, listed.ManifestSHA256) {
+		return Result{}, errors.New("catalog does not allow the release")
+	}
+	if accepted.ReleaseSequence > 0 && manifest.Sequence < accepted.ReleaseSequence {
+		return Result{}, errors.New("release sequence downgrade")
+	}
+	artifacts := platformArtifacts(manifest.Artifacts, request.GOOS, request.GOARCH)
+	if len(artifacts) == 0 {
+		return Result{}, errors.New("release has no artifacts for this platform")
+	}
+	candidate := filepath.Join(request.Directory, candidateSlot)
+	if err := os.RemoveAll(candidate); err != nil {
+		return Result{}, err
+	}
+	if err := os.Mkdir(candidate, 0o700); err != nil {
+		return Result{}, err
+	}
+	var installed []string
+	for _, artifact := range artifacts {
+		body, err := client.Get(artifact.Path, artifact.Length)
+		if err != nil {
+			return Result{}, err
+		}
+		if int64(len(body)) != artifact.Length {
+			return Result{}, errors.New("release artifact length mismatch")
+		}
+		digest := sha256.Sum256(body)
+		if hex.EncodeToString(digest[:]) != artifact.SHA256 {
+			return Result{}, errors.New("release artifact digest mismatch")
+		}
+		name := filepath.Base(artifact.Path)
+		if name != artifactName(artifact.Component, artifact.OS, artifact.Arch) {
+			return Result{}, errors.New("release artifact name is invalid")
+		}
+		if artifact.Mode != 0o755 {
+			return Result{}, errors.New("release artifact mode is invalid")
+		}
+		if err := writeAtomic(filepath.Join(candidate, name), body, 0o755); err != nil {
+			return Result{}, err
+		}
+		installed = append(installed, name)
+	}
+	if err := writeJournal(request.Directory, journal{Schema: 1, Phase: "publishing", Release: manifest.Release, Sequence: manifest.Sequence, ManifestSHA256: listed.ManifestSHA256}); err != nil {
+		return Result{}, err
+	}
+	if err := publishSlot(request.Directory, manifest.Release, manifest.Sequence, listed.ManifestSHA256); err != nil {
+		return Result{}, err
+	}
+	if err := saveAccepted(request.Directory, acceptedState{
+		Schema:          1,
+		Release:         manifest.Release,
+		ReleaseSequence: manifest.Sequence,
+		CatalogSequence: catalog.Sequence,
+		ManifestSHA256:  listed.ManifestSHA256,
+	}); err != nil {
+		return Result{}, err
+	}
+	if err := clearJournal(request.Directory); err != nil {
+		return Result{}, err
+	}
+	return Result{Release: manifest.Release, Sequence: manifest.Sequence, Manifest: listed.ManifestSHA256, Installed: installed}, nil
+}
+
+func (request *Request) normalize() error {
+	if request.Directory == "" || !filepath.IsAbs(request.Directory) {
+		return errors.New("bootstrap directory is invalid")
+	}
+	if len(request.Keys) == 0 {
+		return errors.New("bootstrap has no embedded release keys")
+	}
+	if request.Origin == "" {
+		request.Origin = punarorelease.GitHubReleaseOrigin
+	}
+	if request.GOOS == "" {
+		request.GOOS = runtime.GOOS
+	}
+	if request.GOARCH == "" {
+		request.GOARCH = runtime.GOARCH
+	}
+	if request.Now.IsZero() {
+		request.Now = time.Now().UTC()
+	}
+	return nil
+}
+
+func verifyDocument(document, signature []byte, keys map[string]ed25519.PublicKey) error {
+	envelope, err := punarorelease.ParseEnvelope(signature)
+	if err != nil {
+		return err
+	}
+	return punarorelease.Verify(document, envelope, keys)
+}
+
+func platformArtifacts(artifacts []punarorelease.Artifact, goos, goarch string) []punarorelease.Artifact {
+	var matched []punarorelease.Artifact
+	for _, artifact := range artifacts {
+		if artifact.OS == goos && artifact.Arch == goarch {
+			matched = append(matched, artifact)
+		}
+	}
+	return matched
+}
+
+func artifactName(component, goos, goarch string) string {
+	name := component + "-" + goos + "-" + goarch
+	if goos == "windows" {
+		return name + ".exe"
+	}
+	return name
+}

--- a/internal/bootstrap/update_test.go
+++ b/internal/bootstrap/update_test.go
@@ -24,9 +24,18 @@ const (
 	testArtifact = "adapter-bytes-for-bootstrap"
 )
 
+func privateDir(t *testing.T) string {
+	t.Helper()
+	dir := filepath.Join(t.TempDir(), "bootstrap")
+	if err := os.Mkdir(dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+
 func TestUpdateInstallsSignedPlatformArtifacts(t *testing.T) {
 	origin := newSignedOrigin(t, originSpec{payload: testArtifact, goos: runtime.GOOS, goarch: runtime.GOARCH})
-	dir := t.TempDir()
+	dir := privateDir(t)
 	result, err := Update(Request{
 		Directory: dir,
 		Origin:    origin.URL,
@@ -60,7 +69,7 @@ func TestUpdateInstallsSignedPlatformArtifacts(t *testing.T) {
 
 func TestUpdatePromotesCurrentToPrevious(t *testing.T) {
 	origin := newSignedOrigin(t, originSpec{payload: "first", goos: runtime.GOOS, goarch: runtime.GOARCH})
-	dir := t.TempDir()
+	dir := privateDir(t)
 	req := Request{Directory: dir, Origin: origin.URL, Keys: origin.Keys, GOOS: runtime.GOOS, GOARCH: runtime.GOARCH, Now: time.Date(2026, 8, 20, 0, 0, 0, 0, time.UTC)}
 	if _, err := Update(req); err != nil {
 		t.Fatal(err)
@@ -91,7 +100,7 @@ func TestUpdatePromotesCurrentToPrevious(t *testing.T) {
 
 func TestUpdateDoesNotRotateIdenticalCurrent(t *testing.T) {
 	origin := newSignedOrigin(t, originSpec{payload: testArtifact, goos: runtime.GOOS, goarch: runtime.GOARCH})
-	dir := t.TempDir()
+	dir := privateDir(t)
 	req := Request{Directory: dir, Origin: origin.URL, Keys: origin.Keys, GOOS: runtime.GOOS, GOARCH: runtime.GOARCH, Now: time.Date(2026, 8, 20, 0, 0, 0, 0, time.UTC)}
 	if _, err := Update(req); err != nil {
 		t.Fatal(err)
@@ -110,7 +119,7 @@ func TestUpdateDoesNotRotateIdenticalCurrent(t *testing.T) {
 
 func TestUpdateRepairsCurrentWithoutRotatingPrevious(t *testing.T) {
 	origin := newSignedOrigin(t, originSpec{payload: "first", goos: runtime.GOOS, goarch: runtime.GOARCH})
-	dir := t.TempDir()
+	dir := privateDir(t)
 	req := Request{Directory: dir, Origin: origin.URL, Keys: origin.Keys, GOOS: runtime.GOOS, GOARCH: runtime.GOARCH, Now: time.Date(2026, 8, 20, 0, 0, 0, 0, time.UTC)}
 	if _, err := Update(req); err != nil {
 		t.Fatal(err)
@@ -141,7 +150,7 @@ func TestUpdateRepairsCurrentWithoutRotatingPrevious(t *testing.T) {
 
 func TestRollbackSwapsPublishedSlots(t *testing.T) {
 	origin := newSignedOrigin(t, originSpec{payload: "first", goos: runtime.GOOS, goarch: runtime.GOARCH})
-	dir := t.TempDir()
+	dir := privateDir(t)
 	req := Request{Directory: dir, Origin: origin.URL, Keys: origin.Keys, GOOS: runtime.GOOS, GOARCH: runtime.GOARCH, Now: time.Date(2026, 8, 20, 0, 0, 0, 0, time.UTC)}
 	if _, err := Update(req); err != nil {
 		t.Fatal(err)
@@ -177,7 +186,7 @@ func TestRollbackSwapsPublishedSlots(t *testing.T) {
 }
 
 func TestRollbackRequiresPreviousSlot(t *testing.T) {
-	dir := t.TempDir()
+	dir := privateDir(t)
 	if _, err := Rollback(dir); err == nil {
 		t.Fatal("rollback without slots accepted")
 	}
@@ -186,7 +195,7 @@ func TestRollbackRequiresPreviousSlot(t *testing.T) {
 func TestUpdateRejectsUnsignedCatalog(t *testing.T) {
 	origin := newSignedOrigin(t, originSpec{payload: testArtifact, goos: runtime.GOOS, goarch: runtime.GOARCH})
 	delete(origin.Files, punarorelease.CatalogReleaseName+"/"+punarorelease.CatalogSignatureFile)
-	dir := t.TempDir()
+	dir := privateDir(t)
 	if _, err := Update(Request{Directory: dir, Origin: origin.URL, Keys: origin.Keys, GOOS: runtime.GOOS, GOARCH: runtime.GOARCH, Now: time.Date(2026, 8, 20, 0, 0, 0, 0, time.UTC)}); err == nil {
 		t.Fatal("unsigned catalog accepted")
 	}
@@ -195,7 +204,7 @@ func TestUpdateRejectsUnsignedCatalog(t *testing.T) {
 func TestUpdateRejectsUnsignedManifest(t *testing.T) {
 	origin := newSignedOrigin(t, originSpec{payload: testArtifact, goos: runtime.GOOS, goarch: runtime.GOARCH})
 	delete(origin.Files, "v0.1.0/"+punarorelease.ReleaseSignatureFile)
-	dir := t.TempDir()
+	dir := privateDir(t)
 	if _, err := Update(Request{Directory: dir, Origin: origin.URL, Keys: origin.Keys, GOOS: runtime.GOOS, GOARCH: runtime.GOARCH, Now: time.Date(2026, 8, 20, 0, 0, 0, 0, time.UTC)}); err == nil {
 		t.Fatal("unsigned manifest accepted")
 	}
@@ -205,7 +214,7 @@ func TestUpdateRejectsAlteredArtifactBytes(t *testing.T) {
 	origin := newSignedOrigin(t, originSpec{payload: testArtifact, goos: runtime.GOOS, goarch: runtime.GOARCH})
 	name := artifactName("punaro-adapter", runtime.GOOS, runtime.GOARCH)
 	origin.Files["v0.1.0/"+name] = []byte("tampered-adapter-bytes")
-	dir := t.TempDir()
+	dir := privateDir(t)
 	if _, err := Update(Request{Directory: dir, Origin: origin.URL, Keys: origin.Keys, GOOS: runtime.GOOS, GOARCH: runtime.GOARCH, Now: time.Date(2026, 8, 20, 0, 0, 0, 0, time.UTC)}); err == nil {
 		t.Fatal("altered artifact accepted")
 	}
@@ -213,7 +222,7 @@ func TestUpdateRejectsAlteredArtifactBytes(t *testing.T) {
 
 func TestUpdateRejectsStaleCatalog(t *testing.T) {
 	origin := newSignedOrigin(t, originSpec{payload: testArtifact, goos: runtime.GOOS, goarch: runtime.GOARCH})
-	dir := t.TempDir()
+	dir := privateDir(t)
 	if _, err := Update(Request{Directory: dir, Origin: origin.URL, Keys: origin.Keys, GOOS: runtime.GOOS, GOARCH: runtime.GOARCH, Now: time.Date(2026, 8, 24, 0, 0, 0, 0, time.UTC)}); err == nil {
 		t.Fatal("expired catalog accepted")
 	}
@@ -221,7 +230,7 @@ func TestUpdateRejectsStaleCatalog(t *testing.T) {
 
 func TestUpdateRejectsCriticalBlock(t *testing.T) {
 	origin := newSignedOrigin(t, originSpec{payload: testArtifact, goos: runtime.GOOS, goarch: runtime.GOARCH, criticalBlocks: []int64{1}})
-	dir := t.TempDir()
+	dir := privateDir(t)
 	if _, err := Update(Request{Directory: dir, Origin: origin.URL, Keys: origin.Keys, GOOS: runtime.GOOS, GOARCH: runtime.GOARCH, Now: time.Date(2026, 8, 20, 0, 0, 0, 0, time.UTC)}); err == nil {
 		t.Fatal("critically blocked release accepted")
 	}
@@ -229,7 +238,7 @@ func TestUpdateRejectsCriticalBlock(t *testing.T) {
 
 func TestUpdateRejectsReleaseSequenceDowngrade(t *testing.T) {
 	origin := newSignedOrigin(t, originSpec{payload: testArtifact, goos: runtime.GOOS, goarch: runtime.GOARCH})
-	dir := t.TempDir()
+	dir := privateDir(t)
 	req := Request{Directory: dir, Origin: origin.URL, Keys: origin.Keys, GOOS: runtime.GOOS, GOARCH: runtime.GOARCH, Now: time.Date(2026, 8, 20, 0, 0, 0, 0, time.UTC)}
 	if _, err := Update(req); err != nil {
 		t.Fatal(err)
@@ -244,7 +253,7 @@ func TestUpdateRejectsReleaseSequenceDowngrade(t *testing.T) {
 
 func TestUpdateRejectsCatalogSequenceDowngrade(t *testing.T) {
 	origin := newSignedOrigin(t, originSpec{payload: testArtifact, goos: runtime.GOOS, goarch: runtime.GOARCH})
-	dir := t.TempDir()
+	dir := privateDir(t)
 	req := Request{Directory: dir, Origin: origin.URL, Keys: origin.Keys, GOOS: runtime.GOOS, GOARCH: runtime.GOARCH, Now: time.Date(2026, 8, 20, 0, 0, 0, 0, time.UTC)}
 	if _, err := Update(req); err != nil {
 		t.Fatal(err)
@@ -265,7 +274,7 @@ func TestUpdateRejectsPathTraversalAsset(t *testing.T) {
 		http.NotFound(w, r)
 	}))
 	t.Cleanup(origin.Close)
-	dir := t.TempDir()
+	dir := privateDir(t)
 	_, priv, err := ed25519.GenerateKey(rand.Reader)
 	if err != nil {
 		t.Fatal(err)
@@ -277,7 +286,7 @@ func TestUpdateRejectsPathTraversalAsset(t *testing.T) {
 }
 
 func TestUpdateRejectsNonLocalHTTPOrigin(t *testing.T) {
-	dir := t.TempDir()
+	dir := privateDir(t)
 	_, priv, err := ed25519.GenerateKey(rand.Reader)
 	if err != nil {
 		t.Fatal(err)
@@ -290,7 +299,7 @@ func TestUpdateRejectsNonLocalHTTPOrigin(t *testing.T) {
 
 func TestUpdateSelectsOnlyRequestedPlatform(t *testing.T) {
 	origin := newSignedOrigin(t, originSpec{payload: testArtifact, goos: "linux", goarch: "amd64"})
-	dir := t.TempDir()
+	dir := privateDir(t)
 	if _, err := Update(Request{Directory: dir, Origin: origin.URL, Keys: origin.Keys, GOOS: "windows", GOARCH: "amd64", Now: time.Date(2026, 8, 20, 0, 0, 0, 0, time.UTC)}); err == nil {
 		t.Fatal("missing platform artifacts accepted")
 	}
@@ -318,7 +327,7 @@ func TestUpdateRejectsWritableAncestor(t *testing.T) {
 }
 
 func TestStatusRejectsCorruptSlot(t *testing.T) {
-	dir := t.TempDir()
+	dir := privateDir(t)
 	current := filepath.Join(dir, currentSlot)
 	if err := os.Mkdir(current, 0o700); err != nil {
 		t.Fatal(err)

--- a/internal/bootstrap/update_test.go
+++ b/internal/bootstrap/update_test.go
@@ -340,6 +340,14 @@ func TestStatusRejectsCorruptSlot(t *testing.T) {
 	}
 }
 
+func TestUpdateCreatesNestedDirectory(t *testing.T) {
+	origin := newSignedOrigin(t, originSpec{payload: testArtifact, goos: runtime.GOOS, goarch: runtime.GOARCH})
+	dir := filepath.Join(t.TempDir(), "nested", "bootstrap")
+	if _, err := Update(Request{Directory: dir, Origin: origin.URL, Keys: origin.Keys, GOOS: runtime.GOOS, GOARCH: runtime.GOARCH, Now: time.Date(2026, 8, 20, 0, 0, 0, 0, time.UTC)}); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestUpdateRejectsRelativeDirectory(t *testing.T) {
 	origin := newSignedOrigin(t, originSpec{payload: testArtifact, goos: runtime.GOOS, goarch: runtime.GOARCH})
 	if _, err := Update(Request{Directory: "relative-state", Origin: origin.URL, Keys: origin.Keys, Now: time.Date(2026, 8, 20, 0, 0, 0, 0, time.UTC)}); err == nil {

--- a/internal/bootstrap/update_test.go
+++ b/internal/bootstrap/update_test.go
@@ -108,6 +108,36 @@ func TestUpdateDoesNotRotateIdenticalCurrent(t *testing.T) {
 	}
 }
 
+func TestUpdateRepairsCurrentWithoutRotatingPrevious(t *testing.T) {
+	origin := newSignedOrigin(t, originSpec{payload: "first", goos: runtime.GOOS, goarch: runtime.GOARCH})
+	dir := t.TempDir()
+	req := Request{Directory: dir, Origin: origin.URL, Keys: origin.Keys, GOOS: runtime.GOOS, GOARCH: runtime.GOARCH, Now: time.Date(2026, 8, 20, 0, 0, 0, 0, time.UTC)}
+	if _, err := Update(req); err != nil {
+		t.Fatal(err)
+	}
+	origin.republish(t, originSpec{payload: "second", goos: runtime.GOOS, goarch: runtime.GOARCH, release: "v0.2.0", sequence: 2, catalogSequence: 2})
+	if _, err := Update(req); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, currentSlot, artifactName("punaro-adapter", runtime.GOOS, runtime.GOARCH)), []byte("damaged"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Update(req); err != nil {
+		t.Fatal(err)
+	}
+	status, err := Status(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if status.Current != "v0.2.0" || status.Previous != "v0.1.0" {
+		t.Fatalf("repair rotated slots: %#v", status)
+	}
+	body, err := os.ReadFile(filepath.Join(dir, currentSlot, artifactName("punaro-adapter", runtime.GOOS, runtime.GOARCH))) // #nosec G304 -- path is under t.TempDir.
+	if err != nil || string(body) != "second" {
+		t.Fatalf("repaired current=%q err=%v", body, err)
+	}
+}
+
 func TestRollbackSwapsPublishedSlots(t *testing.T) {
 	origin := newSignedOrigin(t, originSpec{payload: "first", goos: runtime.GOOS, goarch: runtime.GOARCH})
 	dir := t.TempDir()

--- a/internal/bootstrap/update_test.go
+++ b/internal/bootstrap/update_test.go
@@ -119,6 +119,7 @@ func TestUpdateRepairsCurrentWithoutRotatingPrevious(t *testing.T) {
 	if _, err := Update(req); err != nil {
 		t.Fatal(err)
 	}
+	// #nosec G306 -- the regression plants a still-executable damaged artifact.
 	if err := os.WriteFile(filepath.Join(dir, currentSlot, artifactName("punaro-adapter", runtime.GOOS, runtime.GOARCH)), []byte("damaged"), 0o755); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/bootstrap/update_test.go
+++ b/internal/bootstrap/update_test.go
@@ -89,6 +89,25 @@ func TestUpdatePromotesCurrentToPrevious(t *testing.T) {
 	}
 }
 
+func TestUpdateDoesNotRotateIdenticalCurrent(t *testing.T) {
+	origin := newSignedOrigin(t, originSpec{payload: testArtifact, goos: runtime.GOOS, goarch: runtime.GOARCH})
+	dir := t.TempDir()
+	req := Request{Directory: dir, Origin: origin.URL, Keys: origin.Keys, GOOS: runtime.GOOS, GOARCH: runtime.GOARCH, Now: time.Date(2026, 8, 20, 0, 0, 0, 0, time.UTC)}
+	if _, err := Update(req); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Update(req); err != nil {
+		t.Fatal(err)
+	}
+	status, err := Status(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if status.Current != "v0.1.0" || status.Previous != "" {
+		t.Fatalf("identical update rotated slots: %#v", status)
+	}
+}
+
 func TestRollbackSwapsPublishedSlots(t *testing.T) {
 	origin := newSignedOrigin(t, originSpec{payload: "first", goos: runtime.GOOS, goarch: runtime.GOARCH})
 	dir := t.TempDir()

--- a/internal/bootstrap/update_test.go
+++ b/internal/bootstrap/update_test.go
@@ -246,6 +246,41 @@ func TestUpdateSelectsOnlyRequestedPlatform(t *testing.T) {
 	}
 }
 
+func TestUpdateRejectsWritableAncestor(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("writable-ancestor policy is Unix-specific")
+	}
+	origin := newSignedOrigin(t, originSpec{payload: testArtifact, goos: runtime.GOOS, goarch: runtime.GOARCH})
+	parent := filepath.Join(t.TempDir(), "open")
+	if err := os.Mkdir(parent, 0o777); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(parent, 0o777); err != nil {
+		t.Fatal(err)
+	}
+	dir := filepath.Join(parent, "state")
+	if err := os.Mkdir(dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Update(Request{Directory: dir, Origin: origin.URL, Keys: origin.Keys, Now: time.Date(2026, 8, 20, 0, 0, 0, 0, time.UTC)}); err == nil {
+		t.Fatal("writable ancestor accepted")
+	}
+}
+
+func TestStatusRejectsCorruptSlot(t *testing.T) {
+	dir := t.TempDir()
+	current := filepath.Join(dir, currentSlot)
+	if err := os.Mkdir(current, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(current, slotRecord), []byte("not-json"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Status(dir); err == nil {
+		t.Fatal("corrupt slot accepted")
+	}
+}
+
 func TestUpdateRejectsRelativeDirectory(t *testing.T) {
 	origin := newSignedOrigin(t, originSpec{payload: testArtifact, goos: runtime.GOOS, goarch: runtime.GOARCH})
 	if _, err := Update(Request{Directory: "relative-state", Origin: origin.URL, Keys: origin.Keys, Now: time.Date(2026, 8, 20, 0, 0, 0, 0, time.UTC)}); err == nil {

--- a/internal/bootstrap/update_test.go
+++ b/internal/bootstrap/update_test.go
@@ -1,0 +1,372 @@
+package bootstrap
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	punarorelease "github.com/rock3r/punaro/internal/release"
+)
+
+const (
+	testCompose  = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	testMigrate  = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+	testKeyID    = "punaro-release-1"
+	testArtifact = "adapter-bytes-for-bootstrap"
+)
+
+func TestUpdateInstallsSignedPlatformArtifacts(t *testing.T) {
+	origin := newSignedOrigin(t, originSpec{payload: testArtifact, goos: runtime.GOOS, goarch: runtime.GOARCH})
+	dir := t.TempDir()
+	result, err := Update(Request{
+		Directory: dir,
+		Origin:    origin.URL,
+		Keys:      origin.Keys,
+		GOOS:      runtime.GOOS,
+		GOARCH:    runtime.GOARCH,
+		Now:       time.Date(2026, 8, 20, 0, 0, 0, 0, time.UTC),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Release != "v0.1.0" || result.Sequence != 1 {
+		t.Fatalf("result=%#v", result)
+	}
+	installed := filepath.Join(dir, "current", artifactName("punaro-adapter", runtime.GOOS, runtime.GOARCH))
+	body, err := os.ReadFile(installed) // #nosec G304 -- path is under t.TempDir.
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(body) != testArtifact {
+		t.Fatalf("installed=%q", body)
+	}
+	status, err := Status(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if status.Current != "v0.1.0" || status.CurrentSequence != 1 || status.Previous != "" {
+		t.Fatalf("status=%#v", status)
+	}
+}
+
+func TestUpdatePromotesCurrentToPrevious(t *testing.T) {
+	origin := newSignedOrigin(t, originSpec{payload: "first", goos: runtime.GOOS, goarch: runtime.GOARCH})
+	dir := t.TempDir()
+	req := Request{Directory: dir, Origin: origin.URL, Keys: origin.Keys, GOOS: runtime.GOOS, GOARCH: runtime.GOARCH, Now: time.Date(2026, 8, 20, 0, 0, 0, 0, time.UTC)}
+	if _, err := Update(req); err != nil {
+		t.Fatal(err)
+	}
+	origin.republish(t, originSpec{payload: "second", goos: runtime.GOOS, goarch: runtime.GOARCH, release: "v0.2.0", sequence: 2, catalogSequence: 2})
+	if _, err := Update(req); err != nil {
+		t.Fatal(err)
+	}
+	status, err := Status(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if status.Current != "v0.2.0" || status.CurrentSequence != 2 || status.Previous != "v0.1.0" || status.PreviousSequence != 1 {
+		t.Fatalf("status=%#v", status)
+	}
+	current, err := os.ReadFile(filepath.Join(dir, "current", artifactName("punaro-adapter", runtime.GOOS, runtime.GOARCH))) // #nosec G304 -- path is under t.TempDir.
+	if err != nil {
+		t.Fatal(err)
+	}
+	previous, err := os.ReadFile(filepath.Join(dir, "previous", artifactName("punaro-adapter", runtime.GOOS, runtime.GOARCH))) // #nosec G304 -- path is under t.TempDir.
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(current) != "second" || string(previous) != "first" {
+		t.Fatalf("current=%q previous=%q", current, previous)
+	}
+}
+
+func TestRollbackSwapsPublishedSlots(t *testing.T) {
+	origin := newSignedOrigin(t, originSpec{payload: "first", goos: runtime.GOOS, goarch: runtime.GOARCH})
+	dir := t.TempDir()
+	req := Request{Directory: dir, Origin: origin.URL, Keys: origin.Keys, GOOS: runtime.GOOS, GOARCH: runtime.GOARCH, Now: time.Date(2026, 8, 20, 0, 0, 0, 0, time.UTC)}
+	if _, err := Update(req); err != nil {
+		t.Fatal(err)
+	}
+	origin.republish(t, originSpec{payload: "second", goos: runtime.GOOS, goarch: runtime.GOARCH, release: "v0.2.0", sequence: 2, catalogSequence: 2})
+	if _, err := Update(req); err != nil {
+		t.Fatal(err)
+	}
+	result, err := Rollback(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Release != "v0.1.0" || result.Sequence != 1 {
+		t.Fatalf("rollback=%#v", result)
+	}
+	status, err := Status(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if status.Current != "v0.1.0" || status.Previous != "v0.2.0" {
+		t.Fatalf("status=%#v", status)
+	}
+	if _, err := Update(req); err != nil {
+		t.Fatal(err)
+	}
+	status, err = Status(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if status.Current != "v0.2.0" || status.Previous != "v0.1.0" {
+		t.Fatalf("reupdate status=%#v", status)
+	}
+}
+
+func TestRollbackRequiresPreviousSlot(t *testing.T) {
+	dir := t.TempDir()
+	if _, err := Rollback(dir); err == nil {
+		t.Fatal("rollback without slots accepted")
+	}
+}
+
+func TestUpdateRejectsUnsignedCatalog(t *testing.T) {
+	origin := newSignedOrigin(t, originSpec{payload: testArtifact, goos: runtime.GOOS, goarch: runtime.GOARCH})
+	delete(origin.Files, punarorelease.CatalogReleaseName+"/"+punarorelease.CatalogSignatureFile)
+	dir := t.TempDir()
+	if _, err := Update(Request{Directory: dir, Origin: origin.URL, Keys: origin.Keys, GOOS: runtime.GOOS, GOARCH: runtime.GOARCH, Now: time.Date(2026, 8, 20, 0, 0, 0, 0, time.UTC)}); err == nil {
+		t.Fatal("unsigned catalog accepted")
+	}
+}
+
+func TestUpdateRejectsUnsignedManifest(t *testing.T) {
+	origin := newSignedOrigin(t, originSpec{payload: testArtifact, goos: runtime.GOOS, goarch: runtime.GOARCH})
+	delete(origin.Files, "v0.1.0/"+punarorelease.ReleaseSignatureFile)
+	dir := t.TempDir()
+	if _, err := Update(Request{Directory: dir, Origin: origin.URL, Keys: origin.Keys, GOOS: runtime.GOOS, GOARCH: runtime.GOARCH, Now: time.Date(2026, 8, 20, 0, 0, 0, 0, time.UTC)}); err == nil {
+		t.Fatal("unsigned manifest accepted")
+	}
+}
+
+func TestUpdateRejectsAlteredArtifactBytes(t *testing.T) {
+	origin := newSignedOrigin(t, originSpec{payload: testArtifact, goos: runtime.GOOS, goarch: runtime.GOARCH})
+	name := artifactName("punaro-adapter", runtime.GOOS, runtime.GOARCH)
+	origin.Files["v0.1.0/"+name] = []byte("tampered-adapter-bytes")
+	dir := t.TempDir()
+	if _, err := Update(Request{Directory: dir, Origin: origin.URL, Keys: origin.Keys, GOOS: runtime.GOOS, GOARCH: runtime.GOARCH, Now: time.Date(2026, 8, 20, 0, 0, 0, 0, time.UTC)}); err == nil {
+		t.Fatal("altered artifact accepted")
+	}
+}
+
+func TestUpdateRejectsStaleCatalog(t *testing.T) {
+	origin := newSignedOrigin(t, originSpec{payload: testArtifact, goos: runtime.GOOS, goarch: runtime.GOARCH})
+	dir := t.TempDir()
+	if _, err := Update(Request{Directory: dir, Origin: origin.URL, Keys: origin.Keys, GOOS: runtime.GOOS, GOARCH: runtime.GOARCH, Now: time.Date(2026, 8, 24, 0, 0, 0, 0, time.UTC)}); err == nil {
+		t.Fatal("expired catalog accepted")
+	}
+}
+
+func TestUpdateRejectsCriticalBlock(t *testing.T) {
+	origin := newSignedOrigin(t, originSpec{payload: testArtifact, goos: runtime.GOOS, goarch: runtime.GOARCH, criticalBlocks: []int64{1}})
+	dir := t.TempDir()
+	if _, err := Update(Request{Directory: dir, Origin: origin.URL, Keys: origin.Keys, GOOS: runtime.GOOS, GOARCH: runtime.GOARCH, Now: time.Date(2026, 8, 20, 0, 0, 0, 0, time.UTC)}); err == nil {
+		t.Fatal("critically blocked release accepted")
+	}
+}
+
+func TestUpdateRejectsReleaseSequenceDowngrade(t *testing.T) {
+	origin := newSignedOrigin(t, originSpec{payload: testArtifact, goos: runtime.GOOS, goarch: runtime.GOARCH})
+	dir := t.TempDir()
+	req := Request{Directory: dir, Origin: origin.URL, Keys: origin.Keys, GOOS: runtime.GOOS, GOARCH: runtime.GOARCH, Now: time.Date(2026, 8, 20, 0, 0, 0, 0, time.UTC)}
+	if _, err := Update(req); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, acceptedFile), []byte(`{"schema":1,"release":"v9.9.9","release_sequence":9,"catalog_sequence":9,"manifest_sha256":"`+strings.Repeat("c", 64)+`"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Update(req); err == nil {
+		t.Fatal("sequence downgrade accepted")
+	}
+}
+
+func TestUpdateRejectsCatalogSequenceDowngrade(t *testing.T) {
+	origin := newSignedOrigin(t, originSpec{payload: testArtifact, goos: runtime.GOOS, goarch: runtime.GOARCH})
+	dir := t.TempDir()
+	req := Request{Directory: dir, Origin: origin.URL, Keys: origin.Keys, GOOS: runtime.GOOS, GOARCH: runtime.GOARCH, Now: time.Date(2026, 8, 20, 0, 0, 0, 0, time.UTC)}
+	if _, err := Update(req); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, acceptedFile), []byte(`{"schema":1,"release":"v0.1.0","release_sequence":1,"catalog_sequence":9,"manifest_sha256":"`+strings.Repeat("c", 64)+`"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Update(req); err == nil {
+		t.Fatal("catalog sequence downgrade accepted")
+	}
+}
+
+func TestUpdateRejectsPathTraversalAsset(t *testing.T) {
+	origin := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.URL.Path, "..") {
+			t.Fatal("bootstrap requested a parent path")
+		}
+		http.NotFound(w, r)
+	}))
+	t.Cleanup(origin.Close)
+	dir := t.TempDir()
+	_, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pub := priv.Public().(ed25519.PublicKey)
+	if _, err := Update(Request{Directory: dir, Origin: origin.URL + "/../evil", Keys: map[string]ed25519.PublicKey{testKeyID: pub}, GOOS: runtime.GOOS, GOARCH: runtime.GOARCH, Now: time.Date(2026, 8, 20, 0, 0, 0, 0, time.UTC)}); err == nil {
+		t.Fatal("origin with parent path accepted")
+	}
+}
+
+func TestUpdateRejectsNonLocalHTTPOrigin(t *testing.T) {
+	dir := t.TempDir()
+	_, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pub := priv.Public().(ed25519.PublicKey)
+	if _, err := Update(Request{Directory: dir, Origin: "http://example.com/releases", Keys: map[string]ed25519.PublicKey{testKeyID: pub}, Now: time.Date(2026, 8, 20, 0, 0, 0, 0, time.UTC)}); err == nil {
+		t.Fatal("cleartext remote origin accepted")
+	}
+}
+
+func TestUpdateSelectsOnlyRequestedPlatform(t *testing.T) {
+	origin := newSignedOrigin(t, originSpec{payload: testArtifact, goos: "linux", goarch: "amd64"})
+	dir := t.TempDir()
+	if _, err := Update(Request{Directory: dir, Origin: origin.URL, Keys: origin.Keys, GOOS: "windows", GOARCH: "amd64", Now: time.Date(2026, 8, 20, 0, 0, 0, 0, time.UTC)}); err == nil {
+		t.Fatal("missing platform artifacts accepted")
+	}
+}
+
+func TestUpdateRejectsRelativeDirectory(t *testing.T) {
+	origin := newSignedOrigin(t, originSpec{payload: testArtifact, goos: runtime.GOOS, goarch: runtime.GOARCH})
+	if _, err := Update(Request{Directory: "relative-state", Origin: origin.URL, Keys: origin.Keys, Now: time.Date(2026, 8, 20, 0, 0, 0, 0, time.UTC)}); err == nil {
+		t.Fatal("relative directory accepted")
+	}
+}
+
+func TestSignedDocumentDigestMatchesCatalog(t *testing.T) {
+	origin := newSignedOrigin(t, originSpec{payload: testArtifact, goos: "linux", goarch: "amd64"})
+	sum := sha256.Sum256(origin.Files["v0.1.0/"+punarorelease.ReleaseManifestFile])
+	catalog, err := punarorelease.ParseCatalog(origin.Files[punarorelease.CatalogReleaseName+"/"+punarorelease.CatalogFile])
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !catalog.Allows("v0.1.0", 1, hex.EncodeToString(sum[:])) {
+		t.Fatal("test catalog does not bind the assembled manifest")
+	}
+}
+
+type originSpec struct {
+	payload         string
+	goos            string
+	goarch          string
+	release         string
+	sequence        int64
+	catalogSequence int64
+	criticalBlocks  []int64
+}
+
+type signedOrigin struct {
+	URL   string
+	Keys  map[string]ed25519.PublicKey
+	Files map[string][]byte
+	priv  ed25519.PrivateKey
+}
+
+func newSignedOrigin(t *testing.T, spec originSpec) *signedOrigin {
+	t.Helper()
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	files := map[string][]byte{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, ok := files[strings.TrimPrefix(r.URL.Path, "/")]
+		if !ok {
+			http.NotFound(w, r)
+			return
+		}
+		_, _ = w.Write(body)
+	}))
+	t.Cleanup(server.Close)
+	origin := &signedOrigin{
+		URL:   server.URL,
+		Keys:  map[string]ed25519.PublicKey{testKeyID: pub},
+		Files: files,
+		priv:  priv,
+	}
+	origin.republish(t, spec)
+	return origin
+}
+
+func (origin *signedOrigin) republish(t *testing.T, spec originSpec) {
+	t.Helper()
+	if spec.release == "" {
+		spec.release = "v0.1.0"
+	}
+	if spec.sequence == 0 {
+		spec.sequence = 1
+	}
+	if spec.catalogSequence == 0 {
+		spec.catalogSequence = 1
+	}
+	build := t.TempDir()
+	name := artifactName("punaro-adapter", spec.goos, spec.goarch)
+	if err := os.WriteFile(filepath.Join(build, name), []byte(spec.payload), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	assembled, err := punarorelease.Assemble(punarorelease.AssembleRequest{
+		Directory:               build,
+		Release:                 spec.release,
+		Sequence:                spec.sequence,
+		PublishedAt:             time.Date(2026, 8, 16, 12, 0, 0, 0, time.UTC),
+		ExpiresAt:               time.Date(2026, 8, 23, 12, 0, 0, 0, time.UTC),
+		MinimumSafeSequence:     1,
+		CatalogSequence:         spec.catalogSequence,
+		ComposeSHA256:           testCompose,
+		MigrationManifestSHA256: testMigrate,
+		Database:                punarorelease.SchemaRange{Min: 10, Max: 44, Target: 44, RollbackFloor: 10},
+		PostgreSQLMajor:         18,
+		GatewayProtocol:         punarorelease.ProtocolRange{Min: 1, Max: 1},
+		ClientProtocol:          punarorelease.ProtocolRange{Min: 1, Max: 1},
+		MinimumRecoveryProtocol: 1,
+		MinimumBootstrapRelease: "v0.1.0",
+		CriticalBlocks:          spec.criticalBlocks,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	catalogSig, err := punarorelease.Sign(assembled.CatalogJSON, testKeyID, origin.priv)
+	if err != nil {
+		t.Fatal(err)
+	}
+	catalogSigJSON, err := punarorelease.EncodeEnvelope(catalogSig)
+	if err != nil {
+		t.Fatal(err)
+	}
+	manifestSig, err := punarorelease.Sign(assembled.ManifestJSON, testKeyID, origin.priv)
+	if err != nil {
+		t.Fatal(err)
+	}
+	manifestSigJSON, err := punarorelease.EncodeEnvelope(manifestSig)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for key := range origin.Files {
+		delete(origin.Files, key)
+	}
+	origin.Files[punarorelease.CatalogReleaseName+"/"+punarorelease.CatalogFile] = assembled.CatalogJSON
+	origin.Files[punarorelease.CatalogReleaseName+"/"+punarorelease.CatalogSignatureFile] = catalogSigJSON
+	origin.Files[spec.release+"/"+punarorelease.ReleaseManifestFile] = assembled.ManifestJSON
+	origin.Files[spec.release+"/"+punarorelease.ReleaseSignatureFile] = manifestSigJSON
+	origin.Files[spec.release+"/"+name] = []byte(spec.payload)
+}

--- a/internal/bootstrap/update_test.go
+++ b/internal/bootstrap/update_test.go
@@ -252,10 +252,10 @@ func TestUpdateRejectsWritableAncestor(t *testing.T) {
 	}
 	origin := newSignedOrigin(t, originSpec{payload: testArtifact, goos: runtime.GOOS, goarch: runtime.GOARCH})
 	parent := filepath.Join(t.TempDir(), "open")
-	if err := os.Mkdir(parent, 0o777); err != nil {
+	if err := os.Mkdir(parent, 0o777); err != nil { // #nosec G301 -- the regression creates a world-writable ancestor.
 		t.Fatal(err)
 	}
-	if err := os.Chmod(parent, 0o777); err != nil {
+	if err := os.Chmod(parent, 0o777); err != nil { // #nosec G302 -- the regression creates a world-writable ancestor.
 		t.Fatal(err)
 	}
 	dir := filepath.Join(parent, "state")

--- a/scripts/build-release-artifacts.sh
+++ b/scripts/build-release-artifacts.sh
@@ -72,6 +72,7 @@ build punaro-adapter ./cmd/punaro-adapter
 build punaro-trusted-attachment ./cmd/punaro-trusted-attachment
 build punaro-memory ./cmd/punaro-memory
 build punaro-enroll ./cmd/punaro-enroll
+build punaro-bootstrap ./cmd/punaro-bootstrap
 
 if [ "$goos" = linux ]; then
 	build punaro ./cmd/punaro


### PR DESCRIPTION
## Summary
- Add `punaro-bootstrap` so a host can pull signed Punaro artifacts from the fixed GitHub Releases origin `https://github.com/rock3r/punaro/releases/download`.
- `update` fetches the catalog and named manifest, verifies both detached Ed25519 signatures, checks exact length/digest, stages only the current platform's known component filenames, and publishes `current`/`previous` slots behind a crash-recoverable journal.
- `status` reports published slots. `rollback` swaps the two slots and does not lower the highest accepted sequences, so a later automatic update still cannot move backward.
- Fail closed on unsigned documents, stale catalogs, catalog/release sequence downgrades, critical blocks, digest mismatches, non-HTTPS origins (except loopback tests), path traversal, and `latest`.
- Build `punaro-bootstrap` into the native release artifact matrix. No production public key is embedded yet; `--keys-file` is required.

## Testing
- [x] `go test ./internal/bootstrap ./cmd/punaro-bootstrap`
- [x] `make test`
- [x] `make test-race`
- [x] `make lint`
- [x] `make security`

## Risks
- This slice does not implement `run`, candidate health, enrollment, or platform service handoff. Unsigned draft GitHub Releases remain untrusted until both `.sig` files verify.
- Rollback is host-local only and does not change accepted sequences; an immediate `update` will reinstall the catalog current release when that sequence is still allowed.
- No production release public key is committed. Operators must pass an independently obtained `--keys-file`.
