### PR TITLE
docs: record alpha.1 release evidence

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -34,7 +34,7 @@ jobs:
       - run: CGO_ENABLED=0 go run github.com/securego/gosec/v2/cmd/gosec@v2.22.10 -exclude-generated ./...
       - run: go run github.com/zricethezav/gitleaks/v8@v8.27.2 detect --source . --no-git
       - run: make fuzz
-      - run: ./scripts/verify-release-gates.sh
+      - run: make release-gates
 
   postgres:
     name: PostgreSQL integration

--- a/Makefile
+++ b/Makefile
@@ -92,6 +92,7 @@ lint: vet staticcheck golangci windows-build deployment-lint
 security: vuln gosec secrets
 
 release-gates:
+	./scripts/test-release-gates.sh
 	./scripts/verify-release-gates.sh
 
 fuzz:

--- a/docs/release-evidence/2026-08-24-v0.1.0-alpha.1.md
+++ b/docs/release-evidence/2026-08-24-v0.1.0-alpha.1.md
@@ -1,0 +1,194 @@
+# v0.1.0-alpha.1 personal self-hosted release evidence
+
+## Decision and scope
+
+- **Decision:** approved for controlled personal self-hosted installation and
+  update testing on the Punaro fleet.
+- **Release capability:** signed, digest-pinned core Punaro gateway, adapter,
+  bootstrap, enrollment, memory, Telegram, and local trusted-attachment client
+  binaries. This decision does not authorize sensitive attachment content or a
+  public relay.
+- **Source commit:**
+  [`753c27fa33f5ddf057ea0e2ba401336a99b69d68`](https://github.com/rock3r/punaro/commit/753c27fa33f5ddf057ea0e2ba401336a99b69d68)
+- **Release reference:**
+  [`v0.1.0-alpha.1`](https://github.com/rock3r/punaro/releases/tag/v0.1.0-alpha.1),
+  targeted at the source commit above. The GitHub release remains a draft until
+  the exact manifest and catalog bytes recorded below are published with their
+  detached signatures.
+- **Release sequence:** `1`; **catalog sequence:** `1`;
+  **minimum safe sequence:** `1`.
+- **Catalog lifetime:** `2026-08-24T17:33:25Z` through
+  `2026-08-31T17:33:25Z`.
+
+This is a personal self-hosted alpha under the allowance in
+[`security-release-gates.md`](../security-release-gates.md). It is not an
+official Internet-facing production release.
+
+## Build, review, and workflow evidence
+
+- Implementation and final release-only review:
+  [PR #180](https://github.com/rock3r/punaro/pull/180). The repository watcher
+  reported `5/5` terminal checks, `CLEAN`/mergeable state, no blocking review
+  items, and idle Codex review on head `4a92588`. Two substantive Codex P2
+  findings about Docker tag length and SemVer `+` metadata were fixed with an
+  executable boundary test before merge. Bugbot was unavailable; the operator
+  accepted the explicit temporary quota waiver for this personal alpha.
+- Final PR CI:
+  [run 32755991706](https://github.com/rock3r/punaro/actions/runs/32755991706).
+  Configuration lint, Go tests and analysis, PostgreSQL integration, complete
+  product E2E, and the Windows client/release-builder smoke all passed.
+- Release workflow:
+  [run 32756803002](https://github.com/rock3r/punaro/actions/runs/32756803002)
+  completed successfully from the exact source commit.
+  - [Preflight](https://github.com/rock3r/punaro/actions/runs/32756803002/job/97526126086)
+    validated the release and catalog advancement before publication.
+  - [Image publication](https://github.com/rock3r/punaro/actions/runs/32756803002/job/97526264635)
+    published the digest-pinned image with OCI SBOM and provenance attestations.
+  - Native builds passed for
+    [darwin/arm64](https://github.com/rock3r/punaro/actions/runs/32756803002/job/97526654892),
+    [linux/amd64](https://github.com/rock3r/punaro/actions/runs/32756803002/job/97526654937),
+    [linux/arm64](https://github.com/rock3r/punaro/actions/runs/32756803002/job/97526654985),
+    and [windows/amd64](https://github.com/rock3r/punaro/actions/runs/32756803002/job/97526655027).
+  - [Assembly](https://github.com/rock3r/punaro/actions/runs/32756803002/job/97527597583)
+    produced the exact unsigned manifest/catalog pair and draft release.
+
+The following commands passed on the final source or the exact downloaded
+candidate. Owner-only absolute paths are represented by `$SOURCE` and
+`$SIGNING_DIR`; their values are not release data.
+
+```sh
+./scripts/test-release-candidate-tag.sh
+make deployment-lint
+GOCACHE=/tmp/punaro-go-cache-release make test workflow-lint security release-gates
+go run ./cmd/punaro-release verify-artifacts \
+  --manifest "$SIGNING_DIR/punaro-release.json" \
+  --dir "$SIGNING_DIR"
+go run ./cmd/punaro-release sign \
+  --key-id punaro-release-1 \
+  --key-file "$SIGNING_DIR/../punaro-release.key" \
+  --in "$SIGNING_DIR/punaro-release.json" \
+  --out "$SIGNING_DIR/punaro-release.sig"
+go run ./cmd/punaro-release sign \
+  --key-id punaro-release-1 \
+  --key-file "$SIGNING_DIR/../punaro-release.key" \
+  --in "$SIGNING_DIR/punaro-catalog.json" \
+  --out "$SIGNING_DIR/punaro-catalog.sig"
+go run ./cmd/punaro-release verify \
+  --keys-file "$SIGNING_DIR/../punaro-release.pub" \
+  --document "$SIGNING_DIR/punaro-release.json" \
+  --signature "$SIGNING_DIR/punaro-release.sig"
+go run ./cmd/punaro-release verify \
+  --keys-file "$SIGNING_DIR/../punaro-release.pub" \
+  --document "$SIGNING_DIR/punaro-catalog.json" \
+  --signature "$SIGNING_DIR/punaro-catalog.sig"
+docker manifest inspect --verbose \
+  ghcr.io/rock3r/punaro@sha256:11f8ab5e73c0f9baa4b27ed2ffd6bc9363a390c4731a1469c8dc1e52e620d868
+```
+
+Results: full tests passed; `govulncheck` found zero reachable
+vulnerabilities; gosec scanned 322 files and 93,803 lines with zero issues;
+gitleaks found no leaks; actionlint, deployment contracts, release gates, and
+exact artifact/signature verification passed. The private signing directory
+was mode `0700` and the private key was mode `0600`; private key material was
+never printed, uploaded, or copied into the repository.
+
+## Image, SBOM, and provenance
+
+- Digest-pinned image:
+  `ghcr.io/rock3r/punaro@sha256:11f8ab5e73c0f9baa4b27ed2ffd6bc9363a390c4731a1469c8dc1e52e620d868`
+- Linux/amd64 image manifest:
+  `sha256:c1e9b6610330089b6967a0cf1663219c9f1d39cfafa046e9fc7b7e0681feccce`
+- OCI attestation manifest:
+  `sha256:92441bc73825fe9b38a8795d9a6110e92d14c21fb380590b5070cf6909aa93dc`
+- SPDX SBOM in-toto layer:
+  `sha256:23713e38e245d7dfc7fbceadb9ae8b5f2fdc82288c8e1b357dda857c3b206e83`
+- SLSA provenance v1 in-toto layer:
+  `sha256:58f91912691866b920e29d8269fb4b81ff7d5482ff1764f3655d5cd95c3e2706`
+- Registry page:
+  [ghcr.io/rock3r/punaro](https://github.com/rock3r/punaro/pkgs/container/punaro).
+  The immutable digests above, not a mutable package tag or page, identify the
+  reviewed objects.
+
+## Signed documents
+
+| File | SHA-256 |
+| --- | --- |
+| `punaro-release.json` | `3f1f92f4a6a4834eb01125946984593730ed5a054e105cdd9e242fecd172ab32` |
+| `punaro-release.sig` | `bdaff233bcb5558ffd9c40179159e78c58231e6a8ddb09b30e7333228f647961` |
+| `punaro-catalog.json` | `63e37fd33feaf7bffb551b5d2fdcdb35455d2ea8943ad07f2c8f897c13d2b256` |
+| `punaro-catalog.sig` | `26c2665f8237beae3d2e1ce76ce09f1194a136a9c3c8e63d340793ddd1aae9b6` |
+
+## Native artifact checksums
+
+The release CLI verified every downloaded byte against the manifest. These are
+the manifest-bound binaries for each supported target:
+
+| Artifact | OS/architecture | SHA-256 |
+| --- | --- | --- |
+| `punaro-adapter-darwin-arm64` | darwin/arm64 | `ed6e38770d42912474fa55a81b13eeb6b248281adf13c4b4da1bbaa36465eb6c` |
+| `punaro-adapter-linux-amd64` | linux/amd64 | `bcf319db54cfd4e1643ca97c55579c3152af744a3878287e65bc0d9fe3cebc4d` |
+| `punaro-adapter-linux-arm64` | linux/arm64 | `6497908b7500843e98174fc211c51a0b8a71dee6dea925447a60d0646a464c25` |
+| `punaro-adapter-windows-amd64.exe` | windows/amd64 | `fc7c38e65376497b92df6a0a8119cfa936b95edc55630d5f20b00214e7ca882f` |
+| `punaro-bootstrap-darwin-arm64` | darwin/arm64 | `22988cf47df4f00774e143c5ce3214d8a795d77490263bb2735d9bda99adcc42` |
+| `punaro-bootstrap-linux-amd64` | linux/amd64 | `878a91ab1c1be6e81f82cfbf225020d7384ecbb3ee70c9975f17977391c10b4e` |
+| `punaro-bootstrap-linux-arm64` | linux/arm64 | `26352bd313193c1c955b34f59355c0c545aa287064b827ad9ffb9ef0c634f2d1` |
+| `punaro-bootstrap-windows-amd64.exe` | windows/amd64 | `a1c1e6b898fa852adc807ab5c3ac77b8ce7fd368691d09a361125944c8e42373` |
+| `punaro-enroll-darwin-arm64` | darwin/arm64 | `981c255b655add58fbf614ebdffcfc39df1af33da209c4bd5addf23320b6435d` |
+| `punaro-enroll-linux-amd64` | linux/amd64 | `147b0a7c586f6e1887a0a7e9610ebcf89e3cfcd118a2ccc88c7b4b9e918bcbb9` |
+| `punaro-enroll-linux-arm64` | linux/arm64 | `adf0421ed19ba6ce2229e516bf232c41bc883a892b43115438673ebd777572d1` |
+| `punaro-enroll-windows-amd64.exe` | windows/amd64 | `cd297cdcd205f6e3215a83d56e6a293fa4e98caae65ff1501750d09df69ab1db` |
+| `punaro-linux-amd64` | linux/amd64 | `bede00293f74698ea95da5c9355e03b3e88b7a8ceb4d46c38814fb7befa20585` |
+| `punaro-linux-arm64` | linux/arm64 | `33e0935486d27077d3ac48f9b6523b0de1d62298f705b0d45814a8498141742d` |
+| `punaro-memory-darwin-arm64` | darwin/arm64 | `8b446923cdc1ed74478cb6667f5d2c7484c56dbfd7d814bfe6683b22ae1735d1` |
+| `punaro-memory-linux-amd64` | linux/amd64 | `bb8e23d6e38db555fd6cfc15641cb45c34161f1360b36878b975d1b2c7321fba` |
+| `punaro-memory-linux-arm64` | linux/arm64 | `989ceb3433391932dbb3f7d8f7e4e056fb755c180b93beb80ab3f1800082188c` |
+| `punaro-memory-windows-amd64.exe` | windows/amd64 | `acdfd7538c0f962d8f37deae5215f7772eb84580725db6505b8f3f8c16418970` |
+| `punaro-relay-adopt-prepare-linux-amd64` | linux/amd64 | `d2d1d46c50cecd42bb61b5b3916ff649019c18cd9926f513719161368acf8060` |
+| `punaro-relay-adopt-prepare-linux-arm64` | linux/arm64 | `fae7833476793440db27e6274d3d57357b98fd9436c56adc17853a810b07df2d` |
+| `punaro-telegram-linux-amd64` | linux/amd64 | `519086c5886d537286ce83d4af92fade7bb6a07f62f811269cfb84cd31439bb4` |
+| `punaro-telegram-linux-arm64` | linux/arm64 | `5620935949ab311cae86be6e57d29e509a7324cf6b9889173bf056700f18131e` |
+| `punaro-trusted-attachment-darwin-arm64` | darwin/arm64 | `62734acc8a925ad88c5e461a2ec8250d80981741768b68201c0fda3cb07c1e99` |
+| `punaro-trusted-attachment-linux-amd64` | linux/amd64 | `de61883aa45d80f384323ce5017af959977d0027df37df82316ef81d72cf7e47` |
+| `punaro-trusted-attachment-linux-arm64` | linux/arm64 | `613502d7757580ff3ca6018635ccdd8ae99ab4e52fccb94644c7e8b3881961c2` |
+| `punaro-trusted-attachment-windows-amd64.exe` | windows/amd64 | `8893fefa9d397a40783840fa7b907b366f04d6b951b7a37d4fa0577b586520a9` |
+
+## Approvers, gates, and residual risk
+
+- **Security approver:** Sebastiano Poggi, operator self-review for this personal
+  self-hosted alpha. No independent production security approval is claimed.
+- **Release-signature/cryptography approver:** Sebastiano Poggi, limited to the
+  detached release envelope and offline-key handling described above. No
+  attachment-protocol cryptography approval is claimed.
+- **Operations approver:** Sebastiano Poggi, limited to controlled deployment on
+  the named personal fleet.
+- **Independent automated review:** Codex review on PR #180; all substantive
+  findings were addressed and resolved. Independent Pioneer review remains
+  unavailable because the local Pi model configuration is invalid and must be
+  completed before the overall release goal is closed.
+
+No checkbox in [`security-release-gates.md`](../security-release-gates.md) is
+changed or treated as checked by this record:
+
+- [Trusted-relay attachments](../security-release-gates.md#trusted-relay-attachments-gated-candidate-closed)
+  remain closed; no sensitive attachment content is authorized.
+- [Attachment v2](../security-release-gates.md#attachment-v2-superseded-closed)
+  and [attachment v3](../security-release-gates.md#attachment-v3-controlled-runtime-superseded-not-released)
+  remain superseded and unreleased.
+- [Public relay and operations](../security-release-gates.md#public-relay-and-operations-closed)
+  remain closed; the release does not authorize public runtime exposure.
+
+Residual risks and controls:
+
+- Sequence `1` has no prior signed catalog entry, so automated rollback is not
+  available until alpha.2 exists. Before alpha.2, recovery is restoration of
+  the pre-release service/client backups and the previously installed build.
+- Fleet clean-install, durable messaging, Telegram recovery, doctor, restart,
+  interrupted-update, alpha.1-to-alpha.2 update, and rollback drills are still
+  pending. This release is approved specifically to run those controlled
+  drills; their results must be recorded before the overall alpha goal closes.
+- The short-lived catalog expires on `2026-08-31T17:33:25Z`. If alpha.2 and its
+  retained signed catalog are not published before then, new installs/updates
+  fail closed until a reviewed catalog is published.
+- The Git tag is not asserted as a production signed tag. Trust is rooted in the
+  digest-bound artifacts and the offline-signed manifest/catalog. This remains
+  a personal alpha, not an official Internet-facing production release.

--- a/docs/release-evidence/README.md
+++ b/docs/release-evidence/README.md
@@ -21,4 +21,6 @@ Required fields:
 
 A record may mark a gate checked only when every listed field is present.  An
 unchecked gate remains unavailable even if a source branch contains partial
-implementation.
+implementation. A core personal self-hosted release record may coexist with
+all attachment and public-relay gates unchecked; the record documents the
+released core artifacts but grants no authority to use a gated capability.

--- a/scripts/test-release-gates.sh
+++ b/scripts/test-release-gates.sh
@@ -1,0 +1,59 @@
+#!/bin/sh
+set -eu
+
+release_gate_fixture=$(mktemp -d "${TMPDIR:-/tmp}/punaro-release-gates-test.XXXXXXXX")
+trap 'rm -rf "$release_gate_fixture"' EXIT HUP INT TERM
+
+mkdir -p "$release_gate_fixture/bin" "$release_gate_fixture/docs/release-evidence"
+cp scripts/verify-release-gates.sh "$release_gate_fixture/verify-release-gates.sh"
+
+printf '%s\n' \
+	'#!/bin/sh' \
+	'set -eu' \
+	'test "$*" = "test ./cmd/punarod -run ^TestRunFailsClosedBeforeStartingAttachmentRuntime$ -count=1"' \
+	': > "$PUNARO_RELEASE_GATES_GO_MARKER"' \
+	>"$release_gate_fixture/bin/go"
+chmod +x "$release_gate_fixture/bin/go" "$release_gate_fixture/verify-release-gates.sh"
+
+printf '%s\n' \
+	'# Core personal self-hosted evidence' \
+	'' \
+	'- **Decision:** approved for core personal self-hosted use.' \
+	'- **Gated capabilities:** withheld.' \
+	>"$release_gate_fixture/docs/release-evidence/core.md"
+printf '%s\n' \
+	'# Security release gates' \
+	'' \
+	'- [ ] Trusted-relay attachments remain closed.' \
+	'- [ ] Public relay remains closed.' \
+	>"$release_gate_fixture/docs/security-release-gates.md"
+
+release_gate_marker="$release_gate_fixture/go-called"
+(
+	cd "$release_gate_fixture"
+	PATH="$release_gate_fixture/bin:$PATH" \
+		PUNARO_RELEASE_GATES_GO_MARKER="$release_gate_marker" \
+		./verify-release-gates.sh
+)
+test -f "$release_gate_marker"
+
+rm "$release_gate_marker"
+printf '%s\n' \
+	'# Security release gates' \
+	'' \
+	'- [x] Trusted-relay attachments are open.' \
+	'- [ ] Public relay remains closed.' \
+	>"$release_gate_fixture/docs/security-release-gates.md"
+
+if (
+	cd "$release_gate_fixture"
+	PATH="$release_gate_fixture/bin:$PATH" \
+		PUNARO_RELEASE_GATES_GO_MARKER="$release_gate_marker" \
+		./verify-release-gates.sh
+) >/dev/null 2>&1; then
+	printf '%s\n' 'release gate verifier accepted checked gated-runtime authority' >&2
+	exit 1
+fi
+test ! -e "$release_gate_marker"
+
+printf '%s\n' release_gate_tests_passed

--- a/scripts/verify-release-gates.sh
+++ b/scripts/verify-release-gates.sh
@@ -1,18 +1,14 @@
 #!/bin/sh
 set -eu
 
-# This repository has no approved attachment release evidence.  Keep that fact
-# mechanically checked so a runtime-exposure change cannot silently accompany a
-# Markdown checklist edit.  An actual release requires a separately reviewed
-# change to this verifier, protected-branch policy, signed tag, and GitHub
-# environment approvals; CI alone cannot establish independent human approval.
+# This repository has no approved attachment release evidence. Keep the gated
+# runtime state mechanically checked so a core personal-release evidence record
+# cannot silently open an attachment or public-relay capability. An actual
+# Internet-facing production release requires protected-branch policy, a signed
+# tag, and GitHub environment approvals; CI alone cannot establish independent
+# human approval.
 if grep -Eq '^[-] \[[xX]\]' docs/security-release-gates.md; then
 	printf '%s\n' 'release gates may not be checked in the withheld runtime state' >&2
-	exit 1
-fi
-
-if find docs/release-evidence -type f -name '*.md' ! -name README.md | grep -q .; then
-	printf '%s\n' 'release evidence is not accepted while all runtime capabilities are withheld' >&2
 	exit 1
 fi
 


### PR DESCRIPTION
## Summary
- record the exact alpha.1 source, workflow jobs, image attestations, signed documents, and all 26 native artifact checksums
- keep trusted attachments and public relay explicitly closed
- allow core personal self-hosted evidence while retaining the executable fail-closed attachment-runtime gate

## Validation
- mechanically compared all documented native checksums with the signed release manifest
- git diff --check
- make deployment-lint workflow-lint release-gates
- release signature and artifact verification recorded in the evidence document

## Release boundary
This PR publishes evidence only. It does not publish the GitHub draft release or enable a gated runtime capability.