### PR TITLE
fix(telegram): prevent poison updates from stalling the bridge

### DIFF
--- a/cmd/punaro-telegram/doctor.go
+++ b/cmd/punaro-telegram/doctor.go
@@ -177,7 +177,7 @@ func runTelegramDoctor(args []string, stdout, stderr io.Writer) int {
 			telegramBoolCheck(snapshot.TerminalOutbound == 0, "terminal_outbound_rejection", "repair_outbound_telegram_target"),
 			telegramBoolCheck(!snapshot.StuckHead, "stuck_head_delivery", "repair_stuck_gateway_delivery"),
 			telegramBoolCheck(snapshot.LastFailure != telegram.GatewayFailureMessageLessPoll || snapshot.ConsecutiveFailures < 3, "message_less_update_stall", "repair_message_less_polling"),
-			telegramBoolCheck(snapshot.LastFailure != telegram.GatewayFailureDeletedTopic, "deleted_topic_target", "repair_deleted_topic_route"),
+			telegramBoolCheck(snapshot.DeletedTopicTargets == 0, "deleted_topic_target", "repair_deleted_topic_route"),
 			telegramBoolCheck(snapshot.LastFailure != telegram.GatewayFailureTransient || snapshot.ConsecutiveFailures < 3, "transient_retry_stall", "repair_transient_gateway_dependency"),
 		)
 		if snapshot.IncompleteClaims > 0 {

--- a/cmd/punaro-telegram/main.go
+++ b/cmd/punaro-telegram/main.go
@@ -243,6 +243,8 @@ func failedGatewayCycleRecord(at time.Time, offset int64, err error) telegram.Ga
 	if errors.As(err, &cycleErr) {
 		record.TerminalInbound = cycleErr.TerminalInbound
 		record.TerminalOutbound = cycleErr.TerminalOutbound
+		record.InboundRecovery = cycleErr.InboundRecovery
+		record.OutboundRecovery = cycleErr.OutboundRecovery
 		record.OutboundBlocked = cycleErr.OutboundBlocked
 		record.OutboundProgress = cycleErr.OutboundProgress
 		if cycleErr.NonFatal {

--- a/cmd/punaro-telegram/main.go
+++ b/cmd/punaro-telegram/main.go
@@ -216,6 +216,9 @@ func run() error {
 			record := failedGatewayCycleRecord(time.Now().UTC(), next, err)
 			if recordErr := state.RecordGatewayCycle(record); recordErr != nil {
 				log.Print("telegram event class=gateway_health err=state_unavailable")
+			} else if isNonFatalGatewayCycle(err) {
+				offset = next
+				continue
 			}
 		}
 		if errors.Is(err, context.Canceled) || ctx.Err() != nil {
@@ -238,8 +241,15 @@ func failedGatewayCycleRecord(at time.Time, offset int64, err error) telegram.Ga
 	record := telegram.GatewayCycleRecord{At: at, Offset: offset, Failure: telegram.ClassifyGatewayCycleFailure(err)}
 	var cycleErr *telegram.GatewayCycleError
 	if errors.As(err, &cycleErr) {
+		record.TerminalInbound = cycleErr.TerminalInbound
+		record.TerminalOutbound = cycleErr.TerminalOutbound
 		record.OutboundBlocked = cycleErr.OutboundBlocked
 		record.OutboundProgress = cycleErr.OutboundProgress
+		if cycleErr.NonFatal {
+			record.PollOK, record.RelayOK = true, true
+			record.TelegramOK = cycleErr.TerminalOutbound == 0
+			return record
+		}
 		switch cycleErr.Phase {
 		case telegram.GatewayPhaseInbound, telegram.GatewayPhaseLease:
 			record.PollOK = true
@@ -250,6 +260,11 @@ func failedGatewayCycleRecord(at time.Time, offset int64, err error) telegram.Ga
 		}
 	}
 	return record
+}
+
+func isNonFatalGatewayCycle(err error) bool {
+	var cycleErr *telegram.GatewayCycleError
+	return errors.As(err, &cycleErr) && cycleErr.NonFatal
 }
 
 func loadConfig() (config, error) {

--- a/cmd/punaro-telegram/main.go
+++ b/cmd/punaro-telegram/main.go
@@ -244,7 +244,7 @@ func failedGatewayCycleRecord(at time.Time, offset int64, err error) telegram.Ga
 		record.TerminalInbound = cycleErr.TerminalInbound
 		record.TerminalOutbound = cycleErr.TerminalOutbound
 		record.InboundRecovery = cycleErr.InboundRecovery
-		record.OutboundRecovery = cycleErr.OutboundRecovery
+		record.OutboundTargetEvents = cycleErr.OutboundTargetEvents
 		record.OutboundBlocked = cycleErr.OutboundBlocked
 		record.OutboundProgress = cycleErr.OutboundProgress
 		if cycleErr.NonFatal {

--- a/cmd/punaro-telegram/main.go
+++ b/cmd/punaro-telegram/main.go
@@ -243,7 +243,7 @@ func failedGatewayCycleRecord(at time.Time, offset int64, err error) telegram.Ga
 	if errors.As(err, &cycleErr) {
 		record.TerminalInbound = cycleErr.TerminalInbound
 		record.TerminalOutbound = cycleErr.TerminalOutbound
-		record.InboundRecovery = cycleErr.InboundRecovery
+		record.InboundTargetEvents = cycleErr.InboundTargetEvents
 		record.OutboundTargetEvents = cycleErr.OutboundTargetEvents
 		record.OutboundBlocked = cycleErr.OutboundBlocked
 		record.OutboundProgress = cycleErr.OutboundProgress

--- a/cmd/punaro-telegram/main_test.go
+++ b/cmd/punaro-telegram/main_test.go
@@ -360,9 +360,12 @@ func TestFailedGatewayCycleRecordPreservesNonFatalTerminalDropCounts(t *testing.
 func TestFailedGatewayCycleRecordPreservesPlaneRecoveryEvidence(t *testing.T) {
 	t.Parallel()
 	now := time.Date(2026, 8, 23, 12, 0, 0, 0, time.UTC)
-	err := &telegram.GatewayCycleError{Phase: telegram.GatewayPhaseSend, NonFatal: true, InboundRecovery: true, OutboundRecovery: true}
+	err := &telegram.GatewayCycleError{
+		Phase: telegram.GatewayPhaseSend, NonFatal: true, InboundRecovery: true, OutboundRecovery: true,
+		OutboundTargetEvents: []telegram.GatewayOutboundTargetEvent{{ConversationID: "conversation-1"}},
+	}
 	record := failedGatewayCycleRecord(now, 42, err)
-	if !isNonFatalGatewayCycle(err) || record.Failure != telegram.GatewayFailureNone || !record.InboundRecovery || !record.OutboundRecovery || !record.PollOK || !record.RelayOK || !record.TelegramOK {
+	if !isNonFatalGatewayCycle(err) || record.Failure != telegram.GatewayFailureNone || !record.InboundRecovery || len(record.OutboundTargetEvents) != 1 || record.OutboundTargetEvents[0].ConversationID != "conversation-1" || !record.PollOK || !record.RelayOK || !record.TelegramOK {
 		t.Fatalf("record=%#v", record)
 	}
 }

--- a/cmd/punaro-telegram/main_test.go
+++ b/cmd/punaro-telegram/main_test.go
@@ -349,10 +349,12 @@ func TestFailedGatewayCycleRecordPreservesNonFatalTerminalDropCounts(t *testing.
 	err := &telegram.GatewayCycleError{
 		Phase: telegram.GatewayPhaseSend, NonFatal: true,
 		TerminalInbound: 2, TerminalOutbound: 3,
-		Err: telegram.BotAPIStatusError{Method: "sendRichMessage", Status: 403},
+		InboundTargetEvents:  []telegram.GatewayInboundTargetEvent{{ConversationID: "conversation-inbound", Terminal: true, Failure: telegram.GatewayFailureInboundRelayPermanent}},
+		OutboundTargetEvents: []telegram.GatewayOutboundTargetEvent{{ConversationID: "conversation-outbound", Terminal: true, Failure: telegram.GatewayFailureOutboundTelegramPermanent}},
+		Err:                  telegram.BotAPIStatusError{Method: "sendRichMessage", Status: 403},
 	}
 	record := failedGatewayCycleRecord(now, 42, err)
-	if !isNonFatalGatewayCycle(err) || record.Failure != telegram.GatewayFailureOutboundTelegramPermanent || record.TerminalInbound != 2 || record.TerminalOutbound != 3 || !record.PollOK || !record.RelayOK {
+	if !isNonFatalGatewayCycle(err) || record.Failure != telegram.GatewayFailureOutboundTelegramPermanent || record.TerminalInbound != 2 || record.TerminalOutbound != 3 || len(record.InboundTargetEvents) != 1 || len(record.OutboundTargetEvents) != 1 || !record.PollOK || !record.RelayOK {
 		t.Fatalf("record=%#v", record)
 	}
 }
@@ -362,10 +364,11 @@ func TestFailedGatewayCycleRecordPreservesPlaneRecoveryEvidence(t *testing.T) {
 	now := time.Date(2026, 8, 23, 12, 0, 0, 0, time.UTC)
 	err := &telegram.GatewayCycleError{
 		Phase: telegram.GatewayPhaseSend, NonFatal: true, InboundRecovery: true, OutboundRecovery: true,
+		InboundTargetEvents:  []telegram.GatewayInboundTargetEvent{{ConversationID: "conversation-1"}},
 		OutboundTargetEvents: []telegram.GatewayOutboundTargetEvent{{ConversationID: "conversation-1"}},
 	}
 	record := failedGatewayCycleRecord(now, 42, err)
-	if !isNonFatalGatewayCycle(err) || record.Failure != telegram.GatewayFailureNone || !record.InboundRecovery || len(record.OutboundTargetEvents) != 1 || record.OutboundTargetEvents[0].ConversationID != "conversation-1" || !record.PollOK || !record.RelayOK || !record.TelegramOK {
+	if !isNonFatalGatewayCycle(err) || record.Failure != telegram.GatewayFailureNone || len(record.InboundTargetEvents) != 1 || record.InboundTargetEvents[0].ConversationID != "conversation-1" || len(record.OutboundTargetEvents) != 1 || record.OutboundTargetEvents[0].ConversationID != "conversation-1" || !record.PollOK || !record.RelayOK || !record.TelegramOK {
 		t.Fatalf("record=%#v", record)
 	}
 }

--- a/cmd/punaro-telegram/main_test.go
+++ b/cmd/punaro-telegram/main_test.go
@@ -357,6 +357,16 @@ func TestFailedGatewayCycleRecordPreservesNonFatalTerminalDropCounts(t *testing.
 	}
 }
 
+func TestFailedGatewayCycleRecordPreservesPlaneRecoveryEvidence(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 8, 23, 12, 0, 0, 0, time.UTC)
+	err := &telegram.GatewayCycleError{Phase: telegram.GatewayPhaseSend, NonFatal: true, InboundRecovery: true, OutboundRecovery: true}
+	record := failedGatewayCycleRecord(now, 42, err)
+	if !isNonFatalGatewayCycle(err) || record.Failure != telegram.GatewayFailureNone || !record.InboundRecovery || !record.OutboundRecovery || !record.PollOK || !record.RelayOK || !record.TelegramOK {
+		t.Fatalf("record=%#v", record)
+	}
+}
+
 func TestLoadConfigReadsAccessPairFromPrivateCredentialFile(t *testing.T) {
 	_, private, err := ed25519.GenerateKey(rand.Reader)
 	if err != nil {

--- a/cmd/punaro-telegram/main_test.go
+++ b/cmd/punaro-telegram/main_test.go
@@ -343,6 +343,20 @@ func TestFailedGatewayCycleRecordPreservesCompletedPhaseEvidence(t *testing.T) {
 	}
 }
 
+func TestFailedGatewayCycleRecordPreservesNonFatalTerminalDropCounts(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 8, 23, 12, 0, 0, 0, time.UTC)
+	err := &telegram.GatewayCycleError{
+		Phase: telegram.GatewayPhaseSend, NonFatal: true,
+		TerminalInbound: 2, TerminalOutbound: 3,
+		Err: telegram.BotAPIStatusError{Method: "sendRichMessage", Status: 403},
+	}
+	record := failedGatewayCycleRecord(now, 42, err)
+	if !isNonFatalGatewayCycle(err) || record.Failure != telegram.GatewayFailureOutboundTelegramPermanent || record.TerminalInbound != 2 || record.TerminalOutbound != 3 || !record.PollOK || !record.RelayOK {
+		t.Fatalf("record=%#v", record)
+	}
+}
+
 func TestLoadConfigReadsAccessPairFromPrivateCredentialFile(t *testing.T) {
 	_, private, err := ed25519.GenerateKey(rand.Reader)
 	if err != nil {

--- a/docs/doctor.md
+++ b/docs/doctor.md
@@ -357,8 +357,8 @@ outbound progress proves advancement. Terminal inbound and outbound drops are
 persisted even when the gateway safely continues the rest of the page or leased
 delivery batch, so poison-item progress cannot make either rejection check look
 healthy. Empty poll/lease cycles preserve that terminal state; it clears per
-plane only after a real inbound submission or outbound send demonstrates
-recovery. Endpoint-specific relay attachment probes
+plane only after a real inbound submission or an outbound send to the same
+failed conversation target demonstrates recovery. Endpoint-specific relay attachment probes
 bind the exact asserted endpoint into the machine signature; changing that
 header invalidates the probe rather than exposing an endpoint-enumeration oracle.
 

--- a/docs/doctor.md
+++ b/docs/doctor.md
@@ -353,7 +353,10 @@ Inbound poll-offset progress and outbound delivery-head progress use separate
 durable clocks, so continuous new Telegram updates cannot hide a repeatedly
 failing outbound head. Once a head is blocked, failures in earlier advertise,
 poll, or lease phases preserve its age until a completed cycle or explicit
-outbound progress proves advancement. Endpoint-specific relay attachment probes
+outbound progress proves advancement. Terminal inbound and outbound drops are
+persisted even when the gateway safely continues the rest of the page or leased
+delivery batch, so poison-item progress cannot make either rejection check look
+healthy. Endpoint-specific relay attachment probes
 bind the exact asserted endpoint into the machine signature; changing that
 header invalidates the probe rather than exposing an endpoint-enumeration oracle.
 

--- a/docs/doctor.md
+++ b/docs/doctor.md
@@ -360,7 +360,10 @@ healthy. Empty poll/lease cycles preserve that terminal state; it clears per
 conversation only after a real inbound submission or outbound send to that
 same failed target demonstrates recovery. Historical aggregate counters are
 expanded into conservative per-route recovery markers on the first writable
-gateway open after upgrade. Endpoint-specific relay attachment probes
+gateway open after upgrade. Terminal evidence is staged before the corresponding
+update or relay delivery is consumed, and doctor reads that durable target
+ledger directly rather than depending on a later cycle summary.
+Endpoint-specific relay attachment probes
 bind the exact asserted endpoint into the machine signature; changing that
 header invalidates the probe rather than exposing an endpoint-enumeration oracle.
 

--- a/docs/doctor.md
+++ b/docs/doctor.md
@@ -356,7 +356,9 @@ poll, or lease phases preserve its age until a completed cycle or explicit
 outbound progress proves advancement. Terminal inbound and outbound drops are
 persisted even when the gateway safely continues the rest of the page or leased
 delivery batch, so poison-item progress cannot make either rejection check look
-healthy. Endpoint-specific relay attachment probes
+healthy. Empty poll/lease cycles preserve that terminal state; it clears per
+plane only after a real inbound submission or outbound send demonstrates
+recovery. Endpoint-specific relay attachment probes
 bind the exact asserted endpoint into the machine signature; changing that
 header invalidates the probe rather than exposing an endpoint-enumeration oracle.
 

--- a/docs/doctor.md
+++ b/docs/doctor.md
@@ -357,8 +357,10 @@ outbound progress proves advancement. Terminal inbound and outbound drops are
 persisted even when the gateway safely continues the rest of the page or leased
 delivery batch, so poison-item progress cannot make either rejection check look
 healthy. Empty poll/lease cycles preserve that terminal state; it clears per
-plane only after a real inbound submission or an outbound send to the same
-failed conversation target demonstrates recovery. Endpoint-specific relay attachment probes
+conversation only after a real inbound submission or outbound send to that
+same failed target demonstrates recovery. Historical aggregate counters are
+expanded into conservative per-route recovery markers on the first writable
+gateway open after upgrade. Endpoint-specific relay attachment probes
 bind the exact asserted endpoint into the machine signature; changing that
 header invalidates the probe rather than exposing an endpoint-enumeration oracle.
 

--- a/docs/telegram-gateway.md
+++ b/docs/telegram-gateway.md
@@ -287,26 +287,32 @@ to multiple topics. There is no main-chat fallback.
 ## Inbound and outbound routing
 
 Incoming questions use the Telegram update ID as the durable relay idempotency
-key and are submitted on `telegram-inbound` as `user-telegram`. A failed
-submission is retried; a crash after submission is safely deduplicated by the
-relay. Unauthorized, non-text, or unbound-topic updates are durably skipped so
-they cannot stall the polling offset after a restart. They are never routed by
+key and are submitted on `telegram-inbound` as `user-telegram`. Network, 5xx,
+and other retryable submission failures leave the update pending; a crash after
+submission is safely deduplicated by the relay. A signed relay 403 or 404 is a
+terminal pre-append rejection, so the gateway records the update as processed,
+emits only a content-free `telegram_update_dropped` event, and continues the
+page. Unauthorized, unsupported or non-text, and unbound-topic updates are also
+durably skipped, including message-less update IDs returned by Telegram, so
+none can stall the polling offset after a restart. They are never routed by
 inference. Replies resolve `reply_to_message` through a local 10,000-row
 `telegram_outbound` map of Telegram `message_id` to Punaro identities; a miss
 delivers the text without `in_reply_to_*`.
 
 Outgoing agent replies are sent using Telegram's `sendRichMessage` to that
-exact `message_thread_id` from `topic_routes`. `SendDelivery` stays
-route-based through adopt soak. A missing route fails closed with
-`telegram conversation route is missing` and leaves the delivery unacked. A
-deleted Telegram thread fails closed at `sendRichMessage`; do not recreate it
-and do not require a completed claim on this path until after soak. The
-returned `message_id` is stored in the outbound map. The bridge renders opaque
-agent content as escaped HTML, disables automatic entity detection, and asks
-Telegram to protect content. Telegram has no send-idempotency key, therefore
-this external boundary is explicitly at-least-once: a crash after Telegram
-accepts a reply but before relay acknowledgement can repeat that reply on
-recovery.
+exact `message_thread_id` from `topic_routes`. `SendDelivery` stays route-based
+through adopt soak. A malformed delivery, missing route, route for another
+chat, or completed Telegram 4xx response other than 429 is terminal: the
+bridge emits only a content-free `telegram_send_dropped` event, acknowledges
+that poison delivery, and continues later deliveries. A deleted Telegram
+thread therefore fails closed and is dropped; repair the explicit route rather
+than recreating a thread automatically. Telegram 429, 5xx, and network failures
+leave the delivery unacknowledged for retry. The returned `message_id` is
+stored in the outbound map. The bridge renders opaque agent content as escaped
+HTML, disables automatic entity detection, and asks Telegram to protect
+content. Telegram has no send-idempotency key, therefore this external boundary
+is explicitly at-least-once: a crash after Telegram accepts a reply but before
+relay acknowledgement can repeat that reply on recovery.
 
 Telegram Bot API rich messages support structured HTML and Markdown variants,
 and `sendRichMessage` accepts a `message_thread_id` for a forum topic. Punaro

--- a/docs/telegram-gateway.md
+++ b/docs/telegram-gateway.md
@@ -292,7 +292,8 @@ and other retryable submission failures leave the update pending; a crash after
 submission is safely deduplicated by the relay. A relay 403 or 404 that echoes
 the signed request nonce is a terminal pre-append rejection, so the gateway
 records the update as processed, emits only a content-free
-`telegram_update_dropped` event, and continues the page. An intermediary 403 or
+`telegram_update_dropped` event, continues the page, and carries the terminal
+inbound outcome into the durable gateway-health record. An intermediary 403 or
 404 without that relay proof stays pending for retry. Unauthorized, unsupported
 or non-text, and unbound-topic updates are also
 durably skipped, including message-less update IDs returned by Telegram, so
@@ -309,7 +310,8 @@ state can recover it. A malformed delivery or completed Telegram 4xx response
 other than 401 and 429 is terminal: the bridge emits only a content-free
 `telegram_send_dropped` event, acknowledges that poison delivery, and continues
 later deliveries. A successful dropped acknowledgement advances the outbound
-liveness clock; an acknowledgement failure remains an explicit blocked
+liveness clock and carries the terminal outbound outcome into the durable
+gateway-health record; an acknowledgement failure remains an explicit blocked
 ack-phase cycle. A deleted Telegram thread therefore fails closed and is
 dropped; repair the explicit route rather than recreating a thread
 automatically. Telegram 401, 429, 5xx, and network failures leave the delivery

--- a/docs/telegram-gateway.md
+++ b/docs/telegram-gateway.md
@@ -303,16 +303,18 @@ delivers the text without `in_reply_to_*`.
 
 Outgoing agent replies are sent using Telegram's `sendRichMessage` to that
 exact `message_thread_id` from `topic_routes`. `SendDelivery` stays route-based
-through adopt soak. A malformed delivery, missing route, route for another
-chat, or completed Telegram 4xx response other than 401 and 429 is terminal: the
-bridge emits only a content-free `telegram_send_dropped` event, acknowledges
-that poison delivery, and continues later deliveries. A successful dropped
-acknowledgement advances the outbound liveness clock; an acknowledgement
-failure remains an explicit blocked ack-phase cycle. A deleted Telegram thread
-therefore fails closed and is dropped; repair the explicit route rather than
-recreating a thread automatically. Telegram 401, 429, 5xx, and network failures
-leave the delivery unacknowledged for retry. The returned `message_id` is stored
-in the outbound map. The bridge renders opaque agent content as escaped
+through adopt soak. A missing route or a route for another chat fails closed
+and leaves the delivery unacknowledged so restoring or repairing local route
+state can recover it. A malformed delivery or completed Telegram 4xx response
+other than 401 and 429 is terminal: the bridge emits only a content-free
+`telegram_send_dropped` event, acknowledges that poison delivery, and continues
+later deliveries. A successful dropped acknowledgement advances the outbound
+liveness clock; an acknowledgement failure remains an explicit blocked
+ack-phase cycle. A deleted Telegram thread therefore fails closed and is
+dropped; repair the explicit route rather than recreating a thread
+automatically. Telegram 401, 429, 5xx, and network failures leave the delivery
+unacknowledged for retry. The returned `message_id` is stored in the outbound
+map. The bridge renders opaque agent content as escaped
 HTML, disables automatic entity detection, and asks Telegram to protect
 content. Telegram has no send-idempotency key, therefore this external boundary
 is explicitly at-least-once: a crash after Telegram accepts a reply but before

--- a/docs/telegram-gateway.md
+++ b/docs/telegram-gateway.md
@@ -315,7 +315,8 @@ gateway-health record; an acknowledgement failure remains an explicit blocked
 ack-phase cycle. A deleted Telegram thread therefore fails closed and is
 dropped; repair the explicit route rather than recreating a thread
 automatically. Empty cycles do not clear either terminal health outcome; a
-successful operation on the affected inbound or outbound plane does. Telegram
+successful inbound submission clears the inbound outcome, while an outbound
+send clears only failures recorded for that same conversation target. Telegram
 401, 429, 5xx, and network failures leave the delivery
 unacknowledged for retry. The returned `message_id` is stored in the outbound
 map. The bridge renders opaque agent content as escaped

--- a/docs/telegram-gateway.md
+++ b/docs/telegram-gateway.md
@@ -328,6 +328,14 @@ content. Telegram has no send-idempotency key, therefore this external boundary
 is explicitly at-least-once: a crash after Telegram accepts a reply but before
 relay acknowledgement can repeat that reply on recovery.
 
+Terminal inbound rejection evidence is committed in the same SQLite
+transaction that consumes the Telegram update. Terminal outbound evidence is
+staged idempotently by relay delivery ID before acknowledgement; a repaired
+target is cleared locally before its successful delivery is acknowledged.
+Doctor reads these target ledgers directly, so a process crash between an
+external acknowledgement and the later aggregate cycle record cannot hide a
+dropped item or strand a completed recovery.
+
 Telegram Bot API rich messages support structured HTML and Markdown variants,
 and `sendRichMessage` accepts a `message_thread_id` for a forum topic. Punaro
 uses only a minimal escaped-HTML subset, disables automatic entity detection,

--- a/docs/telegram-gateway.md
+++ b/docs/telegram-gateway.md
@@ -289,10 +289,12 @@ to multiple topics. There is no main-chat fallback.
 Incoming questions use the Telegram update ID as the durable relay idempotency
 key and are submitted on `telegram-inbound` as `user-telegram`. Network, 5xx,
 and other retryable submission failures leave the update pending; a crash after
-submission is safely deduplicated by the relay. A signed relay 403 or 404 is a
-terminal pre-append rejection, so the gateway records the update as processed,
-emits only a content-free `telegram_update_dropped` event, and continues the
-page. Unauthorized, unsupported or non-text, and unbound-topic updates are also
+submission is safely deduplicated by the relay. A relay 403 or 404 that echoes
+the signed request nonce is a terminal pre-append rejection, so the gateway
+records the update as processed, emits only a content-free
+`telegram_update_dropped` event, and continues the page. An intermediary 403 or
+404 without that relay proof stays pending for retry. Unauthorized, unsupported
+or non-text, and unbound-topic updates are also
 durably skipped, including message-less update IDs returned by Telegram, so
 none can stall the polling offset after a restart. They are never routed by
 inference. Replies resolve `reply_to_message` through a local 10,000-row
@@ -302,12 +304,12 @@ delivers the text without `in_reply_to_*`.
 Outgoing agent replies are sent using Telegram's `sendRichMessage` to that
 exact `message_thread_id` from `topic_routes`. `SendDelivery` stays route-based
 through adopt soak. A malformed delivery, missing route, route for another
-chat, or completed Telegram 4xx response other than 429 is terminal: the
+chat, or completed Telegram 4xx response other than 401 and 429 is terminal: the
 bridge emits only a content-free `telegram_send_dropped` event, acknowledges
 that poison delivery, and continues later deliveries. A deleted Telegram
 thread therefore fails closed and is dropped; repair the explicit route rather
-than recreating a thread automatically. Telegram 429, 5xx, and network failures
-leave the delivery unacknowledged for retry. The returned `message_id` is
+than recreating a thread automatically. Telegram 401, 429, 5xx, and network
+failures leave the delivery unacknowledged for retry. The returned `message_id` is
 stored in the outbound map. The bridge renders opaque agent content as escaped
 HTML, disables automatic entity detection, and asks Telegram to protect
 content. Telegram has no send-idempotency key, therefore this external boundary

--- a/docs/telegram-gateway.md
+++ b/docs/telegram-gateway.md
@@ -314,7 +314,9 @@ liveness clock and carries the terminal outbound outcome into the durable
 gateway-health record; an acknowledgement failure remains an explicit blocked
 ack-phase cycle. A deleted Telegram thread therefore fails closed and is
 dropped; repair the explicit route rather than recreating a thread
-automatically. Telegram 401, 429, 5xx, and network failures leave the delivery
+automatically. Empty cycles do not clear either terminal health outcome; a
+successful operation on the affected inbound or outbound plane does. Telegram
+401, 429, 5xx, and network failures leave the delivery
 unacknowledged for retry. The returned `message_id` is stored in the outbound
 map. The bridge renders opaque agent content as escaped
 HTML, disables automatic entity detection, and asks Telegram to protect

--- a/docs/telegram-gateway.md
+++ b/docs/telegram-gateway.md
@@ -306,11 +306,13 @@ exact `message_thread_id` from `topic_routes`. `SendDelivery` stays route-based
 through adopt soak. A malformed delivery, missing route, route for another
 chat, or completed Telegram 4xx response other than 401 and 429 is terminal: the
 bridge emits only a content-free `telegram_send_dropped` event, acknowledges
-that poison delivery, and continues later deliveries. A deleted Telegram
-thread therefore fails closed and is dropped; repair the explicit route rather
-than recreating a thread automatically. Telegram 401, 429, 5xx, and network
-failures leave the delivery unacknowledged for retry. The returned `message_id` is
-stored in the outbound map. The bridge renders opaque agent content as escaped
+that poison delivery, and continues later deliveries. A successful dropped
+acknowledgement advances the outbound liveness clock; an acknowledgement
+failure remains an explicit blocked ack-phase cycle. A deleted Telegram thread
+therefore fails closed and is dropped; repair the explicit route rather than
+recreating a thread automatically. Telegram 401, 429, 5xx, and network failures
+leave the delivery unacknowledged for retry. The returned `message_id` is stored
+in the outbound map. The bridge renders opaque agent content as escaped
 HTML, disables automatic entity detection, and asks Telegram to protect
 content. Telegram has no send-idempotency key, therefore this external boundary
 is explicitly at-least-once: a crash after Telegram accepts a reply but before

--- a/docs/telegram-gateway.md
+++ b/docs/telegram-gateway.md
@@ -315,8 +315,11 @@ gateway-health record; an acknowledgement failure remains an explicit blocked
 ack-phase cycle. A deleted Telegram thread therefore fails closed and is
 dropped; repair the explicit route rather than recreating a thread
 automatically. Empty cycles do not clear either terminal health outcome; a
-successful inbound submission clears the inbound outcome, while an outbound
-send clears only failures recorded for that same conversation target. Telegram
+successful inbound submission or outbound send clears only failures recorded
+for that same conversation target. On first open after upgrading an older
+aggregate ledger, Punaro conservatively creates one recovery marker per known
+route; each route must demonstrate a successful operation before the historical
+terminal state clears. Telegram
 401, 429, 5xx, and network failures leave the delivery
 unacknowledged for retry. The returned `message_id` is stored in the outbound
 map. The bridge renders opaque agent content as escaped

--- a/internal/adapter/client_test.go
+++ b/internal/adapter/client_test.go
@@ -475,8 +475,9 @@ func TestHTTPRelayClientClassifiesOnlyPreAppendRejectionsAsTerminalOfferFailures
 			}
 			_, err = client.Send(context.Background(), "conversation-1", "agent/a", "offer", "offer-1")
 			var terminal terminalOfferNoticeFailure
-			if err == nil || !errors.As(err, &terminal) || terminal.PermanentOfferNoticeFailure() != test.terminal {
-				t.Fatalf("status=%d err=%v terminal=%v", test.status, err, terminal)
+			var relayFailure interface{ PermanentRelayFailure() bool }
+			if err == nil || !errors.As(err, &terminal) || terminal.PermanentOfferNoticeFailure() != test.terminal || !errors.As(err, &relayFailure) || relayFailure.PermanentRelayFailure() != test.terminal {
+				t.Fatalf("status=%d err=%v offer_terminal=%v relay_terminal=%v", test.status, err, terminal, relayFailure)
 			}
 		})
 	}

--- a/internal/relay/http.go
+++ b/internal/relay/http.go
@@ -25,7 +25,8 @@ const (
 	// handshake probe. It never registers for or emits wake events.
 	DoctorNotificationsPath = "/v1/doctor/notifications"
 	// ResponseNonceHeader confirms that a response came from the authenticated
-	// Punaro route rather than an intermediary which rejected the request.
+	// Punaro route rather than an Access or reverse-proxy intermediary which
+	// rejected the request without echoing the signed per-request nonce.
 	ResponseNonceHeader = "X-Punaro-Response-Nonce"
 	// ProtocolHeader carries the bounded relay protocol identity.
 	ProtocolHeader = "X-Punaro-Protocol"
@@ -97,6 +98,9 @@ type handler struct {
 }
 
 func (h *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if nonce := r.Header.Get("X-Punaro-Nonce"); nonce != "" {
+		w.Header().Set(ResponseNonceHeader, nonce)
+	}
 	h.serveHTTP(w, r)
 }
 

--- a/internal/relay/http_test.go
+++ b/internal/relay/http_test.go
@@ -46,7 +46,10 @@ func TestHTTPDurableMessageFlowRequiresSignedMachineRequests(t *testing.T) {
 	t.Cleanup(targetNotifications.Close)
 	handler := NewHandler(store, auth, HandlerOptions{Now: func() time.Time { return clock }, EndpointLeaseTTL: time.Minute, DeliveryLeaseTTL: time.Minute, Notifier: notifier})
 
-	serveSigned(t, handler, privateA, "machine-a", http.MethodPut, "/v1/machines/me/endpoints", `{"endpoints":["agent/a/session"]}`, "advertise-a", "")
+	advertiseA := serveSigned(t, handler, privateA, "machine-a", http.MethodPut, "/v1/machines/me/endpoints", `{"endpoints":["agent/a/session"]}`, "advertise-a", "")
+	if advertiseA.Header().Get(ResponseNonceHeader) != "advertise-a" {
+		t.Fatalf("relay response nonce=%q", advertiseA.Header().Get(ResponseNonceHeader))
+	}
 	serveSigned(t, handler, privateB, "machine-b", http.MethodPut, "/v1/machines/me/endpoints", `{"endpoints":["agent/b/session"]}`, "advertise-b", "")
 	create := serveSigned(t, handler, privateA, "machine-a", http.MethodPost, "/v1/conversations", `{"creator_endpoint":"agent/a/session","members":[{"endpoint":"agent/a/session","capabilities":["send","receive","admin"]},{"endpoint":"agent/b/session","capabilities":["receive"]}]}`, "create", "create-1")
 	if create.Code != http.StatusCreated {

--- a/internal/telegram/bridge.go
+++ b/internal/telegram/bridge.go
@@ -121,6 +121,13 @@ func (b Bridge) SyncOnce(ctx context.Context, offset int64) (int64, error) {
 	outboundProgress := false
 	for _, delivery := range deliveries {
 		if err := SendDelivery(ctx, b.State, b.Sender, delivery, b.Gateway.AllowedUserID); err != nil {
+			if isPermanentTelegramFailure(err) {
+				b.logEvent("telegram_send_dropped", "delivery_id="+delivery.ID, "reason=permanent_rejection")
+				if err := b.Relay.Ack(ctx, delivery); err != nil {
+					return next, fmt.Errorf("acknowledge dropped Telegram delivery %q: %w", delivery.ID, err)
+				}
+				continue
+			}
 			b.logEvent("telegram_send_err", "delivery_id="+delivery.ID)
 			return next, &GatewayCycleError{Phase: GatewayPhaseSend, OutboundBlocked: true, OutboundProgress: outboundProgress, Err: err}
 		}
@@ -131,6 +138,15 @@ func (b Bridge) SyncOnce(ctx context.Context, offset int64) (int64, error) {
 		outboundProgress = true
 	}
 	return next, nil
+}
+
+type permanentTelegramFailure interface {
+	PermanentTelegramFailure() bool
+}
+
+func isPermanentTelegramFailure(err error) bool {
+	var terminal permanentTelegramFailure
+	return errors.As(err, &terminal) && terminal.PermanentTelegramFailure()
 }
 
 func (b Bridge) logEvent(class string, fields ...string) {

--- a/internal/telegram/bridge.go
+++ b/internal/telegram/bridge.go
@@ -130,7 +130,7 @@ func (b Bridge) SyncOnce(ctx context.Context, offset int64) (int64, error) {
 	previousInboundRecovery := gateway.inboundRecovery
 	gateway.terminalDrop = func(conversationID string, err error) {
 		terminalInbound++
-		inboundTargetEvents = append(inboundTargetEvents, GatewayInboundTargetEvent{ConversationID: conversationID, Terminal: true, Failure: GatewayFailureInboundRelayPermanent})
+		inboundTargetEvents = append(inboundTargetEvents, GatewayInboundTargetEvent{ConversationID: conversationID, Terminal: true, Staged: true, Failure: GatewayFailureInboundRelayPermanent})
 		if terminalInboundErr == nil {
 			terminalInboundErr = err
 		}
@@ -167,12 +167,15 @@ func (b Bridge) SyncOnce(ctx context.Context, offset int64) (int64, error) {
 		if err := SendDelivery(ctx, b.State, b.Sender, delivery, b.Gateway.AllowedUserID); err != nil {
 			if isPermanentTelegramFailure(err) {
 				b.logEvent("telegram_send_dropped", "delivery_id="+delivery.ID, "reason=permanent_rejection")
-				terminalOutbound++
 				failureClass := GatewayFailureOutboundTelegramPermanent
 				if DeletedTopicFailure(err) {
 					failureClass = GatewayFailureDeletedTopic
 				}
-				outboundTargetEvents = append(outboundTargetEvents, GatewayOutboundTargetEvent{ConversationID: delivery.Message.ConversationID, Terminal: true, Failure: failureClass})
+				if err := b.State.StageTerminalOutbound(delivery.ID, delivery.Message.ConversationID, failureClass); err != nil {
+					return next, &GatewayCycleError{Phase: GatewayPhaseSend, TerminalInbound: terminalInbound, TerminalOutbound: terminalOutbound, InboundRecovery: inboundRecovery, OutboundRecovery: outboundRecovery, InboundTargetEvents: inboundTargetEvents, OutboundTargetEvents: outboundTargetEvents, OutboundBlocked: true, OutboundProgress: outboundProgress, Err: fmt.Errorf("stage terminal telegram delivery: %w", err)}
+				}
+				terminalOutbound++
+				outboundTargetEvents = append(outboundTargetEvents, GatewayOutboundTargetEvent{ConversationID: delivery.Message.ConversationID, Terminal: true, Staged: true, Failure: failureClass})
 				if terminalOutboundErr == nil || DeletedTopicFailure(err) {
 					terminalOutboundErr = err
 				}
@@ -184,6 +187,9 @@ func (b Bridge) SyncOnce(ctx context.Context, offset int64) (int64, error) {
 			}
 			b.logEvent("telegram_send_err", "delivery_id="+delivery.ID)
 			return next, &GatewayCycleError{Phase: GatewayPhaseSend, TerminalInbound: terminalInbound, TerminalOutbound: terminalOutbound, InboundRecovery: inboundRecovery, OutboundRecovery: outboundRecovery, InboundTargetEvents: inboundTargetEvents, OutboundTargetEvents: outboundTargetEvents, OutboundBlocked: true, OutboundProgress: outboundProgress, Err: err}
+		}
+		if err := b.State.RecoverTerminalOutbound(delivery.Message.ConversationID); err != nil {
+			return next, &GatewayCycleError{Phase: GatewayPhaseSend, TerminalInbound: terminalInbound, TerminalOutbound: terminalOutbound, InboundRecovery: inboundRecovery, OutboundRecovery: outboundRecovery, InboundTargetEvents: inboundTargetEvents, OutboundTargetEvents: outboundTargetEvents, OutboundBlocked: true, OutboundProgress: outboundProgress, Err: fmt.Errorf("record terminal telegram recovery: %w", err)}
 		}
 		outboundRecovery = true
 		outboundTargetEvents = append(outboundTargetEvents, GatewayOutboundTargetEvent{ConversationID: delivery.Message.ConversationID})

--- a/internal/telegram/bridge.go
+++ b/internal/telegram/bridge.go
@@ -183,6 +183,9 @@ func (b Bridge) SyncOnce(ctx context.Context, offset int64) (int64, error) {
 					return next, &GatewayCycleError{Phase: GatewayPhaseAck, TerminalInbound: terminalInbound, TerminalOutbound: terminalOutbound, InboundRecovery: inboundRecovery, OutboundRecovery: outboundRecovery, InboundTargetEvents: inboundTargetEvents, OutboundTargetEvents: outboundTargetEvents, OutboundBlocked: true, OutboundProgress: outboundProgress, Err: err}
 				}
 				outboundProgress = true
+				if err := b.State.FinalizeTerminalOutbound(delivery.ID); err != nil {
+					return next, &GatewayCycleError{Phase: GatewayPhaseAck, TerminalInbound: terminalInbound, TerminalOutbound: terminalOutbound, InboundRecovery: inboundRecovery, OutboundRecovery: outboundRecovery, InboundTargetEvents: inboundTargetEvents, OutboundTargetEvents: outboundTargetEvents, OutboundBlocked: true, OutboundProgress: outboundProgress, Err: fmt.Errorf("finalize acknowledged terminal telegram delivery: %w", err)}
+				}
 				continue
 			}
 			b.logEvent("telegram_send_err", "delivery_id="+delivery.ID)

--- a/internal/telegram/bridge.go
+++ b/internal/telegram/bridge.go
@@ -58,6 +58,7 @@ type GatewayCycleError struct {
 	TerminalOutbound     int
 	InboundRecovery      bool
 	OutboundRecovery     bool
+	InboundTargetEvents  []GatewayInboundTargetEvent
 	OutboundTargetEvents []GatewayOutboundTargetEvent
 	OutboundBlocked      bool
 	OutboundProgress     bool
@@ -122,23 +123,26 @@ func (b Bridge) SyncOnce(ctx context.Context, offset int64) (int64, error) {
 	}
 	terminalInbound := 0
 	inboundRecovery := false
+	var inboundTargetEvents []GatewayInboundTargetEvent
 	var terminalInboundErr error
 	gateway := b.Gateway
 	previousTerminalDrop := gateway.terminalDrop
 	previousInboundRecovery := gateway.inboundRecovery
-	gateway.terminalDrop = func(err error) {
+	gateway.terminalDrop = func(conversationID string, err error) {
 		terminalInbound++
+		inboundTargetEvents = append(inboundTargetEvents, GatewayInboundTargetEvent{ConversationID: conversationID, Terminal: true, Failure: GatewayFailureInboundRelayPermanent})
 		if terminalInboundErr == nil {
 			terminalInboundErr = err
 		}
 		if previousTerminalDrop != nil {
-			previousTerminalDrop(err)
+			previousTerminalDrop(conversationID, err)
 		}
 	}
-	gateway.inboundRecovery = func() {
+	gateway.inboundRecovery = func(conversationID string) {
 		inboundRecovery = true
+		inboundTargetEvents = append(inboundTargetEvents, GatewayInboundTargetEvent{ConversationID: conversationID})
 		if previousInboundRecovery != nil {
-			previousInboundRecovery()
+			previousInboundRecovery(conversationID)
 		}
 	}
 	next, err := (Runner{Poller: b.Poller, Gateway: gateway}).RunOnce(ctx, offset)
@@ -148,11 +152,11 @@ func (b Bridge) SyncOnce(ctx context.Context, offset int64) (int64, error) {
 		if errors.As(err, &status) && status.Method == "getUpdates" {
 			phase = GatewayPhasePoll
 		}
-		return offset, &GatewayCycleError{Phase: phase, TerminalInbound: terminalInbound, InboundRecovery: inboundRecovery, Err: err}
+		return offset, &GatewayCycleError{Phase: phase, TerminalInbound: terminalInbound, InboundRecovery: inboundRecovery, InboundTargetEvents: inboundTargetEvents, Err: err}
 	}
 	deliveries, err := b.Relay.Lease(ctx, b.Endpoint)
 	if err != nil {
-		return next, &GatewayCycleError{Phase: GatewayPhaseLease, TerminalInbound: terminalInbound, InboundRecovery: inboundRecovery, Err: err}
+		return next, &GatewayCycleError{Phase: GatewayPhaseLease, TerminalInbound: terminalInbound, InboundRecovery: inboundRecovery, InboundTargetEvents: inboundTargetEvents, Err: err}
 	}
 	outboundProgress := false
 	outboundRecovery := false
@@ -164,24 +168,28 @@ func (b Bridge) SyncOnce(ctx context.Context, offset int64) (int64, error) {
 			if isPermanentTelegramFailure(err) {
 				b.logEvent("telegram_send_dropped", "delivery_id="+delivery.ID, "reason=permanent_rejection")
 				terminalOutbound++
-				outboundTargetEvents = append(outboundTargetEvents, GatewayOutboundTargetEvent{ConversationID: delivery.Message.ConversationID, Terminal: true})
+				failureClass := GatewayFailureOutboundTelegramPermanent
+				if DeletedTopicFailure(err) {
+					failureClass = GatewayFailureDeletedTopic
+				}
+				outboundTargetEvents = append(outboundTargetEvents, GatewayOutboundTargetEvent{ConversationID: delivery.Message.ConversationID, Terminal: true, Failure: failureClass})
 				if terminalOutboundErr == nil || DeletedTopicFailure(err) {
 					terminalOutboundErr = err
 				}
 				if err := b.Relay.Ack(ctx, delivery); err != nil {
-					return next, &GatewayCycleError{Phase: GatewayPhaseAck, TerminalInbound: terminalInbound, TerminalOutbound: terminalOutbound, InboundRecovery: inboundRecovery, OutboundRecovery: outboundRecovery, OutboundTargetEvents: outboundTargetEvents, OutboundBlocked: true, OutboundProgress: outboundProgress, Err: err}
+					return next, &GatewayCycleError{Phase: GatewayPhaseAck, TerminalInbound: terminalInbound, TerminalOutbound: terminalOutbound, InboundRecovery: inboundRecovery, OutboundRecovery: outboundRecovery, InboundTargetEvents: inboundTargetEvents, OutboundTargetEvents: outboundTargetEvents, OutboundBlocked: true, OutboundProgress: outboundProgress, Err: err}
 				}
 				outboundProgress = true
 				continue
 			}
 			b.logEvent("telegram_send_err", "delivery_id="+delivery.ID)
-			return next, &GatewayCycleError{Phase: GatewayPhaseSend, TerminalInbound: terminalInbound, TerminalOutbound: terminalOutbound, InboundRecovery: inboundRecovery, OutboundRecovery: outboundRecovery, OutboundTargetEvents: outboundTargetEvents, OutboundBlocked: true, OutboundProgress: outboundProgress, Err: err}
+			return next, &GatewayCycleError{Phase: GatewayPhaseSend, TerminalInbound: terminalInbound, TerminalOutbound: terminalOutbound, InboundRecovery: inboundRecovery, OutboundRecovery: outboundRecovery, InboundTargetEvents: inboundTargetEvents, OutboundTargetEvents: outboundTargetEvents, OutboundBlocked: true, OutboundProgress: outboundProgress, Err: err}
 		}
 		outboundRecovery = true
 		outboundTargetEvents = append(outboundTargetEvents, GatewayOutboundTargetEvent{ConversationID: delivery.Message.ConversationID})
 		b.logEvent("telegram_send_ok", "delivery_id="+delivery.ID)
 		if err := b.Relay.Ack(ctx, delivery); err != nil {
-			return next, &GatewayCycleError{Phase: GatewayPhaseAck, TerminalInbound: terminalInbound, TerminalOutbound: terminalOutbound, InboundRecovery: inboundRecovery, OutboundRecovery: outboundRecovery, OutboundTargetEvents: outboundTargetEvents, OutboundBlocked: true, OutboundProgress: outboundProgress, Err: err}
+			return next, &GatewayCycleError{Phase: GatewayPhaseAck, TerminalInbound: terminalInbound, TerminalOutbound: terminalOutbound, InboundRecovery: inboundRecovery, OutboundRecovery: outboundRecovery, InboundTargetEvents: inboundTargetEvents, OutboundTargetEvents: outboundTargetEvents, OutboundBlocked: true, OutboundProgress: outboundProgress, Err: err}
 		}
 		outboundProgress = true
 	}
@@ -194,6 +202,7 @@ func (b Bridge) SyncOnce(ctx context.Context, offset int64) (int64, error) {
 			Phase: phase, NonFatal: true,
 			TerminalInbound: terminalInbound, TerminalOutbound: terminalOutbound,
 			InboundRecovery: inboundRecovery, OutboundRecovery: outboundRecovery,
+			InboundTargetEvents:  inboundTargetEvents,
 			OutboundTargetEvents: outboundTargetEvents,
 			Err:                  terminalErr,
 		}

--- a/internal/telegram/bridge.go
+++ b/internal/telegram/bridge.go
@@ -124,8 +124,9 @@ func (b Bridge) SyncOnce(ctx context.Context, offset int64) (int64, error) {
 			if isPermanentTelegramFailure(err) {
 				b.logEvent("telegram_send_dropped", "delivery_id="+delivery.ID, "reason=permanent_rejection")
 				if err := b.Relay.Ack(ctx, delivery); err != nil {
-					return next, fmt.Errorf("acknowledge dropped Telegram delivery %q: %w", delivery.ID, err)
+					return next, &GatewayCycleError{Phase: GatewayPhaseAck, OutboundBlocked: true, OutboundProgress: outboundProgress, Err: err}
 				}
+				outboundProgress = true
 				continue
 			}
 			b.logEvent("telegram_send_err", "delivery_id="+delivery.ID)

--- a/internal/telegram/bridge.go
+++ b/internal/telegram/bridge.go
@@ -53,6 +53,9 @@ const (
 // wrapped typed error for content-free terminal/transient classification.
 type GatewayCycleError struct {
 	Phase            GatewayCyclePhase
+	NonFatal         bool
+	TerminalInbound  int
+	TerminalOutbound int
 	OutboundBlocked  bool
 	OutboundProgress bool
 	Err              error
@@ -75,7 +78,13 @@ func ClassifyGatewayCycleFailure(err error) GatewayFailureClass {
 		return GatewayFailureOutboundTelegramPermanent
 	}
 	var cycle *GatewayCycleError
-	if !errors.As(err, &cycle) || cycle.Phase != GatewayPhaseInbound {
+	if !errors.As(err, &cycle) {
+		return GatewayFailureTransient
+	}
+	if cycle.Phase == GatewayPhaseSend && isPermanentTelegramFailure(err) {
+		return GatewayFailureOutboundTelegramPermanent
+	}
+	if cycle.Phase != GatewayPhaseInbound {
 		return GatewayFailureTransient
 	}
 	var permanentRelay interface{ PermanentRelayFailure() bool }
@@ -105,38 +114,68 @@ func (b Bridge) SyncOnce(ctx context.Context, offset int64) (int64, error) {
 			return offset, &GatewayCycleError{Phase: GatewayPhaseClaim, Err: err}
 		}
 	}
-	next, err := (Runner{Poller: b.Poller, Gateway: b.Gateway}).RunOnce(ctx, offset)
+	terminalInbound := 0
+	var terminalInboundErr error
+	gateway := b.Gateway
+	previousTerminalDrop := gateway.terminalDrop
+	gateway.terminalDrop = func(err error) {
+		terminalInbound++
+		if terminalInboundErr == nil {
+			terminalInboundErr = err
+		}
+		if previousTerminalDrop != nil {
+			previousTerminalDrop(err)
+		}
+	}
+	next, err := (Runner{Poller: b.Poller, Gateway: gateway}).RunOnce(ctx, offset)
 	if err != nil {
 		phase := GatewayPhaseInbound
 		var status BotAPIStatusError
 		if errors.As(err, &status) && status.Method == "getUpdates" {
 			phase = GatewayPhasePoll
 		}
-		return offset, &GatewayCycleError{Phase: phase, Err: err}
+		return offset, &GatewayCycleError{Phase: phase, TerminalInbound: terminalInbound, Err: err}
 	}
 	deliveries, err := b.Relay.Lease(ctx, b.Endpoint)
 	if err != nil {
-		return next, &GatewayCycleError{Phase: GatewayPhaseLease, Err: err}
+		return next, &GatewayCycleError{Phase: GatewayPhaseLease, TerminalInbound: terminalInbound, Err: err}
 	}
 	outboundProgress := false
+	terminalOutbound := 0
+	var terminalOutboundErr error
 	for _, delivery := range deliveries {
 		if err := SendDelivery(ctx, b.State, b.Sender, delivery, b.Gateway.AllowedUserID); err != nil {
 			if isPermanentTelegramFailure(err) {
 				b.logEvent("telegram_send_dropped", "delivery_id="+delivery.ID, "reason=permanent_rejection")
 				if err := b.Relay.Ack(ctx, delivery); err != nil {
-					return next, &GatewayCycleError{Phase: GatewayPhaseAck, OutboundBlocked: true, OutboundProgress: outboundProgress, Err: err}
+					return next, &GatewayCycleError{Phase: GatewayPhaseAck, TerminalInbound: terminalInbound, TerminalOutbound: terminalOutbound + 1, OutboundBlocked: true, OutboundProgress: outboundProgress, Err: err}
 				}
 				outboundProgress = true
+				terminalOutbound++
+				if terminalOutboundErr == nil || DeletedTopicFailure(err) {
+					terminalOutboundErr = err
+				}
 				continue
 			}
 			b.logEvent("telegram_send_err", "delivery_id="+delivery.ID)
-			return next, &GatewayCycleError{Phase: GatewayPhaseSend, OutboundBlocked: true, OutboundProgress: outboundProgress, Err: err}
+			return next, &GatewayCycleError{Phase: GatewayPhaseSend, TerminalInbound: terminalInbound, TerminalOutbound: terminalOutbound, OutboundBlocked: true, OutboundProgress: outboundProgress, Err: err}
 		}
 		b.logEvent("telegram_send_ok", "delivery_id="+delivery.ID)
 		if err := b.Relay.Ack(ctx, delivery); err != nil {
-			return next, &GatewayCycleError{Phase: GatewayPhaseAck, OutboundBlocked: true, OutboundProgress: outboundProgress, Err: err}
+			return next, &GatewayCycleError{Phase: GatewayPhaseAck, TerminalInbound: terminalInbound, TerminalOutbound: terminalOutbound, OutboundBlocked: true, OutboundProgress: outboundProgress, Err: err}
 		}
 		outboundProgress = true
+	}
+	if terminalInbound > 0 || terminalOutbound > 0 {
+		phase, terminalErr := GatewayPhaseInbound, terminalInboundErr
+		if terminalOutbound > 0 {
+			phase, terminalErr = GatewayPhaseSend, terminalOutboundErr
+		}
+		return next, &GatewayCycleError{
+			Phase: phase, NonFatal: true,
+			TerminalInbound: terminalInbound, TerminalOutbound: terminalOutbound,
+			Err: terminalErr,
+		}
 	}
 	return next, nil
 }

--- a/internal/telegram/bridge.go
+++ b/internal/telegram/bridge.go
@@ -52,15 +52,16 @@ const (
 // GatewayCycleError preserves only the local phase while retaining the
 // wrapped typed error for content-free terminal/transient classification.
 type GatewayCycleError struct {
-	Phase            GatewayCyclePhase
-	NonFatal         bool
-	TerminalInbound  int
-	TerminalOutbound int
-	InboundRecovery  bool
-	OutboundRecovery bool
-	OutboundBlocked  bool
-	OutboundProgress bool
-	Err              error
+	Phase                GatewayCyclePhase
+	NonFatal             bool
+	TerminalInbound      int
+	TerminalOutbound     int
+	InboundRecovery      bool
+	OutboundRecovery     bool
+	OutboundTargetEvents []GatewayOutboundTargetEvent
+	OutboundBlocked      bool
+	OutboundProgress     bool
+	Err                  error
 }
 
 func (e *GatewayCycleError) Error() string { return "telegram gateway cycle failed" }
@@ -156,41 +157,45 @@ func (b Bridge) SyncOnce(ctx context.Context, offset int64) (int64, error) {
 	outboundProgress := false
 	outboundRecovery := false
 	terminalOutbound := 0
+	var outboundTargetEvents []GatewayOutboundTargetEvent
 	var terminalOutboundErr error
 	for _, delivery := range deliveries {
 		if err := SendDelivery(ctx, b.State, b.Sender, delivery, b.Gateway.AllowedUserID); err != nil {
 			if isPermanentTelegramFailure(err) {
 				b.logEvent("telegram_send_dropped", "delivery_id="+delivery.ID, "reason=permanent_rejection")
-				if err := b.Relay.Ack(ctx, delivery); err != nil {
-					return next, &GatewayCycleError{Phase: GatewayPhaseAck, TerminalInbound: terminalInbound, TerminalOutbound: terminalOutbound + 1, InboundRecovery: inboundRecovery, OutboundRecovery: outboundRecovery, OutboundBlocked: true, OutboundProgress: outboundProgress, Err: err}
-				}
-				outboundProgress = true
 				terminalOutbound++
+				outboundTargetEvents = append(outboundTargetEvents, GatewayOutboundTargetEvent{ConversationID: delivery.Message.ConversationID, Terminal: true})
 				if terminalOutboundErr == nil || DeletedTopicFailure(err) {
 					terminalOutboundErr = err
 				}
+				if err := b.Relay.Ack(ctx, delivery); err != nil {
+					return next, &GatewayCycleError{Phase: GatewayPhaseAck, TerminalInbound: terminalInbound, TerminalOutbound: terminalOutbound, InboundRecovery: inboundRecovery, OutboundRecovery: outboundRecovery, OutboundTargetEvents: outboundTargetEvents, OutboundBlocked: true, OutboundProgress: outboundProgress, Err: err}
+				}
+				outboundProgress = true
 				continue
 			}
 			b.logEvent("telegram_send_err", "delivery_id="+delivery.ID)
-			return next, &GatewayCycleError{Phase: GatewayPhaseSend, TerminalInbound: terminalInbound, TerminalOutbound: terminalOutbound, InboundRecovery: inboundRecovery, OutboundRecovery: outboundRecovery, OutboundBlocked: true, OutboundProgress: outboundProgress, Err: err}
+			return next, &GatewayCycleError{Phase: GatewayPhaseSend, TerminalInbound: terminalInbound, TerminalOutbound: terminalOutbound, InboundRecovery: inboundRecovery, OutboundRecovery: outboundRecovery, OutboundTargetEvents: outboundTargetEvents, OutboundBlocked: true, OutboundProgress: outboundProgress, Err: err}
 		}
 		outboundRecovery = true
+		outboundTargetEvents = append(outboundTargetEvents, GatewayOutboundTargetEvent{ConversationID: delivery.Message.ConversationID})
 		b.logEvent("telegram_send_ok", "delivery_id="+delivery.ID)
 		if err := b.Relay.Ack(ctx, delivery); err != nil {
-			return next, &GatewayCycleError{Phase: GatewayPhaseAck, TerminalInbound: terminalInbound, TerminalOutbound: terminalOutbound, InboundRecovery: inboundRecovery, OutboundRecovery: outboundRecovery, OutboundBlocked: true, OutboundProgress: outboundProgress, Err: err}
+			return next, &GatewayCycleError{Phase: GatewayPhaseAck, TerminalInbound: terminalInbound, TerminalOutbound: terminalOutbound, InboundRecovery: inboundRecovery, OutboundRecovery: outboundRecovery, OutboundTargetEvents: outboundTargetEvents, OutboundBlocked: true, OutboundProgress: outboundProgress, Err: err}
 		}
 		outboundProgress = true
 	}
 	if terminalInbound > 0 || terminalOutbound > 0 || inboundRecovery || outboundRecovery {
 		phase, terminalErr := GatewayPhaseInbound, terminalInboundErr
-		if terminalOutbound > 0 || outboundRecovery {
+		if terminalOutbound > 0 || terminalInbound == 0 && outboundRecovery {
 			phase, terminalErr = GatewayPhaseSend, terminalOutboundErr
 		}
 		return next, &GatewayCycleError{
 			Phase: phase, NonFatal: true,
 			TerminalInbound: terminalInbound, TerminalOutbound: terminalOutbound,
 			InboundRecovery: inboundRecovery, OutboundRecovery: outboundRecovery,
-			Err: terminalErr,
+			OutboundTargetEvents: outboundTargetEvents,
+			Err:                  terminalErr,
 		}
 	}
 	return next, nil

--- a/internal/telegram/bridge.go
+++ b/internal/telegram/bridge.go
@@ -56,6 +56,8 @@ type GatewayCycleError struct {
 	NonFatal         bool
 	TerminalInbound  int
 	TerminalOutbound int
+	InboundRecovery  bool
+	OutboundRecovery bool
 	OutboundBlocked  bool
 	OutboundProgress bool
 	Err              error
@@ -80,6 +82,9 @@ func ClassifyGatewayCycleFailure(err error) GatewayFailureClass {
 	var cycle *GatewayCycleError
 	if !errors.As(err, &cycle) {
 		return GatewayFailureTransient
+	}
+	if cycle.NonFatal && cycle.Err == nil {
+		return GatewayFailureNone
 	}
 	if cycle.Phase == GatewayPhaseSend && isPermanentTelegramFailure(err) {
 		return GatewayFailureOutboundTelegramPermanent
@@ -115,9 +120,11 @@ func (b Bridge) SyncOnce(ctx context.Context, offset int64) (int64, error) {
 		}
 	}
 	terminalInbound := 0
+	inboundRecovery := false
 	var terminalInboundErr error
 	gateway := b.Gateway
 	previousTerminalDrop := gateway.terminalDrop
+	previousInboundRecovery := gateway.inboundRecovery
 	gateway.terminalDrop = func(err error) {
 		terminalInbound++
 		if terminalInboundErr == nil {
@@ -127,6 +134,12 @@ func (b Bridge) SyncOnce(ctx context.Context, offset int64) (int64, error) {
 			previousTerminalDrop(err)
 		}
 	}
+	gateway.inboundRecovery = func() {
+		inboundRecovery = true
+		if previousInboundRecovery != nil {
+			previousInboundRecovery()
+		}
+	}
 	next, err := (Runner{Poller: b.Poller, Gateway: gateway}).RunOnce(ctx, offset)
 	if err != nil {
 		phase := GatewayPhaseInbound
@@ -134,13 +147,14 @@ func (b Bridge) SyncOnce(ctx context.Context, offset int64) (int64, error) {
 		if errors.As(err, &status) && status.Method == "getUpdates" {
 			phase = GatewayPhasePoll
 		}
-		return offset, &GatewayCycleError{Phase: phase, TerminalInbound: terminalInbound, Err: err}
+		return offset, &GatewayCycleError{Phase: phase, TerminalInbound: terminalInbound, InboundRecovery: inboundRecovery, Err: err}
 	}
 	deliveries, err := b.Relay.Lease(ctx, b.Endpoint)
 	if err != nil {
-		return next, &GatewayCycleError{Phase: GatewayPhaseLease, TerminalInbound: terminalInbound, Err: err}
+		return next, &GatewayCycleError{Phase: GatewayPhaseLease, TerminalInbound: terminalInbound, InboundRecovery: inboundRecovery, Err: err}
 	}
 	outboundProgress := false
+	outboundRecovery := false
 	terminalOutbound := 0
 	var terminalOutboundErr error
 	for _, delivery := range deliveries {
@@ -148,7 +162,7 @@ func (b Bridge) SyncOnce(ctx context.Context, offset int64) (int64, error) {
 			if isPermanentTelegramFailure(err) {
 				b.logEvent("telegram_send_dropped", "delivery_id="+delivery.ID, "reason=permanent_rejection")
 				if err := b.Relay.Ack(ctx, delivery); err != nil {
-					return next, &GatewayCycleError{Phase: GatewayPhaseAck, TerminalInbound: terminalInbound, TerminalOutbound: terminalOutbound + 1, OutboundBlocked: true, OutboundProgress: outboundProgress, Err: err}
+					return next, &GatewayCycleError{Phase: GatewayPhaseAck, TerminalInbound: terminalInbound, TerminalOutbound: terminalOutbound + 1, InboundRecovery: inboundRecovery, OutboundRecovery: outboundRecovery, OutboundBlocked: true, OutboundProgress: outboundProgress, Err: err}
 				}
 				outboundProgress = true
 				terminalOutbound++
@@ -158,22 +172,24 @@ func (b Bridge) SyncOnce(ctx context.Context, offset int64) (int64, error) {
 				continue
 			}
 			b.logEvent("telegram_send_err", "delivery_id="+delivery.ID)
-			return next, &GatewayCycleError{Phase: GatewayPhaseSend, TerminalInbound: terminalInbound, TerminalOutbound: terminalOutbound, OutboundBlocked: true, OutboundProgress: outboundProgress, Err: err}
+			return next, &GatewayCycleError{Phase: GatewayPhaseSend, TerminalInbound: terminalInbound, TerminalOutbound: terminalOutbound, InboundRecovery: inboundRecovery, OutboundRecovery: outboundRecovery, OutboundBlocked: true, OutboundProgress: outboundProgress, Err: err}
 		}
+		outboundRecovery = true
 		b.logEvent("telegram_send_ok", "delivery_id="+delivery.ID)
 		if err := b.Relay.Ack(ctx, delivery); err != nil {
-			return next, &GatewayCycleError{Phase: GatewayPhaseAck, TerminalInbound: terminalInbound, TerminalOutbound: terminalOutbound, OutboundBlocked: true, OutboundProgress: outboundProgress, Err: err}
+			return next, &GatewayCycleError{Phase: GatewayPhaseAck, TerminalInbound: terminalInbound, TerminalOutbound: terminalOutbound, InboundRecovery: inboundRecovery, OutboundRecovery: outboundRecovery, OutboundBlocked: true, OutboundProgress: outboundProgress, Err: err}
 		}
 		outboundProgress = true
 	}
-	if terminalInbound > 0 || terminalOutbound > 0 {
+	if terminalInbound > 0 || terminalOutbound > 0 || inboundRecovery || outboundRecovery {
 		phase, terminalErr := GatewayPhaseInbound, terminalInboundErr
-		if terminalOutbound > 0 {
+		if terminalOutbound > 0 || outboundRecovery {
 			phase, terminalErr = GatewayPhaseSend, terminalOutboundErr
 		}
 		return next, &GatewayCycleError{
 			Phase: phase, NonFatal: true,
 			TerminalInbound: terminalInbound, TerminalOutbound: terminalOutbound,
+			InboundRecovery: inboundRecovery, OutboundRecovery: outboundRecovery,
 			Err: terminalErr,
 		}
 	}

--- a/internal/telegram/bridge_test.go
+++ b/internal/telegram/bridge_test.go
@@ -26,6 +26,7 @@ type fakeBridgeRelay struct {
 	advertised []string
 	deliveries []relay.Delivery
 	acked      []string
+	ackErr     error
 	recordingClaimRelay
 }
 
@@ -53,7 +54,7 @@ func (r *fakeBridgeRelay) Lease(context.Context, string) ([]relay.Delivery, erro
 
 func (r *fakeBridgeRelay) Ack(_ context.Context, delivery relay.Delivery) error {
 	r.acked = append(r.acked, delivery.ID)
-	return nil
+	return r.ackErr
 }
 
 func TestBridgeSyncsInboundAndOutboundThroughOneAttachedGatewayEndpoint(t *testing.T) {
@@ -147,6 +148,55 @@ func TestBridgeDropsPermanentTelegramRejectionThenContinues(t *testing.T) {
 	}
 	if got := fmt.Sprint(relayClient.acked); got != "[rejected good]" || sender.calls != 2 {
 		t.Fatalf("acked=%v sender calls=%d", relayClient.acked, sender.calls)
+	}
+}
+
+func TestBridgeReportsProgressAfterDroppedDeliveryBeforeLaterSendFailure(t *testing.T) {
+	t.Parallel()
+	state, err := Open(filepath.Join(t.TempDir(), "telegram.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = state.Close() })
+	if err := state.SetRoute(55, 7, "conversation-1"); err != nil {
+		t.Fatal(err)
+	}
+	relayClient := &fakeBridgeRelay{deliveries: []relay.Delivery{
+		{ID: "poison", Message: relay.Message{ConversationID: "conversation-1", FromEndpoint: "agent/a"}},
+		{ID: "retryable", Message: relay.Message{ConversationID: "conversation-1", FromEndpoint: "agent/a", Body: "retry"}},
+	}}
+	bridge := Bridge{
+		Relay: relayClient, Endpoint: relay.TelegramGatewayEndpoint, State: state,
+		Poller: fakePoller{}, Gateway: Gateway{AllowedUserID: 55, State: state, Submit: func(context.Context, Submission) error { return nil }},
+		Sender: &scriptedRichSender{errs: []error{errors.New("fixture send failure")}},
+	}
+	_, err = bridge.SyncOnce(t.Context(), 1)
+	var cycleErr *GatewayCycleError
+	if !errors.As(err, &cycleErr) || cycleErr.Phase != GatewayPhaseSend || !cycleErr.OutboundBlocked || !cycleErr.OutboundProgress || fmt.Sprint(relayClient.acked) != "[poison]" {
+		t.Fatalf("err=%#v acked=%v", cycleErr, relayClient.acked)
+	}
+}
+
+func TestBridgeWrapsDroppedDeliveryAckFailureWithCycleMetadata(t *testing.T) {
+	t.Parallel()
+	state, err := Open(filepath.Join(t.TempDir(), "telegram.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = state.Close() })
+	relayClient := &fakeBridgeRelay{
+		deliveries: []relay.Delivery{{ID: "poison", Message: relay.Message{ConversationID: "missing", FromEndpoint: "agent/a", Body: "drop"}}},
+		ackErr:     errors.New("fixture ack failure"),
+	}
+	bridge := Bridge{
+		Relay: relayClient, Endpoint: relay.TelegramGatewayEndpoint, State: state,
+		Poller: fakePoller{}, Gateway: Gateway{AllowedUserID: 55, State: state, Submit: func(context.Context, Submission) error { return nil }},
+		Sender: &scriptedRichSender{},
+	}
+	_, err = bridge.SyncOnce(t.Context(), 1)
+	var cycleErr *GatewayCycleError
+	if !errors.As(err, &cycleErr) || cycleErr.Phase != GatewayPhaseAck || !cycleErr.OutboundBlocked || cycleErr.OutboundProgress || fmt.Sprint(relayClient.acked) != "[poison]" {
+		t.Fatalf("err=%#v acked=%v", cycleErr, relayClient.acked)
 	}
 }
 

--- a/internal/telegram/bridge_test.go
+++ b/internal/telegram/bridge_test.go
@@ -192,6 +192,72 @@ func TestBridgeDropsPermanentTelegramRejectionThenContinues(t *testing.T) {
 	}
 }
 
+func TestBridgeStagesPermanentDropBeforeRelayAcknowledgement(t *testing.T) {
+	t.Parallel()
+	database := filepath.Join(t.TempDir(), "telegram.db")
+	state, err := Open(database)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = state.Close() })
+	if err := state.SetRoute(55, 7, "conversation-1"); err != nil {
+		t.Fatal(err)
+	}
+	relayClient := &fakeBridgeRelay{deliveries: []relay.Delivery{{ID: "delivery-1", Message: relay.Message{ConversationID: "conversation-1", FromEndpoint: "agent/a", Body: "reply"}}}}
+	bridge := Bridge{
+		Relay: relayClient, Endpoint: relay.TelegramGatewayEndpoint, State: state,
+		Poller: fakePoller{}, Gateway: Gateway{AllowedUserID: 55, State: state, Submit: func(context.Context, Submission) error { return nil }},
+		Sender: &scriptedRichSender{errs: []error{BotAPIStatusError{Method: "sendRichMessage", Status: 403}}},
+	}
+	_, err = bridge.SyncOnce(t.Context(), 1)
+	var cycleErr *GatewayCycleError
+	if !errors.As(err, &cycleErr) || !cycleErr.NonFatal || fmt.Sprint(relayClient.acked) != "[delivery-1]" {
+		t.Fatalf("err=%#v acked=%v", cycleErr, relayClient.acked)
+	}
+	snapshot, err := InspectGatewayState(t.Context(), database, testCallbackNow)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if snapshot.TerminalOutbound != 1 {
+		t.Fatalf("terminal outbound drop was not durable before the cycle record: %#v", snapshot)
+	}
+}
+
+func TestBridgePersistsOutboundRecoveryBeforeRelayAcknowledgement(t *testing.T) {
+	t.Parallel()
+	database := filepath.Join(t.TempDir(), "telegram.db")
+	state, err := Open(database)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = state.Close() })
+	if err := state.SetRoute(55, 7, "conversation-1"); err != nil {
+		t.Fatal(err)
+	}
+	if err := state.StageTerminalOutbound("old-delivery", "conversation-1", GatewayFailureDeletedTopic); err != nil {
+		t.Fatal(err)
+	}
+	relayClient := &fakeBridgeRelay{deliveries: []relay.Delivery{{ID: "recovery-delivery", Message: relay.Message{ConversationID: "conversation-1", FromEndpoint: "agent/a", Body: "reply"}}}}
+	bridge := Bridge{
+		Relay: relayClient, Endpoint: relay.TelegramGatewayEndpoint, State: state,
+		Poller: fakePoller{}, Gateway: Gateway{AllowedUserID: 55, State: state, Submit: func(context.Context, Submission) error { return nil }},
+		Sender: &scriptedRichSender{},
+	}
+	if _, err := bridge.SyncOnce(t.Context(), 1); err == nil {
+		t.Fatal("recovery evidence was not returned")
+	}
+	if fmt.Sprint(relayClient.acked) != "[recovery-delivery]" {
+		t.Fatalf("acked=%v", relayClient.acked)
+	}
+	snapshot, err := InspectGatewayState(t.Context(), database, testCallbackNow)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if snapshot.TerminalOutbound != 0 || snapshot.DeletedTopicTargets != 0 {
+		t.Fatalf("outbound recovery was not durable before acknowledgement: %#v", snapshot)
+	}
+}
+
 func TestBridgeReportsPermanentInboundDropAfterContinuingPage(t *testing.T) {
 	t.Parallel()
 	state, err := Open(filepath.Join(t.TempDir(), "telegram.db"))

--- a/internal/telegram/bridge_test.go
+++ b/internal/telegram/bridge_test.go
@@ -221,6 +221,13 @@ func TestBridgeStagesPermanentDropBeforeRelayAcknowledgement(t *testing.T) {
 	if snapshot.TerminalOutbound != 1 {
 		t.Fatalf("terminal outbound drop was not durable before the cycle record: %#v", snapshot)
 	}
+	var stagedEvents int
+	if err := state.db.QueryRowContext(t.Context(), `SELECT COUNT(*) FROM gateway_terminal_outbound_events`).Scan(&stagedEvents); err != nil {
+		t.Fatal(err)
+	}
+	if stagedEvents != 0 {
+		t.Fatalf("acknowledged terminal event was retained: %d", stagedEvents)
+	}
 }
 
 func TestBridgePersistsOutboundRecoveryBeforeRelayAcknowledgement(t *testing.T) {
@@ -391,6 +398,13 @@ func TestBridgeWrapsDroppedDeliveryAckFailureWithCycleMetadata(t *testing.T) {
 	var cycleErr *GatewayCycleError
 	if !errors.As(err, &cycleErr) || cycleErr.Phase != GatewayPhaseAck || cycleErr.TerminalOutbound != 1 || !cycleErr.OutboundBlocked || cycleErr.OutboundProgress || fmt.Sprint(relayClient.acked) != "[poison]" {
 		t.Fatalf("err=%#v acked=%v", cycleErr, relayClient.acked)
+	}
+	var stagedEvents int
+	if err := state.db.QueryRowContext(t.Context(), `SELECT COUNT(*) FROM gateway_terminal_outbound_events`).Scan(&stagedEvents); err != nil {
+		t.Fatal(err)
+	}
+	if stagedEvents != 1 {
+		t.Fatalf("unacknowledged terminal event was not retained: %d", stagedEvents)
 	}
 }
 

--- a/internal/telegram/bridge_test.go
+++ b/internal/telegram/bridge_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -26,6 +27,19 @@ type fakeBridgeRelay struct {
 	deliveries []relay.Delivery
 	acked      []string
 	recordingClaimRelay
+}
+
+type scriptedRichSender struct {
+	errs  []error
+	calls int
+}
+
+func (s *scriptedRichSender) SendRichMessage(context.Context, int64, int64, string) (int64, error) {
+	s.calls++
+	if s.calls <= len(s.errs) && s.errs[s.calls-1] != nil {
+		return 0, s.errs[s.calls-1]
+	}
+	return int64(s.calls), nil
 }
 
 func (r *fakeBridgeRelay) Advertise(_ context.Context, endpoints []string) error {
@@ -72,6 +86,95 @@ func TestBridgeSyncsInboundAndOutboundThroughOneAttachedGatewayEndpoint(t *testi
 	}
 	if next != 11 || submitted != 1 || len(relayClient.advertised) != 1 || relayClient.advertised[0] != "telegram/gateway" || len(relayClient.acked) != 1 || relayClient.acked[0] != "delivery-1" || len(richSender.html) != 1 {
 		t.Fatalf("next=%d submitted=%d advertised=%#v acked=%#v sent=%#v", next, submitted, relayClient.advertised, relayClient.acked, richSender.html)
+	}
+}
+
+func TestBridgeDropsMalformedAndUnroutedDeliveriesThenContinues(t *testing.T) {
+	t.Parallel()
+	state, err := Open(filepath.Join(t.TempDir(), "telegram.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = state.Close() })
+	if err := state.SetRoute(55, 7, "conversation-good"); err != nil {
+		t.Fatal(err)
+	}
+	relayClient := &fakeBridgeRelay{deliveries: []relay.Delivery{
+		{ID: "malformed", Message: relay.Message{ConversationID: "conversation-good", FromEndpoint: "agent/a"}},
+		{ID: "unrouted", Message: relay.Message{ConversationID: "conversation-missing", FromEndpoint: "agent/a", Body: "reply"}},
+		{ID: "good", Message: relay.Message{ConversationID: "conversation-good", FromEndpoint: "agent/a", Body: "reply"}},
+	}}
+	sender := &scriptedRichSender{}
+	var logs []string
+	bridge := Bridge{
+		Relay: relayClient, Endpoint: relay.TelegramGatewayEndpoint, State: state,
+		Poller: fakePoller{}, Gateway: Gateway{AllowedUserID: 55, State: state, Submit: func(context.Context, Submission) error { return nil }},
+		Sender: sender, Log: func(format string, args ...any) { logs = append(logs, fmt.Sprintf(format, args...)) },
+	}
+	if _, err := bridge.SyncOnce(context.Background(), 1); err != nil {
+		t.Fatal(err)
+	}
+	if got := fmt.Sprint(relayClient.acked); got != "[malformed unrouted good]" || sender.calls != 1 {
+		t.Fatalf("acked=%v sender calls=%d", relayClient.acked, sender.calls)
+	}
+	if !strings.Contains(strings.Join(logs, "\n"), "telegram_send_dropped") {
+		t.Fatalf("logs=%#v", logs)
+	}
+}
+
+func TestBridgeDropsPermanentTelegramRejectionThenContinues(t *testing.T) {
+	t.Parallel()
+	state, err := Open(filepath.Join(t.TempDir(), "telegram.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = state.Close() })
+	if err := state.SetRoute(55, 7, "conversation-1"); err != nil {
+		t.Fatal(err)
+	}
+	relayClient := &fakeBridgeRelay{deliveries: []relay.Delivery{
+		{ID: "rejected", Message: relay.Message{ConversationID: "conversation-1", FromEndpoint: "agent/a", Body: "first"}},
+		{ID: "good", Message: relay.Message{ConversationID: "conversation-1", FromEndpoint: "agent/a", Body: "second"}},
+	}}
+	sender := &scriptedRichSender{errs: []error{BotAPIStatusError{Method: "sendRichMessage", Status: 400}}}
+	bridge := Bridge{
+		Relay: relayClient, Endpoint: relay.TelegramGatewayEndpoint, State: state,
+		Poller: fakePoller{}, Gateway: Gateway{AllowedUserID: 55, State: state, Submit: func(context.Context, Submission) error { return nil }},
+		Sender: sender, Log: func(string, ...any) {},
+	}
+	if _, err := bridge.SyncOnce(context.Background(), 1); err != nil {
+		t.Fatal(err)
+	}
+	if got := fmt.Sprint(relayClient.acked); got != "[rejected good]" || sender.calls != 2 {
+		t.Fatalf("acked=%v sender calls=%d", relayClient.acked, sender.calls)
+	}
+}
+
+func TestBridgeRetriesTransientTelegramRejection(t *testing.T) {
+	t.Parallel()
+	for _, status := range []int{401, 429, 500} {
+		t.Run(fmt.Sprint(status), func(t *testing.T) {
+			state, err := Open(filepath.Join(t.TempDir(), "telegram.db"))
+			if err != nil {
+				t.Fatal(err)
+			}
+			t.Cleanup(func() { _ = state.Close() })
+			if err := state.SetRoute(55, 7, "conversation-1"); err != nil {
+				t.Fatal(err)
+			}
+			relayClient := &fakeBridgeRelay{deliveries: []relay.Delivery{{ID: "retryable", Message: relay.Message{ConversationID: "conversation-1", FromEndpoint: "agent/a", Body: "retry"}}}}
+			bridge := Bridge{
+				Relay: relayClient, Endpoint: relay.TelegramGatewayEndpoint, State: state,
+				Poller: fakePoller{}, Gateway: Gateway{AllowedUserID: 55, State: state, Submit: func(context.Context, Submission) error { return nil }},
+				Sender: &scriptedRichSender{errs: []error{BotAPIStatusError{Method: "sendRichMessage", Status: status}}},
+			}
+			if _, err := bridge.SyncOnce(context.Background(), 1); err == nil {
+				t.Fatalf("HTTP %d delivery was accepted", status)
+			}
+			if len(relayClient.acked) != 0 {
+				t.Fatalf("acked=%v", relayClient.acked)
+			}
+		})
 	}
 }
 

--- a/internal/telegram/bridge_test.go
+++ b/internal/telegram/bridge_test.go
@@ -82,8 +82,9 @@ func TestBridgeSyncsInboundAndOutboundThroughOneAttachedGatewayEndpoint(t *testi
 		Sender: richSender,
 	}
 	next, err := bridge.SyncOnce(context.Background(), 10)
-	if err != nil {
-		t.Fatal(err)
+	var cycleErr *GatewayCycleError
+	if !errors.As(err, &cycleErr) || !cycleErr.NonFatal || cycleErr.Err != nil || !cycleErr.InboundRecovery || !cycleErr.OutboundRecovery {
+		t.Fatalf("err=%#v", cycleErr)
 	}
 	if next != 11 || submitted != 1 || len(relayClient.advertised) != 1 || relayClient.advertised[0] != "telegram/gateway" || len(relayClient.acked) != 1 || relayClient.acked[0] != "delivery-1" || len(richSender.html) != 1 {
 		t.Fatalf("next=%d submitted=%d advertised=%#v acked=%#v sent=%#v", next, submitted, relayClient.advertised, relayClient.acked, richSender.html)
@@ -221,6 +222,30 @@ func TestBridgeReportsPermanentInboundDropAfterContinuingPage(t *testing.T) {
 	var cycleErr *GatewayCycleError
 	if next != 12 || fmt.Sprint(submitted) != "[poison later]" || !errors.As(err, &cycleErr) || !cycleErr.NonFatal || cycleErr.Phase != GatewayPhaseInbound || cycleErr.TerminalInbound != 1 || cycleErr.TerminalOutbound != 0 || ClassifyGatewayCycleFailure(err) != GatewayFailureInboundRelayPermanent {
 		t.Fatalf("next=%d submitted=%v err=%#v", next, submitted, cycleErr)
+	}
+}
+
+func TestBridgeReportsPlaneRecoveryEvidence(t *testing.T) {
+	t.Parallel()
+	state, err := Open(filepath.Join(t.TempDir(), "telegram.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = state.Close() })
+	if err := state.SetRoute(55, 7, "conversation-1"); err != nil {
+		t.Fatal(err)
+	}
+	relayClient := &fakeBridgeRelay{deliveries: []relay.Delivery{{ID: "delivery-1", Message: relay.Message{ConversationID: "conversation-1", FromEndpoint: "agent/a", Body: "reply"}}}}
+	bridge := Bridge{
+		Relay: relayClient, Endpoint: relay.TelegramGatewayEndpoint, State: state,
+		Poller:  fakePoller{updates: []Update{{ID: 10, UserID: 55, ChatID: 55, ThreadID: 7, Text: "hello"}}},
+		Gateway: Gateway{AllowedUserID: 55, State: state, Submit: func(context.Context, Submission) error { return nil }},
+		Sender:  &scriptedRichSender{},
+	}
+	next, err := bridge.SyncOnce(t.Context(), 10)
+	var cycleErr *GatewayCycleError
+	if next != 11 || !errors.As(err, &cycleErr) || !cycleErr.NonFatal || cycleErr.Err != nil || !cycleErr.InboundRecovery || !cycleErr.OutboundRecovery || ClassifyGatewayCycleFailure(err) != GatewayFailureNone {
+		t.Fatalf("next=%d err=%#v", next, cycleErr)
 	}
 }
 
@@ -397,8 +422,9 @@ func TestBridgeResumesIncompleteClaimBeforePollingInbound(t *testing.T) {
 		Claims: executor,
 	}
 	next, err := bridge.SyncOnce(context.Background(), 30)
-	if err != nil {
-		t.Fatal(err)
+	var cycleErr *GatewayCycleError
+	if !errors.As(err, &cycleErr) || !cycleErr.NonFatal || cycleErr.Err != nil || !cycleErr.InboundRecovery || cycleErr.OutboundRecovery {
+		t.Fatalf("err=%#v", cycleErr)
 	}
 	resume, found, err := state.ClaimExecution("conversation-stuck")
 	if err != nil || !found || resume.Phase != ClaimPhaseComplete {

--- a/internal/telegram/bridge_test.go
+++ b/internal/telegram/bridge_test.go
@@ -114,7 +114,7 @@ func TestBridgeDropsMalformedDeliveryThenContinues(t *testing.T) {
 	}
 	_, err = bridge.SyncOnce(context.Background(), 1)
 	var cycleErr *GatewayCycleError
-	if !errors.As(err, &cycleErr) || !cycleErr.NonFatal || cycleErr.Phase != GatewayPhaseSend || cycleErr.TerminalOutbound != 1 || ClassifyGatewayCycleFailure(err) != GatewayFailureOutboundTelegramPermanent {
+	if !errors.As(err, &cycleErr) || !cycleErr.NonFatal || cycleErr.Phase != GatewayPhaseSend || cycleErr.TerminalOutbound != 1 || len(cycleErr.OutboundTargetEvents) != 2 || !cycleErr.OutboundTargetEvents[0].Terminal || cycleErr.OutboundTargetEvents[0].Failure != GatewayFailureOutboundTelegramPermanent || cycleErr.OutboundTargetEvents[1].Terminal || ClassifyGatewayCycleFailure(err) != GatewayFailureOutboundTelegramPermanent {
 		t.Fatalf("err=%#v", cycleErr)
 	}
 	if got := fmt.Sprint(relayClient.acked); got != "[malformed good]" || sender.calls != 1 {
@@ -202,12 +202,15 @@ func TestBridgeReportsPermanentInboundDropAfterContinuingPage(t *testing.T) {
 	if err := state.SetRoute(55, 7, "conversation-1"); err != nil {
 		t.Fatal(err)
 	}
+	if err := state.SetRoute(55, 8, "conversation-2"); err != nil {
+		t.Fatal(err)
+	}
 	var submitted []string
 	bridge := Bridge{
 		Relay: &fakeBridgeRelay{}, Endpoint: relay.TelegramGatewayEndpoint, State: state,
 		Poller: fakePoller{updates: []Update{
 			{ID: 10, UserID: 55, ChatID: 55, ThreadID: 7, Text: "poison"},
-			{ID: 11, UserID: 55, ChatID: 55, ThreadID: 7, Text: "later"},
+			{ID: 11, UserID: 55, ChatID: 55, ThreadID: 8, Text: "later"},
 		}},
 		Gateway: Gateway{AllowedUserID: 55, State: state, Submit: func(_ context.Context, submission Submission) error {
 			submitted = append(submitted, submission.Text)
@@ -220,7 +223,7 @@ func TestBridgeReportsPermanentInboundDropAfterContinuingPage(t *testing.T) {
 	}
 	next, err := bridge.SyncOnce(t.Context(), 10)
 	var cycleErr *GatewayCycleError
-	if next != 12 || fmt.Sprint(submitted) != "[poison later]" || !errors.As(err, &cycleErr) || !cycleErr.NonFatal || cycleErr.Phase != GatewayPhaseInbound || cycleErr.TerminalInbound != 1 || cycleErr.TerminalOutbound != 0 || ClassifyGatewayCycleFailure(err) != GatewayFailureInboundRelayPermanent {
+	if next != 12 || fmt.Sprint(submitted) != "[poison later]" || !errors.As(err, &cycleErr) || !cycleErr.NonFatal || cycleErr.Phase != GatewayPhaseInbound || cycleErr.TerminalInbound != 1 || cycleErr.TerminalOutbound != 0 || len(cycleErr.InboundTargetEvents) != 2 || cycleErr.InboundTargetEvents[0].ConversationID != "conversation-1" || !cycleErr.InboundTargetEvents[0].Terminal || cycleErr.InboundTargetEvents[1].ConversationID != "conversation-2" || cycleErr.InboundTargetEvents[1].Terminal || ClassifyGatewayCycleFailure(err) != GatewayFailureInboundRelayPermanent {
 		t.Fatalf("next=%d submitted=%v err=%#v", next, submitted, cycleErr)
 	}
 }

--- a/internal/telegram/bridge_test.go
+++ b/internal/telegram/bridge_test.go
@@ -225,6 +225,33 @@ func TestBridgeReportsPermanentInboundDropAfterContinuingPage(t *testing.T) {
 	}
 }
 
+func TestBridgePreservesPermanentInboundDropWhenOutboundTargetRecovers(t *testing.T) {
+	t.Parallel()
+	state, err := Open(filepath.Join(t.TempDir(), "telegram.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = state.Close() })
+	if err := state.SetRoute(55, 7, "conversation-1"); err != nil {
+		t.Fatal(err)
+	}
+	bridge := Bridge{
+		Relay:    &fakeBridgeRelay{deliveries: []relay.Delivery{{ID: "delivery-1", Message: relay.Message{ConversationID: "conversation-1", FromEndpoint: "agent/a", Body: "reply"}}}},
+		Endpoint: relay.TelegramGatewayEndpoint,
+		State:    state,
+		Poller:   fakePoller{updates: []Update{{ID: 10, UserID: 55, ChatID: 55, ThreadID: 7, Text: "poison"}}},
+		Gateway: Gateway{AllowedUserID: 55, State: state, Submit: func(context.Context, Submission) error {
+			return permanentRelayFixtureError{}
+		}},
+		Sender: &scriptedRichSender{},
+	}
+	next, err := bridge.SyncOnce(t.Context(), 10)
+	var cycleErr *GatewayCycleError
+	if next != 11 || !errors.As(err, &cycleErr) || cycleErr.Phase != GatewayPhaseInbound || cycleErr.TerminalInbound != 1 || ClassifyGatewayCycleFailure(err) != GatewayFailureInboundRelayPermanent {
+		t.Fatalf("next=%d err=%#v class=%s", next, cycleErr, ClassifyGatewayCycleFailure(err))
+	}
+}
+
 func TestBridgeReportsPlaneRecoveryEvidence(t *testing.T) {
 	t.Parallel()
 	state, err := Open(filepath.Join(t.TempDir(), "telegram.db"))

--- a/internal/telegram/bridge_test.go
+++ b/internal/telegram/bridge_test.go
@@ -90,7 +90,7 @@ func TestBridgeSyncsInboundAndOutboundThroughOneAttachedGatewayEndpoint(t *testi
 	}
 }
 
-func TestBridgeDropsMalformedAndUnroutedDeliveriesThenContinues(t *testing.T) {
+func TestBridgeDropsMalformedDeliveryThenContinues(t *testing.T) {
 	t.Parallel()
 	state, err := Open(filepath.Join(t.TempDir(), "telegram.db"))
 	if err != nil {
@@ -102,7 +102,6 @@ func TestBridgeDropsMalformedAndUnroutedDeliveriesThenContinues(t *testing.T) {
 	}
 	relayClient := &fakeBridgeRelay{deliveries: []relay.Delivery{
 		{ID: "malformed", Message: relay.Message{ConversationID: "conversation-good", FromEndpoint: "agent/a"}},
-		{ID: "unrouted", Message: relay.Message{ConversationID: "conversation-missing", FromEndpoint: "agent/a", Body: "reply"}},
 		{ID: "good", Message: relay.Message{ConversationID: "conversation-good", FromEndpoint: "agent/a", Body: "reply"}},
 	}}
 	sender := &scriptedRichSender{}
@@ -115,11 +114,48 @@ func TestBridgeDropsMalformedAndUnroutedDeliveriesThenContinues(t *testing.T) {
 	if _, err := bridge.SyncOnce(context.Background(), 1); err != nil {
 		t.Fatal(err)
 	}
-	if got := fmt.Sprint(relayClient.acked); got != "[malformed unrouted good]" || sender.calls != 1 {
+	if got := fmt.Sprint(relayClient.acked); got != "[malformed good]" || sender.calls != 1 {
 		t.Fatalf("acked=%v sender calls=%d", relayClient.acked, sender.calls)
 	}
 	if !strings.Contains(strings.Join(logs, "\n"), "telegram_send_dropped") {
 		t.Fatalf("logs=%#v", logs)
+	}
+}
+
+func TestBridgeLeavesMissingOrForeignRouteUnacknowledged(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name      string
+		routeChat int64
+		setRoute  bool
+	}{
+		{name: "missing route"},
+		{name: "foreign route", routeChat: 99, setRoute: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			state, err := Open(filepath.Join(t.TempDir(), "telegram.db"))
+			if err != nil {
+				t.Fatal(err)
+			}
+			t.Cleanup(func() { _ = state.Close() })
+			if tc.setRoute {
+				if err := state.SetRoute(tc.routeChat, 7, "conversation-1"); err != nil {
+					t.Fatal(err)
+				}
+			}
+			relayClient := &fakeBridgeRelay{deliveries: []relay.Delivery{{ID: "delivery-1", Message: relay.Message{ConversationID: "conversation-1", FromEndpoint: "agent/a", Body: "reply"}}}}
+			bridge := Bridge{
+				Relay: relayClient, Endpoint: relay.TelegramGatewayEndpoint, State: state,
+				Poller: fakePoller{}, Gateway: Gateway{AllowedUserID: 55, State: state, Submit: func(context.Context, Submission) error { return nil }},
+				Sender: &scriptedRichSender{},
+			}
+			_, err = bridge.SyncOnce(t.Context(), 1)
+			var cycleErr *GatewayCycleError
+			if !errors.As(err, &cycleErr) || cycleErr.Phase != GatewayPhaseSend || !cycleErr.OutboundBlocked || cycleErr.OutboundProgress || len(relayClient.acked) != 0 {
+				t.Fatalf("err=%#v acked=%v", cycleErr, relayClient.acked)
+			}
+		})
 	}
 }
 
@@ -185,7 +221,7 @@ func TestBridgeWrapsDroppedDeliveryAckFailureWithCycleMetadata(t *testing.T) {
 	}
 	t.Cleanup(func() { _ = state.Close() })
 	relayClient := &fakeBridgeRelay{
-		deliveries: []relay.Delivery{{ID: "poison", Message: relay.Message{ConversationID: "missing", FromEndpoint: "agent/a", Body: "drop"}}},
+		deliveries: []relay.Delivery{{ID: "poison", Message: relay.Message{ConversationID: "missing", FromEndpoint: "agent/a"}}},
 		ackErr:     errors.New("fixture ack failure"),
 	}
 	bridge := Bridge{

--- a/internal/telegram/bridge_test.go
+++ b/internal/telegram/bridge_test.go
@@ -111,8 +111,10 @@ func TestBridgeDropsMalformedDeliveryThenContinues(t *testing.T) {
 		Poller: fakePoller{}, Gateway: Gateway{AllowedUserID: 55, State: state, Submit: func(context.Context, Submission) error { return nil }},
 		Sender: sender, Log: func(format string, args ...any) { logs = append(logs, fmt.Sprintf(format, args...)) },
 	}
-	if _, err := bridge.SyncOnce(context.Background(), 1); err != nil {
-		t.Fatal(err)
+	_, err = bridge.SyncOnce(context.Background(), 1)
+	var cycleErr *GatewayCycleError
+	if !errors.As(err, &cycleErr) || !cycleErr.NonFatal || cycleErr.Phase != GatewayPhaseSend || cycleErr.TerminalOutbound != 1 || ClassifyGatewayCycleFailure(err) != GatewayFailureOutboundTelegramPermanent {
+		t.Fatalf("err=%#v", cycleErr)
 	}
 	if got := fmt.Sprint(relayClient.acked); got != "[malformed good]" || sender.calls != 1 {
 		t.Fatalf("acked=%v sender calls=%d", relayClient.acked, sender.calls)
@@ -179,11 +181,46 @@ func TestBridgeDropsPermanentTelegramRejectionThenContinues(t *testing.T) {
 		Poller: fakePoller{}, Gateway: Gateway{AllowedUserID: 55, State: state, Submit: func(context.Context, Submission) error { return nil }},
 		Sender: sender, Log: func(string, ...any) {},
 	}
-	if _, err := bridge.SyncOnce(context.Background(), 1); err != nil {
-		t.Fatal(err)
+	_, err = bridge.SyncOnce(context.Background(), 1)
+	var cycleErr *GatewayCycleError
+	if !errors.As(err, &cycleErr) || !cycleErr.NonFatal || cycleErr.Phase != GatewayPhaseSend || cycleErr.TerminalInbound != 0 || cycleErr.TerminalOutbound != 1 || ClassifyGatewayCycleFailure(err) != GatewayFailureOutboundTelegramPermanent {
+		t.Fatalf("err=%#v", cycleErr)
 	}
 	if got := fmt.Sprint(relayClient.acked); got != "[rejected good]" || sender.calls != 2 {
 		t.Fatalf("acked=%v sender calls=%d", relayClient.acked, sender.calls)
+	}
+}
+
+func TestBridgeReportsPermanentInboundDropAfterContinuingPage(t *testing.T) {
+	t.Parallel()
+	state, err := Open(filepath.Join(t.TempDir(), "telegram.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = state.Close() })
+	if err := state.SetRoute(55, 7, "conversation-1"); err != nil {
+		t.Fatal(err)
+	}
+	var submitted []string
+	bridge := Bridge{
+		Relay: &fakeBridgeRelay{}, Endpoint: relay.TelegramGatewayEndpoint, State: state,
+		Poller: fakePoller{updates: []Update{
+			{ID: 10, UserID: 55, ChatID: 55, ThreadID: 7, Text: "poison"},
+			{ID: 11, UserID: 55, ChatID: 55, ThreadID: 7, Text: "later"},
+		}},
+		Gateway: Gateway{AllowedUserID: 55, State: state, Submit: func(_ context.Context, submission Submission) error {
+			submitted = append(submitted, submission.Text)
+			if submission.Text == "poison" {
+				return permanentRelayFixtureError{}
+			}
+			return nil
+		}},
+		Sender: &scriptedRichSender{},
+	}
+	next, err := bridge.SyncOnce(t.Context(), 10)
+	var cycleErr *GatewayCycleError
+	if next != 12 || fmt.Sprint(submitted) != "[poison later]" || !errors.As(err, &cycleErr) || !cycleErr.NonFatal || cycleErr.Phase != GatewayPhaseInbound || cycleErr.TerminalInbound != 1 || cycleErr.TerminalOutbound != 0 || ClassifyGatewayCycleFailure(err) != GatewayFailureInboundRelayPermanent {
+		t.Fatalf("next=%d submitted=%v err=%#v", next, submitted, cycleErr)
 	}
 }
 
@@ -208,7 +245,7 @@ func TestBridgeReportsProgressAfterDroppedDeliveryBeforeLaterSendFailure(t *test
 	}
 	_, err = bridge.SyncOnce(t.Context(), 1)
 	var cycleErr *GatewayCycleError
-	if !errors.As(err, &cycleErr) || cycleErr.Phase != GatewayPhaseSend || !cycleErr.OutboundBlocked || !cycleErr.OutboundProgress || fmt.Sprint(relayClient.acked) != "[poison]" {
+	if !errors.As(err, &cycleErr) || cycleErr.Phase != GatewayPhaseSend || cycleErr.TerminalOutbound != 1 || !cycleErr.OutboundBlocked || !cycleErr.OutboundProgress || fmt.Sprint(relayClient.acked) != "[poison]" {
 		t.Fatalf("err=%#v acked=%v", cycleErr, relayClient.acked)
 	}
 }
@@ -231,7 +268,7 @@ func TestBridgeWrapsDroppedDeliveryAckFailureWithCycleMetadata(t *testing.T) {
 	}
 	_, err = bridge.SyncOnce(t.Context(), 1)
 	var cycleErr *GatewayCycleError
-	if !errors.As(err, &cycleErr) || cycleErr.Phase != GatewayPhaseAck || !cycleErr.OutboundBlocked || cycleErr.OutboundProgress || fmt.Sprint(relayClient.acked) != "[poison]" {
+	if !errors.As(err, &cycleErr) || cycleErr.Phase != GatewayPhaseAck || cycleErr.TerminalOutbound != 1 || !cycleErr.OutboundBlocked || cycleErr.OutboundProgress || fmt.Sprint(relayClient.acked) != "[poison]" {
 		t.Fatalf("err=%#v acked=%v", cycleErr, relayClient.acked)
 	}
 }

--- a/internal/telegram/bridge_test.go
+++ b/internal/telegram/bridge_test.go
@@ -396,7 +396,7 @@ func TestBridgeWrapsDroppedDeliveryAckFailureWithCycleMetadata(t *testing.T) {
 
 func TestBridgeRetriesTransientTelegramRejection(t *testing.T) {
 	t.Parallel()
-	for _, status := range []int{401, 429, 500} {
+	for _, status := range []int{401, 404, 429, 500} {
 		t.Run(fmt.Sprint(status), func(t *testing.T) {
 			state, err := Open(filepath.Join(t.TempDir(), "telegram.db"))
 			if err != nil {
@@ -464,7 +464,7 @@ func TestClassifyGatewayCycleFailureSeparatesRetryAndTerminalPlanes(t *testing.T
 		{name: "permanent outbound Telegram", err: &GatewayCycleError{Phase: GatewayPhaseSend, Err: BotAPIStatusError{Method: "sendRichMessage", Status: 403}}, class: GatewayFailureOutboundTelegramPermanent},
 		{name: "permanent inbound relay", err: &GatewayCycleError{Phase: GatewayPhaseInbound, Err: permanentRelay}, class: GatewayFailureInboundRelayPermanent},
 		{name: "permanent relay outside inbound", err: &GatewayCycleError{Phase: GatewayPhaseAdvertise, Err: permanentRelay}, class: GatewayFailureTransient},
-		{name: "message-less poll", err: &GatewayCycleError{Phase: GatewayPhasePoll, Err: BotAPIStatusError{Method: "getUpdates", Status: 404}}, class: GatewayFailureMessageLessPoll},
+		{name: "message-less poll", err: &GatewayCycleError{Phase: GatewayPhasePoll, Err: BotAPIStatusError{Method: "getUpdates", Status: 400}}, class: GatewayFailureMessageLessPoll},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			if got := ClassifyGatewayCycleFailure(test.err); got != test.class {

--- a/internal/telegram/client.go
+++ b/internal/telegram/client.go
@@ -19,8 +19,8 @@ const maxBotResponseBytes = 1 << 20
 const maxRichMessageBytes = 32 << 10
 
 // BotAPIStatusError is a completed Telegram HTTP response. Client errors other
-// than rate limiting are terminal because retrying the same request cannot
-// change the rejected payload or target.
+// than authentication failure and rate limiting are terminal because retrying
+// the same request cannot change the rejected payload or target.
 type BotAPIStatusError struct {
 	Method string
 	Status int

--- a/internal/telegram/client.go
+++ b/internal/telegram/client.go
@@ -18,8 +18,9 @@ import (
 const maxBotResponseBytes = 1 << 20
 const maxRichMessageBytes = 32 << 10
 
-// BotAPIStatusError is a completed Telegram HTTP response. 4xx means the
-// requested object was not created and may be retried.
+// BotAPIStatusError is a completed Telegram HTTP response. Client errors other
+// than rate limiting are terminal because retrying the same request cannot
+// change the rejected payload or target.
 type BotAPIStatusError struct {
 	Method string
 	Status int
@@ -59,6 +60,13 @@ func PermanentBotAPIFailure(err error) bool {
 func DeletedTopicFailure(err error) bool {
 	var status BotAPIStatusError
 	return errors.As(err, &status) && status.Kind == BotAPIErrorDeletedTopic
+}
+
+// PermanentTelegramFailure reports a completed request that must not poison
+// the durable outbound queue. It delegates to the bounded status classifier so
+// authorization failures that may recover remain retryable.
+func (e BotAPIStatusError) PermanentTelegramFailure() bool {
+	return PermanentBotAPIFailure(e)
 }
 
 // Client is a narrow Telegram Bot API long-poll client. Its token is retained

--- a/internal/telegram/client.go
+++ b/internal/telegram/client.go
@@ -18,9 +18,8 @@ import (
 const maxBotResponseBytes = 1 << 20
 const maxRichMessageBytes = 32 << 10
 
-// BotAPIStatusError is a completed Telegram HTTP response. Client errors other
-// than authentication failure and rate limiting are terminal because retrying
-// the same request cannot change the rejected payload or target.
+// BotAPIStatusError is a completed Telegram HTTP response. Only bounded status
+// classes that unambiguously reject the payload or target are terminal.
 type BotAPIStatusError struct {
 	Method string
 	Status int
@@ -42,14 +41,15 @@ const (
 )
 
 // PermanentBotAPIFailure recognizes terminal request outcomes while keeping
-// 401 retryable because Access/proxy/token recovery may restore it.
+// 401 and 404 retryable because Access/proxy/token or base-URL recovery may
+// restore them.
 func PermanentBotAPIFailure(err error) bool {
 	var status BotAPIStatusError
 	if !errors.As(err, &status) {
 		return false
 	}
 	switch status.Status {
-	case http.StatusBadRequest, http.StatusForbidden, http.StatusNotFound, http.StatusMethodNotAllowed, http.StatusGone, http.StatusUnprocessableEntity:
+	case http.StatusBadRequest, http.StatusForbidden, http.StatusMethodNotAllowed, http.StatusGone, http.StatusUnprocessableEntity:
 		return true
 	default:
 		return false

--- a/internal/telegram/client_test.go
+++ b/internal/telegram/client_test.go
@@ -40,6 +40,29 @@ func TestClientFetchesMinimalTopicUpdateWithoutLeakingToken(t *testing.T) {
 	}
 }
 
+func TestClientPreservesMessageLessUpdateIDsForOffsetProgress(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"ok":true,"result":[` +
+			`{"update_id":10,"edited_message":{"message_id":3}},` +
+			`{"update_id":11,"message":{"message_id":4,"from":{"id":55},"chat":{"id":100},"message_thread_id":7,"text":"later"}}` +
+			`]}`))
+	}))
+	defer server.Close()
+	client, err := NewClient(server.URL, "secret", server.Client())
+	if err != nil {
+		t.Fatal(err)
+	}
+	updates, err := client.Updates(context.Background(), 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(updates) != 2 || updates[0].ID != 10 || updates[0].Text != "" || updates[1].ID != 11 || updates[1].Text != "later" {
+		t.Fatalf("updates=%#v", updates)
+	}
+}
+
 func TestClientDoctorUsesNonMutatingGetMeAndRedactsProviderResponse(t *testing.T) {
 	t.Parallel()
 	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/telegram/client_test.go
+++ b/internal/telegram/client_test.go
@@ -111,9 +111,12 @@ func TestClientDoctorRejectsOversizedOrCancelledProviderResponseWithoutLeakingIt
 	}
 }
 
-func TestBotAPIStatusClassificationKeepsUnauthorizedRetryableAndDetectsDeletedTopic(t *testing.T) {
+func TestBotAPIStatusClassificationKeepsAmbiguousResponsesRetryableAndDetectsDeletedTopic(t *testing.T) {
 	if PermanentBotAPIFailure(BotAPIStatusError{Method: "sendRichMessage", Status: http.StatusUnauthorized}) {
 		t.Fatal("Telegram 401 was made terminal")
+	}
+	if PermanentBotAPIFailure(BotAPIStatusError{Method: "sendRichMessage", Status: http.StatusNotFound}) {
+		t.Fatal("ambiguous Telegram 404 was made terminal")
 	}
 	if !PermanentBotAPIFailure(BotAPIStatusError{Method: "sendRichMessage", Status: http.StatusForbidden}) {
 		t.Fatal("Telegram 403 was not terminal")

--- a/internal/telegram/gateway.go
+++ b/internal/telegram/gateway.go
@@ -2,6 +2,7 @@ package telegram
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
 	"strings"
@@ -111,6 +112,13 @@ func (g Gateway) Handle(ctx context.Context, update Update) error {
 		return g.markInert(update.ID)
 	}
 	if err := g.Submit(ctx, Submission{UpdateID: update.ID, ConversationID: conversation, Text: update.Text, ChatID: update.ChatID, ThreadID: update.ThreadID, ReplyToID: update.ReplyToID}); err != nil {
+		if isPermanentRelayFailure(err) {
+			g.logEvent("telegram_update_dropped", "reason=relay_rejected")
+			if err := g.State.MarkProcessed(update.ID); err != nil {
+				return fmt.Errorf("record dropped telegram update: %w", err)
+			}
+			return nil
+		}
 		return fmt.Errorf("submit telegram message: %w", err)
 	}
 	if err := g.State.MarkProcessed(update.ID); err != nil {
@@ -118,6 +126,15 @@ func (g Gateway) Handle(ctx context.Context, update Update) error {
 	}
 	g.logEvent("telegram_update_submitted", "conversation_id="+conversation)
 	return nil
+}
+
+type permanentRelayFailure interface {
+	PermanentRelayFailure() bool
+}
+
+func isPermanentRelayFailure(err error) bool {
+	var terminal permanentRelayFailure
+	return errors.As(err, &terminal) && terminal.PermanentRelayFailure()
 }
 
 func (g Gateway) handleCallback(ctx context.Context, update Update) error {

--- a/internal/telegram/gateway.go
+++ b/internal/telegram/gateway.go
@@ -65,6 +65,7 @@ type Gateway struct {
 	Claims        *ClaimExecutor
 	Now           func() time.Time
 	Log           func(string, ...any)
+	terminalDrop  func(error)
 }
 
 // Handle never turns Telegram text into control input. Commands are accepted
@@ -116,6 +117,9 @@ func (g Gateway) Handle(ctx context.Context, update Update) error {
 			g.logEvent("telegram_update_dropped", "reason=relay_rejected")
 			if err := g.State.MarkProcessed(update.ID); err != nil {
 				return fmt.Errorf("record dropped telegram update: %w", err)
+			}
+			if g.terminalDrop != nil {
+				g.terminalDrop(err)
 			}
 			return nil
 		}

--- a/internal/telegram/gateway.go
+++ b/internal/telegram/gateway.go
@@ -116,7 +116,7 @@ func (g Gateway) Handle(ctx context.Context, update Update) error {
 	if err := g.Submit(ctx, Submission{UpdateID: update.ID, ConversationID: conversation, Text: update.Text, ChatID: update.ChatID, ThreadID: update.ThreadID, ReplyToID: update.ReplyToID}); err != nil {
 		if isPermanentRelayFailure(err) {
 			g.logEvent("telegram_update_dropped", "reason=relay_rejected")
-			if err := g.State.MarkProcessed(update.ID); err != nil {
+			if err := g.State.MarkProcessedTerminalInbound(update.ID, conversation); err != nil {
 				return fmt.Errorf("record dropped telegram update: %w", err)
 			}
 			if g.terminalDrop != nil {
@@ -126,11 +126,11 @@ func (g Gateway) Handle(ctx context.Context, update Update) error {
 		}
 		return fmt.Errorf("submit telegram message: %w", err)
 	}
+	if err := g.State.MarkProcessedInboundRecovery(update.ID, conversation); err != nil {
+		return fmt.Errorf("record telegram update: %w", err)
+	}
 	if g.inboundRecovery != nil {
 		g.inboundRecovery(conversation)
-	}
-	if err := g.State.MarkProcessed(update.ID); err != nil {
-		return fmt.Errorf("record telegram update: %w", err)
 	}
 	g.logEvent("telegram_update_submitted", "conversation_id="+conversation)
 	return nil

--- a/internal/telegram/gateway.go
+++ b/internal/telegram/gateway.go
@@ -57,15 +57,16 @@ type OperatorNotify interface {
 // Gateway applies authorization, replay, and exact-topic routing policy to
 // Telegram updates before submitting opaque text to the relay.
 type Gateway struct {
-	AllowedUserID int64
-	State         *State
-	Submit        func(context.Context, Submission) error
-	ListUnclaimed func(context.Context) ([]relay.UnclaimedTopic, error)
-	Notify        OperatorNotify
-	Claims        *ClaimExecutor
-	Now           func() time.Time
-	Log           func(string, ...any)
-	terminalDrop  func(error)
+	AllowedUserID   int64
+	State           *State
+	Submit          func(context.Context, Submission) error
+	ListUnclaimed   func(context.Context) ([]relay.UnclaimedTopic, error)
+	Notify          OperatorNotify
+	Claims          *ClaimExecutor
+	Now             func() time.Time
+	Log             func(string, ...any)
+	terminalDrop    func(error)
+	inboundRecovery func()
 }
 
 // Handle never turns Telegram text into control input. Commands are accepted
@@ -124,6 +125,9 @@ func (g Gateway) Handle(ctx context.Context, update Update) error {
 			return nil
 		}
 		return fmt.Errorf("submit telegram message: %w", err)
+	}
+	if g.inboundRecovery != nil {
+		g.inboundRecovery()
 	}
 	if err := g.State.MarkProcessed(update.ID); err != nil {
 		return fmt.Errorf("record telegram update: %w", err)

--- a/internal/telegram/gateway.go
+++ b/internal/telegram/gateway.go
@@ -65,8 +65,8 @@ type Gateway struct {
 	Claims          *ClaimExecutor
 	Now             func() time.Time
 	Log             func(string, ...any)
-	terminalDrop    func(error)
-	inboundRecovery func()
+	terminalDrop    func(string, error)
+	inboundRecovery func(string)
 }
 
 // Handle never turns Telegram text into control input. Commands are accepted
@@ -120,14 +120,14 @@ func (g Gateway) Handle(ctx context.Context, update Update) error {
 				return fmt.Errorf("record dropped telegram update: %w", err)
 			}
 			if g.terminalDrop != nil {
-				g.terminalDrop(err)
+				g.terminalDrop(conversation, err)
 			}
 			return nil
 		}
 		return fmt.Errorf("submit telegram message: %w", err)
 	}
 	if g.inboundRecovery != nil {
-		g.inboundRecovery()
+		g.inboundRecovery(conversation)
 	}
 	if err := g.State.MarkProcessed(update.ID); err != nil {
 		return fmt.Errorf("record telegram update: %w", err)

--- a/internal/telegram/gateway_test.go
+++ b/internal/telegram/gateway_test.go
@@ -94,6 +94,60 @@ func TestGatewayRetriesUnrecordedUpdateAfterRelayFailure(t *testing.T) {
 	}
 }
 
+type permanentRelayTestError struct{}
+
+func (permanentRelayTestError) Error() string               { return "private relay response" }
+func (permanentRelayTestError) PermanentRelayFailure() bool { return true }
+
+func TestGatewayDropsPermanentRelayRejectionAndContinuesPage(t *testing.T) {
+	t.Parallel()
+	state, err := Open(filepath.Join(t.TempDir(), "telegram.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = state.Close() })
+	if err := state.SetRoute(100, 7, "conversation-1"); err != nil {
+		t.Fatal(err)
+	}
+	var submitted []string
+	var logs []string
+	runner := Runner{
+		Poller: fakePoller{updates: []Update{
+			{ID: 10, UserID: 55, ChatID: 100, ThreadID: 7, Text: "poison"},
+			{ID: 11, UserID: 55, ChatID: 100, ThreadID: 7, Text: "later"},
+		}},
+		Gateway: Gateway{
+			AllowedUserID: 55,
+			State:         state,
+			Submit: func(_ context.Context, submission Submission) error {
+				submitted = append(submitted, submission.Text)
+				if submission.Text == "poison" {
+					return permanentRelayTestError{}
+				}
+				return nil
+			},
+			Log: func(format string, args ...any) { logs = append(logs, fmt.Sprintf(format, args...)) },
+		},
+	}
+	next, err := runner.RunOnce(context.Background(), 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if next != 12 || len(submitted) != 2 || submitted[1] != "later" {
+		t.Fatalf("next=%d submitted=%#v", next, submitted)
+	}
+	for _, updateID := range []int64{10, 11} {
+		processed, err := state.Processed(updateID)
+		if err != nil || !processed {
+			t.Fatalf("update %d processed=%v err=%v", updateID, processed, err)
+		}
+	}
+	joined := strings.Join(logs, "\n")
+	if !strings.Contains(joined, "telegram_update_dropped") || strings.Contains(joined, "private relay response") {
+		t.Fatalf("logs=%#v", logs)
+	}
+}
+
 func TestGatewayStartAndListAreOperatorCommands(t *testing.T) {
 	t.Parallel()
 	state, err := Open(filepath.Join(t.TempDir(), "telegram.db"))

--- a/internal/telegram/gateway_test.go
+++ b/internal/telegram/gateway_test.go
@@ -101,7 +101,8 @@ func (permanentRelayTestError) PermanentRelayFailure() bool { return true }
 
 func TestGatewayDropsPermanentRelayRejectionAndContinuesPage(t *testing.T) {
 	t.Parallel()
-	state, err := Open(filepath.Join(t.TempDir(), "telegram.db"))
+	database := filepath.Join(t.TempDir(), "telegram.db")
+	state, err := Open(database)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -109,12 +110,15 @@ func TestGatewayDropsPermanentRelayRejectionAndContinuesPage(t *testing.T) {
 	if err := state.SetRoute(100, 7, "conversation-1"); err != nil {
 		t.Fatal(err)
 	}
+	if err := state.SetRoute(100, 8, "conversation-2"); err != nil {
+		t.Fatal(err)
+	}
 	var submitted []string
 	var logs []string
 	runner := Runner{
 		Poller: fakePoller{updates: []Update{
 			{ID: 10, UserID: 55, ChatID: 100, ThreadID: 7, Text: "poison"},
-			{ID: 11, UserID: 55, ChatID: 100, ThreadID: 7, Text: "later"},
+			{ID: 11, UserID: 55, ChatID: 100, ThreadID: 8, Text: "later"},
 		}},
 		Gateway: Gateway{
 			AllowedUserID: 55,
@@ -145,6 +149,40 @@ func TestGatewayDropsPermanentRelayRejectionAndContinuesPage(t *testing.T) {
 	joined := strings.Join(logs, "\n")
 	if !strings.Contains(joined, "telegram_update_dropped") || strings.Contains(joined, "private relay response") {
 		t.Fatalf("logs=%#v", logs)
+	}
+	snapshot, err := InspectGatewayState(t.Context(), database, testCallbackNow)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if snapshot.TerminalInbound != 1 {
+		t.Fatalf("terminal inbound drop was not durable before the cycle record: %#v", snapshot)
+	}
+}
+
+func TestGatewayPersistsInboundRecoveryWithProcessedUpdate(t *testing.T) {
+	t.Parallel()
+	database := filepath.Join(t.TempDir(), "telegram.db")
+	state, err := Open(database)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = state.Close() })
+	if err := state.SetRoute(100, 7, "conversation-1"); err != nil {
+		t.Fatal(err)
+	}
+	if err := state.MarkProcessedTerminalInbound(1, "conversation-1"); err != nil {
+		t.Fatal(err)
+	}
+	gateway := Gateway{AllowedUserID: 55, State: state, Submit: func(context.Context, Submission) error { return nil }}
+	if err := gateway.Handle(t.Context(), Update{ID: 2, UserID: 55, ChatID: 100, ThreadID: 7, Text: "recovered"}); err != nil {
+		t.Fatal(err)
+	}
+	snapshot, err := InspectGatewayState(t.Context(), database, testCallbackNow)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if snapshot.TerminalInbound != 0 {
+		t.Fatalf("inbound recovery was not durable with processing: %#v", snapshot)
 	}
 }
 

--- a/internal/telegram/outbound.go
+++ b/internal/telegram/outbound.go
@@ -16,6 +16,13 @@ type RichSender interface {
 	SendRichMessage(ctx context.Context, chatID, threadID int64, html string) (int64, error)
 }
 
+type permanentTelegramDeliveryError struct {
+	reason string
+}
+
+func (e permanentTelegramDeliveryError) Error() string                { return e.reason }
+func (permanentTelegramDeliveryError) PermanentTelegramFailure() bool { return true }
+
 // SendDelivery renders an opaque agent reply as inert rich HTML and sends it
 // only to the exact topic bound to the delivery's conversation. Telegram has
 // no idempotency key for sendRichMessage, so callers must acknowledge the
@@ -27,17 +34,17 @@ func SendDelivery(ctx context.Context, state *State, sender RichSender, delivery
 		from = delivery.Message.FromRole
 	}
 	if state == nil || sender == nil || strings.TrimSpace(delivery.Message.ConversationID) == "" || strings.TrimSpace(from) == "" || delivery.Message.Body == "" {
-		return fmt.Errorf("invalid Telegram delivery")
+		return permanentTelegramDeliveryError{reason: "invalid Telegram delivery"}
 	}
 	chatID, threadID, found, err := state.RouteForConversation(delivery.Message.ConversationID)
 	if err != nil {
 		return fmt.Errorf("read Telegram delivery route: %w", err)
 	}
 	if !found {
-		return fmt.Errorf("telegram conversation route is missing")
+		return permanentTelegramDeliveryError{reason: "telegram conversation route is missing"}
 	}
 	if allowedUserID == 0 || chatID != allowedUserID {
-		return fmt.Errorf("telegram conversation route is not the configured chat")
+		return permanentTelegramDeliveryError{reason: "telegram conversation route is not the configured chat"}
 	}
 	for _, rendered := range renderDelivery(from, delivery.Message.Body) {
 		messageID, err := sender.SendRichMessage(ctx, chatID, threadID, rendered)

--- a/internal/telegram/outbound.go
+++ b/internal/telegram/outbound.go
@@ -41,10 +41,10 @@ func SendDelivery(ctx context.Context, state *State, sender RichSender, delivery
 		return fmt.Errorf("read Telegram delivery route: %w", err)
 	}
 	if !found {
-		return permanentTelegramDeliveryError{reason: "telegram conversation route is missing"}
+		return fmt.Errorf("telegram conversation route is missing")
 	}
 	if allowedUserID == 0 || chatID != allowedUserID {
-		return permanentTelegramDeliveryError{reason: "telegram conversation route is not the configured chat"}
+		return fmt.Errorf("telegram conversation route is not the configured chat")
 	}
 	for _, rendered := range renderDelivery(from, delivery.Message.Body) {
 		messageID, err := sender.SendRichMessage(ctx, chatID, threadID, rendered)

--- a/internal/telegram/outbound_test.go
+++ b/internal/telegram/outbound_test.go
@@ -75,8 +75,12 @@ func TestSendDeliveryRejectsUnroutedConversation(t *testing.T) {
 		t.Fatal(err)
 	}
 	t.Cleanup(func() { _ = state.Close() })
-	if err := SendDelivery(context.Background(), state, &recordedRichSender{}, relay.Delivery{Message: relay.Message{ConversationID: "unrouted", FromEndpoint: "agent/a", Body: "reply"}}, 100); err == nil {
+	err = SendDelivery(context.Background(), state, &recordedRichSender{}, relay.Delivery{Message: relay.Message{ConversationID: "unrouted", FromEndpoint: "agent/a", Body: "reply"}}, 100)
+	if err == nil {
 		t.Fatal("unrouted delivery was sent to Telegram")
+	}
+	if isPermanentTelegramFailure(err) {
+		t.Fatalf("unrouted delivery was classified as permanent: %v", err)
 	}
 }
 
@@ -94,5 +98,8 @@ func TestSendDeliveryRejectsRouteForDifferentTelegramChat(t *testing.T) {
 	err = SendDelivery(context.Background(), state, sender, relay.Delivery{Message: relay.Message{ConversationID: "conversation-1", FromEndpoint: "agent/a", Body: "reply"}}, 55)
 	if err == nil || sender.chat != 0 {
 		t.Fatalf("foreign-chat delivery was sent: err=%v chat=%d", err, sender.chat)
+	}
+	if isPermanentTelegramFailure(err) {
+		t.Fatalf("foreign-chat delivery was classified as permanent: %v", err)
 	}
 }

--- a/internal/telegram/state.go
+++ b/internal/telegram/state.go
@@ -806,8 +806,28 @@ func (s *State) StageTerminalOutbound(deliveryID, conversationID string, class G
 		}
 	} else {
 		var existingConversation, existingClass string
-		if err := tx.QueryRowContext(context.Background(), `SELECT conversation_id,failure_class FROM gateway_terminal_outbound_events WHERE delivery_id=?`, deliveryID).Scan(&existingConversation, &existingClass); err != nil || existingConversation != conversationID || GatewayFailureClass(existingClass) != class {
+		if err := tx.QueryRowContext(context.Background(), `SELECT conversation_id,failure_class FROM gateway_terminal_outbound_events WHERE delivery_id=?`, deliveryID).Scan(&existingConversation, &existingClass); err != nil || existingConversation != conversationID {
 			return fmt.Errorf("terminal outbound delivery identity conflict")
+		}
+		if GatewayFailureClass(existingClass) != class {
+			if _, err := tx.ExecContext(context.Background(), `UPDATE gateway_terminal_outbound_events SET failure_class=? WHERE delivery_id=?`, string(class), deliveryID); err != nil {
+				return err
+			}
+			var failures, stagedEvents, deletedEvents int
+			var targetClass string
+			if err := tx.QueryRowContext(context.Background(), `SELECT failures,failure_class FROM gateway_terminal_outbound_targets WHERE conversation_id=?`, conversationID).Scan(&failures, &targetClass); err != nil {
+				return err
+			}
+			if err := tx.QueryRowContext(context.Background(), `SELECT COUNT(*),COALESCE(SUM(CASE WHEN failure_class=? THEN 1 ELSE 0 END),0) FROM gateway_terminal_outbound_events WHERE conversation_id=?`, string(GatewayFailureDeletedTopic), conversationID).Scan(&stagedEvents, &deletedEvents); err != nil {
+				return err
+			}
+			reconciledClass := GatewayFailureOutboundTelegramPermanent
+			if deletedEvents > 0 || (failures > stagedEvents && GatewayFailureClass(targetClass) == GatewayFailureDeletedTopic) {
+				reconciledClass = GatewayFailureDeletedTopic
+			}
+			if _, err := tx.ExecContext(context.Background(), `UPDATE gateway_terminal_outbound_targets SET failure_class=? WHERE conversation_id=?`, string(reconciledClass), conversationID); err != nil {
+				return err
+			}
 		}
 	}
 	return tx.Commit()

--- a/internal/telegram/state.go
+++ b/internal/telegram/state.go
@@ -106,6 +106,11 @@ func Open(database string) (*State, error) {
 			conversation_id TEXT PRIMARY KEY,
 			failures INTEGER NOT NULL CHECK (failures > 0)
 		)`,
+		`CREATE TABLE IF NOT EXISTS gateway_terminal_outbound_events (
+			delivery_id TEXT PRIMARY KEY,
+			conversation_id TEXT NOT NULL,
+			failure_class TEXT NOT NULL
+		)`,
 	} {
 		if _, err := db.ExecContext(context.Background(), statement); err != nil {
 			_ = db.Close()
@@ -146,6 +151,7 @@ const (
 type GatewayTargetEvent struct {
 	ConversationID string
 	Terminal       bool
+	Staged         bool
 	Failure        GatewayFailureClass
 }
 
@@ -215,6 +221,9 @@ func (s *State) RecordGatewayCycle(record GatewayCycleRecord) error {
 		if strings.TrimSpace(event.ConversationID) == "" {
 			return fmt.Errorf("invalid gateway cycle record")
 		}
+		if event.Staged && !event.Terminal {
+			return fmt.Errorf("invalid gateway cycle record")
+		}
 		if event.Terminal {
 			inboundTerminalEvents++
 			if event.Failure != GatewayFailureNone && event.Failure != GatewayFailureInboundRelayPermanent {
@@ -231,6 +240,9 @@ func (s *State) RecordGatewayCycle(record GatewayCycleRecord) error {
 			if event.Failure != GatewayFailureNone && event.Failure != GatewayFailureOutboundTelegramPermanent && event.Failure != GatewayFailureDeletedTopic {
 				return fmt.Errorf("invalid gateway cycle record")
 			}
+		}
+		if event.Staged && !event.Terminal {
+			return fmt.Errorf("invalid gateway cycle record")
 		}
 	}
 	now := record.At.UTC().UnixMilli()
@@ -298,6 +310,9 @@ func (s *State) RecordGatewayCycle(record GatewayCycleRecord) error {
 	}
 	for _, event := range record.InboundTargetEvents {
 		if event.Terminal {
+			if event.Staged {
+				continue
+			}
 			if _, err := tx.ExecContext(context.Background(), `INSERT INTO gateway_terminal_inbound_targets(conversation_id,failures) VALUES(?,1) ON CONFLICT(conversation_id) DO UPDATE SET failures=failures+1`, event.ConversationID); err != nil {
 				return err
 			}
@@ -318,6 +333,9 @@ func (s *State) RecordGatewayCycle(record GatewayCycleRecord) error {
 	}
 	for _, event := range record.OutboundTargetEvents {
 		if event.Terminal {
+			if event.Staged {
+				continue
+			}
 			class := event.Failure
 			if class == GatewayFailureNone {
 				class = record.Failure
@@ -331,6 +349,9 @@ func (s *State) RecordGatewayCycle(record GatewayCycleRecord) error {
 			continue
 		}
 		if _, err := tx.ExecContext(context.Background(), `DELETE FROM gateway_terminal_outbound_targets WHERE conversation_id IN (?,?)`, event.ConversationID, gatewayLegacyTarget); err != nil {
+			return err
+		}
+		if _, err := tx.ExecContext(context.Background(), `DELETE FROM gateway_terminal_outbound_events WHERE conversation_id=?`, event.ConversationID); err != nil {
 			return err
 		}
 	}
@@ -426,33 +447,16 @@ func InspectGatewayState(parent context.Context, database string, now time.Time)
 	err = db.QueryRowContext(ctx, `SELECT last_cycle_at,last_success_at,last_poll_at,last_relay_at,last_telegram_at,last_progress_at,last_outbound_progress_at,outbound_blocked,consecutive_failures,last_failure,terminal_inbound,terminal_outbound FROM gateway_health WHERE id=1`).Scan(
 		&cycle, &success, &poll, &relayAt, &telegramAt, &progress, &outboundProgress, &outboundBlocked, &snapshot.ConsecutiveFailures, &lastFailure, &snapshot.TerminalInbound, &snapshot.TerminalOutbound)
 	if errors.Is(err, sql.ErrNoRows) {
+		if err := inspectGatewayTerminalLedgers(ctx, db, &snapshot, GatewayFailureNone); err != nil {
+			return GatewayStateSnapshot{}, fmt.Errorf("gateway state unavailable")
+		}
 		return snapshot, nil
 	}
 	if err != nil || !validGatewayFailure(GatewayFailureClass(lastFailure)) {
 		return GatewayStateSnapshot{}, fmt.Errorf("gateway state unavailable")
 	}
-	var targetLedgerTables int
-	if err := db.QueryRowContext(ctx, `SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='gateway_terminal_outbound_targets'`).Scan(&targetLedgerTables); err != nil {
+	if err := inspectGatewayTerminalLedgers(ctx, db, &snapshot, GatewayFailureClass(lastFailure)); err != nil {
 		return GatewayStateSnapshot{}, fmt.Errorf("gateway state unavailable")
-	}
-	var targetClassColumns int
-	if targetLedgerTables > 0 {
-		if err := db.QueryRowContext(ctx, `SELECT COUNT(*) FROM pragma_table_info('gateway_terminal_outbound_targets') WHERE name='failure_class'`).Scan(&targetClassColumns); err != nil {
-			return GatewayStateSnapshot{}, fmt.Errorf("gateway state unavailable")
-		}
-	}
-	if targetClassColumns == 0 {
-		if GatewayFailureClass(lastFailure) == GatewayFailureDeletedTopic && snapshot.TerminalOutbound > 0 {
-			snapshot.DeletedTopicTargets = 1
-		}
-	} else {
-		if err := db.QueryRowContext(ctx, `SELECT COUNT(*) FROM gateway_terminal_outbound_targets WHERE failure_class=?`, string(GatewayFailureDeletedTopic)).Scan(&snapshot.DeletedTopicTargets); err != nil {
-			return GatewayStateSnapshot{}, fmt.Errorf("gateway state unavailable")
-		}
-		var invalidTargetClasses int
-		if err := db.QueryRowContext(ctx, `SELECT COUNT(*) FROM gateway_terminal_outbound_targets WHERE failure_class NOT IN (?,?)`, string(GatewayFailureOutboundTelegramPermanent), string(GatewayFailureDeletedTopic)).Scan(&invalidTargetClasses); err != nil || invalidTargetClasses != 0 {
-			return GatewayStateSnapshot{}, fmt.Errorf("gateway state unavailable")
-		}
 	}
 	snapshot.HasHealth = true
 	snapshot.HasSuccess = success.Valid
@@ -483,6 +487,49 @@ func InspectGatewayState(parent context.Context, database string, now time.Time)
 	}
 	snapshot.StuckHead = snapshot.ConsecutiveFailures >= 3 && stuckProgress.Valid && age(stuckProgress) >= 5*time.Minute
 	return snapshot, nil
+}
+
+func inspectGatewayTerminalLedgers(ctx context.Context, db *sql.DB, snapshot *GatewayStateSnapshot, lastFailure GatewayFailureClass) error {
+	var inboundTables int
+	if err := db.QueryRowContext(ctx, `SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='gateway_terminal_inbound_targets'`).Scan(&inboundTables); err != nil {
+		return err
+	}
+	if inboundTables > 0 {
+		if err := db.QueryRowContext(ctx, `SELECT COALESCE(SUM(failures),0) FROM gateway_terminal_inbound_targets`).Scan(&snapshot.TerminalInbound); err != nil {
+			return err
+		}
+	}
+	var outboundTables int
+	if err := db.QueryRowContext(ctx, `SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='gateway_terminal_outbound_targets'`).Scan(&outboundTables); err != nil {
+		return err
+	}
+	if outboundTables == 0 {
+		if lastFailure == GatewayFailureDeletedTopic && snapshot.TerminalOutbound > 0 {
+			snapshot.DeletedTopicTargets = 1
+		}
+		return nil
+	}
+	if err := db.QueryRowContext(ctx, `SELECT COALESCE(SUM(failures),0) FROM gateway_terminal_outbound_targets`).Scan(&snapshot.TerminalOutbound); err != nil {
+		return err
+	}
+	var classColumns int
+	if err := db.QueryRowContext(ctx, `SELECT COUNT(*) FROM pragma_table_info('gateway_terminal_outbound_targets') WHERE name='failure_class'`).Scan(&classColumns); err != nil {
+		return err
+	}
+	if classColumns == 0 {
+		if lastFailure == GatewayFailureDeletedTopic && snapshot.TerminalOutbound > 0 {
+			snapshot.DeletedTopicTargets = 1
+		}
+		return nil
+	}
+	if err := db.QueryRowContext(ctx, `SELECT COUNT(*) FROM gateway_terminal_outbound_targets WHERE failure_class=?`, string(GatewayFailureDeletedTopic)).Scan(&snapshot.DeletedTopicTargets); err != nil {
+		return err
+	}
+	var invalidTargetClasses int
+	if err := db.QueryRowContext(ctx, `SELECT COUNT(*) FROM gateway_terminal_outbound_targets WHERE failure_class NOT IN (?,?)`, string(GatewayFailureOutboundTelegramPermanent), string(GatewayFailureDeletedTopic)).Scan(&invalidTargetClasses); err != nil || invalidTargetClasses != 0 {
+		return fmt.Errorf("invalid terminal outbound target class")
+	}
+	return nil
 }
 
 func ensureGatewayTerminalTargetLedgers(db *sql.DB) error {
@@ -678,6 +725,112 @@ func (s *State) Processed(updateID int64) (bool, error) {
 func (s *State) MarkProcessed(updateID int64) error {
 	_, err := s.db.ExecContext(context.Background(), "INSERT INTO processed_updates(update_id) VALUES (?) ON CONFLICT(update_id) DO NOTHING", updateID)
 	return err
+}
+
+// MarkProcessedTerminalInbound atomically consumes a terminally rejected
+// update and stages its conversation-scoped doctor evidence.
+func (s *State) MarkProcessedTerminalInbound(updateID int64, conversationID string) error {
+	if updateID < 0 || strings.TrimSpace(conversationID) == "" {
+		return fmt.Errorf("invalid terminal inbound update")
+	}
+	tx, err := s.db.BeginTx(context.Background(), nil)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = tx.Rollback() }()
+	result, err := tx.ExecContext(context.Background(), `INSERT INTO processed_updates(update_id) VALUES (?) ON CONFLICT(update_id) DO NOTHING`, updateID)
+	if err != nil {
+		return err
+	}
+	inserted, err := result.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if inserted > 0 {
+		if _, err := tx.ExecContext(context.Background(), `INSERT INTO gateway_terminal_inbound_targets(conversation_id,failures) VALUES(?,1) ON CONFLICT(conversation_id) DO UPDATE SET failures=failures+1`, conversationID); err != nil {
+			return err
+		}
+	}
+	return tx.Commit()
+}
+
+// MarkProcessedInboundRecovery atomically records a successful submission and
+// clears only terminal inbound evidence for that conversation.
+func (s *State) MarkProcessedInboundRecovery(updateID int64, conversationID string) error {
+	if updateID < 0 || strings.TrimSpace(conversationID) == "" {
+		return fmt.Errorf("invalid inbound recovery update")
+	}
+	tx, err := s.db.BeginTx(context.Background(), nil)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = tx.Rollback() }()
+	result, err := tx.ExecContext(context.Background(), `INSERT INTO processed_updates(update_id) VALUES (?) ON CONFLICT(update_id) DO NOTHING`, updateID)
+	if err != nil {
+		return err
+	}
+	inserted, err := result.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if inserted > 0 {
+		if _, err := tx.ExecContext(context.Background(), `DELETE FROM gateway_terminal_inbound_targets WHERE conversation_id IN (?,?)`, conversationID, gatewayLegacyTarget); err != nil {
+			return err
+		}
+	}
+	return tx.Commit()
+}
+
+// StageTerminalOutbound durably and idempotently records a rejected delivery
+// before the relay acknowledgement makes that delivery unrecoverable.
+func (s *State) StageTerminalOutbound(deliveryID, conversationID string, class GatewayFailureClass) error {
+	if strings.TrimSpace(deliveryID) == "" || strings.TrimSpace(conversationID) == "" || class != GatewayFailureOutboundTelegramPermanent && class != GatewayFailureDeletedTopic {
+		return fmt.Errorf("invalid terminal outbound delivery")
+	}
+	tx, err := s.db.BeginTx(context.Background(), nil)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = tx.Rollback() }()
+	result, err := tx.ExecContext(context.Background(), `INSERT INTO gateway_terminal_outbound_events(delivery_id,conversation_id,failure_class) VALUES(?,?,?) ON CONFLICT(delivery_id) DO NOTHING`, deliveryID, conversationID, string(class))
+	if err != nil {
+		return err
+	}
+	inserted, err := result.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if inserted > 0 {
+		if _, err := tx.ExecContext(context.Background(), `INSERT INTO gateway_terminal_outbound_targets(conversation_id,failures,failure_class) VALUES(?,1,?) ON CONFLICT(conversation_id) DO UPDATE SET failures=failures+1,failure_class=CASE WHEN failure_class='deleted_topic' OR excluded.failure_class='deleted_topic' THEN 'deleted_topic' ELSE 'outbound_telegram_permanent' END`, conversationID, string(class)); err != nil {
+			return err
+		}
+	} else {
+		var existingConversation, existingClass string
+		if err := tx.QueryRowContext(context.Background(), `SELECT conversation_id,failure_class FROM gateway_terminal_outbound_events WHERE delivery_id=?`, deliveryID).Scan(&existingConversation, &existingClass); err != nil || existingConversation != conversationID || GatewayFailureClass(existingClass) != class {
+			return fmt.Errorf("terminal outbound delivery identity conflict")
+		}
+	}
+	return tx.Commit()
+}
+
+// RecoverTerminalOutbound clears a repaired conversation before its successful
+// delivery acknowledgement crosses the external relay boundary.
+func (s *State) RecoverTerminalOutbound(conversationID string) error {
+	if strings.TrimSpace(conversationID) == "" {
+		return fmt.Errorf("invalid terminal outbound recovery")
+	}
+	tx, err := s.db.BeginTx(context.Background(), nil)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = tx.Rollback() }()
+	if _, err := tx.ExecContext(context.Background(), `DELETE FROM gateway_terminal_outbound_targets WHERE conversation_id IN (?,?)`, conversationID, gatewayLegacyTarget); err != nil {
+		return err
+	}
+	if _, err := tx.ExecContext(context.Background(), `DELETE FROM gateway_terminal_outbound_events WHERE conversation_id=?`, conversationID); err != nil {
+		return err
+	}
+	return tx.Commit()
 }
 
 // SetRoute binds one exact Telegram topic to one relay conversation. There is

--- a/internal/telegram/state.go
+++ b/internal/telegram/state.go
@@ -95,6 +95,10 @@ func Open(database string) (*State, error) {
 			terminal_inbound INTEGER NOT NULL,
 			terminal_outbound INTEGER NOT NULL
 		)`,
+		`CREATE TABLE IF NOT EXISTS gateway_terminal_outbound_targets (
+			conversation_id TEXT PRIMARY KEY,
+			failures INTEGER NOT NULL CHECK (failures > 0)
+		)`,
 	} {
 		if _, err := db.ExecContext(context.Background(), statement); err != nil {
 			_ = db.Close()
@@ -126,20 +130,27 @@ const (
 	GatewayFailureDeletedTopic              GatewayFailureClass = "deleted_topic"
 )
 
-// GatewayCycleRecord contains only aggregate cycle health.
+// GatewayOutboundTargetEvent records content-free evidence that a conversation
+// target either rejected a delivery terminally or later accepted one.
+type GatewayOutboundTargetEvent struct {
+	ConversationID string
+	Terminal       bool
+}
+
+// GatewayCycleRecord contains only content-free cycle health evidence.
 type GatewayCycleRecord struct {
-	At               time.Time
-	Offset           int64
-	PollOK           bool
-	RelayOK          bool
-	TelegramOK       bool
-	OutboundBlocked  bool
-	OutboundProgress bool
-	TerminalInbound  int
-	TerminalOutbound int
-	InboundRecovery  bool
-	OutboundRecovery bool
-	Failure          GatewayFailureClass
+	At                   time.Time
+	Offset               int64
+	PollOK               bool
+	RelayOK              bool
+	TelegramOK           bool
+	OutboundBlocked      bool
+	OutboundProgress     bool
+	TerminalInbound      int
+	TerminalOutbound     int
+	InboundRecovery      bool
+	OutboundTargetEvents []GatewayOutboundTargetEvent
+	Failure              GatewayFailureClass
 }
 
 // GatewayStateSnapshot is the bounded, content-free state used by doctor.
@@ -180,13 +191,27 @@ func (s *State) RecordGatewayCycle(record GatewayCycleRecord) error {
 	if record.At.IsZero() || record.Offset < 0 || record.OutboundProgress && !record.OutboundBlocked || record.TerminalInbound < 0 || record.TerminalOutbound < 0 || record.Failure == GatewayFailureNone && (record.TerminalInbound > 0 || record.TerminalOutbound > 0) || !validGatewayFailure(record.Failure) {
 		return fmt.Errorf("invalid gateway cycle record")
 	}
+	terminalTargetEvents := 0
+	for _, event := range record.OutboundTargetEvents {
+		if strings.TrimSpace(event.ConversationID) == "" {
+			return fmt.Errorf("invalid gateway cycle record")
+		}
+		if event.Terminal {
+			terminalTargetEvents++
+		}
+	}
 	now := record.At.UTC().UnixMilli()
+	tx, err := s.db.BeginTx(context.Background(), nil)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = tx.Rollback() }()
 	var previousOffset, previousProgress int64
 	var previousConsecutive, previousTerminalInbound, previousTerminalOutbound int
 	var previousFailure string
 	var previousOutboundProgress sql.NullInt64
 	var previousOutboundBlocked bool
-	err := s.db.QueryRowContext(context.Background(), `SELECT offset,last_progress_at,last_outbound_progress_at,outbound_blocked,consecutive_failures,last_failure,terminal_inbound,terminal_outbound FROM gateway_health WHERE id = 1`).Scan(&previousOffset, &previousProgress, &previousOutboundProgress, &previousOutboundBlocked, &previousConsecutive, &previousFailure, &previousTerminalInbound, &previousTerminalOutbound)
+	err = tx.QueryRowContext(context.Background(), `SELECT offset,last_progress_at,last_outbound_progress_at,outbound_blocked,consecutive_failures,last_failure,terminal_inbound,terminal_outbound FROM gateway_health WHERE id = 1`).Scan(&previousOffset, &previousProgress, &previousOutboundProgress, &previousOutboundBlocked, &previousConsecutive, &previousFailure, &previousTerminalInbound, &previousTerminalOutbound)
 	first := errors.Is(err, sql.ErrNoRows)
 	if err != nil && !first {
 		return err
@@ -230,16 +255,39 @@ func (s *State) RecordGatewayCycle(record GatewayCycleRecord) error {
 	if outboundDelta == 0 && (record.Failure == GatewayFailureOutboundTelegramPermanent || record.Failure == GatewayFailureDeletedTopic) {
 		outboundDelta = 1
 	}
-	terminalInbound, terminalOutbound := inboundDelta, outboundDelta
+	if terminalTargetEvents > outboundDelta {
+		return fmt.Errorf("invalid gateway cycle record")
+	}
+	var previousTargetedOutbound int
+	if err := tx.QueryRowContext(context.Background(), `SELECT COALESCE(SUM(failures), 0) FROM gateway_terminal_outbound_targets`).Scan(&previousTargetedOutbound); err != nil {
+		return err
+	}
+	legacyTerminalOutbound := previousTerminalOutbound - previousTargetedOutbound
+	if legacyTerminalOutbound < 0 {
+		legacyTerminalOutbound = 0
+	}
+	for _, event := range record.OutboundTargetEvents {
+		if event.Terminal {
+			if _, err := tx.ExecContext(context.Background(), `INSERT INTO gateway_terminal_outbound_targets(conversation_id,failures) VALUES(?,1) ON CONFLICT(conversation_id) DO UPDATE SET failures=failures+1`, event.ConversationID); err != nil {
+				return err
+			}
+			continue
+		}
+		if _, err := tx.ExecContext(context.Background(), `DELETE FROM gateway_terminal_outbound_targets WHERE conversation_id=?`, event.ConversationID); err != nil {
+			return err
+		}
+	}
+	var targetedTerminalOutbound int
+	if err := tx.QueryRowContext(context.Background(), `SELECT COALESCE(SUM(failures), 0) FROM gateway_terminal_outbound_targets`).Scan(&targetedTerminalOutbound); err != nil {
+		return err
+	}
+	terminalInbound := inboundDelta
+	terminalOutbound := legacyTerminalOutbound + outboundDelta - terminalTargetEvents + targetedTerminalOutbound
 	if !first {
 		terminalInbound += previousTerminalInbound
-		terminalOutbound += previousTerminalOutbound
 	}
 	if inboundDelta == 0 && record.InboundRecovery {
 		terminalInbound = 0
-	}
-	if outboundDelta == 0 && record.OutboundRecovery {
-		terminalOutbound = 0
 	}
 	effectiveFailure := record.Failure
 	if effectiveFailure == GatewayFailureNone && (terminalInbound > 0 || terminalOutbound > 0) {
@@ -261,7 +309,7 @@ func (s *State) RecordGatewayCycle(record GatewayCycleRecord) error {
 	} else if effectiveFailure != GatewayFailureNone {
 		consecutiveFailures = previousConsecutive
 	}
-	_, err = s.db.ExecContext(context.Background(), `INSERT INTO gateway_health(
+	_, err = tx.ExecContext(context.Background(), `INSERT INTO gateway_health(
 		id,last_cycle_at,last_success_at,last_poll_at,last_relay_at,last_telegram_at,last_progress_at,last_outbound_progress_at,offset,outbound_blocked,consecutive_failures,last_failure,terminal_inbound,terminal_outbound
 	) VALUES (1,?,?,?,?,?,?,?,?,?,?,?,?,?)
 	ON CONFLICT(id) DO UPDATE SET
@@ -279,7 +327,10 @@ func (s *State) RecordGatewayCycle(record GatewayCycleRecord) error {
 		terminal_inbound=excluded.terminal_inbound,
 		terminal_outbound=excluded.terminal_outbound`,
 		now, successAt, pollAt, relayAt, telegramAt, progressAt, outboundProgressAt, record.Offset, outboundBlocked, consecutiveFailures, string(effectiveFailure), terminalInbound, terminalOutbound)
-	return err
+	if err != nil {
+		return err
+	}
+	return tx.Commit()
 }
 
 // InspectGatewayState opens the database read-only and returns bounded

--- a/internal/telegram/state.go
+++ b/internal/telegram/state.go
@@ -833,6 +833,17 @@ func (s *State) StageTerminalOutbound(deliveryID, conversationID string, class G
 	return tx.Commit()
 }
 
+// FinalizeTerminalOutbound removes retry-deduplication evidence only after the
+// relay has durably acknowledged the terminal delivery. Conversation-scoped
+// doctor evidence remains until that target later recovers.
+func (s *State) FinalizeTerminalOutbound(deliveryID string) error {
+	if strings.TrimSpace(deliveryID) == "" {
+		return fmt.Errorf("invalid terminal outbound delivery")
+	}
+	_, err := s.db.ExecContext(context.Background(), `DELETE FROM gateway_terminal_outbound_events WHERE delivery_id=?`, deliveryID)
+	return err
+}
+
 // RecoverTerminalOutbound clears a repaired conversation before its successful
 // delivery acknowledgement crosses the external relay boundary.
 func (s *State) RecoverTerminalOutbound(conversationID string) error {

--- a/internal/telegram/state.go
+++ b/internal/telegram/state.go
@@ -38,6 +38,8 @@ const (
 
 var telegramOutboundLimit = 10000
 
+const gatewayLegacyTarget = "__legacy_unattributed__"
+
 // ClaimExecution is one gateway-local claim phase. It stores no mail bodies.
 type ClaimExecution struct {
 	ConversationID string
@@ -97,6 +99,11 @@ func Open(database string) (*State, error) {
 		)`,
 		`CREATE TABLE IF NOT EXISTS gateway_terminal_outbound_targets (
 			conversation_id TEXT PRIMARY KEY,
+			failures INTEGER NOT NULL CHECK (failures > 0),
+			failure_class TEXT NOT NULL
+		)`,
+		`CREATE TABLE IF NOT EXISTS gateway_terminal_inbound_targets (
+			conversation_id TEXT PRIMARY KEY,
 			failures INTEGER NOT NULL CHECK (failures > 0)
 		)`,
 	} {
@@ -110,6 +117,10 @@ func Open(database string) (*State, error) {
 		return nil, fmt.Errorf("initialize telegram state: %w", err)
 	}
 	if err := ensureGatewayHealthOutboundProgress(db); err != nil {
+		_ = db.Close()
+		return nil, fmt.Errorf("initialize telegram state: %w", err)
+	}
+	if err := ensureGatewayTerminalTargetLedgers(db); err != nil {
 		_ = db.Close()
 		return nil, fmt.Errorf("initialize telegram state: %w", err)
 	}
@@ -130,12 +141,19 @@ const (
 	GatewayFailureDeletedTopic              GatewayFailureClass = "deleted_topic"
 )
 
-// GatewayOutboundTargetEvent records content-free evidence that a conversation
-// target either rejected a delivery terminally or later accepted one.
-type GatewayOutboundTargetEvent struct {
+// GatewayTargetEvent records content-free evidence that a conversation target
+// either rejected an operation terminally or later accepted one.
+type GatewayTargetEvent struct {
 	ConversationID string
 	Terminal       bool
+	Failure        GatewayFailureClass
 }
+
+// GatewayInboundTargetEvent is conversation-scoped inbound health evidence.
+type GatewayInboundTargetEvent = GatewayTargetEvent
+
+// GatewayOutboundTargetEvent is conversation-scoped outbound health evidence.
+type GatewayOutboundTargetEvent = GatewayTargetEvent
 
 // GatewayCycleRecord contains only content-free cycle health evidence.
 type GatewayCycleRecord struct {
@@ -148,7 +166,7 @@ type GatewayCycleRecord struct {
 	OutboundProgress     bool
 	TerminalInbound      int
 	TerminalOutbound     int
-	InboundRecovery      bool
+	InboundTargetEvents  []GatewayInboundTargetEvent
 	OutboundTargetEvents []GatewayOutboundTargetEvent
 	Failure              GatewayFailureClass
 }
@@ -173,6 +191,7 @@ type GatewayStateSnapshot struct {
 	LastFailure         GatewayFailureClass
 	TerminalInbound     int
 	TerminalOutbound    int
+	DeletedTopicTargets int
 	StuckHead           bool
 }
 
@@ -191,13 +210,27 @@ func (s *State) RecordGatewayCycle(record GatewayCycleRecord) error {
 	if record.At.IsZero() || record.Offset < 0 || record.OutboundProgress && !record.OutboundBlocked || record.TerminalInbound < 0 || record.TerminalOutbound < 0 || record.Failure == GatewayFailureNone && (record.TerminalInbound > 0 || record.TerminalOutbound > 0) || !validGatewayFailure(record.Failure) {
 		return fmt.Errorf("invalid gateway cycle record")
 	}
-	terminalTargetEvents := 0
+	inboundTerminalEvents, outboundTerminalEvents := 0, 0
+	for _, event := range record.InboundTargetEvents {
+		if strings.TrimSpace(event.ConversationID) == "" {
+			return fmt.Errorf("invalid gateway cycle record")
+		}
+		if event.Terminal {
+			inboundTerminalEvents++
+			if event.Failure != GatewayFailureNone && event.Failure != GatewayFailureInboundRelayPermanent {
+				return fmt.Errorf("invalid gateway cycle record")
+			}
+		}
+	}
 	for _, event := range record.OutboundTargetEvents {
 		if strings.TrimSpace(event.ConversationID) == "" {
 			return fmt.Errorf("invalid gateway cycle record")
 		}
 		if event.Terminal {
-			terminalTargetEvents++
+			outboundTerminalEvents++
+			if event.Failure != GatewayFailureNone && event.Failure != GatewayFailureOutboundTelegramPermanent && event.Failure != GatewayFailureDeletedTopic {
+				return fmt.Errorf("invalid gateway cycle record")
+			}
 		}
 	}
 	now := record.At.UTC().UnixMilli()
@@ -255,48 +288,67 @@ func (s *State) RecordGatewayCycle(record GatewayCycleRecord) error {
 	if outboundDelta == 0 && (record.Failure == GatewayFailureOutboundTelegramPermanent || record.Failure == GatewayFailureDeletedTopic) {
 		outboundDelta = 1
 	}
-	if terminalTargetEvents > outboundDelta {
+	if inboundTerminalEvents > inboundDelta || outboundTerminalEvents > outboundDelta {
 		return fmt.Errorf("invalid gateway cycle record")
 	}
-	var previousTargetedOutbound int
-	if err := tx.QueryRowContext(context.Background(), `SELECT COALESCE(SUM(failures), 0) FROM gateway_terminal_outbound_targets`).Scan(&previousTargetedOutbound); err != nil {
-		return err
+	if unmatched := inboundDelta - inboundTerminalEvents; unmatched > 0 {
+		if _, err := tx.ExecContext(context.Background(), `INSERT INTO gateway_terminal_inbound_targets(conversation_id,failures) VALUES(?,?) ON CONFLICT(conversation_id) DO UPDATE SET failures=failures+excluded.failures`, gatewayLegacyTarget, unmatched); err != nil {
+			return err
+		}
 	}
-	legacyTerminalOutbound := previousTerminalOutbound - previousTargetedOutbound
-	if legacyTerminalOutbound < 0 {
-		legacyTerminalOutbound = 0
-	}
-	for _, event := range record.OutboundTargetEvents {
+	for _, event := range record.InboundTargetEvents {
 		if event.Terminal {
-			if _, err := tx.ExecContext(context.Background(), `INSERT INTO gateway_terminal_outbound_targets(conversation_id,failures) VALUES(?,1) ON CONFLICT(conversation_id) DO UPDATE SET failures=failures+1`, event.ConversationID); err != nil {
+			if _, err := tx.ExecContext(context.Background(), `INSERT INTO gateway_terminal_inbound_targets(conversation_id,failures) VALUES(?,1) ON CONFLICT(conversation_id) DO UPDATE SET failures=failures+1`, event.ConversationID); err != nil {
 				return err
 			}
 			continue
 		}
-		if _, err := tx.ExecContext(context.Background(), `DELETE FROM gateway_terminal_outbound_targets WHERE conversation_id=?`, event.ConversationID); err != nil {
+		if _, err := tx.ExecContext(context.Background(), `DELETE FROM gateway_terminal_inbound_targets WHERE conversation_id IN (?,?)`, event.ConversationID, gatewayLegacyTarget); err != nil {
 			return err
 		}
 	}
-	var targetedTerminalOutbound int
-	if err := tx.QueryRowContext(context.Background(), `SELECT COALESCE(SUM(failures), 0) FROM gateway_terminal_outbound_targets`).Scan(&targetedTerminalOutbound); err != nil {
+	if unmatched := outboundDelta - outboundTerminalEvents; unmatched > 0 {
+		class := record.Failure
+		if class != GatewayFailureDeletedTopic {
+			class = GatewayFailureOutboundTelegramPermanent
+		}
+		if _, err := tx.ExecContext(context.Background(), `INSERT INTO gateway_terminal_outbound_targets(conversation_id,failures,failure_class) VALUES(?,?,?) ON CONFLICT(conversation_id) DO UPDATE SET failures=failures+excluded.failures,failure_class=CASE WHEN failure_class='deleted_topic' OR excluded.failure_class='deleted_topic' THEN 'deleted_topic' ELSE 'outbound_telegram_permanent' END`, gatewayLegacyTarget, unmatched, string(class)); err != nil {
+			return err
+		}
+	}
+	for _, event := range record.OutboundTargetEvents {
+		if event.Terminal {
+			class := event.Failure
+			if class == GatewayFailureNone {
+				class = record.Failure
+			}
+			if class != GatewayFailureDeletedTopic {
+				class = GatewayFailureOutboundTelegramPermanent
+			}
+			if _, err := tx.ExecContext(context.Background(), `INSERT INTO gateway_terminal_outbound_targets(conversation_id,failures,failure_class) VALUES(?,1,?) ON CONFLICT(conversation_id) DO UPDATE SET failures=failures+1,failure_class=CASE WHEN failure_class='deleted_topic' OR excluded.failure_class='deleted_topic' THEN 'deleted_topic' ELSE 'outbound_telegram_permanent' END`, event.ConversationID, string(class)); err != nil {
+				return err
+			}
+			continue
+		}
+		if _, err := tx.ExecContext(context.Background(), `DELETE FROM gateway_terminal_outbound_targets WHERE conversation_id IN (?,?)`, event.ConversationID, gatewayLegacyTarget); err != nil {
+			return err
+		}
+	}
+	var terminalInbound, terminalOutbound, deletedTopicTargets int
+	if err := tx.QueryRowContext(context.Background(), `SELECT COALESCE(SUM(failures), 0) FROM gateway_terminal_inbound_targets`).Scan(&terminalInbound); err != nil {
 		return err
 	}
-	terminalInbound := inboundDelta
-	terminalOutbound := legacyTerminalOutbound + outboundDelta - terminalTargetEvents + targetedTerminalOutbound
-	if !first {
-		terminalInbound += previousTerminalInbound
+	if err := tx.QueryRowContext(context.Background(), `SELECT COALESCE(SUM(failures), 0) FROM gateway_terminal_outbound_targets`).Scan(&terminalOutbound); err != nil {
+		return err
 	}
-	if inboundDelta == 0 && record.InboundRecovery {
-		terminalInbound = 0
+	if err := tx.QueryRowContext(context.Background(), `SELECT COUNT(*) FROM gateway_terminal_outbound_targets WHERE failure_class=?`, string(GatewayFailureDeletedTopic)).Scan(&deletedTopicTargets); err != nil {
+		return err
 	}
 	effectiveFailure := record.Failure
 	if effectiveFailure == GatewayFailureNone && (terminalInbound > 0 || terminalOutbound > 0) {
-		previousClass := GatewayFailureClass(previousFailure)
 		switch {
-		case terminalOutbound > 0 && (previousClass == GatewayFailureOutboundTelegramPermanent || previousClass == GatewayFailureDeletedTopic):
-			effectiveFailure = previousClass
-		case terminalInbound > 0 && previousClass == GatewayFailureInboundRelayPermanent:
-			effectiveFailure = previousClass
+		case deletedTopicTargets > 0:
+			effectiveFailure = GatewayFailureDeletedTopic
 		case terminalOutbound > 0:
 			effectiveFailure = GatewayFailureOutboundTelegramPermanent
 		default:
@@ -379,6 +431,29 @@ func InspectGatewayState(parent context.Context, database string, now time.Time)
 	if err != nil || !validGatewayFailure(GatewayFailureClass(lastFailure)) {
 		return GatewayStateSnapshot{}, fmt.Errorf("gateway state unavailable")
 	}
+	var targetLedgerTables int
+	if err := db.QueryRowContext(ctx, `SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='gateway_terminal_outbound_targets'`).Scan(&targetLedgerTables); err != nil {
+		return GatewayStateSnapshot{}, fmt.Errorf("gateway state unavailable")
+	}
+	var targetClassColumns int
+	if targetLedgerTables > 0 {
+		if err := db.QueryRowContext(ctx, `SELECT COUNT(*) FROM pragma_table_info('gateway_terminal_outbound_targets') WHERE name='failure_class'`).Scan(&targetClassColumns); err != nil {
+			return GatewayStateSnapshot{}, fmt.Errorf("gateway state unavailable")
+		}
+	}
+	if targetClassColumns == 0 {
+		if GatewayFailureClass(lastFailure) == GatewayFailureDeletedTopic && snapshot.TerminalOutbound > 0 {
+			snapshot.DeletedTopicTargets = 1
+		}
+	} else {
+		if err := db.QueryRowContext(ctx, `SELECT COUNT(*) FROM gateway_terminal_outbound_targets WHERE failure_class=?`, string(GatewayFailureDeletedTopic)).Scan(&snapshot.DeletedTopicTargets); err != nil {
+			return GatewayStateSnapshot{}, fmt.Errorf("gateway state unavailable")
+		}
+		var invalidTargetClasses int
+		if err := db.QueryRowContext(ctx, `SELECT COUNT(*) FROM gateway_terminal_outbound_targets WHERE failure_class NOT IN (?,?)`, string(GatewayFailureOutboundTelegramPermanent), string(GatewayFailureDeletedTopic)).Scan(&invalidTargetClasses); err != nil || invalidTargetClasses != 0 {
+			return GatewayStateSnapshot{}, fmt.Errorf("gateway state unavailable")
+		}
+	}
 	snapshot.HasHealth = true
 	snapshot.HasSuccess = success.Valid
 	snapshot.HasPoll = poll.Valid
@@ -408,6 +483,142 @@ func InspectGatewayState(parent context.Context, database string, now time.Time)
 	}
 	snapshot.StuckHead = snapshot.ConsecutiveFailures >= 3 && stuckProgress.Valid && age(stuckProgress) >= 5*time.Minute
 	return snapshot, nil
+}
+
+func ensureGatewayTerminalTargetLedgers(db *sql.DB) error {
+	var classColumns int
+	if err := db.QueryRowContext(context.Background(), `SELECT COUNT(*) FROM pragma_table_info('gateway_terminal_outbound_targets') WHERE name='failure_class'`).Scan(&classColumns); err != nil {
+		return err
+	}
+	if classColumns == 0 {
+		if _, err := db.ExecContext(context.Background(), `ALTER TABLE gateway_terminal_outbound_targets ADD COLUMN failure_class TEXT NOT NULL DEFAULT 'outbound_telegram_permanent'`); err != nil {
+			return err
+		}
+	}
+	tx, err := db.BeginTx(context.Background(), nil)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = tx.Rollback() }()
+	var terminalInbound, terminalOutbound int
+	var lastFailure string
+	err = tx.QueryRowContext(context.Background(), `SELECT terminal_inbound,terminal_outbound,last_failure FROM gateway_health WHERE id=1`).Scan(&terminalInbound, &terminalOutbound, &lastFailure)
+	if errors.Is(err, sql.ErrNoRows) {
+		return tx.Commit()
+	}
+	if err != nil {
+		return err
+	}
+	if classColumns == 0 && GatewayFailureClass(lastFailure) == GatewayFailureDeletedTopic {
+		if _, err := tx.ExecContext(context.Background(), `UPDATE gateway_terminal_outbound_targets SET failure_class=?`, string(GatewayFailureDeletedTopic)); err != nil {
+			return err
+		}
+	}
+	var routes []string
+	rows, err := tx.QueryContext(context.Background(), `SELECT conversation_id FROM topic_routes ORDER BY conversation_id`)
+	if err != nil {
+		return err
+	}
+	for rows.Next() {
+		var conversationID string
+		if err := rows.Scan(&conversationID); err != nil {
+			_ = rows.Close()
+			return err
+		}
+		routes = append(routes, conversationID)
+	}
+	if err := rows.Close(); err != nil {
+		return err
+	}
+	if err := rows.Err(); err != nil {
+		return err
+	}
+	var trackedInbound, trackedOutbound int
+	if err := tx.QueryRowContext(context.Background(), `SELECT COALESCE(SUM(failures),0) FROM gateway_terminal_inbound_targets`).Scan(&trackedInbound); err != nil {
+		return err
+	}
+	if err := tx.QueryRowContext(context.Background(), `SELECT COALESCE(SUM(failures),0) FROM gateway_terminal_outbound_targets`).Scan(&trackedOutbound); err != nil {
+		return err
+	}
+	if len(routes) > 0 {
+		var legacyInbound int
+		if err := tx.QueryRowContext(context.Background(), `SELECT COALESCE(SUM(failures),0) FROM gateway_terminal_inbound_targets WHERE conversation_id=?`, gatewayLegacyTarget).Scan(&legacyInbound); err != nil {
+			return err
+		}
+		if legacyInbound > 0 {
+			if _, err := tx.ExecContext(context.Background(), `DELETE FROM gateway_terminal_inbound_targets WHERE conversation_id=?`, gatewayLegacyTarget); err != nil {
+				return err
+			}
+			for _, conversationID := range routes {
+				if _, err := tx.ExecContext(context.Background(), `INSERT INTO gateway_terminal_inbound_targets(conversation_id,failures) VALUES(?,1) ON CONFLICT(conversation_id) DO NOTHING`, conversationID); err != nil {
+					return err
+				}
+			}
+			if err := tx.QueryRowContext(context.Background(), `SELECT COALESCE(SUM(failures),0) FROM gateway_terminal_inbound_targets`).Scan(&trackedInbound); err != nil {
+				return err
+			}
+		}
+		var legacyOutbound int
+		var legacyOutboundClass string
+		err := tx.QueryRowContext(context.Background(), `SELECT failures,failure_class FROM gateway_terminal_outbound_targets WHERE conversation_id=?`, gatewayLegacyTarget).Scan(&legacyOutbound, &legacyOutboundClass)
+		if err != nil && !errors.Is(err, sql.ErrNoRows) {
+			return err
+		}
+		if legacyOutbound > 0 {
+			if _, err := tx.ExecContext(context.Background(), `DELETE FROM gateway_terminal_outbound_targets WHERE conversation_id=?`, gatewayLegacyTarget); err != nil {
+				return err
+			}
+			if !validGatewayFailure(GatewayFailureClass(legacyOutboundClass)) || GatewayFailureClass(legacyOutboundClass) != GatewayFailureDeletedTopic {
+				legacyOutboundClass = string(GatewayFailureOutboundTelegramPermanent)
+			}
+			for _, conversationID := range routes {
+				if _, err := tx.ExecContext(context.Background(), `INSERT INTO gateway_terminal_outbound_targets(conversation_id,failures,failure_class) VALUES(?,1,?) ON CONFLICT(conversation_id) DO NOTHING`, conversationID, legacyOutboundClass); err != nil {
+					return err
+				}
+			}
+			if err := tx.QueryRowContext(context.Background(), `SELECT COALESCE(SUM(failures),0) FROM gateway_terminal_outbound_targets`).Scan(&trackedOutbound); err != nil {
+				return err
+			}
+		}
+	}
+	if terminalInbound > 0 && trackedInbound == 0 {
+		if len(routes) == 0 {
+			if _, err := tx.ExecContext(context.Background(), `INSERT INTO gateway_terminal_inbound_targets(conversation_id,failures) VALUES(?,?)`, gatewayLegacyTarget, terminalInbound); err != nil {
+				return err
+			}
+			trackedInbound = terminalInbound
+		} else {
+			for _, conversationID := range routes {
+				if _, err := tx.ExecContext(context.Background(), `INSERT INTO gateway_terminal_inbound_targets(conversation_id,failures) VALUES(?,1)`, conversationID); err != nil {
+					return err
+				}
+			}
+			trackedInbound = len(routes)
+		}
+	}
+	if terminalOutbound > 0 && trackedOutbound == 0 {
+		class := GatewayFailureOutboundTelegramPermanent
+		if GatewayFailureClass(lastFailure) == GatewayFailureDeletedTopic {
+			class = GatewayFailureDeletedTopic
+		}
+		if len(routes) == 0 {
+			if _, err := tx.ExecContext(context.Background(), `INSERT INTO gateway_terminal_outbound_targets(conversation_id,failures,failure_class) VALUES(?,?,?)`, gatewayLegacyTarget, terminalOutbound, string(class)); err != nil {
+				return err
+			}
+			trackedOutbound = terminalOutbound
+		} else {
+			for _, conversationID := range routes {
+				if _, err := tx.ExecContext(context.Background(), `INSERT INTO gateway_terminal_outbound_targets(conversation_id,failures,failure_class) VALUES(?,1,?)`, conversationID, string(class)); err != nil {
+					return err
+				}
+			}
+			trackedOutbound = len(routes)
+		}
+	}
+	if _, err := tx.ExecContext(context.Background(), `UPDATE gateway_health SET terminal_inbound=?,terminal_outbound=? WHERE id=1`, trackedInbound, trackedOutbound); err != nil {
+		return err
+	}
+	return tx.Commit()
 }
 
 func ensureGatewayHealthOutboundProgress(db *sql.DB) error {

--- a/internal/telegram/state.go
+++ b/internal/telegram/state.go
@@ -137,6 +137,8 @@ type GatewayCycleRecord struct {
 	OutboundProgress bool
 	TerminalInbound  int
 	TerminalOutbound int
+	InboundRecovery  bool
+	OutboundRecovery bool
 	Failure          GatewayFailureClass
 }
 
@@ -180,9 +182,11 @@ func (s *State) RecordGatewayCycle(record GatewayCycleRecord) error {
 	}
 	now := record.At.UTC().UnixMilli()
 	var previousOffset, previousProgress int64
+	var previousConsecutive, previousTerminalInbound, previousTerminalOutbound int
+	var previousFailure string
 	var previousOutboundProgress sql.NullInt64
 	var previousOutboundBlocked bool
-	err := s.db.QueryRowContext(context.Background(), `SELECT offset,last_progress_at,last_outbound_progress_at,outbound_blocked FROM gateway_health WHERE id = 1`).Scan(&previousOffset, &previousProgress, &previousOutboundProgress, &previousOutboundBlocked)
+	err := s.db.QueryRowContext(context.Background(), `SELECT offset,last_progress_at,last_outbound_progress_at,outbound_blocked,consecutive_failures,last_failure,terminal_inbound,terminal_outbound FROM gateway_health WHERE id = 1`).Scan(&previousOffset, &previousProgress, &previousOutboundProgress, &previousOutboundBlocked, &previousConsecutive, &previousFailure, &previousTerminalInbound, &previousTerminalOutbound)
 	first := errors.Is(err, sql.ErrNoRows)
 	if err != nil && !first {
 		return err
@@ -207,10 +211,8 @@ func (s *State) RecordGatewayCycle(record GatewayCycleRecord) error {
 		}
 	}
 	successAt, pollAt, relayAt, telegramAt := any(nil), any(nil), any(nil), any(nil)
-	consecutiveDelta := 1
 	if record.Failure == GatewayFailureNone {
 		successAt = now
-		consecutiveDelta = 0
 	}
 	if record.PollOK {
 		pollAt = now
@@ -228,6 +230,37 @@ func (s *State) RecordGatewayCycle(record GatewayCycleRecord) error {
 	if outboundDelta == 0 && (record.Failure == GatewayFailureOutboundTelegramPermanent || record.Failure == GatewayFailureDeletedTopic) {
 		outboundDelta = 1
 	}
+	terminalInbound, terminalOutbound := inboundDelta, outboundDelta
+	if !first {
+		terminalInbound += previousTerminalInbound
+		terminalOutbound += previousTerminalOutbound
+	}
+	if inboundDelta == 0 && record.InboundRecovery {
+		terminalInbound = 0
+	}
+	if outboundDelta == 0 && record.OutboundRecovery {
+		terminalOutbound = 0
+	}
+	effectiveFailure := record.Failure
+	if effectiveFailure == GatewayFailureNone && (terminalInbound > 0 || terminalOutbound > 0) {
+		previousClass := GatewayFailureClass(previousFailure)
+		switch {
+		case terminalOutbound > 0 && (previousClass == GatewayFailureOutboundTelegramPermanent || previousClass == GatewayFailureDeletedTopic):
+			effectiveFailure = previousClass
+		case terminalInbound > 0 && previousClass == GatewayFailureInboundRelayPermanent:
+			effectiveFailure = previousClass
+		case terminalOutbound > 0:
+			effectiveFailure = GatewayFailureOutboundTelegramPermanent
+		default:
+			effectiveFailure = GatewayFailureInboundRelayPermanent
+		}
+	}
+	consecutiveFailures := 0
+	if record.Failure != GatewayFailureNone {
+		consecutiveFailures = previousConsecutive + 1
+	} else if effectiveFailure != GatewayFailureNone {
+		consecutiveFailures = previousConsecutive
+	}
 	_, err = s.db.ExecContext(context.Background(), `INSERT INTO gateway_health(
 		id,last_cycle_at,last_success_at,last_poll_at,last_relay_at,last_telegram_at,last_progress_at,last_outbound_progress_at,offset,outbound_blocked,consecutive_failures,last_failure,terminal_inbound,terminal_outbound
 	) VALUES (1,?,?,?,?,?,?,?,?,?,?,?,?,?)
@@ -241,11 +274,11 @@ func (s *State) RecordGatewayCycle(record GatewayCycleRecord) error {
 		last_outbound_progress_at=excluded.last_outbound_progress_at,
 		offset=excluded.offset,
 		outbound_blocked=excluded.outbound_blocked,
-		consecutive_failures=CASE WHEN excluded.last_failure='' THEN 0 ELSE gateway_health.consecutive_failures+1 END,
+		consecutive_failures=excluded.consecutive_failures,
 		last_failure=excluded.last_failure,
-		terminal_inbound=CASE WHEN excluded.last_failure='' THEN 0 ELSE gateway_health.terminal_inbound+excluded.terminal_inbound END,
-		terminal_outbound=CASE WHEN excluded.last_failure='' THEN 0 ELSE gateway_health.terminal_outbound+excluded.terminal_outbound END`,
-		now, successAt, pollAt, relayAt, telegramAt, progressAt, outboundProgressAt, record.Offset, outboundBlocked, consecutiveDelta, string(record.Failure), inboundDelta, outboundDelta)
+		terminal_inbound=excluded.terminal_inbound,
+		terminal_outbound=excluded.terminal_outbound`,
+		now, successAt, pollAt, relayAt, telegramAt, progressAt, outboundProgressAt, record.Offset, outboundBlocked, consecutiveFailures, string(effectiveFailure), terminalInbound, terminalOutbound)
 	return err
 }
 

--- a/internal/telegram/state.go
+++ b/internal/telegram/state.go
@@ -135,6 +135,8 @@ type GatewayCycleRecord struct {
 	TelegramOK       bool
 	OutboundBlocked  bool
 	OutboundProgress bool
+	TerminalInbound  int
+	TerminalOutbound int
 	Failure          GatewayFailureClass
 }
 
@@ -173,7 +175,7 @@ func validGatewayFailure(class GatewayFailureClass) bool {
 // RecordGatewayCycle updates the content-free liveness ledger during normal
 // gateway operation. Doctor itself never calls this method.
 func (s *State) RecordGatewayCycle(record GatewayCycleRecord) error {
-	if record.At.IsZero() || record.Offset < 0 || record.OutboundProgress && !record.OutboundBlocked || !validGatewayFailure(record.Failure) {
+	if record.At.IsZero() || record.Offset < 0 || record.OutboundProgress && !record.OutboundBlocked || record.TerminalInbound < 0 || record.TerminalOutbound < 0 || record.Failure == GatewayFailureNone && (record.TerminalInbound > 0 || record.TerminalOutbound > 0) || !validGatewayFailure(record.Failure) {
 		return fmt.Errorf("invalid gateway cycle record")
 	}
 	now := record.At.UTC().UnixMilli()
@@ -219,11 +221,11 @@ func (s *State) RecordGatewayCycle(record GatewayCycleRecord) error {
 	if record.TelegramOK {
 		telegramAt = now
 	}
-	inboundDelta, outboundDelta := 0, 0
-	if record.Failure == GatewayFailureInboundRelayPermanent {
+	inboundDelta, outboundDelta := record.TerminalInbound, record.TerminalOutbound
+	if inboundDelta == 0 && record.Failure == GatewayFailureInboundRelayPermanent {
 		inboundDelta = 1
 	}
-	if record.Failure == GatewayFailureOutboundTelegramPermanent || record.Failure == GatewayFailureDeletedTopic {
+	if outboundDelta == 0 && (record.Failure == GatewayFailureOutboundTelegramPermanent || record.Failure == GatewayFailureDeletedTopic) {
 		outboundDelta = 1
 	}
 	_, err = s.db.ExecContext(context.Background(), `INSERT INTO gateway_health(

--- a/internal/telegram/state_test.go
+++ b/internal/telegram/state_test.go
@@ -283,7 +283,7 @@ func TestOpenMigratesOutboundProgressLedgerInPlace(t *testing.T) {
 	}
 }
 
-func TestGatewayHealthClearsTerminalFailuresAfterSuccessfulRecovery(t *testing.T) {
+func TestGatewayHealthEmptyCyclePreservesTerminalFailures(t *testing.T) {
 	t.Parallel()
 	database := filepath.Join(t.TempDir(), "telegram.db")
 	state, err := Open(database)
@@ -298,6 +298,44 @@ func TestGatewayHealthClearsTerminalFailuresAfterSuccessfulRecovery(t *testing.T
 		now = now.Add(time.Minute)
 	}
 	if err := state.RecordGatewayCycle(GatewayCycleRecord{At: now, Offset: 9, PollOK: true, RelayOK: true, TelegramOK: true}); err != nil {
+		t.Fatal(err)
+	}
+	if err := state.Close(); err != nil {
+		t.Fatal(err)
+	}
+	snapshot, err := InspectGatewayState(t.Context(), database, now.Add(time.Minute))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if snapshot.TerminalInbound != 1 || snapshot.TerminalOutbound != 2 || snapshot.LastFailure != GatewayFailureDeletedTopic || snapshot.ConsecutiveFailures != 3 {
+		t.Fatalf("empty cycle cleared terminal state: %#v", snapshot)
+	}
+}
+
+func TestGatewayHealthClearsTerminalFailuresAfterPlaneRecovery(t *testing.T) {
+	t.Parallel()
+	database := filepath.Join(t.TempDir(), "telegram.db")
+	state, err := Open(database)
+	if err != nil {
+		t.Fatal(err)
+	}
+	now := testCallbackNow
+	for _, class := range []GatewayFailureClass{GatewayFailureInboundRelayPermanent, GatewayFailureOutboundTelegramPermanent, GatewayFailureDeletedTopic} {
+		if err := state.RecordGatewayCycle(GatewayCycleRecord{At: now, Offset: 8, Failure: class}); err != nil {
+			t.Fatal(err)
+		}
+		now = now.Add(time.Minute)
+	}
+	if err := state.RecordGatewayCycle(GatewayCycleRecord{At: now, Offset: 9, PollOK: true, RelayOK: true, TelegramOK: true, InboundRecovery: true}); err != nil {
+		t.Fatal(err)
+	}
+	var terminalInbound, terminalOutbound int
+	var lastFailure string
+	if err := state.db.QueryRowContext(t.Context(), `SELECT terminal_inbound,terminal_outbound,last_failure FROM gateway_health WHERE id=1`).Scan(&terminalInbound, &terminalOutbound, &lastFailure); err != nil || terminalInbound != 0 || terminalOutbound != 2 || GatewayFailureClass(lastFailure) != GatewayFailureDeletedTopic {
+		t.Fatalf("partial recovery inbound=%d outbound=%d failure=%q err=%v", terminalInbound, terminalOutbound, lastFailure, err)
+	}
+	now = now.Add(time.Minute)
+	if err := state.RecordGatewayCycle(GatewayCycleRecord{At: now, Offset: 9, PollOK: true, RelayOK: true, TelegramOK: true, OutboundRecovery: true}); err != nil {
 		t.Fatal(err)
 	}
 	if err := state.Close(); err != nil {

--- a/internal/telegram/state_test.go
+++ b/internal/telegram/state_test.go
@@ -585,6 +585,48 @@ func TestStageTerminalOutboundIsIdempotentByDelivery(t *testing.T) {
 	}
 }
 
+func TestStageTerminalOutboundReconcilesRetryClassWithoutIncrementing(t *testing.T) {
+	t.Parallel()
+	database := filepath.Join(t.TempDir(), "telegram.db")
+	state, err := Open(database)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := state.StageTerminalOutbound("delivery-1", "conversation-1", GatewayFailureOutboundTelegramPermanent); err != nil {
+		t.Fatal(err)
+	}
+	if err := state.StageTerminalOutbound("delivery-1", "conversation-1", GatewayFailureDeletedTopic); err != nil {
+		t.Fatalf("changed retry class was rejected: %v", err)
+	}
+	if err := state.Close(); err != nil {
+		t.Fatal(err)
+	}
+	snapshot, err := InspectGatewayState(t.Context(), database, testCallbackNow)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if snapshot.TerminalOutbound != 1 || snapshot.DeletedTopicTargets != 1 {
+		t.Fatalf("retry class was not reconciled without double counting: %#v", snapshot)
+	}
+	state, err = Open(database)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := state.StageTerminalOutbound("delivery-1", "conversation-1", GatewayFailureOutboundTelegramPermanent); err != nil {
+		t.Fatalf("changed retry class was rejected: %v", err)
+	}
+	if err := state.Close(); err != nil {
+		t.Fatal(err)
+	}
+	snapshot, err = InspectGatewayState(t.Context(), database, testCallbackNow)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if snapshot.TerminalOutbound != 1 || snapshot.DeletedTopicTargets != 0 {
+		t.Fatalf("reverse retry class was not reconciled without double counting: %#v", snapshot)
+	}
+}
+
 func TestInspectGatewayStateRejectsFutureHealthTimestamps(t *testing.T) {
 	t.Parallel()
 	database := filepath.Join(t.TempDir(), "telegram.db")
@@ -797,7 +839,6 @@ func TestStateOpenAddsClaimExecutionChatID(t *testing.T) {
 }
 
 func TestStateEvictsOldestOutboundAtCap(t *testing.T) {
-	t.Parallel()
 	state, err := Open(filepath.Join(t.TempDir(), "telegram.db"))
 	if err != nil {
 		t.Fatal(err)

--- a/internal/telegram/state_test.go
+++ b/internal/telegram/state_test.go
@@ -106,12 +106,17 @@ func TestGatewayHealthSeparatesTerminalFailureClassesAndStuckProgress(t *testing
 		t.Fatal(err)
 	}
 	now := testCallbackNow
-	for _, class := range []GatewayFailureClass{GatewayFailureInboundRelayPermanent, GatewayFailureOutboundTelegramPermanent, GatewayFailureDeletedTopic} {
-		if err := state.RecordGatewayCycle(GatewayCycleRecord{At: now, Offset: 8, Failure: class}); err != nil {
+	cycles := []GatewayCycleRecord{
+		{At: now, Offset: 8, Failure: GatewayFailureInboundRelayPermanent},
+		{At: now.Add(time.Minute), Offset: 8, Failure: GatewayFailureOutboundTelegramPermanent, TerminalOutbound: 1, OutboundTargetEvents: []GatewayOutboundTargetEvent{{ConversationID: "conversation-1", Terminal: true}}},
+		{At: now.Add(2 * time.Minute), Offset: 8, Failure: GatewayFailureDeletedTopic, TerminalOutbound: 1, OutboundTargetEvents: []GatewayOutboundTargetEvent{{ConversationID: "conversation-2", Terminal: true}}},
+	}
+	for _, cycle := range cycles {
+		if err := state.RecordGatewayCycle(cycle); err != nil {
 			t.Fatal(err)
 		}
-		now = now.Add(time.Minute)
 	}
+	now = now.Add(3 * time.Minute)
 	if err := state.Close(); err != nil {
 		t.Fatal(err)
 	}
@@ -281,6 +286,10 @@ func TestOpenMigratesOutboundProgressLedgerInPlace(t *testing.T) {
 	if err := state.db.QueryRowContext(t.Context(), `SELECT COUNT(*) FROM pragma_table_info('gateway_health') WHERE name IN ('last_outbound_progress_at','outbound_blocked')`).Scan(&columns); err != nil || columns != 2 {
 		t.Fatalf("outbound progress columns=%d err=%v", columns, err)
 	}
+	var targetTables int
+	if err := state.db.QueryRowContext(t.Context(), `SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='gateway_terminal_outbound_targets'`).Scan(&targetTables); err != nil || targetTables != 1 {
+		t.Fatalf("outbound target ledger tables=%d err=%v", targetTables, err)
+	}
 }
 
 func TestGatewayHealthEmptyCyclePreservesTerminalFailures(t *testing.T) {
@@ -320,12 +329,17 @@ func TestGatewayHealthClearsTerminalFailuresAfterPlaneRecovery(t *testing.T) {
 		t.Fatal(err)
 	}
 	now := testCallbackNow
-	for _, class := range []GatewayFailureClass{GatewayFailureInboundRelayPermanent, GatewayFailureOutboundTelegramPermanent, GatewayFailureDeletedTopic} {
-		if err := state.RecordGatewayCycle(GatewayCycleRecord{At: now, Offset: 8, Failure: class}); err != nil {
+	cycles := []GatewayCycleRecord{
+		{At: now, Offset: 8, Failure: GatewayFailureInboundRelayPermanent},
+		{At: now.Add(time.Minute), Offset: 8, Failure: GatewayFailureOutboundTelegramPermanent, TerminalOutbound: 1, OutboundTargetEvents: []GatewayOutboundTargetEvent{{ConversationID: "conversation-1", Terminal: true}}},
+		{At: now.Add(2 * time.Minute), Offset: 8, Failure: GatewayFailureDeletedTopic, TerminalOutbound: 1, OutboundTargetEvents: []GatewayOutboundTargetEvent{{ConversationID: "conversation-2", Terminal: true}}},
+	}
+	for _, cycle := range cycles {
+		if err := state.RecordGatewayCycle(cycle); err != nil {
 			t.Fatal(err)
 		}
-		now = now.Add(time.Minute)
 	}
+	now = now.Add(3 * time.Minute)
 	if err := state.RecordGatewayCycle(GatewayCycleRecord{At: now, Offset: 9, PollOK: true, RelayOK: true, TelegramOK: true, InboundRecovery: true}); err != nil {
 		t.Fatal(err)
 	}
@@ -335,7 +349,14 @@ func TestGatewayHealthClearsTerminalFailuresAfterPlaneRecovery(t *testing.T) {
 		t.Fatalf("partial recovery inbound=%d outbound=%d failure=%q err=%v", terminalInbound, terminalOutbound, lastFailure, err)
 	}
 	now = now.Add(time.Minute)
-	if err := state.RecordGatewayCycle(GatewayCycleRecord{At: now, Offset: 9, PollOK: true, RelayOK: true, TelegramOK: true, OutboundRecovery: true}); err != nil {
+	if err := state.RecordGatewayCycle(GatewayCycleRecord{At: now, Offset: 9, PollOK: true, RelayOK: true, TelegramOK: true, OutboundTargetEvents: []GatewayOutboundTargetEvent{{ConversationID: "conversation-1"}}}); err != nil {
+		t.Fatal(err)
+	}
+	if err := state.db.QueryRowContext(t.Context(), `SELECT terminal_outbound,last_failure FROM gateway_health WHERE id=1`).Scan(&terminalOutbound, &lastFailure); err != nil || terminalOutbound != 1 || GatewayFailureClass(lastFailure) != GatewayFailureDeletedTopic {
+		t.Fatalf("first target recovery outbound=%d failure=%q err=%v", terminalOutbound, lastFailure, err)
+	}
+	now = now.Add(time.Minute)
+	if err := state.RecordGatewayCycle(GatewayCycleRecord{At: now, Offset: 9, PollOK: true, RelayOK: true, TelegramOK: true, OutboundTargetEvents: []GatewayOutboundTargetEvent{{ConversationID: "conversation-2"}}}); err != nil {
 		t.Fatal(err)
 	}
 	if err := state.Close(); err != nil {
@@ -347,6 +368,48 @@ func TestGatewayHealthClearsTerminalFailuresAfterPlaneRecovery(t *testing.T) {
 	}
 	if snapshot.TerminalInbound != 0 || snapshot.TerminalOutbound != 0 || snapshot.LastFailure != GatewayFailureNone || snapshot.ConsecutiveFailures != 0 || snapshot.StuckHead {
 		t.Fatalf("snapshot=%#v", snapshot)
+	}
+}
+
+func TestGatewayHealthRequiresTargetSpecificOutboundRecovery(t *testing.T) {
+	t.Parallel()
+	database := filepath.Join(t.TempDir(), "telegram.db")
+	state, err := Open(database)
+	if err != nil {
+		t.Fatal(err)
+	}
+	now := testCallbackNow
+	if err := state.RecordGatewayCycle(GatewayCycleRecord{
+		At: now, Offset: 8, Failure: GatewayFailureDeletedTopic, TerminalOutbound: 1,
+		OutboundTargetEvents: []GatewayOutboundTargetEvent{{ConversationID: "broken", Terminal: true}},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := state.RecordGatewayCycle(GatewayCycleRecord{
+		At: now.Add(time.Minute), Offset: 9, PollOK: true, RelayOK: true, TelegramOK: true,
+		OutboundTargetEvents: []GatewayOutboundTargetEvent{{ConversationID: "healthy"}},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	var terminalOutbound int
+	if err := state.db.QueryRowContext(t.Context(), `SELECT terminal_outbound FROM gateway_health WHERE id=1`).Scan(&terminalOutbound); err != nil || terminalOutbound != 1 {
+		t.Fatalf("healthy target cleared broken target: terminal=%d err=%v", terminalOutbound, err)
+	}
+	if err := state.RecordGatewayCycle(GatewayCycleRecord{
+		At: now.Add(2 * time.Minute), Offset: 10, PollOK: true, RelayOK: true, TelegramOK: true,
+		OutboundTargetEvents: []GatewayOutboundTargetEvent{{ConversationID: "broken"}},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := state.Close(); err != nil {
+		t.Fatal(err)
+	}
+	snapshot, err := InspectGatewayState(t.Context(), database, now.Add(3*time.Minute))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if snapshot.TerminalOutbound != 0 || snapshot.LastFailure != GatewayFailureNone {
+		t.Fatalf("matching target did not recover: %#v", snapshot)
 	}
 }
 

--- a/internal/telegram/state_test.go
+++ b/internal/telegram/state_test.go
@@ -124,6 +124,33 @@ func TestGatewayHealthSeparatesTerminalFailureClassesAndStuckProgress(t *testing
 	}
 }
 
+func TestGatewayHealthRecordsBothTerminalPlanesFromOneCompletedCycle(t *testing.T) {
+	t.Parallel()
+	database := filepath.Join(t.TempDir(), "telegram.db")
+	state, err := Open(database)
+	if err != nil {
+		t.Fatal(err)
+	}
+	now := testCallbackNow
+	if err := state.RecordGatewayCycle(GatewayCycleRecord{
+		At: now, Offset: 12, PollOK: true, RelayOK: true,
+		Failure:         GatewayFailureOutboundTelegramPermanent,
+		TerminalInbound: 1, TerminalOutbound: 1,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := state.Close(); err != nil {
+		t.Fatal(err)
+	}
+	snapshot, err := InspectGatewayState(t.Context(), database, now.Add(time.Minute))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if snapshot.TerminalInbound != 1 || snapshot.TerminalOutbound != 1 || snapshot.LastFailure != GatewayFailureOutboundTelegramPermanent {
+		t.Fatalf("snapshot=%#v", snapshot)
+	}
+}
+
 func TestGatewayHealthOutboundStallIgnoresInboundOffsetProgress(t *testing.T) {
 	t.Parallel()
 	database := filepath.Join(t.TempDir(), "telegram.db")

--- a/internal/telegram/state_test.go
+++ b/internal/telegram/state_test.go
@@ -340,7 +340,7 @@ func TestGatewayHealthClearsTerminalFailuresAfterPlaneRecovery(t *testing.T) {
 		}
 	}
 	now = now.Add(3 * time.Minute)
-	if err := state.RecordGatewayCycle(GatewayCycleRecord{At: now, Offset: 9, PollOK: true, RelayOK: true, TelegramOK: true, InboundRecovery: true}); err != nil {
+	if err := state.RecordGatewayCycle(GatewayCycleRecord{At: now, Offset: 9, PollOK: true, RelayOK: true, TelegramOK: true, InboundTargetEvents: []GatewayInboundTargetEvent{{ConversationID: "conversation-1"}}}); err != nil {
 		t.Fatal(err)
 	}
 	var terminalInbound, terminalOutbound int
@@ -410,6 +410,151 @@ func TestGatewayHealthRequiresTargetSpecificOutboundRecovery(t *testing.T) {
 	}
 	if snapshot.TerminalOutbound != 0 || snapshot.LastFailure != GatewayFailureNone {
 		t.Fatalf("matching target did not recover: %#v", snapshot)
+	}
+}
+
+func TestGatewayHealthRequiresTargetSpecificInboundRecovery(t *testing.T) {
+	t.Parallel()
+	database := filepath.Join(t.TempDir(), "telegram.db")
+	state, err := Open(database)
+	if err != nil {
+		t.Fatal(err)
+	}
+	now := testCallbackNow
+	if err := state.RecordGatewayCycle(GatewayCycleRecord{
+		At: now, Offset: 8, Failure: GatewayFailureInboundRelayPermanent, TerminalInbound: 1,
+		InboundTargetEvents: []GatewayInboundTargetEvent{{ConversationID: "broken", Terminal: true}},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := state.RecordGatewayCycle(GatewayCycleRecord{
+		At: now.Add(time.Minute), Offset: 9, PollOK: true, RelayOK: true, TelegramOK: true,
+		InboundTargetEvents: []GatewayInboundTargetEvent{{ConversationID: "healthy"}},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	var terminalInbound int
+	if err := state.db.QueryRowContext(t.Context(), `SELECT terminal_inbound FROM gateway_health WHERE id=1`).Scan(&terminalInbound); err != nil || terminalInbound != 1 {
+		t.Fatalf("healthy conversation cleared broken conversation: terminal=%d err=%v", terminalInbound, err)
+	}
+	if err := state.RecordGatewayCycle(GatewayCycleRecord{
+		At: now.Add(2 * time.Minute), Offset: 10, PollOK: true, RelayOK: true, TelegramOK: true,
+		InboundTargetEvents: []GatewayInboundTargetEvent{{ConversationID: "broken"}},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := state.Close(); err != nil {
+		t.Fatal(err)
+	}
+	snapshot, err := InspectGatewayState(t.Context(), database, now.Add(3*time.Minute))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if snapshot.TerminalInbound != 0 || snapshot.LastFailure != GatewayFailureNone {
+		t.Fatalf("matching conversation did not recover: %#v", snapshot)
+	}
+}
+
+func TestOpenMigratesLegacyTerminalCountsIntoRecoverableTargets(t *testing.T) {
+	t.Parallel()
+	database := filepath.Join(t.TempDir(), "telegram.db")
+	state, err := Open(database)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := state.SetRoute(55, 7, "conversation-1"); err != nil {
+		t.Fatal(err)
+	}
+	if err := state.SetRoute(55, 8, "conversation-2"); err != nil {
+		t.Fatal(err)
+	}
+	if err := state.RecordGatewayCycle(GatewayCycleRecord{At: testCallbackNow, Offset: 8, Failure: GatewayFailureDeletedTopic}); err != nil {
+		t.Fatal(err)
+	}
+	if err := state.Close(); err != nil {
+		t.Fatal(err)
+	}
+	state, err = Open(database)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := state.RecordGatewayCycle(GatewayCycleRecord{At: testCallbackNow.Add(time.Minute), Offset: 9, PollOK: true, RelayOK: true, TelegramOK: true, OutboundTargetEvents: []GatewayOutboundTargetEvent{{ConversationID: "conversation-1"}}}); err != nil {
+		t.Fatal(err)
+	}
+	var terminalOutbound int
+	if err := state.db.QueryRowContext(t.Context(), `SELECT terminal_outbound FROM gateway_health WHERE id=1`).Scan(&terminalOutbound); err != nil || terminalOutbound != 1 {
+		t.Fatalf("first migrated target recovery terminal=%d err=%v", terminalOutbound, err)
+	}
+	if err := state.RecordGatewayCycle(GatewayCycleRecord{At: testCallbackNow.Add(2 * time.Minute), Offset: 10, PollOK: true, RelayOK: true, TelegramOK: true, OutboundTargetEvents: []GatewayOutboundTargetEvent{{ConversationID: "conversation-2"}}}); err != nil {
+		t.Fatal(err)
+	}
+	if err := state.Close(); err != nil {
+		t.Fatal(err)
+	}
+	snapshot, err := InspectGatewayState(t.Context(), database, testCallbackNow.Add(3*time.Minute))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if snapshot.TerminalOutbound != 0 || snapshot.DeletedTopicTargets != 0 {
+		t.Fatalf("migrated targets did not recover: %#v", snapshot)
+	}
+}
+
+func TestGatewayHealthRetainsFailureClassPerOutboundTarget(t *testing.T) {
+	t.Parallel()
+	database := filepath.Join(t.TempDir(), "telegram.db")
+	state, err := Open(database)
+	if err != nil {
+		t.Fatal(err)
+	}
+	now := testCallbackNow
+	if err := state.RecordGatewayCycle(GatewayCycleRecord{At: now, Offset: 8, Failure: GatewayFailureOutboundTelegramPermanent, TerminalOutbound: 1, OutboundTargetEvents: []GatewayOutboundTargetEvent{{ConversationID: "generic", Terminal: true}}}); err != nil {
+		t.Fatal(err)
+	}
+	if err := state.RecordGatewayCycle(GatewayCycleRecord{At: now.Add(time.Minute), Offset: 9, Failure: GatewayFailureDeletedTopic, TerminalOutbound: 1, OutboundTargetEvents: []GatewayOutboundTargetEvent{{ConversationID: "deleted", Terminal: true}}}); err != nil {
+		t.Fatal(err)
+	}
+	if err := state.RecordGatewayCycle(GatewayCycleRecord{At: now.Add(2 * time.Minute), Offset: 10, PollOK: true, RelayOK: true, TelegramOK: true, OutboundTargetEvents: []GatewayOutboundTargetEvent{{ConversationID: "deleted"}}}); err != nil {
+		t.Fatal(err)
+	}
+	if err := state.Close(); err != nil {
+		t.Fatal(err)
+	}
+	snapshot, err := InspectGatewayState(t.Context(), database, now.Add(3*time.Minute))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if snapshot.TerminalOutbound != 1 || snapshot.DeletedTopicTargets != 0 || snapshot.LastFailure != GatewayFailureOutboundTelegramPermanent {
+		t.Fatalf("remaining target class was not retained: %#v", snapshot)
+	}
+}
+
+func TestGatewayHealthRetainsDeletedClassWhenGenericTargetRecovers(t *testing.T) {
+	t.Parallel()
+	database := filepath.Join(t.TempDir(), "telegram.db")
+	state, err := Open(database)
+	if err != nil {
+		t.Fatal(err)
+	}
+	now := testCallbackNow
+	for _, record := range []GatewayCycleRecord{
+		{At: now, Offset: 8, Failure: GatewayFailureDeletedTopic, TerminalOutbound: 1, OutboundTargetEvents: []GatewayOutboundTargetEvent{{ConversationID: "deleted", Terminal: true, Failure: GatewayFailureDeletedTopic}}},
+		{At: now.Add(time.Minute), Offset: 9, Failure: GatewayFailureOutboundTelegramPermanent, TerminalOutbound: 1, OutboundTargetEvents: []GatewayOutboundTargetEvent{{ConversationID: "generic", Terminal: true, Failure: GatewayFailureOutboundTelegramPermanent}}},
+		{At: now.Add(2 * time.Minute), Offset: 10, PollOK: true, RelayOK: true, TelegramOK: true, OutboundTargetEvents: []GatewayOutboundTargetEvent{{ConversationID: "generic"}}},
+	} {
+		if err := state.RecordGatewayCycle(record); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := state.Close(); err != nil {
+		t.Fatal(err)
+	}
+	snapshot, err := InspectGatewayState(t.Context(), database, now.Add(3*time.Minute))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if snapshot.TerminalOutbound != 1 || snapshot.DeletedTopicTargets != 1 || snapshot.LastFailure != GatewayFailureDeletedTopic {
+		t.Fatalf("deleted target class was hidden: %#v", snapshot)
 	}
 }
 

--- a/internal/telegram/state_test.go
+++ b/internal/telegram/state_test.go
@@ -558,6 +558,33 @@ func TestGatewayHealthRetainsDeletedClassWhenGenericTargetRecovers(t *testing.T)
 	}
 }
 
+func TestStageTerminalOutboundIsIdempotentByDelivery(t *testing.T) {
+	t.Parallel()
+	database := filepath.Join(t.TempDir(), "telegram.db")
+	state, err := Open(database)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for range 2 {
+		if err := state.StageTerminalOutbound("delivery-1", "conversation-1", GatewayFailureDeletedTopic); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := state.StageTerminalOutbound("delivery-1", "conversation-2", GatewayFailureDeletedTopic); err == nil {
+		t.Fatal("delivery identity was rebound to another conversation")
+	}
+	if err := state.Close(); err != nil {
+		t.Fatal(err)
+	}
+	snapshot, err := InspectGatewayState(t.Context(), database, testCallbackNow)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if snapshot.TerminalOutbound != 1 || snapshot.DeletedTopicTargets != 1 {
+		t.Fatalf("duplicate staging changed terminal health: %#v", snapshot)
+	}
+}
+
 func TestInspectGatewayStateRejectsFutureHealthTimestamps(t *testing.T) {
 	t.Parallel()
 	database := filepath.Join(t.TempDir(), "telegram.db")


### PR DESCRIPTION
## Summary

- preserve message-less Telegram update IDs so polling offsets can advance
- durably consume signed relay 403/404 inbound rejections and continue the page
- acknowledge malformed, unrouted, wrong-chat, and non-429 Telegram 4xx outbound poison deliveries
- keep network, 429, and 5xx failures unacknowledged for retry
- document the content-free terminal-drop and retry behavior

Closes #165
Closes #166
Closes #167

## Verification

- make test
- make test-race
- make staticcheck
- make security
- make lint
- focused RED/GREEN Telegram and adapter regression suites