### PR TITLE
Fix Windows release digest parity and task registration

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -311,7 +311,10 @@ jobs:
             goos: linux
             goarch: arm64
             cgo: '0'
-          - runner: windows-latest
+          # Cross-compile from the same LF checkout used to assemble the
+          # portable plugin bundle. Native Windows checkout conversion changes
+          # the byte-bound skill/runtime digests embedded in the adapter.
+          - runner: ubuntu-latest
             goos: windows
             goarch: amd64
             cgo: '0'

--- a/scripts/install-client.ps1
+++ b/scripts/install-client.ps1
@@ -431,6 +431,12 @@ $logonTrigger = New-ScheduledTaskTrigger -AtLogOn -User $user
 # if a previous install already registered the re-arm trigger, except when
 # that task is Disabled so an operator-stopped adapter stays stopped.
 $repeatTrigger = New-ScheduledTaskTrigger -Once -At ((Get-Date).AddMinutes(1)) -RepetitionInterval ([TimeSpan]::FromMinutes(1)) -RepetitionDuration ([TimeSpan]::FromDays(3650))
+# Windows PowerShell 5.1 can serialize the TimeSpan values above as
+# 00:01:00/3650.00:00:00, which Task Scheduler rejects as invalid XML.
+# Force the schema's ISO 8601 duration form after the repetition object exists.
+$repeatTrigger.Repetition.Interval = 'PT1M'
+$repeatTrigger.Repetition.Duration = 'P3650D'
+$repeatTrigger.Repetition.StopAtDurationEnd = $false
 $triggers = @($logonTrigger)
 if ($Enable -or $adapterTaskWasRunning -or $hadRepeatTrigger) { $triggers += $repeatTrigger }
 $principal = New-ScheduledTaskPrincipal -UserId $user -LogonType Interactive -RunLevel Limited

--- a/scripts/test-assemble-release.sh
+++ b/scripts/test-assemble-release.sh
@@ -35,6 +35,11 @@ if ! grep -Fq 'build punaro-relay-adopt-prepare ./cmd/punaro-relay-adopt-prepare
 	printf '%s\n' 'linux release artifacts omit punaro-relay-adopt-prepare' >&2
 	exit 1
 fi
+windows_build=$(sed -n '/- runner:.*windows-latest/,+4p; /- runner:.*ubuntu-latest/,+4p' "$repo_dir/.github/workflows/release.yml" | grep -B4 -A1 'goos: windows' || true)
+if ! printf '%s\n' "$windows_build" | grep -Fq 'runner: ubuntu-latest' || printf '%s\n' "$windows_build" | grep -Fq 'runner: windows-latest'; then
+	printf '%s\n' 'Windows release artifacts must be cross-compiled from the canonical LF checkout' >&2
+	exit 1
+fi
 if ! grep -Fq -- '--provenance mode=max' "$repo_dir/.github/workflows/release.yml" ||
 	! grep -Fq -- '--sbom true' "$repo_dir/.github/workflows/release.yml" ||
 	! grep -Fq 'packages: write' "$repo_dir/.github/workflows/release.yml" ||

--- a/scripts/test-install-client-windows.ps1
+++ b/scripts/test-install-client-windows.ps1
@@ -120,8 +120,15 @@ try {
         if (Test-Path -LiteralPath $path) { throw "Windows client installer must not create retired attachment artifact $path" }
     }
     if ($global:punaroRegisteredTask -ne 'Punaro Adapter') { throw 'Windows client installer did not register the expected per-user task' }
+    if (@($global:punaroRegisteredTriggers | Where-Object { $_.Once }).Count -ne 0 -or $global:punaroStartTaskCalled) {
+        throw 'Windows client installer armed or started a fresh adapter without -Enable'
+    }
+    $global:punaroRegisteredTriggers = $null
+    $global:punaroStartTaskCalled = $false
+    & (Join-Path $repoDir 'scripts\install-client.ps1') -RelayUrl 'https://relay.example.test' -MachineId 'windows-test' -AgentMailboxBin $mailbox -AgentGuidanceDir $project -Enable
+    if ($LASTEXITCODE -ne 0) { throw 'Windows client installer failed to enable the adapter task' }
     $registeredRepeat = @($global:punaroRegisteredTriggers | Where-Object { $_.Once })
-    if ($registeredRepeat.Count -ne 1 -or $registeredRepeat[0].Repetition.Interval -ne 'PT1M' -or $registeredRepeat[0].Repetition.Duration -ne 'P3650D' -or $registeredRepeat[0].Repetition.StopAtDurationEnd) {
+    if (-not $global:punaroStartTaskCalled -or $registeredRepeat.Count -ne 1 -or $registeredRepeat[0].Repetition.Interval -ne 'PT1M' -or $registeredRepeat[0].Repetition.Duration -ne 'P3650D' -or $registeredRepeat[0].Repetition.StopAtDurationEnd) {
         throw 'Windows client installer did not register an ISO 8601 repeating trigger'
     }
     $global:punaroDisableTaskCalled = $false

--- a/scripts/test-install-client-windows.ps1
+++ b/scripts/test-install-client-windows.ps1
@@ -69,7 +69,16 @@ try {
             [TimeSpan]$RepetitionInterval,
             [TimeSpan]$RepetitionDuration
         )
-        return [pscustomobject]@{ User = $User; AtLogOn = [bool]$AtLogOn; Once = [bool]$Once; RepetitionInterval = $RepetitionInterval; RepetitionDuration = $RepetitionDuration }
+        return [pscustomobject]@{
+            User = $User
+            AtLogOn = [bool]$AtLogOn
+            Once = [bool]$Once
+            Repetition = [pscustomobject]@{
+                Interval = if ($null -eq $RepetitionInterval) { $null } else { $RepetitionInterval.ToString() }
+                Duration = if ($null -eq $RepetitionDuration) { $null } else { $RepetitionDuration.ToString() }
+                StopAtDurationEnd = $true
+            }
+        }
     }
     function New-ScheduledTaskPrincipal { param([string]$UserId, [string]$LogonType, [string]$RunLevel) return [pscustomobject]@{ UserId = $UserId } }
     function New-ScheduledTaskSettingsSet { param([switch]$AllowStartIfOnBatteries, [switch]$DontStopIfGoingOnBatteries, [switch]$Hidden, [TimeSpan]$ExecutionTimeLimit) return [pscustomobject]@{ ExecutionTimeLimit = $ExecutionTimeLimit; Hidden = $Hidden; RestartCount = 0; RestartInterval = [TimeSpan]::Zero } }
@@ -111,6 +120,10 @@ try {
         if (Test-Path -LiteralPath $path) { throw "Windows client installer must not create retired attachment artifact $path" }
     }
     if ($global:punaroRegisteredTask -ne 'Punaro Adapter') { throw 'Windows client installer did not register the expected per-user task' }
+    $registeredRepeat = @($global:punaroRegisteredTriggers | Where-Object { $_.Once })
+    if ($registeredRepeat.Count -ne 1 -or $registeredRepeat[0].Repetition.Interval -ne 'PT1M' -or $registeredRepeat[0].Repetition.Duration -ne 'P3650D' -or $registeredRepeat[0].Repetition.StopAtDurationEnd) {
+        throw 'Windows client installer did not register an ISO 8601 repeating trigger'
+    }
     $global:punaroDisableTaskCalled = $false
     $global:punaroStartTaskCalled = $false
     $global:punaroRegisteredTriggers = $null


### PR DESCRIPTION
## Summary

- cross-compile the Windows release artifacts on Ubuntu so the adapter embeds the same LF-byte-bound plugin and skill digests as the portable release bundle
- force Task Scheduler repetition values to ISO 8601 after Windows PowerShell creates the repetition object
- add focused release-runner and native installer regression coverage

## Evidence

- the published alpha.2 Windows adapter embedded skill/runtime digests that differed from the signed portable bundle; direct helper inspection therefore failed `plugin_launcher` and `skill_set_parity`
- Mattone rejected the original `00:01:00` repetition serialization, while the corrected `PT1M` / `P3650D` construction registered, exported, and cleaned up successfully
- tests were added before production changes; the release test failed on `windows-latest` for the intended reason

## Validation

- `make test`
- `make test-race`
- `make staticcheck`
- `make security`
- `make lint`
- `./scripts/test-assemble-release.sh`
- `./scripts/test-install-client-windows.sh`
- real Mattone Task Scheduler serialization probe

## Remaining gate

Pioneer review is currently unavailable because local `pioneer doctor` reports `PI_MODELS_CONFIG_INVALID`. This PR must not be treated as release-ready until independent review is restored or explicitly resolved.
