### PR TITLE
docs(release): record alpha.4 evidence

### DIFF
--- a/docs/release-evidence/2026-08-25-v0.1.0-alpha.4.md
+++ b/docs/release-evidence/2026-08-25-v0.1.0-alpha.4.md
@@ -94,9 +94,13 @@ docker manifest inspect --verbose \
 ```
 
 `govulncheck`, gosec, and gitleaks reported zero called vulnerabilities,
-issues, or leaks. The signing directory is mode `0700`; all candidate files and
-the private key are mode `0600`. Private key material was never printed,
-uploaded, or copied into the repository.
+issues, or leaks in the exact
+[Go tests and analysis job](https://github.com/rock3r/punaro/actions/runs/32834532233/job/97760342134).
+The digest-equivalent reviewed container context also passed the
+[Trivy CRITICAL/HIGH scan](https://github.com/rock3r/punaro/actions/runs/32834532233/job/97760341814).
+The signing directory is mode `0700`; all candidate files and the private key
+are mode `0600`. Private key material was never printed, uploaded, or copied
+into the repository.
 
 The downloaded Windows adapter contains release identity `v0.1.0-alpha.4`,
 canonical skill digest
@@ -106,15 +110,15 @@ and canonical runtime digest
 
 ## Image, SBOM, and provenance
 
-- Digest-pinned image:
+- [Digest-pinned image index](https://ghcr.io/v2/rock3r/punaro/manifests/sha256:6db85b68c075ce8fb0fbbb0651f97e5eae940fe2471e4924571b24a26214ebdd):
   `ghcr.io/rock3r/punaro@sha256:6db85b68c075ce8fb0fbbb0651f97e5eae940fe2471e4924571b24a26214ebdd`
-- Linux/amd64 image manifest:
+- [Linux/amd64 image manifest](https://ghcr.io/v2/rock3r/punaro/manifests/sha256:08c95176a91343c9acdc7aae157c3e9b7d8bc63f7ee305b7d34fe357f752e98f):
   `sha256:08c95176a91343c9acdc7aae157c3e9b7d8bc63f7ee305b7d34fe357f752e98f`
-- OCI attestation manifest:
+- [OCI attestation manifest](https://ghcr.io/v2/rock3r/punaro/manifests/sha256:5627234010f8ec758f6107e6cad12cf71a92c01cc2018093883abc8a26e37bbc):
   `sha256:5627234010f8ec758f6107e6cad12cf71a92c01cc2018093883abc8a26e37bbc`
-- SPDX SBOM in-toto layer:
+- [SPDX SBOM in-toto layer](https://ghcr.io/v2/rock3r/punaro/blobs/sha256:c274eabca07c011edc90551ceca10238ec62794f192b69bdb57dad71ff4c2bf5):
   `sha256:c274eabca07c011edc90551ceca10238ec62794f192b69bdb57dad71ff4c2bf5`
-- SLSA provenance v1 in-toto layer:
+- [SLSA provenance v1 in-toto layer](https://ghcr.io/v2/rock3r/punaro/blobs/sha256:bb2cf4a348fc3c5986a5b4f22054655981f9d81100b1e916fb45f5c176789804):
   `sha256:bb2cf4a348fc3c5986a5b4f22054655981f9d81100b1e916fb45f5c176789804`
 
 ## Signed documents

--- a/docs/release-evidence/2026-08-25-v0.1.0-alpha.4.md
+++ b/docs/release-evidence/2026-08-25-v0.1.0-alpha.4.md
@@ -1,0 +1,187 @@
+# v0.1.0-alpha.4 Waypost migration release evidence
+
+## Decision and scope
+
+- **Decision:** approved for publication and controlled fleet migration. Alpha.4
+  adds the supported Waypost 0.8 mailbox lifecycle and completes the live
+  Windows Scheduled Task diagnostic parser needed before fleet rollout.
+- **Release capability:** signed, digest-pinned core Punaro gateway, adapter,
+  bootstrap, enrollment, memory, Telegram, and local trusted-attachment client
+  binaries. This decision does not authorize sensitive attachment content or a
+  public relay.
+- **Source commit:**
+  [`7c742d53d4af1bf90658c4148a1048213e294d84`](https://github.com/rock3r/punaro/commit/7c742d53d4af1bf90658c4148a1048213e294d84).
+- **Release reference:**
+  [`v0.1.0-alpha.4`](https://github.com/rock3r/punaro/releases/tag/v0.1.0-alpha.4),
+  published as a prerelease from the source commit above.
+- **Release sequence:** `4`; **catalog sequence:** `4`;
+  **minimum safe sequence:** `1`; **critical block:** `2`;
+  **minimum bootstrap release:** `v0.1.0-alpha.1`; **supported direct upgrade
+  sources:** `v0.1.0-alpha.1` and `v0.1.0-alpha.3`.
+- **Retained rollback:** sequence `1`, release `v0.1.0-alpha.1`, manifest
+  SHA-256 `3f1f92f4a6a4834eb01125946984593730ed5a054e105cdd9e242fecd172ab32`.
+- **Catalog expiry:** `2026-09-01T10:12:02Z`.
+
+This is a personal self-hosted alpha under the allowance in
+[`security-release-gates.md`](../security-release-gates.md). It is not an
+official Internet-facing production release.
+
+## Change and review evidence
+
+- [PR #189](https://github.com/rock3r/punaro/pull/189) made Windows task
+  diagnostics parse the live `schtasks /Query /XML` shape, including namespace,
+  repetition, restart, and execution-time-limit checks. All five CI jobs passed
+  in [run 32825606411](https://github.com/rock3r/punaro/actions/runs/32825606411).
+- [PR #190](https://github.com/rock3r/punaro/pull/190) added Waypost 0.8
+  `waypost.db` discovery, paginated membership diagnostics and runtime lookup,
+  required MCP-tool checks, local delivery, POSIX/Windows installer selection,
+  Linux service templates, documentation, plugin manifests, and all three
+  Punaro skills. Review fixes required the complete legacy mailbox surface,
+  Waypost systemd sandbox paths, and explicit renamed-binary selection. The
+  real Waypost 0.8 smoke exercised 51 members, pagination, and local delivery.
+  All five CI jobs passed in
+  [run 32834532233](https://github.com/rock3r/punaro/actions/runs/32834532233).
+- The repository watcher reported PR #190 terminal, mergeable, and free of open
+  review items. Bugbot was the sole unavailable reviewer because its team quota
+  was exhausted; the operator explicitly waived that unavailable quota gate for
+  this personal alpha.
+- Independent Pioneer review could not run because the local Pi `models.json`
+  configuration is invalid. No Pi configuration or credentials were inspected
+  or bypassed; this remains an overall-goal follow-up rather than a claim of
+  independent review.
+
+## Release workflow and local gates
+
+- Release workflow:
+  [run 32835712086](https://github.com/rock3r/punaro/actions/runs/32835712086)
+  completed successfully from the exact source commit.
+  - [Preflight](https://github.com/rock3r/punaro/actions/runs/32835712086/job/97763974602)
+    authenticated the sequence-3 live catalog and validated sequence
+    advancement, retained rollback, supported-source policy, and critical block
+    `2` before mutation.
+  - [Image publication](https://github.com/rock3r/punaro/actions/runs/32835712086/job/97764068901)
+    published the digest-pinned image with OCI SBOM and provenance attestations.
+  - Native builds passed for
+    [darwin/arm64](https://github.com/rock3r/punaro/actions/runs/32835712086/job/97764470688),
+    [windows/amd64](https://github.com/rock3r/punaro/actions/runs/32835712086/job/97764470728),
+    [linux/amd64](https://github.com/rock3r/punaro/actions/runs/32835712086/job/97764470664),
+    and [linux/arm64](https://github.com/rock3r/punaro/actions/runs/32835712086/job/97764470745).
+  - [Assembly](https://github.com/rock3r/punaro/actions/runs/32835712086/job/97764729121)
+    produced the exact unsigned manifest/catalog pair and draft release.
+
+The following gates passed on the final source or exact downloaded candidate:
+
+```sh
+make plugin-validate deployment-lint release-gates
+make test
+make test-race
+make staticcheck
+make security
+make lint
+go run ./cmd/punaro-release verify-artifacts \
+  --manifest "$SIGNING_DIR/punaro-release.json" \
+  --dir "$SIGNING_DIR"
+go run ./cmd/punaro-release verify \
+  --keys-file "$SIGNING_DIR/../punaro-release.pub" \
+  --document "$SIGNING_DIR/punaro-release.json" \
+  --signature "$SIGNING_DIR/punaro-release.sig"
+go run ./cmd/punaro-release verify \
+  --keys-file "$SIGNING_DIR/../punaro-release.pub" \
+  --document "$SIGNING_DIR/punaro-catalog.json" \
+  --signature "$SIGNING_DIR/punaro-catalog.sig"
+docker manifest inspect --verbose \
+  ghcr.io/rock3r/punaro@sha256:6db85b68c075ce8fb0fbbb0651f97e5eae940fe2471e4924571b24a26214ebdd
+```
+
+`govulncheck`, gosec, and gitleaks reported zero called vulnerabilities,
+issues, or leaks. The signing directory is mode `0700`; all candidate files and
+the private key are mode `0600`. Private key material was never printed,
+uploaded, or copied into the repository.
+
+The downloaded Windows adapter contains release identity `v0.1.0-alpha.4`,
+canonical skill digest
+`f87d8041e26f2c77daba1d93a0491d5d4764e787c3bd52c00a203a10d41934bb`,
+and canonical runtime digest
+`c4b00a5aee0a1375ad368da6cd541e3f800e35249cd2318d3336edc58a2d81b7`.
+
+## Image, SBOM, and provenance
+
+- Digest-pinned image:
+  `ghcr.io/rock3r/punaro@sha256:6db85b68c075ce8fb0fbbb0651f97e5eae940fe2471e4924571b24a26214ebdd`
+- Linux/amd64 image manifest:
+  `sha256:08c95176a91343c9acdc7aae157c3e9b7d8bc63f7ee305b7d34fe357f752e98f`
+- OCI attestation manifest:
+  `sha256:5627234010f8ec758f6107e6cad12cf71a92c01cc2018093883abc8a26e37bbc`
+- SPDX SBOM in-toto layer:
+  `sha256:c274eabca07c011edc90551ceca10238ec62794f192b69bdb57dad71ff4c2bf5`
+- SLSA provenance v1 in-toto layer:
+  `sha256:bb2cf4a348fc3c5986a5b4f22054655981f9d81100b1e916fb45f5c176789804`
+
+## Signed documents
+
+| File | SHA-256 |
+| --- | --- |
+| `punaro-release.json` | `8c3110a639bf5b4ca484d4c1b9be88f03e2b22e85ef55c35a2e6197c6ce6ebe3` |
+| `punaro-release.sig` | `2141de14e1a8bacb74d4b003015a1e53864c7dbb1cea56939539073183d6df13` |
+| `punaro-catalog.json` | `f25565dc9a4aaa118a026e6f6627821abda9a4282a107af7e845afe3249d21b0` |
+| `punaro-catalog.sig` | `4f2af2bbac98491762b1d4d00ab847c8a1cd7cf269d086b0d0ce17052b99467b` |
+
+Fresh downloads from both GitHub Releases matched these exact hashes. Both
+detached signatures and every manifest-bound artifact verified. The versioned
+catalog was byte-identical to the live catalog. The live `catalog` prerelease is
+non-draft and retains the verified sequence-3 catalog and signature as recovery
+assets.
+
+## Native artifact checksums
+
+| Artifact | OS/architecture | SHA-256 |
+| --- | --- | --- |
+| `punaro-adapter-darwin-arm64` | darwin/arm64 | `58b07bd26cd595b2317f8fe28bb84abc06de173f6f4ed0b28bbe0d43795fba82` |
+| `punaro-adapter-linux-amd64` | linux/amd64 | `a64e1e20f5e49b6e5d1551449b9da799bfe5b7d11dceb226cb95d928e6a34836` |
+| `punaro-adapter-linux-arm64` | linux/arm64 | `0642a134c176968ba638f96eeb8b904467e9add3034812dcf688f49e5f336651` |
+| `punaro-adapter-windows-amd64.exe` | windows/amd64 | `b2763a0db039e20bc4085334daa227e25a0d6c38c673e161347fb4ad32f6b56d` |
+| `punaro-bootstrap-darwin-arm64` | darwin/arm64 | `f526d2b9bcf69a45a61b18dc6121a5a8835dae2245c60e152ee9a3a36be57c7b` |
+| `punaro-bootstrap-linux-amd64` | linux/amd64 | `ef07a495ceec20fe337954357fdd66c339ad16e7a1d1ce3b37482d783f4edc3b` |
+| `punaro-bootstrap-linux-arm64` | linux/arm64 | `a5a9322865d2c166828600bc1cc647d67835db8dff484baab1272f736882f16c` |
+| `punaro-bootstrap-windows-amd64.exe` | windows/amd64 | `c1bd3bcf1e998ad38345363aaecf48f1d74a36efa57eff8ea93c7c75dda19195` |
+| `punaro-enroll-darwin-arm64` | darwin/arm64 | `9dba1259adff4047a98547f555fda2cf1af9811f0bbbaac9b8d66732ea10a499` |
+| `punaro-enroll-linux-amd64` | linux/amd64 | `64ca962631bc200bc40cc188f34f5b8a0a4edcc6ae9f0df9911842c63e656dd1` |
+| `punaro-enroll-linux-arm64` | linux/arm64 | `6b66bb86102d91db1d75cabcc9d0c268d164850b756a4f96db4ba81b4b1e70f1` |
+| `punaro-enroll-windows-amd64.exe` | windows/amd64 | `671ade3626aa37b78b293985df4d29641e8b63a1e22a2d35fd918671e751fb73` |
+| `punaro-linux-amd64` | linux/amd64 | `8f39818d80b8f8ebb966e40ef61bc1067b86ed6635f689363d108ad6fec959b5` |
+| `punaro-linux-arm64` | linux/arm64 | `30c18844345d48eaf6e581a3cfe4a79b9f1da967518154a5ec9812a13f7b005e` |
+| `punaro-memory-darwin-arm64` | darwin/arm64 | `188654946a7f6013bf63a011a0ae9f717896cad34cc37fd32ba0786ac8d09851` |
+| `punaro-memory-linux-amd64` | linux/amd64 | `ff9a5473807a3823b7d82913ca2ce5006fb0023a015f4b3b52619eb4d4f3219d` |
+| `punaro-memory-linux-arm64` | linux/arm64 | `e2567c830ea281db2faf0680552f5d49e21bb4c1242c9b951cc6d13499453668` |
+| `punaro-memory-windows-amd64.exe` | windows/amd64 | `6ba1df33dc21c82734662adafd163f32189fbe44db02c7484c4350898cdb7c75` |
+| `punaro-relay-adopt-prepare-linux-amd64` | linux/amd64 | `63b76e25bd0f9baaca7a37e662f080c3829acde24e2285a13c458e85b5243b3e` |
+| `punaro-relay-adopt-prepare-linux-arm64` | linux/arm64 | `2a03b1d9b3e9842ed4793452c87b589731c558dd5f03604b6a3b7c2e4e13e0b1` |
+| `punaro-telegram-linux-amd64` | linux/amd64 | `7aaef50ec6d029d1f0acf401967ec0200202d662559c0de4543973e454c6a0e3` |
+| `punaro-telegram-linux-arm64` | linux/arm64 | `2bddb78b67f41d4cd6fd35763a53322ab1f3e598033658bb04a660854720d5d7` |
+| `punaro-trusted-attachment-darwin-arm64` | darwin/arm64 | `fbf6331cd0d366945fa1079ef3a57e3e3e51f4b174aeb7289eb1bde5b65c6ec3` |
+| `punaro-trusted-attachment-linux-amd64` | linux/amd64 | `a55ee51d7d84ee5fd6a3da115da8fb071f4f7549d6fbee6c6a98e1795fe7fade` |
+| `punaro-trusted-attachment-linux-arm64` | linux/arm64 | `c3b848ee4585dd3cb3a21c4040c82f8143e3e35ac96ce30d269a1c4e3942a78a` |
+| `punaro-trusted-attachment-windows-amd64.exe` | windows/amd64 | `804bf77b11bb719d07680a6e2148c671f599e808f4d7450e40c77496f0416cf0` |
+
+## Approvers, gates, and residual risk
+
+- **Security, release-signature, and operations approver:** Sebastiano Poggi,
+  limited to this controlled personal self-hosted alpha and the named fleet.
+- No checkbox in [`security-release-gates.md`](../security-release-gates.md) is
+  changed by this record. Trusted-relay attachments, superseded attachment
+  protocols, and public relay/operations remain closed.
+- Publication authorizes controlled migration, not successful general fleet
+  use. Mattone must upgrade from alpha.3 to alpha.4 and migrate to Waypost while
+  retaining alpha.1 as the signed rollback release. Mac Studio and MacBook/Coso
+  must be migrated from their legacy adapters. The Punaro LXC must be migrated
+  with a reviewed backup/restore plan before unified-server and Telegram
+  validation.
+- Durable cross-machine messaging, role routing, Telegram multi-topic restart
+  and recovery, clean process restart, safe rollback/return, interrupted-update
+  recovery, and aggregate fleet doctor reporting remain required completion
+  evidence in [issue #188](https://github.com/rock3r/punaro/issues/188).
+- The catalog expires on `2026-09-01T10:12:02Z`; updates fail closed after
+  expiry unless a reviewed signed catalog succeeds it.
+- Trust is rooted in the digest-bound artifacts and offline-signed
+  manifest/catalog, not a production signed Git tag. This remains a personal
+  alpha, not an official Internet-facing production release.


### PR DESCRIPTION
## Summary

- record the exact alpha.4 source, signed release, catalog policy, and residual fleet scope
- capture CI jobs, local gates, OCI image/SBOM/provenance digests, and signed document hashes
- list every manifest-bound native artifact checksum and retain issue #188 as the live fleet completion tracker

## Validation

- make plugin-validate deployment-lint release-gates
- make test
- make test-race
- make lint
- make security
- fresh GitHub release/catalog download, signature verification, artifact verification, and OCI manifest inspection