### PR TITLE
Enable SBOM and provenance in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -247,6 +247,7 @@ jobs:
       - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:
           go-version-file: go.mod
+      - uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
       - name: Publish image with SBOM and provenance
         id: publish
         env:

--- a/scripts/verify-deployment-files.sh
+++ b/scripts/verify-deployment-files.sh
@@ -125,6 +125,10 @@ if ! grep -Fq 'https://github.com/rock3r/punaro/releases/download' .github/workf
 	printf '%s\n' 'release workflow must name the fixed GitHub Releases origin' >&2
 	exit 1
 fi
+if ! grep -Fq 'docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0' .github/workflows/release.yml; then
+	printf '%s\n' 'release workflow must configure an attestation-capable pinned Buildx builder' >&2
+	exit 1
+fi
 "$release_assemble_test"
 "$release_publish_test"
 "$macos_sign_test"


### PR DESCRIPTION
Closes #176.

The first alpha candidate preflight passed, but image publication failed before creating an image or draft release because the default Docker driver does not support attestations.

## Change

- configure the current official `docker/setup-buildx-action` v4.3.0 at immutable commit `37fe631027851001ddb9b187196cc803df7f5f0e`
- assert the pinned attestation-capable builder in deployment verification

## Evidence

- failing run: https://github.com/rock3r/punaro/actions/runs/32746528767
- RED: deployment assertion absent before the workflow change
- GREEN: `make workflow-lint deployment-lint test test-race lint security release-gates`
- zero reachable vulnerabilities, zero gosec findings across 322 files, no leaks

Bugbot quota/missing status is waived per owner instruction; substantive reviewer findings remain blocking.