### PR TITLE
Fix live Windows Scheduled Task doctor parsing

### DIFF
--- a/cmd/punaro-adapter/doctor.go
+++ b/cmd/punaro-adapter/doctor.go
@@ -936,6 +936,12 @@ func adapterWindowsTaskBound(body, powershell, runner string) bool {
 	if len(body) > 64<<10 || powershell == "" || runner == "" {
 		return false
 	}
+	// schtasks.exe /Query /XML writes UTF-8/ASCII bytes when stdout is captured
+	// while retaining an encoding="UTF-16" declaration. encoding/xml correctly
+	// rejects that contradictory declaration before it can inspect the task.
+	// Remove only the exact schtasks prolog; genuine UTF-16 output contains NUL
+	// bytes and cannot match this UTF-8 prefix.
+	body = strings.TrimPrefix(body, `<?xml version="1.0" encoding="UTF-16"?>`)
 	var task struct {
 		Actions []struct {
 			Exec []struct {

--- a/cmd/punaro-adapter/main_test.go
+++ b/cmd/punaro-adapter/main_test.go
@@ -1939,6 +1939,10 @@ func TestAdapterWindowsTaskRequiresExactProtectedRunner(t *testing.T) {
 	if !adapterWindowsTaskBound(valid, powershell, runner) {
 		t.Fatal("valid scheduled task rejected")
 	}
+	live := `<?xml version="1.0" encoding="UTF-16"?>` + valid
+	if !adapterWindowsTaskBound(live, powershell, runner) {
+		t.Fatal("valid schtasks XML declaration rejected")
+	}
 	for _, stale := range []string{
 		strings.Replace(valid, "Run-PunaroAdapter.ps1", "attacker.ps1", 1),
 		strings.Replace(valid, "-NoProfile ", "", 1),


### PR DESCRIPTION
## Summary
- accept the exact schtasks.exe UTF-16 declaration emitted over UTF-8/ASCII captured output
- retain all existing structural and protected-runner validation
- add a regression test matching the live Mattone output shape

## Validation
- make test
- make test-race
- make staticcheck
- make security
- make lint
- git diff --check

Tracks #188; this fixes the confirmed live Windows service-executable diagnostic, while the issue remains open for the remaining doctor work.