### PR TITLE
Add terminal retention, dead-letter inspection, and queue-age metrics

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -44,6 +44,12 @@ PUNARO_LOG_LEVEL=info
 # PUNARO_RELAY_PENDING_INSTALLATION_COUNT=100000
 # PUNARO_RELAY_PENDING_INSTALLATION_BYTES=268435456
 # PUNARO_RELAY_PENDING_RETRY_AFTER_SECONDS=60
+# Pending-delivery maximum age and content-free terminal retention. Defaults are
+# seven days pending and thirty days of closed metadata. Values must be integers
+# in 1..31536000 (365 days). Maintenance pages must be integers in 1..1000.
+# PUNARO_RELAY_PENDING_MAX_AGE_SECONDS=604800
+# PUNARO_RELAY_TERMINAL_RETENTION_SECONDS=2592000
+# PUNARO_RELAY_DELIVERY_MAINTENANCE_BATCH=100
 # Legacy attachment v2/v3, directory, and permit variables are retired. Their
 # presence, including an empty value or `false`, makes punarod fail startup.
 # Use only the trusted-relay surface and native client documented below.

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -430,7 +430,20 @@ message, delivery, idempotency, or audit row. Explicit counters are updated in
 the append transaction; the send path does not scan pending deliveries.
 Startup and readiness verify counter consistency or fail closed. The operator
 `punaro relay reconcile-capacity` command uses a repair opener that preserves
-that fail-closed path while rebuilding drifted counters. Bodies are
+that fail-closed path while rebuilding drifted counters. Pending deliveries
+older than a startup-validated maximum age (default seven days) transition
+atomically from pending to terminal `expired`, release that capacity once, and
+advance only that recipient's contiguous cursor. Closed metadata is retained
+for a separate bounded window (default thirty days) and pruned in bounded
+pages. Retained rows contain only opaque message, conversation, and recipient
+IDs, sequence, closed reason (`acked`, `expired`, or `revoked`), lease
+generation, and timestamps. They never duplicate bodies or credentials.
+Maintenance uses injected or database time and a startup-validated page size.
+Host-local `punaro relay list-terminals` lists one bounded page;
+`punaro relay maintain-deliveries --yes` runs one expire-then-prune page using
+the installation `punarod.env` policy so the CLI cannot silently undercut the
+daemon. Ordinary agent APIs do not expose dead-letter inventory or delivery
+receipts; sender-facing append remains accepted/queued or rejected. Bodies are
 never hashed, compared, or parsed for loop detection.
 
 The guarantee is **at-least-once delivery**: a crash after a
@@ -490,7 +503,10 @@ deliveries plus a map of conversation IDs to the recipient's highest contiguous
 acknowledged sequence. Every recipient has an independent
 delivery stream; a delivery has a short server-enforced lease, lease generation,
 and lease token. A lease that expires without an acknowledgement becomes
-available again. The recipient must tolerate duplicate delivery by durably
+available again. An aged pending delivery that maintenance marks `expired` is
+no longer pending, so it advances only that recipient's contiguous cursor and
+cannot be acknowledged with a prior lease token. Expiry never mutates another
+recipient's cursor or creates a hole behind an earlier still-pending delivery. The recipient must tolerate duplicate delivery by durably
 recording the Punaro message UUID before local injection, or by using it as the
 local mailbox idempotency key.
 
@@ -1466,7 +1482,11 @@ adds explicit pending-delivery capacity counters per recipient identity and
 installation-wide. Quota tables are derived operational
 state, not cutover content: inspect and fingerprint ignore them, and activation
 rebuilds them from pending deliveries. Capacity denial is distinct from rate
-limiting. Expiry and dead-letter policies remain later slices.
+limiting. Schema version 49 adds content-free `mail_delivery_terminals` rows
+for acked, expired, and revoked deliveries. That inventory is operational
+state, not cutover content: inspect requires the table, fingerprint ignores it,
+and abort deletes it before deliveries because of the foreign key. Pending-age
+and terminal-retention bounds are startup-validated daemon configuration.
 
 The supported cutover action is `punaro mail cutover`. Its dry-run reads the
 service-owned `relay.db` from the installation data directory and prints the

--- a/cmd/punaro/main.go
+++ b/cmd/punaro/main.go
@@ -373,6 +373,12 @@ func run(args []string, stdout, stderr io.Writer) int {
 		if len(args) > 1 && args[1] == "reconcile-capacity" {
 			return runRelayReconcileCapacity(args[2:], stdout, stderr, reconcileRelayCapacity)
 		}
+		if len(args) > 1 && args[1] == "list-terminals" {
+			return runRelayListTerminals(args[2:], stdout, stderr, listRelayTerminals)
+		}
+		if len(args) > 1 && args[1] == "maintain-deliveries" {
+			return runRelayMaintainDeliveries(args[2:], stdout, stderr, maintainRelayDeliveries)
+		}
 	case "backup":
 		return runBackup(args[1:], stdout, stderr)
 	case "restore":

--- a/cmd/punaro/relay_command.go
+++ b/cmd/punaro/relay_command.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/rock3r/punaro/internal/config"
 	"github.com/rock3r/punaro/internal/operator"
 	punaropostgres "github.com/rock3r/punaro/internal/postgres"
 	"github.com/rock3r/punaro/internal/relay"
@@ -125,4 +126,102 @@ func reconcileRelayCapacity(directory string) (relay.QuotaCounters, error) {
 	}
 	defer func() { _ = store.Close() }()
 	return relay.ReconcilePendingQuota(store)
+}
+
+type relayListTerminalsCommand func(string, relay.TerminalListInput) (relay.TerminalListPage, error)
+
+func runRelayListTerminals(args []string, stdout, stderr io.Writer, list relayListTerminalsCommand) int {
+	flags := flag.NewFlagSet("relay list-terminals", flag.ContinueOnError)
+	flags.SetOutput(stderr)
+	directory := flags.String("directory", "", "absolute Punaro installation directory")
+	limit := flags.Int("limit", 0, "bounded terminal page size")
+	cursor := flags.String("cursor", "", "opaque terminal list cursor")
+	if flags.Parse(args) != nil || flags.NArg() != 0 || *directory == "" || list == nil {
+		return 2
+	}
+	page, err := list(*directory, relay.TerminalListInput{Cursor: *cursor, Limit: *limit})
+	if err != nil {
+		_, _ = fmt.Fprintln(stderr, "relay terminal listing did not complete; rerun the exact command to recover safely")
+		return 1
+	}
+	payload := map[string]any{"status": "terminals_listed", "directory": *directory, "terminals": page.Terminals}
+	if page.NextCursor != "" {
+		payload["next_cursor"] = page.NextCursor
+	}
+	return writeJSON(stdout, stderr, payload)
+}
+
+type relayMaintainDeliveriesCommand func(string) (relay.MaintenanceResult, error)
+
+func runRelayMaintainDeliveries(args []string, stdout, stderr io.Writer, maintain relayMaintainDeliveriesCommand) int {
+	flags := flag.NewFlagSet("relay maintain-deliveries", flag.ContinueOnError)
+	flags.SetOutput(stderr)
+	directory := flags.String("directory", "", "absolute Punaro installation directory")
+	confirmed := flags.Bool("yes", false, "confirm bounded pending-age expiry and terminal prune")
+	if flags.Parse(args) != nil || flags.NArg() != 0 || *directory == "" || !*confirmed || maintain == nil {
+		return 2
+	}
+	result, err := maintain(*directory)
+	if err != nil {
+		_, _ = fmt.Fprintln(stderr, "relay delivery maintenance did not complete; rerun the exact command to recover safely")
+		return 1
+	}
+	return writeJSON(stdout, stderr, map[string]any{"status": "deliveries_maintained", "directory": *directory, "expired": result.Expired, "pruned": result.Pruned, "continuation": result.Continuation})
+}
+
+type relayTerminalStore interface {
+	SetRetentionPolicy(relay.RetentionConfig) error
+	MaintainDeliveries(time.Time) (relay.MaintenanceResult, error)
+	ListDeliveryTerminals(relay.TerminalListInput) (relay.TerminalListPage, error)
+	Close() error
+}
+
+func listRelayTerminals(directory string, input relay.TerminalListInput) (relay.TerminalListPage, error) {
+	store, err := openRelayTerminalStore(directory)
+	if err != nil {
+		return relay.TerminalListPage{}, err
+	}
+	defer func() { _ = store.Close() }()
+	return store.ListDeliveryTerminals(input)
+}
+
+func maintainRelayDeliveries(directory string) (relay.MaintenanceResult, error) {
+	cfg, err := config.Load(operator.EnvFile(directory))
+	if err != nil {
+		return relay.MaintenanceResult{}, err
+	}
+	store, err := openRelayTerminalStore(directory)
+	if err != nil {
+		return relay.MaintenanceResult{}, err
+	}
+	defer func() { _ = store.Close() }()
+	policy := cfg.RelayRetentionPolicy()
+	if policy == (relay.RetentionConfig{}) {
+		policy = relay.DefaultRetentionConfig()
+	}
+	if err := store.SetRetentionPolicy(policy); err != nil {
+		return relay.MaintenanceResult{}, err
+	}
+	return store.MaintainDeliveries(time.Now().UTC())
+}
+
+func openRelayTerminalStore(directory string) (relayTerminalStore, error) {
+	installation, err := operator.Load(directory)
+	if err != nil {
+		return nil, err
+	}
+	if installation.MailCutover != nil {
+		ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+		defer cancel()
+		database, err := punaropostgres.OpenApplication(ctx, punaropostgres.Config{DSNFile: installation.AppDSNFile})
+		if err != nil {
+			return nil, err
+		}
+		return database, nil
+	}
+	path := filepath.Join(installation.DataDir, "relay.db")
+	if _, err := os.Stat(path); err != nil {
+		return nil, errors.New("relay terminal store is unavailable")
+	}
+	return relay.Open(path)
 }

--- a/cmd/punaro/relay_command.go
+++ b/cmd/punaro/relay_command.go
@@ -226,10 +226,14 @@ func openRelayTerminalStore(directory string) (relayTerminalStore, error) {
 }
 
 func relayUsesPostgres(installation operator.Installation, store string) bool {
-	if strings.EqualFold(strings.TrimSpace(store), "postgres") {
+	switch strings.ToLower(strings.TrimSpace(store)) {
+	case "postgres":
 		return true
+	case "sqlite":
+		return false
+	default:
+		return installation.RelayEnabled || installation.MailCutover != nil
 	}
-	return installation.RelayEnabled || installation.MailCutover != nil
 }
 
 func retentionPolicyFromEnvFile(path string) (relay.RetentionConfig, error) {

--- a/cmd/punaro/relay_command.go
+++ b/cmd/punaro/relay_command.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bufio"
 	"context"
 	"crypto/ed25519"
 	"errors"
@@ -9,9 +10,10 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strconv"
+	"strings"
 	"time"
 
-	"github.com/rock3r/punaro/internal/config"
 	"github.com/rock3r/punaro/internal/operator"
 	punaropostgres "github.com/rock3r/punaro/internal/postgres"
 	"github.com/rock3r/punaro/internal/relay"
@@ -186,7 +188,7 @@ func listRelayTerminals(directory string, input relay.TerminalListInput) (relay.
 }
 
 func maintainRelayDeliveries(directory string) (relay.MaintenanceResult, error) {
-	cfg, err := config.Load(operator.EnvFile(directory))
+	policy, err := retentionPolicyFromEnvFile(operator.EnvFile(directory))
 	if err != nil {
 		return relay.MaintenanceResult{}, err
 	}
@@ -195,10 +197,6 @@ func maintainRelayDeliveries(directory string) (relay.MaintenanceResult, error) 
 		return relay.MaintenanceResult{}, err
 	}
 	defer func() { _ = store.Close() }()
-	policy := cfg.RelayRetentionPolicy()
-	if policy == (relay.RetentionConfig{}) {
-		policy = relay.DefaultRetentionConfig()
-	}
 	if err := store.SetRetentionPolicy(policy); err != nil {
 		return relay.MaintenanceResult{}, err
 	}
@@ -210,7 +208,8 @@ func openRelayTerminalStore(directory string) (relayTerminalStore, error) {
 	if err != nil {
 		return nil, err
 	}
-	if installation.MailCutover != nil {
+	storeName, _ := dotenvValue(operator.EnvFile(directory), "PUNARO_RELAY_STORE")
+	if relayUsesPostgres(installation, storeName) {
 		ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 		defer cancel()
 		database, err := punaropostgres.OpenApplication(ctx, punaropostgres.Config{DSNFile: installation.AppDSNFile})
@@ -224,4 +223,78 @@ func openRelayTerminalStore(directory string) (relayTerminalStore, error) {
 		return nil, errors.New("relay terminal store is unavailable")
 	}
 	return relay.Open(path)
+}
+
+func relayUsesPostgres(installation operator.Installation, store string) bool {
+	if strings.EqualFold(strings.TrimSpace(store), "postgres") {
+		return true
+	}
+	return installation.RelayEnabled || installation.MailCutover != nil
+}
+
+func retentionPolicyFromEnvFile(path string) (relay.RetentionConfig, error) {
+	cfg := relay.DefaultRetentionConfig()
+	values, err := readDotEnvMap(path)
+	if err != nil {
+		return relay.RetentionConfig{}, err
+	}
+	if raw, ok := values["PUNARO_RELAY_PENDING_MAX_AGE_SECONDS"]; ok {
+		n, err := strconv.Atoi(raw)
+		if err != nil || n < relay.RetentionAgeMinSeconds || n > relay.RetentionAgeMaxSeconds {
+			return relay.RetentionConfig{}, fmt.Errorf("PUNARO_RELAY_PENDING_MAX_AGE_SECONDS must be an integer between %d and %d", relay.RetentionAgeMinSeconds, relay.RetentionAgeMaxSeconds)
+		}
+		cfg.PendingMaxAgeSeconds = n
+	}
+	if raw, ok := values["PUNARO_RELAY_TERMINAL_RETENTION_SECONDS"]; ok {
+		n, err := strconv.Atoi(raw)
+		if err != nil || n < relay.RetentionKeepMinSeconds || n > relay.RetentionKeepMaxSeconds {
+			return relay.RetentionConfig{}, fmt.Errorf("PUNARO_RELAY_TERMINAL_RETENTION_SECONDS must be an integer between %d and %d", relay.RetentionKeepMinSeconds, relay.RetentionKeepMaxSeconds)
+		}
+		cfg.TerminalRetentionSeconds = n
+	}
+	if raw, ok := values["PUNARO_RELAY_DELIVERY_MAINTENANCE_BATCH"]; ok {
+		n, err := strconv.Atoi(raw)
+		if err != nil || n < relay.RetentionBatchMin || n > relay.RetentionBatchMax {
+			return relay.RetentionConfig{}, fmt.Errorf("PUNARO_RELAY_DELIVERY_MAINTENANCE_BATCH must be an integer between %d and %d", relay.RetentionBatchMin, relay.RetentionBatchMax)
+		}
+		cfg.MaintenanceBatch = n
+	}
+	if err := cfg.Validate(); err != nil {
+		return relay.RetentionConfig{}, err
+	}
+	return cfg, nil
+}
+
+func dotenvValue(path, key string) (string, error) {
+	values, err := readDotEnvMap(path)
+	if err != nil {
+		return "", err
+	}
+	return values[key], nil
+}
+
+func readDotEnvMap(path string) (map[string]string, error) {
+	file, err := os.Open(path) // #nosec G304 -- operator-chosen installation dotenv path.
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = file.Close() }()
+	values := map[string]string{}
+	scanner := bufio.NewScanner(file)
+	for line := 1; scanner.Scan(); line++ {
+		raw := strings.TrimSpace(scanner.Text())
+		if raw == "" || strings.HasPrefix(raw, "#") {
+			continue
+		}
+		key, value, found := strings.Cut(raw, "=")
+		key = strings.TrimSpace(strings.TrimPrefix(key, "export "))
+		if !found || key == "" || strings.ContainsAny(key, " \t") {
+			return nil, fmt.Errorf("parse dotenv file line %d", line)
+		}
+		values[key] = strings.Trim(strings.TrimSpace(value), "\"'")
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+	return values, nil
 }

--- a/cmd/punaro/relay_command_test.go
+++ b/cmd/punaro/relay_command_test.go
@@ -180,6 +180,19 @@ func TestRelayUsesPostgresWhenEnabledWithoutCutover(t *testing.T) {
 	}
 }
 
+func TestRelayUsesPostgresHonorsExplicitSQLite(t *testing.T) {
+	if relayUsesPostgres(operator.Installation{RelayEnabled: true}, "sqlite") {
+		t.Fatal("explicit sqlite store was ignored for a relay-enabled installation")
+	}
+	cutover := &operator.MailCutoverPublication{Version: 1}
+	if relayUsesPostgres(operator.Installation{RelayEnabled: true, MailCutover: cutover}, "sqlite") {
+		t.Fatal("explicit sqlite store was ignored during pre-cutover rollback")
+	}
+	if !relayUsesPostgres(operator.Installation{RelayEnabled: true}, "postgres") {
+		t.Fatal("explicit postgres store was ignored for a relay-enabled installation")
+	}
+}
+
 func TestRetentionPolicyFromInstallationEnvIgnoresProcessOverrides(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "punarod.env")
 	if err := os.WriteFile(path, []byte("PUNARO_RELAY_PENDING_MAX_AGE_SECONDS=60\nPUNARO_RELAY_TERMINAL_RETENTION_SECONDS=120\nPUNARO_RELAY_DELIVERY_MAINTENANCE_BATCH=7\n"), 0o600); err != nil {

--- a/cmd/punaro/relay_command_test.go
+++ b/cmd/punaro/relay_command_test.go
@@ -3,6 +3,8 @@ package main
 import (
 	"bytes"
 	"errors"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -163,5 +165,33 @@ func TestRelayMaintainDeliveriesPublishesContentFreeOutcome(t *testing.T) {
 		return relay.MaintenanceResult{}, errors.New("unsafe")
 	}); code != 1 || !bytes.Contains(stderr.Bytes(), []byte("rerun the exact command")) {
 		t.Fatalf("failure code=%d stderr=%q", code, stderr.String())
+	}
+}
+
+func TestRelayUsesPostgresWhenEnabledWithoutCutover(t *testing.T) {
+	if !relayUsesPostgres(operator.Installation{RelayEnabled: true}, "") {
+		t.Fatal("relay-enabled installation did not select postgres")
+	}
+	if relayUsesPostgres(operator.Installation{}, "") {
+		t.Fatal("sqlite-only installation selected postgres")
+	}
+	if !relayUsesPostgres(operator.Installation{}, "postgres") {
+		t.Fatal("explicit postgres store was ignored")
+	}
+}
+
+func TestRetentionPolicyFromInstallationEnvIgnoresProcessOverrides(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "punarod.env")
+	if err := os.WriteFile(path, []byte("PUNARO_RELAY_PENDING_MAX_AGE_SECONDS=60\nPUNARO_RELAY_TERMINAL_RETENTION_SECONDS=120\nPUNARO_RELAY_DELIVERY_MAINTENANCE_BATCH=7\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PUNARO_RELAY_PENDING_MAX_AGE_SECONDS", "1")
+	got, err := retentionPolicyFromEnvFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := relay.RetentionConfig{PendingMaxAgeSeconds: 60, TerminalRetentionSeconds: 120, MaintenanceBatch: 7}
+	if got != want {
+		t.Fatalf("policy=%#v want %#v", got, want)
 	}
 }

--- a/cmd/punaro/relay_command_test.go
+++ b/cmd/punaro/relay_command_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/rock3r/punaro/internal/operator"
@@ -85,6 +86,81 @@ func TestRelayReconcileCapacityPublishesContentFreeOutcome(t *testing.T) {
 	}
 	if code := runRelayReconcileCapacity([]string{"--directory", "/install", "--yes"}, &stdout, &stderr, func(string) (relay.QuotaCounters, error) {
 		return relay.QuotaCounters{}, errors.New("unsafe")
+	}); code != 1 || !bytes.Contains(stderr.Bytes(), []byte("rerun the exact command")) {
+		t.Fatalf("failure code=%d stderr=%q", code, stderr.String())
+	}
+}
+
+func TestRelayListTerminalsIsReadOnlyAndContentFree(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	called := false
+	list := func(directory string, input relay.TerminalListInput) (relay.TerminalListPage, error) {
+		called = directory == "/install" && input.Limit == 2 && input.Cursor == "next"
+		return relay.TerminalListPage{
+			Terminals: []relay.DeliveryTerminal{{
+				DeliveryID:     "delivery-1",
+				MessageID:      "message-1",
+				ConversationID: "conversation-1",
+				RecipientID:    "agent/b",
+				Sequence:       1,
+				ClosedReason:   relay.ClosedReasonExpired,
+			}},
+			NextCursor: "later",
+		}, nil
+	}
+	if code := runRelayListTerminals([]string{"--directory", "/install", "--limit", "2", "--cursor", "next", "--yes"}, &stdout, &stderr, list); code != 2 || called {
+		t.Fatalf("unexpected --yes code=%d called=%t", code, called)
+	}
+	stdout.Reset()
+	stderr.Reset()
+	if code := runRelayListTerminals([]string{"--directory", "/install", "--limit", "2", "--cursor", "next"}, &stdout, &stderr, list); code != 0 || !called {
+		t.Fatalf("code=%d called=%t stdout=%q stderr=%q", code, called, stdout.String(), stderr.String())
+	}
+	body := stdout.String()
+	if !bytes.Contains(stdout.Bytes(), []byte(`"terminals_listed"`)) || !bytes.Contains(stdout.Bytes(), []byte(`"closed_reason": "expired"`)) || !bytes.Contains(stdout.Bytes(), []byte(`"next_cursor": "later"`)) {
+		t.Fatalf("stdout=%q", body)
+	}
+	if strings.Contains(body, "body") || strings.Contains(body, "secret") {
+		t.Fatalf("operator list leaked content: %s", body)
+	}
+	if code := runRelayListTerminals([]string{"--directory", "/install"}, &stdout, &stderr, func(string, relay.TerminalListInput) (relay.TerminalListPage, error) {
+		return relay.TerminalListPage{}, errors.New("unsafe")
+	}); code != 1 || !bytes.Contains(stderr.Bytes(), []byte("rerun the exact command")) {
+		t.Fatalf("failure code=%d stderr=%q", code, stderr.String())
+	}
+}
+
+func TestRelayMaintainDeliveriesRequiresConfirmation(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	called := false
+	maintain := func(string) (relay.MaintenanceResult, error) {
+		called = true
+		return relay.MaintenanceResult{}, nil
+	}
+	if code := runRelayMaintainDeliveries([]string{"--directory", "/install"}, &stdout, &stderr, maintain); code != 2 || called {
+		t.Fatalf("unconfirmed code=%d called=%t", code, called)
+	}
+}
+
+func TestRelayMaintainDeliveriesPublishesContentFreeOutcome(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	called := false
+	maintain := func(directory string) (relay.MaintenanceResult, error) {
+		called = directory == "/install"
+		return relay.MaintenanceResult{Expired: 2, Pruned: 1, Continuation: true}, nil
+	}
+	if code := runRelayMaintainDeliveries([]string{"--directory", "/install", "--yes"}, &stdout, &stderr, maintain); code != 0 || !called {
+		t.Fatalf("code=%d called=%t stdout=%q stderr=%q", code, called, stdout.String(), stderr.String())
+	}
+	body := stdout.String()
+	if !bytes.Contains(stdout.Bytes(), []byte(`"deliveries_maintained"`)) || !bytes.Contains(stdout.Bytes(), []byte(`"expired": 2`)) || !bytes.Contains(stdout.Bytes(), []byte(`"continuation": true`)) {
+		t.Fatalf("stdout=%q", body)
+	}
+	if strings.Contains(body, "body") {
+		t.Fatalf("operator maintain leaked content: %s", body)
+	}
+	if code := runRelayMaintainDeliveries([]string{"--directory", "/install", "--yes"}, &stdout, &stderr, func(string) (relay.MaintenanceResult, error) {
+		return relay.MaintenanceResult{}, errors.New("unsafe")
 	}); code != 1 || !bytes.Contains(stderr.Bytes(), []byte("rerun the exact command")) {
 		t.Fatalf("failure code=%d stderr=%q", code, stderr.String())
 	}

--- a/cmd/punarod/main.go
+++ b/cmd/punarod/main.go
@@ -213,6 +213,13 @@ func run(args []string, stderr io.Writer) int {
 	if relayStore != nil {
 		defer func() { _ = relayStore.Close() }()
 	}
+	maintainCtx, maintainCancel := context.WithCancel(context.Background())
+	defer maintainCancel()
+	if maintainer := relayDeliveryMaintainer(relayStore, postgresRelay); maintainer != nil {
+		ticker := time.NewTicker(deliveryMaintenanceInterval)
+		defer ticker.Stop()
+		go runDeliveryMaintenance(maintainCtx, maintainer, ticker.C)
+	}
 	relayMetricsSnapshot := func() relay.MetricsSnapshot { return relay.MetricsSnapshot{} }
 	if provider, ok := relayHandler.(interface{ MetricsSnapshot() relay.MetricsSnapshot }); ok {
 		relayMetricsSnapshot = provider.MetricsSnapshot
@@ -764,6 +771,20 @@ func buildRelayHandler(cfg config.Config, postgresBackends ...relay.Backend) (ht
 			return nil, nil, err
 		}
 	}
+	if setter, ok := backend.(interface {
+		SetRetentionPolicy(relay.RetentionConfig) error
+	}); ok {
+		policy := cfg.RelayRetentionPolicy()
+		if policy == (relay.RetentionConfig{}) {
+			policy = relay.DefaultRetentionConfig()
+		}
+		if err := setter.SetRetentionPolicy(policy); err != nil {
+			if store != nil {
+				_ = store.Close()
+			}
+			return nil, nil, err
+		}
+	}
 	metrics := &relay.Metrics{}
 	var authenticator *relay.Authenticator
 	if cfg.CredentialTransitionEnabled {
@@ -805,6 +826,39 @@ type relayMetricsHandler struct {
 
 func (h relayMetricsHandler) MetricsSnapshot() relay.MetricsSnapshot {
 	return h.metrics.Snapshot()
+}
+
+const deliveryMaintenanceInterval = time.Minute
+
+type deliveryMaintainer interface {
+	MaintainDeliveries(time.Time) (relay.MaintenanceResult, error)
+}
+
+func relayDeliveryMaintainer(store *relay.Store, postgresBackend relay.Backend) deliveryMaintainer {
+	if store != nil {
+		return store
+	}
+	if maintainer, ok := postgresBackend.(deliveryMaintainer); ok {
+		return maintainer
+	}
+	return nil
+}
+
+func runDeliveryMaintenance(ctx context.Context, maintainer deliveryMaintainer, ticks <-chan time.Time) {
+	if maintainer == nil {
+		return
+	}
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case now, ok := <-ticks:
+			if !ok {
+				return
+			}
+			_, _ = maintainer.MaintainDeliveries(now.UTC())
+		}
+	}
 }
 
 func newAccessVerifier(cfg config.Config) (*access.Verifier, error) {

--- a/cmd/punarod/relay_test.go
+++ b/cmd/punarod/relay_test.go
@@ -524,3 +524,95 @@ func TestBuildDirectoryHandlerRequiresValidPrivateSnapshot(t *testing.T) {
 		t.Fatal("missing snapshot source accepted")
 	}
 }
+
+func TestBuildRelayHandlerRejectsInvalidRetentionPolicy(t *testing.T) {
+	_, store, err := buildRelayHandler(config.Config{
+		DataDir:                       t.TempDir(),
+		RelayEnabled:                  true,
+		RelayMachinesJSON:             `[{"id":"machine-a","public_key":"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA","endpoint_prefixes":["agent/a/"]}]`,
+		RelayPendingMaxAgeSeconds:     0,
+		RelayTerminalRetentionSeconds: 30,
+		RelayDeliveryMaintenanceBatch: 10,
+	})
+	if err == nil {
+		if store != nil {
+			_ = store.Close()
+		}
+		t.Fatal("invalid retention policy enabled relay routes")
+	}
+}
+
+func TestBuildRelayHandlerAppliesRetentionPolicy(t *testing.T) {
+	_, store, err := buildRelayHandler(config.Config{
+		DataDir:                       t.TempDir(),
+		RelayEnabled:                  true,
+		RelayMachinesJSON:             `[{"id":"machine-a","public_key":"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA","endpoint_prefixes":["agent/a/"]},{"id":"machine-b","public_key":"AgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI","endpoint_prefixes":["agent/b/"]}]`,
+		RelayPendingMaxAgeSeconds:     60,
+		RelayTerminalRetentionSeconds: 3600,
+		RelayDeliveryMaintenanceBatch: 10,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	now := time.Date(2026, time.August, 18, 21, 0, 0, 0, time.UTC)
+	if err := store.AdvertiseEndpoints("machine-a", []string{"agent/a/session"}, now, time.Hour); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.AdvertiseEndpoints("machine-b", []string{"agent/b/session"}, now, time.Hour); err != nil {
+		t.Fatal(err)
+	}
+	conversation, err := store.CreateConversation("agent/a/session", []relay.Member{
+		{Endpoint: "agent/a/session", Capabilities: relay.CapSend | relay.CapReceive | relay.CapAdmin},
+		{Endpoint: "agent/b/session", Capabilities: relay.CapReceive},
+	}, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := store.AppendMessage(relay.AppendInput{ConversationID: conversation.ID, SenderMachineID: "machine-a", FromEndpoint: "agent/a/session", Body: "aged", IdempotencyKey: "aged-1", Now: now}); err != nil {
+		t.Fatal(err)
+	}
+	if result, err := store.MaintainDeliveries(now.Add(60*time.Second - time.Millisecond)); err != nil || result.Expired != 0 {
+		t.Fatalf("default policy would not expire this early: result=%#v err=%v", result, err)
+	}
+	if result, err := store.MaintainDeliveries(now.Add(60 * time.Second)); err != nil || result.Expired != 1 {
+		t.Fatalf("configured max age did not expire result=%#v err=%v", result, err)
+	}
+}
+
+type deliveryMaintainerStub struct {
+	calls chan time.Time
+}
+
+func (s *deliveryMaintainerStub) MaintainDeliveries(now time.Time) (relay.MaintenanceResult, error) {
+	s.calls <- now
+	return relay.MaintenanceResult{}, nil
+}
+
+func TestDeliveryMaintenanceTickInvokesMaintainer(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	stub := &deliveryMaintainerStub{calls: make(chan time.Time, 1)}
+	ticks := make(chan time.Time, 1)
+	done := make(chan struct{})
+	go func() {
+		runDeliveryMaintenance(ctx, stub, ticks)
+		close(done)
+	}()
+	tick := time.Date(2026, time.August, 18, 21, 1, 0, 0, time.UTC)
+	ticks <- tick
+	select {
+	case got := <-stub.calls:
+		if !got.Equal(tick.UTC()) {
+			t.Fatalf("maintainer now=%s want %s", got, tick.UTC())
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("maintenance tick was not delivered")
+	}
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("maintenance loop did not stop")
+	}
+}

--- a/docs/alpha-text-relay.md
+++ b/docs/alpha-text-relay.md
@@ -78,9 +78,21 @@ Override with `PUNARO_RELAY_PENDING_RECIPIENT_COUNT`,
 1..3600. Invalid values fail startup. A capacity-limited append is HTTP 429
 with integer `Retry-After` and the content-free error `capacity exceeded`,
 distinct from `rate limited`. Exact committed retries never reserve capacity
-again. The loopback health listener exposes `GET /metrics` with
+again. Pending deliveries older than seven days become terminal `expired` and
+release that capacity once; override with `PUNARO_RELAY_PENDING_MAX_AGE_SECONDS`.
+Closed metadata is retained for thirty days and pruned in pages of 100; override
+with `PUNARO_RELAY_TERMINAL_RETENTION_SECONDS` and
+`PUNARO_RELAY_DELIVERY_MAINTENANCE_BATCH`. Age and retention values must be
+integers in 1..31536000; batch values must be integers in 1..1000. Invalid
+values fail startup. Host-local `punaro relay list-terminals` and
+`punaro relay maintain-deliveries --yes` inspect and trigger that maintenance.
+No agent route exposes dead-letter inventory or delivery receipts. The loopback
+health listener exposes `GET /metrics` with
 `relay_rate_limit_rejections`, `relay_capacity_rejections`,
-`relay_pending_deliveries`, and `relay_pending_bytes` only; it has no body,
+`relay_pending_deliveries`, `relay_pending_bytes`,
+`relay_pending_oldest_age_seconds`, `relay_terminal_transitions_acked`,
+`relay_terminal_transitions_expired`, `relay_terminal_transitions_revoked`,
+`relay_terminals_retained`, and `relay_lease_redeliveries` only; it has no body,
 endpoint, role, or conversation labels.
 
 For a Cloudflare-protected remote route, additionally set the Access issuer,

--- a/docs/operator-guide.md
+++ b/docs/operator-guide.md
@@ -157,8 +157,8 @@ database and investigate. The digest-pinned `make test-postgres` stack is epheme
 test infrastructure, publishes no database port, and deletes its volume on
 exit.
 
-The current binary requires schema version 48 and supports an intact schema
-from version 10 through 48 as an update boundary. Versions 10 through 47 are
+The current binary requires schema version 49 and supports an intact schema
+from version 10 through 49 as an update boundary. Versions 10 through 48 are
 reported as `upgrade_required`; versions below the compatibility floor, newer
 versions, and damaged objects are `incompatible`. The embedded manifest and
 target release metadata are authoritative; check them instead of assuming a
@@ -168,12 +168,16 @@ migration 42 applies those controls to mail cutover, migration 43 adds the
 relay invocation capability, migration 44 adds client lifecycle authority,
 migration 45 adds opt-in canonical role profiles, migration 46 adds durable
 mail rate-limit buckets, migration 47 adds idempotent direct-role
-conversations, and migration 48 adds explicit pending-delivery capacity
-counters. After migration 48, `punaro relay reconcile-capacity
+conversations, migration 48 adds explicit pending-delivery capacity
+counters, and migration 49 adds content-free delivery-terminal inventory.
+After migration 48, `punaro relay reconcile-capacity
 --directory DIR --yes` rebuilds those counters from pending deliveries if
 startup readiness reports inconsistency. Ordinary SQLite `Open` and PostgreSQL
 `Ready` still fail closed on drift; the reconcile command is the only supported
-repair path.
+repair path. After migration 49, `punaro relay list-terminals --directory DIR`
+prints one bounded page of opaque terminal metadata, and
+`punaro relay maintain-deliveries --directory DIR --yes` runs one expire-then-prune
+page using the installation `punarod.env` pending-age and retention policy.
 Migration 44 invalidates unredeemed legacy enrollment invitations while
 converting existing device credentials into lifecycle-managed client records,
 so it must not be applied as an ad hoc repair. The host wrapper's one-shot

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -64,6 +64,9 @@ type Config struct {
 	RelayPendingInstallationCount        int
 	RelayPendingInstallationBytes        int64
 	RelayPendingRetryAfterSeconds        int
+	RelayPendingMaxAgeSeconds            int
+	RelayTerminalRetentionSeconds        int
+	RelayDeliveryMaintenanceBatch        int
 }
 
 // Load reads configuration and optionally loads an explicitly named dotenv file.
@@ -280,7 +283,20 @@ func Load(explicitEnvFile string) (Config, error) {
 	if err != nil {
 		return Config{}, err
 	}
-	return Config{ListenAddr: listenAddr, HealthListenAddr: healthListenAddr, DataDir: dataDir, LogLevel: level, RelayEnabled: relayEnabled, RelayMachinesJSON: relayMachines, RelayStore: relayStore, AccessIssuer: accessIssuer, AccessAudience: accessAudience, AccessJWKSURL: accessJWKSURL, AccessJWKSFile: accessJWKSFile, PostgresEnabled: postgresEnabled, PostgresDSNFile: postgresDSNFile, DeviceAuthEnabled: deviceAuthEnabled, MemoryAPIEnabled: memoryAPIEnabled, MemoryMutationsEnabled: memoryMutationsEnabled, RemoteMCPMetadataEnabled: remoteMCPMetadataEnabled, RemoteMCPResourceURL: remoteMCPResourceURL, RemoteMCPAuthorizationServers: remoteMCPAuthorizationServers, RemoteMCPTokenValidationEnabled: remoteMCPTokenValidationEnabled, RemoteMCPIssuer: remoteMCPIssuer, RemoteMCPJWKSURL: remoteMCPJWKSURL, RemoteMCPSubjectBindingsJSON: remoteMCPSubjectBindingsJSON, MemoryOpenAIEmbeddingsURL: memoryOpenAIEmbeddingsURL, MemoryOpenAIAPIKeyFile: memoryOpenAIAPIKeyFile, TrustedAttachmentsEnabled: trustedAttachmentsEnabled, TrustedAttachmentBlobDir: trustedAttachmentBlobDir, CredentialTransitionEnabled: credentialTransitionEnabled, IngressMode: ingressMode, PublicURL: publicURL, TrustedLANCIDR: trustedLANCIDR, TrustedLANHTTP: trustedLANHTTP, RelaySenderRateBurst: senderBurst, RelaySenderRateRefillPerMinute: senderRefill, RelayConversationRateBurst: conversationBurst, RelayConversationRateRefillPerMinute: conversationRefill, RelayRateRetryAfterMaxSeconds: retryAfterMax, RelayPendingRecipientCount: pendingRecipientCount, RelayPendingRecipientBytes: pendingRecipientBytes, RelayPendingInstallationCount: pendingInstallationCount, RelayPendingInstallationBytes: pendingInstallationBytes, RelayPendingRetryAfterSeconds: pendingRetryAfter}, nil
+	retentionDefaults := relay.DefaultRetentionConfig()
+	pendingMaxAge, err := parseBoundedInt("PUNARO_RELAY_PENDING_MAX_AGE_SECONDS", value("PUNARO_RELAY_PENDING_MAX_AGE_SECONDS", strconv.Itoa(retentionDefaults.PendingMaxAgeSeconds)), relay.RetentionAgeMinSeconds, relay.RetentionAgeMaxSeconds)
+	if err != nil {
+		return Config{}, err
+	}
+	terminalRetention, err := parseBoundedInt("PUNARO_RELAY_TERMINAL_RETENTION_SECONDS", value("PUNARO_RELAY_TERMINAL_RETENTION_SECONDS", strconv.Itoa(retentionDefaults.TerminalRetentionSeconds)), relay.RetentionKeepMinSeconds, relay.RetentionKeepMaxSeconds)
+	if err != nil {
+		return Config{}, err
+	}
+	maintenanceBatch, err := parseBoundedInt("PUNARO_RELAY_DELIVERY_MAINTENANCE_BATCH", value("PUNARO_RELAY_DELIVERY_MAINTENANCE_BATCH", strconv.Itoa(retentionDefaults.MaintenanceBatch)), relay.RetentionBatchMin, relay.RetentionBatchMax)
+	if err != nil {
+		return Config{}, err
+	}
+	return Config{ListenAddr: listenAddr, HealthListenAddr: healthListenAddr, DataDir: dataDir, LogLevel: level, RelayEnabled: relayEnabled, RelayMachinesJSON: relayMachines, RelayStore: relayStore, AccessIssuer: accessIssuer, AccessAudience: accessAudience, AccessJWKSURL: accessJWKSURL, AccessJWKSFile: accessJWKSFile, PostgresEnabled: postgresEnabled, PostgresDSNFile: postgresDSNFile, DeviceAuthEnabled: deviceAuthEnabled, MemoryAPIEnabled: memoryAPIEnabled, MemoryMutationsEnabled: memoryMutationsEnabled, RemoteMCPMetadataEnabled: remoteMCPMetadataEnabled, RemoteMCPResourceURL: remoteMCPResourceURL, RemoteMCPAuthorizationServers: remoteMCPAuthorizationServers, RemoteMCPTokenValidationEnabled: remoteMCPTokenValidationEnabled, RemoteMCPIssuer: remoteMCPIssuer, RemoteMCPJWKSURL: remoteMCPJWKSURL, RemoteMCPSubjectBindingsJSON: remoteMCPSubjectBindingsJSON, MemoryOpenAIEmbeddingsURL: memoryOpenAIEmbeddingsURL, MemoryOpenAIAPIKeyFile: memoryOpenAIAPIKeyFile, TrustedAttachmentsEnabled: trustedAttachmentsEnabled, TrustedAttachmentBlobDir: trustedAttachmentBlobDir, CredentialTransitionEnabled: credentialTransitionEnabled, IngressMode: ingressMode, PublicURL: publicURL, TrustedLANCIDR: trustedLANCIDR, TrustedLANHTTP: trustedLANHTTP, RelaySenderRateBurst: senderBurst, RelaySenderRateRefillPerMinute: senderRefill, RelayConversationRateBurst: conversationBurst, RelayConversationRateRefillPerMinute: conversationRefill, RelayRateRetryAfterMaxSeconds: retryAfterMax, RelayPendingRecipientCount: pendingRecipientCount, RelayPendingRecipientBytes: pendingRecipientBytes, RelayPendingInstallationCount: pendingInstallationCount, RelayPendingInstallationBytes: pendingInstallationBytes, RelayPendingRetryAfterSeconds: pendingRetryAfter, RelayPendingMaxAgeSeconds: pendingMaxAge, RelayTerminalRetentionSeconds: terminalRetention, RelayDeliveryMaintenanceBatch: maintenanceBatch}, nil
 }
 
 func parseBoundedInt(name, raw string, minimum, maximum int) (int, error) {
@@ -318,6 +334,15 @@ func (c Config) RelayQuotaLimits() relay.QuotaConfig {
 		InstallationCount: c.RelayPendingInstallationCount,
 		InstallationBytes: c.RelayPendingInstallationBytes,
 		RetryAfterSeconds: c.RelayPendingRetryAfterSeconds,
+	}
+}
+
+// RelayRetentionPolicy returns the startup-validated pending-age and terminal-retention bounds.
+func (c Config) RelayRetentionPolicy() relay.RetentionConfig {
+	return relay.RetentionConfig{
+		PendingMaxAgeSeconds:     c.RelayPendingMaxAgeSeconds,
+		TerminalRetentionSeconds: c.RelayTerminalRetentionSeconds,
+		MaintenanceBatch:         c.RelayDeliveryMaintenanceBatch,
 	}
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -3,6 +3,7 @@ package config
 import (
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -43,6 +44,9 @@ func TestLoadPostgresDefaultsDisabled(t *testing.T) {
 	}
 	if got, want := cfg.RelayQuotaLimits(), relay.DefaultQuotaConfig(); got != want {
 		t.Fatalf("unexpected default pending quota: %#v", got)
+	}
+	if got, want := cfg.RelayRetentionPolicy(), relay.DefaultRetentionConfig(); got != want {
+		t.Fatalf("unexpected default retention policy: %#v", got)
 	}
 }
 
@@ -587,5 +591,37 @@ func TestLoadAcceptsExplicitRelayQuotaLimits(t *testing.T) {
 	want := relay.QuotaConfig{RecipientCount: 2, RecipientBytes: 64, InstallationCount: 8, InstallationBytes: 256, RetryAfterSeconds: 9}
 	if got != want {
 		t.Fatalf("quota limits=%#v want %#v", got, want)
+	}
+}
+
+func TestLoadRejectsInvalidRelayRetentionPolicy(t *testing.T) {
+	t.Setenv("PUNARO_RELAY_PENDING_MAX_AGE_SECONDS", "0")
+	if _, err := Load(""); err == nil {
+		t.Fatal("zero pending max age was accepted")
+	}
+	t.Setenv("PUNARO_RELAY_PENDING_MAX_AGE_SECONDS", "604800")
+	t.Setenv("PUNARO_RELAY_TERMINAL_RETENTION_SECONDS", strconv.Itoa(relay.RetentionKeepMaxSeconds+1))
+	if _, err := Load(""); err == nil {
+		t.Fatal("oversized terminal retention was accepted")
+	}
+	t.Setenv("PUNARO_RELAY_TERMINAL_RETENTION_SECONDS", "2592000")
+	t.Setenv("PUNARO_RELAY_DELIVERY_MAINTENANCE_BATCH", "nope")
+	if _, err := Load(""); err == nil {
+		t.Fatal("non-integer delivery maintenance batch was accepted")
+	}
+}
+
+func TestLoadAcceptsExplicitRelayRetentionPolicy(t *testing.T) {
+	t.Setenv("PUNARO_RELAY_PENDING_MAX_AGE_SECONDS", "60")
+	t.Setenv("PUNARO_RELAY_TERMINAL_RETENTION_SECONDS", "120")
+	t.Setenv("PUNARO_RELAY_DELIVERY_MAINTENANCE_BATCH", "7")
+	cfg, err := Load("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := cfg.RelayRetentionPolicy()
+	want := relay.RetentionConfig{PendingMaxAgeSeconds: 60, TerminalRetentionSeconds: 120, MaintenanceBatch: 7}
+	if got != want {
+		t.Fatalf("retention policy=%#v want %#v", got, want)
 	}
 }

--- a/internal/postgres/db.go
+++ b/internal/postgres/db.go
@@ -37,6 +37,8 @@ type Database struct {
 	rateLimits                relay.RateLimitConfig
 	quotaMu                   sync.Mutex
 	quota                     relay.QuotaConfig
+	retentionMu               sync.Mutex
+	retention                 relay.RetentionConfig
 	pendingMetricsMu          sync.Mutex
 	metrics                   *relay.Metrics
 }
@@ -99,7 +101,7 @@ func OpenApplication(ctx context.Context, cfg Config) (*Database, error) {
 		return nil, err
 	}
 	database := &Database{
-		db: db, relayDB: relayDB, brainDB: brainDB, embeddingDB: embeddingDB, manifest: CurrentManifest(), rateLimits: relay.DefaultRateLimitConfig(), quota: relay.DefaultQuotaConfig(),
+		db: db, relayDB: relayDB, brainDB: brainDB, embeddingDB: embeddingDB, manifest: CurrentManifest(), rateLimits: relay.DefaultRateLimitConfig(), quota: relay.DefaultQuotaConfig(), retention: relay.DefaultRetentionConfig(),
 		attachmentPhysicalGCSlots: make(chan struct{}, 1),
 		memoryUsageWrites:         make(chan memoryUsageWrite, maxMemoryRecallQueue),
 		memoryUsageStop:           make(chan struct{}),
@@ -1287,6 +1289,13 @@ FROM objects, table_ownership, routine_safety, routine_acl, table_acl, schema_ac
 			return Snapshot{}, errors.New("PostgreSQL relay pending-quota schema cannot be inspected")
 		}
 		snapshot.CurrentObjectsPresent = quotaObjectsPresent
+	}
+	if snapshot.CurrentObjectsPresent && len(snapshot.Records) > 0 && snapshot.Records[len(snapshot.Records)-1].Version >= 49 {
+		terminalObjectsPresent, err := relayDeliveryTerminalsAvailable(ctx, q)
+		if err != nil {
+			return Snapshot{}, errors.New("PostgreSQL relay delivery-terminal schema cannot be inspected")
+		}
+		snapshot.CurrentObjectsPresent = terminalObjectsPresent
 	}
 	return snapshot, nil
 }

--- a/internal/postgres/mail_cutover.go
+++ b/internal/postgres/mail_cutover.go
@@ -312,7 +312,7 @@ func (a *Administration) AbortMailCutover(ctx context.Context, actorPrincipalID,
 		return errors.New("active mail cutover cannot be aborted")
 	}
 	if phase != MailCutoverAborted {
-		for _, table := range []string{"mail_pending_recipients", "mail_pending_install", "mail_direct_message_idempotency", "mail_message_from_roles", "mail_direct_conversations", "mail_request_nonces", "mail_rate_buckets", "mail_role_profile_idempotency", "mail_role_profiles", "mail_conversation_control_idempotency", "mail_conversation_controls", "mail_conversation_idempotency", "mail_message_idempotency", "mail_recipient_cursors", "mail_deliveries", "mail_messages", "mail_role_bindings", "mail_role_memberships", "mail_memberships", "mail_roles", "mail_conversations", "mail_endpoints"} {
+		for _, table := range []string{"mail_delivery_terminals", "mail_pending_recipients", "mail_pending_install", "mail_direct_message_idempotency", "mail_message_from_roles", "mail_direct_conversations", "mail_request_nonces", "mail_rate_buckets", "mail_role_profile_idempotency", "mail_role_profiles", "mail_conversation_control_idempotency", "mail_conversation_controls", "mail_conversation_idempotency", "mail_message_idempotency", "mail_recipient_cursors", "mail_deliveries", "mail_messages", "mail_role_bindings", "mail_role_memberships", "mail_memberships", "mail_roles", "mail_conversations", "mail_endpoints"} {
 			// #nosec G202 -- table comes only from the fixed dependency-order allowlist.
 			if _, err := tx.ExecContext(ctx, `DELETE FROM relay.`+table); err != nil {
 				return errors.New("mail cutover cannot be aborted")

--- a/internal/postgres/mail_cutover_test.go
+++ b/internal/postgres/mail_cutover_test.go
@@ -19,7 +19,7 @@ func (f mailCutoverScannerFunc) Scan(destinations ...any) error { return f(desti
 
 func TestMailCutoverEmptyTargetIgnoresDerivedQuotaTables(t *testing.T) {
 	t.Parallel()
-	if strings.Contains(mailCutoverEmptyTargetCountSQL, "mail_pending_recipients") || strings.Contains(mailCutoverEmptyTargetCountSQL, "mail_pending_install") {
+	if strings.Contains(mailCutoverEmptyTargetCountSQL, "mail_pending_recipients") || strings.Contains(mailCutoverEmptyTargetCountSQL, "mail_pending_install") || strings.Contains(mailCutoverEmptyTargetCountSQL, "mail_delivery_terminals") {
 		t.Fatal("pending quota tables are derived operational state and must not fence an empty cutover target")
 	}
 }

--- a/internal/postgres/migrate.go
+++ b/internal/postgres/migrate.go
@@ -81,6 +81,7 @@ var migrationCompatibilityFloors = map[int64]int64{
 	46: 10,
 	47: 10,
 	48: 10,
+	49: 10,
 }
 
 // CurrentManifest returns the immutable migrations embedded in this binary.

--- a/internal/postgres/migrations/049_mail_delivery_terminals.sql
+++ b/internal/postgres/migrations/049_mail_delivery_terminals.sql
@@ -1,0 +1,23 @@
+CREATE TABLE relay.mail_delivery_terminals (
+    delivery_id uuid PRIMARY KEY REFERENCES relay.mail_deliveries(id) ON DELETE CASCADE,
+    message_id uuid NOT NULL REFERENCES relay.mail_messages(id) ON DELETE CASCADE,
+    conversation_id uuid NOT NULL REFERENCES relay.mail_conversations(id) ON DELETE CASCADE,
+    recipient_id text NOT NULL CHECK (
+        char_length(recipient_id) >= 1 AND char_length(recipient_id) <= 512
+        AND octet_length(recipient_id) <= 2048
+    ),
+    sequence bigint NOT NULL CHECK (sequence >= 0),
+    closed_reason text NOT NULL CHECK (closed_reason IN ('acked', 'expired', 'revoked')),
+    lease_generation bigint NOT NULL CHECK (lease_generation >= 0),
+    closed_at timestamptz NOT NULL,
+    created_at timestamptz NOT NULL
+);
+
+CREATE INDEX mail_delivery_terminals_closed_at ON relay.mail_delivery_terminals (closed_at, delivery_id);
+
+CREATE TRIGGER mail_delivery_terminals_mutation_guard
+BEFORE INSERT OR UPDATE OR DELETE ON relay.mail_delivery_terminals
+FOR EACH STATEMENT EXECUTE FUNCTION relay.guard_mail_mutation();
+
+REVOKE ALL ON relay.mail_delivery_terminals FROM PUBLIC;
+GRANT SELECT, INSERT, DELETE ON relay.mail_delivery_terminals TO punaro_app;

--- a/internal/postgres/postgres_integration_test.go
+++ b/internal/postgres/postgres_integration_test.go
@@ -501,6 +501,7 @@ RETURNS boolean LANGUAGE plpgsql SECURITY DEFINER SET search_path=pg_catalog AS 
 	testRelayMembershipControlSchemaDrift(ctx, t, app, ownerDB)
 	testRelayRateLimitSchemaDrift(ctx, t, app, ownerDB)
 	testRelayPendingQuotaSchemaDrift(ctx, t, app, ownerDB)
+	testRelayDeliveryTerminalsSchemaDrift(ctx, t, app, ownerDB)
 	testRelayIntegration(t, app)
 	if err := app.Close(); err != nil {
 		t.Fatal(err)
@@ -1703,6 +1704,22 @@ func testRelayPendingQuotaSchemaDrift(ctx context.Context, t *testing.T, app *Da
 	}
 	if restored, err := app.SchemaState(ctx); err != nil || restored.Classification != Compatible {
 		t.Fatalf("restored pending-quota count constraint state=%#v err=%v", restored, err)
+	}
+}
+
+func testRelayDeliveryTerminalsSchemaDrift(ctx context.Context, t *testing.T, app *Database, ownerDB *sql.DB) {
+	t.Helper()
+	if _, err := ownerDB.ExecContext(ctx, `ALTER TABLE relay.mail_delivery_terminals DROP CONSTRAINT mail_delivery_terminals_closed_reason_check; ALTER TABLE relay.mail_delivery_terminals ADD CONSTRAINT mail_delivery_terminals_closed_reason_check CHECK (closed_reason IS NOT NULL)`); err != nil {
+		t.Fatal(err)
+	}
+	if drifted, err := app.SchemaState(ctx); err != nil || drifted.Classification != Incompatible {
+		t.Fatalf("permissive delivery-terminal closed-reason constraint state=%#v err=%v", drifted, err)
+	}
+	if _, err := ownerDB.ExecContext(ctx, `ALTER TABLE relay.mail_delivery_terminals DROP CONSTRAINT mail_delivery_terminals_closed_reason_check; ALTER TABLE relay.mail_delivery_terminals ADD CONSTRAINT mail_delivery_terminals_closed_reason_check CHECK (closed_reason = ANY (ARRAY['acked'::text, 'expired'::text, 'revoked'::text]))`); err != nil {
+		t.Fatal(err)
+	}
+	if restored, err := app.SchemaState(ctx); err != nil || restored.Classification != Compatible {
+		t.Fatalf("restored delivery-terminal closed-reason constraint state=%#v err=%v", restored, err)
 	}
 }
 

--- a/internal/postgres/relay_delivery_terminals.go
+++ b/internal/postgres/relay_delivery_terminals.go
@@ -137,7 +137,7 @@ func postgresRecordDeliveryTerminal(tx *sql.Tx, deliveryID, reason string, now t
 		SELECT delivery.id, delivery.message_id, message.conversation_id, delivery.recipient_endpoint, message.sequence, $2, COALESCE(delivery.lease_generation, 0), $3, message.created_at
 		FROM relay.mail_deliveries AS delivery JOIN relay.mail_messages AS message ON message.id=delivery.message_id
 		WHERE delivery.id=$1::uuid
-		ON CONFLICT (delivery_id) DO NOTHING`, deliveryID, reason, now.UTC()); err != nil {
+		ON CONFLICT (delivery_id) DO NOTHING`, deliveryID, reason, now.UTC().Truncate(time.Microsecond)); err != nil {
 		return relayDatabaseError(err, "record delivery terminal")
 	}
 	return nil

--- a/internal/postgres/relay_delivery_terminals.go
+++ b/internal/postgres/relay_delivery_terminals.go
@@ -1,0 +1,240 @@
+package postgres
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/rock3r/punaro/internal/relay"
+)
+
+// SetRetentionPolicy replaces the in-process pending-age and terminal-retention policy.
+func (d *Database) SetRetentionPolicy(cfg relay.RetentionConfig) error {
+	if err := cfg.Validate(); err != nil {
+		return err
+	}
+	d.retentionMu.Lock()
+	d.retention = cfg
+	d.retentionMu.Unlock()
+	return nil
+}
+
+func (d *Database) retentionConfig() relay.RetentionConfig {
+	d.retentionMu.Lock()
+	defer d.retentionMu.Unlock()
+	if d.retention == (relay.RetentionConfig{}) {
+		return relay.DefaultRetentionConfig()
+	}
+	return d.retention
+}
+
+// MaintainDeliveries expires due pending deliveries and prunes aged terminal metadata.
+func (d *Database) MaintainDeliveries(now time.Time) (relay.MaintenanceResult, error) {
+	now = now.UTC().Truncate(time.Microsecond)
+	cfg := d.retentionConfig()
+	tx, cancel, err := d.beginRelayTransaction(nil)
+	if err != nil {
+		return relay.MaintenanceResult{}, errors.New("delivery maintenance cannot start")
+	}
+	defer cancel()
+	defer func() { _ = tx.Rollback() }()
+	expired, err := postgresExpireDueDeliveries(tx, now, cfg)
+	if err != nil {
+		return relay.MaintenanceResult{}, err
+	}
+	pruned, err := postgresPruneTerminals(tx, now, cfg)
+	if err != nil {
+		return relay.MaintenanceResult{}, err
+	}
+	if err := tx.Commit(); err != nil {
+		return relay.MaintenanceResult{}, relayDatabaseError(err, "commit delivery maintenance")
+	}
+	d.metrics.ObserveTerminalTransition(relay.ClosedReasonExpired, uint64(expired)) // #nosec G115 -- expired is bounded by MaintenanceBatch.
+	d.refreshDeliveryMetrics(context.Background(), now)
+	return relay.MaintenanceResult{
+		Expired:      expired,
+		Pruned:       pruned,
+		Continuation: expired == cfg.MaintenanceBatch || pruned == cfg.MaintenanceBatch,
+	}, nil
+}
+
+func postgresExpireDueDeliveries(tx *sql.Tx, now time.Time, cfg relay.RetentionConfig) (int, error) {
+	cutoff := now.Add(-cfg.PendingMaxAge())
+	rows, err := tx.QueryContext(context.Background(), `SELECT delivery.id::text, delivery.recipient_endpoint, `+postgresPendingBodyBytes+`, message.conversation_id::text
+		FROM relay.mail_deliveries AS delivery JOIN relay.mail_messages AS message ON message.id=delivery.message_id
+		WHERE delivery.acked_at IS NULL AND message.created_at <= $1
+		ORDER BY message.created_at, delivery.id
+		LIMIT $2
+		FOR UPDATE OF delivery SKIP LOCKED`, cutoff, cfg.MaintenanceBatch)
+	if err != nil {
+		return 0, errors.New("expired deliveries cannot be inspected")
+	}
+	type candidate struct {
+		id, recipient, conversationID string
+		bodyBytes                     int64
+	}
+	var due []candidate
+	for rows.Next() {
+		var row candidate
+		if err := rows.Scan(&row.id, &row.recipient, &row.bodyBytes, &row.conversationID); err != nil {
+			_ = rows.Close()
+			return 0, errors.New("expired deliveries cannot be inspected")
+		}
+		due = append(due, row)
+	}
+	if err := rows.Close(); err != nil || rows.Err() != nil {
+		return 0, errors.New("expired deliveries cannot be inspected")
+	}
+	closed := 0
+	for _, row := range due {
+		result, err := tx.ExecContext(context.Background(), `UPDATE relay.mail_deliveries
+			SET acked_at=$1, lease_machine_id=NULL, lease_token=NULL, ownership_generation=NULL, consumer_generation=NULL, lease_until=NULL
+			WHERE id=$2::uuid AND acked_at IS NULL`, now, row.id)
+		if err != nil {
+			return 0, relayDatabaseError(err, "expire delivery")
+		}
+		affected, err := result.RowsAffected()
+		if err != nil {
+			return 0, errors.New("expire delivery is unavailable")
+		}
+		if affected != 1 {
+			continue
+		}
+		if err := postgresRecordDeliveryTerminal(tx, row.id, relay.ClosedReasonExpired, now); err != nil {
+			return 0, err
+		}
+		if err := postgresReleaseQuota(tx, row.recipient, row.bodyBytes); err != nil {
+			return 0, err
+		}
+		if err := postgresAdvanceRecipientCursor(tx, row.recipient, row.conversationID); err != nil {
+			return 0, err
+		}
+		closed++
+	}
+	return closed, nil
+}
+
+func postgresPruneTerminals(tx *sql.Tx, now time.Time, cfg relay.RetentionConfig) (int, error) {
+	cutoff := now.Add(-cfg.TerminalRetention())
+	result, err := tx.ExecContext(context.Background(), `DELETE FROM relay.mail_delivery_terminals WHERE delivery_id IN (
+		SELECT delivery_id FROM relay.mail_delivery_terminals WHERE closed_at <= $1 ORDER BY closed_at, delivery_id LIMIT $2
+	)`, cutoff, cfg.MaintenanceBatch)
+	if err != nil {
+		return 0, relayDatabaseError(err, "prune delivery terminals")
+	}
+	affected, err := result.RowsAffected()
+	if err != nil {
+		return 0, errors.New("prune delivery terminals is unavailable")
+	}
+	return int(affected), nil
+}
+
+func postgresRecordDeliveryTerminal(tx *sql.Tx, deliveryID, reason string, now time.Time) error {
+	if _, err := tx.ExecContext(context.Background(), `INSERT INTO relay.mail_delivery_terminals(
+		delivery_id, message_id, conversation_id, recipient_id, sequence, closed_reason, lease_generation, closed_at, created_at)
+		SELECT delivery.id, delivery.message_id, message.conversation_id, delivery.recipient_endpoint, message.sequence, $2, COALESCE(delivery.lease_generation, 0), $3, message.created_at
+		FROM relay.mail_deliveries AS delivery JOIN relay.mail_messages AS message ON message.id=delivery.message_id
+		WHERE delivery.id=$1::uuid
+		ON CONFLICT (delivery_id) DO NOTHING`, deliveryID, reason, now.UTC()); err != nil {
+		return relayDatabaseError(err, "record delivery terminal")
+	}
+	return nil
+}
+
+// ListDeliveryTerminals returns one bounded page of retained terminal metadata.
+func (d *Database) ListDeliveryTerminals(input relay.TerminalListInput) (relay.TerminalListPage, error) {
+	limit := input.Limit
+	if limit <= 0 {
+		limit = relay.DefaultTerminalListLimit
+	}
+	if limit > relay.MaxTerminalListLimit {
+		limit = relay.MaxTerminalListLimit
+	}
+	closedAt, deliveryID, ok := relay.DecodeTerminalListCursor(input.Cursor)
+	if !ok {
+		return relay.TerminalListPage{}, errors.New("invalid terminal cursor")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), operationTimeout)
+	defer cancel()
+	var rows *sql.Rows
+	var err error
+	if deliveryID == "" {
+		rows, err = d.relayPool().QueryContext(ctx, `SELECT delivery_id::text, message_id::text, conversation_id::text, recipient_id, sequence, closed_reason, lease_generation, closed_at, created_at
+			FROM relay.mail_delivery_terminals ORDER BY closed_at, delivery_id LIMIT $1`, limit+1)
+	} else {
+		if _, parseErr := uuid.Parse(deliveryID); parseErr != nil {
+			return relay.TerminalListPage{}, errors.New("invalid terminal cursor")
+		}
+		rows, err = d.relayPool().QueryContext(ctx, `SELECT delivery_id::text, message_id::text, conversation_id::text, recipient_id, sequence, closed_reason, lease_generation, closed_at, created_at
+			FROM relay.mail_delivery_terminals
+			WHERE closed_at > $1 OR (closed_at = $1 AND delivery_id > $2::uuid)
+			ORDER BY closed_at, delivery_id LIMIT $3`, closedAt.UTC(), deliveryID, limit+1)
+	}
+	if err != nil {
+		return relay.TerminalListPage{}, errors.New("delivery terminals are unavailable")
+	}
+	defer func() { _ = rows.Close() }()
+	var terminals []relay.DeliveryTerminal
+	for rows.Next() {
+		var terminal relay.DeliveryTerminal
+		if err := rows.Scan(&terminal.DeliveryID, &terminal.MessageID, &terminal.ConversationID, &terminal.RecipientID, &terminal.Sequence, &terminal.ClosedReason, &terminal.LeaseGeneration, &terminal.ClosedAt, &terminal.CreatedAt); err != nil {
+			return relay.TerminalListPage{}, errors.New("delivery terminal is malformed")
+		}
+		terminal.ClosedAt = terminal.ClosedAt.UTC()
+		terminal.CreatedAt = terminal.CreatedAt.UTC()
+		terminals = append(terminals, terminal)
+	}
+	if err := rows.Err(); err != nil {
+		return relay.TerminalListPage{}, errors.New("delivery terminals are unavailable")
+	}
+	page := relay.TerminalListPage{Terminals: terminals}
+	if len(page.Terminals) > limit {
+		last := page.Terminals[limit-1]
+		page.Terminals = page.Terminals[:limit]
+		page.NextCursor = relay.EncodeTerminalListCursor(last.ClosedAt, last.DeliveryID)
+	}
+	return page, nil
+}
+
+func (d *Database) refreshDeliveryMetrics(ctx context.Context, now time.Time) {
+	d.refreshPendingMetrics(ctx)
+	if d.metrics == nil {
+		return
+	}
+	var oldest sql.NullTime
+	if err := d.relayPool().QueryRowContext(ctx, `SELECT MIN(message.created_at)
+		FROM relay.mail_deliveries AS delivery JOIN relay.mail_messages AS message ON message.id=delivery.message_id
+		WHERE delivery.acked_at IS NULL`).Scan(&oldest); err != nil {
+		return
+	}
+	if oldest.Valid {
+		d.metrics.SetQueueAge(pendingAgeSecondsFor(oldest.Time, now))
+	} else {
+		d.metrics.SetQueueAge(0)
+	}
+	var retained int64
+	if err := d.relayPool().QueryRowContext(ctx, `SELECT COUNT(*) FROM relay.mail_delivery_terminals`).Scan(&retained); err != nil {
+		return
+	}
+	d.metrics.SetTerminalsRetained(uint64(max64(retained, 0))) // #nosec G115 -- retained count is CHECK-constrained to non-negative values.
+}
+
+func pendingAgeSecondsFor(oldest, now time.Time) uint64 {
+	if oldest.IsZero() || now.Before(oldest) {
+		return 0
+	}
+	seconds := int64(now.Sub(oldest) / time.Second)
+	if seconds < 0 {
+		return 0
+	}
+	return uint64(seconds) // #nosec G115 -- pending age is non-negative.
+}
+
+func max64(value, floor int64) int64 {
+	if value < floor {
+		return floor
+	}
+	return value
+}

--- a/internal/postgres/relay_delivery_terminals_schema.go
+++ b/internal/postgres/relay_delivery_terminals_schema.go
@@ -1,0 +1,60 @@
+package postgres
+
+import "context"
+
+// relayDeliveryTerminalsAvailable confirms content-free terminal inventory is
+// owned by the schema role and writable only through bounded application grants.
+func relayDeliveryTerminalsAvailable(ctx context.Context, q queryer) (bool, error) {
+	var available bool
+	err := q.QueryRowContext(ctx, `
+WITH objects AS (
+    SELECT to_regclass('relay.mail_delivery_terminals') AS terminals_oid,
+           to_regprocedure('relay.guard_mail_mutation()') AS guard_oid
+), relations AS (
+    SELECT count(*)=1 AND bool_and(pg_get_userbyid(class.relowner)='punaro_owner' AND class.relkind='r'
+       AND class.relpersistence='p' AND NOT class.relrowsecurity AND NOT class.relforcerowsecurity) AS exact
+    FROM objects JOIN pg_class AS class ON class.oid=terminals_oid
+), columns AS (
+    SELECT count(*)=9
+       AND bool_and((attribute.attrelid,attribute.attname,attribute.atttypid,attribute.attnotnull) IN (
+           (terminals_oid,'delivery_id','uuid'::regtype,true),(terminals_oid,'message_id','uuid'::regtype,true),
+           (terminals_oid,'conversation_id','uuid'::regtype,true),(terminals_oid,'recipient_id','text'::regtype,true),
+           (terminals_oid,'sequence','int8'::regtype,true),(terminals_oid,'closed_reason','text'::regtype,true),
+           (terminals_oid,'lease_generation','int8'::regtype,true),(terminals_oid,'closed_at','timestamptz'::regtype,true),
+           (terminals_oid,'created_at','timestamptz'::regtype,true))) AS exact
+    FROM objects JOIN pg_attribute AS attribute ON attribute.attrelid=terminals_oid
+       AND attribute.attnum>0 AND NOT attribute.attisdropped
+), expected_constraints(table_oid,constraint_name,constraint_type,column_keys,check_expression) AS (
+    SELECT expected.* FROM objects, LATERAL (VALUES
+        (terminals_oid,'mail_delivery_terminals_pkey','p'::"char",ARRAY[1]::smallint[],NULL::text),
+        (terminals_oid,'mail_delivery_terminals_recipient_id_check','c'::"char",ARRAY[4]::smallint[],'((char_length(recipient_id) >= 1) AND (char_length(recipient_id) <= 512) AND (octet_length(recipient_id) <= 2048))'),
+        (terminals_oid,'mail_delivery_terminals_sequence_check','c'::"char",ARRAY[5]::smallint[],'(sequence >= 0)'),
+        (terminals_oid,'mail_delivery_terminals_closed_reason_check','c'::"char",ARRAY[6]::smallint[],'(closed_reason = ANY (ARRAY[''acked''::text, ''expired''::text, ''revoked''::text]))'),
+        (terminals_oid,'mail_delivery_terminals_lease_generation_check','c'::"char",ARRAY[7]::smallint[],'(lease_generation >= 0)')
+    ) AS expected(table_oid,constraint_name,constraint_type,column_keys,check_expression)
+), actual_constraints AS (
+    SELECT constraint_.conrelid,constraint_.conname,constraint_.contype,constraint_.conkey,
+           CASE WHEN constraint_.contype='c' THEN pg_get_expr(constraint_.conbin,constraint_.conrelid) END
+    FROM objects JOIN pg_constraint AS constraint_ ON constraint_.conrelid=terminals_oid
+    WHERE constraint_.contype IN ('p','c')
+      AND constraint_.convalidated AND NOT constraint_.condeferrable AND NOT constraint_.condeferred
+), constraints AS (
+    SELECT NOT EXISTS (SELECT * FROM expected_constraints EXCEPT SELECT * FROM actual_constraints)
+       AND NOT EXISTS (SELECT * FROM actual_constraints EXCEPT SELECT * FROM expected_constraints) AS exact
+), guards AS (
+    SELECT count(*)=1 AND bool_and(trigger.tgfoid=guard_oid AND trigger.tgenabled='O' AND NOT trigger.tgisinternal
+       AND trigger.tgtype=30 AND trigger.tgconstraint=0 AND NOT trigger.tgdeferrable AND NOT trigger.tginitdeferred
+       AND trigger.tgnargs=0 AND trigger.tgqual IS NULL AND trigger.tgnewtable IS NULL AND trigger.tgoldtable IS NULL
+       AND trigger.tgattr::text='') AS exact
+    FROM objects JOIN pg_trigger AS trigger ON trigger.tgrelid=terminals_oid
+       AND trigger.tgname='mail_delivery_terminals_mutation_guard'
+), acl AS (
+    SELECT has_table_privilege('punaro_app',terminals_oid,'SELECT,INSERT,DELETE')
+       AND NOT has_table_privilege('punaro_app',terminals_oid,'UPDATE,TRUNCATE,REFERENCES,TRIGGER') AS exact
+    FROM objects
+)
+SELECT terminals_oid IS NOT NULL AND guard_oid IS NOT NULL
+   AND relations.exact AND columns.exact AND constraints.exact AND guards.exact AND acl.exact
+FROM objects,relations,columns,constraints,guards,acl`).Scan(&available)
+	return available, err
+}

--- a/internal/postgres/relay_pending_quota.go
+++ b/internal/postgres/relay_pending_quota.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"errors"
 	"sort"
+	"time"
 
 	"github.com/rock3r/punaro/internal/relay"
 )
@@ -150,35 +151,42 @@ func postgresAppendDeliveryRecipients(tx *sql.Tx, conversationID, fromEndpoint, 
 	return recipients, nil
 }
 
-func postgresRetireConversationDeliveries(tx *sql.Tx, recipient, conversationID string, ackedAt any) error {
-	rows, err := tx.QueryContext(context.Background(), `SELECT `+postgresPendingBodyBytes+`
+func postgresRetireConversationDeliveries(tx *sql.Tx, recipient, conversationID string, ackedAt time.Time) (int, error) {
+	rows, err := tx.QueryContext(context.Background(), `SELECT delivery.id::text, `+postgresPendingBodyBytes+`
 		FROM relay.mail_deliveries AS delivery JOIN relay.mail_messages AS message ON message.id=delivery.message_id
 		WHERE delivery.recipient_endpoint=$1 AND delivery.acked_at IS NULL AND message.conversation_id=$2::uuid
 		FOR UPDATE OF delivery`, recipient, conversationID)
 	if err != nil {
-		return errors.New("revoked deliveries cannot be inspected")
+		return 0, errors.New("revoked deliveries cannot be inspected")
 	}
-	var bodies []int64
+	type pending struct {
+		id    string
+		bytes int64
+	}
+	var retired []pending
 	for rows.Next() {
-		var bodyBytes int64
-		if err := rows.Scan(&bodyBytes); err != nil {
+		var row pending
+		if err := rows.Scan(&row.id, &row.bytes); err != nil {
 			_ = rows.Close()
-			return errors.New("revoked deliveries cannot be inspected")
+			return 0, errors.New("revoked deliveries cannot be inspected")
 		}
-		bodies = append(bodies, bodyBytes)
+		retired = append(retired, row)
 	}
 	if err := rows.Close(); err != nil || rows.Err() != nil {
-		return errors.New("revoked deliveries cannot be inspected")
+		return 0, errors.New("revoked deliveries cannot be inspected")
 	}
-	for _, bodyBytes := range bodies {
-		if err := postgresReleaseQuota(tx, recipient, bodyBytes); err != nil {
-			return err
+	for _, row := range retired {
+		if err := postgresReleaseQuota(tx, recipient, row.bytes); err != nil {
+			return 0, err
+		}
+		if err := postgresRecordDeliveryTerminal(tx, row.id, relay.ClosedReasonRevoked, ackedAt); err != nil {
+			return 0, err
 		}
 	}
 	if _, err := tx.ExecContext(context.Background(), `UPDATE relay.mail_deliveries SET acked_at=$3 WHERE recipient_endpoint=$1 AND acked_at IS NULL AND message_id IN (SELECT id FROM relay.mail_messages WHERE conversation_id=$2::uuid)`, recipient, conversationID, ackedAt); err != nil {
-		return relayDatabaseError(err, "retire revoked deliveries")
+		return 0, relayDatabaseError(err, "retire revoked deliveries")
 	}
-	return nil
+	return len(retired), nil
 }
 
 func (d *Database) refreshPendingMetrics(ctx context.Context) {
@@ -299,7 +307,7 @@ func (d *Database) ReconcilePendingQuota(ctx context.Context) (relay.QuotaCounte
 	if err := tx.Commit(); err != nil {
 		return relay.QuotaCounters{}, errors.New("pending quota reconciliation cannot commit")
 	}
-	d.refreshPendingMetrics(ctx)
+	d.refreshDeliveryMetrics(ctx, time.Now().UTC())
 	return install, nil
 }
 

--- a/internal/postgres/relay_store.go
+++ b/internal/postgres/relay_store.go
@@ -636,7 +636,7 @@ func (d *Database) SendDirectMessage(input relay.DirectMessageInput) (relay.Mess
 	if err := tx.Commit(); err != nil {
 		return relay.Message{}, false, relayDatabaseError(err, "commit direct message")
 	}
-	d.refreshPendingMetrics(context.Background())
+	d.refreshDeliveryMetrics(context.Background(), now)
 	return message, false, nil
 }
 
@@ -824,10 +824,13 @@ func (d *Database) ApplyControl(input relay.ControlInput) (relay.ControlEvent, b
 			return relay.ControlEvent{}, false, relay.ErrConflict
 		}
 	}
+	revoked := 0
 	if input.Operation == relay.ControlUpsertMember && err == nil && previous&relay.CapReceive != 0 && input.Member.Capabilities&relay.CapReceive == 0 {
-		if err := postgresRetireConversationDeliveries(tx, input.Member.Endpoint, input.ConversationID, input.Now.UTC()); err != nil {
+		count, err := postgresRetireConversationDeliveries(tx, input.Member.Endpoint, input.ConversationID, input.Now.UTC())
+		if err != nil {
 			return relay.ControlEvent{}, false, err
 		}
+		revoked += count
 		if err := postgresAdvanceRecipientCursor(tx, input.Member.Endpoint, input.ConversationID); err != nil {
 			return relay.ControlEvent{}, false, err
 		}
@@ -842,9 +845,11 @@ func (d *Database) ApplyControl(input relay.ControlInput) (relay.ControlEvent, b
 			}
 		}
 	} else {
-		if err := postgresRetireConversationDeliveries(tx, input.Member.Endpoint, input.ConversationID, input.Now.UTC()); err != nil {
+		count, err := postgresRetireConversationDeliveries(tx, input.Member.Endpoint, input.ConversationID, input.Now.UTC())
+		if err != nil {
 			return relay.ControlEvent{}, false, err
 		}
+		revoked += count
 		if err := postgresAdvanceRecipientCursor(tx, input.Member.Endpoint, input.ConversationID); err != nil {
 			return relay.ControlEvent{}, false, err
 		}
@@ -870,7 +875,8 @@ func (d *Database) ApplyControl(input relay.ControlInput) (relay.ControlEvent, b
 	if err := tx.Commit(); err != nil {
 		return relay.ControlEvent{}, false, relayDatabaseError(err, "commit control")
 	}
-	d.refreshPendingMetrics(context.Background())
+	d.metrics.ObserveTerminalTransition(relay.ClosedReasonRevoked, uint64(revoked)) // #nosec G115 -- revoked count is bounded by pending deliveries for one recipient.
+	d.refreshDeliveryMetrics(context.Background(), input.Now)
 	return event, false, nil
 }
 
@@ -1265,7 +1271,7 @@ func (d *Database) AppendMessage(input relay.AppendInput) (relay.Message, bool, 
 	if err := tx.Commit(); err != nil {
 		return relay.Message{}, false, relayDatabaseError(err, "commit message")
 	}
-	d.refreshPendingMetrics(context.Background())
+	d.refreshDeliveryMetrics(context.Background(), input.Now)
 	return message, false, nil
 }
 
@@ -1283,7 +1289,7 @@ func (d *Database) SetRateLimits(cfg relay.RateLimitConfig) error {
 // SetMetrics attaches the shared content-free counter sink.
 func (d *Database) SetMetrics(metrics *relay.Metrics) {
 	d.metrics = metrics
-	d.refreshPendingMetrics(context.Background())
+	d.refreshDeliveryMetrics(context.Background(), time.Now().UTC())
 }
 
 func (d *Database) rateLimitConfig() relay.RateLimitConfig {
@@ -1443,12 +1449,16 @@ func (d *Database) LeaseDeliveries(machineID, consumerID, endpoint, conversation
 		return relay.DeliveryLeasePage{}, errors.New("pending deliveries are unavailable")
 	}
 	deliveries := make([]relay.Delivery, 0, len(pending))
+	redeliveries := 0
 	for _, row := range pending {
 		delivery := row.delivery
 		if row.leaseMachine.Valid && row.leaseMachine.String == machineID && row.leaseToken.Valid && row.leaseOwnership.Valid && row.leaseOwnership.Int64 == ownershipGeneration && row.leaseConsumer.Valid && row.leaseConsumer.Int64 == consumerGeneration && row.leaseUntil.Valid && row.leaseUntil.Time.After(now) {
 			delivery.LeaseToken = row.leaseToken.String
 			delivery.LeaseUntil = row.leaseUntil.Time.UTC()
 		} else {
+			if row.leaseToken.Valid || row.leaseUntil.Valid {
+				redeliveries++
+			}
 			delivery.LeaseGeneration++
 			delivery.LeaseToken = uuid.NewString()
 			delivery.LeaseUntil = now.Add(ttl).UTC()
@@ -1475,6 +1485,9 @@ func (d *Database) LeaseDeliveries(machineID, consumerID, endpoint, conversation
 	}
 	if err := tx.Commit(); err != nil {
 		return relay.DeliveryLeasePage{}, relayDatabaseError(err, "commit delivery lease")
+	}
+	for i := 0; i < redeliveries; i++ {
+		d.metrics.ObserveLeaseRedelivery()
 	}
 	return relay.DeliveryLeasePage{Deliveries: deliveries, Cursors: cursors}, nil
 }
@@ -1617,17 +1630,23 @@ func (d *Database) AckDelivery(machineID, endpoint, deliveryID, token string, ge
 	if !leaseMachine.Valid || leaseMachine.String != machineID || !leaseToken.Valid || leaseToken.String != token || leaseGeneration != generation || !leaseOwnership.Valid || leaseOwnership.Int64 != ownershipGeneration || !leaseConsumer.Valid || leaseConsumer.Int64 != currentConsumerGeneration || !leaseUntil.Valid || !leaseUntil.Time.After(now) {
 		return relay.ErrForbidden
 	}
-	if _, err := tx.ExecContext(context.Background(), `UPDATE relay.mail_deliveries SET acked_at=$1 WHERE id=$2::uuid AND acked_at IS NULL`, now.UTC(), deliveryID); err != nil {
+	result, err := tx.ExecContext(context.Background(), `UPDATE relay.mail_deliveries SET acked_at=$1 WHERE id=$2::uuid AND acked_at IS NULL`, now.UTC(), deliveryID)
+	if err != nil {
 		return relayDatabaseError(err, "acknowledge delivery")
 	}
-	if !acknowledged.Valid {
-		var bodyBytes int64
-		if err := tx.QueryRowContext(context.Background(), `SELECT octet_length(message.body) FROM relay.mail_deliveries AS delivery JOIN relay.mail_messages AS message ON message.id=delivery.message_id WHERE delivery.id=$1::uuid`, deliveryID).Scan(&bodyBytes); err != nil {
-			return errors.New("delivery body length is unavailable")
-		}
-		if err := postgresReleaseQuota(tx, recipient, bodyBytes); err != nil {
-			return err
-		}
+	affected, err := result.RowsAffected()
+	if err != nil || affected != 1 {
+		return relay.ErrForbidden
+	}
+	var bodyBytes int64
+	if err := tx.QueryRowContext(context.Background(), `SELECT octet_length(message.body) FROM relay.mail_deliveries AS delivery JOIN relay.mail_messages AS message ON message.id=delivery.message_id WHERE delivery.id=$1::uuid`, deliveryID).Scan(&bodyBytes); err != nil {
+		return errors.New("delivery body length is unavailable")
+	}
+	if err := postgresReleaseQuota(tx, recipient, bodyBytes); err != nil {
+		return err
+	}
+	if err := postgresRecordDeliveryTerminal(tx, deliveryID, relay.ClosedReasonAcked, now); err != nil {
+		return err
 	}
 	if err := postgresAdvanceRecipientCursor(tx, recipient, conversationID); err != nil {
 		return err
@@ -1635,7 +1654,8 @@ func (d *Database) AckDelivery(machineID, endpoint, deliveryID, token string, ge
 	if err := tx.Commit(); err != nil {
 		return relayDatabaseError(err, "commit delivery acknowledgement")
 	}
-	d.refreshPendingMetrics(context.Background())
+	d.metrics.ObserveTerminalTransition(relay.ClosedReasonAcked, 1)
+	d.refreshDeliveryMetrics(context.Background(), now)
 	return nil
 }
 

--- a/internal/postgres/state_test.go
+++ b/internal/postgres/state_test.go
@@ -69,8 +69,8 @@ func TestManifestValidationRejectsMutableOrNonContiguousHistory(t *testing.T) {
 
 func TestCurrentManifestRequiresControlPlaneSchema(t *testing.T) {
 	manifest := CurrentManifest()
-	if manifest.MinSupported != 10 || manifest.MaxSupported != 48 || len(manifest.Migrations) != 48 {
-		t.Fatalf("manifest=%#v, want exact v48 compatibility window", manifest)
+	if manifest.MinSupported != 10 || manifest.MaxSupported != 49 || len(manifest.Migrations) != 49 {
+		t.Fatalf("manifest=%#v, want exact v49 compatibility window", manifest)
 	}
 	embedding := manifest.Migrations[23]
 	if embedding.Version != 24 || embedding.Name != "024_memory_embedding_worker_control" ||
@@ -88,7 +88,7 @@ func TestCurrentManifestRequiresControlPlaneSchema(t *testing.T) {
 			want = 10
 		case 12, 13:
 			want = 10
-		case 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48:
+		case 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49:
 			want = 10
 		}
 		if migration.CompatibilityFloor != want {
@@ -225,7 +225,10 @@ func TestCompatibleSchemaCanStillHavePendingMigrations(t *testing.T) {
 	if !migrationPending(SchemaState{Classification: Compatible, Version: 47}, manifest) {
 		t.Fatal("compatible v47 schema must still apply the pending v48 migration")
 	}
-	if migrationPending(SchemaState{Classification: Compatible, Version: 48}, manifest) {
-		t.Fatal("current v48 schema reported a pending migration")
+	if !migrationPending(SchemaState{Classification: Compatible, Version: 48}, manifest) {
+		t.Fatal("compatible v48 schema must still apply the pending v49 migration")
+	}
+	if migrationPending(SchemaState{Classification: Compatible, Version: 49}, manifest) {
+		t.Fatal("current v49 schema reported a pending migration")
 	}
 }

--- a/internal/relay/contracttest/contract.go
+++ b/internal/relay/contracttest/contract.go
@@ -3,6 +3,7 @@
 package contracttest
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"sort"
@@ -245,6 +246,7 @@ func Run(t *testing.T, backend relay.Backend, namespace string) {
 	runLeasePageContract(t, backend, namespace, now)
 	RunRateLimits(t, backend, namespace+"-rate")
 	RunPendingQuota(t, backend, namespace+"-quota")
+	RunTerminalRetention(t, backend, namespace+"-retain")
 }
 
 // RateLimitSetter is implemented by durable stores that keep token-bucket
@@ -567,6 +569,156 @@ func RunPendingQuota(t *testing.T, backend relay.Backend, namespace string) {
 	if err := limiter.SetQuotaLimits(relay.DefaultQuotaConfig()); err != nil {
 		t.Fatal(err)
 	}
+}
+
+// RetentionSetter is implemented by durable stores that keep pending-age and
+// terminal-retention policy in process and closed metadata in the database.
+type RetentionSetter interface {
+	relay.Backend
+	SetRetentionPolicy(relay.RetentionConfig) error
+	SetQuotaLimits(relay.QuotaConfig) error
+	MaintainDeliveries(time.Time) (relay.MaintenanceResult, error)
+	ListDeliveryTerminals(relay.TerminalListInput) (relay.TerminalListPage, error)
+}
+
+// RunTerminalRetention proves pending-age expiry, once-only capacity release,
+// recipient-local cursor advancement, and content-free terminal inspection
+// against every backend. Other namespaces stay untouched because this page uses
+// a historical clock so the inclusive cutoff cannot select later contract rows.
+func RunTerminalRetention(t *testing.T, backend relay.Backend, namespace string) {
+	t.Helper()
+	limiter, ok := backend.(RetentionSetter)
+	if !ok {
+		t.Fatal("backend does not expose terminal retention")
+	}
+	if err := limiter.SetRetentionPolicy(relay.DefaultRetentionConfig()); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		_ = limiter.SetRetentionPolicy(relay.DefaultRetentionConfig())
+		_ = limiter.SetQuotaLimits(relay.DefaultQuotaConfig())
+	})
+	cfg := relay.RetentionConfig{PendingMaxAgeSeconds: 60, TerminalRetentionSeconds: 3600, MaintenanceBatch: 10}
+	if err := limiter.SetRetentionPolicy(cfg); err != nil {
+		t.Fatal(err)
+	}
+	now := time.Date(2024, time.January, 2, 12, 0, 0, 0, time.UTC)
+	machineA, machineB, machineC := namespace+"-a", namespace+"-b", namespace+"-c"
+	endpointA, endpointB, endpointC := "agent/"+namespace+"/a", "agent/"+namespace+"/b", "agent/"+namespace+"/c"
+	if err := backend.AdvertiseEndpoints(machineA, []string{endpointA}, now, time.Hour); err != nil {
+		t.Fatal(err)
+	}
+	if err := backend.AdvertiseEndpoints(machineB, []string{endpointB}, now, time.Hour); err != nil {
+		t.Fatal(err)
+	}
+	if err := backend.AdvertiseEndpoints(machineC, []string{endpointC}, now, time.Hour); err != nil {
+		t.Fatal(err)
+	}
+	conversation, err := backend.CreateConversationIdempotent(relay.CreateConversationInput{
+		MachineID: machineA, IdempotencyKey: namespace + "-create", CreatorEndpoint: endpointA, Now: now,
+		Members: []relay.Member{
+			{Endpoint: endpointA, Capabilities: relay.CapSend | relay.CapReceive | relay.CapAdmin},
+			{Endpoint: endpointB, Capabilities: relay.CapReceive},
+			{Endpoint: endpointC, Capabilities: relay.CapReceive},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	secret := namespace + "-secret-body"
+	message, duplicate, err := backend.AppendMessage(relay.AppendInput{ConversationID: conversation.ID, SenderMachineID: machineA, FromEndpoint: endpointA, Body: secret, IdempotencyKey: namespace + "-1", Now: now})
+	if err != nil || duplicate {
+		t.Fatalf("append message=%#v duplicate=%t err=%v", message, duplicate, err)
+	}
+	pageB, err := backend.LeaseDeliveries(machineB, namespace+"-consumer-b", endpointB, conversation.ID, now, time.Hour, 10)
+	if err != nil || len(pageB.Deliveries) != 1 {
+		t.Fatalf("lease b=%#v err=%v", pageB, err)
+	}
+	if err := backend.AckDelivery(machineB, endpointB, pageB.Deliveries[0].ID, pageB.Deliveries[0].LeaseToken, pageB.Deliveries[0].LeaseGeneration, now); err != nil {
+		t.Fatal(err)
+	}
+	before := now.Add(60*time.Second - time.Millisecond)
+	if result, err := limiter.MaintainDeliveries(before); err != nil || result.Expired != 0 {
+		t.Fatalf("just before expiry result=%#v err=%v", result, err)
+	}
+	at := now.Add(60 * time.Second)
+	if result, err := limiter.MaintainDeliveries(at); err != nil || result.Expired != 1 {
+		t.Fatalf("at expiry result=%#v err=%v", result, err)
+	}
+	if result, err := limiter.MaintainDeliveries(at); err != nil || result.Expired != 0 {
+		t.Fatalf("repeat expiry result=%#v err=%v", result, err)
+	}
+	if cursor, err := backend.RecipientCursor(machineB, endpointB, conversation.ID, at); err != nil || cursor != message.Sequence {
+		t.Fatalf("acked recipient cursor=%d err=%v", cursor, err)
+	}
+	if cursor, err := backend.RecipientCursor(machineC, endpointC, conversation.ID, at); err != nil || cursor != message.Sequence {
+		t.Fatalf("expired recipient cursor=%d err=%v", cursor, err)
+	}
+	pageC, err := backend.LeaseDeliveries(machineC, namespace+"-consumer-c", endpointC, conversation.ID, at, time.Hour, 10)
+	if err != nil || len(pageC.Deliveries) != 0 {
+		t.Fatalf("expired recipient still pending=%#v err=%v", pageC, err)
+	}
+	found := listTerminalsForMessage(t, limiter, message.ID)
+	if len(found) != 2 {
+		t.Fatalf("terminals for expired fan-out=%#v", found)
+	}
+	reasons := map[string]int{}
+	encoded, err := json.Marshal(found)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(encoded), secret) || strings.Contains(string(encoded), `"body"`) {
+		t.Fatalf("terminal inventory leaked body: %s", encoded)
+	}
+	for _, terminal := range found {
+		reasons[terminal.ClosedReason]++
+		if terminal.RecipientID == "" || terminal.ConversationID != conversation.ID || terminal.Sequence != message.Sequence {
+			t.Fatalf("terminal=%#v", terminal)
+		}
+	}
+	if reasons[relay.ClosedReasonAcked] != 1 || reasons[relay.ClosedReasonExpired] != 1 {
+		t.Fatalf("reasons=%v", reasons)
+	}
+
+	quota := relay.QuotaConfig{RecipientCount: 1, RecipientBytes: 1024, InstallationCount: 10_000_000, InstallationBytes: 64 << 30, RetryAfterSeconds: 9}
+	if err := limiter.SetQuotaLimits(quota); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := backend.AppendMessage(relay.AppendInput{ConversationID: conversation.ID, SenderMachineID: machineA, FromEndpoint: endpointA, Body: "after-expiry", IdempotencyKey: namespace + "-2", Now: at}); err != nil {
+		t.Fatal(err)
+	}
+	_, _, err = backend.AppendMessage(relay.AppendInput{ConversationID: conversation.ID, SenderMachineID: machineA, FromEndpoint: endpointA, Body: "over-capacity", IdempotencyKey: namespace + "-3", Now: at})
+	if !errors.Is(err, relay.ErrCapacityExceeded) {
+		t.Fatalf("capacity after exact-once release err=%v", err)
+	}
+	if err := limiter.SetRetentionPolicy(relay.DefaultRetentionConfig()); err != nil {
+		t.Fatal(err)
+	}
+	if err := limiter.SetQuotaLimits(relay.DefaultQuotaConfig()); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func listTerminalsForMessage(t *testing.T, backend RetentionSetter, messageID string) []relay.DeliveryTerminal {
+	t.Helper()
+	var found []relay.DeliveryTerminal
+	cursor := ""
+	for {
+		page, err := backend.ListDeliveryTerminals(relay.TerminalListInput{Cursor: cursor, Limit: relay.MaxTerminalListLimit})
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, terminal := range page.Terminals {
+			if terminal.MessageID == messageID {
+				found = append(found, terminal)
+			}
+		}
+		if page.NextCursor == "" {
+			break
+		}
+		cursor = page.NextCursor
+	}
+	return found
 }
 
 // RunRoleTargeting proves the same targeted-role and compatible-broadcast

--- a/internal/relay/migration_source.go
+++ b/internal/relay/migration_source.go
@@ -866,6 +866,13 @@ func verifyMigrationSourceSchema(ctx context.Context, q migrationQueryer, contro
 	if quotaTables == 2 {
 		wantTriggers += 6
 	}
+	var terminalTables int
+	if err := q.QueryRowContext(ctx, `SELECT count(*) FROM sqlite_master WHERE type='table' AND name='delivery_terminals'`).Scan(&terminalTables); err != nil || terminalTables != 0 && terminalTables != 1 {
+		return errors.New("relay migration source schema is unavailable")
+	}
+	if terminalTables == 1 {
+		wantTriggers += 3
+	}
 	if err := triggerRows.Close(); err != nil || triggerRows.Err() != nil || len(seenTriggers) != wantTriggers {
 		return errors.New("relay migration source guard inventory is incomplete")
 	}

--- a/internal/relay/rate_limit.go
+++ b/internal/relay/rate_limit.go
@@ -184,10 +184,16 @@ func boundRetryAfter(wait time.Duration, maxSeconds int) int {
 // Metrics counts content-free relay pressure signals. Labels are fixed names
 // only; bodies, endpoints, roles, and conversation IDs are never recorded.
 type Metrics struct {
-	rateLimitRejections atomic.Uint64
-	capacityRejections  atomic.Uint64
-	pendingDeliveries   atomic.Uint64
-	pendingBytes        atomic.Uint64
+	rateLimitRejections         atomic.Uint64
+	capacityRejections          atomic.Uint64
+	pendingDeliveries           atomic.Uint64
+	pendingBytes                atomic.Uint64
+	pendingOldestAgeSeconds     atomic.Uint64
+	terminalTransitionsAcked    atomic.Uint64
+	terminalTransitionsExpired  atomic.Uint64
+	terminalTransitionsRevoked  atomic.Uint64
+	terminalsRetained           atomic.Uint64
+	leaseRedeliveries           atomic.Uint64
 }
 
 // ObserveRateLimited increments the rate-rejection counter.
@@ -200,10 +206,16 @@ func (m *Metrics) ObserveRateLimited() {
 
 // MetricsSnapshot is the bounded JSON body served on the local health listener.
 type MetricsSnapshot struct {
-	RelayRateLimitRejections uint64 `json:"relay_rate_limit_rejections"`
-	RelayCapacityRejections  uint64 `json:"relay_capacity_rejections"`
-	RelayPendingDeliveries   uint64 `json:"relay_pending_deliveries"`
-	RelayPendingBytes        uint64 `json:"relay_pending_bytes"`
+	RelayRateLimitRejections         uint64 `json:"relay_rate_limit_rejections"`
+	RelayCapacityRejections          uint64 `json:"relay_capacity_rejections"`
+	RelayPendingDeliveries           uint64 `json:"relay_pending_deliveries"`
+	RelayPendingBytes                uint64 `json:"relay_pending_bytes"`
+	RelayPendingOldestAgeSeconds     uint64 `json:"relay_pending_oldest_age_seconds"`
+	RelayTerminalTransitionsAcked    uint64 `json:"relay_terminal_transitions_acked"`
+	RelayTerminalTransitionsExpired  uint64 `json:"relay_terminal_transitions_expired"`
+	RelayTerminalTransitionsRevoked  uint64 `json:"relay_terminal_transitions_revoked"`
+	RelayTerminalsRetained           uint64 `json:"relay_terminals_retained"`
+	RelayLeaseRedeliveries           uint64 `json:"relay_lease_redeliveries"`
 }
 
 // Snapshot returns the current content-free counters.
@@ -212,10 +224,16 @@ func (m *Metrics) Snapshot() MetricsSnapshot {
 		return MetricsSnapshot{}
 	}
 	return MetricsSnapshot{
-		RelayRateLimitRejections: m.rateLimitRejections.Load(),
-		RelayCapacityRejections:  m.capacityRejections.Load(),
-		RelayPendingDeliveries:   m.pendingDeliveries.Load(),
-		RelayPendingBytes:        m.pendingBytes.Load(),
+		RelayRateLimitRejections:        m.rateLimitRejections.Load(),
+		RelayCapacityRejections:         m.capacityRejections.Load(),
+		RelayPendingDeliveries:          m.pendingDeliveries.Load(),
+		RelayPendingBytes:               m.pendingBytes.Load(),
+		RelayPendingOldestAgeSeconds:    m.pendingOldestAgeSeconds.Load(),
+		RelayTerminalTransitionsAcked:   m.terminalTransitionsAcked.Load(),
+		RelayTerminalTransitionsExpired: m.terminalTransitionsExpired.Load(),
+		RelayTerminalTransitionsRevoked: m.terminalTransitionsRevoked.Load(),
+		RelayTerminalsRetained:          m.terminalsRetained.Load(),
+		RelayLeaseRedeliveries:          m.leaseRedeliveries.Load(),
 	}
 }
 
@@ -234,7 +252,7 @@ func (s *Store) SetRateLimits(cfg RateLimitConfig) error {
 // SetMetrics attaches the shared content-free counter sink.
 func (s *Store) SetMetrics(metrics *Metrics) {
 	s.metrics = metrics
-	s.refreshPendingMetrics()
+	s.refreshDeliveryMetrics(time.Now().UTC())
 }
 
 func (s *Store) rateLimitConfig() RateLimitConfig {
@@ -265,4 +283,25 @@ func (s *Store) quotaConfig() QuotaConfig {
 		return DefaultQuotaConfig()
 	}
 	return s.quota
+}
+
+// SetRetentionPolicy replaces the in-process pending-age and terminal-retention
+// policy. Durable closed rows remain in the store; this does not expire work.
+func (s *Store) SetRetentionPolicy(cfg RetentionConfig) error {
+	if err := cfg.Validate(); err != nil {
+		return err
+	}
+	s.retentionMu.Lock()
+	s.retention = cfg
+	s.retentionMu.Unlock()
+	return nil
+}
+
+func (s *Store) retentionConfig() RetentionConfig {
+	s.retentionMu.Lock()
+	defer s.retentionMu.Unlock()
+	if s.retention == (RetentionConfig{}) {
+		return DefaultRetentionConfig()
+	}
+	return s.retention
 }

--- a/internal/relay/rate_limit.go
+++ b/internal/relay/rate_limit.go
@@ -184,16 +184,16 @@ func boundRetryAfter(wait time.Duration, maxSeconds int) int {
 // Metrics counts content-free relay pressure signals. Labels are fixed names
 // only; bodies, endpoints, roles, and conversation IDs are never recorded.
 type Metrics struct {
-	rateLimitRejections         atomic.Uint64
-	capacityRejections          atomic.Uint64
-	pendingDeliveries           atomic.Uint64
-	pendingBytes                atomic.Uint64
-	pendingOldestAgeSeconds     atomic.Uint64
-	terminalTransitionsAcked    atomic.Uint64
-	terminalTransitionsExpired  atomic.Uint64
-	terminalTransitionsRevoked  atomic.Uint64
-	terminalsRetained           atomic.Uint64
-	leaseRedeliveries           atomic.Uint64
+	rateLimitRejections        atomic.Uint64
+	capacityRejections         atomic.Uint64
+	pendingDeliveries          atomic.Uint64
+	pendingBytes               atomic.Uint64
+	pendingOldestAgeSeconds    atomic.Uint64
+	terminalTransitionsAcked   atomic.Uint64
+	terminalTransitionsExpired atomic.Uint64
+	terminalTransitionsRevoked atomic.Uint64
+	terminalsRetained          atomic.Uint64
+	leaseRedeliveries          atomic.Uint64
 }
 
 // ObserveRateLimited increments the rate-rejection counter.
@@ -206,16 +206,16 @@ func (m *Metrics) ObserveRateLimited() {
 
 // MetricsSnapshot is the bounded JSON body served on the local health listener.
 type MetricsSnapshot struct {
-	RelayRateLimitRejections         uint64 `json:"relay_rate_limit_rejections"`
-	RelayCapacityRejections          uint64 `json:"relay_capacity_rejections"`
-	RelayPendingDeliveries           uint64 `json:"relay_pending_deliveries"`
-	RelayPendingBytes                uint64 `json:"relay_pending_bytes"`
-	RelayPendingOldestAgeSeconds     uint64 `json:"relay_pending_oldest_age_seconds"`
-	RelayTerminalTransitionsAcked    uint64 `json:"relay_terminal_transitions_acked"`
-	RelayTerminalTransitionsExpired  uint64 `json:"relay_terminal_transitions_expired"`
-	RelayTerminalTransitionsRevoked  uint64 `json:"relay_terminal_transitions_revoked"`
-	RelayTerminalsRetained           uint64 `json:"relay_terminals_retained"`
-	RelayLeaseRedeliveries           uint64 `json:"relay_lease_redeliveries"`
+	RelayRateLimitRejections        uint64 `json:"relay_rate_limit_rejections"`
+	RelayCapacityRejections         uint64 `json:"relay_capacity_rejections"`
+	RelayPendingDeliveries          uint64 `json:"relay_pending_deliveries"`
+	RelayPendingBytes               uint64 `json:"relay_pending_bytes"`
+	RelayPendingOldestAgeSeconds    uint64 `json:"relay_pending_oldest_age_seconds"`
+	RelayTerminalTransitionsAcked   uint64 `json:"relay_terminal_transitions_acked"`
+	RelayTerminalTransitionsExpired uint64 `json:"relay_terminal_transitions_expired"`
+	RelayTerminalTransitionsRevoked uint64 `json:"relay_terminal_transitions_revoked"`
+	RelayTerminalsRetained          uint64 `json:"relay_terminals_retained"`
+	RelayLeaseRedeliveries          uint64 `json:"relay_lease_redeliveries"`
 }
 
 // Snapshot returns the current content-free counters.

--- a/internal/relay/retention.go
+++ b/internal/relay/retention.go
@@ -1,0 +1,188 @@
+package relay
+
+import (
+	"encoding/base64"
+	"fmt"
+	"strings"
+	"time"
+)
+
+const (
+	// RetentionAgeMinSeconds is the smallest accepted pending-delivery max age.
+	RetentionAgeMinSeconds = 1
+	// RetentionAgeMaxSeconds is the largest accepted pending-delivery max age (365 days).
+	RetentionAgeMaxSeconds = 365 * 24 * 60 * 60
+	// RetentionKeepMinSeconds is the smallest accepted terminal retention window.
+	RetentionKeepMinSeconds = 1
+	// RetentionKeepMaxSeconds is the largest accepted terminal retention window (365 days).
+	RetentionKeepMaxSeconds = 365 * 24 * 60 * 60
+	// RetentionBatchMin is the smallest accepted maintenance page size.
+	RetentionBatchMin = 1
+	// RetentionBatchMax is the largest accepted maintenance page size.
+	RetentionBatchMax = 1000
+	// DefaultTerminalListLimit is the page size when a list request omits limit.
+	DefaultTerminalListLimit = 50
+	// MaxTerminalListLimit is the inclusive upper bound for one terminal page.
+	MaxTerminalListLimit = 100
+
+	// ClosedReasonAcked records a successful local-mailbox acknowledgement.
+	ClosedReasonAcked = "acked"
+	// ClosedReasonExpired records a pending-delivery age expiry.
+	ClosedReasonExpired = "expired"
+	// ClosedReasonRevoked records membership-revocation retirement.
+	ClosedReasonRevoked = "revoked"
+)
+
+// RetentionConfig is the startup-validated pending-age and terminal-retention policy.
+type RetentionConfig struct {
+	PendingMaxAgeSeconds     int
+	TerminalRetentionSeconds int
+	MaintenanceBatch         int
+}
+
+// DefaultRetentionConfig is conservative: seven days pending, thirty days of
+// content-free terminal metadata, and 100-row maintenance pages.
+func DefaultRetentionConfig() RetentionConfig {
+	return RetentionConfig{
+		PendingMaxAgeSeconds:     7 * 24 * 60 * 60,
+		TerminalRetentionSeconds: 30 * 24 * 60 * 60,
+		MaintenanceBatch:         100,
+	}
+}
+
+// Validate reports whether every bound is an explicit integer in range.
+func (c RetentionConfig) Validate() error {
+	if err := boundedRateInt("pending max age seconds", c.PendingMaxAgeSeconds, RetentionAgeMinSeconds, RetentionAgeMaxSeconds); err != nil {
+		return err
+	}
+	if err := boundedRateInt("terminal retention seconds", c.TerminalRetentionSeconds, RetentionKeepMinSeconds, RetentionKeepMaxSeconds); err != nil {
+		return err
+	}
+	return boundedRateInt("delivery maintenance batch", c.MaintenanceBatch, RetentionBatchMin, RetentionBatchMax)
+}
+
+// PendingMaxAge is the inclusive pending-delivery lifetime.
+func (c RetentionConfig) PendingMaxAge() time.Duration {
+	return time.Duration(c.PendingMaxAgeSeconds) * time.Second
+}
+
+// TerminalRetention is how long closed metadata remains inspectable.
+func (c RetentionConfig) TerminalRetention() time.Duration {
+	return time.Duration(c.TerminalRetentionSeconds) * time.Second
+}
+
+// DeliveryTerminal is one content-free closed-delivery record. It never
+// includes message bodies, credentials, or endpoint display names.
+type DeliveryTerminal struct {
+	DeliveryID      string    `json:"delivery_id"`
+	MessageID       string    `json:"message_id"`
+	ConversationID  string    `json:"conversation_id"`
+	RecipientID     string    `json:"recipient_id"`
+	Sequence        int64     `json:"sequence"`
+	ClosedReason    string    `json:"closed_reason"`
+	LeaseGeneration int64     `json:"lease_generation"`
+	ClosedAt        time.Time `json:"closed_at"`
+	CreatedAt       time.Time `json:"created_at"`
+}
+
+// TerminalListInput is one host-local, bounded inventory page request.
+type TerminalListInput struct {
+	Cursor string
+	Limit  int
+}
+
+// TerminalListPage is one cursor-stable page of retained terminal metadata.
+type TerminalListPage struct {
+	Terminals  []DeliveryTerminal `json:"terminals"`
+	NextCursor string             `json:"next_cursor,omitempty"`
+}
+
+// MaintenanceResult reports one bounded expire-then-prune page.
+type MaintenanceResult struct {
+	Expired      int  `json:"expired"`
+	Pruned       int  `json:"pruned"`
+	Continuation bool `json:"continuation"`
+}
+
+// EncodeTerminalListCursor hides the last closed timestamp and delivery ID.
+func EncodeTerminalListCursor(closedAt time.Time, deliveryID string) string {
+	if deliveryID == "" || closedAt.IsZero() {
+		return ""
+	}
+	raw := fmt.Sprintf("%d\x1e%s", closedAt.UTC().UnixMilli(), deliveryID)
+	return base64.RawURLEncoding.EncodeToString([]byte(raw))
+}
+
+// DecodeTerminalListCursor reports the last closed timestamp and delivery ID.
+func DecodeTerminalListCursor(cursor string) (time.Time, string, bool) {
+	if cursor == "" {
+		return time.Time{}, "", true
+	}
+	raw, err := base64.RawURLEncoding.DecodeString(cursor)
+	if err != nil {
+		return time.Time{}, "", false
+	}
+	millis, deliveryID, ok := strings.Cut(string(raw), "\x1e")
+	if !ok || deliveryID == "" {
+		return time.Time{}, "", false
+	}
+	var value int64
+	if _, err := fmt.Sscan(millis, &value); err != nil || value < 0 {
+		return time.Time{}, "", false
+	}
+	return fromMillis(value), deliveryID, true
+}
+
+func (m *Metrics) observeTerminalTransition(reason string, count uint64) {
+	m.ObserveTerminalTransition(reason, count)
+}
+
+// ObserveTerminalTransition increments one closed-reason counter after a durable commit.
+func (m *Metrics) ObserveTerminalTransition(reason string, count uint64) {
+	if m == nil || count == 0 {
+		return
+	}
+	switch reason {
+	case ClosedReasonAcked:
+		m.terminalTransitionsAcked.Add(count)
+	case ClosedReasonExpired:
+		m.terminalTransitionsExpired.Add(count)
+	case ClosedReasonRevoked:
+		m.terminalTransitionsRevoked.Add(count)
+	}
+}
+
+// ObserveLeaseRedelivery increments the unlabeled lease-expiry/redelivery counter.
+func (m *Metrics) ObserveLeaseRedelivery() {
+	if m == nil {
+		return
+	}
+	m.leaseRedeliveries.Add(1)
+}
+
+// SetQueueAge replaces the unlabeled oldest-pending-age gauge.
+func (m *Metrics) SetQueueAge(seconds uint64) {
+	if m == nil {
+		return
+	}
+	m.pendingOldestAgeSeconds.Store(seconds)
+}
+
+// SetTerminalsRetained replaces the unlabeled retained-terminal gauge.
+func (m *Metrics) SetTerminalsRetained(count uint64) {
+	if m == nil {
+		return
+	}
+	m.terminalsRetained.Store(count)
+}
+
+func pendingAgeSeconds(oldest time.Time, now time.Time) uint64 {
+	if oldest.IsZero() || now.Before(oldest) {
+		return 0
+	}
+	seconds := int64(now.Sub(oldest) / time.Second)
+	if seconds < 0 {
+		return 0
+	}
+	return uint64(seconds) // #nosec G115 -- pending age is CHECK-constrained to non-negative durations.
+}

--- a/internal/relay/retention.go
+++ b/internal/relay/retention.go
@@ -109,7 +109,7 @@ func EncodeTerminalListCursor(closedAt time.Time, deliveryID string) string {
 	if deliveryID == "" || closedAt.IsZero() {
 		return ""
 	}
-	raw := fmt.Sprintf("%d\x1e%s", closedAt.UTC().UnixMilli(), deliveryID)
+	raw := fmt.Sprintf("%d\x1e%s", closedAt.UTC().Truncate(time.Microsecond).UnixMicro(), deliveryID)
 	return base64.RawURLEncoding.EncodeToString([]byte(raw))
 }
 
@@ -122,15 +122,15 @@ func DecodeTerminalListCursor(cursor string) (time.Time, string, bool) {
 	if err != nil {
 		return time.Time{}, "", false
 	}
-	millis, deliveryID, ok := strings.Cut(string(raw), "\x1e")
+	micros, deliveryID, ok := strings.Cut(string(raw), "\x1e")
 	if !ok || deliveryID == "" {
 		return time.Time{}, "", false
 	}
 	var value int64
-	if _, err := fmt.Sscan(millis, &value); err != nil || value < 0 {
+	if _, err := fmt.Sscan(micros, &value); err != nil || value < 0 {
 		return time.Time{}, "", false
 	}
-	return fromMillis(value), deliveryID, true
+	return time.UnixMicro(value).UTC(), deliveryID, true
 }
 
 func (m *Metrics) observeTerminalTransition(reason string, count uint64) {

--- a/internal/relay/store.go
+++ b/internal/relay/store.go
@@ -319,6 +319,8 @@ type Store struct {
 	rateLimits       RateLimitConfig
 	quotaMu          sync.Mutex
 	quota            QuotaConfig
+	retentionMu      sync.Mutex
+	retention        RetentionConfig
 	pendingMetricsMu sync.Mutex
 	metrics          *Metrics
 }
@@ -351,7 +353,7 @@ func openStore(database string, verifyQuota bool) (*Store, error) {
 	// from surfacing SQLITE_BUSY instead of orderly transactional serialization.
 	db.SetMaxOpenConns(1)
 	db.SetMaxIdleConns(1)
-	store := &Store{db: db, rateLimits: DefaultRateLimitConfig(), quota: DefaultQuotaConfig()}
+	store := &Store{db: db, rateLimits: DefaultRateLimitConfig(), quota: DefaultQuotaConfig(), retention: DefaultRetentionConfig()}
 	var migrationControlExists bool
 	if err := db.QueryRowContext(context.Background(), `SELECT EXISTS (SELECT 1 FROM sqlite_schema WHERE type='table' AND name='relay_migration_control')`).Scan(&migrationControlExists); err != nil {
 		_ = db.Close()
@@ -577,6 +579,17 @@ func (s *Store) migrate(ctx context.Context) error {
 			pending_count INTEGER NOT NULL CHECK (pending_count >= 0),
 			pending_bytes INTEGER NOT NULL CHECK (pending_bytes >= 0)
 		)`,
+		`CREATE TABLE IF NOT EXISTS delivery_terminals (
+			delivery_id TEXT PRIMARY KEY REFERENCES deliveries(id) ON DELETE CASCADE,
+			message_id TEXT NOT NULL REFERENCES messages(id) ON DELETE CASCADE,
+			conversation_id TEXT NOT NULL REFERENCES conversations(id) ON DELETE CASCADE,
+			recipient_id TEXT NOT NULL,
+			sequence INTEGER NOT NULL CHECK (sequence >= 0),
+			closed_reason TEXT NOT NULL CHECK (closed_reason IN ('acked','expired','revoked')),
+			lease_generation INTEGER NOT NULL CHECK (lease_generation >= 0),
+			closed_at INTEGER NOT NULL,
+			created_at INTEGER NOT NULL
+		)`,
 		`CREATE TABLE IF NOT EXISTS direct_conversations (
 			role_low TEXT NOT NULL REFERENCES roles(role) ON DELETE RESTRICT,
 			role_high TEXT NOT NULL REFERENCES roles(role) ON DELETE RESTRICT,
@@ -621,6 +634,7 @@ func (s *Store) migrate(ctx context.Context) error {
 			)
 		)`,
 		"CREATE INDEX IF NOT EXISTS deliveries_recipient_pending ON deliveries(recipient_endpoint, acked_at, lease_until)",
+		"CREATE INDEX IF NOT EXISTS delivery_terminals_closed ON delivery_terminals(closed_at, delivery_id)",
 		"CREATE INDEX IF NOT EXISTS role_bindings_session ON role_bindings(machine_id, session_endpoint, ownership_generation, lease_until)",
 		"CREATE INDEX IF NOT EXISTS request_nonces_expiry ON request_nonces(expires_at)",
 	} {
@@ -633,7 +647,7 @@ func (s *Store) migrate(ctx context.Context) error {
 			return fmt.Errorf("initialize relay migration control: %w", err)
 		}
 	}
-	for _, table := range []string{"endpoints", "conversations", "memberships", "roles", "role_memberships", "role_bindings", "role_profiles", "role_profile_idempotency", "messages", "deliveries", "recipient_cursors", "idempotency", "conversation_idempotency", "conversation_controls", "conversation_control_idempotency", "request_nonces", "rate_buckets", "pending_quota_recipients", "pending_quota_install", "direct_conversations", "message_from_roles", "direct_message_idempotency"} {
+	for _, table := range []string{"endpoints", "conversations", "memberships", "roles", "role_memberships", "role_bindings", "role_profiles", "role_profile_idempotency", "messages", "deliveries", "recipient_cursors", "idempotency", "conversation_idempotency", "conversation_controls", "conversation_control_idempotency", "request_nonces", "rate_buckets", "pending_quota_recipients", "pending_quota_install", "delivery_terminals", "direct_conversations", "message_from_roles", "direct_message_idempotency"} {
 		for _, operation := range []string{"INSERT", "UPDATE", "DELETE"} {
 			name := "relay_migration_guard_" + table + "_" + strings.ToLower(operation)
 			statement := fmt.Sprintf(`CREATE TRIGGER IF NOT EXISTS %s BEFORE %s ON %s
@@ -714,6 +728,7 @@ func (s *Store) ApplyControl(input ControlInput) (ControlEvent, bool, error) {
 	if !errors.Is(err, sql.ErrNoRows) {
 		return ControlEvent{}, false, fmt.Errorf("read control idempotency key: %w", err)
 	}
+	revoked := 0
 	if input.Operation == ControlUpsertMember {
 		var previous Capability
 		err := tx.QueryRowContext(context.Background(), "SELECT capabilities FROM memberships WHERE conversation_id=? AND endpoint=?", input.ConversationID, input.Member.Endpoint).Scan(&previous)
@@ -742,9 +757,11 @@ func (s *Store) ApplyControl(input ControlInput) (ControlEvent, bool, error) {
 			}
 		}
 		if err == nil && previous&CapReceive != 0 && input.Member.Capabilities&CapReceive == 0 {
-			if err := retireRecipientDeliveries(tx, input.Member.Endpoint, input.ConversationID, input.Now); err != nil {
+			count, err := retireRecipientDeliveries(tx, input.Member.Endpoint, input.ConversationID, input.Now)
+			if err != nil {
 				return ControlEvent{}, false, err
 			}
+			revoked += count
 			if err := advanceRecipientCursor(tx, input.Member.Endpoint, input.ConversationID); err != nil {
 				return ControlEvent{}, false, err
 			}
@@ -778,9 +795,11 @@ func (s *Store) ApplyControl(input ControlInput) (ControlEvent, bool, error) {
 				return ControlEvent{}, false, ErrConflict
 			}
 		}
-		if err := retireRecipientDeliveries(tx, input.Member.Endpoint, input.ConversationID, input.Now); err != nil {
+		count, err := retireRecipientDeliveries(tx, input.Member.Endpoint, input.ConversationID, input.Now)
+		if err != nil {
 			return ControlEvent{}, false, err
 		}
+		revoked += count
 		if err := advanceRecipientCursor(tx, input.Member.Endpoint, input.ConversationID); err != nil {
 			return ControlEvent{}, false, err
 		}
@@ -809,7 +828,8 @@ func (s *Store) ApplyControl(input ControlInput) (ControlEvent, bool, error) {
 	if err := tx.Commit(); err != nil {
 		return ControlEvent{}, false, err
 	}
-	s.refreshPendingMetrics()
+	s.metrics.observeTerminalTransition(ClosedReasonRevoked, uint64(revoked)) // #nosec G115 -- revoked count is bounded by pending deliveries for one recipient.
+	s.refreshDeliveryMetrics(input.Now)
 	return event, false, nil
 }
 
@@ -1251,7 +1271,7 @@ func (s *Store) SendDirectMessage(input DirectMessageInput) (Message, bool, erro
 	if err := tx.Commit(); err != nil {
 		return Message{}, false, err
 	}
-	s.refreshPendingMetrics()
+	s.refreshDeliveryMetrics(now)
 	return message, false, nil
 }
 
@@ -1794,7 +1814,7 @@ func (s *Store) AppendMessage(input AppendInput) (Message, bool, error) {
 	if err := tx.Commit(); err != nil {
 		return Message{}, false, err
 	}
-	s.refreshPendingMetrics()
+	s.refreshDeliveryMetrics(input.Now)
 	return message, false, nil
 }
 
@@ -1900,6 +1920,7 @@ func (s *Store) LeaseDeliveries(machineID, consumerID, endpoint, conversationID 
 	}
 	defer func() { _ = rows.Close() }()
 	var deliveries []Delivery
+	redeliveries := 0
 	for rows.Next() {
 		var delivery Delivery
 		var leaseMachine, leaseToken sql.NullString
@@ -1920,6 +1941,9 @@ func (s *Store) LeaseDeliveries(machineID, consumerID, endpoint, conversationID 
 			delivery.LeaseToken = leaseToken.String
 			delivery.LeaseUntil = fromMillis(leaseUntil.Int64)
 		} else {
+			if leaseToken.Valid || leaseUntil.Valid {
+				redeliveries++
+			}
 			token, err := randomToken()
 			if err != nil {
 				return DeliveryLeasePage{}, err
@@ -1956,6 +1980,9 @@ func (s *Store) LeaseDeliveries(machineID, consumerID, endpoint, conversationID 
 	}
 	if err := tx.Commit(); err != nil {
 		return DeliveryLeasePage{}, err
+	}
+	for i := 0; i < redeliveries; i++ {
+		s.metrics.ObserveLeaseRedelivery()
 	}
 	return DeliveryLeasePage{Deliveries: deliveries, Cursors: cursors}, nil
 }
@@ -2041,6 +2068,9 @@ func (s *Store) AckDelivery(machineID, endpoint, deliveryID, token string, gener
 	if err != nil {
 		return fmt.Errorf("acknowledge delivery: %w", err)
 	}
+	if affected != 1 {
+		return ErrForbidden
+	}
 	var conversationID string
 	var bodyBytes int64
 	if err := tx.QueryRowContext(context.Background(), `SELECT message.conversation_id, length(CAST(message.body AS BLOB))
@@ -2048,10 +2078,11 @@ func (s *Store) AckDelivery(machineID, endpoint, deliveryID, token string, gener
 		WHERE delivery.id = ?`, deliveryID).Scan(&conversationID, &bodyBytes); err != nil {
 		return fmt.Errorf("read delivery conversation: %w", err)
 	}
-	if affected == 1 {
-		if err := releaseQuota(tx, recipient.String, bodyBytes); err != nil {
-			return err
-		}
+	if err := releaseQuota(tx, recipient.String, bodyBytes); err != nil {
+		return err
+	}
+	if err := recordDeliveryTerminal(tx, deliveryID, ClosedReasonAcked, now); err != nil {
+		return err
 	}
 	if err := advanceRecipientCursor(tx, recipient.String, conversationID); err != nil {
 		return err
@@ -2059,7 +2090,8 @@ func (s *Store) AckDelivery(machineID, endpoint, deliveryID, token string, gener
 	if err := tx.Commit(); err != nil {
 		return err
 	}
-	s.refreshPendingMetrics()
+	s.metrics.observeTerminalTransition(ClosedReasonAcked, 1)
+	s.refreshDeliveryMetrics(now)
 	return nil
 }
 

--- a/internal/relay/store_quota.go
+++ b/internal/relay/store_quota.go
@@ -154,12 +154,12 @@ func releaseQuota(tx *sql.Tx, recipient string, bodyBytes int64) error {
 	return nil
 }
 
-func retireRecipientDeliveries(tx *sql.Tx, recipient, conversationID string, now time.Time) error {
+func retireRecipientDeliveries(tx *sql.Tx, recipient, conversationID string, now time.Time) (int, error) {
 	rows, err := tx.QueryContext(context.Background(), `SELECT delivery.id, `+sqlitePendingBodyBytes+`
 		FROM deliveries AS delivery JOIN messages AS message ON message.id = delivery.message_id
 		WHERE delivery.recipient_endpoint = ? AND delivery.acked_at IS NULL AND message.conversation_id = ?`, recipient, conversationID)
 	if err != nil {
-		return fmt.Errorf("find revoked deliveries: %w", err)
+		return 0, fmt.Errorf("find revoked deliveries: %w", err)
 	}
 	type pending struct {
 		id    string
@@ -170,25 +170,28 @@ func retireRecipientDeliveries(tx *sql.Tx, recipient, conversationID string, now
 		var row pending
 		if err := rows.Scan(&row.id, &row.bytes); err != nil {
 			_ = rows.Close()
-			return err
+			return 0, err
 		}
 		retired = append(retired, row)
 	}
 	if err := rows.Close(); err != nil {
-		return err
+		return 0, err
 	}
 	if err := rows.Err(); err != nil {
-		return err
+		return 0, err
 	}
 	for _, row := range retired {
 		if err := releaseQuota(tx, recipient, row.bytes); err != nil {
-			return err
+			return 0, err
+		}
+		if err := recordDeliveryTerminal(tx, row.id, ClosedReasonRevoked, now); err != nil {
+			return 0, err
 		}
 	}
 	if _, err := tx.ExecContext(context.Background(), "UPDATE deliveries SET acked_at=? WHERE recipient_endpoint=? AND acked_at IS NULL AND message_id IN (SELECT id FROM messages WHERE conversation_id=?)", now.UTC().UnixMilli(), recipient, conversationID); err != nil {
-		return fmt.Errorf("retire revoked deliveries: %w", err)
+		return 0, fmt.Errorf("retire revoked deliveries: %w", err)
 	}
-	return nil
+	return len(retired), nil
 }
 
 func (s *Store) refreshPendingMetrics() {
@@ -335,12 +338,12 @@ func ReconcilePendingQuota(store *Store) (QuotaCounters, error) {
 	if err := tx.Commit(); err != nil {
 		return QuotaCounters{}, err
 	}
-	store.refreshPendingMetrics()
+	store.refreshDeliveryMetrics(time.Now().UTC())
 	return install, nil
 }
 
 func isOperationalQuotaTable(name string) bool {
-	return name == "pending_quota_recipients" || name == "pending_quota_install"
+	return name == "pending_quota_recipients" || name == "pending_quota_install" || name == "delivery_terminals"
 }
 
 func filterOperationalQuotaTables(names []string) []string {

--- a/internal/relay/store_retention.go
+++ b/internal/relay/store_retention.go
@@ -1,0 +1,198 @@
+package relay
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"time"
+)
+
+// MaintainDeliveries expires due pending deliveries and prunes aged terminal
+// metadata in one bounded page. Callers inject now; tests must not sleep.
+func (s *Store) MaintainDeliveries(now time.Time) (MaintenanceResult, error) {
+	now = now.UTC().Truncate(time.Millisecond)
+	cfg := s.retentionConfig()
+	tx, err := s.db.BeginTx(context.Background(), nil)
+	if err != nil {
+		return MaintenanceResult{}, err
+	}
+	defer rollback(tx)
+	expired, err := expireDueDeliveries(tx, now, cfg)
+	if err != nil {
+		return MaintenanceResult{}, err
+	}
+	pruned, err := pruneExpiredTerminals(tx, now, cfg)
+	if err != nil {
+		return MaintenanceResult{}, err
+	}
+	if err := tx.Commit(); err != nil {
+		return MaintenanceResult{}, err
+	}
+	s.metrics.observeTerminalTransition(ClosedReasonExpired, uint64(expired)) // #nosec G115 -- expired is bounded by MaintenanceBatch.
+	s.refreshDeliveryMetrics(now)
+	return MaintenanceResult{
+		Expired:      expired,
+		Pruned:       pruned,
+		Continuation: expired == cfg.MaintenanceBatch || pruned == cfg.MaintenanceBatch,
+	}, nil
+}
+
+func expireDueDeliveries(tx *sql.Tx, now time.Time, cfg RetentionConfig) (int, error) {
+	cutoff := now.Add(-cfg.PendingMaxAge()).UnixMilli()
+	rows, err := tx.QueryContext(context.Background(), `SELECT delivery.id, delivery.recipient_endpoint, `+sqlitePendingBodyBytes+`, message.conversation_id
+		FROM deliveries AS delivery JOIN messages AS message ON message.id = delivery.message_id
+		WHERE delivery.acked_at IS NULL AND message.created_at <= ?
+		ORDER BY message.created_at, delivery.id
+		LIMIT ?`, cutoff, cfg.MaintenanceBatch)
+	if err != nil {
+		return 0, fmt.Errorf("find expired deliveries: %w", err)
+	}
+	type candidate struct {
+		id, recipient, conversationID string
+		bodyBytes                     int64
+	}
+	var due []candidate
+	for rows.Next() {
+		var row candidate
+		if err := rows.Scan(&row.id, &row.recipient, &row.bodyBytes, &row.conversationID); err != nil {
+			_ = rows.Close()
+			return 0, err
+		}
+		due = append(due, row)
+	}
+	if err := rows.Close(); err != nil {
+		return 0, err
+	}
+	if err := rows.Err(); err != nil {
+		return 0, err
+	}
+	closed := 0
+	for _, row := range due {
+		result, err := tx.ExecContext(context.Background(), `UPDATE deliveries
+			SET acked_at = ?, lease_machine_id = NULL, lease_token = NULL, ownership_generation = NULL, consumer_generation = NULL, lease_until = NULL
+			WHERE id = ? AND acked_at IS NULL`, now.UnixMilli(), row.id)
+		if err != nil {
+			return 0, fmt.Errorf("expire delivery: %w", err)
+		}
+		affected, err := result.RowsAffected()
+		if err != nil {
+			return 0, fmt.Errorf("expire delivery: %w", err)
+		}
+		if affected != 1 {
+			continue
+		}
+		if err := recordDeliveryTerminal(tx, row.id, ClosedReasonExpired, now); err != nil {
+			return 0, err
+		}
+		if err := releaseQuota(tx, row.recipient, row.bodyBytes); err != nil {
+			return 0, err
+		}
+		if err := advanceRecipientCursor(tx, row.recipient, row.conversationID); err != nil {
+			return 0, err
+		}
+		closed++
+	}
+	return closed, nil
+}
+
+func pruneExpiredTerminals(tx *sql.Tx, now time.Time, cfg RetentionConfig) (int, error) {
+	cutoff := now.Add(-cfg.TerminalRetention()).UnixMilli()
+	result, err := tx.ExecContext(context.Background(), `DELETE FROM delivery_terminals WHERE delivery_id IN (
+		SELECT delivery_id FROM (
+			SELECT delivery_id FROM delivery_terminals WHERE closed_at <= ? ORDER BY closed_at, delivery_id LIMIT ?
+		)
+	)`, cutoff, cfg.MaintenanceBatch)
+	if err != nil {
+		return 0, fmt.Errorf("prune delivery terminals: %w", err)
+	}
+	affected, err := result.RowsAffected()
+	if err != nil {
+		return 0, fmt.Errorf("prune delivery terminals: %w", err)
+	}
+	return int(affected), nil
+}
+
+func recordDeliveryTerminal(tx *sql.Tx, deliveryID, reason string, now time.Time) error {
+	if _, err := tx.ExecContext(context.Background(), `INSERT OR IGNORE INTO delivery_terminals(
+		delivery_id, message_id, conversation_id, recipient_id, sequence, closed_reason, lease_generation, closed_at, created_at)
+		SELECT delivery.id, delivery.message_id, message.conversation_id, delivery.recipient_endpoint, message.sequence, ?, COALESCE(delivery.lease_generation, 0), ?, message.created_at
+		FROM deliveries AS delivery JOIN messages AS message ON message.id = delivery.message_id
+		WHERE delivery.id = ?`, reason, now.UTC().Truncate(time.Millisecond).UnixMilli(), deliveryID); err != nil {
+		return fmt.Errorf("record delivery terminal: %w", err)
+	}
+	return nil
+}
+
+// ListDeliveryTerminals returns one bounded page of retained terminal metadata.
+func (s *Store) ListDeliveryTerminals(input TerminalListInput) (TerminalListPage, error) {
+	limit := input.Limit
+	if limit <= 0 {
+		limit = DefaultTerminalListLimit
+	}
+	if limit > MaxTerminalListLimit {
+		limit = MaxTerminalListLimit
+	}
+	closedAt, deliveryID, ok := DecodeTerminalListCursor(input.Cursor)
+	if !ok {
+		return TerminalListPage{}, fmt.Errorf("invalid terminal cursor")
+	}
+	var rows *sql.Rows
+	var err error
+	if deliveryID == "" {
+		rows, err = s.db.QueryContext(context.Background(), `SELECT delivery_id, message_id, conversation_id, recipient_id, sequence, closed_reason, lease_generation, closed_at, created_at
+			FROM delivery_terminals ORDER BY closed_at, delivery_id LIMIT ?`, limit+1)
+	} else {
+		rows, err = s.db.QueryContext(context.Background(), `SELECT delivery_id, message_id, conversation_id, recipient_id, sequence, closed_reason, lease_generation, closed_at, created_at
+			FROM delivery_terminals
+			WHERE closed_at > ? OR (closed_at = ? AND delivery_id > ?)
+			ORDER BY closed_at, delivery_id LIMIT ?`, closedAt.UnixMilli(), closedAt.UnixMilli(), deliveryID, limit+1)
+	}
+	if err != nil {
+		return TerminalListPage{}, fmt.Errorf("list delivery terminals: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	var terminals []DeliveryTerminal
+	for rows.Next() {
+		var terminal DeliveryTerminal
+		var closedMillis, createdMillis int64
+		if err := rows.Scan(&terminal.DeliveryID, &terminal.MessageID, &terminal.ConversationID, &terminal.RecipientID, &terminal.Sequence, &terminal.ClosedReason, &terminal.LeaseGeneration, &closedMillis, &createdMillis); err != nil {
+			return TerminalListPage{}, err
+		}
+		terminal.ClosedAt = fromMillis(closedMillis)
+		terminal.CreatedAt = fromMillis(createdMillis)
+		terminals = append(terminals, terminal)
+	}
+	if err := rows.Err(); err != nil {
+		return TerminalListPage{}, err
+	}
+	page := TerminalListPage{Terminals: terminals}
+	if len(page.Terminals) > limit {
+		last := page.Terminals[limit-1]
+		page.Terminals = page.Terminals[:limit]
+		page.NextCursor = EncodeTerminalListCursor(last.ClosedAt, last.DeliveryID)
+	}
+	return page, nil
+}
+
+func (s *Store) refreshDeliveryMetrics(now time.Time) {
+	s.refreshPendingMetrics()
+	if s.metrics == nil {
+		return
+	}
+	var oldest sql.NullInt64
+	if err := s.db.QueryRowContext(context.Background(), `SELECT MIN(message.created_at)
+		FROM deliveries AS delivery JOIN messages AS message ON message.id = delivery.message_id
+		WHERE delivery.acked_at IS NULL`).Scan(&oldest); err != nil {
+		return
+	}
+	if oldest.Valid {
+		s.metrics.SetQueueAge(pendingAgeSeconds(fromMillis(oldest.Int64), now.UTC()))
+	} else {
+		s.metrics.SetQueueAge(0)
+	}
+	var retained int64
+	if err := s.db.QueryRowContext(context.Background(), `SELECT COUNT(*) FROM delivery_terminals`).Scan(&retained); err != nil {
+		return
+	}
+	s.metrics.SetTerminalsRetained(unsignedPending(retained))
+}

--- a/internal/relay/store_retention_test.go
+++ b/internal/relay/store_retention_test.go
@@ -1,0 +1,544 @@
+package relay
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+func tightRetention(maxAge, keep time.Duration, batch int) RetentionConfig {
+	return RetentionConfig{
+		PendingMaxAgeSeconds:     int(maxAge / time.Second),
+		TerminalRetentionSeconds: int(keep / time.Second),
+		MaintenanceBatch:         batch,
+	}
+}
+
+func TestRetentionConfigRejectsOutOfBoundsValues(t *testing.T) {
+	cfg := DefaultRetentionConfig()
+	cfg.PendingMaxAgeSeconds = 0
+	if err := cfg.Validate(); err == nil {
+		t.Fatal("zero pending max age was accepted")
+	}
+	cfg = DefaultRetentionConfig()
+	cfg.TerminalRetentionSeconds = RetentionKeepMaxSeconds + 1
+	if err := cfg.Validate(); err == nil {
+		t.Fatal("oversized terminal retention was accepted")
+	}
+	cfg = DefaultRetentionConfig()
+	cfg.MaintenanceBatch = 0
+	if err := cfg.Validate(); err == nil {
+		t.Fatal("zero maintenance batch was accepted")
+	}
+}
+
+func TestStoreExpiryBoundaryJustBeforeAtAfter(t *testing.T) {
+	t.Parallel()
+	store := openRetentionStore(t, tightRetention(time.Minute, time.Hour, 10))
+	now := retentionNow()
+	conversation := createQuotaConversation(t, store, now, "machine-a", "machine-b", "agent/a", "agent/b")
+	message, _, err := store.AppendMessage(quotaAppend(conversation, "machine-a", "agent/a", "pending-age", "send-1", now))
+	if err != nil {
+		t.Fatal(err)
+	}
+	before := now.Add(time.Minute - time.Millisecond)
+	if result, err := store.MaintainDeliveries(before); err != nil || result.Expired != 0 {
+		t.Fatalf("just before expiry result=%#v err=%v", result, err)
+	}
+	if pending := quotaInstallCounters(t, store); pending.Count != 1 {
+		t.Fatalf("pending before boundary=%#v", pending)
+	}
+	at := now.Add(time.Minute)
+	if result, err := store.MaintainDeliveries(at); err != nil || result.Expired != 1 {
+		t.Fatalf("at expiry result=%#v err=%v", result, err)
+	}
+	if pending := quotaInstallCounters(t, store); pending != (QuotaCounters{}) {
+		t.Fatalf("pending at boundary=%#v", pending)
+	}
+	page, err := store.ListDeliveryTerminals(TerminalListInput{Limit: 10})
+	if err != nil || len(page.Terminals) != 1 || page.Terminals[0].ClosedReason != ClosedReasonExpired || page.Terminals[0].MessageID != message.ID || page.Terminals[0].Sequence != message.Sequence {
+		t.Fatalf("expired terminal=%#v err=%v", page, err)
+	}
+	after := now.Add(time.Minute + time.Millisecond)
+	if result, err := store.MaintainDeliveries(after); err != nil || result.Expired != 0 {
+		t.Fatalf("after expiry result=%#v err=%v", result, err)
+	}
+}
+
+func TestStoreMaintainBoundedBatchAndStableContinuation(t *testing.T) {
+	t.Parallel()
+	store := openRetentionStore(t, tightRetention(time.Minute, time.Hour, 2))
+	now := retentionNow()
+	conversation := createQuotaConversation(t, store, now, "machine-a", "machine-b", "agent/a", "agent/b")
+	for _, body := range []string{"one", "two", "three", "four", "five"} {
+		if _, _, err := store.AppendMessage(quotaAppend(conversation, "machine-a", "agent/a", body, "send-"+body, now)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if pending := quotaInstallCounters(t, store); pending.Count != 5 {
+		t.Fatalf("pending after appends=%#v", pending)
+	}
+	later := now.Add(time.Minute)
+	first, err := store.MaintainDeliveries(later)
+	if err != nil || first.Expired != 2 || !first.Continuation {
+		t.Fatalf("first page=%#v err=%v", first, err)
+	}
+	second, err := store.MaintainDeliveries(later)
+	if err != nil || second.Expired != 2 || !second.Continuation {
+		t.Fatalf("second page=%#v err=%v", second, err)
+	}
+	third, err := store.MaintainDeliveries(later)
+	if err != nil || third.Expired != 1 || third.Continuation {
+		t.Fatalf("third page=%#v err=%v", third, err)
+	}
+	if pending := quotaInstallCounters(t, store); pending != (QuotaCounters{}) {
+		t.Fatalf("pending after continuation=%#v", pending)
+	}
+}
+
+func TestStoreExpiryReleasesCapacityOnce(t *testing.T) {
+	t.Parallel()
+	store := openRetentionStore(t, tightRetention(time.Minute, time.Hour, 10))
+	if err := store.SetQuotaLimits(tightQuota(1, 1024, 8, 4096)); err != nil {
+		t.Fatal(err)
+	}
+	now := retentionNow()
+	conversation := createQuotaConversation(t, store, now, "machine-a", "machine-b", "agent/a", "agent/b")
+	if _, _, err := store.AppendMessage(quotaAppend(conversation, "machine-a", "agent/a", "one", "send-1", now)); err != nil {
+		t.Fatal(err)
+	}
+	later := now.Add(time.Minute)
+	if result, err := store.MaintainDeliveries(later); err != nil || result.Expired != 1 {
+		t.Fatalf("expire=%#v err=%v", result, err)
+	}
+	if result, err := store.MaintainDeliveries(later); err != nil || result.Expired != 0 {
+		t.Fatalf("repeat expire=%#v err=%v", result, err)
+	}
+	if counters := quotaInstallCounters(t, store); counters != (QuotaCounters{}) {
+		t.Fatalf("install counters after expiry=%#v", counters)
+	}
+	if _, _, err := store.AppendMessage(quotaAppend(conversation, "machine-a", "agent/a", "two", "send-2", later)); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestStoreExpiredActiveLeaseCannotAck(t *testing.T) {
+	t.Parallel()
+	store := openRetentionStore(t, tightRetention(time.Minute, time.Hour, 10))
+	now := retentionNow()
+	conversation := createQuotaConversation(t, store, now, "machine-a", "machine-b", "agent/a", "agent/b")
+	if _, _, err := store.AppendMessage(quotaAppend(conversation, "machine-a", "agent/a", "leased", "send-1", now)); err != nil {
+		t.Fatal(err)
+	}
+	page, err := store.LeaseDeliveries("machine-b", "consumer-b", "agent/b", conversation.ID, now, time.Hour, 10)
+	if err != nil || len(page.Deliveries) != 1 {
+		t.Fatalf("lease=%#v err=%v", page, err)
+	}
+	later := now.Add(time.Minute)
+	if result, err := store.MaintainDeliveries(later); err != nil || result.Expired != 1 {
+		t.Fatalf("expire=%#v err=%v", result, err)
+	}
+	if err := store.AckDelivery("machine-b", "agent/b", page.Deliveries[0].ID, page.Deliveries[0].LeaseToken, page.Deliveries[0].LeaseGeneration, later); !errors.Is(err, ErrForbidden) {
+		t.Fatalf("expired lease ack err=%v", err)
+	}
+}
+
+func TestStoreCursorContiguousExpiryAdvancesRecipient(t *testing.T) {
+	t.Parallel()
+	store := openRetentionStore(t, tightRetention(time.Minute, time.Hour, 10))
+	now := retentionNow()
+	conversation := createQuotaConversation(t, store, now, "machine-a", "machine-b", "agent/a", "agent/b")
+	if _, _, err := store.AppendMessage(quotaAppend(conversation, "machine-a", "agent/a", "first", "send-1", now)); err != nil {
+		t.Fatal(err)
+	}
+	second, _, err := store.AppendMessage(quotaAppend(conversation, "machine-a", "agent/a", "second", "send-2", now.Add(time.Second)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	later := second.CreatedAt.Add(time.Minute)
+	if result, err := store.MaintainDeliveries(later); err != nil || result.Expired != 2 {
+		t.Fatalf("expire both=%#v err=%v", result, err)
+	}
+	if cursor, err := store.RecipientCursor("machine-b", "agent/b", conversation.ID, later); err != nil || cursor != second.Sequence {
+		t.Fatalf("cursor after contiguous expiry=%d err=%v want %d", cursor, err, second.Sequence)
+	}
+}
+
+func TestStoreCursorExpiredLaterDoesNotSkipEarlierPending(t *testing.T) {
+	t.Parallel()
+	store := openRetentionStore(t, tightRetention(time.Minute, time.Hour, 10))
+	now := retentionNow()
+	conversation := createQuotaConversation(t, store, now, "machine-a", "machine-b", "agent/a", "agent/b")
+	first, _, err := store.AppendMessage(quotaAppend(conversation, "machine-a", "agent/a", "newer-first", "send-1", now.Add(30*time.Second)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, _, err := store.AppendMessage(quotaAppend(conversation, "machine-a", "agent/a", "older-second", "send-2", now))
+	if err != nil {
+		t.Fatal(err)
+	}
+	page, err := store.LeaseDeliveries("machine-b", "consumer-b", "agent/b", conversation.ID, now.Add(30*time.Second), time.Hour, 10)
+	if err != nil || len(page.Deliveries) != 2 {
+		t.Fatalf("lease=%#v err=%v", page, err)
+	}
+	expireAt := now.Add(time.Minute)
+	if result, err := store.MaintainDeliveries(expireAt); err != nil || result.Expired != 1 {
+		t.Fatalf("expire older only=%#v err=%v", result, err)
+	}
+	if cursor, err := store.RecipientCursor("machine-b", "agent/b", conversation.ID, expireAt); err != nil || cursor != 0 {
+		t.Fatalf("cursor with earlier pending=%d err=%v", cursor, err)
+	}
+	var live Delivery
+	for _, delivery := range page.Deliveries {
+		if delivery.Message.ID == first.ID {
+			live = delivery
+		}
+	}
+	if live.ID == "" {
+		t.Fatal("missing live delivery")
+	}
+	if err := store.AckDelivery("machine-b", "agent/b", live.ID, live.LeaseToken, live.LeaseGeneration, expireAt); err != nil {
+		t.Fatal(err)
+	}
+	if cursor, err := store.RecipientCursor("machine-b", "agent/b", conversation.ID, expireAt); err != nil || cursor != second.Sequence {
+		t.Fatalf("cursor after pending ack plus expired gap=%d err=%v want %d", cursor, err, second.Sequence)
+	}
+}
+
+func TestStoreExpiryIndependentRecipients(t *testing.T) {
+	t.Parallel()
+	store := openRetentionStore(t, tightRetention(time.Minute, time.Hour, 10))
+	now := retentionNow()
+	if err := store.AdvertiseEndpoints("machine-a", []string{"agent/a"}, now, time.Hour); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.AdvertiseEndpoints("machine-b", []string{"agent/b"}, now, time.Hour); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.AdvertiseEndpoints("machine-c", []string{"agent/c"}, now, time.Hour); err != nil {
+		t.Fatal(err)
+	}
+	conversation, err := store.CreateConversation("agent/a", []Member{
+		{Endpoint: "agent/a", Capabilities: CapSend | CapReceive | CapAdmin},
+		{Endpoint: "agent/b", Capabilities: CapReceive},
+		{Endpoint: "agent/c", Capabilities: CapReceive},
+	}, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := store.AppendMessage(quotaAppend(conversation, "machine-a", "agent/a", "fan-out", "send-1", now)); err != nil {
+		t.Fatal(err)
+	}
+	pageB, err := store.LeaseDeliveries("machine-b", "consumer-b", "agent/b", conversation.ID, now, time.Hour, 10)
+	if err != nil || len(pageB.Deliveries) != 1 {
+		t.Fatalf("lease b=%#v err=%v", pageB, err)
+	}
+	if err := store.AckDelivery("machine-b", "agent/b", pageB.Deliveries[0].ID, pageB.Deliveries[0].LeaseToken, pageB.Deliveries[0].LeaseGeneration, now); err != nil {
+		t.Fatal(err)
+	}
+	later := now.Add(time.Minute)
+	if result, err := store.MaintainDeliveries(later); err != nil || result.Expired != 1 {
+		t.Fatalf("expire remaining=%#v err=%v", result, err)
+	}
+	if cursor, err := store.RecipientCursor("machine-b", "agent/b", conversation.ID, later); err != nil || cursor != 1 {
+		t.Fatalf("acked recipient cursor=%d err=%v", cursor, err)
+	}
+	if cursor, err := store.RecipientCursor("machine-c", "agent/c", conversation.ID, later); err != nil || cursor != 1 {
+		t.Fatalf("expired recipient cursor=%d err=%v", cursor, err)
+	}
+	pageC, err := store.LeaseDeliveries("machine-c", "consumer-c", "agent/c", conversation.ID, later, time.Hour, 10)
+	if err != nil || len(pageC.Deliveries) != 0 {
+		t.Fatalf("expired recipient still pending=%#v err=%v", pageC, err)
+	}
+}
+
+func TestStoreTerminalRetentionAndBoundedPrune(t *testing.T) {
+	t.Parallel()
+	store := openRetentionStore(t, tightRetention(time.Minute, 2*time.Minute, 2))
+	now := retentionNow()
+	conversation := createQuotaConversation(t, store, now, "machine-a", "machine-b", "agent/a", "agent/b")
+	for _, body := range []string{"one", "two", "three"} {
+		if _, _, err := store.AppendMessage(quotaAppend(conversation, "machine-a", "agent/a", body, "send-"+body, now)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	expiredAt := now.Add(time.Minute)
+	for {
+		result, err := store.MaintainDeliveries(expiredAt)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !result.Continuation {
+			break
+		}
+	}
+	page, err := store.ListDeliveryTerminals(TerminalListInput{Limit: 10})
+	if err != nil || len(page.Terminals) != 3 {
+		t.Fatalf("retained before prune=%#v err=%v", page, err)
+	}
+	pruneAt := expiredAt.Add(2 * time.Minute)
+	first, err := store.MaintainDeliveries(pruneAt)
+	if err != nil || first.Pruned != 2 || !first.Continuation {
+		t.Fatalf("first prune=%#v err=%v", first, err)
+	}
+	second, err := store.MaintainDeliveries(pruneAt)
+	if err != nil || second.Pruned != 1 || second.Continuation {
+		t.Fatalf("second prune=%#v err=%v", second, err)
+	}
+	empty, err := store.ListDeliveryTerminals(TerminalListInput{Limit: 10})
+	if err != nil || len(empty.Terminals) != 0 {
+		t.Fatalf("retained after prune=%#v err=%v", empty, err)
+	}
+}
+
+func TestStoreRestartPreservesExpiryAndTerminals(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "relay.db")
+	store, err := Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.SetRetentionPolicy(tightRetention(time.Minute, time.Hour, 10)); err != nil {
+		t.Fatal(err)
+	}
+	now := retentionNow()
+	conversation := createQuotaConversation(t, store, now, "machine-a", "machine-b", "agent/a", "agent/b")
+	if _, _, err := store.AppendMessage(quotaAppend(conversation, "machine-a", "agent/a", "durable", "send-1", now)); err != nil {
+		t.Fatal(err)
+	}
+	later := now.Add(time.Minute)
+	if result, err := store.MaintainDeliveries(later); err != nil || result.Expired != 1 {
+		t.Fatalf("expire=%#v err=%v", result, err)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatal(err)
+	}
+	restarted, err := Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = restarted.Close() })
+	if err := restarted.SetRetentionPolicy(tightRetention(time.Minute, time.Hour, 10)); err != nil {
+		t.Fatal(err)
+	}
+	if pending := quotaInstallCounters(t, restarted); pending != (QuotaCounters{}) {
+		t.Fatalf("pending after restart=%#v", pending)
+	}
+	page, err := restarted.ListDeliveryTerminals(TerminalListInput{Limit: 10})
+	if err != nil || len(page.Terminals) != 1 || page.Terminals[0].ClosedReason != ClosedReasonExpired {
+		t.Fatalf("terminals after restart=%#v err=%v", page, err)
+	}
+}
+
+func TestStoreConcurrentExpiryAckAndLease(t *testing.T) {
+	t.Parallel()
+	store := openRetentionStore(t, tightRetention(time.Minute, time.Hour, 10))
+	now := retentionNow()
+	conversation := createQuotaConversation(t, store, now, "machine-a", "machine-b", "agent/a", "agent/b")
+	if _, _, err := store.AppendMessage(quotaAppend(conversation, "machine-a", "agent/a", "race", "send-1", now)); err != nil {
+		t.Fatal(err)
+	}
+	page, err := store.LeaseDeliveries("machine-b", "consumer-b", "agent/b", conversation.ID, now, time.Hour, 10)
+	if err != nil || len(page.Deliveries) != 1 {
+		t.Fatalf("lease=%#v err=%v", page, err)
+	}
+	later := now.Add(time.Minute)
+	var wait sync.WaitGroup
+	errs := make(chan error, 3)
+	wait.Add(3)
+	go func() {
+		defer wait.Done()
+		_, err := store.MaintainDeliveries(later)
+		errs <- err
+	}()
+	go func() {
+		defer wait.Done()
+		err := store.AckDelivery("machine-b", "agent/b", page.Deliveries[0].ID, page.Deliveries[0].LeaseToken, page.Deliveries[0].LeaseGeneration, later)
+		if err != nil && !errors.Is(err, ErrForbidden) {
+			errs <- err
+			return
+		}
+		errs <- nil
+	}()
+	go func() {
+		defer wait.Done()
+		_, err := store.LeaseDeliveries("machine-b", "consumer-b", "agent/b", conversation.ID, later, time.Hour, 10)
+		errs <- err
+	}()
+	wait.Wait()
+	close(errs)
+	for err := range errs {
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	if counters := quotaInstallCounters(t, store); counters != (QuotaCounters{}) {
+		t.Fatalf("pending after race=%#v", counters)
+	}
+	terminals, err := store.ListDeliveryTerminals(TerminalListInput{Limit: 10})
+	if err != nil || len(terminals.Terminals) != 1 {
+		t.Fatalf("terminals after race=%#v err=%v", terminals, err)
+	}
+	if reason := terminals.Terminals[0].ClosedReason; reason != ClosedReasonAcked && reason != ClosedReasonExpired {
+		t.Fatalf("closed reason=%q", reason)
+	}
+}
+
+func TestStoreAckAndRevokeRecordTerminalsWithoutBodies(t *testing.T) {
+	t.Parallel()
+	store := openRetentionStore(t, tightRetention(time.Hour, time.Hour, 10))
+	now := retentionNow()
+	conversation := createQuotaConversation(t, store, now, "machine-a", "machine-b", "agent/a", "agent/b")
+	if _, _, err := store.AppendMessage(quotaAppend(conversation, "machine-a", "agent/a", "secret-body", "send-1", now)); err != nil {
+		t.Fatal(err)
+	}
+	page, err := store.LeaseDeliveries("machine-b", "consumer-b", "agent/b", conversation.ID, now, time.Hour, 10)
+	if err != nil || len(page.Deliveries) != 1 {
+		t.Fatalf("lease=%#v err=%v", page, err)
+	}
+	if err := store.AckDelivery("machine-b", "agent/b", page.Deliveries[0].ID, page.Deliveries[0].LeaseToken, page.Deliveries[0].LeaseGeneration, now); err != nil {
+		t.Fatal(err)
+	}
+	listed, err := store.ListDeliveryTerminals(TerminalListInput{Limit: 10})
+	if err != nil || len(listed.Terminals) != 1 || listed.Terminals[0].ClosedReason != ClosedReasonAcked {
+		t.Fatalf("acked terminal=%#v err=%v", listed, err)
+	}
+	if _, _, err := store.AppendMessage(quotaAppend(conversation, "machine-a", "agent/a", "revoke-me", "send-2", now)); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := store.ApplyControl(ControlInput{
+		ConversationID: conversation.ID, ActorMachineID: "machine-a", ActorEndpoint: "agent/a",
+		Operation: ControlUpsertMember, Member: Member{Endpoint: "agent/b", Capabilities: CapSend},
+		IdempotencyKey: "revoke-receive", Now: now,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	listed, err = store.ListDeliveryTerminals(TerminalListInput{Limit: 10})
+	if err != nil || len(listed.Terminals) != 2 {
+		t.Fatalf("terminals after revoke=%#v err=%v", listed, err)
+	}
+	reasons := map[string]int{}
+	for _, terminal := range listed.Terminals {
+		reasons[terminal.ClosedReason]++
+		if terminal.RecipientID == "" || terminal.MessageID == "" || terminal.ConversationID == "" {
+			t.Fatalf("terminal missing opaque ids: %#v", terminal)
+		}
+	}
+	if reasons[ClosedReasonAcked] != 1 || reasons[ClosedReasonRevoked] != 1 {
+		t.Fatalf("reasons=%v", reasons)
+	}
+	encoded, err := json.Marshal(listed.Terminals)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(encoded), "secret-body") || strings.Contains(string(encoded), "revoke-me") || strings.Contains(string(encoded), `"body"`) {
+		t.Fatalf("terminal metadata leaked bodies: %s", encoded)
+	}
+}
+
+func TestStoreLeaseRedeliveryAndQueueMetricsAreContentFree(t *testing.T) {
+	t.Parallel()
+	store := openRetentionStore(t, tightRetention(time.Minute, time.Hour, 10))
+	metrics := &Metrics{}
+	store.SetMetrics(metrics)
+	now := retentionNow()
+	conversation := createQuotaConversation(t, store, now, "machine-a", "machine-b", "agent/a", "agent/b")
+	if _, _, err := store.AppendMessage(quotaAppend(conversation, "machine-a", "agent/a", "metric-body", "send-1", now)); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.LeaseDeliveries("machine-b", "consumer-b", "agent/b", conversation.ID, now, time.Minute, 10); err != nil {
+		t.Fatal(err)
+	}
+	if snapshot := metrics.Snapshot(); snapshot.RelayLeaseRedeliveries != 0 || snapshot.RelayPendingDeliveries != 1 || snapshot.RelayPendingOldestAgeSeconds != 0 {
+		t.Fatalf("initial metrics=%#v", snapshot)
+	}
+	redeliverAt := now.Add(2 * time.Minute)
+	if _, err := store.LeaseDeliveries("machine-b", "consumer-b", "agent/b", conversation.ID, redeliverAt, time.Minute, 10); err != nil {
+		t.Fatal(err)
+	}
+	store.refreshDeliveryMetrics(redeliverAt)
+	snapshot := metrics.Snapshot()
+	if snapshot.RelayLeaseRedeliveries != 1 || snapshot.RelayPendingOldestAgeSeconds != 120 {
+		t.Fatalf("redelivery metrics=%#v", snapshot)
+	}
+	if result, err := store.MaintainDeliveries(redeliverAt); err != nil || result.Expired != 1 {
+		t.Fatalf("expire=%#v err=%v", result, err)
+	}
+	snapshot = metrics.Snapshot()
+	if snapshot.RelayTerminalTransitionsExpired != 1 || snapshot.RelayTerminalsRetained != 1 || snapshot.RelayPendingDeliveries != 0 || snapshot.RelayPendingOldestAgeSeconds != 0 {
+		t.Fatalf("expiry metrics=%#v", snapshot)
+	}
+	encoded, err := json.Marshal(snapshot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	body := string(encoded)
+	for _, key := range []string{
+		`"relay_pending_deliveries"`,
+		`"relay_pending_bytes"`,
+		`"relay_pending_oldest_age_seconds"`,
+		`"relay_terminal_transitions_acked"`,
+		`"relay_terminal_transitions_expired"`,
+		`"relay_terminal_transitions_revoked"`,
+		`"relay_terminals_retained"`,
+		`"relay_lease_redeliveries"`,
+	} {
+		if !strings.Contains(body, key) {
+			t.Fatalf("metrics JSON missing %s: %s", key, body)
+		}
+	}
+	if strings.Contains(body, "metric-body") || strings.Contains(body, "agent/") || strings.Contains(body, conversation.ID) {
+		t.Fatalf("metrics JSON leaked content: %s", body)
+	}
+}
+
+func TestHTTPDoesNotExposeTerminalInventory(t *testing.T) {
+	t.Parallel()
+	public, private, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	store, err := Open(filepath.Join(t.TempDir(), "relay.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	auth, err := NewAuthenticator(store, []Machine{{ID: "machine-a", PublicKey: public, EndpointPrefixes: []string{"agent/a/"}}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	handler := NewHandler(store, auth, HandlerOptions{Now: func() time.Time {
+		return time.Date(2026, time.July, 13, 12, 0, 0, 0, time.UTC)
+	}, EndpointLeaseTTL: time.Minute, DeliveryLeaseTTL: time.Minute})
+	for _, path := range []string{"/v1/terminals", "/v1/deliveries/receipts"} {
+		response := serveSigned(t, handler, private, "machine-a", http.MethodGet, path, `{}`, "terminal-"+path, "")
+		if response.Code != http.StatusNotFound || !strings.Contains(response.Body.String(), "route not found") {
+			t.Fatalf("%s status=%d body=%s", path, response.Code, response.Body.String())
+		}
+	}
+}
+
+func openRetentionStore(t *testing.T, cfg RetentionConfig) *Store {
+	t.Helper()
+	store, err := Open(filepath.Join(t.TempDir(), "relay.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	if err := store.SetRetentionPolicy(cfg); err != nil {
+		t.Fatal(err)
+	}
+	return store
+}
+
+func retentionNow() time.Time {
+	return time.Date(2026, time.August, 18, 20, 0, 0, 0, time.UTC)
+}

--- a/internal/relay/store_retention_test.go
+++ b/internal/relay/store_retention_test.go
@@ -39,6 +39,46 @@ func TestRetentionConfigRejectsOutOfBoundsValues(t *testing.T) {
 	}
 }
 
+func TestTerminalListCursorRoundTripsMicrosecondTimestamps(t *testing.T) {
+	ts := time.Date(2026, time.August, 18, 21, 0, 0, 123456000, time.UTC)
+	cursor := EncodeTerminalListCursor(ts, "delivery-1")
+	got, id, ok := DecodeTerminalListCursor(cursor)
+	if !ok || id != "delivery-1" || !got.Equal(ts) {
+		t.Fatalf("cursor round-trip got=%s id=%q ok=%t want %s", got, id, ok, ts)
+	}
+}
+
+func TestStoreListDeliveryTerminalsPagesWithoutRepeating(t *testing.T) {
+	t.Parallel()
+	store := openRetentionStore(t, tightRetention(time.Minute, time.Hour, 10))
+	now := retentionNow()
+	conversation := createQuotaConversation(t, store, now, "machine-a", "machine-b", "agent/a", "agent/b")
+	first, _, err := store.AppendMessage(quotaAppend(conversation, "machine-a", "agent/a", "one", "send-1", now))
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, _, err := store.AppendMessage(quotaAppend(conversation, "machine-a", "agent/a", "two", "send-2", now))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result, err := store.MaintainDeliveries(now.Add(time.Minute)); err != nil || result.Expired != 2 {
+		t.Fatalf("expire=%#v err=%v", result, err)
+	}
+	page, err := store.ListDeliveryTerminals(TerminalListInput{Limit: 1})
+	if err != nil || len(page.Terminals) != 1 || page.NextCursor == "" {
+		t.Fatalf("first page=%#v err=%v", page, err)
+	}
+	seen := page.Terminals[0].MessageID
+	next, err := store.ListDeliveryTerminals(TerminalListInput{Cursor: page.NextCursor, Limit: 1})
+	if err != nil || len(next.Terminals) != 1 || next.Terminals[0].MessageID == seen {
+		t.Fatalf("second page repeated or missing next=%#v first=%q err=%v", next, seen, err)
+	}
+	ids := map[string]bool{seen: true, next.Terminals[0].MessageID: true}
+	if !ids[first.ID] || !ids[second.ID] {
+		t.Fatalf("paged ids=%v want %s and %s", ids, first.ID, second.ID)
+	}
+}
+
 func TestStoreExpiryBoundaryJustBeforeAtAfter(t *testing.T) {
 	t.Parallel()
 	store := openRetentionStore(t, tightRetention(time.Minute, time.Hour, 10))


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements #151: indefinitely undeliverable work gets an explicit bounded terminal lifecycle, and operators get content-free evidence to diagnose it. This is not a sender read-receipt feature.

Pending deliveries older than a startup-validated maximum age transition atomically to terminal `expired`, release pending capacity exactly once, and advance only that recipient’s contiguous cursor. Closed metadata (opaque IDs, sequence, closed reason, lease generation, timestamps — no bodies or credentials) is retained for a separate bounded window and pruned in bounded pages. Host-local `punaro relay list-terminals` and `punaro relay maintain-deliveries --yes` inspect and trigger that maintenance. Sender-facing append stays accepted/queued or rejected. No agent `/v1/terminals` or receipt route exists.

## Policy

Startup-validated:

- `PUNARO_RELAY_PENDING_MAX_AGE_SECONDS` (default 604800, 7 days; 1..31536000)
- `PUNARO_RELAY_TERMINAL_RETENTION_SECONDS` (default 2592000, 30 days; 1..31536000)
- `PUNARO_RELAY_DELIVERY_MAINTENANCE_BATCH` (default 100; 1..1000)

Inclusive age: expire when `created_at <= now - maxAge`. Closed reasons: `acked`, `expired`, `revoked`. Expire clears lease fields so a later ack with the old token is forbidden. Revoke keeps leases so existing ack-after-revoke behavior is unchanged. Role recipients (`\x1erole:`) are preserved.

## Persistence

SQLite `delivery_terminals` and Postgres `relay.mail_delivery_terminals` (schema 49) hold content-free closed metadata. They are operational state, not cutover content: fingerprint/empty-target ignore them; abort deletes terminals first because of the delivery foreign key. The operator maintain command loads `punarod.env` so CLI max-age cannot silently undercut the daemon.

List cursors encode microsecond `closed_at` plus delivery ID so Postgres timestamptz pages cannot repeat a row whose timestamp is finer than milliseconds.

## Metrics

Fixed keys only; no body, endpoint, role, or conversation labels:

- `relay_pending_deliveries`
- `relay_pending_bytes`
- `relay_pending_oldest_age_seconds`
- `relay_terminal_transitions_acked`
- `relay_terminal_transitions_expired`
- `relay_terminal_transitions_revoked`
- `relay_terminals_retained`
- `relay_lease_redeliveries`

## Tests added first

- Boundary just before / at / after expiry
- Bounded batch and stable continuation
- Exact-once capacity release
- Expired active lease cannot later ack
- Cursor with expired gap followed by acknowledged work
- Independent recipients for one message
- Terminal retention and bounded prune
- Restart and concurrent expiry/ack/lease races
- Operator output contains no body
- Metric labels are bounded and content-free
- SQLite/PostgreSQL contract parity
- Signed agent GET `/v1/terminals` and `/v1/deliveries/receipts` remain 404
- Terminal list cursor round-trips microsecond timestamps and pages without repeating

## Quality gate

From repository root:

- `make test` passed
- `make test-race` passed
- `make staticcheck` passed
- `make security` passed
- `make lint` passed

PostgreSQL integration (`make test-postgres`) was not run here because Docker Compose is unavailable in this environment.

## Vibe check vs #151 DoD

- Pending and terminal retention policies are explicit, validated, and documented in `DESIGN.md`, `.env.example`, and operator docs.
- Bounded maintenance, host-local inspection, and metrics are implemented.
- Capacity is released exactly once and cursor semantics are proved by tests.
- No ordinary agent API exposes dead-letter inventory or delivery receipts.
- Listed tests and existing delivery contract tests are included.

Closes #151

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-99218356-bb07-488f-a930-23b9582a75e4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-99218356-bb07-488f-a930-23b9582a75e4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

