### PR TITLE
Add terminal retention, dead-letter inspection, and queue-age metrics

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -44,6 +44,12 @@ PUNARO_LOG_LEVEL=info
 # PUNARO_RELAY_PENDING_INSTALLATION_COUNT=100000
 # PUNARO_RELAY_PENDING_INSTALLATION_BYTES=268435456
 # PUNARO_RELAY_PENDING_RETRY_AFTER_SECONDS=60
+# Pending-age and terminal retention. Defaults expire work after 7 days and
+# retain terminal metadata for 30 days. Age values must be integers in
+# 1..31536000; maintenance batch 1..1000.
+# PUNARO_RELAY_PENDING_MAX_AGE_SECONDS=604800
+# PUNARO_RELAY_TERMINAL_RETENTION_SECONDS=2592000
+# PUNARO_RELAY_DELIVERY_MAINTENANCE_BATCH=100
 # Legacy attachment v2/v3, directory, and permit variables are retired. Their
 # presence, including an empty value or `false`, makes punarod fail startup.
 # Use only the trusted-relay surface and native client documented below.

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -433,6 +433,26 @@ Startup and readiness verify counter consistency or fail closed. The operator
 that fail-closed path while rebuilding drifted counters. Bodies are
 never hashed, compared, or parsed for loop detection.
 
+Pending deliveries also have a startup-validated maximum age. Conservative
+defaults expire work after seven days. Maintenance uses injected or database
+time, never sleep-based tests, and processes expiry and terminal prune in
+bounded pages with stable continuation. A delivery older than the inclusive
+age boundary transitions atomically from pending to terminal `expired`,
+releases pending capacity once, and advances only that recipient's contiguous
+cursor through the expired sequence. Another recipient of the same message is
+unchanged. An expired active lease cannot later acknowledge. Closed reasons
+are `acked`, `expired`, and `revoked`. Terminal records keep opaque
+message, conversation, and recipient identifiers, sequence, closed reason,
+lease generation, and timestamps; they never duplicate bodies or credentials.
+A separate terminal retention period, default thirty days, then prunes that
+metadata in bounded pages. Host-local `punaro relay list-terminals` and
+`punaro relay maintain-deliveries --yes` inspect and trigger that work.
+Ordinary agent HTTP exposes neither dead-letter inventory nor delivery
+receipts. Sender-facing append remains accepted/queued or rejected only.
+The loopback health listener publishes unlabeled counters for pending count
+and bytes, oldest pending age, terminal transitions by closed reason, retained
+terminals, and lease redeliveries.
+
 The guarantee is **at-least-once delivery**: a crash after a
 local mailbox injection but before the relay receives the acknowledgement can
 produce a redelivery.
@@ -1466,7 +1486,12 @@ adds explicit pending-delivery capacity counters per recipient identity and
 installation-wide. Quota tables are derived operational
 state, not cutover content: inspect and fingerprint ignore them, and activation
 rebuilds them from pending deliveries. Capacity denial is distinct from rate
-limiting. Expiry and dead-letter policies remain later slices.
+limiting. Schema version 49 adds content-free `mail_delivery_terminals` for
+acked, expired, and revoked deliveries. Terminal tables are the same class of
+derived operational state: inspect and fingerprint ignore them, abort still
+deletes them, and they are not cutover content. Pending-age expiry and
+terminal prune run in bounded host-local maintenance; they are not an agent
+receipt API.
 
 The supported cutover action is `punaro mail cutover`. Its dry-run reads the
 service-owned `relay.db` from the installation data directory and prints the

--- a/cmd/punaro/main.go
+++ b/cmd/punaro/main.go
@@ -373,6 +373,12 @@ func run(args []string, stdout, stderr io.Writer) int {
 		if len(args) > 1 && args[1] == "reconcile-capacity" {
 			return runRelayReconcileCapacity(args[2:], stdout, stderr, reconcileRelayCapacity)
 		}
+		if len(args) > 1 && args[1] == "list-terminals" {
+			return runRelayListTerminals(args[2:], stdout, stderr, listRelayTerminals)
+		}
+		if len(args) > 1 && args[1] == "maintain-deliveries" {
+			return runRelayMaintainDeliveries(args[2:], stdout, stderr, maintainRelayDeliveries)
+		}
 	case "backup":
 		return runBackup(args[1:], stdout, stderr)
 	case "restore":

--- a/cmd/punaro/relay_command.go
+++ b/cmd/punaro/relay_command.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/rock3r/punaro/internal/config"
 	"github.com/rock3r/punaro/internal/operator"
 	punaropostgres "github.com/rock3r/punaro/internal/postgres"
 	"github.com/rock3r/punaro/internal/relay"
@@ -125,4 +126,110 @@ func reconcileRelayCapacity(directory string) (relay.QuotaCounters, error) {
 	}
 	defer func() { _ = store.Close() }()
 	return relay.ReconcilePendingQuota(store)
+}
+
+type relayListTerminalsCommand func(string, string, int) (relay.TerminalPage, error)
+
+func runRelayListTerminals(args []string, stdout, stderr io.Writer, list relayListTerminalsCommand) int {
+	flags := flag.NewFlagSet("relay list-terminals", flag.ContinueOnError)
+	flags.SetOutput(stderr)
+	directory := flags.String("directory", "", "absolute Punaro installation directory")
+	after := flags.String("after", "", "opaque terminal page cursor")
+	limit := flags.Int("limit", 50, "bounded terminal page size")
+	if flags.Parse(args) != nil || flags.NArg() != 0 || *directory == "" || list == nil {
+		return 2
+	}
+	page, err := list(*directory, *after, *limit)
+	if err != nil {
+		_, _ = fmt.Fprintln(stderr, "relay terminal listing did not complete; rerun the exact command to recover safely")
+		return 1
+	}
+	return writeJSON(stdout, stderr, page)
+}
+
+func listRelayTerminals(directory, after string, limit int) (relay.TerminalPage, error) {
+	store, closer, err := openRelayOperatorStore(directory)
+	if err != nil {
+		return relay.TerminalPage{}, err
+	}
+	defer closer()
+	return store.ListTerminalDeliveries(after, limit)
+}
+
+type relayMaintainDeliveriesCommand func(string) (relay.MaintenanceResult, error)
+
+func runRelayMaintainDeliveries(args []string, stdout, stderr io.Writer, maintain relayMaintainDeliveriesCommand) int {
+	flags := flag.NewFlagSet("relay maintain-deliveries", flag.ContinueOnError)
+	flags.SetOutput(stderr)
+	directory := flags.String("directory", "", "absolute Punaro installation directory")
+	confirmed := flags.Bool("yes", false, "confirm bounded expiry and terminal prune")
+	if flags.Parse(args) != nil || flags.NArg() != 0 || *directory == "" || !*confirmed || maintain == nil {
+		return 2
+	}
+	result, err := maintain(*directory)
+	if err != nil {
+		_, _ = fmt.Fprintln(stderr, "relay delivery maintenance did not complete; rerun the exact command to recover safely")
+		return 1
+	}
+	return writeJSON(stdout, stderr, map[string]any{"status": "deliveries_maintained", "directory": *directory, "expired": result.Expired, "pruned": result.Pruned, "scanned": result.Scanned})
+}
+
+func maintainRelayDeliveries(directory string) (relay.MaintenanceResult, error) {
+	store, closer, err := openRelayOperatorStore(directory)
+	if err != nil {
+		return relay.MaintenanceResult{}, err
+	}
+	defer closer()
+	if err := applyInstallationRetention(directory, store); err != nil {
+		return relay.MaintenanceResult{}, err
+	}
+	return store.MaintainDeliveries(time.Now().UTC())
+}
+
+type operatorRelayStore interface {
+	ListTerminalDeliveries(string, int) (relay.TerminalPage, error)
+	MaintainDeliveries(time.Time) (relay.MaintenanceResult, error)
+	SetRetentionPolicy(relay.RetentionConfig) error
+}
+
+func applyInstallationRetention(directory string, store interface {
+	SetRetentionPolicy(relay.RetentionConfig) error
+}) error {
+	cfg, err := config.Load(operator.EnvFile(directory))
+	if err != nil {
+		return err
+	}
+	policy := cfg.RelayRetentionPolicy()
+	if policy == (relay.RetentionConfig{}) {
+		policy = relay.DefaultRetentionConfig()
+	}
+	return store.SetRetentionPolicy(policy)
+}
+
+func openRelayOperatorStore(directory string) (operatorRelayStore, func(), error) {
+	installation, err := operator.Load(directory)
+	if err != nil {
+		return nil, nil, err
+	}
+	if installation.MailCutover != nil {
+		ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+		database, err := punaropostgres.OpenApplication(ctx, punaropostgres.Config{DSNFile: installation.AppDSNFile})
+		if err != nil {
+			cancel()
+			return nil, nil, err
+		}
+		return database, func() {
+			_ = database.Close()
+			cancel()
+		}, nil
+	}
+	path := filepath.Join(installation.DataDir, "relay.db")
+	if _, err := os.Stat(path); err != nil {
+		return nil, nil, errors.New("relay terminal store is unavailable")
+	}
+	store, err := relay.Open(path)
+	if err != nil {
+		return nil, nil, err
+	}
+	return store, func() { _ = store.Close() }, nil
 }

--- a/cmd/punaro/relay_command.go
+++ b/cmd/punaro/relay_command.go
@@ -195,13 +195,9 @@ type operatorRelayStore interface {
 func applyInstallationRetention(directory string, store interface {
 	SetRetentionPolicy(relay.RetentionConfig) error
 }) error {
-	cfg, err := config.Load(operator.EnvFile(directory))
+	policy, err := config.RetentionPolicyFromFile(operator.EnvFile(directory))
 	if err != nil {
 		return err
-	}
-	policy := cfg.RelayRetentionPolicy()
-	if policy == (relay.RetentionConfig{}) {
-		policy = relay.DefaultRetentionConfig()
 	}
 	return store.SetRetentionPolicy(policy)
 }

--- a/cmd/punaro/relay_command_test.go
+++ b/cmd/punaro/relay_command_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"errors"
+	"os"
 	"testing"
 
 	"github.com/rock3r/punaro/internal/operator"
@@ -88,4 +89,75 @@ func TestRelayReconcileCapacityPublishesContentFreeOutcome(t *testing.T) {
 	}); code != 1 || !bytes.Contains(stderr.Bytes(), []byte("rerun the exact command")) {
 		t.Fatalf("failure code=%d stderr=%q", code, stderr.String())
 	}
+}
+
+func TestRelayListTerminalsPublishesContentFreePages(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	called := false
+	list := func(directory, after string, limit int) (relay.TerminalPage, error) {
+		called = directory == "/install" && after == "cursor-1" && limit == 2
+		return relay.TerminalPage{Terminals: []relay.TerminalRecord{{DeliveryID: "d1", MessageID: "m1", ConversationID: "c1", RecipientID: "r1", Sequence: 1, ClosedReason: relay.ClosedExpired}}, NextCursor: "d1"}, nil
+	}
+	if code := runRelayListTerminals([]string{"--directory", "/install", "--after", "cursor-1", "--limit", "2"}, &stdout, &stderr, list); code != 0 || !called || !bytes.Contains(stdout.Bytes(), []byte(`"closed_reason": "expired"`)) || bytes.Contains(stdout.Bytes(), []byte("body")) {
+		t.Fatalf("code=%d called=%t stdout=%q stderr=%q", code, called, stdout.String(), stderr.String())
+	}
+}
+
+func TestRelayMaintainDeliveriesRequiresConfirmation(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	called := false
+	maintain := func(string) (relay.MaintenanceResult, error) {
+		called = true
+		return relay.MaintenanceResult{}, nil
+	}
+	if code := runRelayMaintainDeliveries([]string{"--directory", "/install"}, &stdout, &stderr, maintain); code != 2 || called {
+		t.Fatalf("unconfirmed code=%d called=%t", code, called)
+	}
+	if code := runRelayMaintainDeliveries([]string{"--directory", "/install", "--yes"}, &stdout, &stderr, func(string) (relay.MaintenanceResult, error) {
+		return relay.MaintenanceResult{Expired: 1, Pruned: 0, Scanned: 1}, nil
+	}); code != 0 || !bytes.Contains(stdout.Bytes(), []byte(`"deliveries_maintained"`)) || !bytes.Contains(stdout.Bytes(), []byte(`"expired": 1`)) {
+		t.Fatalf("code=%d stdout=%q stderr=%q", code, stdout.String(), stderr.String())
+	}
+}
+
+func TestApplyInstallationRetentionHonorsDaemonEnvFile(t *testing.T) {
+	directory := t.TempDir()
+	want := relay.RetentionConfig{PendingMaxAgeSeconds: 90, TerminalRetentionSeconds: 180, MaintenanceBatch: 7}
+	body := "PUNARO_RELAY_PENDING_MAX_AGE_SECONDS=90\nPUNARO_RELAY_TERMINAL_RETENTION_SECONDS=180\nPUNARO_RELAY_DELIVERY_MAINTENANCE_BATCH=7\n"
+	if err := os.WriteFile(operator.EnvFile(directory), []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	for _, key := range []string{
+		"PUNARO_RELAY_PENDING_MAX_AGE_SECONDS",
+		"PUNARO_RELAY_TERMINAL_RETENTION_SECONDS",
+		"PUNARO_RELAY_DELIVERY_MAINTENANCE_BATCH",
+	} {
+		previous, present := os.LookupEnv(key)
+		if err := os.Unsetenv(key); err != nil {
+			t.Fatal(err)
+		}
+		t.Cleanup(func() {
+			if present {
+				_ = os.Setenv(key, previous)
+				return
+			}
+			_ = os.Unsetenv(key)
+		})
+	}
+	store := &recordingOperatorStore{}
+	if err := applyInstallationRetention(directory, store); err != nil {
+		t.Fatal(err)
+	}
+	if store.policy != want {
+		t.Fatalf("policy=%#v want %#v", store.policy, want)
+	}
+}
+
+type recordingOperatorStore struct {
+	policy relay.RetentionConfig
+}
+
+func (s *recordingOperatorStore) SetRetentionPolicy(cfg relay.RetentionConfig) error {
+	s.policy = cfg
+	return nil
 }

--- a/cmd/punaro/relay_command_test.go
+++ b/cmd/punaro/relay_command_test.go
@@ -153,6 +153,25 @@ func TestApplyInstallationRetentionHonorsDaemonEnvFile(t *testing.T) {
 	}
 }
 
+func TestApplyInstallationRetentionIgnoresProcessEnvOverrides(t *testing.T) {
+	directory := t.TempDir()
+	want := relay.RetentionConfig{PendingMaxAgeSeconds: 90, TerminalRetentionSeconds: 180, MaintenanceBatch: 7}
+	body := "PUNARO_RELAY_PENDING_MAX_AGE_SECONDS=90\nPUNARO_RELAY_TERMINAL_RETENTION_SECONDS=180\nPUNARO_RELAY_DELIVERY_MAINTENANCE_BATCH=7\n"
+	if err := os.WriteFile(operator.EnvFile(directory), []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PUNARO_RELAY_PENDING_MAX_AGE_SECONDS", "1")
+	t.Setenv("PUNARO_RELAY_TERMINAL_RETENTION_SECONDS", "2")
+	t.Setenv("PUNARO_RELAY_DELIVERY_MAINTENANCE_BATCH", "3")
+	store := &recordingOperatorStore{}
+	if err := applyInstallationRetention(directory, store); err != nil {
+		t.Fatal(err)
+	}
+	if store.policy != want {
+		t.Fatalf("policy=%#v want %#v", store.policy, want)
+	}
+}
+
 type recordingOperatorStore struct {
 	policy relay.RetentionConfig
 }

--- a/cmd/punarod/main.go
+++ b/cmd/punarod/main.go
@@ -37,10 +37,10 @@ import (
 )
 
 const (
-	trustedReconcileBatch    = 100
-	trustedReconcileMaxPages = 1000
-	trustedOrphanGrace       = 24 * time.Hour
-	trustedGCClaimLifetime   = time.Minute
+	trustedReconcileBatch       = 100
+	trustedReconcileMaxPages    = 1000
+	trustedOrphanGrace          = 24 * time.Hour
+	trustedGCClaimLifetime      = time.Minute
 	trustedReconcileInterval    = 5 * time.Minute
 	deliveryMaintenanceInterval = time.Minute
 )
@@ -841,6 +841,7 @@ func startDeliveryMaintenance(store *relay.Store, postgresRelay relay.Backend) f
 	if maintainer == nil {
 		return nil
 	}
+	// #nosec G118 -- the returned stop function owns and invokes cancel.
 	ctx, cancel := context.WithCancel(context.Background())
 	done := make(chan struct{})
 	go func() {

--- a/cmd/punarod/main.go
+++ b/cmd/punarod/main.go
@@ -41,7 +41,8 @@ const (
 	trustedReconcileMaxPages = 1000
 	trustedOrphanGrace       = 24 * time.Hour
 	trustedGCClaimLifetime   = time.Minute
-	trustedReconcileInterval = 5 * time.Minute
+	trustedReconcileInterval    = 5 * time.Minute
+	deliveryMaintenanceInterval = time.Minute
 )
 
 type platformDatabase interface {
@@ -212,6 +213,11 @@ func run(args []string, stderr io.Writer) int {
 	}
 	if relayStore != nil {
 		defer func() { _ = relayStore.Close() }()
+	}
+	if relayHandler != nil {
+		if stopMaintain := startDeliveryMaintenance(relayStore, postgresRelay); stopMaintain != nil {
+			defer stopMaintain()
+		}
 	}
 	relayMetricsSnapshot := func() relay.MetricsSnapshot { return relay.MetricsSnapshot{} }
 	if provider, ok := relayHandler.(interface{ MetricsSnapshot() relay.MetricsSnapshot }); ok {
@@ -764,6 +770,20 @@ func buildRelayHandler(cfg config.Config, postgresBackends ...relay.Backend) (ht
 			return nil, nil, err
 		}
 	}
+	if setter, ok := backend.(interface {
+		SetRetentionPolicy(relay.RetentionConfig) error
+	}); ok {
+		policy := cfg.RelayRetentionPolicy()
+		if policy == (relay.RetentionConfig{}) {
+			policy = relay.DefaultRetentionConfig()
+		}
+		if err := setter.SetRetentionPolicy(policy); err != nil {
+			if store != nil {
+				_ = store.Close()
+			}
+			return nil, nil, err
+		}
+	}
 	metrics := &relay.Metrics{}
 	var authenticator *relay.Authenticator
 	if cfg.CredentialTransitionEnabled {
@@ -805,6 +825,42 @@ type relayMetricsHandler struct {
 
 func (h relayMetricsHandler) MetricsSnapshot() relay.MetricsSnapshot {
 	return h.metrics.Snapshot()
+}
+
+type deliveryMaintainer interface {
+	MaintainDeliveries(time.Time) (relay.MaintenanceResult, error)
+}
+
+func startDeliveryMaintenance(store *relay.Store, postgresRelay relay.Backend) func() {
+	var maintainer deliveryMaintainer
+	if store != nil {
+		maintainer = store
+	} else if postgres, ok := postgresRelay.(deliveryMaintainer); ok {
+		maintainer = postgres
+	}
+	if maintainer == nil {
+		return nil
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		ticker := time.NewTicker(deliveryMaintenanceInterval)
+		defer ticker.Stop()
+		_, _ = maintainer.MaintainDeliveries(time.Now().UTC())
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				_, _ = maintainer.MaintainDeliveries(time.Now().UTC())
+			}
+		}
+	}()
+	return func() {
+		cancel()
+		<-done
+	}
 }
 
 func newAccessVerifier(cfg config.Config) (*access.Verifier, error) {

--- a/cmd/punarod/main.go
+++ b/cmd/punarod/main.go
@@ -848,13 +848,17 @@ func startDeliveryMaintenance(store *relay.Store, postgresRelay relay.Backend) f
 		defer close(done)
 		ticker := time.NewTicker(deliveryMaintenanceInterval)
 		defer ticker.Stop()
-		_, _ = maintainer.MaintainDeliveries(time.Now().UTC())
+		if _, err := maintainer.MaintainDeliveries(time.Now().UTC()); err != nil {
+			log.Printf("punarod delivery maintenance did not complete")
+		}
 		for {
 			select {
 			case <-ctx.Done():
 				return
 			case <-ticker.C:
-				_, _ = maintainer.MaintainDeliveries(time.Now().UTC())
+				if _, err := maintainer.MaintainDeliveries(time.Now().UTC()); err != nil {
+					log.Printf("punarod delivery maintenance did not complete")
+				}
 			}
 		}
 	}()

--- a/docs/alpha-text-relay.md
+++ b/docs/alpha-text-relay.md
@@ -78,9 +78,20 @@ Override with `PUNARO_RELAY_PENDING_RECIPIENT_COUNT`,
 1..3600. Invalid values fail startup. A capacity-limited append is HTTP 429
 with integer `Retry-After` and the content-free error `capacity exceeded`,
 distinct from `rate limited`. Exact committed retries never reserve capacity
-again. The loopback health listener exposes `GET /metrics` with
+again. Pending deliveries older than
+`PUNARO_RELAY_PENDING_MAX_AGE_SECONDS` (default 7 days) expire in bounded
+maintenance pages, release capacity once, and keep content-free terminal
+metadata for `PUNARO_RELAY_TERMINAL_RETENTION_SECONDS` (default 30 days).
+Override those values and `PUNARO_RELAY_DELIVERY_MAINTENANCE_BATCH` (default
+100, 1..1000). Age values must be integers in 1..31536000 seconds. Invalid
+values fail startup. Host-local `punaro relay list-terminals` and
+`punaro relay maintain-deliveries --yes` inspect and trigger that work; ordinary
+agent routes do not. The loopback health listener exposes `GET /metrics` with
 `relay_rate_limit_rejections`, `relay_capacity_rejections`,
-`relay_pending_deliveries`, and `relay_pending_bytes` only; it has no body,
+`relay_pending_deliveries`, `relay_pending_bytes`,
+`relay_pending_oldest_age_seconds`, `relay_terminal_transitions_acked`,
+`relay_terminal_transitions_expired`, `relay_terminal_transitions_revoked`,
+`relay_terminals_retained`, and `relay_lease_redeliveries` only; it has no body,
 endpoint, role, or conversation labels.
 
 For a Cloudflare-protected remote route, additionally set the Access issuer,

--- a/docs/operator-guide.md
+++ b/docs/operator-guide.md
@@ -157,8 +157,8 @@ database and investigate. The digest-pinned `make test-postgres` stack is epheme
 test infrastructure, publishes no database port, and deletes its volume on
 exit.
 
-The current binary requires schema version 48 and supports an intact schema
-from version 10 through 48 as an update boundary. Versions 10 through 47 are
+The current binary requires schema version 49 and supports an intact schema
+from version 10 through 49 as an update boundary. Versions 10 through 48 are
 reported as `upgrade_required`; versions below the compatibility floor, newer
 versions, and damaged objects are `incompatible`. The embedded manifest and
 target release metadata are authoritative; check them instead of assuming a
@@ -168,12 +168,19 @@ migration 42 applies those controls to mail cutover, migration 43 adds the
 relay invocation capability, migration 44 adds client lifecycle authority,
 migration 45 adds opt-in canonical role profiles, migration 46 adds durable
 mail rate-limit buckets, migration 47 adds idempotent direct-role
-conversations, and migration 48 adds explicit pending-delivery capacity
-counters. After migration 48, `punaro relay reconcile-capacity
+conversations, migration 48 adds explicit pending-delivery capacity
+counters, and migration 49 adds content-free terminal delivery metadata.
+After migration 48, `punaro relay reconcile-capacity
 --directory DIR --yes` rebuilds those counters from pending deliveries if
 startup readiness reports inconsistency. Ordinary SQLite `Open` and PostgreSQL
 `Ready` still fail closed on drift; the reconcile command is the only supported
 repair path.
+After migration 49, pending deliveries older than the configured maximum age
+expire in bounded pages, release capacity once, and retain inspectable
+terminal metadata until the separate retention window elapses.
+`punaro relay list-terminals --directory DIR` prints one content-free page.
+`punaro relay maintain-deliveries --directory DIR --yes` runs one expire-and-prune
+page. Neither command is an agent API; they stay host-local.
 Migration 44 invalidates unredeemed legacy enrollment invitations while
 converting existing device credentials into lifecycle-managed client records,
 so it must not be applied as an ad hoc repair. The host wrapper's one-shot

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -482,16 +482,76 @@ func parseLogLevel(raw string) (string, error) {
 	}
 }
 
+// RetentionPolicyFromFile reads pending-age and terminal-retention keys from one
+// installation dotenv file. Process environment values do not override the file,
+// so host-local maintenance uses the daemon policy for that directory.
+func RetentionPolicyFromFile(path string) (relay.RetentionConfig, error) {
+	values, err := readDotEnvFile(path)
+	if err != nil {
+		return relay.RetentionConfig{}, err
+	}
+	defaults := relay.DefaultRetentionConfig()
+	lookup := func(key string, fallback int) (int, error) {
+		raw, ok := values[key]
+		if !ok {
+			return fallback, nil
+		}
+		return parseBoundedInt(key, raw, relay.RetentionAgeMinSeconds, relay.RetentionAgeMaxSeconds)
+	}
+	pendingMaxAge, err := lookup("PUNARO_RELAY_PENDING_MAX_AGE_SECONDS", defaults.PendingMaxAgeSeconds)
+	if err != nil {
+		return relay.RetentionConfig{}, err
+	}
+	terminalRetention, err := lookup("PUNARO_RELAY_TERMINAL_RETENTION_SECONDS", defaults.TerminalRetentionSeconds)
+	if err != nil {
+		return relay.RetentionConfig{}, err
+	}
+	maintenanceRaw, ok := values["PUNARO_RELAY_DELIVERY_MAINTENANCE_BATCH"]
+	maintenanceBatch := defaults.MaintenanceBatch
+	if ok {
+		maintenanceBatch, err = parseBoundedInt("PUNARO_RELAY_DELIVERY_MAINTENANCE_BATCH", maintenanceRaw, relay.RetentionBatchMin, relay.RetentionBatchMax)
+		if err != nil {
+			return relay.RetentionConfig{}, err
+		}
+	}
+	cfg := relay.RetentionConfig{
+		PendingMaxAgeSeconds:     pendingMaxAge,
+		TerminalRetentionSeconds: terminalRetention,
+		MaintenanceBatch:         maintenanceBatch,
+	}
+	if err := cfg.Validate(); err != nil {
+		return relay.RetentionConfig{}, err
+	}
+	return cfg, nil
+}
+
 // loadDotEnv supports the deliberately small KEY=VALUE subset needed for local
 // development. Existing process variables win over dotenv values.
 func loadDotEnv(path string) error {
-	// #nosec G304,G703 -- the operator explicitly chooses this local dotenv
-	// path via CLI or PUNARO_ENV_FILE; it is never derived from remote input.
+	values, err := readDotEnvFile(path)
+	if err != nil {
+		return err
+	}
+	for key, v := range values {
+		if _, present := os.LookupEnv(key); present {
+			continue
+		}
+		if err := os.Setenv(key, v); err != nil { // #nosec G703 -- dotenv values are operator-chosen local config
+			return fmt.Errorf("set dotenv value %s: %w", key, err)
+		}
+	}
+	return nil
+}
+
+func readDotEnvFile(path string) (map[string]string, error) {
+	// #nosec G304 -- the operator explicitly chooses this local dotenv path via
+	// CLI or PUNARO_ENV_FILE; it is never derived from remote input.
 	file, err := os.Open(path)
 	if err != nil {
-		return fmt.Errorf("read dotenv file: %w", err)
+		return nil, fmt.Errorf("read dotenv file: %w", err)
 	}
 	defer func() { _ = file.Close() }()
+	values := make(map[string]string)
 	scanner := bufio.NewScanner(file)
 	for line := 1; scanner.Scan(); line++ {
 		raw := strings.TrimSpace(scanner.Text())
@@ -501,16 +561,15 @@ func loadDotEnv(path string) error {
 		key, v, found := strings.Cut(raw, "=")
 		key = strings.TrimSpace(strings.TrimPrefix(key, "export "))
 		if !found || key == "" || strings.ContainsAny(key, " \t") {
-			return fmt.Errorf("parse dotenv file line %d", line)
+			return nil, fmt.Errorf("parse dotenv file line %d", line)
 		}
-		if _, present := os.LookupEnv(key); !present {
-			if err := os.Setenv(key, strings.Trim(strings.TrimSpace(v), "\"'")); err != nil {
-				return fmt.Errorf("set dotenv value line %d: %w", line, err)
-			}
+		if _, exists := values[key]; exists {
+			continue
 		}
+		values[key] = strings.Trim(strings.TrimSpace(v), "\"'")
 	}
 	if err := scanner.Err(); err != nil {
-		return fmt.Errorf("scan dotenv file: %w", err)
+		return nil, fmt.Errorf("scan dotenv file: %w", err)
 	}
-	return nil
+	return values, nil
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -544,8 +544,8 @@ func loadDotEnv(path string) error {
 }
 
 func readDotEnvFile(path string) (map[string]string, error) {
-	// #nosec G304 -- the operator explicitly chooses this local dotenv path via
-	// CLI or PUNARO_ENV_FILE; it is never derived from remote input.
+	// #nosec G304,G703 -- the operator explicitly chooses this local dotenv
+	// path via CLI or PUNARO_ENV_FILE; it is never derived from remote input.
 	file, err := os.Open(path)
 	if err != nil {
 		return nil, fmt.Errorf("read dotenv file: %w", err)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -64,6 +64,9 @@ type Config struct {
 	RelayPendingInstallationCount        int
 	RelayPendingInstallationBytes        int64
 	RelayPendingRetryAfterSeconds        int
+	RelayPendingMaxAgeSeconds            int
+	RelayTerminalRetentionSeconds        int
+	RelayDeliveryMaintenanceBatch        int
 }
 
 // Load reads configuration and optionally loads an explicitly named dotenv file.
@@ -280,7 +283,20 @@ func Load(explicitEnvFile string) (Config, error) {
 	if err != nil {
 		return Config{}, err
 	}
-	return Config{ListenAddr: listenAddr, HealthListenAddr: healthListenAddr, DataDir: dataDir, LogLevel: level, RelayEnabled: relayEnabled, RelayMachinesJSON: relayMachines, RelayStore: relayStore, AccessIssuer: accessIssuer, AccessAudience: accessAudience, AccessJWKSURL: accessJWKSURL, AccessJWKSFile: accessJWKSFile, PostgresEnabled: postgresEnabled, PostgresDSNFile: postgresDSNFile, DeviceAuthEnabled: deviceAuthEnabled, MemoryAPIEnabled: memoryAPIEnabled, MemoryMutationsEnabled: memoryMutationsEnabled, RemoteMCPMetadataEnabled: remoteMCPMetadataEnabled, RemoteMCPResourceURL: remoteMCPResourceURL, RemoteMCPAuthorizationServers: remoteMCPAuthorizationServers, RemoteMCPTokenValidationEnabled: remoteMCPTokenValidationEnabled, RemoteMCPIssuer: remoteMCPIssuer, RemoteMCPJWKSURL: remoteMCPJWKSURL, RemoteMCPSubjectBindingsJSON: remoteMCPSubjectBindingsJSON, MemoryOpenAIEmbeddingsURL: memoryOpenAIEmbeddingsURL, MemoryOpenAIAPIKeyFile: memoryOpenAIAPIKeyFile, TrustedAttachmentsEnabled: trustedAttachmentsEnabled, TrustedAttachmentBlobDir: trustedAttachmentBlobDir, CredentialTransitionEnabled: credentialTransitionEnabled, IngressMode: ingressMode, PublicURL: publicURL, TrustedLANCIDR: trustedLANCIDR, TrustedLANHTTP: trustedLANHTTP, RelaySenderRateBurst: senderBurst, RelaySenderRateRefillPerMinute: senderRefill, RelayConversationRateBurst: conversationBurst, RelayConversationRateRefillPerMinute: conversationRefill, RelayRateRetryAfterMaxSeconds: retryAfterMax, RelayPendingRecipientCount: pendingRecipientCount, RelayPendingRecipientBytes: pendingRecipientBytes, RelayPendingInstallationCount: pendingInstallationCount, RelayPendingInstallationBytes: pendingInstallationBytes, RelayPendingRetryAfterSeconds: pendingRetryAfter}, nil
+	retentionDefaults := relay.DefaultRetentionConfig()
+	pendingMaxAge, err := parseBoundedInt("PUNARO_RELAY_PENDING_MAX_AGE_SECONDS", value("PUNARO_RELAY_PENDING_MAX_AGE_SECONDS", strconv.Itoa(retentionDefaults.PendingMaxAgeSeconds)), relay.RetentionAgeMinSeconds, relay.RetentionAgeMaxSeconds)
+	if err != nil {
+		return Config{}, err
+	}
+	terminalRetention, err := parseBoundedInt("PUNARO_RELAY_TERMINAL_RETENTION_SECONDS", value("PUNARO_RELAY_TERMINAL_RETENTION_SECONDS", strconv.Itoa(retentionDefaults.TerminalRetentionSeconds)), relay.RetentionAgeMinSeconds, relay.RetentionAgeMaxSeconds)
+	if err != nil {
+		return Config{}, err
+	}
+	maintenanceBatch, err := parseBoundedInt("PUNARO_RELAY_DELIVERY_MAINTENANCE_BATCH", value("PUNARO_RELAY_DELIVERY_MAINTENANCE_BATCH", strconv.Itoa(retentionDefaults.MaintenanceBatch)), relay.RetentionBatchMin, relay.RetentionBatchMax)
+	if err != nil {
+		return Config{}, err
+	}
+	return Config{ListenAddr: listenAddr, HealthListenAddr: healthListenAddr, DataDir: dataDir, LogLevel: level, RelayEnabled: relayEnabled, RelayMachinesJSON: relayMachines, RelayStore: relayStore, AccessIssuer: accessIssuer, AccessAudience: accessAudience, AccessJWKSURL: accessJWKSURL, AccessJWKSFile: accessJWKSFile, PostgresEnabled: postgresEnabled, PostgresDSNFile: postgresDSNFile, DeviceAuthEnabled: deviceAuthEnabled, MemoryAPIEnabled: memoryAPIEnabled, MemoryMutationsEnabled: memoryMutationsEnabled, RemoteMCPMetadataEnabled: remoteMCPMetadataEnabled, RemoteMCPResourceURL: remoteMCPResourceURL, RemoteMCPAuthorizationServers: remoteMCPAuthorizationServers, RemoteMCPTokenValidationEnabled: remoteMCPTokenValidationEnabled, RemoteMCPIssuer: remoteMCPIssuer, RemoteMCPJWKSURL: remoteMCPJWKSURL, RemoteMCPSubjectBindingsJSON: remoteMCPSubjectBindingsJSON, MemoryOpenAIEmbeddingsURL: memoryOpenAIEmbeddingsURL, MemoryOpenAIAPIKeyFile: memoryOpenAIAPIKeyFile, TrustedAttachmentsEnabled: trustedAttachmentsEnabled, TrustedAttachmentBlobDir: trustedAttachmentBlobDir, CredentialTransitionEnabled: credentialTransitionEnabled, IngressMode: ingressMode, PublicURL: publicURL, TrustedLANCIDR: trustedLANCIDR, TrustedLANHTTP: trustedLANHTTP, RelaySenderRateBurst: senderBurst, RelaySenderRateRefillPerMinute: senderRefill, RelayConversationRateBurst: conversationBurst, RelayConversationRateRefillPerMinute: conversationRefill, RelayRateRetryAfterMaxSeconds: retryAfterMax, RelayPendingRecipientCount: pendingRecipientCount, RelayPendingRecipientBytes: pendingRecipientBytes, RelayPendingInstallationCount: pendingInstallationCount, RelayPendingInstallationBytes: pendingInstallationBytes, RelayPendingRetryAfterSeconds: pendingRetryAfter, RelayPendingMaxAgeSeconds: pendingMaxAge, RelayTerminalRetentionSeconds: terminalRetention, RelayDeliveryMaintenanceBatch: maintenanceBatch}, nil
 }
 
 func parseBoundedInt(name, raw string, minimum, maximum int) (int, error) {
@@ -318,6 +334,15 @@ func (c Config) RelayQuotaLimits() relay.QuotaConfig {
 		InstallationCount: c.RelayPendingInstallationCount,
 		InstallationBytes: c.RelayPendingInstallationBytes,
 		RetryAfterSeconds: c.RelayPendingRetryAfterSeconds,
+	}
+}
+
+// RelayRetentionPolicy returns the startup-validated pending-age and terminal retention.
+func (c Config) RelayRetentionPolicy() relay.RetentionConfig {
+	return relay.RetentionConfig{
+		PendingMaxAgeSeconds:     c.RelayPendingMaxAgeSeconds,
+		TerminalRetentionSeconds: c.RelayTerminalRetentionSeconds,
+		MaintenanceBatch:         c.RelayDeliveryMaintenanceBatch,
 	}
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -603,6 +603,42 @@ func TestLoadAcceptsExplicitRelayRetention(t *testing.T) {
 	}
 }
 
+func TestRetentionPolicyFromFileIgnoresProcessEnv(t *testing.T) {
+	t.Setenv("PUNARO_RELAY_PENDING_MAX_AGE_SECONDS", "1")
+	t.Setenv("PUNARO_RELAY_TERMINAL_RETENTION_SECONDS", "2")
+	t.Setenv("PUNARO_RELAY_DELIVERY_MAINTENANCE_BATCH", "3")
+	path := filepath.Join(t.TempDir(), ".env")
+	body := "PUNARO_RELAY_PENDING_MAX_AGE_SECONDS=90\nPUNARO_RELAY_TERMINAL_RETENTION_SECONDS=180\nPUNARO_RELAY_DELIVERY_MAINTENANCE_BATCH=7\n"
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	got, err := RetentionPolicyFromFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := relay.RetentionConfig{PendingMaxAgeSeconds: 90, TerminalRetentionSeconds: 180, MaintenanceBatch: 7}
+	if got != want {
+		t.Fatalf("retention=%#v want %#v", got, want)
+	}
+}
+
+func TestRetentionPolicyFromFileUsesDefaultsWhenKeysAbsent(t *testing.T) {
+	t.Setenv("PUNARO_RELAY_PENDING_MAX_AGE_SECONDS", "1")
+	t.Setenv("PUNARO_RELAY_TERMINAL_RETENTION_SECONDS", "2")
+	t.Setenv("PUNARO_RELAY_DELIVERY_MAINTENANCE_BATCH", "3")
+	path := filepath.Join(t.TempDir(), ".env")
+	if err := os.WriteFile(path, []byte("PUNARO_LOG_LEVEL=info\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	got, err := RetentionPolicyFromFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != relay.DefaultRetentionConfig() {
+		t.Fatalf("retention=%#v want defaults", got)
+	}
+}
+
 func TestLoadAcceptsExplicitRelayQuotaLimits(t *testing.T) {
 	t.Setenv("PUNARO_RELAY_PENDING_RECIPIENT_COUNT", "2")
 	t.Setenv("PUNARO_RELAY_PENDING_RECIPIENT_BYTES", "64")

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -44,6 +44,9 @@ func TestLoadPostgresDefaultsDisabled(t *testing.T) {
 	if got, want := cfg.RelayQuotaLimits(), relay.DefaultQuotaConfig(); got != want {
 		t.Fatalf("unexpected default pending quota: %#v", got)
 	}
+	if got, want := cfg.RelayRetentionPolicy(), relay.DefaultRetentionConfig(); got != want {
+		t.Fatalf("unexpected default retention: %#v", got)
+	}
 }
 
 func TestLoadAcceptsProductionComposeRuntimeConfiguration(t *testing.T) {
@@ -570,6 +573,33 @@ func TestLoadRejectsInvalidRelayQuotaLimits(t *testing.T) {
 	t.Setenv("PUNARO_RELAY_PENDING_RETRY_AFTER_SECONDS", "nope")
 	if _, err := Load(""); err == nil {
 		t.Fatal("non-integer pending retry-after was accepted")
+	}
+}
+
+func TestLoadRejectsInvalidRelayRetention(t *testing.T) {
+	t.Setenv("PUNARO_RELAY_PENDING_MAX_AGE_SECONDS", "0")
+	if _, err := Load(""); err == nil {
+		t.Fatal("zero pending max age was accepted")
+	}
+	t.Setenv("PUNARO_RELAY_PENDING_MAX_AGE_SECONDS", "604800")
+	t.Setenv("PUNARO_RELAY_TERMINAL_RETENTION_SECONDS", "nope")
+	if _, err := Load(""); err == nil {
+		t.Fatal("non-integer terminal retention was accepted")
+	}
+}
+
+func TestLoadAcceptsExplicitRelayRetention(t *testing.T) {
+	t.Setenv("PUNARO_RELAY_PENDING_MAX_AGE_SECONDS", "90")
+	t.Setenv("PUNARO_RELAY_TERMINAL_RETENTION_SECONDS", "180")
+	t.Setenv("PUNARO_RELAY_DELIVERY_MAINTENANCE_BATCH", "7")
+	cfg, err := Load("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := cfg.RelayRetentionPolicy()
+	want := relay.RetentionConfig{PendingMaxAgeSeconds: 90, TerminalRetentionSeconds: 180, MaintenanceBatch: 7}
+	if got != want {
+		t.Fatalf("retention=%#v want %#v", got, want)
 	}
 }
 

--- a/internal/postgres/db.go
+++ b/internal/postgres/db.go
@@ -37,6 +37,8 @@ type Database struct {
 	rateLimits                relay.RateLimitConfig
 	quotaMu                   sync.Mutex
 	quota                     relay.QuotaConfig
+	retentionMu               sync.Mutex
+	retention                 relay.RetentionConfig
 	pendingMetricsMu          sync.Mutex
 	metrics                   *relay.Metrics
 }
@@ -99,7 +101,7 @@ func OpenApplication(ctx context.Context, cfg Config) (*Database, error) {
 		return nil, err
 	}
 	database := &Database{
-		db: db, relayDB: relayDB, brainDB: brainDB, embeddingDB: embeddingDB, manifest: CurrentManifest(), rateLimits: relay.DefaultRateLimitConfig(), quota: relay.DefaultQuotaConfig(),
+		db: db, relayDB: relayDB, brainDB: brainDB, embeddingDB: embeddingDB, manifest: CurrentManifest(), rateLimits: relay.DefaultRateLimitConfig(), quota: relay.DefaultQuotaConfig(), retention: relay.DefaultRetentionConfig(),
 		attachmentPhysicalGCSlots: make(chan struct{}, 1),
 		memoryUsageWrites:         make(chan memoryUsageWrite, maxMemoryRecallQueue),
 		memoryUsageStop:           make(chan struct{}),
@@ -1287,6 +1289,13 @@ FROM objects, table_ownership, routine_safety, routine_acl, table_acl, schema_ac
 			return Snapshot{}, errors.New("PostgreSQL relay pending-quota schema cannot be inspected")
 		}
 		snapshot.CurrentObjectsPresent = quotaObjectsPresent
+	}
+	if snapshot.CurrentObjectsPresent && len(snapshot.Records) > 0 && snapshot.Records[len(snapshot.Records)-1].Version >= 49 {
+		terminalObjectsPresent, err := relayDeliveryTerminalsAvailable(ctx, q)
+		if err != nil {
+			return Snapshot{}, errors.New("PostgreSQL relay delivery-terminal schema cannot be inspected")
+		}
+		snapshot.CurrentObjectsPresent = terminalObjectsPresent
 	}
 	return snapshot, nil
 }

--- a/internal/postgres/mail_cutover.go
+++ b/internal/postgres/mail_cutover.go
@@ -312,7 +312,7 @@ func (a *Administration) AbortMailCutover(ctx context.Context, actorPrincipalID,
 		return errors.New("active mail cutover cannot be aborted")
 	}
 	if phase != MailCutoverAborted {
-		for _, table := range []string{"mail_pending_recipients", "mail_pending_install", "mail_direct_message_idempotency", "mail_message_from_roles", "mail_direct_conversations", "mail_request_nonces", "mail_rate_buckets", "mail_role_profile_idempotency", "mail_role_profiles", "mail_conversation_control_idempotency", "mail_conversation_controls", "mail_conversation_idempotency", "mail_message_idempotency", "mail_recipient_cursors", "mail_deliveries", "mail_messages", "mail_role_bindings", "mail_role_memberships", "mail_memberships", "mail_roles", "mail_conversations", "mail_endpoints"} {
+		for _, table := range []string{"mail_delivery_terminals", "mail_pending_recipients", "mail_pending_install", "mail_direct_message_idempotency", "mail_message_from_roles", "mail_direct_conversations", "mail_request_nonces", "mail_rate_buckets", "mail_role_profile_idempotency", "mail_role_profiles", "mail_conversation_control_idempotency", "mail_conversation_controls", "mail_conversation_idempotency", "mail_message_idempotency", "mail_recipient_cursors", "mail_deliveries", "mail_messages", "mail_role_bindings", "mail_role_memberships", "mail_memberships", "mail_roles", "mail_conversations", "mail_endpoints"} {
 			// #nosec G202 -- table comes only from the fixed dependency-order allowlist.
 			if _, err := tx.ExecContext(ctx, `DELETE FROM relay.`+table); err != nil {
 				return errors.New("mail cutover cannot be aborted")

--- a/internal/postgres/mail_cutover_test.go
+++ b/internal/postgres/mail_cutover_test.go
@@ -19,8 +19,8 @@ func (f mailCutoverScannerFunc) Scan(destinations ...any) error { return f(desti
 
 func TestMailCutoverEmptyTargetIgnoresDerivedQuotaTables(t *testing.T) {
 	t.Parallel()
-	if strings.Contains(mailCutoverEmptyTargetCountSQL, "mail_pending_recipients") || strings.Contains(mailCutoverEmptyTargetCountSQL, "mail_pending_install") {
-		t.Fatal("pending quota tables are derived operational state and must not fence an empty cutover target")
+	if strings.Contains(mailCutoverEmptyTargetCountSQL, "mail_pending_recipients") || strings.Contains(mailCutoverEmptyTargetCountSQL, "mail_pending_install") || strings.Contains(mailCutoverEmptyTargetCountSQL, "mail_delivery_terminals") {
+		t.Fatal("pending quota and terminal tables are derived operational state and must not fence an empty cutover target")
 	}
 }
 

--- a/internal/postgres/migrate.go
+++ b/internal/postgres/migrate.go
@@ -81,6 +81,7 @@ var migrationCompatibilityFloors = map[int64]int64{
 	46: 10,
 	47: 10,
 	48: 10,
+	49: 10,
 }
 
 // CurrentManifest returns the immutable migrations embedded in this binary.

--- a/internal/postgres/migrations/049_mail_delivery_terminals.sql
+++ b/internal/postgres/migrations/049_mail_delivery_terminals.sql
@@ -1,0 +1,24 @@
+CREATE TABLE relay.mail_delivery_terminals (
+    delivery_id uuid PRIMARY KEY,
+    message_id uuid NOT NULL,
+    conversation_id uuid NOT NULL,
+    recipient_endpoint text NOT NULL CHECK (
+        char_length(recipient_endpoint) >= 1 AND char_length(recipient_endpoint) <= 512
+        AND octet_length(recipient_endpoint) <= 2048
+    ),
+    sequence bigint NOT NULL CHECK (sequence >= 1),
+    closed_reason text NOT NULL CHECK (closed_reason IN ('acked', 'expired', 'revoked')),
+    lease_generation bigint NOT NULL CHECK (lease_generation >= 0),
+    created_at timestamptz NOT NULL,
+    closed_at timestamptz NOT NULL
+);
+
+CREATE INDEX mail_delivery_terminals_closed_at
+ON relay.mail_delivery_terminals (closed_at, delivery_id);
+
+CREATE TRIGGER mail_delivery_terminals_mutation_guard
+BEFORE INSERT OR UPDATE OR DELETE ON relay.mail_delivery_terminals
+FOR EACH STATEMENT EXECUTE FUNCTION relay.guard_mail_mutation();
+
+REVOKE ALL ON relay.mail_delivery_terminals FROM PUBLIC;
+GRANT SELECT, INSERT, UPDATE, DELETE ON relay.mail_delivery_terminals TO punaro_app;

--- a/internal/postgres/relay_delivery_retention.go
+++ b/internal/postgres/relay_delivery_retention.go
@@ -42,81 +42,102 @@ func (d *Database) retentionConfig() relay.RetentionConfig {
 }
 
 // MaintainDeliveries expires due pending deliveries and prunes retained terminals.
+// Each close is its own bounded transaction so the five-second relay budget
+// cannot roll back earlier expiry or quota release.
 func (d *Database) MaintainDeliveries(now time.Time) (relay.MaintenanceResult, error) {
 	cfg := d.retentionConfig()
 	now = now.UTC()
-	tx, cancel, err := d.beginRelayTransaction(nil)
-	if err != nil {
-		return relay.MaintenanceResult{}, errors.New("delivery maintenance cannot start")
-	}
-	defer cancel()
-	defer func() { _ = tx.Rollback() }()
 	expireCutoff := now.Add(-time.Duration(cfg.PendingMaxAgeSeconds) * time.Second)
-	rows, err := tx.QueryContext(context.Background(), `SELECT delivery.id::text, delivery.recipient_endpoint, message.id::text, message.conversation_id::text, message.sequence, delivery.lease_generation, `+postgresPendingBodyBytes+`, message.created_at
-		FROM relay.mail_deliveries AS delivery JOIN relay.mail_messages AS message ON message.id=delivery.message_id
-		WHERE delivery.acked_at IS NULL AND message.created_at <= $1
-		ORDER BY message.created_at, delivery.id
-		LIMIT $2
-		FOR UPDATE OF delivery SKIP LOCKED`, expireCutoff, cfg.MaintenanceBatch)
-	if err != nil {
-		return relay.MaintenanceResult{}, errors.New("expired deliveries cannot be inspected")
-	}
-	var pending []postgresPendingClose
-	for rows.Next() {
-		var row postgresPendingClose
-		if err := rows.Scan(&row.ID, &row.Recipient, &row.MessageID, &row.ConversationID, &row.Sequence, &row.LeaseGeneration, &row.BodyBytes, &row.CreatedAt); err != nil {
-			_ = rows.Close()
-			return relay.MaintenanceResult{}, errors.New("expired delivery is malformed")
-		}
-		pending = append(pending, row)
-	}
-	if err := rows.Close(); err != nil || rows.Err() != nil {
-		return relay.MaintenanceResult{}, errors.New("expired deliveries cannot be inspected")
-	}
 	var result relay.MaintenanceResult
-	result.Scanned = len(pending)
-	for _, row := range pending {
-		closed, err := postgresClosePendingDelivery(tx, row, relay.ClosedExpired, now)
+	for i := 0; i < cfg.MaintenanceBatch; i++ {
+		found, closed, err := d.expireOneDueDelivery(expireCutoff, now)
 		if err != nil {
-			return relay.MaintenanceResult{}, err
+			return result, err
 		}
+		if !found {
+			break
+		}
+		result.Scanned++
 		if closed {
 			result.Expired++
 		}
 	}
+	d.metrics.ObserveTerminals(relay.ClosedExpired, result.Expired)
 	pruneCutoff := now.Add(-time.Duration(cfg.TerminalRetentionSeconds) * time.Second)
-	pruneRows, err := tx.QueryContext(context.Background(), `SELECT delivery_id::text FROM relay.mail_delivery_terminals
-		WHERE closed_at <= $1
-		ORDER BY closed_at, delivery_id
-		LIMIT $2
-		FOR UPDATE SKIP LOCKED`, pruneCutoff, cfg.MaintenanceBatch)
-	if err != nil {
-		return relay.MaintenanceResult{}, errors.New("retained terminals cannot be inspected")
-	}
-	var pruneIDs []string
-	for pruneRows.Next() {
-		var id string
-		if err := pruneRows.Scan(&id); err != nil {
-			_ = pruneRows.Close()
-			return relay.MaintenanceResult{}, errors.New("retained terminal is malformed")
+	for i := 0; i < cfg.MaintenanceBatch; i++ {
+		found, err := d.pruneOneTerminal(pruneCutoff)
+		if err != nil {
+			d.refreshPendingMetrics(context.Background(), now)
+			return result, err
 		}
-		pruneIDs = append(pruneIDs, id)
-	}
-	if err := pruneRows.Close(); err != nil || pruneRows.Err() != nil {
-		return relay.MaintenanceResult{}, errors.New("retained terminals cannot be inspected")
-	}
-	for _, id := range pruneIDs {
-		if _, err := tx.ExecContext(context.Background(), `DELETE FROM relay.mail_delivery_terminals WHERE delivery_id=$1::uuid`, id); err != nil {
-			return relay.MaintenanceResult{}, relayDatabaseError(err, "prune terminal metadata")
+		if !found {
+			break
 		}
 		result.Pruned++
 	}
-	if err := tx.Commit(); err != nil {
-		return relay.MaintenanceResult{}, relayDatabaseError(err, "commit delivery maintenance")
-	}
-	d.metrics.ObserveTerminals(relay.ClosedExpired, result.Expired)
 	d.refreshPendingMetrics(context.Background(), now)
 	return result, nil
+}
+
+func (d *Database) expireOneDueDelivery(cutoff, now time.Time) (bool, bool, error) {
+	tx, cancel, err := d.beginRelayTransaction(nil)
+	if err != nil {
+		return false, false, errors.New("delivery maintenance cannot start")
+	}
+	defer cancel()
+	defer func() { _ = tx.Rollback() }()
+	var row postgresPendingClose
+	err = tx.QueryRowContext(context.Background(), `SELECT delivery.id::text, delivery.recipient_endpoint, message.id::text, message.conversation_id::text, message.sequence, delivery.lease_generation, `+postgresPendingBodyBytes+`, message.created_at
+		FROM relay.mail_deliveries AS delivery JOIN relay.mail_messages AS message ON message.id=delivery.message_id
+		WHERE delivery.acked_at IS NULL AND message.created_at <= $1
+		ORDER BY message.created_at, delivery.id
+		LIMIT 1
+		FOR UPDATE OF delivery SKIP LOCKED`, cutoff).Scan(&row.ID, &row.Recipient, &row.MessageID, &row.ConversationID, &row.Sequence, &row.LeaseGeneration, &row.BodyBytes, &row.CreatedAt)
+	if errors.Is(err, sql.ErrNoRows) {
+		return false, false, nil
+	}
+	if err != nil {
+		return false, false, errors.New("expired deliveries cannot be inspected")
+	}
+	closed, err := postgresClosePendingDelivery(tx, row, relay.ClosedExpired, now)
+	if err != nil {
+		return true, false, err
+	}
+	if !closed {
+		return true, false, nil
+	}
+	if err := tx.Commit(); err != nil {
+		return true, false, relayDatabaseError(err, "commit expired delivery")
+	}
+	return true, true, nil
+}
+
+func (d *Database) pruneOneTerminal(cutoff time.Time) (bool, error) {
+	tx, cancel, err := d.beginRelayTransaction(nil)
+	if err != nil {
+		return false, errors.New("delivery maintenance cannot start")
+	}
+	defer cancel()
+	defer func() { _ = tx.Rollback() }()
+	var id string
+	err = tx.QueryRowContext(context.Background(), `SELECT delivery_id::text FROM relay.mail_delivery_terminals
+		WHERE closed_at <= $1
+		ORDER BY closed_at, delivery_id
+		LIMIT 1
+		FOR UPDATE SKIP LOCKED`, cutoff).Scan(&id)
+	if errors.Is(err, sql.ErrNoRows) {
+		return false, nil
+	}
+	if err != nil {
+		return false, errors.New("retained terminals cannot be inspected")
+	}
+	if _, err := tx.ExecContext(context.Background(), `DELETE FROM relay.mail_delivery_terminals WHERE delivery_id=$1::uuid`, id); err != nil {
+		return false, relayDatabaseError(err, "prune terminal metadata")
+	}
+	if err := tx.Commit(); err != nil {
+		return false, relayDatabaseError(err, "commit terminal prune")
+	}
+	return true, nil
 }
 
 // ListTerminalDeliveries returns one content-free operator page of retained terminals.

--- a/internal/postgres/relay_delivery_retention.go
+++ b/internal/postgres/relay_delivery_retention.go
@@ -49,6 +49,10 @@ func (d *Database) MaintainDeliveries(now time.Time) (relay.MaintenanceResult, e
 	now = now.UTC()
 	expireCutoff := now.Add(-time.Duration(cfg.PendingMaxAgeSeconds) * time.Second)
 	var result relay.MaintenanceResult
+	defer func() {
+		d.metrics.ObserveTerminals(relay.ClosedExpired, result.Expired)
+		d.refreshPendingMetrics(context.Background(), now)
+	}()
 	for i := 0; i < cfg.MaintenanceBatch; i++ {
 		found, closed, err := d.expireOneDueDelivery(expireCutoff, now)
 		if err != nil {
@@ -62,12 +66,10 @@ func (d *Database) MaintainDeliveries(now time.Time) (relay.MaintenanceResult, e
 			result.Expired++
 		}
 	}
-	d.metrics.ObserveTerminals(relay.ClosedExpired, result.Expired)
 	pruneCutoff := now.Add(-time.Duration(cfg.TerminalRetentionSeconds) * time.Second)
 	for i := 0; i < cfg.MaintenanceBatch; i++ {
 		found, err := d.pruneOneTerminal(pruneCutoff)
 		if err != nil {
-			d.refreshPendingMetrics(context.Background(), now)
 			return result, err
 		}
 		if !found {
@@ -75,7 +77,6 @@ func (d *Database) MaintainDeliveries(now time.Time) (relay.MaintenanceResult, e
 		}
 		result.Pruned++
 	}
-	d.refreshPendingMetrics(context.Background(), now)
 	return result, nil
 }
 

--- a/internal/postgres/relay_delivery_retention.go
+++ b/internal/postgres/relay_delivery_retention.go
@@ -1,0 +1,203 @@
+package postgres
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/rock3r/punaro/internal/relay"
+)
+
+type postgresPendingClose struct {
+	ID              string
+	MessageID       string
+	ConversationID  string
+	Recipient       string
+	Sequence        int64
+	LeaseGeneration int64
+	BodyBytes       int64
+	CreatedAt       time.Time
+}
+
+// SetRetentionPolicy replaces the in-process pending-age and terminal-retention policy.
+func (d *Database) SetRetentionPolicy(cfg relay.RetentionConfig) error {
+	if err := cfg.Validate(); err != nil {
+		return err
+	}
+	d.retentionMu.Lock()
+	d.retention = cfg
+	d.retentionMu.Unlock()
+	return nil
+}
+
+func (d *Database) retentionConfig() relay.RetentionConfig {
+	d.retentionMu.Lock()
+	defer d.retentionMu.Unlock()
+	if d.retention == (relay.RetentionConfig{}) {
+		return relay.DefaultRetentionConfig()
+	}
+	return d.retention
+}
+
+// MaintainDeliveries expires due pending deliveries and prunes retained terminals.
+func (d *Database) MaintainDeliveries(now time.Time) (relay.MaintenanceResult, error) {
+	cfg := d.retentionConfig()
+	now = now.UTC()
+	tx, cancel, err := d.beginRelayTransaction(nil)
+	if err != nil {
+		return relay.MaintenanceResult{}, errors.New("delivery maintenance cannot start")
+	}
+	defer cancel()
+	defer func() { _ = tx.Rollback() }()
+	expireCutoff := now.Add(-time.Duration(cfg.PendingMaxAgeSeconds) * time.Second)
+	rows, err := tx.QueryContext(context.Background(), `SELECT delivery.id::text, delivery.recipient_endpoint, message.id::text, message.conversation_id::text, message.sequence, delivery.lease_generation, `+postgresPendingBodyBytes+`, message.created_at
+		FROM relay.mail_deliveries AS delivery JOIN relay.mail_messages AS message ON message.id=delivery.message_id
+		WHERE delivery.acked_at IS NULL AND message.created_at <= $1
+		ORDER BY message.created_at, delivery.id
+		LIMIT $2
+		FOR UPDATE OF delivery SKIP LOCKED`, expireCutoff, cfg.MaintenanceBatch)
+	if err != nil {
+		return relay.MaintenanceResult{}, errors.New("expired deliveries cannot be inspected")
+	}
+	var pending []postgresPendingClose
+	for rows.Next() {
+		var row postgresPendingClose
+		if err := rows.Scan(&row.ID, &row.Recipient, &row.MessageID, &row.ConversationID, &row.Sequence, &row.LeaseGeneration, &row.BodyBytes, &row.CreatedAt); err != nil {
+			_ = rows.Close()
+			return relay.MaintenanceResult{}, errors.New("expired delivery is malformed")
+		}
+		pending = append(pending, row)
+	}
+	if err := rows.Close(); err != nil || rows.Err() != nil {
+		return relay.MaintenanceResult{}, errors.New("expired deliveries cannot be inspected")
+	}
+	var result relay.MaintenanceResult
+	result.Scanned = len(pending)
+	for _, row := range pending {
+		closed, err := postgresClosePendingDelivery(tx, row, relay.ClosedExpired, now)
+		if err != nil {
+			return relay.MaintenanceResult{}, err
+		}
+		if closed {
+			result.Expired++
+		}
+	}
+	pruneCutoff := now.Add(-time.Duration(cfg.TerminalRetentionSeconds) * time.Second)
+	pruneRows, err := tx.QueryContext(context.Background(), `SELECT delivery_id::text FROM relay.mail_delivery_terminals
+		WHERE closed_at <= $1
+		ORDER BY closed_at, delivery_id
+		LIMIT $2
+		FOR UPDATE SKIP LOCKED`, pruneCutoff, cfg.MaintenanceBatch)
+	if err != nil {
+		return relay.MaintenanceResult{}, errors.New("retained terminals cannot be inspected")
+	}
+	var pruneIDs []string
+	for pruneRows.Next() {
+		var id string
+		if err := pruneRows.Scan(&id); err != nil {
+			_ = pruneRows.Close()
+			return relay.MaintenanceResult{}, errors.New("retained terminal is malformed")
+		}
+		pruneIDs = append(pruneIDs, id)
+	}
+	if err := pruneRows.Close(); err != nil || pruneRows.Err() != nil {
+		return relay.MaintenanceResult{}, errors.New("retained terminals cannot be inspected")
+	}
+	for _, id := range pruneIDs {
+		if _, err := tx.ExecContext(context.Background(), `DELETE FROM relay.mail_delivery_terminals WHERE delivery_id=$1::uuid`, id); err != nil {
+			return relay.MaintenanceResult{}, relayDatabaseError(err, "prune terminal metadata")
+		}
+		result.Pruned++
+	}
+	if err := tx.Commit(); err != nil {
+		return relay.MaintenanceResult{}, relayDatabaseError(err, "commit delivery maintenance")
+	}
+	d.metrics.ObserveTerminals(relay.ClosedExpired, result.Expired)
+	d.refreshPendingMetrics(context.Background(), now)
+	return result, nil
+}
+
+// ListTerminalDeliveries returns one content-free operator page of retained terminals.
+func (d *Database) ListTerminalDeliveries(after string, limit int) (relay.TerminalPage, error) {
+	if limit < relay.TerminalListLimitMin || limit > relay.TerminalListLimitMax {
+		return relay.TerminalPage{}, fmt.Errorf("relay terminal page limit must be an integer between %d and %d", relay.TerminalListLimitMin, relay.TerminalListLimitMax)
+	}
+	if after == "" {
+		after = "00000000-0000-0000-0000-000000000000"
+	}
+	tx, cancel, err := d.beginRelayTransaction(&sql.TxOptions{ReadOnly: true})
+	if err != nil {
+		return relay.TerminalPage{}, errors.New("terminal listing cannot start")
+	}
+	defer cancel()
+	defer func() { _ = tx.Rollback() }()
+	rows, err := tx.QueryContext(context.Background(), `SELECT delivery_id::text, message_id::text, conversation_id::text, recipient_endpoint, sequence, closed_reason, lease_generation, created_at, closed_at
+		FROM relay.mail_delivery_terminals WHERE delivery_id > $1::uuid ORDER BY delivery_id LIMIT $2`, after, limit)
+	if err != nil {
+		return relay.TerminalPage{}, errors.New("terminal deliveries cannot be listed")
+	}
+	defer func() { _ = rows.Close() }()
+	var page relay.TerminalPage
+	for rows.Next() {
+		var record relay.TerminalRecord
+		if err := rows.Scan(&record.DeliveryID, &record.MessageID, &record.ConversationID, &record.RecipientID, &record.Sequence, &record.ClosedReason, &record.LeaseGeneration, &record.CreatedAt, &record.ClosedAt); err != nil {
+			return relay.TerminalPage{}, errors.New("terminal delivery is malformed")
+		}
+		record.CreatedAt = record.CreatedAt.UTC()
+		record.ClosedAt = record.ClosedAt.UTC()
+		page.Terminals = append(page.Terminals, record)
+	}
+	if err := rows.Err(); err != nil {
+		return relay.TerminalPage{}, errors.New("terminal deliveries cannot be listed")
+	}
+	if err := tx.Commit(); err != nil {
+		return relay.TerminalPage{}, errors.New("terminal listing cannot commit")
+	}
+	if len(page.Terminals) == limit {
+		page.NextCursor = page.Terminals[len(page.Terminals)-1].DeliveryID
+	}
+	return page, nil
+}
+
+func postgresClosePendingDelivery(tx *sql.Tx, row postgresPendingClose, reason string, now time.Time) (bool, error) {
+	closedAt := now.UTC()
+	result, err := tx.ExecContext(context.Background(), `UPDATE relay.mail_deliveries SET acked_at=$1, lease_machine_id=NULL, lease_token=NULL, ownership_generation=NULL, consumer_generation=NULL, lease_until=NULL
+		WHERE id=$2::uuid AND acked_at IS NULL`, closedAt, row.ID)
+	if err != nil {
+		return false, relayDatabaseError(err, "close pending delivery")
+	}
+	affected, err := result.RowsAffected()
+	if err != nil {
+		return false, relayDatabaseError(err, "close pending delivery")
+	}
+	if affected != 1 {
+		return false, nil
+	}
+	if _, err := tx.ExecContext(context.Background(), `INSERT INTO relay.mail_delivery_terminals(delivery_id,message_id,conversation_id,recipient_endpoint,sequence,closed_reason,lease_generation,created_at,closed_at)
+		VALUES ($1::uuid,$2::uuid,$3::uuid,$4,$5,$6,$7,$8,$9) ON CONFLICT (delivery_id) DO NOTHING`, row.ID, row.MessageID, row.ConversationID, row.Recipient, row.Sequence, reason, row.LeaseGeneration, row.CreatedAt.UTC(), closedAt); err != nil {
+		return false, relayDatabaseError(err, "record terminal delivery")
+	}
+	if err := postgresReleaseQuota(tx, row.Recipient, row.BodyBytes); err != nil {
+		return false, err
+	}
+	if err := postgresAdvanceRecipientCursor(tx, row.Recipient, row.ConversationID); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+func postgresRecordAckedTerminal(tx *sql.Tx, deliveryID string, now time.Time) error {
+	var row postgresPendingClose
+	if err := tx.QueryRowContext(context.Background(), `SELECT delivery.id::text, delivery.recipient_endpoint, message.id::text, message.conversation_id::text, message.sequence, delivery.lease_generation, `+postgresPendingBodyBytes+`, message.created_at
+		FROM relay.mail_deliveries AS delivery JOIN relay.mail_messages AS message ON message.id=delivery.message_id
+		WHERE delivery.id=$1::uuid`, deliveryID).Scan(&row.ID, &row.Recipient, &row.MessageID, &row.ConversationID, &row.Sequence, &row.LeaseGeneration, &row.BodyBytes, &row.CreatedAt); err != nil {
+		return errors.New("acknowledged delivery is unavailable")
+	}
+	if _, err := tx.ExecContext(context.Background(), `INSERT INTO relay.mail_delivery_terminals(delivery_id,message_id,conversation_id,recipient_endpoint,sequence,closed_reason,lease_generation,created_at,closed_at)
+		VALUES ($1::uuid,$2::uuid,$3::uuid,$4,$5,$6,$7,$8,$9) ON CONFLICT (delivery_id) DO NOTHING`, row.ID, row.MessageID, row.ConversationID, row.Recipient, row.Sequence, relay.ClosedAcked, row.LeaseGeneration, row.CreatedAt.UTC(), now.UTC()); err != nil {
+		return relayDatabaseError(err, "record acknowledged terminal")
+	}
+	return nil
+}

--- a/internal/postgres/relay_delivery_retention_schema.go
+++ b/internal/postgres/relay_delivery_retention_schema.go
@@ -47,7 +47,10 @@ WITH objects AS (
     FROM objects JOIN pg_trigger AS trigger ON trigger.tgrelid=terminals_oid
        AND trigger.tgname='mail_delivery_terminals_mutation_guard'
 ), acl AS (
-    SELECT has_table_privilege('punaro_app',terminals_oid,'SELECT,INSERT,UPDATE,DELETE')
+    SELECT has_table_privilege('punaro_app',terminals_oid,'SELECT')
+       AND has_table_privilege('punaro_app',terminals_oid,'INSERT')
+       AND has_table_privilege('punaro_app',terminals_oid,'UPDATE')
+       AND has_table_privilege('punaro_app',terminals_oid,'DELETE')
        AND NOT has_table_privilege('punaro_app',terminals_oid,'TRUNCATE,REFERENCES,TRIGGER') AS exact
     FROM objects
 )

--- a/internal/postgres/relay_delivery_retention_schema.go
+++ b/internal/postgres/relay_delivery_retention_schema.go
@@ -1,0 +1,58 @@
+package postgres
+
+import "context"
+
+func relayDeliveryTerminalsAvailable(ctx context.Context, q queryer) (bool, error) {
+	var available bool
+	err := q.QueryRowContext(ctx, `
+WITH objects AS (
+    SELECT to_regclass('relay.mail_delivery_terminals') AS terminals_oid,
+           to_regprocedure('relay.guard_mail_mutation()') AS guard_oid
+), relations AS (
+    SELECT count(*)=1 AND bool_and(pg_get_userbyid(class.relowner)='punaro_owner' AND class.relkind='r'
+       AND class.relpersistence='p' AND NOT class.relrowsecurity AND NOT class.relforcerowsecurity) AS exact
+    FROM objects JOIN pg_class AS class ON class.oid=terminals_oid
+), columns AS (
+    SELECT count(*)=9
+       AND bool_and((attribute.attrelid,attribute.attname,attribute.atttypid,attribute.attnotnull) IN (
+           (terminals_oid,'delivery_id','uuid'::regtype,true),(terminals_oid,'message_id','uuid'::regtype,true),
+           (terminals_oid,'conversation_id','uuid'::regtype,true),(terminals_oid,'recipient_endpoint','text'::regtype,true),
+           (terminals_oid,'sequence','int8'::regtype,true),(terminals_oid,'closed_reason','text'::regtype,true),
+           (terminals_oid,'lease_generation','int8'::regtype,true),(terminals_oid,'created_at','timestamptz'::regtype,true),
+           (terminals_oid,'closed_at','timestamptz'::regtype,true))) AS exact
+    FROM objects JOIN pg_attribute AS attribute ON attribute.attrelid=terminals_oid
+       AND attribute.attnum>0 AND NOT attribute.attisdropped
+), expected_constraints(table_oid,constraint_name,constraint_type,column_keys,check_expression) AS (
+    SELECT expected.* FROM objects, LATERAL (VALUES
+        (terminals_oid,'mail_delivery_terminals_pkey','p'::"char",ARRAY[1]::smallint[],NULL::text),
+        (terminals_oid,'mail_delivery_terminals_recipient_endpoint_check','c'::"char",ARRAY[4]::smallint[],'((char_length(recipient_endpoint) >= 1) AND (char_length(recipient_endpoint) <= 512) AND (octet_length(recipient_endpoint) <= 2048))'),
+        (terminals_oid,'mail_delivery_terminals_sequence_check','c'::"char",ARRAY[5]::smallint[],'(sequence >= 1)'),
+        (terminals_oid,'mail_delivery_terminals_closed_reason_check','c'::"char",ARRAY[6]::smallint[],'(closed_reason = ANY (ARRAY[''acked''::text, ''expired''::text, ''revoked''::text]))'),
+        (terminals_oid,'mail_delivery_terminals_lease_generation_check','c'::"char",ARRAY[7]::smallint[],'(lease_generation >= 0)')
+    ) AS expected(table_oid,constraint_name,constraint_type,column_keys,check_expression)
+), actual_constraints AS (
+    SELECT constraint_.conrelid,constraint_.conname,constraint_.contype,constraint_.conkey,
+           CASE WHEN constraint_.contype='c' THEN pg_get_expr(constraint_.conbin,constraint_.conrelid) END
+    FROM objects JOIN pg_constraint AS constraint_ ON constraint_.conrelid=terminals_oid
+    WHERE constraint_.contype IN ('p','c')
+      AND constraint_.convalidated AND NOT constraint_.condeferrable AND NOT constraint_.condeferred
+), constraints AS (
+    SELECT NOT EXISTS (SELECT * FROM expected_constraints EXCEPT SELECT * FROM actual_constraints)
+       AND NOT EXISTS (SELECT * FROM actual_constraints EXCEPT SELECT * FROM expected_constraints) AS exact
+), guards AS (
+    SELECT count(*)=1 AND bool_and(trigger.tgfoid=guard_oid AND trigger.tgenabled='O' AND NOT trigger.tgisinternal
+       AND trigger.tgtype=30 AND trigger.tgconstraint=0 AND NOT trigger.tgdeferrable AND NOT trigger.tginitdeferred
+       AND trigger.tgnargs=0 AND trigger.tgqual IS NULL AND trigger.tgnewtable IS NULL AND trigger.tgoldtable IS NULL
+       AND trigger.tgattr::text='') AS exact
+    FROM objects JOIN pg_trigger AS trigger ON trigger.tgrelid=terminals_oid
+       AND trigger.tgname='mail_delivery_terminals_mutation_guard'
+), acl AS (
+    SELECT has_table_privilege('punaro_app',terminals_oid,'SELECT,INSERT,UPDATE,DELETE')
+       AND NOT has_table_privilege('punaro_app',terminals_oid,'TRUNCATE,REFERENCES,TRIGGER') AS exact
+    FROM objects
+)
+SELECT terminals_oid IS NOT NULL AND guard_oid IS NOT NULL
+   AND relations.exact AND columns.exact AND constraints.exact AND guards.exact AND acl.exact
+FROM objects,relations,columns,constraints,guards,acl`).Scan(&available)
+	return available, err
+}

--- a/internal/postgres/relay_pending_quota.go
+++ b/internal/postgres/relay_pending_quota.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"errors"
 	"sort"
+	"time"
 
 	"github.com/rock3r/punaro/internal/relay"
 )
@@ -150,38 +151,40 @@ func postgresAppendDeliveryRecipients(tx *sql.Tx, conversationID, fromEndpoint, 
 	return recipients, nil
 }
 
-func postgresRetireConversationDeliveries(tx *sql.Tx, recipient, conversationID string, ackedAt any) error {
-	rows, err := tx.QueryContext(context.Background(), `SELECT `+postgresPendingBodyBytes+`
+func postgresRetireConversationDeliveries(tx *sql.Tx, recipient, conversationID string, ackedAt time.Time) (int, error) {
+	rows, err := tx.QueryContext(context.Background(), `SELECT delivery.id::text, delivery.recipient_endpoint, message.id::text, message.conversation_id::text, message.sequence, delivery.lease_generation, `+postgresPendingBodyBytes+`, message.created_at
 		FROM relay.mail_deliveries AS delivery JOIN relay.mail_messages AS message ON message.id=delivery.message_id
 		WHERE delivery.recipient_endpoint=$1 AND delivery.acked_at IS NULL AND message.conversation_id=$2::uuid
 		FOR UPDATE OF delivery`, recipient, conversationID)
 	if err != nil {
-		return errors.New("revoked deliveries cannot be inspected")
+		return 0, errors.New("revoked deliveries cannot be inspected")
 	}
-	var bodies []int64
+	var pending []postgresPendingClose
 	for rows.Next() {
-		var bodyBytes int64
-		if err := rows.Scan(&bodyBytes); err != nil {
+		var row postgresPendingClose
+		if err := rows.Scan(&row.ID, &row.Recipient, &row.MessageID, &row.ConversationID, &row.Sequence, &row.LeaseGeneration, &row.BodyBytes, &row.CreatedAt); err != nil {
 			_ = rows.Close()
-			return errors.New("revoked deliveries cannot be inspected")
+			return 0, errors.New("revoked deliveries cannot be inspected")
 		}
-		bodies = append(bodies, bodyBytes)
+		pending = append(pending, row)
 	}
 	if err := rows.Close(); err != nil || rows.Err() != nil {
-		return errors.New("revoked deliveries cannot be inspected")
+		return 0, errors.New("revoked deliveries cannot be inspected")
 	}
-	for _, bodyBytes := range bodies {
-		if err := postgresReleaseQuota(tx, recipient, bodyBytes); err != nil {
-			return err
+	closed := 0
+	for _, row := range pending {
+		ok, err := postgresClosePendingDelivery(tx, row, relay.ClosedRevoked, ackedAt)
+		if err != nil {
+			return 0, err
+		}
+		if ok {
+			closed++
 		}
 	}
-	if _, err := tx.ExecContext(context.Background(), `UPDATE relay.mail_deliveries SET acked_at=$3 WHERE recipient_endpoint=$1 AND acked_at IS NULL AND message_id IN (SELECT id FROM relay.mail_messages WHERE conversation_id=$2::uuid)`, recipient, conversationID, ackedAt); err != nil {
-		return relayDatabaseError(err, "retire revoked deliveries")
-	}
-	return nil
+	return closed, nil
 }
 
-func (d *Database) refreshPendingMetrics(ctx context.Context) {
+func (d *Database) refreshPendingMetrics(ctx context.Context, now time.Time) {
 	d.pendingMetricsMu.Lock()
 	defer d.pendingMetricsMu.Unlock()
 	counters, err := postgresReadInstallQuota(ctx, d.relayPool())
@@ -189,6 +192,25 @@ func (d *Database) refreshPendingMetrics(ctx context.Context) {
 		return
 	}
 	d.metrics.SetPending(counters.Count, counters.Bytes)
+	var oldest sql.NullTime
+	if err := d.relayPool().QueryRowContext(ctx, `SELECT MIN(message.created_at)
+		FROM relay.mail_deliveries AS delivery JOIN relay.mail_messages AS message ON message.id=delivery.message_id
+		WHERE delivery.acked_at IS NULL`).Scan(&oldest); err != nil {
+		return
+	}
+	var age int64
+	if oldest.Valid && !now.IsZero() {
+		age = int64(now.UTC().Sub(oldest.Time.UTC()).Seconds())
+		if age < 0 {
+			age = 0
+		}
+	}
+	d.metrics.SetPendingOldestAge(age)
+	var retained int64
+	if err := d.relayPool().QueryRowContext(ctx, `SELECT COUNT(*) FROM relay.mail_delivery_terminals`).Scan(&retained); err != nil {
+		return
+	}
+	d.metrics.SetTerminalsRetained(retained)
 }
 
 func postgresReadInstallQuota(ctx context.Context, q interface {
@@ -299,7 +321,7 @@ func (d *Database) ReconcilePendingQuota(ctx context.Context) (relay.QuotaCounte
 	if err := tx.Commit(); err != nil {
 		return relay.QuotaCounters{}, errors.New("pending quota reconciliation cannot commit")
 	}
-	d.refreshPendingMetrics(ctx)
+	d.refreshPendingMetrics(ctx, time.Now().UTC())
 	return install, nil
 }
 

--- a/internal/postgres/relay_store.go
+++ b/internal/postgres/relay_store.go
@@ -636,7 +636,7 @@ func (d *Database) SendDirectMessage(input relay.DirectMessageInput) (relay.Mess
 	if err := tx.Commit(); err != nil {
 		return relay.Message{}, false, relayDatabaseError(err, "commit direct message")
 	}
-	d.refreshPendingMetrics(context.Background())
+	d.refreshPendingMetrics(context.Background(), now)
 	return message, false, nil
 }
 
@@ -773,6 +773,7 @@ func (d *Database) ApplyControl(input relay.ControlInput) (relay.ControlEvent, b
 	if actorCapabilities&relay.CapAdmin == 0 {
 		return relay.ControlEvent{}, false, relay.ErrForbidden
 	}
+	revoked := 0
 	requestHash := relay.ControlRequestHash(input)
 	var existingID, existingHash string
 	err = tx.QueryRowContext(context.Background(), `SELECT control_id::text,request_hash FROM relay.mail_conversation_control_idempotency WHERE machine_id=$1 AND key=$2`, input.ActorMachineID, input.IdempotencyKey).Scan(&existingID, &existingHash)
@@ -825,9 +826,11 @@ func (d *Database) ApplyControl(input relay.ControlInput) (relay.ControlEvent, b
 		}
 	}
 	if input.Operation == relay.ControlUpsertMember && err == nil && previous&relay.CapReceive != 0 && input.Member.Capabilities&relay.CapReceive == 0 {
-		if err := postgresRetireConversationDeliveries(tx, input.Member.Endpoint, input.ConversationID, input.Now.UTC()); err != nil {
+		n, err := postgresRetireConversationDeliveries(tx, input.Member.Endpoint, input.ConversationID, input.Now.UTC())
+		if err != nil {
 			return relay.ControlEvent{}, false, err
 		}
+		revoked += n
 		if err := postgresAdvanceRecipientCursor(tx, input.Member.Endpoint, input.ConversationID); err != nil {
 			return relay.ControlEvent{}, false, err
 		}
@@ -842,9 +845,11 @@ func (d *Database) ApplyControl(input relay.ControlInput) (relay.ControlEvent, b
 			}
 		}
 	} else {
-		if err := postgresRetireConversationDeliveries(tx, input.Member.Endpoint, input.ConversationID, input.Now.UTC()); err != nil {
+		n, err := postgresRetireConversationDeliveries(tx, input.Member.Endpoint, input.ConversationID, input.Now.UTC())
+		if err != nil {
 			return relay.ControlEvent{}, false, err
 		}
+		revoked += n
 		if err := postgresAdvanceRecipientCursor(tx, input.Member.Endpoint, input.ConversationID); err != nil {
 			return relay.ControlEvent{}, false, err
 		}
@@ -870,7 +875,8 @@ func (d *Database) ApplyControl(input relay.ControlInput) (relay.ControlEvent, b
 	if err := tx.Commit(); err != nil {
 		return relay.ControlEvent{}, false, relayDatabaseError(err, "commit control")
 	}
-	d.refreshPendingMetrics(context.Background())
+	d.metrics.ObserveTerminals(relay.ClosedRevoked, revoked)
+	d.refreshPendingMetrics(context.Background(), input.Now)
 	return event, false, nil
 }
 
@@ -1265,7 +1271,7 @@ func (d *Database) AppendMessage(input relay.AppendInput) (relay.Message, bool, 
 	if err := tx.Commit(); err != nil {
 		return relay.Message{}, false, relayDatabaseError(err, "commit message")
 	}
-	d.refreshPendingMetrics(context.Background())
+	d.refreshPendingMetrics(context.Background(), input.Now)
 	return message, false, nil
 }
 
@@ -1283,7 +1289,7 @@ func (d *Database) SetRateLimits(cfg relay.RateLimitConfig) error {
 // SetMetrics attaches the shared content-free counter sink.
 func (d *Database) SetMetrics(metrics *relay.Metrics) {
 	d.metrics = metrics
-	d.refreshPendingMetrics(context.Background())
+	d.refreshPendingMetrics(context.Background(), time.Time{})
 }
 
 func (d *Database) rateLimitConfig() relay.RateLimitConfig {
@@ -1443,12 +1449,16 @@ func (d *Database) LeaseDeliveries(machineID, consumerID, endpoint, conversation
 		return relay.DeliveryLeasePage{}, errors.New("pending deliveries are unavailable")
 	}
 	deliveries := make([]relay.Delivery, 0, len(pending))
+	redeliveries := 0
 	for _, row := range pending {
 		delivery := row.delivery
 		if row.leaseMachine.Valid && row.leaseMachine.String == machineID && row.leaseToken.Valid && row.leaseOwnership.Valid && row.leaseOwnership.Int64 == ownershipGeneration && row.leaseConsumer.Valid && row.leaseConsumer.Int64 == consumerGeneration && row.leaseUntil.Valid && row.leaseUntil.Time.After(now) {
 			delivery.LeaseToken = row.leaseToken.String
 			delivery.LeaseUntil = row.leaseUntil.Time.UTC()
 		} else {
+			if row.leaseUntil.Valid && !row.leaseUntil.Time.After(now) {
+				redeliveries++
+			}
 			delivery.LeaseGeneration++
 			delivery.LeaseToken = uuid.NewString()
 			delivery.LeaseUntil = now.Add(ttl).UTC()
@@ -1476,6 +1486,7 @@ func (d *Database) LeaseDeliveries(machineID, consumerID, endpoint, conversation
 	if err := tx.Commit(); err != nil {
 		return relay.DeliveryLeasePage{}, relayDatabaseError(err, "commit delivery lease")
 	}
+	d.metrics.ObserveLeaseRedeliveries(redeliveries)
 	return relay.DeliveryLeasePage{Deliveries: deliveries, Cursors: cursors}, nil
 }
 
@@ -1620,6 +1631,7 @@ func (d *Database) AckDelivery(machineID, endpoint, deliveryID, token string, ge
 	if _, err := tx.ExecContext(context.Background(), `UPDATE relay.mail_deliveries SET acked_at=$1 WHERE id=$2::uuid AND acked_at IS NULL`, now.UTC(), deliveryID); err != nil {
 		return relayDatabaseError(err, "acknowledge delivery")
 	}
+	acked := 0
 	if !acknowledged.Valid {
 		var bodyBytes int64
 		if err := tx.QueryRowContext(context.Background(), `SELECT octet_length(message.body) FROM relay.mail_deliveries AS delivery JOIN relay.mail_messages AS message ON message.id=delivery.message_id WHERE delivery.id=$1::uuid`, deliveryID).Scan(&bodyBytes); err != nil {
@@ -1628,6 +1640,10 @@ func (d *Database) AckDelivery(machineID, endpoint, deliveryID, token string, ge
 		if err := postgresReleaseQuota(tx, recipient, bodyBytes); err != nil {
 			return err
 		}
+		if err := postgresRecordAckedTerminal(tx, deliveryID, now); err != nil {
+			return err
+		}
+		acked = 1
 	}
 	if err := postgresAdvanceRecipientCursor(tx, recipient, conversationID); err != nil {
 		return err
@@ -1635,7 +1651,8 @@ func (d *Database) AckDelivery(machineID, endpoint, deliveryID, token string, ge
 	if err := tx.Commit(); err != nil {
 		return relayDatabaseError(err, "commit delivery acknowledgement")
 	}
-	d.refreshPendingMetrics(context.Background())
+	d.metrics.ObserveTerminals(relay.ClosedAcked, acked)
+	d.refreshPendingMetrics(context.Background(), now)
 	return nil
 }
 

--- a/internal/postgres/state_test.go
+++ b/internal/postgres/state_test.go
@@ -69,8 +69,8 @@ func TestManifestValidationRejectsMutableOrNonContiguousHistory(t *testing.T) {
 
 func TestCurrentManifestRequiresControlPlaneSchema(t *testing.T) {
 	manifest := CurrentManifest()
-	if manifest.MinSupported != 10 || manifest.MaxSupported != 48 || len(manifest.Migrations) != 48 {
-		t.Fatalf("manifest=%#v, want exact v48 compatibility window", manifest)
+	if manifest.MinSupported != 10 || manifest.MaxSupported != 49 || len(manifest.Migrations) != 49 {
+		t.Fatalf("manifest=%#v, want exact v49 compatibility window", manifest)
 	}
 	embedding := manifest.Migrations[23]
 	if embedding.Version != 24 || embedding.Name != "024_memory_embedding_worker_control" ||
@@ -88,7 +88,7 @@ func TestCurrentManifestRequiresControlPlaneSchema(t *testing.T) {
 			want = 10
 		case 12, 13:
 			want = 10
-		case 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48:
+		case 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49:
 			want = 10
 		}
 		if migration.CompatibilityFloor != want {
@@ -225,7 +225,10 @@ func TestCompatibleSchemaCanStillHavePendingMigrations(t *testing.T) {
 	if !migrationPending(SchemaState{Classification: Compatible, Version: 47}, manifest) {
 		t.Fatal("compatible v47 schema must still apply the pending v48 migration")
 	}
-	if migrationPending(SchemaState{Classification: Compatible, Version: 48}, manifest) {
-		t.Fatal("current v48 schema reported a pending migration")
+	if !migrationPending(SchemaState{Classification: Compatible, Version: 48}, manifest) {
+		t.Fatal("compatible v48 schema must still apply the pending v49 migration")
+	}
+	if migrationPending(SchemaState{Classification: Compatible, Version: 49}, manifest) {
+		t.Fatal("current v49 schema reported a pending migration")
 	}
 }

--- a/internal/relay/contracttest/contract.go
+++ b/internal/relay/contracttest/contract.go
@@ -245,6 +245,7 @@ func Run(t *testing.T, backend relay.Backend, namespace string) {
 	runLeasePageContract(t, backend, namespace, now)
 	RunRateLimits(t, backend, namespace+"-rate")
 	RunPendingQuota(t, backend, namespace+"-quota")
+	RunDeliveryRetention(t, backend, namespace+"-retain")
 }
 
 // RateLimitSetter is implemented by durable stores that keep token-bucket
@@ -565,6 +566,113 @@ func RunPendingQuota(t *testing.T, backend relay.Backend, namespace string) {
 		t.Fatalf("concurrent accepted=%d limited=%d", accepted, limited)
 	}
 	if err := limiter.SetQuotaLimits(relay.DefaultQuotaConfig()); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// RetentionSetter is implemented by durable stores that expire pending
+// deliveries and retain content-free terminal metadata.
+type RetentionSetter interface {
+	relay.Backend
+	SetRetentionPolicy(relay.RetentionConfig) error
+	MaintainDeliveries(time.Time) (relay.MaintenanceResult, error)
+	ListTerminalDeliveries(string, int) (relay.TerminalPage, error)
+}
+
+// RunDeliveryRetention proves pending-age expiry, exact-once capacity release,
+// and contiguous cursor advancement against every backend.
+func RunDeliveryRetention(t *testing.T, backend relay.Backend, namespace string) {
+	t.Helper()
+	store, ok := backend.(RetentionSetter)
+	if !ok {
+		t.Fatal("backend does not expose delivery retention")
+	}
+	if err := store.SetRetentionPolicy(relay.DefaultRetentionConfig()); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		_ = store.SetRetentionPolicy(relay.DefaultRetentionConfig())
+	})
+	now := time.Date(2026, time.August, 18, 21, 0, 0, 0, time.UTC)
+	cfg := relay.RetentionConfig{PendingMaxAgeSeconds: 60, TerminalRetentionSeconds: relay.RetentionAgeMaxSeconds, MaintenanceBatch: 100}
+	if err := store.SetRetentionPolicy(cfg); err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < 32; i++ {
+		result, err := store.MaintainDeliveries(now)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if result.Expired == 0 && result.Pruned == 0 {
+			break
+		}
+	}
+	machineA, machineB := namespace+"-a", namespace+"-b"
+	endpointA, endpointB := "agent/"+namespace+"/a", "agent/"+namespace+"/b"
+	if err := backend.AdvertiseEndpoints(machineA, []string{endpointA}, now, time.Hour); err != nil {
+		t.Fatal(err)
+	}
+	if err := backend.AdvertiseEndpoints(machineB, []string{endpointB}, now, time.Hour); err != nil {
+		t.Fatal(err)
+	}
+	conversation, err := backend.CreateConversationIdempotent(relay.CreateConversationInput{
+		MachineID: machineA, IdempotencyKey: namespace + "-create", CreatorEndpoint: endpointA, Now: now,
+		Members: []relay.Member{
+			{Endpoint: endpointA, Capabilities: relay.CapSend | relay.CapReceive | relay.CapAdmin},
+			{Endpoint: endpointB, Capabilities: relay.CapReceive},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	first, _, err := backend.AppendMessage(relay.AppendInput{ConversationID: conversation.ID, SenderMachineID: machineA, FromEndpoint: endpointA, Body: "one", IdempotencyKey: namespace + "-1", Now: now})
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, _, err := backend.AppendMessage(relay.AppendInput{ConversationID: conversation.ID, SenderMachineID: machineA, FromEndpoint: endpointA, Body: "two", IdempotencyKey: namespace + "-2", Now: now.Add(30 * time.Second)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	page, err := backend.LeaseDeliveries(machineB, namespace+"-consumer", endpointB, conversation.ID, now, time.Minute, 10)
+	if err != nil || len(page.Deliveries) != 2 {
+		t.Fatalf("lease=%#v err=%v", page, err)
+	}
+	before := now.Add(59 * time.Second)
+	if result, err := store.MaintainDeliveries(before); err != nil || result.Expired != 0 {
+		t.Fatalf("before expiry=%#v err=%v", result, err)
+	}
+	expireAt := now.Add(60 * time.Second)
+	result, err := store.MaintainDeliveries(expireAt)
+	if err != nil || result.Expired != 1 {
+		t.Fatalf("at expiry=%#v err=%v", result, err)
+	}
+	if err := backend.AckDelivery(machineB, endpointB, page.Deliveries[0].ID, page.Deliveries[0].LeaseToken, page.Deliveries[0].LeaseGeneration, expireAt); !errors.Is(err, relay.ErrForbidden) {
+		t.Fatalf("expired lease ack err=%v", err)
+	}
+	cursor, err := backend.RecipientCursor(machineB, endpointB, conversation.ID, expireAt)
+	if err != nil || cursor != first.Sequence {
+		t.Fatalf("cursor after expiry=%d want=%d err=%v", cursor, first.Sequence, err)
+	}
+	remaining, err := backend.LeaseDeliveries(machineB, namespace+"-consumer", endpointB, conversation.ID, expireAt, time.Minute, 10)
+	if err != nil || len(remaining.Deliveries) != 1 || remaining.Deliveries[0].Message.ID != second.ID {
+		t.Fatalf("remaining=%#v err=%v", remaining, err)
+	}
+	if err := backend.AckDelivery(machineB, endpointB, remaining.Deliveries[0].ID, remaining.Deliveries[0].LeaseToken, remaining.Deliveries[0].LeaseGeneration, expireAt); err != nil {
+		t.Fatal(err)
+	}
+	cursor, err = backend.RecipientCursor(machineB, endpointB, conversation.ID, expireAt)
+	if err != nil || cursor != second.Sequence {
+		t.Fatalf("cursor after ack across expiry=%d want=%d err=%v", cursor, second.Sequence, err)
+	}
+	listed, err := store.ListTerminalDeliveries("", 10)
+	if err != nil || len(listed.Terminals) < 1 {
+		t.Fatalf("terminals=%#v err=%v", listed, err)
+	}
+	encoded := fmt.Sprintf("%#v", listed)
+	if strings.Contains(encoded, "one") || strings.Contains(encoded, "two") {
+		t.Fatalf("terminal listing leaked body: %s", encoded)
+	}
+	if err := store.SetRetentionPolicy(relay.DefaultRetentionConfig()); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/internal/relay/http_test.go
+++ b/internal/relay/http_test.go
@@ -852,3 +852,33 @@ func serveSigned(t *testing.T, handler http.Handler, private ed25519.PrivateKey,
 	handler.ServeHTTP(response, request)
 	return response
 }
+
+func TestHTTPDoesNotExposeTerminalInventory(t *testing.T) {
+	t.Parallel()
+	public, private, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	store, err := Open(filepath.Join(t.TempDir(), "relay.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	auth, err := NewAuthenticator(store, []Machine{{ID: "machine-a", PublicKey: public, EndpointPrefixes: []string{"agent/a/"}}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	clock := time.Date(2026, time.July, 13, 12, 0, 0, 0, time.UTC)
+	handler := NewHandler(store, auth, HandlerOptions{Now: func() time.Time { return clock }, EndpointLeaseTTL: time.Minute, DeliveryLeaseTTL: time.Minute})
+	for _, path := range []string{"/v1/terminals", "/v1/deliveries/terminals", "/v1/dead-letters"} {
+		nonce := strings.ReplaceAll(path, "/", "-")
+		response := serveSigned(t, handler, private, "machine-a", http.MethodGet, path, "", "get"+nonce, "")
+		if response.Code != http.StatusNotFound {
+			t.Fatalf("path=%s status=%d body=%s", path, response.Code, response.Body.String())
+		}
+		posted := serveSigned(t, handler, private, "machine-a", http.MethodPost, path, `{}`, "post"+nonce, "")
+		if posted.Code != http.StatusNotFound {
+			t.Fatalf("post path=%s status=%d body=%s", path, posted.Code, posted.Body.String())
+		}
+	}
+}

--- a/internal/relay/migration_source.go
+++ b/internal/relay/migration_source.go
@@ -860,11 +860,14 @@ func verifyMigrationSourceSchema(ctx context.Context, q migrationQueryer, contro
 		wantTriggers = 36
 	}
 	var quotaTables int
-	if err := q.QueryRowContext(ctx, `SELECT count(*) FROM sqlite_master WHERE type='table' AND name IN ('pending_quota_recipients','pending_quota_install')`).Scan(&quotaTables); err != nil || quotaTables != 0 && quotaTables != 2 {
+	if err := q.QueryRowContext(ctx, `SELECT count(*) FROM sqlite_master WHERE type='table' AND name IN ('pending_quota_recipients','pending_quota_install','delivery_terminals')`).Scan(&quotaTables); err != nil || quotaTables != 0 && quotaTables != 2 && quotaTables != 3 {
 		return errors.New("relay migration source schema is unavailable")
 	}
-	if quotaTables == 2 {
+	if quotaTables >= 2 {
 		wantTriggers += 6
+	}
+	if quotaTables == 3 {
+		wantTriggers += 3
 	}
 	if err := triggerRows.Close(); err != nil || triggerRows.Err() != nil || len(seenTriggers) != wantTriggers {
 		return errors.New("relay migration source guard inventory is incomplete")

--- a/internal/relay/rate_limit.go
+++ b/internal/relay/rate_limit.go
@@ -184,10 +184,16 @@ func boundRetryAfter(wait time.Duration, maxSeconds int) int {
 // Metrics counts content-free relay pressure signals. Labels are fixed names
 // only; bodies, endpoints, roles, and conversation IDs are never recorded.
 type Metrics struct {
-	rateLimitRejections atomic.Uint64
-	capacityRejections  atomic.Uint64
-	pendingDeliveries   atomic.Uint64
-	pendingBytes        atomic.Uint64
+	rateLimitRejections        atomic.Uint64
+	capacityRejections         atomic.Uint64
+	pendingDeliveries          atomic.Uint64
+	pendingBytes               atomic.Uint64
+	pendingOldestAgeSeconds    atomic.Uint64
+	terminalTransitionsAcked   atomic.Uint64
+	terminalTransitionsExpired atomic.Uint64
+	terminalTransitionsRevoked atomic.Uint64
+	terminalsRetained          atomic.Uint64
+	leaseRedeliveries          atomic.Uint64
 }
 
 // ObserveRateLimited increments the rate-rejection counter.
@@ -200,10 +206,16 @@ func (m *Metrics) ObserveRateLimited() {
 
 // MetricsSnapshot is the bounded JSON body served on the local health listener.
 type MetricsSnapshot struct {
-	RelayRateLimitRejections uint64 `json:"relay_rate_limit_rejections"`
-	RelayCapacityRejections  uint64 `json:"relay_capacity_rejections"`
-	RelayPendingDeliveries   uint64 `json:"relay_pending_deliveries"`
-	RelayPendingBytes        uint64 `json:"relay_pending_bytes"`
+	RelayRateLimitRejections        uint64 `json:"relay_rate_limit_rejections"`
+	RelayCapacityRejections         uint64 `json:"relay_capacity_rejections"`
+	RelayPendingDeliveries          uint64 `json:"relay_pending_deliveries"`
+	RelayPendingBytes               uint64 `json:"relay_pending_bytes"`
+	RelayPendingOldestAgeSeconds    uint64 `json:"relay_pending_oldest_age_seconds"`
+	RelayTerminalTransitionsAcked   uint64 `json:"relay_terminal_transitions_acked"`
+	RelayTerminalTransitionsExpired uint64 `json:"relay_terminal_transitions_expired"`
+	RelayTerminalTransitionsRevoked uint64 `json:"relay_terminal_transitions_revoked"`
+	RelayTerminalsRetained          uint64 `json:"relay_terminals_retained"`
+	RelayLeaseRedeliveries          uint64 `json:"relay_lease_redeliveries"`
 }
 
 // Snapshot returns the current content-free counters.
@@ -212,11 +224,56 @@ func (m *Metrics) Snapshot() MetricsSnapshot {
 		return MetricsSnapshot{}
 	}
 	return MetricsSnapshot{
-		RelayRateLimitRejections: m.rateLimitRejections.Load(),
-		RelayCapacityRejections:  m.capacityRejections.Load(),
-		RelayPendingDeliveries:   m.pendingDeliveries.Load(),
-		RelayPendingBytes:        m.pendingBytes.Load(),
+		RelayRateLimitRejections:        m.rateLimitRejections.Load(),
+		RelayCapacityRejections:         m.capacityRejections.Load(),
+		RelayPendingDeliveries:          m.pendingDeliveries.Load(),
+		RelayPendingBytes:               m.pendingBytes.Load(),
+		RelayPendingOldestAgeSeconds:    m.pendingOldestAgeSeconds.Load(),
+		RelayTerminalTransitionsAcked:   m.terminalTransitionsAcked.Load(),
+		RelayTerminalTransitionsExpired: m.terminalTransitionsExpired.Load(),
+		RelayTerminalTransitionsRevoked: m.terminalTransitionsRevoked.Load(),
+		RelayTerminalsRetained:          m.terminalsRetained.Load(),
+		RelayLeaseRedeliveries:          m.leaseRedeliveries.Load(),
 	}
+}
+
+// ObserveTerminals increments one closed-reason transition counter after a durable commit.
+func (m *Metrics) ObserveTerminals(reason string, count int) {
+	if m == nil || count <= 0 {
+		return
+	}
+	switch reason {
+	case ClosedAcked:
+		m.terminalTransitionsAcked.Add(uint64(count)) // #nosec G115 -- transition counts are bounded by the maintenance page size.
+	case ClosedExpired:
+		m.terminalTransitionsExpired.Add(uint64(count)) // #nosec G115 -- transition counts are bounded by the maintenance page size.
+	case ClosedRevoked:
+		m.terminalTransitionsRevoked.Add(uint64(count)) // #nosec G115 -- transition counts are bounded by the maintenance page size.
+	}
+}
+
+// ObserveLeaseRedeliveries counts deliveries whose previous lease had expired.
+func (m *Metrics) ObserveLeaseRedeliveries(count int) {
+	if m == nil || count <= 0 {
+		return
+	}
+	m.leaseRedeliveries.Add(uint64(count)) // #nosec G115 -- redelivery counts are bounded by the lease page size.
+}
+
+// SetPendingOldestAge publishes the oldest pending delivery age in seconds.
+func (m *Metrics) SetPendingOldestAge(seconds int64) {
+	if m == nil {
+		return
+	}
+	m.pendingOldestAgeSeconds.Store(unsignedPending(seconds))
+}
+
+// SetTerminalsRetained publishes the number of retained terminal rows.
+func (m *Metrics) SetTerminalsRetained(count int64) {
+	if m == nil {
+		return
+	}
+	m.terminalsRetained.Store(unsignedPending(count))
 }
 
 // SetRateLimits replaces the in-process bucket policy. Token state remains in
@@ -234,7 +291,7 @@ func (s *Store) SetRateLimits(cfg RateLimitConfig) error {
 // SetMetrics attaches the shared content-free counter sink.
 func (s *Store) SetMetrics(metrics *Metrics) {
 	s.metrics = metrics
-	s.refreshPendingMetrics()
+	s.refreshPendingMetrics(time.Time{})
 }
 
 func (s *Store) rateLimitConfig() RateLimitConfig {

--- a/internal/relay/retention.go
+++ b/internal/relay/retention.go
@@ -1,0 +1,96 @@
+package relay
+
+import (
+	"fmt"
+	"time"
+)
+
+const (
+	// RetentionAgeMinSeconds is the smallest accepted pending-delivery max age.
+	RetentionAgeMinSeconds = 1
+	// RetentionAgeMaxSeconds is the largest accepted pending or terminal age (365 days).
+	RetentionAgeMaxSeconds = 365 * 24 * 60 * 60
+	// RetentionBatchMin is the smallest accepted maintenance page.
+	RetentionBatchMin = 1
+	// RetentionBatchMax is the largest accepted maintenance page.
+	RetentionBatchMax = 1000
+	// TerminalListLimitMin is the smallest operator terminal page.
+	TerminalListLimitMin = 1
+	// TerminalListLimitMax is the largest operator terminal page.
+	TerminalListLimitMax = 100
+
+	// ClosedAcked records a successful local mailbox acknowledgement.
+	ClosedAcked = "acked"
+	// ClosedExpired records pending-age dead-lettering.
+	ClosedExpired = "expired"
+	// ClosedRevoked records membership-revocation retirement.
+	ClosedRevoked = "revoked"
+)
+
+// RetentionConfig is the startup-validated pending-age and terminal-retention policy.
+type RetentionConfig struct {
+	PendingMaxAgeSeconds     int
+	TerminalRetentionSeconds int
+	MaintenanceBatch         int
+}
+
+// DefaultRetentionConfig expires work after seven days and retains terminal
+// metadata for thirty days. Ordinary contract tests stay inside the window.
+func DefaultRetentionConfig() RetentionConfig {
+	return RetentionConfig{
+		PendingMaxAgeSeconds:     7 * 24 * 60 * 60,
+		TerminalRetentionSeconds: 30 * 24 * 60 * 60,
+		MaintenanceBatch:         100,
+	}
+}
+
+// Validate reports whether every bound is an explicit integer in range.
+func (c RetentionConfig) Validate() error {
+	if err := boundedRateInt("pending max age seconds", c.PendingMaxAgeSeconds, RetentionAgeMinSeconds, RetentionAgeMaxSeconds); err != nil {
+		return err
+	}
+	if err := boundedRateInt("terminal retention seconds", c.TerminalRetentionSeconds, RetentionAgeMinSeconds, RetentionAgeMaxSeconds); err != nil {
+		return err
+	}
+	if err := boundedRateInt("delivery maintenance batch", c.MaintenanceBatch, RetentionBatchMin, RetentionBatchMax); err != nil {
+		return err
+	}
+	return nil
+}
+
+// MaintenanceResult is one bounded expire-and-prune page.
+type MaintenanceResult struct {
+	Expired int
+	Pruned  int
+	Scanned int
+}
+
+// TerminalRecord is host-local, content-free closed-delivery metadata.
+type TerminalRecord struct {
+	DeliveryID      string    `json:"delivery_id"`
+	MessageID       string    `json:"message_id"`
+	ConversationID  string    `json:"conversation_id"`
+	RecipientID     string    `json:"recipient_id"`
+	Sequence        int64     `json:"sequence"`
+	ClosedReason    string    `json:"closed_reason"`
+	LeaseGeneration int64     `json:"lease_generation"`
+	CreatedAt       time.Time `json:"created_at"`
+	ClosedAt        time.Time `json:"closed_at"`
+}
+
+// TerminalPage is one bounded operator inspection page.
+type TerminalPage struct {
+	Terminals  []TerminalRecord `json:"terminals"`
+	NextCursor string           `json:"next_cursor,omitempty"`
+}
+
+func validClosedReason(reason string) bool {
+	return reason == ClosedAcked || reason == ClosedExpired || reason == ClosedRevoked
+}
+
+func boundedListLimit(limit int) (int, error) {
+	if limit < TerminalListLimitMin || limit > TerminalListLimitMax {
+		return 0, fmt.Errorf("relay terminal page limit must be an integer between %d and %d", TerminalListLimitMin, TerminalListLimitMax)
+	}
+	return limit, nil
+}

--- a/internal/relay/store.go
+++ b/internal/relay/store.go
@@ -319,6 +319,8 @@ type Store struct {
 	rateLimits       RateLimitConfig
 	quotaMu          sync.Mutex
 	quota            QuotaConfig
+	retentionMu      sync.Mutex
+	retention        RetentionConfig
 	pendingMetricsMu sync.Mutex
 	metrics          *Metrics
 }
@@ -351,7 +353,7 @@ func openStore(database string, verifyQuota bool) (*Store, error) {
 	// from surfacing SQLITE_BUSY instead of orderly transactional serialization.
 	db.SetMaxOpenConns(1)
 	db.SetMaxIdleConns(1)
-	store := &Store{db: db, rateLimits: DefaultRateLimitConfig(), quota: DefaultQuotaConfig()}
+	store := &Store{db: db, rateLimits: DefaultRateLimitConfig(), quota: DefaultQuotaConfig(), retention: DefaultRetentionConfig()}
 	var migrationControlExists bool
 	if err := db.QueryRowContext(context.Background(), `SELECT EXISTS (SELECT 1 FROM sqlite_schema WHERE type='table' AND name='relay_migration_control')`).Scan(&migrationControlExists); err != nil {
 		_ = db.Close()
@@ -577,6 +579,18 @@ func (s *Store) migrate(ctx context.Context) error {
 			pending_count INTEGER NOT NULL CHECK (pending_count >= 0),
 			pending_bytes INTEGER NOT NULL CHECK (pending_bytes >= 0)
 		)`,
+		`CREATE TABLE IF NOT EXISTS delivery_terminals (
+			delivery_id TEXT PRIMARY KEY,
+			message_id TEXT NOT NULL,
+			conversation_id TEXT NOT NULL,
+			recipient_endpoint TEXT NOT NULL,
+			sequence INTEGER NOT NULL CHECK (sequence >= 1),
+			closed_reason TEXT NOT NULL CHECK (closed_reason IN ('acked','expired','revoked')),
+			lease_generation INTEGER NOT NULL CHECK (lease_generation >= 0),
+			created_at INTEGER NOT NULL,
+			closed_at INTEGER NOT NULL
+		)`,
+		"CREATE INDEX IF NOT EXISTS delivery_terminals_closed_at ON delivery_terminals(closed_at, delivery_id)",
 		`CREATE TABLE IF NOT EXISTS direct_conversations (
 			role_low TEXT NOT NULL REFERENCES roles(role) ON DELETE RESTRICT,
 			role_high TEXT NOT NULL REFERENCES roles(role) ON DELETE RESTRICT,
@@ -633,7 +647,7 @@ func (s *Store) migrate(ctx context.Context) error {
 			return fmt.Errorf("initialize relay migration control: %w", err)
 		}
 	}
-	for _, table := range []string{"endpoints", "conversations", "memberships", "roles", "role_memberships", "role_bindings", "role_profiles", "role_profile_idempotency", "messages", "deliveries", "recipient_cursors", "idempotency", "conversation_idempotency", "conversation_controls", "conversation_control_idempotency", "request_nonces", "rate_buckets", "pending_quota_recipients", "pending_quota_install", "direct_conversations", "message_from_roles", "direct_message_idempotency"} {
+	for _, table := range []string{"endpoints", "conversations", "memberships", "roles", "role_memberships", "role_bindings", "role_profiles", "role_profile_idempotency", "messages", "deliveries", "recipient_cursors", "idempotency", "conversation_idempotency", "conversation_controls", "conversation_control_idempotency", "request_nonces", "rate_buckets", "pending_quota_recipients", "pending_quota_install", "delivery_terminals", "direct_conversations", "message_from_roles", "direct_message_idempotency"} {
 		for _, operation := range []string{"INSERT", "UPDATE", "DELETE"} {
 			name := "relay_migration_guard_" + table + "_" + strings.ToLower(operation)
 			statement := fmt.Sprintf(`CREATE TRIGGER IF NOT EXISTS %s BEFORE %s ON %s
@@ -696,6 +710,7 @@ func (s *Store) ApplyControl(input ControlInput) (ControlEvent, bool, error) {
 	if actorCapabilities&CapAdmin == 0 {
 		return ControlEvent{}, false, ErrForbidden
 	}
+	revoked := 0
 	var existingID, existingHash string
 	err = tx.QueryRowContext(context.Background(), "SELECT control_id,request_hash FROM conversation_control_idempotency WHERE machine_id=? AND key=?", input.ActorMachineID, input.IdempotencyKey).Scan(&existingID, &existingHash)
 	if err == nil {
@@ -742,9 +757,11 @@ func (s *Store) ApplyControl(input ControlInput) (ControlEvent, bool, error) {
 			}
 		}
 		if err == nil && previous&CapReceive != 0 && input.Member.Capabilities&CapReceive == 0 {
-			if err := retireRecipientDeliveries(tx, input.Member.Endpoint, input.ConversationID, input.Now); err != nil {
+			n, err := retireRecipientDeliveries(tx, input.Member.Endpoint, input.ConversationID, input.Now)
+			if err != nil {
 				return ControlEvent{}, false, err
 			}
+			revoked += n
 			if err := advanceRecipientCursor(tx, input.Member.Endpoint, input.ConversationID); err != nil {
 				return ControlEvent{}, false, err
 			}
@@ -778,9 +795,11 @@ func (s *Store) ApplyControl(input ControlInput) (ControlEvent, bool, error) {
 				return ControlEvent{}, false, ErrConflict
 			}
 		}
-		if err := retireRecipientDeliveries(tx, input.Member.Endpoint, input.ConversationID, input.Now); err != nil {
+		n, err := retireRecipientDeliveries(tx, input.Member.Endpoint, input.ConversationID, input.Now)
+		if err != nil {
 			return ControlEvent{}, false, err
 		}
+		revoked += n
 		if err := advanceRecipientCursor(tx, input.Member.Endpoint, input.ConversationID); err != nil {
 			return ControlEvent{}, false, err
 		}
@@ -809,7 +828,8 @@ func (s *Store) ApplyControl(input ControlInput) (ControlEvent, bool, error) {
 	if err := tx.Commit(); err != nil {
 		return ControlEvent{}, false, err
 	}
-	s.refreshPendingMetrics()
+	s.metrics.ObserveTerminals(ClosedRevoked, revoked)
+	s.refreshPendingMetrics(input.Now)
 	return event, false, nil
 }
 
@@ -1251,7 +1271,7 @@ func (s *Store) SendDirectMessage(input DirectMessageInput) (Message, bool, erro
 	if err := tx.Commit(); err != nil {
 		return Message{}, false, err
 	}
-	s.refreshPendingMetrics()
+	s.refreshPendingMetrics(now)
 	return message, false, nil
 }
 
@@ -1794,7 +1814,7 @@ func (s *Store) AppendMessage(input AppendInput) (Message, bool, error) {
 	if err := tx.Commit(); err != nil {
 		return Message{}, false, err
 	}
-	s.refreshPendingMetrics()
+	s.refreshPendingMetrics(input.Now)
 	return message, false, nil
 }
 
@@ -1900,6 +1920,7 @@ func (s *Store) LeaseDeliveries(machineID, consumerID, endpoint, conversationID 
 	}
 	defer func() { _ = rows.Close() }()
 	var deliveries []Delivery
+	var redeliveries int
 	for rows.Next() {
 		var delivery Delivery
 		var leaseMachine, leaseToken sql.NullString
@@ -1923,6 +1944,9 @@ func (s *Store) LeaseDeliveries(machineID, consumerID, endpoint, conversationID 
 			token, err := randomToken()
 			if err != nil {
 				return DeliveryLeasePage{}, err
+			}
+			if leaseUntil.Valid && leaseUntil.Int64 <= now.UnixMilli() {
+				redeliveries++
 			}
 			delivery.LeaseGeneration++
 			delivery.LeaseToken = token
@@ -1957,6 +1981,7 @@ func (s *Store) LeaseDeliveries(machineID, consumerID, endpoint, conversationID 
 	if err := tx.Commit(); err != nil {
 		return DeliveryLeasePage{}, err
 	}
+	s.metrics.ObserveLeaseRedeliveries(redeliveries)
 	return DeliveryLeasePage{Deliveries: deliveries, Cursors: cursors}, nil
 }
 
@@ -2048,10 +2073,15 @@ func (s *Store) AckDelivery(machineID, endpoint, deliveryID, token string, gener
 		WHERE delivery.id = ?`, deliveryID).Scan(&conversationID, &bodyBytes); err != nil {
 		return fmt.Errorf("read delivery conversation: %w", err)
 	}
+	acked := 0
 	if affected == 1 {
 		if err := releaseQuota(tx, recipient.String, bodyBytes); err != nil {
 			return err
 		}
+		if err := recordAckedTerminal(tx, deliveryID, now); err != nil {
+			return err
+		}
+		acked = 1
 	}
 	if err := advanceRecipientCursor(tx, recipient.String, conversationID); err != nil {
 		return err
@@ -2059,7 +2089,8 @@ func (s *Store) AckDelivery(machineID, endpoint, deliveryID, token string, gener
 	if err := tx.Commit(); err != nil {
 		return err
 	}
-	s.refreshPendingMetrics()
+	s.metrics.ObserveTerminals(ClosedAcked, acked)
+	s.refreshPendingMetrics(now)
 	return nil
 }
 

--- a/internal/relay/store_quota.go
+++ b/internal/relay/store_quota.go
@@ -154,44 +154,43 @@ func releaseQuota(tx *sql.Tx, recipient string, bodyBytes int64) error {
 	return nil
 }
 
-func retireRecipientDeliveries(tx *sql.Tx, recipient, conversationID string, now time.Time) error {
-	rows, err := tx.QueryContext(context.Background(), `SELECT delivery.id, `+sqlitePendingBodyBytes+`
+func retireRecipientDeliveries(tx *sql.Tx, recipient, conversationID string, now time.Time) (int, error) {
+	rows, err := tx.QueryContext(context.Background(), `SELECT delivery.id, delivery.lease_generation, `+sqlitePendingBodyBytes+`, message.id, message.conversation_id, message.sequence, message.created_at
 		FROM deliveries AS delivery JOIN messages AS message ON message.id = delivery.message_id
 		WHERE delivery.recipient_endpoint = ? AND delivery.acked_at IS NULL AND message.conversation_id = ?`, recipient, conversationID)
 	if err != nil {
-		return fmt.Errorf("find revoked deliveries: %w", err)
+		return 0, fmt.Errorf("find revoked deliveries: %w", err)
 	}
-	type pending struct {
-		id    string
-		bytes int64
-	}
-	var retired []pending
+	var pending []pendingClose
 	for rows.Next() {
-		var row pending
-		if err := rows.Scan(&row.id, &row.bytes); err != nil {
+		var row pendingClose
+		if err := rows.Scan(&row.ID, &row.LeaseGeneration, &row.BodyBytes, &row.MessageID, &row.ConversationID, &row.Sequence, &row.CreatedAt); err != nil {
 			_ = rows.Close()
-			return err
+			return 0, err
 		}
-		retired = append(retired, row)
+		row.Recipient = recipient
+		pending = append(pending, row)
 	}
 	if err := rows.Close(); err != nil {
-		return err
+		return 0, err
 	}
 	if err := rows.Err(); err != nil {
-		return err
+		return 0, err
 	}
-	for _, row := range retired {
-		if err := releaseQuota(tx, recipient, row.bytes); err != nil {
-			return err
+	closed := 0
+	for _, row := range pending {
+		ok, err := closePendingDelivery(tx, row, ClosedRevoked, now)
+		if err != nil {
+			return 0, err
+		}
+		if ok {
+			closed++
 		}
 	}
-	if _, err := tx.ExecContext(context.Background(), "UPDATE deliveries SET acked_at=? WHERE recipient_endpoint=? AND acked_at IS NULL AND message_id IN (SELECT id FROM messages WHERE conversation_id=?)", now.UTC().UnixMilli(), recipient, conversationID); err != nil {
-		return fmt.Errorf("retire revoked deliveries: %w", err)
-	}
-	return nil
+	return closed, nil
 }
 
-func (s *Store) refreshPendingMetrics() {
+func (s *Store) refreshPendingMetrics(now time.Time) {
 	s.pendingMetricsMu.Lock()
 	defer s.pendingMetricsMu.Unlock()
 	counters, err := readInstallQuota(context.Background(), s.db)
@@ -199,6 +198,27 @@ func (s *Store) refreshPendingMetrics() {
 		return
 	}
 	s.metrics.SetPending(counters.Count, counters.Bytes)
+	var oldest sql.NullInt64
+	if err := s.db.QueryRowContext(context.Background(), `SELECT MIN(message.created_at)
+		FROM deliveries AS delivery JOIN messages AS message ON message.id = delivery.message_id
+		WHERE delivery.acked_at IS NULL`).Scan(&oldest); err != nil {
+		return
+	}
+	var age int64
+	if oldest.Valid && !now.IsZero() {
+		age = now.UTC().UnixMilli() - oldest.Int64
+		if age < 0 {
+			age = 0
+		} else {
+			age = age / 1000
+		}
+	}
+	s.metrics.SetPendingOldestAge(age)
+	var retained int64
+	if err := s.db.QueryRowContext(context.Background(), `SELECT COUNT(*) FROM delivery_terminals`).Scan(&retained); err != nil {
+		return
+	}
+	s.metrics.SetTerminalsRetained(retained)
 }
 
 func readInstallQuota(ctx context.Context, q interface {
@@ -335,12 +355,12 @@ func ReconcilePendingQuota(store *Store) (QuotaCounters, error) {
 	if err := tx.Commit(); err != nil {
 		return QuotaCounters{}, err
 	}
-	store.refreshPendingMetrics()
+	store.refreshPendingMetrics(time.Now().UTC())
 	return install, nil
 }
 
 func isOperationalQuotaTable(name string) bool {
-	return name == "pending_quota_recipients" || name == "pending_quota_install"
+	return name == "pending_quota_recipients" || name == "pending_quota_install" || name == "delivery_terminals"
 }
 
 func filterOperationalQuotaTables(names []string) []string {

--- a/internal/relay/store_quota.go
+++ b/internal/relay/store_quota.go
@@ -210,7 +210,7 @@ func (s *Store) refreshPendingMetrics(now time.Time) {
 		if age < 0 {
 			age = 0
 		} else {
-			age = age / 1000
+			age /= 1000
 		}
 	}
 	s.metrics.SetPendingOldestAge(age)

--- a/internal/relay/store_retention.go
+++ b/internal/relay/store_retention.go
@@ -1,0 +1,204 @@
+package relay
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"time"
+)
+
+type pendingClose struct {
+	ID              string
+	MessageID       string
+	ConversationID  string
+	Recipient       string
+	Sequence        int64
+	LeaseGeneration int64
+	BodyBytes       int64
+	CreatedAt       int64
+}
+
+// SetRetentionPolicy replaces the in-process pending-age and terminal-retention policy.
+func (s *Store) SetRetentionPolicy(cfg RetentionConfig) error {
+	if err := cfg.Validate(); err != nil {
+		return err
+	}
+	s.retentionMu.Lock()
+	s.retention = cfg
+	s.retentionMu.Unlock()
+	return nil
+}
+
+func (s *Store) retentionConfig() RetentionConfig {
+	s.retentionMu.Lock()
+	defer s.retentionMu.Unlock()
+	if s.retention == (RetentionConfig{}) {
+		return DefaultRetentionConfig()
+	}
+	return s.retention
+}
+
+// MaintainDeliveries expires pending deliveries past the max-age boundary and
+// prunes retained terminal metadata, each in one bounded page.
+func (s *Store) MaintainDeliveries(now time.Time) (MaintenanceResult, error) {
+	cfg := s.retentionConfig()
+	now = now.UTC().Truncate(time.Millisecond)
+	tx, err := s.db.BeginTx(context.Background(), nil)
+	if err != nil {
+		return MaintenanceResult{}, err
+	}
+	defer rollback(tx)
+	cutoff := now.Add(-time.Duration(cfg.PendingMaxAgeSeconds) * time.Second).UnixMilli()
+	rows, err := tx.QueryContext(context.Background(), `SELECT delivery.id, delivery.recipient_endpoint, message.id, message.conversation_id, message.sequence, delivery.lease_generation, `+sqlitePendingBodyBytes+`, message.created_at
+		FROM deliveries AS delivery JOIN messages AS message ON message.id = delivery.message_id
+		WHERE delivery.acked_at IS NULL AND message.created_at <= ?
+		ORDER BY message.created_at, delivery.id
+		LIMIT ?`, cutoff, cfg.MaintenanceBatch)
+	if err != nil {
+		return MaintenanceResult{}, fmt.Errorf("find expired deliveries: %w", err)
+	}
+	var pending []pendingClose
+	for rows.Next() {
+		var row pendingClose
+		if err := rows.Scan(&row.ID, &row.Recipient, &row.MessageID, &row.ConversationID, &row.Sequence, &row.LeaseGeneration, &row.BodyBytes, &row.CreatedAt); err != nil {
+			_ = rows.Close()
+			return MaintenanceResult{}, err
+		}
+		pending = append(pending, row)
+	}
+	if err := rows.Close(); err != nil {
+		return MaintenanceResult{}, err
+	}
+	if err := rows.Err(); err != nil {
+		return MaintenanceResult{}, err
+	}
+	var result MaintenanceResult
+	result.Scanned = len(pending)
+	for _, row := range pending {
+		closed, err := closePendingDelivery(tx, row, ClosedExpired, now)
+		if err != nil {
+			return MaintenanceResult{}, err
+		}
+		if closed {
+			result.Expired++
+		}
+	}
+	pruneCutoff := now.Add(-time.Duration(cfg.TerminalRetentionSeconds) * time.Second).UnixMilli()
+	pruneRows, err := tx.QueryContext(context.Background(), `SELECT delivery_id FROM delivery_terminals
+		WHERE closed_at <= ? ORDER BY closed_at, delivery_id LIMIT ?`, pruneCutoff, cfg.MaintenanceBatch)
+	if err != nil {
+		return MaintenanceResult{}, fmt.Errorf("find retained terminals: %w", err)
+	}
+	var pruneIDs []string
+	for pruneRows.Next() {
+		var id string
+		if err := pruneRows.Scan(&id); err != nil {
+			_ = pruneRows.Close()
+			return MaintenanceResult{}, err
+		}
+		pruneIDs = append(pruneIDs, id)
+	}
+	if err := pruneRows.Close(); err != nil {
+		return MaintenanceResult{}, err
+	}
+	if err := pruneRows.Err(); err != nil {
+		return MaintenanceResult{}, err
+	}
+	for _, id := range pruneIDs {
+		if _, err := tx.ExecContext(context.Background(), `DELETE FROM delivery_terminals WHERE delivery_id = ?`, id); err != nil {
+			return MaintenanceResult{}, fmt.Errorf("prune terminal metadata: %w", err)
+		}
+		result.Pruned++
+	}
+	if err := tx.Commit(); err != nil {
+		return MaintenanceResult{}, err
+	}
+	s.metrics.ObserveTerminals(ClosedExpired, result.Expired)
+	s.refreshPendingMetrics(now)
+	return result, nil
+}
+
+// ListTerminalDeliveries returns one content-free operator page of retained terminals.
+func (s *Store) ListTerminalDeliveries(after string, limit int) (TerminalPage, error) {
+	limit, err := boundedListLimit(limit)
+	if err != nil {
+		return TerminalPage{}, err
+	}
+	tx, err := s.db.BeginTx(context.Background(), &sql.TxOptions{ReadOnly: true})
+	if err != nil {
+		return TerminalPage{}, err
+	}
+	defer rollback(tx)
+	rows, err := tx.QueryContext(context.Background(), `SELECT delivery_id, message_id, conversation_id, recipient_endpoint, sequence, closed_reason, lease_generation, created_at, closed_at
+		FROM delivery_terminals WHERE delivery_id > ? ORDER BY delivery_id LIMIT ?`, after, limit)
+	if err != nil {
+		return TerminalPage{}, fmt.Errorf("list terminal deliveries: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	var page TerminalPage
+	for rows.Next() {
+		var record TerminalRecord
+		var createdAt, closedAt int64
+		if err := rows.Scan(&record.DeliveryID, &record.MessageID, &record.ConversationID, &record.RecipientID, &record.Sequence, &record.ClosedReason, &record.LeaseGeneration, &createdAt, &closedAt); err != nil {
+			return TerminalPage{}, err
+		}
+		record.CreatedAt = fromMillis(createdAt)
+		record.ClosedAt = fromMillis(closedAt)
+		page.Terminals = append(page.Terminals, record)
+	}
+	if err := rows.Err(); err != nil {
+		return TerminalPage{}, err
+	}
+	if err := tx.Commit(); err != nil {
+		return TerminalPage{}, err
+	}
+	if len(page.Terminals) == limit {
+		page.NextCursor = page.Terminals[len(page.Terminals)-1].DeliveryID
+	}
+	return page, nil
+}
+
+func closePendingDelivery(tx *sql.Tx, row pendingClose, reason string, now time.Time) (bool, error) {
+	if !validClosedReason(reason) || row.ID == "" || row.Recipient == "" {
+		return false, fmt.Errorf("invalid terminal close")
+	}
+	closedAt := now.UTC().Truncate(time.Millisecond).UnixMilli()
+	result, err := tx.ExecContext(context.Background(), `UPDATE deliveries SET acked_at = ?, lease_machine_id = NULL, lease_token = NULL, ownership_generation = NULL, consumer_generation = NULL, lease_until = NULL
+		WHERE id = ? AND acked_at IS NULL`, closedAt, row.ID)
+	if err != nil {
+		return false, fmt.Errorf("close pending delivery: %w", err)
+	}
+	affected, err := result.RowsAffected()
+	if err != nil {
+		return false, fmt.Errorf("close pending delivery: %w", err)
+	}
+	if affected != 1 {
+		return false, nil
+	}
+	if _, err := tx.ExecContext(context.Background(), `INSERT OR IGNORE INTO delivery_terminals(delivery_id, message_id, conversation_id, recipient_endpoint, sequence, closed_reason, lease_generation, created_at, closed_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`, row.ID, row.MessageID, row.ConversationID, row.Recipient, row.Sequence, reason, row.LeaseGeneration, row.CreatedAt, closedAt); err != nil {
+		return false, fmt.Errorf("record terminal delivery: %w", err)
+	}
+	if err := releaseQuota(tx, row.Recipient, row.BodyBytes); err != nil {
+		return false, err
+	}
+	if err := advanceRecipientCursor(tx, row.Recipient, row.ConversationID); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+func recordAckedTerminal(tx *sql.Tx, deliveryID string, now time.Time) error {
+	var row pendingClose
+	if err := tx.QueryRowContext(context.Background(), `SELECT delivery.id, delivery.recipient_endpoint, message.id, message.conversation_id, message.sequence, delivery.lease_generation, `+sqlitePendingBodyBytes+`, message.created_at
+		FROM deliveries AS delivery JOIN messages AS message ON message.id = delivery.message_id
+		WHERE delivery.id = ?`, deliveryID).Scan(&row.ID, &row.Recipient, &row.MessageID, &row.ConversationID, &row.Sequence, &row.LeaseGeneration, &row.BodyBytes, &row.CreatedAt); err != nil {
+		return fmt.Errorf("read acknowledged delivery: %w", err)
+	}
+	closedAt := now.UTC().Truncate(time.Millisecond).UnixMilli()
+	if _, err := tx.ExecContext(context.Background(), `INSERT OR IGNORE INTO delivery_terminals(delivery_id, message_id, conversation_id, recipient_endpoint, sequence, closed_reason, lease_generation, created_at, closed_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`, row.ID, row.MessageID, row.ConversationID, row.Recipient, row.Sequence, ClosedAcked, row.LeaseGeneration, row.CreatedAt, closedAt); err != nil {
+		return fmt.Errorf("record acknowledged terminal: %w", err)
+	}
+	return nil
+}

--- a/internal/relay/store_retention.go
+++ b/internal/relay/store_retention.go
@@ -47,6 +47,10 @@ func (s *Store) MaintainDeliveries(now time.Time) (MaintenanceResult, error) {
 	now = now.UTC().Truncate(time.Millisecond)
 	cutoff := now.Add(-time.Duration(cfg.PendingMaxAgeSeconds) * time.Second).UnixMilli()
 	var result MaintenanceResult
+	defer func() {
+		s.metrics.ObserveTerminals(ClosedExpired, result.Expired)
+		s.refreshPendingMetrics(now)
+	}()
 	for i := 0; i < cfg.MaintenanceBatch; i++ {
 		found, closed, err := s.expireOneDueDelivery(cutoff, now)
 		if err != nil {
@@ -64,8 +68,6 @@ func (s *Store) MaintainDeliveries(now time.Time) (MaintenanceResult, error) {
 	for i := 0; i < cfg.MaintenanceBatch; i++ {
 		found, err := s.pruneOneTerminal(pruneCutoff)
 		if err != nil {
-			s.metrics.ObserveTerminals(ClosedExpired, result.Expired)
-			s.refreshPendingMetrics(now)
 			return result, err
 		}
 		if !found {
@@ -73,8 +75,6 @@ func (s *Store) MaintainDeliveries(now time.Time) (MaintenanceResult, error) {
 		}
 		result.Pruned++
 	}
-	s.metrics.ObserveTerminals(ClosedExpired, result.Expired)
-	s.refreshPendingMetrics(now)
 	return result, nil
 }
 

--- a/internal/relay/store_retention.go
+++ b/internal/relay/store_retention.go
@@ -3,6 +3,7 @@ package relay
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"time"
 )
@@ -39,83 +40,97 @@ func (s *Store) retentionConfig() RetentionConfig {
 }
 
 // MaintainDeliveries expires pending deliveries past the max-age boundary and
-// prunes retained terminal metadata, each in one bounded page.
+// prunes retained terminal metadata, each in one bounded page of independent
+// transactions so a later timeout cannot undo earlier closes.
 func (s *Store) MaintainDeliveries(now time.Time) (MaintenanceResult, error) {
 	cfg := s.retentionConfig()
 	now = now.UTC().Truncate(time.Millisecond)
-	tx, err := s.db.BeginTx(context.Background(), nil)
-	if err != nil {
-		return MaintenanceResult{}, err
-	}
-	defer rollback(tx)
 	cutoff := now.Add(-time.Duration(cfg.PendingMaxAgeSeconds) * time.Second).UnixMilli()
-	rows, err := tx.QueryContext(context.Background(), `SELECT delivery.id, delivery.recipient_endpoint, message.id, message.conversation_id, message.sequence, delivery.lease_generation, `+sqlitePendingBodyBytes+`, message.created_at
-		FROM deliveries AS delivery JOIN messages AS message ON message.id = delivery.message_id
-		WHERE delivery.acked_at IS NULL AND message.created_at <= ?
-		ORDER BY message.created_at, delivery.id
-		LIMIT ?`, cutoff, cfg.MaintenanceBatch)
-	if err != nil {
-		return MaintenanceResult{}, fmt.Errorf("find expired deliveries: %w", err)
-	}
-	var pending []pendingClose
-	for rows.Next() {
-		var row pendingClose
-		if err := rows.Scan(&row.ID, &row.Recipient, &row.MessageID, &row.ConversationID, &row.Sequence, &row.LeaseGeneration, &row.BodyBytes, &row.CreatedAt); err != nil {
-			_ = rows.Close()
-			return MaintenanceResult{}, err
-		}
-		pending = append(pending, row)
-	}
-	if err := rows.Close(); err != nil {
-		return MaintenanceResult{}, err
-	}
-	if err := rows.Err(); err != nil {
-		return MaintenanceResult{}, err
-	}
 	var result MaintenanceResult
-	result.Scanned = len(pending)
-	for _, row := range pending {
-		closed, err := closePendingDelivery(tx, row, ClosedExpired, now)
+	for i := 0; i < cfg.MaintenanceBatch; i++ {
+		found, closed, err := s.expireOneDueDelivery(cutoff, now)
 		if err != nil {
-			return MaintenanceResult{}, err
+			return result, err
 		}
+		if !found {
+			break
+		}
+		result.Scanned++
 		if closed {
 			result.Expired++
 		}
 	}
 	pruneCutoff := now.Add(-time.Duration(cfg.TerminalRetentionSeconds) * time.Second).UnixMilli()
-	pruneRows, err := tx.QueryContext(context.Background(), `SELECT delivery_id FROM delivery_terminals
-		WHERE closed_at <= ? ORDER BY closed_at, delivery_id LIMIT ?`, pruneCutoff, cfg.MaintenanceBatch)
-	if err != nil {
-		return MaintenanceResult{}, fmt.Errorf("find retained terminals: %w", err)
-	}
-	var pruneIDs []string
-	for pruneRows.Next() {
-		var id string
-		if err := pruneRows.Scan(&id); err != nil {
-			_ = pruneRows.Close()
-			return MaintenanceResult{}, err
+	for i := 0; i < cfg.MaintenanceBatch; i++ {
+		found, err := s.pruneOneTerminal(pruneCutoff)
+		if err != nil {
+			s.metrics.ObserveTerminals(ClosedExpired, result.Expired)
+			s.refreshPendingMetrics(now)
+			return result, err
 		}
-		pruneIDs = append(pruneIDs, id)
-	}
-	if err := pruneRows.Close(); err != nil {
-		return MaintenanceResult{}, err
-	}
-	if err := pruneRows.Err(); err != nil {
-		return MaintenanceResult{}, err
-	}
-	for _, id := range pruneIDs {
-		if _, err := tx.ExecContext(context.Background(), `DELETE FROM delivery_terminals WHERE delivery_id = ?`, id); err != nil {
-			return MaintenanceResult{}, fmt.Errorf("prune terminal metadata: %w", err)
+		if !found {
+			break
 		}
 		result.Pruned++
-	}
-	if err := tx.Commit(); err != nil {
-		return MaintenanceResult{}, err
 	}
 	s.metrics.ObserveTerminals(ClosedExpired, result.Expired)
 	s.refreshPendingMetrics(now)
 	return result, nil
+}
+
+func (s *Store) expireOneDueDelivery(cutoff int64, now time.Time) (bool, bool, error) {
+	tx, err := s.db.BeginTx(context.Background(), nil)
+	if err != nil {
+		return false, false, err
+	}
+	defer rollback(tx)
+	var row pendingClose
+	err = tx.QueryRowContext(context.Background(), `SELECT delivery.id, delivery.recipient_endpoint, message.id, message.conversation_id, message.sequence, delivery.lease_generation, `+sqlitePendingBodyBytes+`, message.created_at
+		FROM deliveries AS delivery JOIN messages AS message ON message.id = delivery.message_id
+		WHERE delivery.acked_at IS NULL AND message.created_at <= ?
+		ORDER BY message.created_at, delivery.id
+		LIMIT 1`, cutoff).Scan(&row.ID, &row.Recipient, &row.MessageID, &row.ConversationID, &row.Sequence, &row.LeaseGeneration, &row.BodyBytes, &row.CreatedAt)
+	if errors.Is(err, sql.ErrNoRows) {
+		return false, false, nil
+	}
+	if err != nil {
+		return false, false, fmt.Errorf("find expired delivery: %w", err)
+	}
+	closed, err := closePendingDelivery(tx, row, ClosedExpired, now)
+	if err != nil {
+		return true, false, err
+	}
+	if !closed {
+		return true, false, nil
+	}
+	if err := tx.Commit(); err != nil {
+		return true, false, err
+	}
+	return true, true, nil
+}
+
+func (s *Store) pruneOneTerminal(cutoff int64) (bool, error) {
+	tx, err := s.db.BeginTx(context.Background(), nil)
+	if err != nil {
+		return false, err
+	}
+	defer rollback(tx)
+	var id string
+	err = tx.QueryRowContext(context.Background(), `SELECT delivery_id FROM delivery_terminals
+		WHERE closed_at <= ? ORDER BY closed_at, delivery_id LIMIT 1`, cutoff).Scan(&id)
+	if errors.Is(err, sql.ErrNoRows) {
+		return false, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("find retained terminal: %w", err)
+	}
+	if _, err := tx.ExecContext(context.Background(), `DELETE FROM delivery_terminals WHERE delivery_id = ?`, id); err != nil {
+		return false, fmt.Errorf("prune terminal metadata: %w", err)
+	}
+	if err := tx.Commit(); err != nil {
+		return false, err
+	}
+	return true, nil
 }
 
 // ListTerminalDeliveries returns one content-free operator page of retained terminals.

--- a/internal/relay/store_retention_test.go
+++ b/internal/relay/store_retention_test.go
@@ -1,6 +1,7 @@
 package relay
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"path/filepath"
@@ -560,7 +561,7 @@ func TestStorePartialExpireFailurePublishesCommittedMetrics(t *testing.T) {
 			t.Fatal(err)
 		}
 	}
-	if _, err := store.db.Exec(`CREATE TRIGGER fail_second_terminal BEFORE INSERT ON delivery_terminals
+	if _, err := store.db.ExecContext(context.Background(), `CREATE TRIGGER fail_second_terminal BEFORE INSERT ON delivery_terminals
 		WHEN (SELECT COUNT(*) FROM delivery_terminals) >= 1
 		BEGIN SELECT RAISE(ABORT, 'injected terminal insert failure'); END`); err != nil {
 		t.Fatal(err)

--- a/internal/relay/store_retention_test.go
+++ b/internal/relay/store_retention_test.go
@@ -399,7 +399,7 @@ func TestStoreConcurrentExpireAndLeaseLeavesAtMostOneCloser(t *testing.T) {
 	}
 	later := now.Add(61 * time.Second)
 	var wg sync.WaitGroup
-	var leased atomic.Int32
+	var leased atomic.Int64
 	wg.Add(2)
 	go func() {
 		defer wg.Done()
@@ -409,7 +409,7 @@ func TestStoreConcurrentExpireAndLeaseLeavesAtMostOneCloser(t *testing.T) {
 		defer wg.Done()
 		page, err := store.LeaseDeliveries("machine-b", "consumer-b", "agent/b", conversation.ID, later, time.Minute, 10)
 		if err == nil {
-			leased.Store(int32(len(page.Deliveries)))
+			leased.Store(int64(len(page.Deliveries)))
 		}
 	}()
 	wg.Wait()
@@ -417,7 +417,7 @@ func TestStoreConcurrentExpireAndLeaseLeavesAtMostOneCloser(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if int(leased.Load())+len(page.Deliveries) > 1 {
+	if leased.Load()+int64(len(page.Deliveries)) > 1 {
 		t.Fatalf("expired work was leased after close leased=%d later=%d", leased.Load(), len(page.Deliveries))
 	}
 	if pending := quotaInstallCounters(t, store); pending.Count > 1 {

--- a/internal/relay/store_retention_test.go
+++ b/internal/relay/store_retention_test.go
@@ -1,0 +1,649 @@
+package relay
+
+import (
+	"encoding/json"
+	"errors"
+	"path/filepath"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func tightRetention(maxAge, retention, batch int) RetentionConfig {
+	return RetentionConfig{PendingMaxAgeSeconds: maxAge, TerminalRetentionSeconds: retention, MaintenanceBatch: batch}
+}
+
+func TestRetentionConfigRejectsOutOfBoundsValues(t *testing.T) {
+	cfg := DefaultRetentionConfig()
+	cfg.PendingMaxAgeSeconds = 0
+	if err := cfg.Validate(); err == nil {
+		t.Fatal("zero pending max age was accepted")
+	}
+	cfg = DefaultRetentionConfig()
+	cfg.TerminalRetentionSeconds = RetentionAgeMaxSeconds + 1
+	if err := cfg.Validate(); err == nil {
+		t.Fatal("oversized terminal retention was accepted")
+	}
+	cfg = DefaultRetentionConfig()
+	cfg.MaintenanceBatch = 0
+	if err := cfg.Validate(); err == nil {
+		t.Fatal("zero maintenance batch was accepted")
+	}
+}
+
+func TestStoreExpiresAtPendingAgeBoundary(t *testing.T) {
+	t.Parallel()
+	store := openRetentionStore(t, tightRetention(60, 3600, 10))
+	now := retentionNow()
+	conversation := createQuotaConversation(t, store, now, "machine-a", "machine-b", "agent/a", "agent/b")
+	first, _, err := store.AppendMessage(quotaAppend(conversation, "machine-a", "agent/a", "one", "send-1", now))
+	if err != nil {
+		t.Fatal(err)
+	}
+	justBefore := now.Add(60*time.Second - time.Millisecond)
+	before, err := store.MaintainDeliveries(justBefore)
+	if err != nil || before.Expired != 0 {
+		t.Fatalf("just before expiry result=%#v err=%v", before, err)
+	}
+	if pending := quotaInstallCounters(t, store); pending.Count != 1 {
+		t.Fatalf("pending before expiry=%#v", pending)
+	}
+	atBoundary, err := store.MaintainDeliveries(now.Add(60 * time.Second))
+	if err != nil || atBoundary.Expired != 1 {
+		t.Fatalf("at expiry result=%#v err=%v", atBoundary, err)
+	}
+	if pending := quotaInstallCounters(t, store); pending != (QuotaCounters{}) {
+		t.Fatalf("pending after expiry=%#v", pending)
+	}
+	page, err := store.LeaseDeliveries("machine-b", "consumer-b", "agent/b", conversation.ID, now.Add(61*time.Second), time.Minute, 10)
+	if err != nil || len(page.Deliveries) != 0 {
+		t.Fatalf("expired delivery was leased page=%#v err=%v", page, err)
+	}
+	cursor, err := store.RecipientCursor("machine-b", "agent/b", conversation.ID, now.Add(61*time.Second))
+	if err != nil || cursor != first.Sequence {
+		t.Fatalf("expired cursor=%d want=%d err=%v", cursor, first.Sequence, err)
+	}
+	after, err := store.MaintainDeliveries(now.Add(61 * time.Second))
+	if err != nil || after.Expired != 0 {
+		t.Fatalf("after expiry result=%#v err=%v", after, err)
+	}
+}
+
+func TestStoreMaintainDeliveriesPagesWithStableContinuation(t *testing.T) {
+	t.Parallel()
+	store := openRetentionStore(t, tightRetention(60, 3600, 2))
+	now := retentionNow()
+	conversation := createQuotaConversation(t, store, now, "machine-a", "machine-b", "agent/a", "agent/b")
+	for i, key := range []string{"send-1", "send-2", "send-3"} {
+		if _, _, err := store.AppendMessage(quotaAppend(conversation, "machine-a", "agent/a", key, key, now.Add(time.Duration(i)*time.Millisecond))); err != nil {
+			t.Fatal(err)
+		}
+	}
+	later := now.Add(61 * time.Second)
+	first, err := store.MaintainDeliveries(later)
+	if err != nil || first.Expired != 2 || first.Scanned < 2 {
+		t.Fatalf("first page=%#v err=%v", first, err)
+	}
+	if pending := quotaInstallCounters(t, store); pending.Count != 1 {
+		t.Fatalf("pending after first page=%#v", pending)
+	}
+	second, err := store.MaintainDeliveries(later)
+	if err != nil || second.Expired != 1 {
+		t.Fatalf("second page=%#v err=%v", second, err)
+	}
+	if pending := quotaInstallCounters(t, store); pending != (QuotaCounters{}) {
+		t.Fatalf("pending after second page=%#v", pending)
+	}
+	third, err := store.MaintainDeliveries(later)
+	if err != nil || third.Expired != 0 {
+		t.Fatalf("empty continuation=%#v err=%v", third, err)
+	}
+}
+
+func TestStoreExpiryReleasesCapacityOnce(t *testing.T) {
+	t.Parallel()
+	store := openRetentionStore(t, tightRetention(60, 3600, 10))
+	now := retentionNow()
+	conversation := createQuotaConversation(t, store, now, "machine-a", "machine-b", "agent/a", "agent/b")
+	if _, _, err := store.AppendMessage(quotaAppend(conversation, "machine-a", "agent/a", "one", "send-1", now)); err != nil {
+		t.Fatal(err)
+	}
+	later := now.Add(61 * time.Second)
+	first, err := store.MaintainDeliveries(later)
+	if err != nil || first.Expired != 1 {
+		t.Fatalf("first expire=%#v err=%v", first, err)
+	}
+	second, err := store.MaintainDeliveries(later)
+	if err != nil || second.Expired != 0 {
+		t.Fatalf("repeat expire=%#v err=%v", second, err)
+	}
+	if pending := quotaInstallCounters(t, store); pending != (QuotaCounters{}) {
+		t.Fatalf("quota after repeat expire=%#v", pending)
+	}
+	if _, _, err := store.AppendMessage(quotaAppend(conversation, "machine-a", "agent/a", "two", "send-2", later)); err != nil {
+		t.Fatal(err)
+	}
+	if pending := quotaInstallCounters(t, store); pending.Count != 1 {
+		t.Fatalf("quota after reuse=%#v", pending)
+	}
+}
+
+func TestStoreExpiredActiveLeaseCannotAck(t *testing.T) {
+	t.Parallel()
+	store := openRetentionStore(t, tightRetention(60, 3600, 10))
+	now := retentionNow()
+	conversation := createQuotaConversation(t, store, now, "machine-a", "machine-b", "agent/a", "agent/b")
+	if _, _, err := store.AppendMessage(quotaAppend(conversation, "machine-a", "agent/a", "one", "send-1", now)); err != nil {
+		t.Fatal(err)
+	}
+	page, err := store.LeaseDeliveries("machine-b", "consumer-b", "agent/b", conversation.ID, now, time.Minute, 10)
+	if err != nil || len(page.Deliveries) != 1 {
+		t.Fatalf("lease=%#v err=%v", page, err)
+	}
+	if _, err := store.MaintainDeliveries(now.Add(61 * time.Second)); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.AckDelivery("machine-b", "agent/b", page.Deliveries[0].ID, page.Deliveries[0].LeaseToken, page.Deliveries[0].LeaseGeneration, now.Add(61*time.Second)); !errors.Is(err, ErrForbidden) {
+		t.Fatalf("expired lease ack err=%v", err)
+	}
+	if pending := quotaInstallCounters(t, store); pending != (QuotaCounters{}) {
+		t.Fatalf("quota after forbidden ack=%#v", pending)
+	}
+}
+
+func TestStoreExpiredGapThenAckAdvancesContiguousCursor(t *testing.T) {
+	t.Parallel()
+	store := openRetentionStore(t, tightRetention(60, 3600, 10))
+	now := retentionNow()
+	conversation := createQuotaConversation(t, store, now, "machine-a", "machine-b", "agent/a", "agent/b")
+	first, _, err := store.AppendMessage(quotaAppend(conversation, "machine-a", "agent/a", "one", "send-1", now))
+	if err != nil {
+		t.Fatal(err)
+	}
+	secondAt := now.Add(30 * time.Second)
+	second, _, err := store.AppendMessage(quotaAppend(conversation, "machine-a", "agent/a", "two", "send-2", secondAt))
+	if err != nil {
+		t.Fatal(err)
+	}
+	expireAt := now.Add(60 * time.Second)
+	result, err := store.MaintainDeliveries(expireAt)
+	if err != nil || result.Expired != 1 {
+		t.Fatalf("expire older only result=%#v err=%v", result, err)
+	}
+	cursor, err := store.RecipientCursor("machine-b", "agent/b", conversation.ID, expireAt)
+	if err != nil || cursor != first.Sequence {
+		t.Fatalf("cursor after expired gap=%d want=%d err=%v", cursor, first.Sequence, err)
+	}
+	page, err := store.LeaseDeliveries("machine-b", "consumer-b", "agent/b", conversation.ID, expireAt, time.Minute, 10)
+	if err != nil || len(page.Deliveries) != 1 || page.Deliveries[0].Message.ID != second.ID {
+		t.Fatalf("remaining lease=%#v err=%v", page, err)
+	}
+	if err := store.AckDelivery("machine-b", "agent/b", page.Deliveries[0].ID, page.Deliveries[0].LeaseToken, page.Deliveries[0].LeaseGeneration, expireAt); err != nil {
+		t.Fatal(err)
+	}
+	cursor, err = store.RecipientCursor("machine-b", "agent/b", conversation.ID, expireAt)
+	if err != nil || cursor != second.Sequence {
+		t.Fatalf("cursor after ack across expired gap=%d want=%d err=%v", cursor, second.Sequence, err)
+	}
+}
+
+func TestStoreExpiryDoesNotAdvanceAnotherRecipient(t *testing.T) {
+	t.Parallel()
+	store := openRetentionStore(t, tightRetention(60, 3600, 10))
+	now := retentionNow()
+	if err := store.AdvertiseEndpoints("machine-a", []string{"agent/a"}, now, time.Hour); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.AdvertiseEndpoints("machine-b", []string{"agent/b"}, now, time.Hour); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.AdvertiseEndpoints("machine-c", []string{"agent/c"}, now, time.Hour); err != nil {
+		t.Fatal(err)
+	}
+	conversation, err := store.CreateConversation("agent/a", []Member{
+		{Endpoint: "agent/a", Capabilities: CapSend | CapReceive | CapAdmin},
+		{Endpoint: "agent/b", Capabilities: CapSend | CapReceive},
+		{Endpoint: "agent/c", Capabilities: CapReceive},
+	}, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	first, _, err := store.AppendMessage(quotaAppend(conversation, "machine-a", "agent/a", "one", "send-1", now))
+	if err != nil {
+		t.Fatal(err)
+	}
+	secondAt := now.Add(30 * time.Second)
+	if _, _, err := store.AppendMessage(quotaAppend(conversation, "machine-a", "agent/a", "two", "send-2", secondAt)); err != nil {
+		t.Fatal(err)
+	}
+	expireAt := now.Add(60 * time.Second)
+	if _, err := store.MaintainDeliveries(expireAt); err != nil {
+		t.Fatal(err)
+	}
+	page, err := store.LeaseDeliveries("machine-c", "consumer-c", "agent/c", conversation.ID, expireAt, time.Minute, 10)
+	if err != nil || len(page.Deliveries) != 1 {
+		t.Fatalf("recipient c remaining lease=%#v err=%v", page, err)
+	}
+	if err := store.AckDelivery("machine-c", "agent/c", page.Deliveries[0].ID, page.Deliveries[0].LeaseToken, page.Deliveries[0].LeaseGeneration, expireAt); err != nil {
+		t.Fatal(err)
+	}
+	cursorB, err := store.RecipientCursor("machine-b", "agent/b", conversation.ID, expireAt)
+	if err != nil || cursorB != first.Sequence {
+		t.Fatalf("recipient b cursor=%d want=%d err=%v", cursorB, first.Sequence, err)
+	}
+	cursorC, err := store.RecipientCursor("machine-c", "agent/c", conversation.ID, expireAt)
+	if err != nil || cursorC != 2 {
+		t.Fatalf("recipient c cursor=%d err=%v", cursorC, err)
+	}
+	pageB, err := store.LeaseDeliveries("machine-b", "consumer-b", "agent/b", conversation.ID, expireAt, time.Minute, 10)
+	if err != nil || len(pageB.Deliveries) != 1 || pageB.Deliveries[0].Message.Sequence != 2 {
+		t.Fatalf("recipient b remaining=%#v err=%v", pageB, err)
+	}
+}
+
+func TestStoreTargetedRoleExpiryDoesNotAffectSessionRecipient(t *testing.T) {
+	t.Parallel()
+	store := openRetentionStore(t, tightRetention(60, 3600, 10))
+	now := retentionNow()
+	if err := store.AdvertiseEndpoints("machine-a", []string{"agent/a"}, now, time.Hour); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.AdvertiseEndpoints("machine-b", []string{"agent/b"}, now, time.Hour); err != nil {
+		t.Fatal(err)
+	}
+	conversation, err := store.CreateConversation("agent/a", []Member{
+		{Endpoint: "agent/a", Capabilities: CapSend | CapReceive | CapAdmin},
+		{Endpoint: "agent/b", Capabilities: CapReceive},
+		{Role: "role/reviewer", RoleMachineID: "machine-b", Capabilities: CapReceive},
+	}, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.BindRoleToSession("machine-b", "role/reviewer", "agent/b", now, time.Hour); err != nil {
+		t.Fatal(err)
+	}
+	first, _, err := store.AppendMessage(AppendInput{
+		ConversationID: conversation.ID, SenderMachineID: "machine-a", FromEndpoint: "agent/a",
+		TargetRole: "role/reviewer", Body: "review", IdempotencyKey: "role-1", Now: now,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := quotaRecipientCounters(t, store, "agent/b"); got != (QuotaCounters{}) {
+		t.Fatalf("session recipient charged for targeted role send: %#v", got)
+	}
+	expireAt := now.Add(60 * time.Second)
+	result, err := store.MaintainDeliveries(expireAt)
+	if err != nil || result.Expired != 1 {
+		t.Fatalf("role expiry=%#v err=%v", result, err)
+	}
+	if pending := quotaRecipientCounters(t, store, roleRecipient("role/reviewer")); pending != (QuotaCounters{}) {
+		t.Fatalf("role quota after expiry=%#v", pending)
+	}
+	page, err := store.LeaseDeliveries("machine-b", "consumer-b", "agent/b", conversation.ID, expireAt, time.Minute, 10)
+	if err != nil || len(page.Deliveries) != 0 {
+		t.Fatalf("expired role delivery was leased page=%#v err=%v", page, err)
+	}
+	cursor, err := store.RecipientCursor("machine-b", "agent/b", conversation.ID, expireAt)
+	if err != nil || cursor != first.Sequence {
+		t.Fatalf("role cursor=%d want=%d err=%v", cursor, first.Sequence, err)
+	}
+}
+
+func TestStoreRevocationWritesTerminalAndReleasesOnce(t *testing.T) {
+	t.Parallel()
+	metrics := &Metrics{}
+	store := openRetentionStore(t, tightRetention(60, 3600, 10))
+	store.SetMetrics(metrics)
+	now := retentionNow()
+	conversation := createQuotaConversation(t, store, now, "machine-a", "machine-b", "agent/a", "agent/b")
+	if _, _, err := store.AppendMessage(quotaAppend(conversation, "machine-a", "agent/a", "one", "send-1", now)); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := store.ApplyControl(ControlInput{
+		ConversationID: conversation.ID, ActorMachineID: "machine-a", ActorEndpoint: "agent/a",
+		Operation: ControlRemoveMember, Member: Member{Endpoint: "agent/b"}, IdempotencyKey: "revoke-1", Now: now,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if pending := quotaInstallCounters(t, store); pending != (QuotaCounters{}) {
+		t.Fatalf("quota after revoke=%#v", pending)
+	}
+	snap := metrics.Snapshot()
+	if snap.RelayTerminalTransitionsRevoked != 1 || snap.RelayPendingDeliveries != 0 {
+		t.Fatalf("revoked metrics=%#v", snap)
+	}
+	page, err := store.ListTerminalDeliveries("", 10)
+	if err != nil || len(page.Terminals) != 1 || page.Terminals[0].ClosedReason != ClosedRevoked {
+		t.Fatalf("revoked terminals=%#v err=%v", page, err)
+	}
+	if _, err := store.MaintainDeliveries(now.Add(61 * time.Second)); err != nil {
+		t.Fatal(err)
+	}
+	if pending := quotaInstallCounters(t, store); pending != (QuotaCounters{}) {
+		t.Fatalf("quota after expire of revoked=%#v", pending)
+	}
+}
+
+func TestStorePrunesTerminalsAfterRetention(t *testing.T) {
+	t.Parallel()
+	store := openRetentionStore(t, tightRetention(60, 120, 10))
+	now := retentionNow()
+	conversation := createQuotaConversation(t, store, now, "machine-a", "machine-b", "agent/a", "agent/b")
+	if _, _, err := store.AppendMessage(quotaAppend(conversation, "machine-a", "agent/a", "secret-body", "send-1", now)); err != nil {
+		t.Fatal(err)
+	}
+	expireAt := now.Add(61 * time.Second)
+	if _, err := store.MaintainDeliveries(expireAt); err != nil {
+		t.Fatal(err)
+	}
+	listed, err := store.ListTerminalDeliveries("", 10)
+	if err != nil || len(listed.Terminals) != 1 || listed.Terminals[0].ClosedReason != ClosedExpired {
+		t.Fatalf("retained terminals=%#v err=%v", listed, err)
+	}
+	encoded, err := json.Marshal(listed)
+	if err != nil || strings.Contains(string(encoded), "secret-body") || strings.Contains(string(encoded), `"body"`) {
+		t.Fatalf("operator listing leaked body encoded=%s err=%v", encoded, err)
+	}
+	beforePrune, err := store.MaintainDeliveries(expireAt.Add(119 * time.Second))
+	if err != nil || beforePrune.Pruned != 0 {
+		t.Fatalf("before retention prune=%#v err=%v", beforePrune, err)
+	}
+	pruned, err := store.MaintainDeliveries(expireAt.Add(120 * time.Second))
+	if err != nil || pruned.Pruned != 1 {
+		t.Fatalf("at retention prune=%#v err=%v", pruned, err)
+	}
+	empty, err := store.ListTerminalDeliveries("", 10)
+	if err != nil || len(empty.Terminals) != 0 {
+		t.Fatalf("pruned listing=%#v err=%v", empty, err)
+	}
+}
+
+func TestStoreListTerminalsPagesWithoutBodies(t *testing.T) {
+	t.Parallel()
+	store := openRetentionStore(t, tightRetention(60, 3600, 10))
+	now := retentionNow()
+	conversation := createQuotaConversation(t, store, now, "machine-a", "machine-b", "agent/a", "agent/b")
+	for i, key := range []string{"alpha-body", "beta-body"} {
+		if _, _, err := store.AppendMessage(quotaAppend(conversation, "machine-a", "agent/a", key, key, now.Add(time.Duration(i)*time.Millisecond))); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if _, err := store.MaintainDeliveries(now.Add(61 * time.Second)); err != nil {
+		t.Fatal(err)
+	}
+	first, err := store.ListTerminalDeliveries("", 1)
+	if err != nil || len(first.Terminals) != 1 || first.NextCursor == "" {
+		t.Fatalf("first page=%#v err=%v", first, err)
+	}
+	second, err := store.ListTerminalDeliveries(first.NextCursor, 1)
+	if err != nil || len(second.Terminals) != 1 || first.Terminals[0].DeliveryID == second.Terminals[0].DeliveryID {
+		t.Fatalf("second page=%#v first=%#v err=%v", second, first, err)
+	}
+	for _, record := range append(first.Terminals, second.Terminals...) {
+		if record.ClosedReason != ClosedExpired || record.MessageID == "" || record.ConversationID == "" || record.RecipientID == "" || record.Sequence < 1 {
+			t.Fatalf("terminal metadata=%#v", record)
+		}
+	}
+}
+
+func TestStoreConcurrentExpireAndLeaseLeavesAtMostOneCloser(t *testing.T) {
+	t.Parallel()
+	store := openRetentionStore(t, tightRetention(60, 3600, 10))
+	now := retentionNow()
+	conversation := createQuotaConversation(t, store, now, "machine-a", "machine-b", "agent/a", "agent/b")
+	if _, _, err := store.AppendMessage(quotaAppend(conversation, "machine-a", "agent/a", "one", "send-1", now)); err != nil {
+		t.Fatal(err)
+	}
+	later := now.Add(61 * time.Second)
+	var wg sync.WaitGroup
+	var leased atomic.Int32
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		_, _ = store.MaintainDeliveries(later)
+	}()
+	go func() {
+		defer wg.Done()
+		page, err := store.LeaseDeliveries("machine-b", "consumer-b", "agent/b", conversation.ID, later, time.Minute, 10)
+		if err == nil {
+			leased.Store(int32(len(page.Deliveries)))
+		}
+	}()
+	wg.Wait()
+	page, err := store.LeaseDeliveries("machine-b", "consumer-b", "agent/b", conversation.ID, later.Add(time.Second), time.Minute, 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if int(leased.Load())+len(page.Deliveries) > 1 {
+		t.Fatalf("expired work was leased after close leased=%d later=%d", leased.Load(), len(page.Deliveries))
+	}
+	if pending := quotaInstallCounters(t, store); pending.Count > 1 {
+		t.Fatalf("quota after concurrent expire/lease=%#v", pending)
+	}
+}
+
+func TestStoreConcurrentExpireAndAckCannotDoubleRelease(t *testing.T) {
+	t.Parallel()
+	store := openRetentionStore(t, tightRetention(60, 3600, 10))
+	now := retentionNow()
+	conversation := createQuotaConversation(t, store, now, "machine-a", "machine-b", "agent/a", "agent/b")
+	if _, _, err := store.AppendMessage(quotaAppend(conversation, "machine-a", "agent/a", "one", "send-1", now)); err != nil {
+		t.Fatal(err)
+	}
+	page, err := store.LeaseDeliveries("machine-b", "consumer-b", "agent/b", conversation.ID, now, time.Minute, 10)
+	if err != nil || len(page.Deliveries) != 1 {
+		t.Fatalf("lease=%#v err=%v", page, err)
+	}
+	later := now.Add(61 * time.Second)
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		_, _ = store.MaintainDeliveries(later)
+	}()
+	go func() {
+		defer wg.Done()
+		_ = store.AckDelivery("machine-b", "agent/b", page.Deliveries[0].ID, page.Deliveries[0].LeaseToken, page.Deliveries[0].LeaseGeneration, later)
+	}()
+	wg.Wait()
+	if pending := quotaInstallCounters(t, store); pending != (QuotaCounters{}) {
+		t.Fatalf("quota after concurrent close=%#v", pending)
+	}
+	if _, _, err := store.AppendMessage(quotaAppend(conversation, "machine-a", "agent/a", "two", "send-2", later)); err != nil {
+		t.Fatal(err)
+	}
+	if pending := quotaInstallCounters(t, store); pending.Count != 1 {
+		t.Fatalf("quota after reuse=%#v", pending)
+	}
+}
+
+func TestStoreRetentionSurvivesRestart(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "relay.db")
+	store, err := Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cfg := tightRetention(60, 120, 10)
+	if err := store.SetRetentionPolicy(cfg); err != nil {
+		t.Fatal(err)
+	}
+	now := retentionNow()
+	conversation := createQuotaConversation(t, store, now, "machine-a", "machine-b", "agent/a", "agent/b")
+	if _, _, err := store.AppendMessage(quotaAppend(conversation, "machine-a", "agent/a", "one", "send-1", now)); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatal(err)
+	}
+	restarted, err := Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = restarted.Close() })
+	if err := restarted.SetRetentionPolicy(cfg); err != nil {
+		t.Fatal(err)
+	}
+	result, err := restarted.MaintainDeliveries(now.Add(61 * time.Second))
+	if err != nil || result.Expired != 1 {
+		t.Fatalf("restart expire=%#v err=%v", result, err)
+	}
+	listed, err := restarted.ListTerminalDeliveries("", 10)
+	if err != nil || len(listed.Terminals) != 1 || listed.Terminals[0].ClosedReason != ClosedExpired {
+		t.Fatalf("restart terminals=%#v err=%v", listed, err)
+	}
+}
+
+func TestStoreMetricsAreContentFreeAndBounded(t *testing.T) {
+	t.Parallel()
+	metrics := &Metrics{}
+	store := openRetentionStore(t, tightRetention(60, 3600, 10))
+	store.SetMetrics(metrics)
+	now := retentionNow()
+	conversation := createQuotaConversation(t, store, now, "machine-a", "machine-b", "agent/a", "agent/b")
+	if _, _, err := store.AppendMessage(quotaAppend(conversation, "machine-a", "agent/a", "secret-body", "send-1", now)); err != nil {
+		t.Fatal(err)
+	}
+	page, err := store.LeaseDeliveries("machine-b", "consumer-b", "agent/b", conversation.ID, now, time.Second, 10)
+	if err != nil || len(page.Deliveries) != 1 {
+		t.Fatalf("lease=%#v err=%v", page, err)
+	}
+	if _, err := store.LeaseDeliveries("machine-b", "consumer-b", "agent/b", conversation.ID, now.Add(2*time.Second), time.Second, 10); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.MaintainDeliveries(now.Add(61 * time.Second)); err != nil {
+		t.Fatal(err)
+	}
+	snap := metrics.Snapshot()
+	if snap.RelayPendingDeliveries != 0 || snap.RelayPendingOldestAgeSeconds != 0 || snap.RelayTerminalTransitionsExpired != 1 || snap.RelayTerminalsRetained != 1 || snap.RelayLeaseRedeliveries != 1 {
+		t.Fatalf("metrics=%#v", snap)
+	}
+	encoded, err := json.Marshal(snap)
+	if err != nil || strings.Contains(string(encoded), "secret-body") || strings.Contains(string(encoded), "agent/b") || strings.Contains(string(encoded), conversation.ID) {
+		t.Fatalf("metric snapshot leaked identifiers encoded=%s err=%v", encoded, err)
+	}
+}
+
+func TestStoreTwoAgentDistinctLoopIsBoundedAcrossRestart(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "relay.db")
+	store, err := Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rate := RateLimitConfig{SenderBurst: 1, SenderRefillPerMinute: 60, ConversationBurst: 2, ConversationRefillPerMinute: 60, RetryAfterMaxSeconds: 9}
+	quota := tightQuota(1, 1024, 2, 4096)
+	retention := tightRetention(60, 3600, 10)
+	if err := store.SetRateLimits(rate); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.SetQuotaLimits(quota); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.SetRetentionPolicy(retention); err != nil {
+		t.Fatal(err)
+	}
+	now := retentionNow()
+	if err := store.AdvertiseEndpoints("machine-a", []string{"agent/a"}, now, time.Hour); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.AdvertiseEndpoints("machine-b", []string{"agent/b"}, now, time.Hour); err != nil {
+		t.Fatal(err)
+	}
+	conversation, err := store.CreateConversation("agent/a", []Member{
+		{Endpoint: "agent/a", Capabilities: CapSend | CapReceive | CapAdmin},
+		{Endpoint: "agent/b", Capabilities: CapSend | CapReceive},
+	}, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	first, _, err := store.AppendMessage(quotaAppend(conversation, "machine-a", "agent/a", "ping-1", "a-1", now))
+	if err != nil {
+		t.Fatal(err)
+	}
+	reply, _, err := store.AppendMessage(quotaAppend(conversation, "machine-b", "agent/b", "pong-1", "b-1", now))
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, _, err = store.AppendMessage(quotaAppend(conversation, "machine-a", "agent/a", "ping-2", "a-2", now))
+	assertRateLimited(t, err, 1)
+	retry, duplicate, err := store.AppendMessage(quotaAppend(conversation, "machine-a", "agent/a", "ping-1", "a-1", now))
+	if err != nil || !duplicate || retry.ID != first.ID {
+		t.Fatalf("idempotent retry=%#v duplicate=%t err=%v", retry, duplicate, err)
+	}
+	refilled := now.Add(time.Second)
+	_, _, err = store.AppendMessage(quotaAppend(conversation, "machine-a", "agent/a", "ping-2", "a-2", refilled))
+	assertCapacityExceeded(t, err, 9)
+	if err := store.Close(); err != nil {
+		t.Fatal(err)
+	}
+	restarted, err := Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = restarted.Close() })
+	if err := restarted.SetRateLimits(rate); err != nil {
+		t.Fatal(err)
+	}
+	if err := restarted.SetQuotaLimits(quota); err != nil {
+		t.Fatal(err)
+	}
+	if err := restarted.SetRetentionPolicy(retention); err != nil {
+		t.Fatal(err)
+	}
+	_, _, err = restarted.AppendMessage(quotaAppend(conversation, "machine-a", "agent/a", "ping-2", "a-2", refilled))
+	assertCapacityExceeded(t, err, 9)
+	expireAt := now.Add(60 * time.Second)
+	result, err := restarted.MaintainDeliveries(expireAt)
+	if err != nil || result.Expired != 2 {
+		t.Fatalf("loop expiry=%#v err=%v", result, err)
+	}
+	if pending := quotaInstallCounters(t, restarted); pending != (QuotaCounters{}) {
+		t.Fatalf("quota after loop expiry=%#v", pending)
+	}
+	cursorA, err := restarted.RecipientCursor("machine-a", "agent/a", conversation.ID, expireAt)
+	if err != nil || cursorA != reply.Sequence {
+		t.Fatalf("after expiry agent a cursor=%d want=%d err=%v", cursorA, reply.Sequence, err)
+	}
+	cursorB, err := restarted.RecipientCursor("machine-b", "agent/b", conversation.ID, expireAt)
+	if err != nil || cursorB != reply.Sequence {
+		t.Fatalf("after expiry agent b cursor=%d want=%d err=%v", cursorB, reply.Sequence, err)
+	}
+	third, _, err := restarted.AppendMessage(quotaAppend(conversation, "machine-a", "agent/a", "ping-3", "a-3", expireAt))
+	if err != nil {
+		t.Fatal(err)
+	}
+	cursorA, err = restarted.RecipientCursor("machine-a", "agent/a", conversation.ID, expireAt)
+	if err != nil || cursorA != third.Sequence {
+		t.Fatalf("sender cursor=%d want=%d err=%v", cursorA, third.Sequence, err)
+	}
+	cursorB, err = restarted.RecipientCursor("machine-b", "agent/b", conversation.ID, expireAt)
+	if err != nil || cursorB != reply.Sequence {
+		t.Fatalf("pending recipient cursor=%d want=%d err=%v", cursorB, reply.Sequence, err)
+	}
+	if third.Sequence != 3 {
+		t.Fatalf("sequence after bounded loop=%d", third.Sequence)
+	}
+}
+
+func openRetentionStore(t *testing.T, cfg RetentionConfig) *Store {
+	t.Helper()
+	store, err := Open(filepath.Join(t.TempDir(), "relay.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	if err := store.SetRetentionPolicy(cfg); err != nil {
+		t.Fatal(err)
+	}
+	return store
+}
+
+func retentionNow() time.Time {
+	return time.Date(2026, time.August, 18, 20, 0, 0, 0, time.UTC)
+}

--- a/internal/relay/store_retention_test.go
+++ b/internal/relay/store_retention_test.go
@@ -548,6 +548,39 @@ func TestStoreRetentionSurvivesRestart(t *testing.T) {
 	}
 }
 
+func TestStorePartialExpireFailurePublishesCommittedMetrics(t *testing.T) {
+	t.Parallel()
+	metrics := &Metrics{}
+	store := openRetentionStore(t, tightRetention(60, 3600, 10))
+	store.SetMetrics(metrics)
+	now := retentionNow()
+	conversation := createQuotaConversation(t, store, now, "machine-a", "machine-b", "agent/a", "agent/b")
+	for i, key := range []string{"send-1", "send-2"} {
+		if _, _, err := store.AppendMessage(quotaAppend(conversation, "machine-a", "agent/a", key, key, now.Add(time.Duration(i)*time.Millisecond))); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if _, err := store.db.Exec(`CREATE TRIGGER fail_second_terminal BEFORE INSERT ON delivery_terminals
+		WHEN (SELECT COUNT(*) FROM delivery_terminals) >= 1
+		BEGIN SELECT RAISE(ABORT, 'injected terminal insert failure'); END`); err != nil {
+		t.Fatal(err)
+	}
+	result, err := store.MaintainDeliveries(now.Add(61 * time.Second))
+	if err == nil {
+		t.Fatal("expected injected expire failure")
+	}
+	if result.Expired != 1 {
+		t.Fatalf("committed expires=%#v", result)
+	}
+	if pending := quotaInstallCounters(t, store); pending.Count != 1 {
+		t.Fatalf("pending after partial expire=%#v", pending)
+	}
+	snap := metrics.Snapshot()
+	if snap.RelayTerminalTransitionsExpired != 1 || snap.RelayPendingDeliveries != 1 || snap.RelayTerminalsRetained != 1 {
+		t.Fatalf("partial expire dropped metrics=%#v", snap)
+	}
+}
+
 func TestStoreMetricsAreContentFreeAndBounded(t *testing.T) {
 	t.Parallel()
 	metrics := &Metrics{}

--- a/internal/relay/store_retention_test.go
+++ b/internal/relay/store_retention_test.go
@@ -102,6 +102,56 @@ func TestStoreMaintainDeliveriesPagesWithStableContinuation(t *testing.T) {
 	}
 }
 
+func TestStoreMaintainDeliveriesPersistsPartialPageAcrossRestart(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "relay.db")
+	store, err := Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.SetRetentionPolicy(tightRetention(60, 3600, 2)); err != nil {
+		_ = store.Close()
+		t.Fatal(err)
+	}
+	now := retentionNow()
+	conversation := createQuotaConversation(t, store, now, "machine-a", "machine-b", "agent/a", "agent/b")
+	for i, key := range []string{"send-1", "send-2", "send-3"} {
+		if _, _, err := store.AppendMessage(quotaAppend(conversation, "machine-a", "agent/a", key, key, now.Add(time.Duration(i)*time.Millisecond))); err != nil {
+			_ = store.Close()
+			t.Fatal(err)
+		}
+	}
+	later := now.Add(61 * time.Second)
+	first, err := store.MaintainDeliveries(later)
+	if err != nil || first.Expired != 2 {
+		_ = store.Close()
+		t.Fatalf("first page=%#v err=%v", first, err)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatal(err)
+	}
+	restarted, err := Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = restarted.Close() })
+	if err := restarted.SetRetentionPolicy(tightRetention(60, 3600, 2)); err != nil {
+		t.Fatal(err)
+	}
+	if pending := quotaInstallCounters(t, restarted); pending.Count != 1 {
+		t.Fatalf("pending after restart=%#v", pending)
+	}
+	listed, err := restarted.ListTerminalDeliveries("", 10)
+	if err != nil || len(listed.Terminals) != 2 {
+		t.Fatalf("terminals after restart=%#v err=%v", listed, err)
+	}
+	second, err := restarted.MaintainDeliveries(later)
+	if err != nil || second.Expired != 1 {
+		t.Fatalf("second page after restart=%#v err=%v", second, err)
+	}
+}
+
 func TestStoreExpiryReleasesCapacityOnce(t *testing.T) {
 	t.Parallel()
 	store := openRetentionStore(t, tightRetention(60, 3600, 10))


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements #151 (final child of #145). Pending deliveries older than a startup-validated maximum age transition atomically to content-free terminal `expired` state, release pending capacity exactly once, and advance only that recipient's contiguous cursor. Acked and revoked deliveries write the same terminal metadata. A separate retention window then prunes those rows in bounded pages.

Ordinary agent HTTP does not expose dead-letter inventory or delivery receipts. Sender-facing append remains accepted/queued or rejected only.

## Policy

Startup-validated:

- `PUNARO_RELAY_PENDING_MAX_AGE_SECONDS` (default 7 days)
- `PUNARO_RELAY_TERMINAL_RETENTION_SECONDS` (default 30 days)
- `PUNARO_RELAY_DELIVERY_MAINTENANCE_BATCH` (default 100, 1..1000)

Inclusive expiry uses message `created_at` and injected/database time. `punarod` runs one maintenance page per minute. Host-local `punaro relay list-terminals` and `punaro relay maintain-deliveries --yes` inspect and trigger that work. CLI maintenance loads those three keys from the selected installation env file only; process environment values cannot shorten the pending-age window.

Closed reasons are `acked`, `expired`, and `revoked`. Terminal rows keep opaque IDs, sequence, closed reason, lease generation, and timestamps; they never duplicate bodies or credentials.

## Persistence

SQLite `delivery_terminals` and PostgreSQL `relay.mail_delivery_terminals` (schema 49). Terminal tables are derived operational state like quota counters: inspect/fingerprint ignore them, abort still deletes them, and they are not cutover content. `punaro_app` still has no DELETE on `mail_deliveries`. Each expire and prune uses its own five-second relay transaction. A later timeout cannot roll back earlier terminal transitions or quota release.

## Tests added first

- Boundary just before/at/after expiry
- Bounded batch and stable continuation
- Exact-once capacity release
- Expired active lease cannot later ack
- Expired gap then acknowledged work
- Independent recipients for one message
- Targeted-role expiry does not charge or expire the session endpoint
- Revoke writes a terminal and releases once
- Terminal retention and bounded prune
- Operator listing contains no body
- Concurrent expiry/lease/ack
- Restart-safe policy and counters
- Content-free metrics including oldest pending age
- Partial expire failure still publishes committed transition and pending gauges
- CLI maintenance ignores process env overrides of the installation file
- Sustained two-agent distinct-body loop across restart (parent #145)
- HTTP 404 for `/v1/terminals`, `/v1/deliveries/terminals`, `/v1/dead-letters`
- SQLite/PostgreSQL contract coverage

## Metrics

Unlabeled:

- `relay_pending_deliveries` / `relay_pending_bytes`
- `relay_pending_oldest_age_seconds`
- `relay_terminal_transitions_acked` / `_expired` / `_revoked`
- `relay_terminals_retained`
- `relay_lease_redeliveries`

## Vibe check vs #151 DoD

- Pending and terminal retention policies are explicit, startup-validated, and documented in `DESIGN.md`, `docs/alpha-text-relay.md`, `docs/operator-guide.md`, and `.env.example`.
- Bounded maintenance, host-local inspection (`punaro relay list-terminals`, `punaro relay maintain-deliveries --yes`), and unlabeled metrics are implemented. Agent HTTP has no dead-letter or receipt surface.
- Capacity is released exactly once; expired-lease ack is refused; cursor advance is recipient-local and covered by tests, including an expired gap followed by acknowledged work.
- Existing at-least-once delivery, idempotency, role targeting, and contiguous cursor tests remain in the suite. Targeted-role expiry does not charge or expire session endpoint `agent/b`.
- Recurring daemon maintenance failures log a content-free line; CLI destructive maintenance uses the installation file, not the operator shell env.

## Out of scope

No body hashing, no semantic loop detection, no agent-facing receipts.

Closes #151
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ae307e24-e2ba-46c8-a5ba-36466fe6c73d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ae307e24-e2ba-46c8-a5ba-36466fe6c73d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

