### PR TITLE
test(relay): cover durable role addressing end to end

### DIFF
--- a/cmd/punaro-adapter/relay_lifecycle_e2e_test.go
+++ b/cmd/punaro-adapter/relay_lifecycle_e2e_test.go
@@ -135,8 +135,7 @@ func TestE2ERealTwoClientRelayLifecycle(t *testing.T) {
 	e2eInstallClient(t, root, receiverHome, relayURL, receiverMachineID, mailbox, receiverMailboxState, false)
 	e2eRewriteRelayURL(t, senderProfile, "http://"+proxy.listener.Addr().String())
 	e2eRewriteRelayURL(t, receiverProfile, "http://"+proxy.listener.Addr().String())
-	receiverAdapter := filepath.Join(receiverHome, ".local", "bin", "punaro-adapter")
-	servicePath := e2eIsolatedLaunchAgent(t, installedServicePath, receiverHome, receiverProfile, receiverAdapter, fixture)
+	servicePath := e2eIsolatedLaunchAgent(t, installedServicePath, receiverHome, receiverProfile, fixture)
 	t.Cleanup(func() { _ = e2eLaunchctl("bootout", launchDomain, servicePath) })
 
 	senderEndpoint := "agent/" + senderMachineID + "/session"
@@ -383,7 +382,7 @@ func e2eRewriteRelayURL(t *testing.T, profile, relayURL string) {
 	}
 }
 
-func e2eIsolatedLaunchAgent(t *testing.T, installedServicePath, home, profile, binary, fixture string) string {
+func e2eIsolatedLaunchAgent(t *testing.T, installedServicePath, home, profile, fixture string) string {
 	t.Helper()
 	raw, err := os.ReadFile(installedServicePath)
 	if err != nil {
@@ -392,10 +391,12 @@ func e2eIsolatedLaunchAgent(t *testing.T, installedServicePath, home, profile, b
 	label := "org.punaro.adapter.e2e-" + strings.ReplaceAll(uuid.NewString(), "-", "")
 	labelPattern := regexp.MustCompile(`<key>Label</key>\s*<string>org\.punaro\.adapter</string>`)
 	rewritten := labelPattern.ReplaceAll(raw, []byte("<key>Label</key>\n  <string>"+label+"</string>"))
-	rewritten = []byte(strings.Replace(string(rewritten), `set -a; . "$HOME/.config/punaro/adapter.env"; set +a; `, "", 1))
-	isolationCommand := `exec /usr/bin/env -i HOME="` + home + `" PATH="/usr/bin:/bin:/usr/sbin:/sbin" ` + adapterProfileFileEnv + `="` + profile + `" "` + binary + `"`
-	rewritten = []byte(strings.Replace(string(rewritten), `exec "$HOME/.local/bin/punaro-adapter"`, isolationCommand, 1))
-	if string(rewritten) == string(raw) || strings.Contains(string(rewritten), `"$HOME/.config/punaro/adapter.env"`) || strings.Contains(string(rewritten), `"$HOME/.local/bin/punaro-adapter"`) || !strings.Contains(string(rewritten), `exec /usr/bin/env -i`) || !strings.Contains(string(rewritten), adapterProfileFileEnv) {
+	serviceCommand := `exec "$HOME/.local/bin/punaro-bootstrap" run --directory "$HOME/.local/state/punaro-bootstrap"`
+	bootstrap := filepath.Join(home, ".local", "bin", "punaro-bootstrap")
+	bootstrapState := filepath.Join(home, ".local", "state", "punaro-bootstrap")
+	isolationCommand := `exec /usr/bin/env -i HOME="` + home + `" PATH="/usr/bin:/bin:/usr/sbin:/sbin" ` + adapterProfileFileEnv + `="` + profile + `" "` + bootstrap + `" run --directory "` + bootstrapState + `"`
+	rewritten = []byte(strings.Replace(string(rewritten), serviceCommand, isolationCommand, 1))
+	if string(rewritten) == string(raw) || strings.Contains(string(rewritten), `"$HOME/.local/bin/punaro-bootstrap"`) || strings.Contains(string(rewritten), `"$HOME/.local/state/punaro-bootstrap"`) || !strings.Contains(string(rewritten), `exec /usr/bin/env -i`) || !strings.Contains(string(rewritten), adapterProfileFileEnv) || !strings.Contains(string(rewritten), bootstrap) {
 		t.Fatal("isolate installed receiver service definition")
 	}
 	path := filepath.Join(fixture, "receiver-launch-agent.plist")

--- a/internal/postgres/postgres_integration_test.go
+++ b/internal/postgres/postgres_integration_test.go
@@ -1589,6 +1589,7 @@ func testRelayIntegration(t *testing.T, app *Database) {
 	contracttest.RunRoleTargeting(t, app, "postgres-target")
 	contracttest.RunRoleProfiles(t, app, "postgres-profile")
 	contracttest.RunDirectMessages(t, app, "postgres-direct")
+	contracttest.RunDurableRoleAddressingE2E(t, app, "postgres-addressing")
 	contracttest.RunNamedOccupancy(t, app, "postgres-occupancy")
 	testPostgresTelegramClaimReserveOccupancy(t, app)
 	testPostgresTelegramClaimBindsEnsureKeyToExistingClaim(t, app)

--- a/internal/relay/contracttest/contract.go
+++ b/internal/relay/contracttest/contract.go
@@ -1379,3 +1379,127 @@ func RunDirectMessages(t *testing.T, backend relay.Backend, namespace string) {
 		t.Fatalf("named append=%#v duplicate=%t err=%v", namedMessage, duplicate, err)
 	}
 }
+
+// RunDurableRoleAddressingE2E proves the parent #143 discover, resolve,
+// offline send, receive, and rebind outcome against every durable backend.
+func RunDurableRoleAddressingE2E(t *testing.T, backend relay.Backend, namespace string) {
+	t.Helper()
+	profiles, ok := backend.(relay.RoleProfileBackend)
+	if !ok {
+		t.Fatal("backend does not implement durable role profiles")
+	}
+	bindings, ok := backend.(relay.RoleBindingBackend)
+	if !ok {
+		t.Fatal("backend does not implement durable role bindings")
+	}
+	direct, ok := backend.(relay.DirectMessageBackend)
+	if !ok {
+		t.Fatal("backend does not implement direct messages")
+	}
+	now := time.Date(2026, time.August, 23, 10, 0, 0, 0, time.UTC)
+	machineA, machineB := namespace+"-a", namespace+"-b"
+	machineC, machineD := namespace+"-c", namespace+"-d"
+	endpointA := "agent/" + namespace + "/reviewer"
+	endpointB1, endpointB2 := "agent/"+namespace+"/implementer-1", "agent/"+namespace+"/implementer-2"
+	fromRole := "role/" + machineA + "/source-e2e"
+	toRole := "role/" + machineB + "/target-e2e"
+	ambiguousRole := "role/" + machineC + "/target-e2e"
+	hiddenRole := "role/" + machineD + "/hidden"
+	if err := backend.AdvertiseEndpoints(machineA, []string{endpointA}, now, time.Hour); err != nil {
+		t.Fatal(err)
+	}
+	registrations := []relay.RegisterRoleInput{
+		{MachineID: machineA, Role: fromRole, DisplayName: "Reviewer", DirectAddressable: true, IdempotencyKey: namespace + "-register-a", Now: now},
+		{MachineID: machineB, Role: toRole, DisplayName: "Implementer", DirectAddressable: true, IdempotencyKey: namespace + "-register-b", Now: now},
+		{MachineID: machineC, Role: ambiguousRole, DisplayName: "Other implementer", DirectAddressable: true, IdempotencyKey: namespace + "-register-c", Now: now},
+		{MachineID: machineD, Role: hiddenRole, DisplayName: "Hidden", DirectAddressable: false, IdempotencyKey: namespace + "-register-d", Now: now},
+	}
+	for _, input := range registrations {
+		if _, created, err := profiles.RegisterRoleProfile(input); err != nil || !created {
+			t.Fatalf("register role %q created=%t err=%v", input.Role, created, err)
+		}
+	}
+	if err := bindings.BindRoleToSession(machineA, fromRole, endpointA, now, time.Hour); err != nil {
+		t.Fatal(err)
+	}
+
+	page, err := profiles.ListAddressableRoles(relay.RoleListInput{Limit: 50, Now: now})
+	if err != nil || len(page.Roles) < 3 || page.NextCursor != "" {
+		t.Fatalf("addressable roles=%#v err=%v", page, err)
+	}
+	listed := make(map[string]relay.RoleContact, len(page.Roles))
+	for _, contact := range page.Roles {
+		listed[contact.Role] = contact
+	}
+	if listed[fromRole].Role == "" || !listed[fromRole].Online || listed[toRole].Role == "" || listed[toRole].Online || listed[ambiguousRole].Role == "" {
+		t.Fatalf("addressable roles=%#v", page.Roles)
+	}
+	if _, found := listed[hiddenRole]; found {
+		t.Fatalf("opted-out role was listed: %#v", page.Roles)
+	}
+	qualified, err := profiles.ResolveAddressableRole(relay.RoleResolveInput{Name: toRole, Now: now})
+	if err != nil || qualified.Status != relay.RoleResolveResolved || qualified.Role != toRole || qualified.Online {
+		t.Fatalf("qualified resolve=%#v err=%v", qualified, err)
+	}
+	unique, err := profiles.ResolveAddressableRole(relay.RoleResolveInput{Name: "source-e2e", Now: now})
+	if err != nil || unique.Status != relay.RoleResolveResolved || unique.Role != fromRole || !unique.Online {
+		t.Fatalf("unique resolve=%#v err=%v", unique, err)
+	}
+	ambiguous, err := profiles.ResolveAddressableRole(relay.RoleResolveInput{Name: "target-e2e", Now: now})
+	if err != nil || ambiguous.Status != relay.RoleResolveAmbiguous || len(ambiguous.Matches) != 2 {
+		t.Fatalf("ambiguous resolve=%#v err=%v", ambiguous, err)
+	}
+	hidden, err := profiles.ResolveAddressableRole(relay.RoleResolveInput{Name: hiddenRole, Now: now})
+	if err != nil || hidden.Status != relay.RoleResolveNotFound {
+		t.Fatalf("hidden resolve=%#v err=%v", hidden, err)
+	}
+	if _, _, err := direct.SendDirectMessage(relay.DirectMessageInput{
+		SenderMachineID: machineA, FromRole: fromRole, ToRole: hiddenRole, Body: "must fail", IdempotencyKey: namespace + "-hidden-send", Now: now,
+	}); !errors.Is(err, relay.ErrForbidden) {
+		t.Fatalf("opted-out direct send err=%v", err)
+	}
+
+	first, duplicate, err := direct.SendDirectMessage(relay.DirectMessageInput{
+		SenderMachineID: machineA, FromRole: fromRole, ToRole: toRole, Body: "sent while offline", IdempotencyKey: namespace + "-offline-send", Now: now,
+	})
+	if err != nil || duplicate || first.ConversationID == "" {
+		t.Fatalf("offline send=%#v duplicate=%t err=%v", first, duplicate, err)
+	}
+	boundAt := now.Add(time.Minute)
+	if err := backend.AdvertiseEndpoints(machineB, []string{endpointB1}, boundAt, time.Hour); err != nil {
+		t.Fatal(err)
+	}
+	if err := bindings.BindRoleToSession(machineB, toRole, endpointB1, boundAt, time.Hour); err != nil {
+		t.Fatal(err)
+	}
+	firstPage, err := backend.LeaseDeliveries(machineB, namespace+"-consumer-1", endpointB1, first.ConversationID, boundAt, time.Minute, 10)
+	if err != nil || len(firstPage.Deliveries) != 1 || firstPage.Deliveries[0].Message.ID != first.ID || firstPage.Deliveries[0].RecipientRole != toRole {
+		t.Fatalf("offline receive=%#v err=%v", firstPage, err)
+	}
+	firstDelivery := firstPage.Deliveries[0]
+	if err := backend.AckDelivery(machineB, endpointB1, firstDelivery.ID, firstDelivery.LeaseToken, firstDelivery.LeaseGeneration, boundAt); err != nil {
+		t.Fatal(err)
+	}
+
+	reboundAt := boundAt.Add(2 * time.Minute)
+	if err := backend.AdvertiseEndpoints(machineB, []string{endpointB2}, reboundAt, time.Hour); err != nil {
+		t.Fatal(err)
+	}
+	if err := bindings.BindRoleToSession(machineB, toRole, endpointB2, reboundAt, time.Hour); err != nil {
+		t.Fatal(err)
+	}
+	second, duplicate, err := direct.SendDirectMessage(relay.DirectMessageInput{
+		SenderMachineID: machineA, FromRole: fromRole, ToRole: toRole, Body: "same address after rebind", IdempotencyKey: namespace + "-rebound-send", Now: reboundAt,
+	})
+	if err != nil || duplicate || second.ConversationID != first.ConversationID {
+		t.Fatalf("rebound send=%#v first=%#v duplicate=%t err=%v", second, first, duplicate, err)
+	}
+	secondPage, err := backend.LeaseDeliveries(machineB, namespace+"-consumer-2", endpointB2, second.ConversationID, reboundAt, time.Minute, 10)
+	if err != nil || len(secondPage.Deliveries) != 1 || secondPage.Deliveries[0].Message.ID != second.ID || secondPage.Deliveries[0].RecipientRole != toRole {
+		t.Fatalf("rebound receive=%#v err=%v", secondPage, err)
+	}
+	secondDelivery := secondPage.Deliveries[0]
+	if err := backend.AckDelivery(machineB, endpointB2, secondDelivery.ID, secondDelivery.LeaseToken, secondDelivery.LeaseGeneration, reboundAt); err != nil {
+		t.Fatalf("ack rebound delivery: %v", err)
+	}
+}

--- a/internal/relay/store_conformance_test.go
+++ b/internal/relay/store_conformance_test.go
@@ -18,5 +18,6 @@ func TestSQLiteStoreConformance(t *testing.T) {
 	contracttest.RunRoleTargeting(t, store, "sqlite-target")
 	contracttest.RunRoleProfiles(t, store, "sqlite-profile")
 	contracttest.RunDirectMessages(t, store, "sqlite-direct")
+	contracttest.RunDurableRoleAddressingE2E(t, store, "sqlite-addressing")
 	contracttest.RunNamedOccupancy(t, store, "sqlite-occupancy")
 }


### PR DESCRIPTION
Closes #143

## Summary
- add one contract-level discover, resolve, offline send, receive, and role-rebind scenario
- run the same observable flow against SQLite and PostgreSQL
- keep the real installed two-client macOS E2E aligned with the bootstrap-run service handoff from #142
- verify ambiguous short names fail, qualified handles succeed, and opted-out roles remain hidden and forbidden

## Validation
- `go test ./internal/relay -run ^TestSQLiteStoreConformance$ -count=1`
- native-arm64 PostgreSQL integration: `go test -p 1 -count=1 -timeout 8m ./internal/postgres ./cmd/punaro`
- `make test-real-relay-e2e`
- `make test test-race`
- `make vet staticcheck windows-build deployment-lint security fuzz release-gates`
- pinned golangci v2.11.1: native and Linux amd64 passes clean

## Known upstream local-only gate delta
`make lint` also runs golangci with `GOOS=windows` over current main. That reports seven findings in unchanged Canopi Windows files introduced by #171; GitHub quality lint is Linux-only and current main is green. This PR does not alter Canopi.