### PR TITLE
docs(release): record alpha.2 candidate evidence

### DIFF
--- a/docs/release-evidence/2026-08-24-v0.1.0-alpha.2.md
+++ b/docs/release-evidence/2026-08-24-v0.1.0-alpha.2.md
@@ -1,0 +1,204 @@
+# v0.1.0-alpha.2 personal self-hosted release evidence
+
+## Decision and scope
+
+- **Decision:** approved for publication and controlled personal self-hosted
+  alpha.1-to-alpha.2 update, rollback, restart, recovery, and fleet validation.
+  General unattended fleet use remains withheld until the drills listed below
+  pass on the named machines.
+- **Release capability:** signed, digest-pinned core Punaro gateway, adapter,
+  bootstrap, enrollment, memory, Telegram, and local trusted-attachment client
+  binaries. This decision does not authorize sensitive attachment content or a
+  public relay.
+- **Source commit:**
+  [`138beb324679ecb7dc4d0500b9ca016ccdf3eeb0`](https://github.com/rock3r/punaro/commit/138beb324679ecb7dc4d0500b9ca016ccdf3eeb0),
+  which GitHub reports as a valid verified commit.
+- **Release reference:**
+  [`v0.1.0-alpha.2`](https://github.com/rock3r/punaro/releases/tag/v0.1.0-alpha.2),
+  targeted at the source commit above. The GitHub release remains a draft until
+  the exact manifest and catalog bytes recorded below are published with their
+  detached signatures.
+- **Release sequence:** `2`; **catalog sequence:** `2`;
+  **minimum safe sequence:** `1`; **minimum bootstrap release:**
+  `v0.1.0-alpha.1`; **supported direct upgrade source:**
+  `v0.1.0-alpha.1`.
+- **Retained rollback:** sequence `1`, release `v0.1.0-alpha.1`, manifest
+  SHA-256 `3f1f92f4a6a4834eb01125946984593730ed5a054e105cdd9e242fecd172ab32`.
+- **Catalog expiry:** `2026-08-31T19:51:20Z`.
+
+This is a personal self-hosted alpha under the allowance in
+[`security-release-gates.md`](../security-release-gates.md). It is not an
+official Internet-facing production release.
+
+## Build, review, and workflow evidence
+
+- Release preparation and final release-only review:
+  [PR #183](https://github.com/rock3r/punaro/pull/183). All five required CI
+  jobs passed, the repository watcher reported `CLEAN`/mergeable state and no
+  blocking review items, and the sole missing gate was Bugbot. The operator
+  applied the explicit temporary Bugbot quota waiver for this personal alpha.
+- Final PR CI:
+  [run 32769231352](https://github.com/rock3r/punaro/actions/runs/32769231352).
+  Configuration lint, Go tests and analysis, PostgreSQL integration, complete
+  product E2E, and Windows client build all passed.
+- Release workflow:
+  [run 32770167902](https://github.com/rock3r/punaro/actions/runs/32770167902)
+  completed successfully from the exact source commit.
+  - [Preflight](https://github.com/rock3r/punaro/actions/runs/32770167902/job/97568499495)
+    authenticated the live alpha.1 catalog, validated sequence advancement,
+    retained rollback coverage, and direct-upgrade policy before mutation.
+  - [Image publication](https://github.com/rock3r/punaro/actions/runs/32770167902/job/97568633512)
+    published the digest-pinned image with OCI SBOM and provenance attestations.
+  - Native builds passed for
+    [darwin/arm64](https://github.com/rock3r/punaro/actions/runs/32770167902/job/97569079144),
+    [linux/amd64](https://github.com/rock3r/punaro/actions/runs/32770167902/job/97569078962),
+    [linux/arm64](https://github.com/rock3r/punaro/actions/runs/32770167902/job/97569079001),
+    and [windows/amd64](https://github.com/rock3r/punaro/actions/runs/32770167902/job/97569078985).
+  - [Assembly](https://github.com/rock3r/punaro/actions/runs/32770167902/job/97569539272)
+    produced the exact unsigned manifest/catalog pair and draft release.
+
+The following commands passed on the final source or exact downloaded
+candidate. Owner-only absolute paths are represented by `$SIGNING_DIR`; their
+values are not release data.
+
+```sh
+make plugin-validate deployment-lint release-gates
+go test ./cmd/punaro-adapter ./cmd/punaro-release
+make test test-race staticcheck security lint
+go run ./cmd/punaro-release verify-artifacts \
+  --manifest "$SIGNING_DIR/punaro-release.json" \
+  --dir "$SIGNING_DIR"
+go run ./cmd/punaro-release sign \
+  --key-id punaro-release-1 \
+  --key-file "$SIGNING_DIR/../punaro-release.key" \
+  --in "$SIGNING_DIR/punaro-release.json" \
+  --out "$SIGNING_DIR/punaro-release.sig"
+go run ./cmd/punaro-release sign \
+  --key-id punaro-release-1 \
+  --key-file "$SIGNING_DIR/../punaro-release.key" \
+  --in "$SIGNING_DIR/punaro-catalog.json" \
+  --out "$SIGNING_DIR/punaro-catalog.sig"
+go run ./cmd/punaro-release verify \
+  --keys-file "$SIGNING_DIR/../punaro-release.pub" \
+  --document "$SIGNING_DIR/punaro-release.json" \
+  --signature "$SIGNING_DIR/punaro-release.sig"
+go run ./cmd/punaro-release verify \
+  --keys-file "$SIGNING_DIR/../punaro-release.pub" \
+  --document "$SIGNING_DIR/punaro-catalog.json" \
+  --signature "$SIGNING_DIR/punaro-catalog.sig"
+docker manifest inspect --verbose \
+  ghcr.io/rock3r/punaro@sha256:f8ea447106986e37aea752bbd43dd4ea68c49be19eb4ba74c9dc545350b51a06
+```
+
+Results: plugin parity, documentation/skill contracts, release gates, full
+tests, race tests, static analysis, Windows cross-build, deployment checks,
+and exact artifact/signature verification passed. `govulncheck` found zero
+reachable vulnerabilities; gosec scanned 322 files and 93,803 lines with zero
+issues; gitleaks found no leaks. The signing directory is mode `0700`; every
+candidate file and the private key are mode `0600`. Private key material was
+never printed, uploaded, or copied into the repository.
+
+## Image, SBOM, and provenance
+
+- Digest-pinned image:
+  `ghcr.io/rock3r/punaro@sha256:f8ea447106986e37aea752bbd43dd4ea68c49be19eb4ba74c9dc545350b51a06`
+- Linux/amd64 image manifest:
+  `sha256:a5ab4822a06ebbc3fced56bee6f072670887832bdfeeb4947d3e21dfcf2be6f5`
+- OCI attestation manifest:
+  `sha256:0d89e1e17a9dc8a9115dd65a2678407db34cafd293c38a6d61a37860ecc4890f`
+- SPDX SBOM in-toto layer:
+  `sha256:3c60baf2a8457d81b1643e10e11e91cc037089b12f4c5bbcb728c13282e2b2d6`
+- SLSA provenance v1 in-toto layer:
+  `sha256:f160022c2904945b3e29ce18250b27ac2395da2a8ec642ab07b078314db70fac`
+- Registry page:
+  [ghcr.io/rock3r/punaro](https://github.com/rock3r/punaro/pkgs/container/punaro).
+  The immutable digests above, not a mutable tag or page, identify the
+  reviewed objects.
+
+## Signed documents
+
+| File | SHA-256 |
+| --- | --- |
+| `punaro-release.json` | `3808d898cafb2ec9c719714fae84c901dd702bc9fa5b968be20ba8adf68f7410` |
+| `punaro-release.sig` | `5bb1f722156fd52d83acb31b0636122e1767896bc9c71e5cf8fb818ed2fc2a0b` |
+| `punaro-catalog.json` | `9f4313e073199dc7e61ee12e1af20263ebbdfb8074572154cab4d57aafc424be` |
+| `punaro-catalog.sig` | `404bcaed4d2b8f8d720d7c85be363bbf31e93a6256a9ade1e2865aea39c737f2` |
+
+## Native artifact checksums
+
+The release CLI verified every downloaded byte against the manifest.
+
+| Artifact | OS/architecture | SHA-256 |
+| --- | --- | --- |
+| `punaro-adapter-darwin-arm64` | darwin/arm64 | `b50820f64cd3d49890923500587ab4474dabc253ca7ab1ea846f0ed43a910ab5` |
+| `punaro-adapter-linux-amd64` | linux/amd64 | `d3df25a5a750a5f17b6b996c73db6a1c7635fe9e85f5cd72735c13490a925fa1` |
+| `punaro-adapter-linux-arm64` | linux/arm64 | `f1b71d3437455ba93760e09e028eed0f77ac03dfc22b8f8360abb093ca558de6` |
+| `punaro-adapter-windows-amd64.exe` | windows/amd64 | `314473206f170ebe5477cc7f5eae3942cabfe81bdf13018f20564c6eac69acb8` |
+| `punaro-bootstrap-darwin-arm64` | darwin/arm64 | `48319f8f1dbbe798903d7b0c9c4f87b5557dce96cbe92f97eb263b65ee1695b0` |
+| `punaro-bootstrap-linux-amd64` | linux/amd64 | `39274eb56bef8c92086fdb62cc8f063b633ee229ed25e99feb0d548d44e86e23` |
+| `punaro-bootstrap-linux-arm64` | linux/arm64 | `5f890b357dc97c6d57bfe22e32ceece2bfaf2986d2ac7e8c8d339dd54dd5aeda` |
+| `punaro-bootstrap-windows-amd64.exe` | windows/amd64 | `cecfd94784d0886b8aebbf44faa8172536337a19e967773ff8772ca92bb98ab0` |
+| `punaro-enroll-darwin-arm64` | darwin/arm64 | `91219439d0cb10e2440e4f553c992f5951693cf0e50a551d61b01f581280b81f` |
+| `punaro-enroll-linux-amd64` | linux/amd64 | `7c765529d4101d5adce91d7e68ece8a463736329620bf9d9061456eb5e1fad00` |
+| `punaro-enroll-linux-arm64` | linux/arm64 | `0d39526cb3ccb57f9740d44788b967329f84b3dce68f479b84ff9ef392166c12` |
+| `punaro-enroll-windows-amd64.exe` | windows/amd64 | `16476a4ccf27e9f5c7528b2da02060ff4b0745658a4d638efb7bf9f040b98373` |
+| `punaro-linux-amd64` | linux/amd64 | `349aa4a61c80f7b8f99d89171db0a13a61f987b641036ce212e6a56e48f88835` |
+| `punaro-linux-arm64` | linux/arm64 | `97eacf2fd54bcecee9ef5b495c8351df5cee2966cbacf087ab0a5e6cb986422b` |
+| `punaro-memory-darwin-arm64` | darwin/arm64 | `1a9383a697ff7ae5da452499d6665dba91a97e3ccc961752e34e387bd958346d` |
+| `punaro-memory-linux-amd64` | linux/amd64 | `adecf345110f5d7afa3010c9097e6dbdd855fa5abae41929f39c2e158672e781` |
+| `punaro-memory-linux-arm64` | linux/arm64 | `9174bf95282a8f4adc18e767344d0684a0b2f547892864df993d0ce76c720a04` |
+| `punaro-memory-windows-amd64.exe` | windows/amd64 | `fc01610fdc4b861f18b2025c2b9c800edb2bf9d725a8883eed445b57617f0cb8` |
+| `punaro-relay-adopt-prepare-linux-amd64` | linux/amd64 | `526053b6ea6073e41a8bb53d8c622e143fd158320a09a10e2d6a6821f8e5714b` |
+| `punaro-relay-adopt-prepare-linux-arm64` | linux/arm64 | `692f2d574cfa7fc3ef51442a8fe0b290468913c548a1087a683b08b6dcf10bfc` |
+| `punaro-telegram-linux-amd64` | linux/amd64 | `fe9539aaa3f6f98d66d0b07e59cf338f1d2152ae0f3ec1b5961ef36f2019cbaa` |
+| `punaro-telegram-linux-arm64` | linux/arm64 | `870c554828f029026de35985794d4245e92fbfd0db8fcca8539709b32500b43c` |
+| `punaro-trusted-attachment-darwin-arm64` | darwin/arm64 | `29569874ee340c8a725836dbd648ea2d5a6926a37bf22c2b4e418a9cbf57f99f` |
+| `punaro-trusted-attachment-linux-amd64` | linux/amd64 | `121e9effbf566cf73b68f0b3c3935d9d5abff47d656d0859968e050ad5b88856` |
+| `punaro-trusted-attachment-linux-arm64` | linux/arm64 | `6bb832cfe16425ac8482aa655f293a6ce415f3da2727665f0fa5445916320998` |
+| `punaro-trusted-attachment-windows-amd64.exe` | windows/amd64 | `de2c3bfc3a371e43853ca71e9d5a7bfb0d28da366b7a2680e712f51b131d425c` |
+
+## Approvers, gates, and residual risk
+
+- **Security approver:** Sebastiano Poggi, operator self-review for this
+  personal self-hosted alpha. No independent production security approval is
+  claimed.
+- **Release-signature/cryptography approver:** Sebastiano Poggi, limited to the
+  detached release envelope and owner-only key handling described above. No
+  attachment-protocol cryptography approval is claimed.
+- **Operations approver:** Sebastiano Poggi, limited to controlled deployment
+  and recovery drills on Mac Studio, MacBook/Coso, Mattone, and the Punaro LXC.
+- **Independent automated review:** repository review and CI on PR #183; no
+  substantive finding remained. Independent Pioneer review remains unavailable
+  because the local Pi model configuration is invalid and must be completed
+  before the overall release goal closes.
+
+No checkbox in [`security-release-gates.md`](../security-release-gates.md) is
+changed or treated as checked by this record:
+
+- [Trusted-relay attachments](../security-release-gates.md#trusted-relay-attachments-gated-candidate-closed)
+  remain closed; no sensitive attachment content is authorized.
+- [Attachment v2](../security-release-gates.md#attachment-v2-superseded-closed)
+  and [attachment v3](../security-release-gates.md#attachment-v3-controlled-runtime-superseded-not-released)
+  remain superseded and unreleased.
+- [Public relay and operations](../security-release-gates.md#public-relay-and-operations-closed)
+  remain closed; the release does not authorize public runtime exposure.
+
+Residual risks and required completion evidence:
+
+- Publication authorizes controlled drills, not successful general fleet use.
+  Alpha.1 installation/inventory is not yet complete on MacBook/Coso, Mattone,
+  or the Punaro LXC, and the Mac Studio has only an isolated alpha.1 bootstrap
+  smoke; its legacy validation adapter remains untouched.
+- Prove alpha.1-to-alpha.2 signed update and doctor on every supported fleet
+  role, then prove alpha.2-to-alpha.1 rollback and return to alpha.2.
+- Prove durable cross-machine messaging and role routing, Telegram restart and
+  recovery, clean process restart, interrupted-update recovery, and aggregate
+  fleet doctor reporting. Record exact artifact identities and results.
+- Remote SSH access currently fails before reaching the hosts because the local
+  1Password SSH agent exposes no usable signing identity intermittently. Do not
+  claim a remote host changed until host-side evidence exists.
+- The short-lived catalog expires on `2026-08-31T19:51:20Z`; new installs and
+  updates fail closed after expiry unless a reviewed signed catalog succeeds it.
+- The Git tag is not asserted as a production signed tag. Trust is rooted in
+  the digest-bound artifacts and offline-signed manifest/catalog. This remains
+  a personal alpha, not an official Internet-facing production release.


### PR DESCRIPTION
## Summary

- record the exact alpha.2 source, workflow, image, SBOM/provenance, signed-document, and native-artifact identities
- approve publication only for controlled personal update/rollback/recovery drills
- explicitly withhold general fleet-use claims until cross-machine, Telegram, doctor, restart, interruption, and rollback evidence exists
- retain all public-relay and attachment gates as closed

## Validation

- `make release-gates`
- exact manifest/catalog signatures verified against the owner trust root
- all 26 downloaded native artifacts verified against the signed manifest
- release workflow 32770167902 passed all seven jobs

Bugbot quota-only absence may be waived per maintainer direction; substantive review feedback remains blocking.