### PR TITLE
Add durable per-sender and per-conversation relay rate limits

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -405,7 +405,10 @@ conversation tokens with a 120/minute refill, and a 60-second Retry-After
 ceiling; hard bounds are 1–10000 tokens/refill and 1–3600 Retry-After seconds.
 SQLite and PostgreSQL implement the same observable contract. Metrics count
 rate rejections without labels derived from bodies, endpoints, roles, or
-conversation IDs.
+conversation IDs. Token-bucket rows are store-local operational state: a
+daemon restart of the same SQLite or PostgreSQL store cannot restore a
+depleted bucket, but mail cutover fingerprints and import batches omit them
+so a prepared source identity cannot change with limiter refill.
 
 An adapter does not receive a message merely because it has opened a WebSocket.
 It fetches durable deliveries, injects them into its local `agent_mailbox`, and

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -390,6 +390,23 @@ transactionally at acceptance. The guarantee is **at-least-once delivery**: a cr
 local mailbox injection but before the relay receives the acknowledgement can
 produce a redelivery.
 
+Accepted appends consume one token from independent durable buckets for the
+authenticated sender machine and the conversation. The limiter uses server time
+supplied by `punarod`, never a client timestamp, and stores enough state that a
+daemon restart cannot restore a depleted bucket. Exact retries of a committed
+idempotency key return the original message without charging. A new request
+consumes both buckets in the same transaction as sequence allocation; a
+rate-limit, authorization, or conflict refusal creates no sequence, message,
+delivery, idempotency, or audit row. HTTP maps that refusal to `429` with a
+bounded integer `Retry-After` and the stable content-free error
+`rate limit exceeded`. Bodies are never hashed, compared, or parsed for loop
+detection. Defaults are 60 sender tokens with a 60/minute refill, 120
+conversation tokens with a 120/minute refill, and a 60-second Retry-After
+ceiling; hard bounds are 1–10000 tokens/refill and 1–3600 Retry-After seconds.
+SQLite and PostgreSQL implement the same observable contract. Metrics count
+rate rejections without labels derived from bodies, endpoints, roles, or
+conversation IDs.
+
 An adapter does not receive a message merely because it has opened a WebSocket.
 It fetches durable deliveries, injects them into its local `agent_mailbox`, and
 acknowledges each only after local acceptance succeeds.

--- a/README.md
+++ b/README.md
@@ -133,6 +133,11 @@ precedence over dotenv values.
 | `PUNARO_RELAY_ENABLED` | `false` | Enables the loopback text relay; requires public machine enrollment records. |
 | `PUNARO_RELAY_STORE` | `sqlite` | Explicit relay backend selector. Before cutover, `postgres` is limited to empty-destination parity/qualification. The supported one-shot executor publishes `postgres` marker-last only after verified import, SQLite retirement, legacy-gate closure, and PostgreSQL activation. It never dual-writes. |
 | `PUNARO_RELAY_MACHINES_JSON` | unset | Explicit public-key machine enrollment records. `endpoint_prefixes` claims disjoint machine namespaces; `endpoints` can grant a named exact endpoint without creating a prefix. |
+| `PUNARO_RELAY_SENDER_RATE_BURST` | `60` | Startup-validated sender-machine token-bucket burst. Integer 1–10000. |
+| `PUNARO_RELAY_SENDER_RATE_REFILL_PER_MINUTE` | `60` | Startup-validated sender-machine refill. Integer 1–10000 tokens/minute. |
+| `PUNARO_RELAY_CONVERSATION_RATE_BURST` | `120` | Startup-validated conversation token-bucket burst. Integer 1–10000. |
+| `PUNARO_RELAY_CONVERSATION_RATE_REFILL_PER_MINUTE` | `120` | Startup-validated conversation refill. Integer 1–10000 tokens/minute. |
+| `PUNARO_RELAY_RATE_RETRY_AFTER_MAX_SECONDS` | `60` | Ceiling for the integer `Retry-After` advertised on a `429` rate-limit refusal. Integer 1–3600. |
 | `PUNARO_TRUSTED_ATTACHMENTS_ENABLED` | `false` | Separately gates the authenticated trusted-relay attachment surface; requires PostgreSQL device authentication, a valid ingress policy, schema v13, and successful startup reconciliation. |
 | `PUNARO_TRUSTED_ATTACHMENT_BLOB_DIR` | unset | Required with trusted attachments: absolute private (`0700`) daemon-owned blob root. |
 

--- a/cmd/punarod/main.go
+++ b/cmd/punarod/main.go
@@ -746,7 +746,14 @@ func buildRelayHandler(cfg config.Config, postgresBackends ...relay.Backend) (ht
 		}
 		return nil, nil, err
 	}
-	handler := relay.NewHandler(backend, authenticator, relay.HandlerOptions{})
+	if err := applyRelayRateLimitPolicy(cfg, backend); err != nil {
+		if store != nil {
+			_ = store.Close()
+		}
+		return nil, nil, err
+	}
+	metrics := &relay.Metrics{}
+	handler := relay.NewHandler(backend, authenticator, relay.HandlerOptions{Metrics: metrics})
 	if cfg.AccessIssuer != "" {
 		verifier, err := newAccessVerifier(cfg)
 		if err != nil {
@@ -758,6 +765,27 @@ func buildRelayHandler(cfg config.Config, postgresBackends ...relay.Backend) (ht
 		handler = verifier.Middleware(handler)
 	}
 	return handler, store, nil
+}
+
+func applyRelayRateLimitPolicy(cfg config.Config, backend relay.Backend) error {
+	policy := relay.DefaultRateLimitPolicy()
+	if cfg.RelaySenderRateBurst != 0 || cfg.RelaySenderRateRefillPerMinute != 0 || cfg.RelayConversationRateBurst != 0 || cfg.RelayConversationRateRefillPerMinute != 0 || cfg.RelayRateRetryAfterMaxSeconds != 0 {
+		policy = relay.RateLimitPolicy{
+			SenderBurst:                 cfg.RelaySenderRateBurst,
+			SenderRefillPerMinute:       cfg.RelaySenderRateRefillPerMinute,
+			ConversationBurst:           cfg.RelayConversationRateBurst,
+			ConversationRefillPerMinute: cfg.RelayConversationRateRefillPerMinute,
+			MaxRetryAfterSeconds:        cfg.RelayRateRetryAfterMaxSeconds,
+		}
+	}
+	if err := policy.Validate(); err != nil {
+		return err
+	}
+	configurer, ok := backend.(relay.RateLimitConfigurer)
+	if !ok {
+		return errors.New("relay rate limiter is unavailable")
+	}
+	return configurer.SetRateLimitPolicy(policy)
 }
 
 func newAccessVerifier(cfg config.Config) (*access.Verifier, error) {

--- a/cmd/punarod/relay_test.go
+++ b/cmd/punarod/relay_test.go
@@ -73,6 +73,26 @@ func TestBuildRelayHandlerRejectsInvalidEnrollment(t *testing.T) {
 	}
 }
 
+func TestBuildRelayHandlerRejectsInvalidRateLimitPolicy(t *testing.T) {
+	public, _, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	machines := `[{"id":"machine-a","public_key":"` + base64.RawURLEncoding.EncodeToString(public) + `","endpoint_prefixes":["agent/a/"]}]`
+	_, closer, err := buildRelayHandler(config.Config{
+		DataDir: t.TempDir(), RelayEnabled: true, RelayMachinesJSON: machines,
+		RelaySenderRateBurst: 0, RelaySenderRateRefillPerMinute: 60,
+		RelayConversationRateBurst: 60, RelayConversationRateRefillPerMinute: 60,
+		RelayRateRetryAfterMaxSeconds: 60,
+	})
+	if closer != nil {
+		t.Fatal("invalid rate-limit policy returned a closer")
+	}
+	if err == nil {
+		t.Fatal("invalid rate-limit policy enabled relay routes")
+	}
+}
+
 func TestBuildRelayHandlerRevokedEnrollmentFailsClosedAfterRestart(t *testing.T) {
 	public, private, err := ed25519.GenerateKey(rand.Reader)
 	if err != nil {

--- a/docs/alpha-text-relay.md
+++ b/docs/alpha-text-relay.md
@@ -57,6 +57,18 @@ PUNARO_LISTEN_ADDR=127.0.0.1:8080
 PUNARO_DATA_DIR=/var/lib/punaro
 ```
 
+Optional relay rate-limit overrides are startup-validated. Defaults are 60
+sender tokens refilling at 60/minute, 120 conversation tokens refilling at
+120/minute, and a 60-second Retry-After ceiling:
+
+```text
+PUNARO_RELAY_SENDER_RATE_BURST=60
+PUNARO_RELAY_SENDER_RATE_REFILL_PER_MINUTE=60
+PUNARO_RELAY_CONVERSATION_RATE_BURST=120
+PUNARO_RELAY_CONVERSATION_RATE_REFILL_PER_MINUTE=120
+PUNARO_RELAY_RATE_RETRY_AFTER_MAX_SECONDS=60
+```
+
 For a Cloudflare-protected remote route, additionally set the Access issuer,
 application audience tag, and JWKS URL. Configure the tunnel origin to require
 the Access assertion. The process validates `Cf-Access-Jwt-Assertion` itself;

--- a/docs/operator-guide.md
+++ b/docs/operator-guide.md
@@ -36,7 +36,17 @@ Set `PUNARO_RELAY_ENABLED=true` plus a public
 `PUNARO_RELAY_MACHINES_JSON` enrollment set to enable the alpha relay; see the
 [onboarding guide](alpha-text-relay.md). `PUNARO_DATA_DIR` holds its SQLite
 WAL state. `PUNARO_LOG_LEVEL` is validated as `debug`, `info`, `warn`, or
-`error`, but does not yet filter the standard logger. An explicitly
+`error`, but does not yet filter the standard logger. Relay appends enforce
+independent durable token buckets for the authenticated sender machine and the
+conversation. Defaults are `PUNARO_RELAY_SENDER_RATE_BURST=60`,
+`PUNARO_RELAY_SENDER_RATE_REFILL_PER_MINUTE=60`,
+`PUNARO_RELAY_CONVERSATION_RATE_BURST=120`,
+`PUNARO_RELAY_CONVERSATION_RATE_REFILL_PER_MINUTE=120`, and
+`PUNARO_RELAY_RATE_RETRY_AFTER_MAX_SECONDS=60`. Burst and refill values must be
+integers from 1 through 10000; Retry-After must be an integer from 1 through
+3600. Exhausted buckets return `429` with a bounded integer `Retry-After` and
+the content-free error `rate limit exceeded`. Exact committed idempotency
+retries do not consume tokens. An explicitly
 named dotenv file is for local development only:
 
 ```sh
@@ -157,8 +167,8 @@ database and investigate. The digest-pinned `make test-postgres` stack is epheme
 test infrastructure, publishes no database port, and deletes its volume on
 exit.
 
-The current binary requires schema version 45 and supports an intact schema
-from version 10 through 45 as an update boundary. Versions 10 through 44 are
+The current binary requires schema version 46 and supports an intact schema
+from version 10 through 46 as an update boundary. Versions 10 through 45 are
 reported as `upgrade_required`; versions below the compatibility floor, newer
 versions, and damaged objects are `incompatible`. The embedded manifest and
 target release metadata are authoritative; check them instead of assuming a
@@ -166,7 +176,8 @@ version from this guide when preparing a future release. Migration 40 adds
 durable conversation roles, migration 41 adds relay membership controls,
 migration 42 applies those controls to mail cutover, migration 43 adds the
 relay invocation capability, migration 44 adds client lifecycle authority,
-and migration 45 adds opt-in canonical role profiles. Migration 44 invalidates unredeemed legacy enrollment invitations while
+migration 45 adds opt-in canonical role profiles, and migration 46 adds
+durable sender and conversation relay rate buckets. Migration 44 invalidates unredeemed legacy enrollment invitations while
 converting existing device credentials into lifecycle-managed client records,
 so it must not be applied as an ad hoc repair. The host wrapper's one-shot
 executor is the only supported authority transition. It always reads `relay.db`

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -383,10 +383,10 @@ func value(name, fallback string) string {
 	return fallback
 }
 
-func parseBoundedInt(name, raw string, min, max int) (int, error) {
+func parseBoundedInt(name, raw string, minimum, maximum int) (int, error) {
 	value, err := strconv.Atoi(raw)
-	if err != nil || value < min || value > max {
-		return 0, fmt.Errorf("%s must be an integer between %d and %d", name, min, max)
+	if err != nil || value < minimum || value > maximum {
+		return 0, fmt.Errorf("%s must be an integer between %d and %d", name, minimum, maximum)
 	}
 	return value, nil
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -21,38 +21,43 @@ import (
 
 // Config is the explicit environment-derived daemon configuration.
 type Config struct {
-	ListenAddr                      string
-	HealthListenAddr                string
-	DataDir                         string
-	LogLevel                        string
-	RelayEnabled                    bool
-	RelayMachinesJSON               string
-	RelayStore                      string
-	AccessIssuer                    string
-	AccessAudience                  string
-	AccessJWKSURL                   string
-	AccessJWKSFile                  string
-	PostgresEnabled                 bool
-	PostgresDSNFile                 string
-	DeviceAuthEnabled               bool
-	MemoryAPIEnabled                bool
-	MemoryMutationsEnabled          bool
-	RemoteMCPMetadataEnabled        bool
-	RemoteMCPResourceURL            string
-	RemoteMCPAuthorizationServers   string
-	RemoteMCPTokenValidationEnabled bool
-	RemoteMCPIssuer                 string
-	RemoteMCPJWKSURL                string
-	RemoteMCPSubjectBindingsJSON    string
-	MemoryOpenAIEmbeddingsURL       string
-	MemoryOpenAIAPIKeyFile          string
-	TrustedAttachmentsEnabled       bool
-	TrustedAttachmentBlobDir        string
-	CredentialTransitionEnabled     bool
-	IngressMode                     string
-	PublicURL                       string
-	TrustedLANCIDR                  string
-	TrustedLANHTTP                  bool
+	ListenAddr                           string
+	HealthListenAddr                     string
+	DataDir                              string
+	LogLevel                             string
+	RelayEnabled                         bool
+	RelayMachinesJSON                    string
+	RelayStore                           string
+	AccessIssuer                         string
+	AccessAudience                       string
+	AccessJWKSURL                        string
+	AccessJWKSFile                       string
+	PostgresEnabled                      bool
+	PostgresDSNFile                      string
+	DeviceAuthEnabled                    bool
+	MemoryAPIEnabled                     bool
+	MemoryMutationsEnabled               bool
+	RemoteMCPMetadataEnabled             bool
+	RemoteMCPResourceURL                 string
+	RemoteMCPAuthorizationServers        string
+	RemoteMCPTokenValidationEnabled      bool
+	RemoteMCPIssuer                      string
+	RemoteMCPJWKSURL                     string
+	RemoteMCPSubjectBindingsJSON         string
+	MemoryOpenAIEmbeddingsURL            string
+	MemoryOpenAIAPIKeyFile               string
+	TrustedAttachmentsEnabled            bool
+	TrustedAttachmentBlobDir             string
+	CredentialTransitionEnabled          bool
+	IngressMode                          string
+	PublicURL                            string
+	TrustedLANCIDR                       string
+	TrustedLANHTTP                       bool
+	RelaySenderRateBurst                 int
+	RelaySenderRateRefillPerMinute       int
+	RelayConversationRateBurst           int
+	RelayConversationRateRefillPerMinute int
+	RelayRateRetryAfterMaxSeconds        int
 }
 
 // Load reads configuration and optionally loads an explicitly named dotenv file.
@@ -138,6 +143,26 @@ func Load(explicitEnvFile string) (Config, error) {
 	trustedLANHTTP, err := strconv.ParseBool(value("PUNARO_TRUSTED_LAN_HTTP", "false"))
 	if err != nil {
 		return Config{}, fmt.Errorf("parse PUNARO_TRUSTED_LAN_HTTP: %w", err)
+	}
+	senderBurst, err := parseBoundedInt("PUNARO_RELAY_SENDER_RATE_BURST", value("PUNARO_RELAY_SENDER_RATE_BURST", "60"), 1, 10000)
+	if err != nil {
+		return Config{}, err
+	}
+	senderRefill, err := parseBoundedInt("PUNARO_RELAY_SENDER_RATE_REFILL_PER_MINUTE", value("PUNARO_RELAY_SENDER_RATE_REFILL_PER_MINUTE", "60"), 1, 10000)
+	if err != nil {
+		return Config{}, err
+	}
+	conversationBurst, err := parseBoundedInt("PUNARO_RELAY_CONVERSATION_RATE_BURST", value("PUNARO_RELAY_CONVERSATION_RATE_BURST", "120"), 1, 10000)
+	if err != nil {
+		return Config{}, err
+	}
+	conversationRefill, err := parseBoundedInt("PUNARO_RELAY_CONVERSATION_RATE_REFILL_PER_MINUTE", value("PUNARO_RELAY_CONVERSATION_RATE_REFILL_PER_MINUTE", "120"), 1, 10000)
+	if err != nil {
+		return Config{}, err
+	}
+	retryAfterMax, err := parseBoundedInt("PUNARO_RELAY_RATE_RETRY_AFTER_MAX_SECONDS", value("PUNARO_RELAY_RATE_RETRY_AFTER_MAX_SECONDS", "60"), 1, 3600)
+	if err != nil {
+		return Config{}, err
 	}
 	listenAddr := value("PUNARO_LISTEN_ADDR", "127.0.0.1:8080")
 	healthListenAddr := value("PUNARO_HEALTH_LISTEN_ADDR", "127.0.0.1:8081")
@@ -227,7 +252,7 @@ func Load(explicitEnvFile string) (Config, error) {
 	if !postgresEnabled && postgresDSNFile != "" {
 		return Config{}, fmt.Errorf("PUNARO_POSTGRES_DSN_FILE requires PUNARO_POSTGRES_ENABLED")
 	}
-	return Config{ListenAddr: listenAddr, HealthListenAddr: healthListenAddr, DataDir: dataDir, LogLevel: level, RelayEnabled: relayEnabled, RelayMachinesJSON: relayMachines, RelayStore: relayStore, AccessIssuer: accessIssuer, AccessAudience: accessAudience, AccessJWKSURL: accessJWKSURL, AccessJWKSFile: accessJWKSFile, PostgresEnabled: postgresEnabled, PostgresDSNFile: postgresDSNFile, DeviceAuthEnabled: deviceAuthEnabled, MemoryAPIEnabled: memoryAPIEnabled, MemoryMutationsEnabled: memoryMutationsEnabled, RemoteMCPMetadataEnabled: remoteMCPMetadataEnabled, RemoteMCPResourceURL: remoteMCPResourceURL, RemoteMCPAuthorizationServers: remoteMCPAuthorizationServers, RemoteMCPTokenValidationEnabled: remoteMCPTokenValidationEnabled, RemoteMCPIssuer: remoteMCPIssuer, RemoteMCPJWKSURL: remoteMCPJWKSURL, RemoteMCPSubjectBindingsJSON: remoteMCPSubjectBindingsJSON, MemoryOpenAIEmbeddingsURL: memoryOpenAIEmbeddingsURL, MemoryOpenAIAPIKeyFile: memoryOpenAIAPIKeyFile, TrustedAttachmentsEnabled: trustedAttachmentsEnabled, TrustedAttachmentBlobDir: trustedAttachmentBlobDir, CredentialTransitionEnabled: credentialTransitionEnabled, IngressMode: ingressMode, PublicURL: publicURL, TrustedLANCIDR: trustedLANCIDR, TrustedLANHTTP: trustedLANHTTP}, nil
+	return Config{ListenAddr: listenAddr, HealthListenAddr: healthListenAddr, DataDir: dataDir, LogLevel: level, RelayEnabled: relayEnabled, RelayMachinesJSON: relayMachines, RelayStore: relayStore, AccessIssuer: accessIssuer, AccessAudience: accessAudience, AccessJWKSURL: accessJWKSURL, AccessJWKSFile: accessJWKSFile, PostgresEnabled: postgresEnabled, PostgresDSNFile: postgresDSNFile, DeviceAuthEnabled: deviceAuthEnabled, MemoryAPIEnabled: memoryAPIEnabled, MemoryMutationsEnabled: memoryMutationsEnabled, RemoteMCPMetadataEnabled: remoteMCPMetadataEnabled, RemoteMCPResourceURL: remoteMCPResourceURL, RemoteMCPAuthorizationServers: remoteMCPAuthorizationServers, RemoteMCPTokenValidationEnabled: remoteMCPTokenValidationEnabled, RemoteMCPIssuer: remoteMCPIssuer, RemoteMCPJWKSURL: remoteMCPJWKSURL, RemoteMCPSubjectBindingsJSON: remoteMCPSubjectBindingsJSON, MemoryOpenAIEmbeddingsURL: memoryOpenAIEmbeddingsURL, MemoryOpenAIAPIKeyFile: memoryOpenAIAPIKeyFile, TrustedAttachmentsEnabled: trustedAttachmentsEnabled, TrustedAttachmentBlobDir: trustedAttachmentBlobDir, CredentialTransitionEnabled: credentialTransitionEnabled, IngressMode: ingressMode, PublicURL: publicURL, TrustedLANCIDR: trustedLANCIDR, TrustedLANHTTP: trustedLANHTTP, RelaySenderRateBurst: senderBurst, RelaySenderRateRefillPerMinute: senderRefill, RelayConversationRateBurst: conversationBurst, RelayConversationRateRefillPerMinute: conversationRefill, RelayRateRetryAfterMaxSeconds: retryAfterMax}, nil
 }
 
 func validRemoteMCPHTTPSURL(raw string, permitPath bool) bool {
@@ -356,6 +381,14 @@ func value(name, fallback string) string {
 		return strings.TrimSpace(v)
 	}
 	return fallback
+}
+
+func parseBoundedInt(name, raw string, min, max int) (int, error) {
+	value, err := strconv.Atoi(raw)
+	if err != nil || value < min || value > max {
+		return 0, fmt.Errorf("%s must be an integer between %d and %d", name, min, max)
+	}
+	return value, nil
 }
 func parseLogLevel(raw string) (string, error) {
 	switch strings.ToLower(raw) {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -38,6 +38,41 @@ func TestLoadPostgresDefaultsDisabled(t *testing.T) {
 	}
 }
 
+func TestLoadRelayRateLimitDefaultsAndBounds(t *testing.T) {
+	cfg, err := Load("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.RelaySenderRateBurst != 60 || cfg.RelaySenderRateRefillPerMinute != 60 || cfg.RelayConversationRateBurst != 120 || cfg.RelayConversationRateRefillPerMinute != 120 || cfg.RelayRateRetryAfterMaxSeconds != 60 {
+		t.Fatalf("rate-limit defaults=%#v", cfg)
+	}
+	t.Setenv("PUNARO_RELAY_SENDER_RATE_BURST", "2")
+	t.Setenv("PUNARO_RELAY_SENDER_RATE_REFILL_PER_MINUTE", "30")
+	t.Setenv("PUNARO_RELAY_CONVERSATION_RATE_BURST", "4")
+	t.Setenv("PUNARO_RELAY_CONVERSATION_RATE_REFILL_PER_MINUTE", "15")
+	t.Setenv("PUNARO_RELAY_RATE_RETRY_AFTER_MAX_SECONDS", "9")
+	cfg, err = Load("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.RelaySenderRateBurst != 2 || cfg.RelaySenderRateRefillPerMinute != 30 || cfg.RelayConversationRateBurst != 4 || cfg.RelayConversationRateRefillPerMinute != 15 || cfg.RelayRateRetryAfterMaxSeconds != 9 {
+		t.Fatalf("configured rate limits=%#v", cfg)
+	}
+	for _, env := range []struct{ name, value string }{
+		{"PUNARO_RELAY_SENDER_RATE_BURST", "0"},
+		{"PUNARO_RELAY_SENDER_RATE_BURST", "10001"},
+		{"PUNARO_RELAY_SENDER_RATE_REFILL_PER_MINUTE", "-1"},
+		{"PUNARO_RELAY_CONVERSATION_RATE_BURST", "nope"},
+		{"PUNARO_RELAY_RATE_RETRY_AFTER_MAX_SECONDS", "3601"},
+	} {
+		t.Setenv(env.name, env.value)
+		if _, err := Load(""); err == nil {
+			t.Fatalf("%s=%q was accepted", env.name, env.value)
+		}
+		t.Setenv(env.name, "")
+	}
+}
+
 func TestLoadAcceptsProductionComposeRuntimeConfiguration(t *testing.T) {
 	for key, value := range map[string]string{
 		"PUNARO_LISTEN_ADDR":         "127.0.0.1:8080",

--- a/internal/postgres/db.go
+++ b/internal/postgres/db.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	_ "github.com/jackc/pgx/v5/stdlib" // Register the audited pgx database/sql driver.
+	"github.com/rock3r/punaro/internal/relay"
 )
 
 const operationTimeout = 5 * time.Second
@@ -31,6 +32,8 @@ type Database struct {
 	memoryUsageWrites         chan memoryUsageWrite
 	memoryUsageStop           chan struct{}
 	memoryUsageDone           chan struct{}
+	rateMu                    sync.Mutex
+	rateLimit                 relay.RateLimitPolicy
 	memoryUsageStopOnce       sync.Once
 }
 
@@ -97,6 +100,7 @@ func OpenApplication(ctx context.Context, cfg Config) (*Database, error) {
 		memoryUsageWrites:         make(chan memoryUsageWrite, maxMemoryRecallQueue),
 		memoryUsageStop:           make(chan struct{}),
 		memoryUsageDone:           make(chan struct{}),
+		rateLimit:                 relay.DefaultRateLimitPolicy(),
 	}
 	go database.runMemoryUsageWriter(ctx)
 	return database, nil
@@ -1253,6 +1257,13 @@ FROM objects, table_ownership, routine_safety, routine_acl, table_acl, schema_ac
 			return Snapshot{}, errors.New("PostgreSQL relay role-profile schema cannot be inspected")
 		}
 		snapshot.CurrentObjectsPresent = profileObjectsPresent
+	}
+	if snapshot.CurrentObjectsPresent && len(snapshot.Records) > 0 && snapshot.Records[len(snapshot.Records)-1].Version >= 46 {
+		rateLimitObjectsPresent, err := relayRateLimitControlsAvailable(ctx, q)
+		if err != nil {
+			return Snapshot{}, errors.New("PostgreSQL relay rate-limit schema cannot be inspected")
+		}
+		snapshot.CurrentObjectsPresent = rateLimitObjectsPresent
 	}
 	return snapshot, nil
 }

--- a/internal/postgres/migrate.go
+++ b/internal/postgres/migrate.go
@@ -78,6 +78,7 @@ var migrationCompatibilityFloors = map[int64]int64{
 	43: 10,
 	44: 10,
 	45: 10,
+	46: 10,
 }
 
 // CurrentManifest returns the immutable migrations embedded in this binary.

--- a/internal/postgres/migrations/046_relay_rate_limits.sql
+++ b/internal/postgres/migrations/046_relay_rate_limits.sql
@@ -1,0 +1,21 @@
+-- Durable sender-machine and conversation token buckets. Restart must not
+-- restore capacity; exact committed retries never charge these rows.
+CREATE TABLE relay.mail_rate_buckets (
+    scope text NOT NULL CHECK (scope IN ('sender_machine', 'conversation')),
+    bucket_key text NOT NULL CHECK (
+        char_length(bucket_key) >= 1 AND char_length(bucket_key) <= 512
+        AND octet_length(bucket_key) <= 2048
+        AND bucket_key !~ '[[:cntrl:]]'
+    ),
+    tokens_milli bigint NOT NULL CHECK (tokens_milli >= 0),
+    last_refill_at timestamptz NOT NULL,
+    PRIMARY KEY (scope, bucket_key)
+);
+
+CREATE TRIGGER mail_rate_buckets_mutation_guard
+BEFORE INSERT OR UPDATE OR DELETE ON relay.mail_rate_buckets
+FOR EACH STATEMENT EXECUTE FUNCTION relay.guard_mail_mutation();
+
+REVOKE ALL ON relay.mail_rate_buckets FROM PUBLIC;
+GRANT SELECT, INSERT ON relay.mail_rate_buckets TO punaro_app;
+GRANT UPDATE (tokens_milli, last_refill_at) ON relay.mail_rate_buckets TO punaro_app;

--- a/internal/postgres/postgres_integration_test.go
+++ b/internal/postgres/postgres_integration_test.go
@@ -1583,6 +1583,7 @@ func testRelayIntegration(t *testing.T, app *Database) {
 	contracttest.Run(t, app, "postgres-contract")
 	contracttest.RunRoleTargeting(t, app, "postgres-target")
 	contracttest.RunRoleProfiles(t, app, "postgres-profile")
+	contracttest.RunRateLimits(t, app, "postgres-rate")
 	testPostgresMembershipControls(t, app)
 	testRecipientCursorDoesNotCrossUncommittedAppend(t, app)
 	testEndpointAdvertisementUsesCanonicalLockOrder(t, app)

--- a/internal/postgres/relay_rate_limit_schema.go
+++ b/internal/postgres/relay_rate_limit_schema.go
@@ -1,0 +1,61 @@
+package postgres
+
+import "context"
+
+// relayRateLimitControlsAvailable confirms that durable sender and conversation
+// token buckets remain owned by the schema role with column-bounded updates.
+func relayRateLimitControlsAvailable(ctx context.Context, q queryer) (bool, error) {
+	var available bool
+	err := q.QueryRowContext(ctx, `
+WITH objects AS (
+    SELECT to_regclass('relay.mail_rate_buckets') AS buckets_oid,
+           to_regprocedure('relay.guard_mail_mutation()') AS guard_oid
+), relations AS (
+    SELECT count(*)=1 AND bool_and(pg_get_userbyid(class.relowner)='punaro_owner' AND class.relkind='r'
+       AND class.relpersistence='p' AND NOT class.relrowsecurity AND NOT class.relforcerowsecurity) AS exact
+    FROM objects JOIN pg_class AS class ON class.oid=buckets_oid
+), columns AS (
+    SELECT count(*)=4
+       AND bool_and((attribute.attrelid,attribute.attname,attribute.atttypid,attribute.attnotnull) IN (
+           (buckets_oid,'scope','text'::regtype,true),(buckets_oid,'bucket_key','text'::regtype,true),
+           (buckets_oid,'tokens_milli','int8'::regtype,true),(buckets_oid,'last_refill_at','timestamptz'::regtype,true))) AS exact
+    FROM objects JOIN pg_attribute AS attribute ON attribute.attrelid=buckets_oid
+       AND attribute.attnum>0 AND NOT attribute.attisdropped
+), expected_constraints(table_oid,constraint_name,constraint_type,column_keys,check_expression) AS (
+    SELECT expected.* FROM objects, LATERAL (VALUES
+        (buckets_oid,'mail_rate_buckets_pkey','p'::"char",ARRAY[1,2]::smallint[],NULL::text),
+        (buckets_oid,'mail_rate_buckets_scope_check','c'::"char",ARRAY[1]::smallint[],'(scope = ANY (ARRAY[''sender_machine''::text, ''conversation''::text]))'),
+        (buckets_oid,'mail_rate_buckets_bucket_key_check','c'::"char",ARRAY[2]::smallint[],'((char_length(bucket_key) >= 1) AND (char_length(bucket_key) <= 512) AND (octet_length(bucket_key) <= 2048) AND (bucket_key !~ ''[[:cntrl:]]''::text))'),
+        (buckets_oid,'mail_rate_buckets_tokens_milli_check','c'::"char",ARRAY[3]::smallint[],'(tokens_milli >= 0)')
+    ) AS expected(table_oid,constraint_name,constraint_type,column_keys,check_expression)
+), actual_constraints AS (
+    SELECT constraint_.conrelid,constraint_.conname,constraint_.contype,constraint_.conkey,
+           CASE WHEN constraint_.contype='c' THEN pg_get_expr(constraint_.conbin,constraint_.conrelid) END
+    FROM objects JOIN pg_constraint AS constraint_ ON constraint_.conrelid=buckets_oid
+    WHERE constraint_.contype IN ('p','c')
+      AND constraint_.convalidated AND NOT constraint_.condeferrable AND NOT constraint_.condeferred
+), constraints AS (
+    SELECT NOT EXISTS (SELECT * FROM expected_constraints EXCEPT SELECT * FROM actual_constraints)
+       AND NOT EXISTS (SELECT * FROM actual_constraints EXCEPT SELECT * FROM expected_constraints) AS exact
+    FROM expected_constraints
+), guards AS (
+    SELECT count(*)=1 AND bool_and(trigger.tgfoid=guard_oid AND trigger.tgenabled='O' AND NOT trigger.tgisinternal
+       AND trigger.tgtype=30 AND trigger.tgconstraint=0 AND NOT trigger.tgdeferrable AND NOT trigger.tginitdeferred
+       AND trigger.tgnargs=0 AND trigger.tgqual IS NULL AND trigger.tgnewtable IS NULL AND trigger.tgoldtable IS NULL
+       AND trigger.tgattr::text='') AS exact
+    FROM objects JOIN pg_trigger AS trigger ON trigger.tgrelid=buckets_oid
+       AND trigger.tgname='mail_rate_buckets_mutation_guard'
+), acl AS (
+    SELECT has_table_privilege('punaro_app',buckets_oid,'SELECT,INSERT')
+       AND NOT has_table_privilege('punaro_app',buckets_oid,'UPDATE,DELETE,TRUNCATE,REFERENCES,TRIGGER')
+       AND has_column_privilege('punaro_app',buckets_oid,'tokens_milli','UPDATE')
+       AND has_column_privilege('punaro_app',buckets_oid,'last_refill_at','UPDATE')
+       AND NOT has_column_privilege('punaro_app',buckets_oid,'scope','UPDATE')
+       AND NOT has_column_privilege('punaro_app',buckets_oid,'bucket_key','UPDATE') AS exact
+    FROM objects
+)
+SELECT buckets_oid IS NOT NULL AND guard_oid IS NOT NULL
+   AND relations.exact AND columns.exact AND constraints.exact AND guards.exact AND acl.exact
+FROM objects,relations,columns,constraints,guards,acl`).Scan(&available)
+	return available, err
+}

--- a/internal/postgres/relay_store.go
+++ b/internal/postgres/relay_store.go
@@ -18,8 +18,29 @@ var _ relay.Backend = (*Database)(nil)
 var _ relay.RoleBindingBackend = (*Database)(nil)
 var _ relay.RoleProfileBackend = (*Database)(nil)
 var _ relay.ControlBackend = (*Database)(nil)
+var _ relay.RateLimitConfigurer = (*Database)(nil)
 
 const postgresRelayMaxMessageBytes = 32 << 10
+
+// SetRateLimitPolicy replaces the durable limiter bounds after startup validation.
+func (d *Database) SetRateLimitPolicy(policy relay.RateLimitPolicy) error {
+	if err := policy.Validate(); err != nil {
+		return err
+	}
+	d.rateMu.Lock()
+	d.rateLimit = policy
+	d.rateMu.Unlock()
+	return nil
+}
+
+func (d *Database) rateLimitPolicy() relay.RateLimitPolicy {
+	d.rateMu.Lock()
+	defer d.rateMu.Unlock()
+	if d.rateLimit == (relay.RateLimitPolicy{}) {
+		return relay.DefaultRateLimitPolicy()
+	}
+	return d.rateLimit
+}
 
 // ConsumeRequestNonce atomically consumes one signed-request replay token
 // through the schema-owner routine. The application role cannot delete nonce
@@ -836,6 +857,12 @@ func (d *Database) AppendMessage(input relay.AppendInput) (relay.Message, bool, 
 	if !errors.Is(err, sql.ErrNoRows) {
 		return relay.Message{}, false, errors.New("message retry state is unavailable")
 	}
+	if _, err := tx.ExecContext(context.Background(), `SELECT pg_advisory_xact_lock(hashtextextended(jsonb_build_array('rate-sender',$1::text)::text, 579001230613))`, input.SenderMachineID); err != nil {
+		return relay.Message{}, false, errors.New("message sender rate lock is unavailable")
+	}
+	if err := consumePostgresRateLimits(tx, d.rateLimitPolicy(), input.SenderMachineID, input.ConversationID, input.Now); err != nil {
+		return relay.Message{}, false, err
+	}
 	message := relay.Message{ID: uuid.NewString(), ConversationID: input.ConversationID, FromEndpoint: input.FromEndpoint, Body: input.Body, CreatedAt: input.Now.UTC().Truncate(time.Millisecond)}
 	if err := tx.QueryRowContext(context.Background(), `UPDATE relay.mail_conversations SET next_sequence=next_sequence+1 WHERE id=$1::uuid RETURNING next_sequence`, input.ConversationID).Scan(&message.Sequence); errors.Is(err, sql.ErrNoRows) {
 		return relay.Message{}, false, relay.ErrForbidden
@@ -1361,6 +1388,58 @@ func postgresAdvanceRecipientCursor(tx *sql.Tx, endpoint, conversationID string)
 		}
 	}
 	return nil
+}
+
+func consumePostgresRateLimits(tx *sql.Tx, policy relay.RateLimitPolicy, senderMachineID, conversationID string, now time.Time) error {
+	senderRetry, senderOK, err := consumePostgresRateBucket(tx, "sender_machine", senderMachineID, now, policy.SenderBurst, policy.SenderRefillPerMinute, policy.MaxRetryAfterSeconds)
+	if err != nil {
+		return err
+	}
+	conversationRetry, conversationOK, err := consumePostgresRateBucket(tx, "conversation", conversationID, now, policy.ConversationBurst, policy.ConversationRefillPerMinute, policy.MaxRetryAfterSeconds)
+	if err != nil {
+		return err
+	}
+	if senderOK && conversationOK {
+		return nil
+	}
+	retryAfter := senderRetry
+	if !conversationOK && conversationRetry > retryAfter {
+		retryAfter = conversationRetry
+	}
+	if senderOK {
+		retryAfter = conversationRetry
+	}
+	if conversationOK {
+		retryAfter = senderRetry
+	}
+	seconds := int((retryAfter + time.Second - 1) / time.Second)
+	if seconds < 1 {
+		seconds = 1
+	}
+	if policy.MaxRetryAfterSeconds > 0 && seconds > policy.MaxRetryAfterSeconds {
+		seconds = policy.MaxRetryAfterSeconds
+	}
+	return &relay.RateLimitedError{RetryAfter: time.Duration(seconds) * time.Second}
+}
+
+func consumePostgresRateBucket(tx *sql.Tx, scope, key string, now time.Time, burst, refillPerMinute, maxRetryAfterSeconds int) (time.Duration, bool, error) {
+	nowUTC := now.UTC()
+	if _, err := tx.ExecContext(context.Background(), `INSERT INTO relay.mail_rate_buckets(scope, bucket_key, tokens_milli, last_refill_at) VALUES ($1, $2, $3, $4) ON CONFLICT (scope, bucket_key) DO NOTHING`, scope, key, int64(burst)*1000, nowUTC); err != nil {
+		return 0, false, errors.New("rate bucket cannot be created")
+	}
+	var tokensMilli int64
+	var lastRefill time.Time
+	if err := tx.QueryRowContext(context.Background(), `SELECT tokens_milli, last_refill_at FROM relay.mail_rate_buckets WHERE scope=$1 AND bucket_key=$2 FOR UPDATE`, scope, key).Scan(&tokensMilli, &lastRefill); err != nil {
+		return 0, false, errors.New("rate bucket is unavailable")
+	}
+	nextTokens, nextRefillMilli, retryAfter, ok := relay.ApplyRateBucket(tokensMilli, lastRefill.UTC().UnixMilli(), nowUTC, burst, refillPerMinute, maxRetryAfterSeconds)
+	if !ok {
+		return retryAfter, false, nil
+	}
+	if _, err := tx.ExecContext(context.Background(), `UPDATE relay.mail_rate_buckets SET tokens_milli=$1, last_refill_at=$2 WHERE scope=$3 AND bucket_key=$4`, nextTokens, time.UnixMilli(nextRefillMilli).UTC(), scope, key); err != nil {
+		return 0, false, errors.New("rate bucket cannot be updated")
+	}
+	return 0, true, nil
 }
 
 func postgresAdvanceSkippedTargetCursors(tx *sql.Tx, conversationID, senderEndpoint, targetRole string) error {

--- a/internal/postgres/state_test.go
+++ b/internal/postgres/state_test.go
@@ -69,8 +69,8 @@ func TestManifestValidationRejectsMutableOrNonContiguousHistory(t *testing.T) {
 
 func TestCurrentManifestRequiresControlPlaneSchema(t *testing.T) {
 	manifest := CurrentManifest()
-	if manifest.MinSupported != 10 || manifest.MaxSupported != 45 || len(manifest.Migrations) != 45 {
-		t.Fatalf("manifest=%#v, want exact v45 compatibility window", manifest)
+	if manifest.MinSupported != 10 || manifest.MaxSupported != 46 || len(manifest.Migrations) != 46 {
+		t.Fatalf("manifest=%#v, want exact v46 compatibility window", manifest)
 	}
 	embedding := manifest.Migrations[23]
 	if embedding.Version != 24 || embedding.Name != "024_memory_embedding_worker_control" ||
@@ -88,7 +88,7 @@ func TestCurrentManifestRequiresControlPlaneSchema(t *testing.T) {
 			want = 10
 		case 12, 13:
 			want = 10
-		case 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45:
+		case 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46:
 			want = 10
 		}
 		if migration.CompatibilityFloor != want {
@@ -216,7 +216,10 @@ func TestCompatibleSchemaCanStillHavePendingMigrations(t *testing.T) {
 	if !migrationPending(SchemaState{Classification: Compatible, Version: 44}, manifest) {
 		t.Fatal("compatible v44 schema must still apply the pending v45 migration")
 	}
-	if migrationPending(SchemaState{Classification: Compatible, Version: 45}, manifest) {
-		t.Fatal("current v45 schema reported a pending migration")
+	if !migrationPending(SchemaState{Classification: Compatible, Version: 45}, manifest) {
+		t.Fatal("compatible v45 schema must still apply the pending v46 migration")
+	}
+	if migrationPending(SchemaState{Classification: Compatible, Version: 46}, manifest) {
+		t.Fatal("current v46 schema reported a pending migration")
 	}
 }

--- a/internal/relay/backend.go
+++ b/internal/relay/backend.go
@@ -177,3 +177,4 @@ type NonceStore interface {
 
 var _ Backend = (*Store)(nil)
 var _ RoleProfileBackend = (*Store)(nil)
+var _ RateLimitConfigurer = (*Store)(nil)

--- a/internal/relay/contracttest/ratelimit.go
+++ b/internal/relay/contracttest/ratelimit.go
@@ -1,0 +1,155 @@
+package contracttest
+
+import (
+	"errors"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/rock3r/punaro/internal/relay"
+)
+
+// RunRateLimits exercises durable sender and conversation token buckets against
+// one otherwise-empty backend namespace. Each case uses distinct machines so
+// durable buckets cannot leak across scenarios.
+func RunRateLimits(t *testing.T, backend relay.Backend, namespace string) {
+	t.Helper()
+	configurer, ok := backend.(relay.RateLimitConfigurer)
+	if !ok {
+		t.Fatal("relay backend does not persist rate-limit policy")
+	}
+	t.Cleanup(func() {
+		if err := configurer.SetRateLimitPolicy(relay.DefaultRateLimitPolicy()); err != nil {
+			t.Errorf("restore default rate-limit policy: %v", err)
+		}
+	})
+	now := time.Date(2026, time.August, 18, 18, 0, 0, 0, time.UTC)
+	setup := func(suffix, peerSuffix string) (string, string, string, string, relay.Conversation) {
+		t.Helper()
+		machine := namespace + "-rate-" + suffix
+		peer := namespace + "-rate-" + peerSuffix
+		endpoint := "agent/" + namespace + "/rate/" + suffix
+		peerEndpoint := "agent/" + namespace + "/rate/" + peerSuffix
+		if err := backend.AdvertiseEndpoints(machine, []string{endpoint}, now, 24*time.Hour); err != nil {
+			t.Fatal(err)
+		}
+		if err := backend.AdvertiseEndpoints(peer, []string{peerEndpoint}, now, 24*time.Hour); err != nil {
+			t.Fatal(err)
+		}
+		members := []relay.Member{
+			{Endpoint: endpoint, Capabilities: relay.CapSend | relay.CapReceive | relay.CapAdmin},
+			{Endpoint: peerEndpoint, Capabilities: relay.CapSend | relay.CapReceive},
+		}
+		conversation, err := backend.CreateConversationIdempotent(relay.CreateConversationInput{
+			MachineID: machine, IdempotencyKey: namespace + "-" + suffix + "-create", CreatorEndpoint: endpoint, Members: members, Now: now,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		return machine, peer, endpoint, peerEndpoint, conversation
+	}
+	appendMessage := func(conversationID, machine, endpoint, key, body string, clock time.Time) (relay.Message, bool, error) {
+		return backend.AppendMessage(relay.AppendInput{
+			ConversationID: conversationID, SenderMachineID: machine, FromEndpoint: endpoint, Body: body, IdempotencyKey: namespace + "-" + key, Now: clock,
+		})
+	}
+
+	if err := configurer.SetRateLimitPolicy(relay.RateLimitPolicy{SenderBurst: 1, SenderRefillPerMinute: 60, ConversationBurst: 10, ConversationRefillPerMinute: 60, MaxRetryAfterSeconds: 60}); err != nil {
+		t.Fatal(err)
+	}
+	sender, _, senderEndpoint, _, firstRoom := setup("sender-a", "sender-b")
+	peerC := namespace + "-rate-sender-c"
+	endpointC := "agent/" + namespace + "/rate/sender-c"
+	if err := backend.AdvertiseEndpoints(peerC, []string{endpointC}, now, 24*time.Hour); err != nil {
+		t.Fatal(err)
+	}
+	crossRoom, err := backend.CreateConversationIdempotent(relay.CreateConversationInput{
+		MachineID: sender, IdempotencyKey: namespace + "-sender-cross-create", CreatorEndpoint: senderEndpoint,
+		Members: []relay.Member{
+			{Endpoint: senderEndpoint, Capabilities: relay.CapSend | relay.CapReceive | relay.CapAdmin},
+			{Endpoint: endpointC, Capabilities: relay.CapSend | relay.CapReceive},
+		},
+		Now: now,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := appendMessage(firstRoom.ID, sender, senderEndpoint, "sender-send-1", "one", now); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := appendMessage(crossRoom.ID, sender, senderEndpoint, "sender-send-2", "two", now); !errors.Is(err, relay.ErrRateLimited) {
+		t.Fatalf("sender bucket across conversations err=%v", err)
+	}
+
+	if err := configurer.SetRateLimitPolicy(relay.RateLimitPolicy{SenderBurst: 10, SenderRefillPerMinute: 60, ConversationBurst: 1, ConversationRefillPerMinute: 60, MaxRetryAfterSeconds: 60}); err != nil {
+		t.Fatal(err)
+	}
+	convA, convB, convAEndpoint, convBEndpoint, shared := setup("conv-a", "conv-b")
+	if _, _, err := appendMessage(shared.ID, convA, convAEndpoint, "conv-send-a", "one", now); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := appendMessage(shared.ID, convB, convBEndpoint, "conv-send-b", "two", now); !errors.Is(err, relay.ErrRateLimited) {
+		t.Fatalf("conversation bucket across senders err=%v", err)
+	}
+
+	if err := configurer.SetRateLimitPolicy(relay.RateLimitPolicy{SenderBurst: 1, SenderRefillPerMinute: 30, ConversationBurst: 10, ConversationRefillPerMinute: 60, MaxRetryAfterSeconds: 60}); err != nil {
+		t.Fatal(err)
+	}
+	refillA, _, refillEndpoint, _, refillRoom := setup("refill-a", "refill-b")
+	original, _, err := appendMessage(refillRoom.ID, refillA, refillEndpoint, "refill-send-1", "original", now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	repeated, duplicate, err := appendMessage(refillRoom.ID, refillA, refillEndpoint, "refill-send-1", "original", now)
+	if err != nil || !duplicate || repeated != original {
+		t.Fatalf("committed retry message=%#v duplicate=%t err=%v", repeated, duplicate, err)
+	}
+	changed := relay.AppendInput{ConversationID: refillRoom.ID, SenderMachineID: refillA, FromEndpoint: refillEndpoint, Body: "changed", IdempotencyKey: namespace + "-refill-send-1", Now: now}
+	if _, _, err := backend.AppendMessage(changed); !errors.Is(err, relay.ErrConflict) {
+		t.Fatalf("changed-body err=%v", err)
+	}
+	_, _, err = appendMessage(refillRoom.ID, refillA, refillEndpoint, "refill-send-2", "two", now)
+	var limited *relay.RateLimitedError
+	if !errors.As(err, &limited) || limited.RetryAfterSeconds() != 2 {
+		t.Fatalf("retry-after err=%v limited=%#v", err, limited)
+	}
+	if _, _, err := appendMessage(refillRoom.ID, refillA, refillEndpoint, "refill-send-2", "two", now.Add(2*time.Second)); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := configurer.SetRateLimitPolicy(relay.RateLimitPolicy{SenderBurst: 1, SenderRefillPerMinute: 60, ConversationBurst: 8, ConversationRefillPerMinute: 60, MaxRetryAfterSeconds: 60}); err != nil {
+		t.Fatal(err)
+	}
+	concurrentA, _, concurrentEndpoint, _, concurrentRoom := setup("concurrent-a", "concurrent-b")
+	const workers = 8
+	results := make(chan error, workers)
+	var started sync.WaitGroup
+	started.Add(workers)
+	release := make(chan struct{})
+	for index := 0; index < workers; index++ {
+		go func(index int) {
+			started.Done()
+			<-release
+			_, _, err := appendMessage(concurrentRoom.ID, concurrentA, concurrentEndpoint, fmt.Sprintf("concurrent-%d", index), fmt.Sprintf("body-%d", index), now)
+			results <- err
+		}(index)
+	}
+	started.Wait()
+	close(release)
+	accepted, rejected := 0, 0
+	for index := 0; index < workers; index++ {
+		err := <-results
+		switch {
+		case err == nil:
+			accepted++
+		case errors.Is(err, relay.ErrRateLimited):
+			rejected++
+		default:
+			t.Fatalf("concurrent send err=%v", err)
+		}
+	}
+	if accepted != 1 || rejected != workers-1 {
+		t.Fatalf("accepted=%d rejected=%d", accepted, rejected)
+	}
+}

--- a/internal/relay/http.go
+++ b/internal/relay/http.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strconv"
 	"strings"
 	"time"
 
@@ -27,6 +28,7 @@ type HandlerOptions struct {
 	DeliveryLeaseTTL          time.Duration
 	Notifier                  *Notifier
 	SessionRevalidateInterval time.Duration
+	Metrics                   *Metrics
 }
 
 // NewHandler returns the authenticated relay API, including the wake-metadata
@@ -47,7 +49,7 @@ func NewHandler(store Backend, auth *Authenticator, options HandlerOptions) http
 	if options.SessionRevalidateInterval <= 0 || options.SessionRevalidateInterval > maximumSessionFenceAge/2 {
 		options.SessionRevalidateInterval = defaultSessionRevalidateInterval
 	}
-	h := &handler{store: store, auth: auth, notifier: options.Notifier, now: options.Now, endpointLeaseTTL: options.EndpointLeaseTTL, deliveryLeaseTTL: options.DeliveryLeaseTTL, sessionRevalidateInterval: options.SessionRevalidateInterval}
+	h := &handler{store: store, auth: auth, notifier: options.Notifier, now: options.Now, endpointLeaseTTL: options.EndpointLeaseTTL, deliveryLeaseTTL: options.DeliveryLeaseTTL, sessionRevalidateInterval: options.SessionRevalidateInterval, metrics: options.Metrics}
 	return http.HandlerFunc(h.serveHTTP)
 }
 
@@ -59,6 +61,7 @@ type handler struct {
 	endpointLeaseTTL          time.Duration
 	deliveryLeaseTTL          time.Duration
 	sessionRevalidateInterval time.Duration
+	metrics                   *Metrics
 }
 
 func (h *handler) serveHTTP(w http.ResponseWriter, r *http.Request) {
@@ -74,7 +77,7 @@ func (h *handler) serveHTTP(w http.ResponseWriter, r *http.Request) {
 	session, err := h.authenticate(r, body)
 	if err != nil {
 		if errors.Is(err, ErrMaintenance) {
-			writeStoreError(w, err)
+			h.writeStoreError(w, err)
 			return
 		}
 		writeError(w, http.StatusUnauthorized, "authentication required")
@@ -210,7 +213,7 @@ func (h *handler) bindRole(w http.ResponseWriter, body []byte, machineID string,
 		return
 	}
 	if err := store.BindRoleToSession(machineID, request.Role, request.SessionEndpoint, now, h.endpointLeaseTTL); err != nil {
-		writeStoreError(w, err)
+		h.writeStoreError(w, err)
 		return
 	}
 	w.WriteHeader(http.StatusNoContent)
@@ -255,7 +258,7 @@ func (h *handler) applyControl(w http.ResponseWriter, body []byte, machineID, co
 	}
 	event, duplicate, err := store.ApplyControl(ControlInput{ConversationID: conversationID, ActorMachineID: machineID, ActorEndpoint: request.ActorEndpoint, Operation: request.Operation, Member: Member{Endpoint: request.Member.Endpoint, Capabilities: capabilities}, IdempotencyKey: idempotencyKey, Now: now})
 	if err != nil {
-		writeStoreError(w, err)
+		h.writeStoreError(w, err)
 		return
 	}
 	status := http.StatusCreated
@@ -280,7 +283,7 @@ func (h *handler) controlAudit(w http.ResponseWriter, body []byte, machineID, co
 	}
 	events, err := store.ControlAudit(conversationID, machineID, request.ActorEndpoint, now)
 	if err != nil {
-		writeStoreError(w, err)
+		h.writeStoreError(w, err)
 		return
 	}
 	writeJSON(w, http.StatusOK, map[string]any{"events": events})
@@ -299,7 +302,7 @@ func (h *handler) validateSender(w http.ResponseWriter, body []byte, machineID, 
 		return
 	}
 	if err := h.store.AuthorizeSender(conversationID, machineID, request.FromEndpoint, now); err != nil {
-		writeStoreError(w, err)
+		h.writeStoreError(w, err)
 		return
 	}
 	writeJSON(w, http.StatusOK, map[string]any{"authorized": true})
@@ -308,7 +311,7 @@ func (h *handler) validateSender(w http.ResponseWriter, body []byte, machineID, 
 func (h *handler) listConversations(w http.ResponseWriter, machineID string, now time.Time) {
 	conversations, err := h.store.ConversationsForMachine(machineID, now)
 	if err != nil {
-		writeStoreError(w, err)
+		h.writeStoreError(w, err)
 		return
 	}
 	writeJSON(w, http.StatusOK, map[string]any{"conversations": conversations})
@@ -420,7 +423,7 @@ func (h *handler) advertiseEndpoints(w http.ResponseWriter, body []byte, machine
 		err = h.store.AdvertiseEndpoints(machineID, request.Endpoints, now, h.endpointLeaseTTL)
 	}
 	if err != nil {
-		writeStoreError(w, err)
+		h.writeStoreError(w, err)
 		return
 	}
 	writeJSON(w, http.StatusOK, map[string]any{"lease_until": now.Add(h.endpointLeaseTTL).Format(time.RFC3339Nano)})
@@ -450,7 +453,7 @@ func (h *handler) createConversation(w http.ResponseWriter, body []byte, machine
 		return
 	}
 	if err := h.store.AssertEndpointOwnership(machineID, request.CreatorEndpoint, now); err != nil {
-		writeStoreError(w, err)
+		h.writeStoreError(w, err)
 		return
 	}
 	members := make([]Member, 0, len(request.Members))
@@ -474,7 +477,7 @@ func (h *handler) createConversation(w http.ResponseWriter, body []byte, machine
 	}
 	conversation, err := h.store.CreateConversationIdempotent(CreateConversationInput{MachineID: machineID, PrincipalID: authority.PrincipalID, CredentialLookupID: authority.CredentialLookupID, CredentialGeneration: authority.CredentialGeneration, ProjectID: request.ProjectID, IdempotencyKey: idempotencyKey, CreatorEndpoint: request.CreatorEndpoint, Members: members, Now: now})
 	if err != nil {
-		writeStoreError(w, err)
+		h.writeStoreError(w, err)
 		return
 	}
 	writeJSON(w, http.StatusCreated, conversation)
@@ -501,13 +504,13 @@ func (h *handler) appendMessage(w http.ResponseWriter, body []byte, machineID st
 	}
 	message, duplicate, err := h.store.AppendMessage(AppendInput{ConversationID: conversationID, SenderMachineID: machineID, PrincipalID: authority.PrincipalID, CredentialLookupID: authority.CredentialLookupID, CredentialGeneration: authority.CredentialGeneration, FromEndpoint: request.FromEndpoint, TargetRole: request.TargetRole, Body: request.Body, ArtifactIDs: request.ArtifactIDs, IdempotencyKey: idempotencyKey, Now: now})
 	if err != nil {
-		writeStoreError(w, err)
+		h.writeStoreError(w, err)
 		return
 	}
 	if !duplicate {
 		machines, err := h.store.RecipientMachines(message.ID, now)
 		if err != nil {
-			writeStoreError(w, err)
+			h.writeStoreError(w, err)
 			return
 		}
 		for _, recipientMachine := range machines {
@@ -528,7 +531,7 @@ func (h *handler) requestInvocation(w http.ResponseWriter, body []byte, machineI
 	}
 	invocations, ok := h.store.(InvocationBackend)
 	if !ok {
-		writeStoreError(w, ErrMaintenance)
+		h.writeStoreError(w, ErrMaintenance)
 		return
 	}
 	var request struct {
@@ -545,7 +548,7 @@ func (h *handler) requestInvocation(w http.ResponseWriter, body []byte, machineI
 	}
 	invocation, duplicate, err := invocations.RequestInvocation(InvokeInput{ConversationID: conversationID, SenderMachineID: machineID, FromEndpoint: request.FromEndpoint, TargetEndpoint: request.TargetEndpoint, IdempotencyKey: idempotencyKey, Now: now})
 	if err != nil {
-		writeStoreError(w, err)
+		h.writeStoreError(w, err)
 		return
 	}
 	status := http.StatusCreated
@@ -564,7 +567,7 @@ func (h *handler) requestInvocation(w http.ResponseWriter, body []byte, machineI
 func (h *handler) leaseInvocations(w http.ResponseWriter, body []byte, machineID string, now time.Time) {
 	invocations, ok := h.store.(InvocationBackend)
 	if !ok {
-		writeStoreError(w, ErrMaintenance)
+		h.writeStoreError(w, ErrMaintenance)
 		return
 	}
 	var request struct {
@@ -580,7 +583,7 @@ func (h *handler) leaseInvocations(w http.ResponseWriter, body []byte, machineID
 	}
 	leased, err := invocations.LeaseInvocations(machineID, request.ConsumerID, now, h.deliveryLeaseTTL, request.Limit)
 	if err != nil {
-		writeStoreError(w, err)
+		h.writeStoreError(w, err)
 		return
 	}
 	allowed := leased[:0]
@@ -594,7 +597,7 @@ func (h *handler) leaseInvocations(w http.ResponseWriter, body []byte, machineID
 		// scope. This is terminal policy rejection, not a runtime failure, so it
 		// must not consume the bounded runtime retry budget.
 		if err := invocations.RejectInvocation(machineID, invocation.ID, invocation.LeaseToken, invocation.LeaseGeneration, now); err != nil {
-			writeStoreError(w, err)
+			h.writeStoreError(w, err)
 			return
 		}
 	}
@@ -604,7 +607,7 @@ func (h *handler) leaseInvocations(w http.ResponseWriter, body []byte, machineID
 func (h *handler) reportInvocation(w http.ResponseWriter, body []byte, machineID, invocationID string, now time.Time) {
 	invocations, ok := h.store.(InvocationBackend)
 	if !ok {
-		writeStoreError(w, ErrMaintenance)
+		h.writeStoreError(w, ErrMaintenance)
 		return
 	}
 	var request struct {
@@ -617,7 +620,7 @@ func (h *handler) reportInvocation(w http.ResponseWriter, body []byte, machineID
 		return
 	}
 	if err := invocations.ReportInvocation(machineID, invocationID, request.LeaseToken, request.LeaseGeneration, request.Accepted, now); err != nil {
-		writeStoreError(w, err)
+		h.writeStoreError(w, err)
 		return
 	}
 	w.WriteHeader(http.StatusNoContent)
@@ -647,7 +650,7 @@ func (h *handler) leaseDeliveries(w http.ResponseWriter, body []byte, machineID 
 	}
 	page, err := h.store.LeaseDeliveries(machineID, request.ConsumerID, request.Endpoint, request.ConversationID, now, h.deliveryLeaseTTL, request.Limit)
 	if err != nil {
-		writeStoreError(w, err)
+		h.writeStoreError(w, err)
 		return
 	}
 	writeJSON(w, http.StatusOK, page)
@@ -668,7 +671,7 @@ func (h *handler) ackDelivery(w http.ResponseWriter, body []byte, machineID, del
 		return
 	}
 	if err := h.store.AckDelivery(machineID, request.Endpoint, deliveryID, request.LeaseToken, request.LeaseGeneration, now); err != nil {
-		writeStoreError(w, err)
+		h.writeStoreError(w, err)
 		return
 	}
 	w.WriteHeader(http.StatusNoContent)
@@ -720,12 +723,21 @@ func parseCapabilities(values []string) (Capability, error) {
 	return capabilities, nil
 }
 
-func writeStoreError(w http.ResponseWriter, err error) {
+func (h *handler) writeStoreError(w http.ResponseWriter, err error) {
 	switch {
 	case errors.Is(err, ErrForbidden):
 		writeError(w, http.StatusForbidden, "authorization denied")
 	case errors.Is(err, ErrConflict):
 		writeError(w, http.StatusConflict, "request conflicts with durable state")
+	case errors.Is(err, ErrRateLimited):
+		seconds := minRateRetryAfterSeconds
+		var limited *RateLimitedError
+		if errors.As(err, &limited) {
+			seconds = limited.RetryAfterSeconds()
+		}
+		w.Header().Set("Retry-After", strconv.Itoa(seconds))
+		h.metrics.AddRateRejection()
+		writeError(w, http.StatusTooManyRequests, "rate limit exceeded")
 	case errors.Is(err, ErrMaintenance):
 		w.Header().Set("Retry-After", "5")
 		writeError(w, http.StatusServiceUnavailable, "relay maintenance in progress")

--- a/internal/relay/http.go
+++ b/internal/relay/http.go
@@ -188,7 +188,7 @@ func (h *handler) registerRole(w http.ResponseWriter, body []byte, machineID str
 		MachineID: machineID, Role: request.Role, DisplayName: displayName, DirectAddressable: directAddressable, IdempotencyKey: idempotencyKey, Now: now,
 	})
 	if err != nil {
-		writeStoreError(w, err)
+		h.writeStoreError(w, err)
 		return
 	}
 	status := http.StatusOK

--- a/internal/relay/http_rate_limit_test.go
+++ b/internal/relay/http_rate_limit_test.go
@@ -1,0 +1,79 @@
+package relay
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/json"
+	"net/http"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestHTTPAppendRateLimitReturnsBoundedRetryAfterAndContentFreeError(t *testing.T) {
+	t.Parallel()
+	publicA, privateA, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	publicB, privateB, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	store, err := Open(filepath.Join(t.TempDir(), "relay.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	if err := store.SetRateLimitPolicy(RateLimitPolicy{SenderBurst: 1, SenderRefillPerMinute: 30, ConversationBurst: 10, ConversationRefillPerMinute: 60, MaxRetryAfterSeconds: 60}); err != nil {
+		t.Fatal(err)
+	}
+	auth, err := NewAuthenticator(store, []Machine{
+		{ID: "machine-a", PublicKey: publicA, EndpointPrefixes: []string{"agent/a/"}},
+		{ID: "machine-b", PublicKey: publicB, EndpointPrefixes: []string{"agent/b/"}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	clock := time.Date(2026, time.July, 13, 12, 0, 0, 0, time.UTC)
+	metrics := &Metrics{}
+	handler := NewHandler(store, auth, HandlerOptions{Now: func() time.Time { return clock }, EndpointLeaseTTL: time.Minute, DeliveryLeaseTTL: time.Minute, Metrics: metrics})
+	serveSigned(t, handler, privateA, "machine-a", http.MethodPut, "/v1/machines/me/endpoints", `{"endpoints":["agent/a/session"]}`, "advertise-a", "")
+	serveSigned(t, handler, privateB, "machine-b", http.MethodPut, "/v1/machines/me/endpoints", `{"endpoints":["agent/b/session"]}`, "advertise-b", "")
+	create := serveSigned(t, handler, privateA, "machine-a", http.MethodPost, "/v1/conversations", `{"creator_endpoint":"agent/a/session","members":[{"endpoint":"agent/a/session","capabilities":["send","receive","admin"]},{"endpoint":"agent/b/session","capabilities":["receive"]}]}`, "create", "create-1")
+	if create.Code != http.StatusCreated {
+		t.Fatalf("create status=%d body=%s", create.Code, create.Body.String())
+	}
+	var conversation struct {
+		ID string `json:"id"`
+	}
+	if err := json.NewDecoder(create.Body).Decode(&conversation); err != nil {
+		t.Fatal(err)
+	}
+	first := serveSigned(t, handler, privateA, "machine-a", http.MethodPost, "/v1/conversations/"+conversation.ID+"/messages", `{"from_endpoint":"agent/a/session","body":"one"}`, "send-1", "send-1")
+	if first.Code != http.StatusCreated {
+		t.Fatalf("first message status=%d body=%s", first.Code, first.Body.String())
+	}
+	retry := serveSigned(t, handler, privateA, "machine-a", http.MethodPost, "/v1/conversations/"+conversation.ID+"/messages", `{"from_endpoint":"agent/a/session","body":"one"}`, "send-1-retry", "send-1")
+	if retry.Code != http.StatusOK {
+		t.Fatalf("committed retry status=%d body=%s", retry.Code, retry.Body.String())
+	}
+	conflict := serveSigned(t, handler, privateA, "machine-a", http.MethodPost, "/v1/conversations/"+conversation.ID+"/messages", `{"from_endpoint":"agent/a/session","body":"changed"}`, "send-1-changed", "send-1")
+	if conflict.Code != http.StatusConflict {
+		t.Fatalf("changed-body status=%d body=%s", conflict.Code, conflict.Body.String())
+	}
+	limited := serveSigned(t, handler, privateA, "machine-a", http.MethodPost, "/v1/conversations/"+conversation.ID+"/messages", `{"from_endpoint":"agent/a/session","body":"secret-body"}`, "send-2", "send-2")
+	if limited.Code != http.StatusTooManyRequests || limited.Header().Get("Retry-After") != "2" {
+		t.Fatalf("rate limit status=%d retry-after=%q body=%s", limited.Code, limited.Header().Get("Retry-After"), limited.Body.String())
+	}
+	var payload map[string]any
+	if err := json.NewDecoder(limited.Body).Decode(&payload); err != nil {
+		t.Fatal(err)
+	}
+	if len(payload) != 1 || payload["error"] != "rate limit exceeded" {
+		t.Fatalf("rate limit payload=%#v", payload)
+	}
+	if metrics.RateRejections() != 1 {
+		t.Fatalf("rate rejection metric=%d", metrics.RateRejections())
+	}
+}

--- a/internal/relay/migration_source.go
+++ b/internal/relay/migration_source.go
@@ -528,8 +528,9 @@ func verifyLegacyMigrationSourceSchema(ctx context.Context, q migrationQueryer) 
 		}
 		names = append(names, name)
 	}
-	want := []string{"conversation_idempotency", "conversations", "deliveries", "endpoints", "idempotency", "memberships", "messages", "rate_buckets", "recipient_cursors", "relay_migration_control", "request_nonces"}
-	if err := rows.Err(); err != nil || strings.Join(names, "\x00") != strings.Join(want, "\x00") {
+	want := []string{"conversation_idempotency", "conversations", "deliveries", "endpoints", "idempotency", "memberships", "messages", "recipient_cursors", "relay_migration_control", "request_nonces"}
+	filtered, _ := partitionRateBucketTable(names)
+	if err := rows.Err(); err != nil || strings.Join(filtered, "\x00") != strings.Join(want, "\x00") {
 		return errors.New("relay migration source has an unexpected schema")
 	}
 	var integrity string
@@ -560,13 +561,14 @@ func verifyMigrationSourceSchema(ctx context.Context, q migrationQueryer, contro
 		}
 		names = append(names, name)
 	}
-	want := []string{"conversation_control_idempotency", "conversation_controls", "conversation_idempotency", "conversations", "deliveries", "endpoints", "idempotency", "memberships", "messages", "rate_buckets", "recipient_cursors", "relay_migration_control", "request_nonces", "role_bindings", "role_memberships", "roles"}
+	want := []string{"conversation_control_idempotency", "conversation_controls", "conversation_idempotency", "conversations", "deliveries", "endpoints", "idempotency", "memberships", "messages", "recipient_cursors", "relay_migration_control", "request_nonces", "role_bindings", "role_memberships", "roles"}
 	if profiles {
-		want = []string{"conversation_control_idempotency", "conversation_controls", "conversation_idempotency", "conversations", "deliveries", "endpoints", "idempotency", "memberships", "messages", "rate_buckets", "recipient_cursors", "relay_migration_control", "request_nonces", "role_bindings", "role_memberships", "role_profile_idempotency", "role_profiles", "roles"}
+		want = []string{"conversation_control_idempotency", "conversation_controls", "conversation_idempotency", "conversations", "deliveries", "endpoints", "idempotency", "memberships", "messages", "recipient_cursors", "relay_migration_control", "request_nonces", "role_bindings", "role_memberships", "role_profile_idempotency", "role_profiles", "roles"}
 	} else if !controls {
-		want = []string{"conversation_idempotency", "conversations", "deliveries", "endpoints", "idempotency", "memberships", "messages", "rate_buckets", "recipient_cursors", "relay_migration_control", "request_nonces", "role_bindings", "role_memberships", "roles"}
+		want = []string{"conversation_idempotency", "conversations", "deliveries", "endpoints", "idempotency", "memberships", "messages", "recipient_cursors", "relay_migration_control", "request_nonces", "role_bindings", "role_memberships", "roles"}
 	}
-	if strings.Join(names, "\x00") != strings.Join(want, "\x00") {
+	filtered, hasRateBuckets := partitionRateBucketTable(names)
+	if strings.Join(filtered, "\x00") != strings.Join(want, "\x00") {
 		return errors.New("relay migration source has an unexpected schema")
 	}
 	expectedColumns := map[string][]string{
@@ -596,6 +598,9 @@ func verifyMigrationSourceSchema(ctx context.Context, q migrationQueryer, contro
 	if !profiles {
 		delete(expectedColumns, "role_profiles")
 		delete(expectedColumns, "role_profile_idempotency")
+	}
+	if !hasRateBuckets {
+		delete(expectedColumns, "rate_buckets")
 	}
 	for table, expected := range expectedColumns {
 		columns, err := q.QueryContext(ctx, fmt.Sprintf("PRAGMA table_info(%s)", table)) // #nosec G202 -- table comes only from the fixed expectedColumns allowlist.
@@ -694,6 +699,9 @@ func verifyMigrationSourceSchema(ctx context.Context, q migrationQueryer, contro
 			"endpoints:1:pk:0:endpoint", "conversations:1:pk:0:id", "memberships:1:pk:0:conversation_id,endpoint", "roles:1:pk:0:role", "role_memberships:1:pk:0:conversation_id,role", "role_bindings:1:pk:0:role", "role_bindings:0:c:0:machine_id,session_endpoint,ownership_generation,lease_until", "messages:1:pk:0:id", "messages:1:u:0:conversation_id,sequence", "rate_buckets:1:pk:0:scope,bucket_key", "deliveries:1:pk:0:id", "deliveries:1:u:0:message_id,recipient_endpoint", "deliveries:0:c:0:recipient_endpoint,acked_at,lease_until", "recipient_cursors:1:pk:0:recipient_endpoint,conversation_id", "idempotency:1:pk:0:machine_id,key", "conversation_idempotency:1:pk:0:machine_id,key", "request_nonces:1:pk:0:machine_id,nonce", "request_nonces:0:c:0:expires_at",
 		}
 	}
+	if !hasRateBuckets {
+		expectedIndexes = omitPrefixedIndexEvidence(expectedIndexes, "rate_buckets:")
+	}
 	var actualIndexes []string
 	for table := range expectedColumns {
 		indexes, err := q.QueryContext(ctx, fmt.Sprintf("PRAGMA index_list(%s)", table)) // #nosec G202 -- table comes only from the fixed expectedColumns allowlist.
@@ -777,11 +785,14 @@ func verifyMigrationSourceSchema(ctx context.Context, q migrationQueryer, contro
 			return errors.New("relay migration source has an unexpected trigger")
 		}
 	}
-	wantTriggers := 45
+	wantTriggers := 42
 	if profiles {
-		wantTriggers = 51
+		wantTriggers = 48
 	} else if !controls {
-		wantTriggers = 39
+		wantTriggers = 36
+	}
+	if hasRateBuckets {
+		wantTriggers += 3
 	}
 	if err := triggerRows.Close(); err != nil || triggerRows.Err() != nil || len(seenTriggers) != wantTriggers {
 		return errors.New("relay migration source guard inventory is incomplete")
@@ -1047,4 +1058,28 @@ func validMigrationDigest(value string) bool {
 	}
 	_, err := hex.DecodeString(value)
 	return err == nil && value == strings.ToLower(value)
+}
+
+func partitionRateBucketTable(names []string) ([]string, bool) {
+	filtered := make([]string, 0, len(names))
+	present := false
+	for _, name := range names {
+		if name == "rate_buckets" {
+			present = true
+			continue
+		}
+		filtered = append(filtered, name)
+	}
+	return filtered, present
+}
+
+func omitPrefixedIndexEvidence(indexes []string, prefix string) []string {
+	filtered := make([]string, 0, len(indexes))
+	for _, index := range indexes {
+		if strings.HasPrefix(index, prefix) {
+			continue
+		}
+		filtered = append(filtered, index)
+	}
+	return filtered
 }

--- a/internal/relay/migration_source.go
+++ b/internal/relay/migration_source.go
@@ -528,7 +528,7 @@ func verifyLegacyMigrationSourceSchema(ctx context.Context, q migrationQueryer) 
 		}
 		names = append(names, name)
 	}
-	want := []string{"conversation_idempotency", "conversations", "deliveries", "endpoints", "idempotency", "memberships", "messages", "recipient_cursors", "relay_migration_control", "request_nonces"}
+	want := []string{"conversation_idempotency", "conversations", "deliveries", "endpoints", "idempotency", "memberships", "messages", "rate_buckets", "recipient_cursors", "relay_migration_control", "request_nonces"}
 	if err := rows.Err(); err != nil || strings.Join(names, "\x00") != strings.Join(want, "\x00") {
 		return errors.New("relay migration source has an unexpected schema")
 	}
@@ -560,11 +560,11 @@ func verifyMigrationSourceSchema(ctx context.Context, q migrationQueryer, contro
 		}
 		names = append(names, name)
 	}
-	want := []string{"conversation_control_idempotency", "conversation_controls", "conversation_idempotency", "conversations", "deliveries", "endpoints", "idempotency", "memberships", "messages", "recipient_cursors", "relay_migration_control", "request_nonces", "role_bindings", "role_memberships", "roles"}
+	want := []string{"conversation_control_idempotency", "conversation_controls", "conversation_idempotency", "conversations", "deliveries", "endpoints", "idempotency", "memberships", "messages", "rate_buckets", "recipient_cursors", "relay_migration_control", "request_nonces", "role_bindings", "role_memberships", "roles"}
 	if profiles {
-		want = []string{"conversation_control_idempotency", "conversation_controls", "conversation_idempotency", "conversations", "deliveries", "endpoints", "idempotency", "memberships", "messages", "recipient_cursors", "relay_migration_control", "request_nonces", "role_bindings", "role_memberships", "role_profile_idempotency", "role_profiles", "roles"}
+		want = []string{"conversation_control_idempotency", "conversation_controls", "conversation_idempotency", "conversations", "deliveries", "endpoints", "idempotency", "memberships", "messages", "rate_buckets", "recipient_cursors", "relay_migration_control", "request_nonces", "role_bindings", "role_memberships", "role_profile_idempotency", "role_profiles", "roles"}
 	} else if !controls {
-		want = []string{"conversation_idempotency", "conversations", "deliveries", "endpoints", "idempotency", "memberships", "messages", "recipient_cursors", "relay_migration_control", "request_nonces", "role_bindings", "role_memberships", "roles"}
+		want = []string{"conversation_idempotency", "conversations", "deliveries", "endpoints", "idempotency", "memberships", "messages", "rate_buckets", "recipient_cursors", "relay_migration_control", "request_nonces", "role_bindings", "role_memberships", "roles"}
 	}
 	if strings.Join(names, "\x00") != strings.Join(want, "\x00") {
 		return errors.New("relay migration source has an unexpected schema")
@@ -577,6 +577,7 @@ func verifyMigrationSourceSchema(ctx context.Context, q migrationQueryer, contro
 		"role_memberships":                 {"conversation_id:TEXT:1:1:-", "role:TEXT:1:2:-", "capabilities:INTEGER:1:0:-"},
 		"role_bindings":                    {"role:TEXT:0:1:-", "session_endpoint:TEXT:1:0:-", "machine_id:TEXT:1:0:-", "ownership_generation:INTEGER:1:0:-", "lease_until:INTEGER:1:0:-"},
 		"messages":                         {"id:TEXT:0:1:-", "conversation_id:TEXT:1:0:-", "sequence:INTEGER:1:0:-", "from_endpoint:TEXT:1:0:-", "body:TEXT:1:0:-", "created_at:INTEGER:1:0:-"},
+		"rate_buckets":                     {"scope:TEXT:1:1:-", "bucket_key:TEXT:1:2:-", "tokens_milli:INTEGER:1:0:-", "last_refill_unix_milli:INTEGER:1:0:-"},
 		"deliveries":                       {"id:TEXT:0:1:-", "message_id:TEXT:1:0:-", "recipient_endpoint:TEXT:1:0:-", "lease_machine_id:TEXT:0:0:-", "lease_token:TEXT:0:0:-", "lease_generation:INTEGER:1:0:0", "ownership_generation:INTEGER:0:0:-", "consumer_generation:INTEGER:0:0:-", "lease_until:INTEGER:0:0:-", "acked_at:INTEGER:0:0:-"},
 		"recipient_cursors":                {"recipient_endpoint:TEXT:1:1:-", "conversation_id:TEXT:1:2:-", "sequence:INTEGER:1:0:0"},
 		"idempotency":                      {"machine_id:TEXT:1:1:-", "key:TEXT:1:2:-", "request_hash:TEXT:1:0:-", "message_id:TEXT:1:0:-", "created_at:INTEGER:1:0:-"},
@@ -674,6 +675,7 @@ func verifyMigrationSourceSchema(ctx context.Context, q migrationQueryer, contro
 		"role_memberships:1:pk:0:conversation_id,role",
 		"role_bindings:1:pk:0:role", "role_bindings:0:c:0:machine_id,session_endpoint,ownership_generation,lease_until",
 		"messages:1:pk:0:id", "messages:1:u:0:conversation_id,sequence",
+		"rate_buckets:1:pk:0:scope,bucket_key",
 		"deliveries:1:pk:0:id", "deliveries:1:u:0:message_id,recipient_endpoint", "deliveries:0:c:0:recipient_endpoint,acked_at,lease_until",
 		"recipient_cursors:1:pk:0:recipient_endpoint,conversation_id",
 		"idempotency:1:pk:0:machine_id,key",
@@ -689,7 +691,7 @@ func verifyMigrationSourceSchema(ctx context.Context, q migrationQueryer, contro
 	}
 	if !controls {
 		expectedIndexes = []string{
-			"endpoints:1:pk:0:endpoint", "conversations:1:pk:0:id", "memberships:1:pk:0:conversation_id,endpoint", "roles:1:pk:0:role", "role_memberships:1:pk:0:conversation_id,role", "role_bindings:1:pk:0:role", "role_bindings:0:c:0:machine_id,session_endpoint,ownership_generation,lease_until", "messages:1:pk:0:id", "messages:1:u:0:conversation_id,sequence", "deliveries:1:pk:0:id", "deliveries:1:u:0:message_id,recipient_endpoint", "deliveries:0:c:0:recipient_endpoint,acked_at,lease_until", "recipient_cursors:1:pk:0:recipient_endpoint,conversation_id", "idempotency:1:pk:0:machine_id,key", "conversation_idempotency:1:pk:0:machine_id,key", "request_nonces:1:pk:0:machine_id,nonce", "request_nonces:0:c:0:expires_at",
+			"endpoints:1:pk:0:endpoint", "conversations:1:pk:0:id", "memberships:1:pk:0:conversation_id,endpoint", "roles:1:pk:0:role", "role_memberships:1:pk:0:conversation_id,role", "role_bindings:1:pk:0:role", "role_bindings:0:c:0:machine_id,session_endpoint,ownership_generation,lease_until", "messages:1:pk:0:id", "messages:1:u:0:conversation_id,sequence", "rate_buckets:1:pk:0:scope,bucket_key", "deliveries:1:pk:0:id", "deliveries:1:u:0:message_id,recipient_endpoint", "deliveries:0:c:0:recipient_endpoint,acked_at,lease_until", "recipient_cursors:1:pk:0:recipient_endpoint,conversation_id", "idempotency:1:pk:0:machine_id,key", "conversation_idempotency:1:pk:0:machine_id,key", "request_nonces:1:pk:0:machine_id,nonce", "request_nonces:0:c:0:expires_at",
 		}
 	}
 	var actualIndexes []string
@@ -775,11 +777,11 @@ func verifyMigrationSourceSchema(ctx context.Context, q migrationQueryer, contro
 			return errors.New("relay migration source has an unexpected trigger")
 		}
 	}
-	wantTriggers := 42
+	wantTriggers := 45
 	if profiles {
-		wantTriggers = 48
+		wantTriggers = 51
 	} else if !controls {
-		wantTriggers = 36
+		wantTriggers = 39
 	}
 	if err := triggerRows.Close(); err != nil || triggerRows.Err() != nil || len(seenTriggers) != wantTriggers {
 		return errors.New("relay migration source guard inventory is incomplete")

--- a/internal/relay/migration_source_test.go
+++ b/internal/relay/migration_source_test.go
@@ -222,6 +222,34 @@ func TestMigrationSourceManifestAndBarrier(t *testing.T) {
 	}
 }
 
+func TestMigrationSourceFingerprintIgnoresRateBuckets(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	path := filepath.Join(t.TempDir(), "relay.db")
+	store, err := Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	before, err := InspectMigrationSource(ctx, path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.db.ExecContext(ctx, `INSERT INTO rate_buckets(scope, bucket_key, tokens_milli, last_refill_unix_milli) VALUES ('sender_machine', 'cutover-ignored', 0, 1)`); err != nil {
+		t.Fatal(err)
+	}
+	after, err := InspectMigrationSource(ctx, path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if before.Fingerprint != after.Fingerprint || before.Counts != after.Counts {
+		t.Fatalf("rate-bucket mutation changed cutover identity before=%#v after=%#v", before, after)
+	}
+	if _, err := ReadMigrationSourceBatch(ctx, path, "mail_rate_buckets", "", 1); err == nil {
+		t.Fatal("cutover export accepted rate-bucket rows")
+	}
+}
+
 func TestMigrationSourceAcceptsInvokeCapabilityBeforePreparation(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()

--- a/internal/relay/migration_source_test.go
+++ b/internal/relay/migration_source_test.go
@@ -250,6 +250,51 @@ func TestMigrationSourceFingerprintIgnoresRateBuckets(t *testing.T) {
 	}
 }
 
+func TestPreparedMigrationSourceWithoutRateBucketsRemainsRecoverable(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	path := filepath.Join(t.TempDir(), "relay.db")
+	now := time.Date(2026, time.August, 18, 16, 0, 0, 0, time.UTC)
+	store, err := Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.AdvertiseEndpoints("machine-a", []string{"agent/a"}, now, time.Hour); err != nil {
+		_ = store.Close()
+		t.Fatal(err)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatal(err)
+	}
+	source, err := InspectMigrationSource(ctx, path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	prepared, err := PrepareMigrationSource(ctx, path, uuid.NewString(), strings.Repeat("a", 64), source.Fingerprint, now.Add(time.Minute))
+	if err != nil {
+		t.Fatal(err)
+	}
+	db, err := openMigrationSourceDatabase(path, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.ExecContext(ctx, `DROP TABLE rate_buckets`); err != nil {
+		_ = db.Close()
+		t.Fatal(err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatal(err)
+	}
+	inspected, err := InspectMigrationSource(ctx, path)
+	if err != nil || inspected.Phase != MigrationSourcePrepared || inspected.Fingerprint != prepared.Fingerprint {
+		t.Fatalf("prepared source without rate_buckets inspect=%#v err=%v", inspected, err)
+	}
+	aborted, err := AbortPreparedMigrationSource(ctx, path, prepared.EpochID, prepared.TargetIdentity, prepared.Fingerprint)
+	if err != nil || aborted.Phase != MigrationSourceActive {
+		t.Fatalf("abort prepared source without rate_buckets=%#v err=%v", aborted, err)
+	}
+}
+
 func TestMigrationSourceAcceptsInvokeCapabilityBeforePreparation(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()

--- a/internal/relay/migration_source_test.go
+++ b/internal/relay/migration_source_test.go
@@ -245,8 +245,16 @@ func TestMigrationSourceFingerprintIgnoresRateBuckets(t *testing.T) {
 	if before.Fingerprint != after.Fingerprint || before.Counts != after.Counts {
 		t.Fatalf("rate-bucket mutation changed cutover identity before=%#v after=%#v", before, after)
 	}
-	if _, err := ReadMigrationSourceBatch(ctx, path, "mail_rate_buckets", "", 1); err == nil {
-		t.Fatal("cutover export accepted rate-bucket rows")
+	now := time.Date(2026, time.August, 18, 16, 0, 0, 0, time.UTC)
+	prepared, err := PrepareMigrationSource(ctx, path, uuid.NewString(), strings.Repeat("c", 64), after.Fingerprint, now.Add(time.Minute))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ReadMigrationSourceBatch(ctx, path, "mail_rate_buckets", "", 1); err == nil || err.Error() != "invalid relay migration batch" {
+		t.Fatalf("prepared rate-bucket export err=%v", err)
+	}
+	if _, err := AbortPreparedMigrationSource(ctx, path, prepared.EpochID, prepared.TargetIdentity, prepared.Fingerprint); err != nil {
+		t.Fatal(err)
 	}
 }
 

--- a/internal/relay/ratelimit.go
+++ b/internal/relay/ratelimit.go
@@ -94,9 +94,9 @@ func (p RateLimitPolicy) Validate() error {
 	return validateRateBound("rate retry-after max seconds", p.MaxRetryAfterSeconds, minRateRetryAfterSeconds, maxRateRetryAfterSeconds)
 }
 
-func validateRateBound(name string, value, min, max int) error {
-	if value < min || value > max {
-		return fmt.Errorf("relay %s must be between %d and %d", name, min, max)
+func validateRateBound(name string, value, minimum, maximum int) error {
+	if value < minimum || value > maximum {
+		return fmt.Errorf("relay %s must be between %d and %d", name, minimum, maximum)
 	}
 	return nil
 }
@@ -155,7 +155,7 @@ func refillRateBucket(snapshot rateBucketSnapshot, now time.Time, burst, refillP
 	return rateBucketSnapshot{TokensMilli: tokens, LastRefillUnixMilli: nowMilli}
 }
 
-func consumeRefilledBucket(snapshot rateBucketSnapshot, burst, refillPerMinute, maxRetryAfterSeconds int) (rateBucketSnapshot, time.Duration, bool) {
+func consumeRefilledBucket(snapshot rateBucketSnapshot, _ int, refillPerMinute, maxRetryAfterSeconds int) (rateBucketSnapshot, time.Duration, bool) {
 	if snapshot.TokensMilli >= millitokensPerToken {
 		snapshot.TokensMilli -= millitokensPerToken
 		return snapshot, 0, true

--- a/internal/relay/ratelimit.go
+++ b/internal/relay/ratelimit.go
@@ -141,10 +141,14 @@ func refillRateBucket(snapshot rateBucketSnapshot, now time.Time, burst, refillP
 		return rateBucketSnapshot{TokensMilli: maxTokens, LastRefillUnixMilli: nowMilli}
 	}
 	last := snapshot.LastRefillUnixMilli
-	if last <= 0 || last > nowMilli {
+	if last <= 0 {
 		last = nowMilli
 	}
 	elapsed := nowMilli - last
+	if elapsed < 0 {
+		// Keep a future watermark so clock correction cannot refill the same interval twice.
+		return rateBucketSnapshot{TokensMilli: snapshot.TokensMilli, LastRefillUnixMilli: last}
+	}
 	tokens := snapshot.TokensMilli + elapsed*int64(refillPerMinute)/60
 	if tokens > maxTokens {
 		tokens = maxTokens

--- a/internal/relay/ratelimit.go
+++ b/internal/relay/ratelimit.go
@@ -1,0 +1,200 @@
+package relay
+
+import (
+	"errors"
+	"fmt"
+	"sync/atomic"
+	"time"
+)
+
+const (
+	rateScopeSenderMachine = "sender_machine"
+	rateScopeConversation  = "conversation"
+	millitokensPerToken    = int64(1000)
+
+	defaultSenderRateBurst                 = 60
+	defaultSenderRateRefillPerMinute       = 60
+	defaultConversationRateBurst           = 120
+	defaultConversationRateRefillPerMinute = 120
+	defaultRateRetryAfterMaxSeconds        = 60
+
+	minRateBurst             = 1
+	maxRateBurst             = 10000
+	minRateRefillPerMinute   = 1
+	maxRateRefillPerMinute   = 10000
+	minRateRetryAfterSeconds = 1
+	maxRateRetryAfterSeconds = 3600
+)
+
+// ErrRateLimited is a retryable, content-free refusal when a durable sender
+// or conversation token bucket has no remaining capacity.
+var ErrRateLimited = errors.New("relay rate limit exceeded")
+
+// RateLimitedError carries the bounded Retry-After interval for one refusal.
+type RateLimitedError struct {
+	RetryAfter time.Duration
+}
+
+func (e *RateLimitedError) Error() string { return ErrRateLimited.Error() }
+
+func (e *RateLimitedError) Unwrap() error { return ErrRateLimited }
+
+// RetryAfterSeconds is the bounded integer Retry-After value advertised to clients.
+func (e *RateLimitedError) RetryAfterSeconds() int {
+	if e == nil {
+		return minRateRetryAfterSeconds
+	}
+	seconds := int((e.RetryAfter + time.Second - 1) / time.Second)
+	if seconds < minRateRetryAfterSeconds {
+		return minRateRetryAfterSeconds
+	}
+	if seconds > maxRateRetryAfterSeconds {
+		return maxRateRetryAfterSeconds
+	}
+	return seconds
+}
+
+// RateLimitPolicy is the startup-validated token-bucket configuration for
+// authenticated sender machines and conversations.
+type RateLimitPolicy struct {
+	SenderBurst                 int
+	SenderRefillPerMinute       int
+	ConversationBurst           int
+	ConversationRefillPerMinute int
+	MaxRetryAfterSeconds        int
+}
+
+// DefaultRateLimitPolicy returns the conservative production defaults.
+func DefaultRateLimitPolicy() RateLimitPolicy {
+	return RateLimitPolicy{
+		SenderBurst:                 defaultSenderRateBurst,
+		SenderRefillPerMinute:       defaultSenderRateRefillPerMinute,
+		ConversationBurst:           defaultConversationRateBurst,
+		ConversationRefillPerMinute: defaultConversationRateRefillPerMinute,
+		MaxRetryAfterSeconds:        defaultRateRetryAfterMaxSeconds,
+	}
+}
+
+// Validate reports whether every bound is an explicit integer inside the hard
+// min/max window. Zero values are not defaults here; callers that want the
+// production defaults must use DefaultRateLimitPolicy.
+func (p RateLimitPolicy) Validate() error {
+	if err := validateRateBound("sender burst", p.SenderBurst, minRateBurst, maxRateBurst); err != nil {
+		return err
+	}
+	if err := validateRateBound("sender refill per minute", p.SenderRefillPerMinute, minRateRefillPerMinute, maxRateRefillPerMinute); err != nil {
+		return err
+	}
+	if err := validateRateBound("conversation burst", p.ConversationBurst, minRateBurst, maxRateBurst); err != nil {
+		return err
+	}
+	if err := validateRateBound("conversation refill per minute", p.ConversationRefillPerMinute, minRateRefillPerMinute, maxRateRefillPerMinute); err != nil {
+		return err
+	}
+	return validateRateBound("rate retry-after max seconds", p.MaxRetryAfterSeconds, minRateRetryAfterSeconds, maxRateRetryAfterSeconds)
+}
+
+func validateRateBound(name string, value, min, max int) error {
+	if value < min || value > max {
+		return fmt.Errorf("relay %s must be between %d and %d", name, min, max)
+	}
+	return nil
+}
+
+// RateLimitConfigurer is the narrow store boundary for durable limiter policy.
+// HTTP adapters must not keep an in-memory-only bucket map.
+type RateLimitConfigurer interface {
+	SetRateLimitPolicy(RateLimitPolicy) error
+}
+
+// Metrics holds bounded-cardinality relay counters. Values are never labeled
+// with endpoints, roles, conversations, bodies, or credentials.
+type Metrics struct {
+	rateRejections atomic.Int64
+}
+
+// AddRateRejection records one content-free rate-limit refusal.
+func (m *Metrics) AddRateRejection() {
+	if m == nil {
+		return
+	}
+	m.rateRejections.Add(1)
+}
+
+// RateRejections returns the number of rate-limit refusals observed.
+func (m *Metrics) RateRejections() int64 {
+	if m == nil {
+		return 0
+	}
+	return m.rateRejections.Load()
+}
+
+type rateBucketSnapshot struct {
+	TokensMilli         int64
+	LastRefillUnixMilli int64
+}
+
+func refillRateBucket(snapshot rateBucketSnapshot, now time.Time, burst, refillPerMinute int) rateBucketSnapshot {
+	nowMilli := now.UTC().UnixMilli()
+	maxTokens := int64(burst) * millitokensPerToken
+	if snapshot.LastRefillUnixMilli == 0 && snapshot.TokensMilli == 0 {
+		return rateBucketSnapshot{TokensMilli: maxTokens, LastRefillUnixMilli: nowMilli}
+	}
+	last := snapshot.LastRefillUnixMilli
+	if last <= 0 || last > nowMilli {
+		last = nowMilli
+	}
+	elapsed := nowMilli - last
+	tokens := snapshot.TokensMilli + elapsed*int64(refillPerMinute)/60
+	if tokens > maxTokens {
+		tokens = maxTokens
+	}
+	if tokens < 0 {
+		tokens = 0
+	}
+	return rateBucketSnapshot{TokensMilli: tokens, LastRefillUnixMilli: nowMilli}
+}
+
+func consumeRefilledBucket(snapshot rateBucketSnapshot, burst, refillPerMinute, maxRetryAfterSeconds int) (rateBucketSnapshot, time.Duration, bool) {
+	if snapshot.TokensMilli >= millitokensPerToken {
+		snapshot.TokensMilli -= millitokensPerToken
+		return snapshot, 0, true
+	}
+	need := millitokensPerToken - snapshot.TokensMilli
+	if need < 1 {
+		need = 1
+	}
+	waitMs := (need*60 + int64(refillPerMinute) - 1) / int64(refillPerMinute)
+	seconds := (waitMs + 999) / 1000
+	if seconds < int64(minRateRetryAfterSeconds) {
+		seconds = minRateRetryAfterSeconds
+	}
+	if maxRetryAfterSeconds > 0 && seconds > int64(maxRetryAfterSeconds) {
+		seconds = int64(maxRetryAfterSeconds)
+	}
+	return snapshot, time.Duration(seconds) * time.Second, false
+}
+
+func newRateLimitedError(retryAfter time.Duration, maxRetryAfterSeconds int) error {
+	seconds := int((retryAfter + time.Second - 1) / time.Second)
+	if seconds < minRateRetryAfterSeconds {
+		seconds = minRateRetryAfterSeconds
+	}
+	if maxRetryAfterSeconds > 0 && seconds > maxRetryAfterSeconds {
+		seconds = maxRetryAfterSeconds
+	}
+	return &RateLimitedError{RetryAfter: time.Duration(seconds) * time.Second}
+}
+
+// ApplyRateBucket refills one durable token bucket from server time and tries
+// to consume a single token. Stores must persist the returned snapshot only
+// when ok is true and the surrounding append transaction commits.
+func ApplyRateBucket(tokensMilli, lastRefillUnixMilli int64, now time.Time, burst, refillPerMinute, maxRetryAfterSeconds int) (int64, int64, time.Duration, bool) {
+	snapshot := refillRateBucket(rateBucketSnapshot{TokensMilli: tokensMilli, LastRefillUnixMilli: lastRefillUnixMilli}, now, burst, refillPerMinute)
+	consumed, retryAfter, ok := consumeRefilledBucket(snapshot, burst, refillPerMinute, maxRetryAfterSeconds)
+	return consumed.TokensMilli, consumed.LastRefillUnixMilli, retryAfter, ok
+}
+
+func initialRateBucketTokens(burst int) int64 {
+	return int64(burst) * millitokensPerToken
+}

--- a/internal/relay/ratelimit_test.go
+++ b/internal/relay/ratelimit_test.go
@@ -1,0 +1,70 @@
+package relay
+
+import (
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestRateLimitPolicyRejectsOutOfBoundsValues(t *testing.T) {
+	t.Parallel()
+	valid := DefaultRateLimitPolicy()
+	if err := valid.Validate(); err != nil {
+		t.Fatalf("default policy: %v", err)
+	}
+	invalid := []RateLimitPolicy{
+		{SenderBurst: 0, SenderRefillPerMinute: 60, ConversationBurst: 60, ConversationRefillPerMinute: 60, MaxRetryAfterSeconds: 60},
+		{SenderBurst: 60, SenderRefillPerMinute: 0, ConversationBurst: 60, ConversationRefillPerMinute: 60, MaxRetryAfterSeconds: 60},
+		{SenderBurst: 60, SenderRefillPerMinute: 60, ConversationBurst: 0, ConversationRefillPerMinute: 60, MaxRetryAfterSeconds: 60},
+		{SenderBurst: 60, SenderRefillPerMinute: 60, ConversationBurst: 60, ConversationRefillPerMinute: 0, MaxRetryAfterSeconds: 60},
+		{SenderBurst: 60, SenderRefillPerMinute: 60, ConversationBurst: 60, ConversationRefillPerMinute: 60, MaxRetryAfterSeconds: 0},
+		{SenderBurst: maxRateBurst + 1, SenderRefillPerMinute: 60, ConversationBurst: 60, ConversationRefillPerMinute: 60, MaxRetryAfterSeconds: 60},
+		{SenderBurst: 60, SenderRefillPerMinute: maxRateRefillPerMinute + 1, ConversationBurst: 60, ConversationRefillPerMinute: 60, MaxRetryAfterSeconds: 60},
+		{SenderBurst: 60, SenderRefillPerMinute: 60, ConversationBurst: 60, ConversationRefillPerMinute: 60, MaxRetryAfterSeconds: maxRateRetryAfterSeconds + 1},
+	}
+	for _, policy := range invalid {
+		if err := policy.Validate(); err == nil {
+			t.Fatalf("invalid policy accepted: %#v", policy)
+		}
+	}
+}
+
+func TestTokenBucketRefillAndExactRetryAfter(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, time.August, 18, 12, 0, 0, 0, time.UTC)
+	full := refillRateBucket(rateBucketSnapshot{}, now, 1, 30)
+	consumed, retry, ok := consumeRefilledBucket(full, 1, 30, 60)
+	if !ok || retry != 0 || consumed.TokensMilli != 0 {
+		t.Fatalf("first consume snapshot=%#v retry=%s ok=%t", consumed, retry, ok)
+	}
+	empty := refillRateBucket(consumed, now, 1, 30)
+	_, retry, ok = consumeRefilledBucket(empty, 1, 30, 60)
+	if ok || retry != 2*time.Second {
+		t.Fatalf("empty bucket retry=%s ok=%t, want 2s", retry, ok)
+	}
+	half := refillRateBucket(consumed, now.Add(time.Second), 1, 30)
+	if half.TokensMilli != 500 {
+		t.Fatalf("one-second refill millitokens=%d, want 500", half.TokensMilli)
+	}
+	_, retry, ok = consumeRefilledBucket(half, 1, 30, 60)
+	if ok || retry != time.Second {
+		t.Fatalf("half bucket retry=%s ok=%t, want 1s", retry, ok)
+	}
+	ready := refillRateBucket(consumed, now.Add(2*time.Second), 1, 30)
+	_, retry, ok = consumeRefilledBucket(ready, 1, 30, 60)
+	if !ok || retry != 0 {
+		t.Fatalf("refilled consume retry=%s ok=%t", retry, ok)
+	}
+}
+
+func TestRateLimitedErrorIsRetryableAndContentFree(t *testing.T) {
+	t.Parallel()
+	err := newRateLimitedError(1500*time.Millisecond, 60)
+	var limited *RateLimitedError
+	if !errors.As(err, &limited) || !errors.Is(err, ErrRateLimited) {
+		t.Fatalf("error=%v", err)
+	}
+	if limited.RetryAfterSeconds() != 2 || limited.Error() != ErrRateLimited.Error() {
+		t.Fatalf("limited=%#v", limited)
+	}
+}

--- a/internal/relay/ratelimit_test.go
+++ b/internal/relay/ratelimit_test.go
@@ -57,6 +57,29 @@ func TestTokenBucketRefillAndExactRetryAfter(t *testing.T) {
 	}
 }
 
+func TestTokenBucketClockRollbackDoesNotRestoreCapacity(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, time.August, 18, 12, 0, 0, 0, time.UTC)
+	first := refillRateBucket(rateBucketSnapshot{}, now, 2, 60)
+	afterFirst, _, ok := consumeRefilledBucket(first, 2, 60, 60)
+	if !ok {
+		t.Fatal("first consume was refused")
+	}
+	rolled := refillRateBucket(afterFirst, now.Add(-time.Second), 2, 60)
+	if rolled.LastRefillUnixMilli != afterFirst.LastRefillUnixMilli || rolled.TokensMilli != afterFirst.TokensMilli {
+		t.Fatalf("clock rollback mutated watermark rolled=%#v afterFirst=%#v", rolled, afterFirst)
+	}
+	afterSecond, _, ok := consumeRefilledBucket(rolled, 2, 60, 60)
+	if !ok {
+		t.Fatal("remaining token was refused during clock rollback")
+	}
+	restored := refillRateBucket(afterSecond, now, 2, 60)
+	_, _, ok = consumeRefilledBucket(restored, 2, 60, 60)
+	if ok {
+		t.Fatal("clock correction restored a third token")
+	}
+}
+
 func TestRateLimitedErrorIsRetryableAndContentFree(t *testing.T) {
 	t.Parallel()
 	err := newRateLimitedError(1500*time.Millisecond, 60)

--- a/internal/relay/store.go
+++ b/internal/relay/store.go
@@ -17,6 +17,7 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/google/uuid"
@@ -241,7 +242,9 @@ type InvocationAuditEvent struct {
 
 // Store owns SQLite-backed relay state.
 type Store struct {
-	db *sql.DB
+	db        *sql.DB
+	rateMu    sync.Mutex
+	rateLimit RateLimitPolicy
 }
 
 // Open creates or opens a SQLite WAL database with the full durable delivery
@@ -262,7 +265,7 @@ func Open(database string) (*Store, error) {
 	// from surfacing SQLITE_BUSY instead of orderly transactional serialization.
 	db.SetMaxOpenConns(1)
 	db.SetMaxIdleConns(1)
-	store := &Store{db: db}
+	store := &Store{db: db, rateLimit: DefaultRateLimitPolicy()}
 	var migrationControlExists bool
 	if err := db.QueryRowContext(context.Background(), `SELECT EXISTS (SELECT 1 FROM sqlite_schema WHERE type='table' AND name='relay_migration_control')`).Scan(&migrationControlExists); err != nil {
 		_ = db.Close()
@@ -313,6 +316,26 @@ func Open(database string) (*Store, error) {
 
 // Close closes the durable state database.
 func (s *Store) Close() error { return s.db.Close() }
+
+// SetRateLimitPolicy replaces the durable limiter bounds after startup validation.
+func (s *Store) SetRateLimitPolicy(policy RateLimitPolicy) error {
+	if err := policy.Validate(); err != nil {
+		return err
+	}
+	s.rateMu.Lock()
+	s.rateLimit = policy
+	s.rateMu.Unlock()
+	return nil
+}
+
+func (s *Store) rateLimitPolicy() RateLimitPolicy {
+	s.rateMu.Lock()
+	defer s.rateMu.Unlock()
+	if s.rateLimit == (RateLimitPolicy{}) {
+		return DefaultRateLimitPolicy()
+	}
+	return s.rateLimit
+}
 
 // ConsumeRequestNonce atomically prunes expired replay records and records one
 // signed request nonce. A duplicate is intentionally indistinguishable from
@@ -465,6 +488,13 @@ func (s *Store) migrate(ctx context.Context) error {
 			expires_at INTEGER NOT NULL,
 			PRIMARY KEY (machine_id, nonce)
 		)`,
+		`CREATE TABLE IF NOT EXISTS rate_buckets (
+			scope TEXT NOT NULL CHECK (scope IN ('sender_machine', 'conversation')),
+			bucket_key TEXT NOT NULL,
+			tokens_milli INTEGER NOT NULL CHECK (tokens_milli >= 0),
+			last_refill_unix_milli INTEGER NOT NULL,
+			PRIMARY KEY (scope, bucket_key)
+		)`,
 		`CREATE TABLE IF NOT EXISTS relay_migration_control (
 			singleton INTEGER PRIMARY KEY CHECK (singleton = 1),
 			source_id TEXT NOT NULL,
@@ -497,7 +527,7 @@ func (s *Store) migrate(ctx context.Context) error {
 			return fmt.Errorf("initialize relay migration control: %w", err)
 		}
 	}
-	for _, table := range []string{"endpoints", "conversations", "memberships", "roles", "role_memberships", "role_bindings", "role_profiles", "role_profile_idempotency", "messages", "deliveries", "recipient_cursors", "idempotency", "conversation_idempotency", "conversation_controls", "conversation_control_idempotency", "request_nonces"} {
+	for _, table := range []string{"endpoints", "conversations", "memberships", "roles", "role_memberships", "role_bindings", "role_profiles", "role_profile_idempotency", "messages", "deliveries", "recipient_cursors", "idempotency", "conversation_idempotency", "conversation_controls", "conversation_control_idempotency", "request_nonces", "rate_buckets"} {
 		for _, operation := range []string{"INSERT", "UPDATE", "DELETE"} {
 			name := "relay_migration_guard_" + table + "_" + strings.ToLower(operation)
 			statement := fmt.Sprintf(`CREATE TRIGGER IF NOT EXISTS %s BEFORE %s ON %s
@@ -1257,6 +1287,9 @@ func (s *Store) AppendMessage(input AppendInput) (Message, bool, error) {
 	if !errors.Is(err, sql.ErrNoRows) {
 		return Message{}, false, fmt.Errorf("read idempotency key: %w", err)
 	}
+	if err := consumeSQLiteRateLimits(tx, s.rateLimitPolicy(), input.SenderMachineID, input.ConversationID, input.Now); err != nil {
+		return Message{}, false, err
+	}
 	message := Message{ID: uuid.NewString(), ConversationID: input.ConversationID, FromEndpoint: input.FromEndpoint, Body: input.Body, CreatedAt: input.Now.UTC().Truncate(time.Millisecond)}
 	if err := tx.QueryRowContext(context.Background(), "UPDATE conversations SET next_sequence = next_sequence + 1 WHERE id = ? RETURNING next_sequence", input.ConversationID).Scan(&message.Sequence); errors.Is(err, sql.ErrNoRows) {
 		return Message{}, false, ErrForbidden
@@ -1845,6 +1878,51 @@ func createConversationHash(creatorEndpoint string, members []Member) string {
 	}
 	digest := sha256.Sum256([]byte(strings.Join(parts, "\x00")))
 	return hex.EncodeToString(digest[:])
+}
+
+func consumeSQLiteRateLimits(tx *sql.Tx, policy RateLimitPolicy, senderMachineID, conversationID string, now time.Time) error {
+	senderRetry, senderOK, err := consumeSQLiteRateBucket(tx, rateScopeSenderMachine, senderMachineID, now, policy.SenderBurst, policy.SenderRefillPerMinute, policy.MaxRetryAfterSeconds)
+	if err != nil {
+		return err
+	}
+	conversationRetry, conversationOK, err := consumeSQLiteRateBucket(tx, rateScopeConversation, conversationID, now, policy.ConversationBurst, policy.ConversationRefillPerMinute, policy.MaxRetryAfterSeconds)
+	if err != nil {
+		return err
+	}
+	if senderOK && conversationOK {
+		return nil
+	}
+	retryAfter := senderRetry
+	if !conversationOK && conversationRetry > retryAfter {
+		retryAfter = conversationRetry
+	}
+	if senderOK {
+		retryAfter = conversationRetry
+	}
+	if conversationOK {
+		retryAfter = senderRetry
+	}
+	return newRateLimitedError(retryAfter, policy.MaxRetryAfterSeconds)
+}
+
+func consumeSQLiteRateBucket(tx *sql.Tx, scope, key string, now time.Time, burst, refillPerMinute, maxRetryAfterSeconds int) (time.Duration, bool, error) {
+	nowMilli := now.UTC().UnixMilli()
+	if _, err := tx.ExecContext(context.Background(), `INSERT OR IGNORE INTO rate_buckets(scope, bucket_key, tokens_milli, last_refill_unix_milli) VALUES (?, ?, ?, ?)`, scope, key, initialRateBucketTokens(burst), nowMilli); err != nil {
+		return 0, false, fmt.Errorf("create rate bucket: %w", err)
+	}
+	var snapshot rateBucketSnapshot
+	if err := tx.QueryRowContext(context.Background(), `SELECT tokens_milli, last_refill_unix_milli FROM rate_buckets WHERE scope=? AND bucket_key=?`, scope, key).Scan(&snapshot.TokensMilli, &snapshot.LastRefillUnixMilli); err != nil {
+		return 0, false, fmt.Errorf("read rate bucket: %w", err)
+	}
+	refilled := refillRateBucket(snapshot, now, burst, refillPerMinute)
+	consumed, retryAfter, ok := consumeRefilledBucket(refilled, burst, refillPerMinute, maxRetryAfterSeconds)
+	if !ok {
+		return retryAfter, false, nil
+	}
+	if _, err := tx.ExecContext(context.Background(), `UPDATE rate_buckets SET tokens_milli=?, last_refill_unix_milli=? WHERE scope=? AND bucket_key=?`, consumed.TokensMilli, consumed.LastRefillUnixMilli, scope, key); err != nil {
+		return 0, false, fmt.Errorf("update rate bucket: %w", err)
+	}
+	return 0, true, nil
 }
 
 func memberIdentity(member Member) string {

--- a/internal/relay/store_conformance_test.go
+++ b/internal/relay/store_conformance_test.go
@@ -17,4 +17,5 @@ func TestSQLiteStoreConformance(t *testing.T) {
 	contracttest.Run(t, store, "sqlite-contract")
 	contracttest.RunRoleTargeting(t, store, "sqlite-target")
 	contracttest.RunRoleProfiles(t, store, "sqlite-profile")
+	contracttest.RunRateLimits(t, store, "sqlite-rate")
 }

--- a/internal/relay/store_rate_limit_test.go
+++ b/internal/relay/store_rate_limit_test.go
@@ -1,6 +1,7 @@
 package relay
 
 import (
+	"context"
 	"database/sql"
 	"errors"
 	"fmt"
@@ -236,19 +237,19 @@ type durableRelaySnapshot struct {
 func durableAppendSnapshot(t *testing.T, store *Store, conversationID string) durableRelaySnapshot {
 	t.Helper()
 	var snapshot durableRelaySnapshot
-	if err := store.db.QueryRow(`SELECT next_sequence FROM conversations WHERE id=?`, conversationID).Scan(&snapshot.Sequence); err != nil {
+	if err := store.db.QueryRowContext(context.Background(), `SELECT next_sequence FROM conversations WHERE id=?`, conversationID).Scan(&snapshot.Sequence); err != nil {
 		t.Fatal(err)
 	}
-	if err := store.db.QueryRow(`SELECT count(*) FROM messages WHERE conversation_id=?`, conversationID).Scan(&snapshot.Messages); err != nil {
+	if err := store.db.QueryRowContext(context.Background(), `SELECT count(*) FROM messages WHERE conversation_id=?`, conversationID).Scan(&snapshot.Messages); err != nil {
 		t.Fatal(err)
 	}
-	if err := store.db.QueryRow(`SELECT count(*) FROM deliveries`).Scan(&snapshot.Deliveries); err != nil {
+	if err := store.db.QueryRowContext(context.Background(), `SELECT count(*) FROM deliveries`).Scan(&snapshot.Deliveries); err != nil {
 		t.Fatal(err)
 	}
-	if err := store.db.QueryRow(`SELECT count(*) FROM idempotency`).Scan(&snapshot.Idempotency); err != nil {
+	if err := store.db.QueryRowContext(context.Background(), `SELECT count(*) FROM idempotency`).Scan(&snapshot.Idempotency); err != nil {
 		t.Fatal(err)
 	}
-	if err := store.db.QueryRow(`SELECT count(*), COALESCE(sum(tokens_milli),0) FROM rate_buckets`).Scan(&snapshot.RateBuckets, &snapshot.BucketTokens); err != nil && !errors.Is(err, sql.ErrNoRows) {
+	if err := store.db.QueryRowContext(context.Background(), `SELECT count(*), COALESCE(sum(tokens_milli),0) FROM rate_buckets`).Scan(&snapshot.RateBuckets, &snapshot.BucketTokens); err != nil && !errors.Is(err, sql.ErrNoRows) {
 		t.Fatal(err)
 	}
 	return snapshot

--- a/internal/relay/store_rate_limit_test.go
+++ b/internal/relay/store_rate_limit_test.go
@@ -1,0 +1,290 @@
+package relay
+
+import (
+	"database/sql"
+	"errors"
+	"fmt"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestStoreSenderBucketExhaustionAcrossConversations(t *testing.T) {
+	t.Parallel()
+	store, now := openRateLimitedStore(t, RateLimitPolicy{SenderBurst: 1, SenderRefillPerMinute: 60, ConversationBurst: 10, ConversationRefillPerMinute: 60, MaxRetryAfterSeconds: 60})
+	first := createRateLimitConversation(t, store, now, "machine-a", "machine-b", "agent/a", "agent/b")
+	second := createRateLimitConversation(t, store, now, "machine-a", "machine-c", "agent/a", "agent/c")
+	if _, _, err := store.AppendMessage(rateLimitAppend(first.ID, "machine-a", "agent/a", "one", "send-1", now)); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := store.AppendMessage(rateLimitAppend(second.ID, "machine-a", "agent/a", "two", "send-2", now)); !errors.Is(err, ErrRateLimited) {
+		t.Fatalf("cross-conversation sender exhaustion err=%v", err)
+	}
+}
+
+func TestStoreConversationBucketExhaustionAcrossSenders(t *testing.T) {
+	t.Parallel()
+	store, now := openRateLimitedStore(t, RateLimitPolicy{SenderBurst: 10, SenderRefillPerMinute: 60, ConversationBurst: 1, ConversationRefillPerMinute: 60, MaxRetryAfterSeconds: 60})
+	conversation := createRateLimitConversation(t, store, now, "machine-a", "machine-b", "agent/a", "agent/b")
+	if _, _, err := store.AppendMessage(rateLimitAppend(conversation.ID, "machine-a", "agent/a", "one", "send-a", now)); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := store.AppendMessage(rateLimitAppend(conversation.ID, "machine-b", "agent/b", "two", "send-b", now)); !errors.Is(err, ErrRateLimited) {
+		t.Fatalf("cross-sender conversation exhaustion err=%v", err)
+	}
+}
+
+func TestStoreTokenRefillAndExactRetryAfter(t *testing.T) {
+	t.Parallel()
+	store, now := openRateLimitedStore(t, RateLimitPolicy{SenderBurst: 1, SenderRefillPerMinute: 30, ConversationBurst: 10, ConversationRefillPerMinute: 60, MaxRetryAfterSeconds: 60})
+	conversation := createRateLimitConversation(t, store, now, "machine-a", "machine-b", "agent/a", "agent/b")
+	if _, _, err := store.AppendMessage(rateLimitAppend(conversation.ID, "machine-a", "agent/a", "one", "send-1", now)); err != nil {
+		t.Fatal(err)
+	}
+	_, _, err := store.AppendMessage(rateLimitAppend(conversation.ID, "machine-a", "agent/a", "two", "send-2", now))
+	var limited *RateLimitedError
+	if !errors.As(err, &limited) || limited.RetryAfterSeconds() != 2 {
+		t.Fatalf("retry-after err=%v limited=%#v", err, limited)
+	}
+	if _, _, err := store.AppendMessage(rateLimitAppend(conversation.ID, "machine-a", "agent/a", "two", "send-2", now.Add(time.Second))); !errors.Is(err, ErrRateLimited) {
+		t.Fatalf("partial refill err=%v", err)
+	}
+	if _, _, err := store.AppendMessage(rateLimitAppend(conversation.ID, "machine-a", "agent/a", "two", "send-2", now.Add(2*time.Second))); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestStoreExactCommittedRetryWhileBucketEmpty(t *testing.T) {
+	t.Parallel()
+	store, now := openRateLimitedStore(t, RateLimitPolicy{SenderBurst: 1, SenderRefillPerMinute: 60, ConversationBurst: 1, ConversationRefillPerMinute: 60, MaxRetryAfterSeconds: 60})
+	conversation := createRateLimitConversation(t, store, now, "machine-a", "machine-b", "agent/a", "agent/b")
+	input := rateLimitAppend(conversation.ID, "machine-a", "agent/a", "original", "send-1", now)
+	first, _, err := store.AppendMessage(input)
+	if err != nil {
+		t.Fatal(err)
+	}
+	repeated, duplicate, err := store.AppendMessage(input)
+	if err != nil || !duplicate || repeated != first {
+		t.Fatalf("committed retry message=%#v duplicate=%t err=%v", repeated, duplicate, err)
+	}
+	if _, _, err := store.AppendMessage(rateLimitAppend(conversation.ID, "machine-a", "agent/a", "other", "send-2", now)); !errors.Is(err, ErrRateLimited) {
+		t.Fatalf("empty-bucket new send err=%v", err)
+	}
+}
+
+func TestStoreChangedBodyKeyConflictIsNotRateLimited(t *testing.T) {
+	t.Parallel()
+	store, now := openRateLimitedStore(t, RateLimitPolicy{SenderBurst: 1, SenderRefillPerMinute: 60, ConversationBurst: 1, ConversationRefillPerMinute: 60, MaxRetryAfterSeconds: 60})
+	conversation := createRateLimitConversation(t, store, now, "machine-a", "machine-b", "agent/a", "agent/b")
+	input := rateLimitAppend(conversation.ID, "machine-a", "agent/a", "original", "send-1", now)
+	if _, _, err := store.AppendMessage(input); err != nil {
+		t.Fatal(err)
+	}
+	changed := input
+	changed.Body = "changed"
+	if _, _, err := store.AppendMessage(changed); !errors.Is(err, ErrConflict) || errors.Is(err, ErrRateLimited) {
+		t.Fatalf("changed-body err=%v", err)
+	}
+}
+
+func TestStoreRejectedRequestHasZeroDurableSideEffects(t *testing.T) {
+	t.Parallel()
+	store, now := openRateLimitedStore(t, RateLimitPolicy{SenderBurst: 1, SenderRefillPerMinute: 60, ConversationBurst: 10, ConversationRefillPerMinute: 60, MaxRetryAfterSeconds: 60})
+	conversation := createRateLimitConversation(t, store, now, "machine-a", "machine-b", "agent/a", "agent/b")
+	if _, _, err := store.AppendMessage(rateLimitAppend(conversation.ID, "machine-a", "agent/a", "one", "send-1", now)); err != nil {
+		t.Fatal(err)
+	}
+	before := durableAppendSnapshot(t, store, conversation.ID)
+	if _, _, err := store.AppendMessage(rateLimitAppend(conversation.ID, "machine-a", "agent/a", "two", "send-2", now)); !errors.Is(err, ErrRateLimited) {
+		t.Fatalf("rejected send err=%v", err)
+	}
+	after := durableAppendSnapshot(t, store, conversation.ID)
+	if after != before {
+		t.Fatalf("rate-limit rejection mutated durable state before=%#v after=%#v", before, after)
+	}
+	if _, _, err := store.AppendMessage(rateLimitAppend(conversation.ID, "machine-a", "agent/a", "two", "send-2", now.Add(time.Second))); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestStoreConcurrentSendsCannotOverspendBucket(t *testing.T) {
+	t.Parallel()
+	store, now := openRateLimitedStore(t, RateLimitPolicy{SenderBurst: 1, SenderRefillPerMinute: 60, ConversationBurst: 8, ConversationRefillPerMinute: 60, MaxRetryAfterSeconds: 60})
+	conversation := createRateLimitConversation(t, store, now, "machine-a", "machine-b", "agent/a", "agent/b")
+	const workers = 8
+	results := make(chan error, workers)
+	var started sync.WaitGroup
+	started.Add(workers)
+	release := make(chan struct{})
+	for index := 0; index < workers; index++ {
+		go func(index int) {
+			started.Done()
+			<-release
+			_, _, err := store.AppendMessage(rateLimitAppend(conversation.ID, "machine-a", "agent/a", fmt.Sprintf("body-%d", index), fmt.Sprintf("send-%d", index), now))
+			results <- err
+		}(index)
+	}
+	started.Wait()
+	close(release)
+	accepted, rejected := 0, 0
+	for index := 0; index < workers; index++ {
+		err := <-results
+		switch {
+		case err == nil:
+			accepted++
+		case errors.Is(err, ErrRateLimited):
+			rejected++
+		default:
+			t.Fatalf("concurrent send err=%v", err)
+		}
+	}
+	if accepted != 1 || rejected != workers-1 {
+		t.Fatalf("accepted=%d rejected=%d", accepted, rejected)
+	}
+	snapshot := durableAppendSnapshot(t, store, conversation.ID)
+	if snapshot.Messages != 1 || snapshot.Sequence != 1 || snapshot.Idempotency != 1 {
+		t.Fatalf("overspend snapshot=%#v", snapshot)
+	}
+}
+
+func TestStoreRestartPreservesDepletion(t *testing.T) {
+	t.Parallel()
+	policy := RateLimitPolicy{SenderBurst: 1, SenderRefillPerMinute: 60, ConversationBurst: 10, ConversationRefillPerMinute: 60, MaxRetryAfterSeconds: 60}
+	database := filepath.Join(t.TempDir(), "relay.db")
+	now := time.Date(2026, time.August, 18, 15, 0, 0, 0, time.UTC)
+	store, err := Open(database)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.SetRateLimitPolicy(policy); err != nil {
+		t.Fatal(err)
+	}
+	conversation := createRateLimitConversation(t, store, now, "machine-a", "machine-b", "agent/a", "agent/b")
+	if _, _, err := store.AppendMessage(rateLimitAppend(conversation.ID, "machine-a", "agent/a", "one", "send-1", now)); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatal(err)
+	}
+	restarted, err := Open(database)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = restarted.Close() })
+	if err := restarted.SetRateLimitPolicy(policy); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := restarted.AppendMessage(rateLimitAppend(conversation.ID, "machine-a", "agent/a", "two", "send-2", now)); !errors.Is(err, ErrRateLimited) {
+		t.Fatalf("restarted depletion err=%v", err)
+	}
+}
+
+func TestStoreInvalidRateLimitPolicyIsRejected(t *testing.T) {
+	t.Parallel()
+	store, err := Open(filepath.Join(t.TempDir(), "relay.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	if err := store.SetRateLimitPolicy(RateLimitPolicy{}); err == nil {
+		t.Fatal("empty rate-limit policy was accepted")
+	}
+}
+
+func TestStoreTargetedRoleSendStillChargesSenderAndConversation(t *testing.T) {
+	t.Parallel()
+	store, now := openRateLimitedStore(t, RateLimitPolicy{SenderBurst: 1, SenderRefillPerMinute: 60, ConversationBurst: 10, ConversationRefillPerMinute: 60, MaxRetryAfterSeconds: 60})
+	if err := store.AdvertiseEndpoints("machine-sender", []string{"agent/sender/session"}, now, time.Hour); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.AdvertiseEndpoints("machine-reviewer", []string{"agent/reviewer/session"}, now, time.Hour); err != nil {
+		t.Fatal(err)
+	}
+	conversation, err := store.CreateConversation("agent/sender/session", []Member{
+		{Endpoint: "agent/sender/session", Capabilities: CapSend | CapReceive | CapAdmin},
+		{Role: "role/reviewer", RoleMachineID: "machine-reviewer", Capabilities: CapReceive},
+	}, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.BindRoleToSession("machine-reviewer", "role/reviewer", "agent/reviewer/session", now, time.Hour); err != nil {
+		t.Fatal(err)
+	}
+	input := AppendInput{ConversationID: conversation.ID, SenderMachineID: "machine-sender", FromEndpoint: "agent/sender/session", TargetRole: "role/reviewer", Body: "targeted", IdempotencyKey: "targeted-1", Now: now}
+	if _, _, err := store.AppendMessage(input); err != nil {
+		t.Fatal(err)
+	}
+	broadcast := input
+	broadcast.TargetRole = ""
+	broadcast.IdempotencyKey = "broadcast-2"
+	broadcast.Body = "broadcast"
+	if _, _, err := store.AppendMessage(broadcast); !errors.Is(err, ErrRateLimited) {
+		t.Fatalf("targeted send did not charge the sender bucket err=%v", err)
+	}
+}
+
+type durableRelaySnapshot struct {
+	Sequence     int64
+	Messages     int64
+	Deliveries   int64
+	Idempotency  int64
+	RateBuckets  int64
+	BucketTokens int64
+}
+
+func durableAppendSnapshot(t *testing.T, store *Store, conversationID string) durableRelaySnapshot {
+	t.Helper()
+	var snapshot durableRelaySnapshot
+	if err := store.db.QueryRow(`SELECT next_sequence FROM conversations WHERE id=?`, conversationID).Scan(&snapshot.Sequence); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.db.QueryRow(`SELECT count(*) FROM messages WHERE conversation_id=?`, conversationID).Scan(&snapshot.Messages); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.db.QueryRow(`SELECT count(*) FROM deliveries`).Scan(&snapshot.Deliveries); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.db.QueryRow(`SELECT count(*) FROM idempotency`).Scan(&snapshot.Idempotency); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.db.QueryRow(`SELECT count(*), COALESCE(sum(tokens_milli),0) FROM rate_buckets`).Scan(&snapshot.RateBuckets, &snapshot.BucketTokens); err != nil && !errors.Is(err, sql.ErrNoRows) {
+		t.Fatal(err)
+	}
+	return snapshot
+}
+
+func openRateLimitedStore(t *testing.T, policy RateLimitPolicy) (*Store, time.Time) {
+	t.Helper()
+	store, err := Open(filepath.Join(t.TempDir(), "relay.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	if err := store.SetRateLimitPolicy(policy); err != nil {
+		t.Fatal(err)
+	}
+	return store, time.Date(2026, time.August, 18, 15, 0, 0, 0, time.UTC)
+}
+
+func createRateLimitConversation(t *testing.T, store *Store, now time.Time, machineA, machineB, endpointA, endpointB string) Conversation {
+	t.Helper()
+	if err := store.AdvertiseEndpoints(machineA, []string{endpointA}, now, time.Hour); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.AdvertiseEndpoints(machineB, []string{endpointB}, now, time.Hour); err != nil {
+		t.Fatal(err)
+	}
+	conversation, err := store.CreateConversation(endpointA, []Member{
+		{Endpoint: endpointA, Capabilities: CapSend | CapReceive | CapAdmin},
+		{Endpoint: endpointB, Capabilities: CapSend | CapReceive},
+	}, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return conversation
+}
+
+func rateLimitAppend(conversationID, machineID, endpoint, body, key string, now time.Time) AppendInput {
+	return AppendInput{ConversationID: conversationID, SenderMachineID: machineID, FromEndpoint: endpoint, Body: body, IdempotencyKey: key, Now: now}
+}

--- a/internal/relay/store_rate_limit_test.go
+++ b/internal/relay/store_rate_limit_test.go
@@ -56,6 +56,21 @@ func TestStoreTokenRefillAndExactRetryAfter(t *testing.T) {
 	}
 }
 
+func TestStoreClockRollbackDoesNotRestoreCapacity(t *testing.T) {
+	t.Parallel()
+	store, now := openRateLimitedStore(t, RateLimitPolicy{SenderBurst: 2, SenderRefillPerMinute: 60, ConversationBurst: 10, ConversationRefillPerMinute: 60, MaxRetryAfterSeconds: 60})
+	conversation := createRateLimitConversation(t, store, now, "machine-a", "machine-b", "agent/a", "agent/b")
+	if _, _, err := store.AppendMessage(rateLimitAppend(conversation.ID, "machine-a", "agent/a", "one", "send-1", now)); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := store.AppendMessage(rateLimitAppend(conversation.ID, "machine-a", "agent/a", "two", "send-2", now.Add(-time.Second))); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := store.AppendMessage(rateLimitAppend(conversation.ID, "machine-a", "agent/a", "three", "send-3", now)); !errors.Is(err, ErrRateLimited) {
+		t.Fatalf("clock correction restored capacity err=%v", err)
+	}
+}
+
 func TestStoreExactCommittedRetryWhileBucketEmpty(t *testing.T) {
 	t.Parallel()
 	store, now := openRateLimitedStore(t, RateLimitPolicy{SenderBurst: 1, SenderRefillPerMinute: 60, ConversationBurst: 1, ConversationRefillPerMinute: 60, MaxRetryAfterSeconds: 60})


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Implements #149.

Bound sustained creation of distinct authorized messages with independent durable token buckets for the authenticated sender machine and the conversation. Queue quotas, expiry, semantic dedupe, and read receipts are out of scope.

## Behavior

- Sender and conversation buckets are charged atomically with append acceptance.
- Exact committed idempotency retries return the original message without charging.
- Changed-body key reuse remains conflict, not 429.
- Rejected requests create no sequence, message, delivery, idempotency, or audit side effects.
- HTTP maps exhaustion to `429` with a bounded integer `Retry-After` and the content-free error `rate limit exceeded`.
- Restart of the same SQLite or PostgreSQL store cannot refill a depleted bucket. Both stores share the same observable contract.
- Existing role targeting still delivers only to the named role and still charges both buckets.
- Mail cutover fingerprints and import batches omit token-bucket rows. Those rows are store-local operational state, not message identity; a cut-over PostgreSQL relay starts with empty buckets.

## Tests first

Covered before production wiring: sender exhaustion across conversations, conversation exhaustion across senders, refill/`Retry-After`, committed retry while empty, changed-body conflict, zero durable side effects, concurrent overspend, restart, invalid config, HTTP mapping/metrics, SQLite/PostgreSQL contract parity, and cutover fingerprint stability when only rate buckets change.

## Testing

- [x] Tests written first for store, HTTP, config, SQLite/PostgreSQL contract, and punarod startup
- [x] `go test ./internal/relay ./internal/postgres ./internal/config ./cmd/punarod`
- [x] `make test`
- [x] `make test-race`
- [x] `make staticcheck`
- [x] `make security`
- [x] `make lint`

## Config

Startup-validated defaults: 60/60 sender, 120/120 conversation, 60s Retry-After ceiling. Hard bounds 1–10000 tokens/refill and 1–3600 Retry-After seconds.

PostgreSQL schema v46 (`046_relay_rate_limits.sql`) after #154’s v45 role profiles.

## Risks

- `make test-postgres` was not run here because Docker is unavailable; CI still has to exercise the postgres job.
- Rate-rejection metrics are an unlabeled in-process counter. Queue capacity, expiry, and operator-facing metric surfaces stay in #150/#151.

Closes #149.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0eedf6c1-1a59-480d-87a8-7b84327a0fe2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0eedf6c1-1a59-480d-87a8-7b84327a0fe2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

