### PR TITLE
fix: canonicalize release publisher temp path

### DIFF
--- a/scripts/publish-signed-release.sh
+++ b/scripts/publish-signed-release.sh
@@ -77,6 +77,7 @@ if [ "$release_is_draft" = false ] && [ "$release_is_prerelease" = false ]; then
 fi
 
 download_dir=$(mktemp -d "${TMPDIR:-/tmp}/punaro-release-publish.XXXXXXXX")
+download_dir=$(CDPATH= cd -- "$download_dir" && pwd -P) || fail 'temporary publication directory is invalid'
 catalog_restore_required=false
 catalog_redraft_required=false
 previous_catalog=

--- a/scripts/test-publish-signed-release.sh
+++ b/scripts/test-publish-signed-release.sh
@@ -5,6 +5,9 @@ repo_dir=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
 temporary=$(mktemp -d "${TMPDIR:-/tmp}/punaro-publish-test.XXXXXXXX")
 cleanup() { rm -rf -- "$temporary"; }
 trap cleanup EXIT HUP INT TERM
+publisher_tmp="$temporary/publisher-tmp"
+mkdir "$publisher_tmp"
+export TMPDIR="$publisher_tmp/"
 
 prepare_case() {
 	case_root=$1

--- a/scripts/testdata/fake-publish-go.sh
+++ b/scripts/testdata/fake-publish-go.sh
@@ -13,6 +13,7 @@ case " $* " in
 				shift
 			fi
 		done
+		case "$directory" in *'//'*) exit 2 ;; esac
 		[ -n "$directory" ] && [ "$(cat "$directory/punaro-adapter-linux-amd64" 2>/dev/null)" = artifact ] || exit 2
 		;;
 	*' publication-check '*)


### PR DESCRIPTION
## Summary
- canonicalize the publisher temporary directory before passing it to the strict artifact verifier
- reproduce macOS TMPDIR values with a trailing slash in the publisher regression suite
- make the fake verifier reject non-canonical double-slash paths

## Root cause
macOS TMPDIR already ends in a slash. The mktemp template added another slash, and the strict verifier correctly rejected that non-canonical absolute path before hashing the draft assets. GitHub asset digests match the signed manifest; no release bytes changed.

## Validation
- focused RED: test publisher failed with draft release artifacts differ from the signed manifest
- focused GREEN: scripts/test-publish-signed-release.sh
- make test test-race staticcheck security lint
- git diff --check

The alpha.1 GitHub release remains a draft. This PR does not publish or alter release assets.