### PR TITLE
Prepare v0.1.0-alpha.3 corrective release

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "punaro",
   "displayName": "Punaro",
-  "version": "0.1.0-alpha.2",
+  "version": "0.1.0-alpha.3",
   "description": "Safely receive and reply to durable Punaro messages and handle explicitly authorized trusted attachments.",
   "author": {
     "name": "Punaro contributors",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "punaro",
-  "version": "0.1.0-alpha.2",
+  "version": "0.1.0-alpha.3",
   "description": "Safely receive and reply to durable Punaro messages and handle explicitly authorized trusted attachments.",
   "author": {
     "name": "Punaro contributors",

--- a/cmd/punaro-adapter/main_test.go
+++ b/cmd/punaro-adapter/main_test.go
@@ -824,12 +824,12 @@ func TestPluginDoctorValidatesAllAdaptersLauncherAndExactSkillTree(t *testing.T)
 		t.Fatal(err)
 	}
 	oldRelease, oldDigest, oldRuntimeDigest := adapterBuildRelease, adapterExpectedSkillSetDigest, adapterExpectedPluginRuntimeDigest
-	adapterBuildRelease, adapterExpectedSkillSetDigest, adapterExpectedPluginRuntimeDigest = "v0.1.0-alpha.2", digest, runtimeDigest
+	adapterBuildRelease, adapterExpectedSkillSetDigest, adapterExpectedPluginRuntimeDigest = "v0.1.0-alpha.3", digest, runtimeDigest
 	t.Cleanup(func() {
 		adapterBuildRelease, adapterExpectedSkillSetDigest, adapterExpectedPluginRuntimeDigest = oldRelease, oldDigest, oldRuntimeDigest
 	})
 	result := inspectAdapterPlugin(t.Context(), root)
-	if !result.Portable || !result.Codex || !result.Claude || !result.Launcher || result.Version != "v0.1.0-alpha.2" || result.SkillDigest != "sha256:"+digest {
+	if !result.Portable || !result.Codex || !result.Claude || !result.Launcher || result.Version != "v0.1.0-alpha.3" || result.SkillDigest != "sha256:"+digest {
 		t.Fatalf("plugin=%#v", result)
 	}
 	var helperOutput bytes.Buffer

--- a/cmd/punaro-release/main_test.go
+++ b/cmd/punaro-release/main_test.go
@@ -171,8 +171,8 @@ func TestBuildFactsBindsPluginSkillsGeneratedComposeAndMigrations(t *testing.T) 
 	if err != nil {
 		t.Fatal(err)
 	}
-	facts, err := buildFacts([]string{"--release", "v0.1.0-alpha.2", "--plugin-root", root})
-	if err != nil || facts.Release != "v0.1.0-alpha.2" || facts.ComposeSHA256 != operator.ComposeManifestSHA256() || len(facts.MigrationManifestSHA256) != 64 || len(facts.SkillSetSHA256) != 64 || len(facts.PluginRuntimeSHA256) != 64 {
+	facts, err := buildFacts([]string{"--release", "v0.1.0-alpha.3", "--plugin-root", root})
+	if err != nil || facts.Release != "v0.1.0-alpha.3" || facts.ComposeSHA256 != operator.ComposeManifestSHA256() || len(facts.MigrationManifestSHA256) != 64 || len(facts.SkillSetSHA256) != 64 || len(facts.PluginRuntimeSHA256) != 64 {
 		t.Fatalf("facts=%#v err=%v", facts, err)
 	}
 	if _, err := buildFacts([]string{"--release", "v0.1.0", "--plugin-root", root}); err == nil {

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -124,7 +124,7 @@ and keep the fixed bootstrap-owned service lifecycle:
 punaro-bootstrap update \
   --directory "$HOME/.local/state/punaro-bootstrap" \
   --keys-file /absolute/private/punaro-release.pub \
-  --release v0.1.0-alpha.2
+  --release v0.1.0-alpha.3
 punaro-bootstrap doctor \
   --directory "$HOME/.local/state/punaro-bootstrap" \
   --keys-file /absolute/private/punaro-release.pub \

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "punaro",
-  "version": "0.1.0-alpha.2",
+  "version": "0.1.0-alpha.3",
   "description": "Safely receive and reply to durable Punaro messages and handle explicitly authorized trusted attachments.",
   "author": {
     "name": "Punaro contributors",

--- a/scripts/test-install-adapter.sh
+++ b/scripts/test-install-adapter.sh
@@ -104,8 +104,8 @@ file_mode() {
 
 [ -x "$adapter" ] || { printf '%s\n' 'adapter binary was not installed' >&2; exit 1; }
 [ -x "$bootstrap" ] || { printf '%s\n' 'bootstrap binary was not installed' >&2; exit 1; }
-[ "$("$adapter" version)" = 'v0.1.0-alpha.2' ] || { printf '%s\n' 'adapter binary lacks the source release identity' >&2; exit 1; }
-[ "$("$bootstrap" version)" = 'v0.1.0-alpha.2' ] || { printf '%s\n' 'bootstrap binary lacks the source release identity' >&2; exit 1; }
+[ "$("$adapter" version)" = 'v0.1.0-alpha.3' ] || { printf '%s\n' 'adapter binary lacks the source release identity' >&2; exit 1; }
+[ "$("$bootstrap" version)" = 'v0.1.0-alpha.3' ] || { printf '%s\n' 'bootstrap binary lacks the source release identity' >&2; exit 1; }
 [ -d "$home/.local/state/punaro-bootstrap/current" ] || { printf '%s\n' 'bootstrap current slot was not seeded' >&2; exit 1; }
 [ -x "$attachment" ] || { printf '%s\n' 'attachment binary was not installed' >&2; exit 1; }
 [ -x "$memory" ] || { printf '%s\n' 'memory binary was not installed' >&2; exit 1; }


### PR DESCRIPTION
## Summary

- advance all portable plugin manifests and installer examples to `v0.1.0-alpha.3`
- keep adapter and release build-fact tests bound to the exact corrective release identity
- prepare the immutable corrective build after the merged Windows digest-parity and Task Scheduler fixes

## Release policy

- release sequence: `3`
- catalog sequence: `3`
- minimum bootstrap: `v0.1.0-alpha.1`
- supported direct sources: `v0.1.0-alpha.1`, `v0.1.0-alpha.2`
- critical block: sequence `2`, because the published alpha.2 Windows adapter does not match the portable plugin/skill digests
- alpha.1 remains the safe rollback entry

The downloaded live catalog signature, request policy, and monotonic advancement with critical block `2` were verified locally against the independently distributed public trust root.

## Validation

- `make test`
- `make test-race`
- `make staticcheck`
- `make security`
- `make lint`
- temporary Windows cross-build embeds `v0.1.0-alpha.3`, skill digest `f5bcba1b1177c0a50ef1bfa2aa884ff68e22927517bf045291d5ee49aab2b2b8`, and runtime digest `e52f0d81a02b0ae4bf4616c53c3aacae8fbab2fd636d928140106e8b3a21a5a3`

## Remaining gate

Pioneer review remains unavailable because local `pioneer doctor` reports `PI_MODELS_CONFIG_INVALID`; publication and fleet evidence must continue to treat that as an unresolved independent-review gate.
