### PR TITLE
docs(release): record alpha.3 evidence

### DIFF
--- a/docs/release-evidence/2026-08-25-v0.1.0-alpha.3.md
+++ b/docs/release-evidence/2026-08-25-v0.1.0-alpha.3.md
@@ -1,0 +1,180 @@
+# v0.1.0-alpha.3 corrective personal self-hosted release evidence
+
+## Decision and scope
+
+- **Decision:** approved for publication and controlled fleet migration. Alpha.3
+  supersedes alpha.2 because the published alpha.2 Windows adapter contained
+  checkout-dependent plugin and skill digests. Sequence `2` is therefore
+  critically blocked; sequence `1` remains the rollback release.
+- **Release capability:** signed, digest-pinned core Punaro gateway, adapter,
+  bootstrap, enrollment, memory, Telegram, and local trusted-attachment client
+  binaries. This decision does not authorize sensitive attachment content or a
+  public relay.
+- **Source commit:**
+  [`8a9a6b9bb0b4e908a701f169cf6d77e7d6a3f057`](https://github.com/rock3r/punaro/commit/8a9a6b9bb0b4e908a701f169cf6d77e7d6a3f057).
+- **Release reference:**
+  [`v0.1.0-alpha.3`](https://github.com/rock3r/punaro/releases/tag/v0.1.0-alpha.3),
+  published as a prerelease from the source commit above.
+- **Release sequence:** `3`; **catalog sequence:** `3`;
+  **minimum safe sequence:** `1`; **critical block:** `2`;
+  **minimum bootstrap release:** `v0.1.0-alpha.1`; **supported direct upgrade
+  sources:** `v0.1.0-alpha.1` and `v0.1.0-alpha.2`.
+- **Retained rollback:** sequence `1`, release `v0.1.0-alpha.1`, manifest
+  SHA-256 `3f1f92f4a6a4834eb01125946984593730ed5a054e105cdd9e242fecd172ab32`.
+- **Catalog expiry:** `2026-09-01T07:04:48Z`.
+
+This is a personal self-hosted alpha under the allowance in
+[`security-release-gates.md`](../security-release-gates.md). It is not an
+official Internet-facing production release.
+
+## Corrective change and review evidence
+
+- [PR #185](https://github.com/rock3r/punaro/pull/185) moved Windows release
+  artifact construction to an LF-stable Ubuntu cross-build and corrected the
+  Windows Scheduled Task repetition duration to ISO `P3650D`. Review found and
+  fixed a test that incorrectly expected a repeating trigger on a default-
+  disabled install. All five CI jobs passed before merge.
+- [PR #186](https://github.com/rock3r/punaro/pull/186) prepared alpha.3 and the
+  explicit critical block for alpha.2. The repository watcher reported all five
+  checks terminal and passing, a clean mergeable state, and no blocking review
+  items. Bugbot was the sole missing gate and was waived by the operator because
+  its team quota was exhausted.
+- Final PR CI:
+  [run 32818798978](https://github.com/rock3r/punaro/actions/runs/32818798978).
+  Configuration lint, Go tests and analysis, PostgreSQL integration, complete
+  product E2E, and Windows client build all passed.
+- Independent Pioneer review could not run because the local Pi `models.json`
+  configuration is invalid. No Pi configuration or credentials were inspected
+  or bypassed; this remains an overall-goal follow-up rather than a claim of
+  independent review.
+
+## Release workflow and local gates
+
+- Release workflow:
+  [run 32819617825](https://github.com/rock3r/punaro/actions/runs/32819617825)
+  completed successfully from the exact source commit.
+  - [Preflight](https://github.com/rock3r/punaro/actions/runs/32819617825/job/97714822900)
+    authenticated the live catalog and validated sequence advancement, retained
+    rollback, supported-source policy, and critical block `2` before mutation.
+  - [Image publication](https://github.com/rock3r/punaro/actions/runs/32819617825/job/97714917362)
+    published the digest-pinned image with OCI SBOM and provenance attestations.
+  - Native builds passed for
+    [darwin/arm64](https://github.com/rock3r/punaro/actions/runs/32819617825/job/97715202765),
+    [windows/amd64](https://github.com/rock3r/punaro/actions/runs/32819617825/job/97715202787),
+    [linux/amd64](https://github.com/rock3r/punaro/actions/runs/32819617825/job/97715202809),
+    and [linux/arm64](https://github.com/rock3r/punaro/actions/runs/32819617825/job/97715202883).
+  - [Assembly](https://github.com/rock3r/punaro/actions/runs/32819617825/job/97715417465)
+    produced the exact unsigned manifest/catalog pair and draft release.
+
+The following gates passed on the final source or exact downloaded candidate:
+
+```sh
+make test
+make test-race
+make staticcheck
+make security
+make lint
+go run ./cmd/punaro-release verify-artifacts \
+  --manifest "$SIGNING_DIR/punaro-release.json" \
+  --dir "$SIGNING_DIR"
+go run ./cmd/punaro-release verify \
+  --keys-file "$SIGNING_DIR/../punaro-release.pub" \
+  --document "$SIGNING_DIR/punaro-release.json" \
+  --signature "$SIGNING_DIR/punaro-release.sig"
+go run ./cmd/punaro-release verify \
+  --keys-file "$SIGNING_DIR/../punaro-release.pub" \
+  --document "$SIGNING_DIR/punaro-catalog.json" \
+  --signature "$SIGNING_DIR/punaro-catalog.sig"
+docker manifest inspect --verbose \
+  ghcr.io/rock3r/punaro@sha256:f5abfcb57c4c0eb0e0a0b8a7426c945b39a1999090802059120246b2c599f544
+```
+
+`govulncheck`, gosec, and gitleaks reported zero called vulnerabilities,
+issues, or leaks. The signing directory is mode `0700`; all candidate files and
+the private key are mode `0600`. Private key material was never printed,
+uploaded, or copied into the repository.
+
+The downloaded Windows adapter contains release identity `v0.1.0-alpha.3`,
+canonical skill digest
+`f5bcba1b1177c0a50ef1bfa2aa884ff68e22927517bf045291d5ee49aab2b2b8`,
+and canonical runtime digest
+`e52f0d81a02b0ae4bf4616c53c3aacae8fbab2fd636d928140106e8b3a21a5a3`.
+
+## Image, SBOM, and provenance
+
+- Digest-pinned image:
+  `ghcr.io/rock3r/punaro@sha256:f5abfcb57c4c0eb0e0a0b8a7426c945b39a1999090802059120246b2c599f544`
+- Linux/amd64 image manifest:
+  `sha256:7da588c780c2970374391687564cf1bbbfc7d67420596018ebbf2e9a6c991446`
+- OCI attestation manifest:
+  `sha256:df2876aaad8015af2a4eed1a99a4e43aaf4226991a4ab0dd4851c4c73ba96625`
+- SPDX SBOM in-toto layer:
+  `sha256:6727a0845ce37e555d0ee011dcd0734a65c3b4ba28d3a791af77fc148fba4176`
+- SLSA provenance v1 in-toto layer:
+  `sha256:8761ce39bacee0075f443a2c002923179dbda3ac3d39cfb1b481bd61d963b3e4`
+
+## Signed documents
+
+| File | SHA-256 |
+| --- | --- |
+| `punaro-release.json` | `be0f3892e1ed60869fe36735d06f44b85f481ce3462c95818993eadaa78a9631` |
+| `punaro-release.sig` | `adf25a789d3d4895cec50f49a93b4add42106b13cd357c37d0289a648a7771a3` |
+| `punaro-catalog.json` | `6a52ab3139e9c72452238a93176259f0473431276bebb9cb0894ea00fd2babda` |
+| `punaro-catalog.sig` | `a7a0a6c23ad5ef358fc25f20ae877e8c76c76b30d0b4b9f484d425f4875865b1` |
+
+Fresh downloads from both GitHub Releases matched these exact hashes. Both
+detached signatures and every manifest-bound artifact verified. The live
+`catalog` prerelease is non-draft and retains the previous verified catalog and
+signature as recovery assets.
+
+## Native artifact checksums
+
+| Artifact | OS/architecture | SHA-256 |
+| --- | --- | --- |
+| `punaro-adapter-darwin-arm64` | darwin/arm64 | `84240868240e580ce2908efcb33461ba0f701b0631d757e8bf542f5f78947d64` |
+| `punaro-adapter-linux-amd64` | linux/amd64 | `6442d7b98284f4fbbc28431bd44fb6de05898a462856561b304eb89b3c4c69d9` |
+| `punaro-adapter-linux-arm64` | linux/arm64 | `45f7fc8fd5a6181e42f97fe23d7e30fbe334fbcb042e6886e70511130d7600ca` |
+| `punaro-adapter-windows-amd64.exe` | windows/amd64 | `32c39db7d958a606a95474c9142031b2796c810e12d0e4e4c760a447d95e23df` |
+| `punaro-bootstrap-darwin-arm64` | darwin/arm64 | `d534bf7a71d9cf2275d4369d9d806005486a07a194b5e2e4dae94fb60a9cf904` |
+| `punaro-bootstrap-linux-amd64` | linux/amd64 | `41ddbf6cbfc77c8b7a3fb4bab6ac93a9d73e635b6e8010b5ac3655a32e91e58c` |
+| `punaro-bootstrap-linux-arm64` | linux/arm64 | `88225b4a4702a38c9af0702b849ab9ada672dd873a67b041777144932ecd554f` |
+| `punaro-bootstrap-windows-amd64.exe` | windows/amd64 | `870f866dd4e0c2d5ce2d8f741f209680f087a9d1789a35c8416ef0ae8b4df1a1` |
+| `punaro-enroll-darwin-arm64` | darwin/arm64 | `ae76afe53947b5dcd9bc46869676502ac38f0785870a0c7edf31a8757af8b2e8` |
+| `punaro-enroll-linux-amd64` | linux/amd64 | `8211385c222642dc843b2f47fdfad0ff332d08d2192eb721728f35e7c8784b37` |
+| `punaro-enroll-linux-arm64` | linux/arm64 | `0b5bfc10026beda9924131b7c2175998a3e7e5ac89ba63a1f82de2c28f2f5ffb` |
+| `punaro-enroll-windows-amd64.exe` | windows/amd64 | `43bd97969fc317d99a50b5bc89c468e4b1c641bc54b49e85891af2daaa498aef` |
+| `punaro-linux-amd64` | linux/amd64 | `29fd602830c13becceccd96be951c75d8f4ef097d49048d95672011e87580d35` |
+| `punaro-linux-arm64` | linux/arm64 | `6a0b405f424a471c93c46d67abedb4974ce7bebffb7946e0cfcaca50c24ae784` |
+| `punaro-memory-darwin-arm64` | darwin/arm64 | `f05e558b69fe0bb65f120828fc877ec7d8773e7757c0ef09b6b66201dc4a350f` |
+| `punaro-memory-linux-amd64` | linux/amd64 | `9c3426afe281377b7ed59500855622f48521313506117213e8f4d7c646c8ebd7` |
+| `punaro-memory-linux-arm64` | linux/arm64 | `d1a7e9389e3e1a60c1c63a2a2b0efaeb1b4bcbbea7f5e028b6a320e972795a33` |
+| `punaro-memory-windows-amd64.exe` | windows/amd64 | `36bc1587bcaf22b6c340e4be535412017662c51f0d4170f86f306a2eb0c9c09f` |
+| `punaro-relay-adopt-prepare-linux-amd64` | linux/amd64 | `d765f2ac80a862aff09856e553ef598a9e5141cf9c16e18448975055f1b00be6` |
+| `punaro-relay-adopt-prepare-linux-arm64` | linux/arm64 | `4fe6924f3ab072983133668a6215ab3bbaf5d76a86944cff498b06e70b0d3aea` |
+| `punaro-telegram-linux-amd64` | linux/amd64 | `d0496d01c58defce7376ef7f30a77f513fac2bba68eb5dbbfec7c6b1aacb3852` |
+| `punaro-telegram-linux-arm64` | linux/arm64 | `b2e9dce2365b16f259f7e0ae651cb9c384f090faeea7840f899f09d85d792db6` |
+| `punaro-trusted-attachment-darwin-arm64` | darwin/arm64 | `80160b45615fac4e380d4bd63c53847df0c4c537d010d35acb62535cc477f047` |
+| `punaro-trusted-attachment-linux-amd64` | linux/amd64 | `d61b8b5b18480d5f6c693775c8769c04395b686ac3177c01f007d4e7027b7895` |
+| `punaro-trusted-attachment-linux-arm64` | linux/arm64 | `8cf00ba95dd15031a463eba5838e0ef455c8a15ea57dcab9c06ba79930531b4b` |
+| `punaro-trusted-attachment-windows-amd64.exe` | windows/amd64 | `6f1b7a1ccb1821edae6707cda416907c357cb01b2b1cb2be4a0edbaf2c917d96` |
+
+## Approvers, gates, and residual risk
+
+- **Security, release-signature, and operations approver:** Sebastiano Poggi,
+  limited to this controlled personal self-hosted alpha and the named fleet.
+- No checkbox in [`security-release-gates.md`](../security-release-gates.md) is
+  changed by this record. Trusted-relay attachments, superseded attachment
+  protocols, and public relay/operations remain closed.
+- Publication authorizes controlled drills, not successful general fleet use.
+  Mattone must update from alpha.2 to alpha.3 and complete doctor, restart,
+  rollback, and interrupted-update drills. Mac Studio and MacBook/Coso must be
+  migrated from their legacy adapters. The Punaro LXC must be migrated with a
+  reviewed backup/restore plan before unified-server and Telegram validation.
+- Durable cross-machine messaging, role routing, Telegram multi-topic restart
+  and recovery, clean process restart, and aggregate fleet doctor reporting
+  remain required completion evidence.
+- The catalog expires on `2026-09-01T07:04:48Z`; updates fail closed after
+  expiry unless a reviewed signed catalog succeeds it.
+- Trust is rooted in the digest-bound artifacts and offline-signed
+  manifest/catalog, not a production signed Git tag. This remains a personal
+  alpha, not an official Internet-facing production release.

--- a/docs/release-evidence/2026-08-25-v0.1.0-alpha.3.md
+++ b/docs/release-evidence/2026-08-25-v0.1.0-alpha.3.md
@@ -69,6 +69,7 @@ official Internet-facing production release.
 The following gates passed on the final source or exact downloaded candidate:
 
 ```sh
+make plugin-validate deployment-lint release-gates
 make test
 make test-race
 make staticcheck
@@ -166,10 +167,13 @@ signature as recovery assets.
   changed by this record. Trusted-relay attachments, superseded attachment
   protocols, and public relay/operations remain closed.
 - Publication authorizes controlled drills, not successful general fleet use.
-  Mattone must update from alpha.2 to alpha.3 and complete doctor, restart,
-  rollback, and interrupted-update drills. Mac Studio and MacBook/Coso must be
-  migrated from their legacy adapters. The Punaro LXC must be migrated with a
-  reviewed backup/restore plan before unified-server and Telegram validation.
+  Mattone must first explicitly switch from current alpha.2 to the already
+  staged safe alpha.1 rollback slot, then install alpha.3 so the blocked alpha.2
+  slot is overwritten and alpha.1 remains the rollback target. It must then
+  complete doctor, restart, safe rollback/return, and interrupted-update drills.
+  Mac Studio and MacBook/Coso must be migrated from their legacy adapters. The
+  Punaro LXC must be migrated with a reviewed backup/restore plan before
+  unified-server and Telegram validation.
 - Durable cross-machine messaging, role routing, Telegram multi-topic restart
   and recovery, clean process restart, and aggregate fleet doctor reporting
   remain required completion evidence.


### PR DESCRIPTION
Records the published v0.1.0-alpha.3 source, CI and release workflow, offline signature verification, public byte-for-byte verification, critical block for alpha.2, retained alpha.1 rollback, artifact checksums, image attestations, and remaining fleet drills.

Validation:
- make plugin-validate deployment-lint release-gates
- fresh remote manifest/catalog signature verification
- fresh remote artifact verification