### PR TITLE
Fix Windows lint gate before first alpha

### DIFF
--- a/internal/canopi/store_pinned_windows.go
+++ b/internal/canopi/store_pinned_windows.go
@@ -145,24 +145,43 @@ func renamePinnedWindowsStateFile(directory *os.File, file *os.File, targetName 
 		return err
 	}
 	nameBytes := (len(name) - 1) * 2
+	nameLength, err := checkedWindowsInformationLength(nameBytes)
+	if err != nil {
+		return err
+	}
+	nameUnits := nameBytes / 2
+	if nameUnits > windows.MAX_LONG_PATH {
+		return errors.New("canopi state filename is too long")
+	}
 	var information pinnedWindowsFileRenameInformation
 	buffer := make([]byte, int(unsafe.Offsetof(information.FileName))+nameBytes)
-	typed := (*pinnedWindowsFileRenameInformation)(unsafe.Pointer(&buffer[0]))
+	bufferLength, err := checkedWindowsInformationLength(len(buffer))
+	if err != nil {
+		return err
+	}
+	typed := (*pinnedWindowsFileRenameInformation)(unsafe.Pointer(&buffer[0])) // #nosec G103 -- buffer is sized for this documented variable-length Windows structure.
 	typed.ReplaceIfExists = windows.FILE_RENAME_REPLACE_IF_EXISTS | windows.FILE_RENAME_POSIX_SEMANTICS
 	typed.RootDirectory = windows.Handle(directory.Fd())
-	typed.FileNameLength = uint32(nameBytes)
-	copy((*[windows.MAX_LONG_PATH]uint16)(unsafe.Pointer(&typed.FileName[0]))[:nameBytes/2:nameBytes/2], name)
+	typed.FileNameLength = nameLength
+	copy((*[windows.MAX_LONG_PATH]uint16)(unsafe.Pointer(&typed.FileName[0]))[:nameUnits:nameUnits], name) // #nosec G103 -- the checked name length bounds this documented trailing array.
 	var iosb windows.IO_STATUS_BLOCK
-	return windows.NtSetInformationFile(windows.Handle(file.Fd()), &iosb, &buffer[0], uint32(len(buffer)), windows.FileRenameInformation)
+	return windows.NtSetInformationFile(windows.Handle(file.Fd()), &iosb, &buffer[0], bufferLength, windows.FileRenameInformation)
 }
 
 func discardPinnedWindowsStateFile(file *os.File) error {
 	var iosb windows.IO_STATUS_BLOCK
 	deleteFile := []byte{1}
-	err := windows.NtSetInformationFile(windows.Handle(file.Fd()), &iosb, &deleteFile[0], uint32(len(deleteFile)), windows.FileDispositionInformation)
+	err := windows.NtSetInformationFile(windows.Handle(file.Fd()), &iosb, &deleteFile[0], 1, windows.FileDispositionInformation)
 	closeErr := file.Close()
 	if err != nil {
 		return err
 	}
 	return closeErr
+}
+
+func checkedWindowsInformationLength(length int) (uint32, error) {
+	if length < 0 || uint64(length) > uint64(^uint32(0)) {
+		return 0, errors.New("windows file information is too large")
+	}
+	return uint32(length), nil // #nosec G115 -- the range is checked above.
 }

--- a/internal/canopi/store_pinned_windows_test.go
+++ b/internal/canopi/store_pinned_windows_test.go
@@ -1,0 +1,40 @@
+//go:build windows
+
+package canopi
+
+import (
+	"math"
+	"testing"
+)
+
+func TestCheckedWindowsInformationLength(t *testing.T) {
+	t.Parallel()
+
+	for _, testCase := range []struct {
+		length int
+		want   uint32
+	}{
+		{length: 0, want: 0},
+		{length: 1, want: 1},
+		{length: math.MaxUint32, want: math.MaxUint32},
+	} {
+		got, err := checkedWindowsInformationLength(testCase.length)
+		if err != nil {
+			t.Fatalf("checkedWindowsInformationLength(%d): %v", testCase.length, err)
+		}
+		if got != testCase.want {
+			t.Fatalf("checkedWindowsInformationLength(%d) = %d, want %d", testCase.length, got, testCase.want)
+		}
+	}
+}
+
+func TestCheckedWindowsInformationLengthRejectsOverflow(t *testing.T) {
+	t.Parallel()
+
+	if uint64(^uint(0)) <= math.MaxUint32 {
+		t.Skip("int cannot represent a uint32 overflow on this platform")
+	}
+	if _, err := checkedWindowsInformationLength(int(uint64(math.MaxUint32) + 1)); err == nil {
+		t.Fatal("checkedWindowsInformationLength accepted a uint32 overflow")
+	}
+}

--- a/internal/canopi/store_privacy_windows.go
+++ b/internal/canopi/store_privacy_windows.go
@@ -40,46 +40,6 @@ func privateStateFile(path string, info os.FileInfo) bool {
 	return info.Mode().IsRegular() && info.Mode()&os.ModeSymlink == 0 && privateStateWindowsACL(path)
 }
 
-func openStateFile(path string) (*os.File, error) {
-	name, err := windows.UTF16PtrFromString(path)
-	if err != nil {
-		return nil, err
-	}
-	handle, err := windows.CreateFile(name, windows.GENERIC_READ, windows.FILE_SHARE_READ, nil, windows.OPEN_EXISTING, windows.FILE_ATTRIBUTE_NORMAL|windows.FILE_FLAG_OPEN_REPARSE_POINT, 0) // #nosec G304 -- absolute operator-selected state path is validated before and after open.
-	if err != nil {
-		return nil, err
-	}
-	var details windows.ByHandleFileInformation
-	if err := windows.GetFileInformationByHandle(handle, &details); err != nil || details.FileAttributes&windows.FILE_ATTRIBUTE_REPARSE_POINT != 0 || details.FileAttributes&windows.FILE_ATTRIBUTE_DIRECTORY != 0 {
-		_ = windows.CloseHandle(handle)
-		if err != nil {
-			return nil, err
-		}
-		return nil, os.ErrInvalid
-	}
-	return os.NewFile(uintptr(handle), path), nil // #nosec G115 -- successful Win32 handles are nonnegative.
-}
-
-func openPrivateStateFile(path string) (*os.File, error) {
-	before, err := os.Lstat(path)
-	if err != nil {
-		return nil, err
-	}
-	if !privateStateFile(path, before) {
-		return nil, errors.New("canopi state must be a private current-user-owned regular file")
-	}
-	file, err := openStateFile(path)
-	if err != nil {
-		return nil, err
-	}
-	after, err := file.Stat()
-	if err != nil || !os.SameFile(before, after) || !privateStateFile(path, after) {
-		_ = file.Close()
-		return nil, errors.New("canopi state changed while opening")
-	}
-	return file, nil
-}
-
 func protectStateFile(path string, file *os.File) error {
 	if err := setPrivateStateACL(path); err != nil {
 		return err


### PR DESCRIPTION
Closes #174.

## What changed

- remove two superseded Windows-only state open helpers
- bounds-check native file-information lengths before `uint32` conversion
- document the two required unsafe casts around the Windows variable-length rename structure
- cover accepted and rejected conversion bounds in a Windows-target test

## Validation

- `GOOS=windows GOARCH=amd64 go test -c -o /tmp/punaro-canopi-windows.test ./internal/canopi`
- `go test ./internal/canopi`
- `make test test-race lint security release-gates`
- 0 reachable vulnerabilities, 0 gosec issues across 322 files, and no leaks

Bugbot quota/missing status is waived per owner instruction; any substantive reviewer finding remains blocking.