### PR TITLE
fix(release): harden Windows candidate builds

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -101,6 +101,16 @@ jobs:
       - run: go test ./cmd/punaro-memory -run '^TestWindows'
 
       - run: go test ./internal/memoryclient -run '^TestWindows'
+      - name: Build release artifacts on Windows
+        shell: bash
+        run: |
+          version=$(sed -n 's/.*"version": *"\([^"]*\)".*/\1/p' plugin.json)
+          ./scripts/build-release-artifacts.sh \
+            --output-dir "$RUNNER_TEMP/release-smoke" \
+            --release "v$version" \
+            --sequence 1 \
+            --catalog-sequence 1 \
+            --image "ghcr.io/rock3r/punaro@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
       - run: go vet ./...
       - run: go build ./...
       - shell: pwsh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -266,6 +266,7 @@ jobs:
           skill_sha256=$(printf '%s\n' "$facts" | jq -er .skill_set_sha256)
           plugin_runtime_sha256=$(printf '%s\n' "$facts" | jq -er .plugin_runtime_sha256)
           printf '%s' "$GHCR_TOKEN" | docker login ghcr.io --username "$GITHUB_ACTOR" --password-stdin
+          candidate_tag=$(./scripts/release-candidate-tag.sh "$GITHUB_SHA" "$GITHUB_RUN_ID" "$GITHUB_RUN_ATTEMPT")
           metadata="$RUNNER_TEMP/punaro-image-metadata.json"
           docker buildx build \
             --platform linux/amd64 \
@@ -282,7 +283,7 @@ jobs:
             --label "org.opencontainers.image.revision=$GITHUB_SHA" \
             --label "org.opencontainers.image.version=$RELEASE" \
             --metadata-file "$metadata" \
-            --tag "$repository:$RELEASE" \
+            --tag "$repository:$candidate_tag" \
             --push .
           digest=$(jq -er '."containerimage.digest"' "$metadata")
           case "$digest" in sha256:[0-9a-f][0-9a-f]*) ;; *) printf '%s\n' 'published image digest is invalid' >&2; exit 2 ;; esac

--- a/docs/github-releases.md
+++ b/docs/github-releases.md
@@ -61,11 +61,16 @@ retention policy advance it. Only after that
 read-only preflight passes does it publish the Linux/amd64 gateway image to GHCR
 with OCI SBOM and provenance attestations, capture its registry digest, and bind
 that exact `ghcr.io/rock3r/punaro@sha256:...` identity into the release manifest
-and native build provenance. Invalid or reused release requests therefore
-cannot create or move an official image tag. The image carries the release name
-as `org.opencontainers.image.version`; its pre-digest operator binary is bound
-to the release-tagged GHCR repository identity known at build time and requires
-a digest-pinned installation from that repository. It then builds:
+and native build provenance. The pushed image uses a validated run-scoped
+candidate tag containing only the source commit, workflow run, and attempt, so
+its length is independent of the release name and remains within Docker's tag
+limit. A failed or retried candidate therefore cannot move a release-named image
+tag. The candidate tag is not an update authority. The image carries the release
+name as
+`org.opencontainers.image.version`; its pre-digest operator binary is bound to
+the release-named GHCR repository identity known at build time so doctor can
+compare the final digest-pinned installation from that repository. The
+release-named identity is embedded metadata, not a pushed tag. It then builds:
 
 - `punaro-adapter`, `punaro-trusted-attachment`, `punaro-memory`,
   `punaro-enroll`, and `punaro-bootstrap` for `darwin/arm64`, `linux/amd64`,

--- a/scripts/build-release-artifacts.sh
+++ b/scripts/build-release-artifacts.sh
@@ -51,10 +51,16 @@ fi
 script_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
 repo_dir=$(CDPATH= cd -- "$script_dir/.." && pwd)
 [ -f "$repo_dir/go.mod" ] && [ -d "$repo_dir/cmd/punaro-adapter" ] || fail 'run this builder from a complete Punaro source checkout'
+plugin_root=$repo_dir
+host_os=$(env -u GOOS -u GOARCH -u CGO_ENABLED go env GOHOSTOS)
+if [ "$host_os" = windows ]; then
+	command -v cygpath >/dev/null 2>&1 || fail 'cygpath is required for Windows release builds'
+	plugin_root=$(cygpath -w "$repo_dir") || fail 'Windows plugin root is invalid'
+fi
 
 facts=$(
 	cd "$repo_dir"
-	env -u GOOS -u GOARCH -u CGO_ENABLED go run ./cmd/punaro-release build-facts --release "$release" --plugin-root "$repo_dir"
+	env -u GOOS -u GOARCH -u CGO_ENABLED go run ./cmd/punaro-release build-facts --release "$release" --plugin-root "$plugin_root"
 ) || fail 'release build identity is invalid'
 compose_sha256=$(printf '%s\n' "$facts" | sed -n 's/.*"compose_sha256":"\([0-9a-f]*\)".*/\1/p')
 migration_sha256=$(printf '%s\n' "$facts" | sed -n 's/.*"migration_manifest_sha256":"\([0-9a-f]*\)".*/\1/p')

--- a/scripts/release-candidate-tag.sh
+++ b/scripts/release-candidate-tag.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+set -eu
+
+fail() {
+	printf '%s\n' "$1" >&2
+	exit 2
+}
+
+[ "$#" -eq 3 ] || fail 'usage: release-candidate-tag.sh GITHUB_SHA GITHUB_RUN_ID GITHUB_RUN_ATTEMPT'
+
+sha=$1
+run_id=$2
+attempt=$3
+
+[ "${#sha}" -eq 40 ] || fail 'GitHub commit SHA must contain 40 lowercase hexadecimal characters'
+case "$sha" in *[!0-9a-f]*) fail 'GitHub commit SHA must contain 40 lowercase hexadecimal characters' ;; esac
+case "$run_id" in '' | *[!0-9]*) fail 'GitHub workflow run ID must be numeric' ;; esac
+case "$attempt" in '' | *[!0-9]*) fail 'GitHub workflow run attempt must be numeric' ;; esac
+
+tag="candidate-$sha-$run_id-$attempt"
+[ "${#tag}" -le 128 ] || fail 'release candidate tag exceeds the Docker tag limit'
+
+printf '%s\n' "$tag"

--- a/scripts/test-release-candidate-tag.sh
+++ b/scripts/test-release-candidate-tag.sh
@@ -1,0 +1,51 @@
+#!/bin/sh
+set -eu
+
+repo_dir=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+generator="$repo_dir/scripts/release-candidate-tag.sh"
+
+sha=ffffffffffffffffffffffffffffffffffffffff
+run_id=18446744073709551615
+attempt=4294967295
+expected="candidate-$sha-$run_id-$attempt"
+
+actual=$($generator "$sha" "$run_id" "$attempt")
+[ "$actual" = "$expected" ] || {
+	printf '%s\n' 'release candidate tag is not deterministic' >&2
+	exit 1
+}
+[ "${#actual}" -le 128 ] || {
+	printf '%s\n' 'release candidate tag exceeds the Docker limit' >&2
+	exit 1
+}
+printf '%s\n' "$actual" | grep -Eq '^[A-Za-z0-9_][A-Za-z0-9_.-]{0,127}$' || {
+	printf '%s\n' 'release candidate tag is not Docker-compatible' >&2
+	exit 1
+}
+
+next=$($generator "$sha" "$run_id" 2)
+[ "$next" != "$actual" ] || {
+	printf '%s\n' 'release candidate tag does not distinguish workflow attempts' >&2
+	exit 1
+}
+
+if "$generator" "$sha" "$(printf '%0130d' 1)" 1 >/dev/null 2>&1; then
+	printf '%s\n' 'release candidate tag generator accepted an oversized tag' >&2
+	exit 1
+fi
+if "$generator" invalid-sha 1 1 >/dev/null 2>&1; then
+	printf '%s\n' 'release candidate tag generator accepted an invalid commit SHA' >&2
+	exit 1
+fi
+if "$generator" "$sha" run 1 >/dev/null 2>&1; then
+	printf '%s\n' 'release candidate tag generator accepted an invalid run ID' >&2
+	exit 1
+fi
+if "$generator" "$sha" 1 attempt >/dev/null 2>&1; then
+	printf '%s\n' 'release candidate tag generator accepted an invalid attempt' >&2
+	exit 1
+fi
+if "$generator" "$sha" 1 1 unexpected >/dev/null 2>&1; then
+	printf '%s\n' 'release candidate tag generator accepted an unexpected release-name argument' >&2
+	exit 1
+fi

--- a/scripts/verify-deployment-files.sh
+++ b/scripts/verify-deployment-files.sh
@@ -23,20 +23,22 @@ production_compose_test=scripts/test-production-compose.sh
 production_compose_bootstrap_test=scripts/test-production-compose-bootstrap.sh
 memory_onboarding_e2e_test=scripts/test-memory-onboarding-e2e.sh
 release_artifact_builder=scripts/build-release-artifacts.sh
+release_candidate_tag_generator=scripts/release-candidate-tag.sh
+release_candidate_tag_test=scripts/test-release-candidate-tag.sh
 release_assemble_test=scripts/test-assemble-release.sh
 release_publish_test=scripts/test-publish-signed-release.sh
 macos_sign_script=scripts/sign-notarize-macos.sh
 macos_import_script=scripts/import-macos-signing-cert.sh
 macos_sign_test=scripts/test-sign-notarize-macos.sh
 
-for path in "$unit" "$example" "$launch_agent" "$adapter_installer" "$client_installer" "$adapter_installer_test" "$server_installer" "$server_installer_test" "$attachment_relay_configurer" "$attachment_relay_configurer_test" "$agent_guidance_installer" "$agent_guidance_installer_test" "$windows_client_installer" "$windows_guidance_installer" "$windows_client_installer_test" "$windows_adapter_runner" "$windows_environment_importer" "$production_compose_verifier" "$production_compose_test" "$production_compose_bootstrap_test" "$memory_onboarding_e2e_test" "$release_artifact_builder" "$release_assemble_test" "$release_publish_test" "$macos_sign_script" "$macos_import_script" "$macos_sign_test" scripts/production-compose deploy/compose/postgres-bootstrap.sh deploy/compose/postgres-entrypoint.sh docker-compose.memory-onboarding-e2e.yml .github/workflows/release.yml .github/workflows/macos-notarize.yml deploy/macos/hardened-runtime.entitlements; do
+for path in "$unit" "$example" "$launch_agent" "$adapter_installer" "$client_installer" "$adapter_installer_test" "$server_installer" "$server_installer_test" "$attachment_relay_configurer" "$attachment_relay_configurer_test" "$agent_guidance_installer" "$agent_guidance_installer_test" "$windows_client_installer" "$windows_guidance_installer" "$windows_client_installer_test" "$windows_adapter_runner" "$windows_environment_importer" "$production_compose_verifier" "$production_compose_test" "$production_compose_bootstrap_test" "$memory_onboarding_e2e_test" "$release_artifact_builder" "$release_candidate_tag_generator" "$release_candidate_tag_test" "$release_assemble_test" "$release_publish_test" "$macos_sign_script" "$macos_import_script" "$macos_sign_test" scripts/production-compose deploy/compose/postgres-bootstrap.sh deploy/compose/postgres-entrypoint.sh docker-compose.memory-onboarding-e2e.yml .github/workflows/release.yml .github/workflows/macos-notarize.yml deploy/macos/hardened-runtime.entitlements; do
 	if [ ! -f "$path" ]; then
 		printf '%s\n' "missing adapter deployment artifact: $path" >&2
 		exit 1
 	fi
 done
 
-for executable in "$adapter_installer" "$client_installer" "$adapter_installer_test" "$server_installer" "$server_installer_test" "$attachment_relay_configurer" "$attachment_relay_configurer_test" "$agent_guidance_installer" "$agent_guidance_installer_test" "$windows_client_installer_test" "$production_compose_verifier" "$production_compose_test" "$production_compose_bootstrap_test" "$memory_onboarding_e2e_test" "$release_artifact_builder" "$release_assemble_test" "$release_publish_test" "$macos_sign_script" "$macos_import_script" "$macos_sign_test" scripts/production-compose deploy/compose/postgres-bootstrap.sh deploy/compose/postgres-entrypoint.sh; do
+for executable in "$adapter_installer" "$client_installer" "$adapter_installer_test" "$server_installer" "$server_installer_test" "$attachment_relay_configurer" "$attachment_relay_configurer_test" "$agent_guidance_installer" "$agent_guidance_installer_test" "$windows_client_installer_test" "$production_compose_verifier" "$production_compose_test" "$production_compose_bootstrap_test" "$memory_onboarding_e2e_test" "$release_artifact_builder" "$release_candidate_tag_generator" "$release_candidate_tag_test" "$release_assemble_test" "$release_publish_test" "$macos_sign_script" "$macos_import_script" "$macos_sign_test" scripts/production-compose deploy/compose/postgres-bootstrap.sh deploy/compose/postgres-entrypoint.sh; do
 	if [ ! -x "$executable" ]; then
 		printf '%s\n' "deployment helper is not executable: $executable" >&2
 		exit 1
@@ -129,6 +131,19 @@ if ! grep -Fq 'docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f
 	printf '%s\n' 'release workflow must configure an attestation-capable pinned Buildx builder' >&2
 	exit 1
 fi
+if ! grep -Fq 'candidate_tag=$(./scripts/release-candidate-tag.sh "$GITHUB_SHA" "$GITHUB_RUN_ID" "$GITHUB_RUN_ATTEMPT")' .github/workflows/release.yml; then
+	printf '%s\n' 'release workflow must publish under a validated run-scoped candidate image tag' >&2
+	exit 1
+fi
+if ! grep -Fq 'cygpath -w "$repo_dir"' "$release_artifact_builder"; then
+	printf '%s\n' 'release artifact builder must normalize its plugin root for native Windows tools' >&2
+	exit 1
+fi
+if ! grep -Fq 'Build release artifacts on Windows' .github/workflows/quality.yml; then
+	printf '%s\n' 'quality workflow must exercise the release artifact builder on Windows' >&2
+	exit 1
+fi
 "$release_assemble_test"
 "$release_publish_test"
 "$macos_sign_test"
+"$release_candidate_tag_test"


### PR DESCRIPTION
## Summary
- normalize the Git Bash checkout path before native Windows release identity validation
- smoke-test the actual release artifact builder in Windows quality CI
- publish GHCR release candidates under immutable run-scoped tags while retaining digest-bound release identity metadata
- document and mechanically verify both contracts

## RED
- release workflow run 32749729035 failed on windows/amd64 with `release build facts are invalid` / `release build identity is invalid`
- local deployment assertions proved Windows path normalization and retry-safe candidate tags were absent

## GREEN
- `make test test-race lint`
- `make workflow-lint deployment-lint`
- `make security release-gates`
- Windows cross-build lint passed
- actionlint passed
- govulncheck found no reachable vulnerabilities
- gosec: 322 files, 93,803 lines, 0 issues
- gitleaks: no leaks
- release publisher tests passed

Closes #178
Closes #179