### PR TITLE
fix(doctor): protect Windows mailbox snapshots

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "punaro",
   "displayName": "Punaro",
-  "version": "0.1.0-alpha.4",
+  "version": "0.1.0-alpha.5",
   "description": "Safely receive and reply to durable Punaro messages and handle explicitly authorized trusted attachments.",
   "author": {
     "name": "Punaro contributors",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "punaro",
-  "version": "0.1.0-alpha.4",
+  "version": "0.1.0-alpha.5",
   "description": "Safely receive and reply to durable Punaro messages and handle explicitly authorized trusted attachments.",
   "author": {
     "name": "Punaro contributors",

--- a/cmd/punaro-adapter/doctor.go
+++ b/cmd/punaro-adapter/doctor.go
@@ -11,7 +11,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"net/url"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -138,7 +137,8 @@ var (
 	adapterDoctorBootstrapProbe             = func(ctx context.Context, directory, bootstrapRelease string) (punarodiagnostic.Report, error) {
 		return bootstrap.IsolatedDoctor(ctx, bootstrap.DoctorRequest{Directory: directory, BootstrapRelease: bootstrapRelease})
 	}
-	adapterDoctorPluginProbe = inspectAdapterPluginIsolated
+	adapterDoctorPluginProbe     = inspectAdapterPluginIsolated
+	mailboxDoctorSnapshotProtect = protectMailboxDoctorSnapshot
 )
 
 func runAdapterDoctor(args []string, stdout, stderr io.Writer) int {
@@ -544,26 +544,38 @@ func mailboxDoctorSnapshot(ctx context.Context, root string) (string, error) {
 			_ = os.RemoveAll(snapshot)
 		}
 	}()
+	if err := mailboxDoctorSnapshotProtect(snapshot); err != nil {
+		return "", fmt.Errorf("mailbox snapshot directory protection failed: %w", err)
+	}
+	if !privateDoctorDirectory(snapshot) {
+		return "", errors.New("mailbox snapshot directory is unsafe")
+	}
 	destination := filepath.Join(snapshot, filepath.Base(source))
-	uri := (&url.URL{Scheme: "file", Path: source, RawQuery: "mode=ro"}).String()
+	uri := mailboxDoctorReadOnlyURI(source)
 	database, err := sql.Open("sqlite", uri)
 	if err != nil {
-		return "", errors.New("mailbox snapshot is unavailable")
+		return "", fmt.Errorf("mailbox snapshot database open failed: %w", err)
 	}
 	database.SetMaxOpenConns(1)
 	database.SetMaxIdleConns(1)
 	if err := database.PingContext(ctx); err != nil {
 		_ = database.Close()
-		return "", errors.New("mailbox snapshot is unavailable")
+		return "", fmt.Errorf("mailbox snapshot database ping failed: %w", err)
 	}
 	_, snapshotErr := database.ExecContext(ctx, `VACUUM INTO ?`, destination)
 	closeErr := database.Close()
-	if snapshotErr != nil || closeErr != nil {
-		return "", errors.New("mailbox snapshot is unavailable")
+	if snapshotErr != nil {
+		return "", fmt.Errorf("mailbox snapshot copy failed: %w", snapshotErr)
+	}
+	if closeErr != nil {
+		return "", fmt.Errorf("mailbox snapshot database close failed: %w", closeErr)
 	}
 	copyInfo, err := os.Lstat(destination) // #nosec G703 -- fresh private snapshot destination.
-	if err != nil || !copyInfo.Mode().IsRegular() || copyInfo.Mode()&os.ModeSymlink != 0 || copyInfo.Size() < 0 || copyInfo.Size() > maximumMailboxDoctorBytes || os.Chmod(destination, 0o600) != nil {
+	if err != nil || !copyInfo.Mode().IsRegular() || copyInfo.Mode()&os.ModeSymlink != 0 || copyInfo.Size() < 0 || copyInfo.Size() > maximumMailboxDoctorBytes {
 		return "", errors.New("mailbox snapshot is unsafe")
+	}
+	if err := os.Chmod(destination, 0o600); err != nil {
+		return "", fmt.Errorf("mailbox snapshot file protection failed: %w", err)
 	}
 	cleanup = false
 	return snapshot, nil

--- a/cmd/punaro-adapter/doctor_snapshot_unix.go
+++ b/cmd/punaro-adapter/doctor_snapshot_unix.go
@@ -1,0 +1,16 @@
+//go:build !windows
+
+package main
+
+import (
+	"net/url"
+	"os"
+)
+
+func protectMailboxDoctorSnapshot(path string) error {
+	return os.Chmod(path, 0o700) // #nosec G302 -- snapshot directory must be owner-only and traversable.
+}
+
+func mailboxDoctorReadOnlyURI(path string) string {
+	return (&url.URL{Scheme: "file", Path: path, RawQuery: "mode=ro"}).String()
+}

--- a/cmd/punaro-adapter/doctor_snapshot_windows.go
+++ b/cmd/punaro-adapter/doctor_snapshot_windows.go
@@ -1,0 +1,48 @@
+//go:build windows
+
+package main
+
+import (
+	"errors"
+	"net/url"
+	"path/filepath"
+
+	"golang.org/x/sys/windows"
+)
+
+func protectMailboxDoctorSnapshot(path string) error {
+	user, err := windows.GetCurrentProcessToken().GetTokenUser()
+	if err != nil || user.User.Sid == nil {
+		return errors.New("current user is unavailable")
+	}
+	acl, err := windows.ACLFromEntries([]windows.EXPLICIT_ACCESS{{
+		AccessPermissions: windows.ACCESS_MASK(0x1f01ff),
+		AccessMode:        windows.GRANT_ACCESS,
+		Inheritance:       windows.OBJECT_INHERIT_ACE | windows.CONTAINER_INHERIT_ACE,
+		Trustee: windows.TRUSTEE{
+			TrusteeForm:  windows.TRUSTEE_IS_SID,
+			TrusteeValue: windows.TrusteeValueFromSID(user.User.Sid),
+		},
+	}}, nil)
+	if err != nil {
+		return err
+	}
+	return windows.SetNamedSecurityInfo(
+		path,
+		windows.SE_FILE_OBJECT,
+		windows.OWNER_SECURITY_INFORMATION|windows.DACL_SECURITY_INFORMATION|windows.PROTECTED_DACL_SECURITY_INFORMATION,
+		user.User.Sid,
+		nil,
+		acl,
+		nil,
+	)
+}
+
+func mailboxDoctorReadOnlyURI(path string) string {
+	normalized := filepath.ToSlash(path)
+	volume := filepath.VolumeName(path)
+	if len(volume) == 2 && volume[1] == ':' {
+		normalized = "/" + normalized
+	}
+	return (&url.URL{Scheme: "file", Path: normalized, RawQuery: "mode=ro"}).String()
+}

--- a/cmd/punaro-adapter/doctor_snapshot_windows_test.go
+++ b/cmd/punaro-adapter/doctor_snapshot_windows_test.go
@@ -1,0 +1,66 @@
+//go:build windows
+
+package main
+
+import (
+	"database/sql"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestProtectMailboxDoctorSnapshotMakesPrivateDirectory(t *testing.T) {
+	directory := filepath.Join(t.TempDir(), "snapshot")
+	if err := protectMailboxDoctorSnapshot(directory); err == nil {
+		t.Fatal("missing snapshot directory was protected")
+	}
+	if err := os.Mkdir(directory, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := protectMailboxDoctorSnapshot(directory); err != nil {
+		t.Fatal(err)
+	}
+	if !privateDoctorDirectory(directory) {
+		t.Fatal("protected snapshot directory was rejected")
+	}
+}
+
+func TestMailboxDoctorReadOnlyURIUsesWindowsSlashes(t *testing.T) {
+	got := mailboxDoctorReadOnlyURI(`C:\Users\operator\AppData\Local\waypost\waypost.db`)
+	want := "file:///C:/Users/operator/AppData/Local/waypost/waypost.db?mode=ro"
+	if got != want {
+		t.Fatalf("mailboxDoctorReadOnlyURI() = %q, want %q", got, want)
+	}
+}
+
+func TestMailboxDoctorSnapshotIsPrivateOnWindows(t *testing.T) {
+	state := filepath.Join(t.TempDir(), "state")
+	if err := os.Mkdir(state, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := protectMailboxDoctorSnapshot(state); err != nil {
+		t.Fatal(err)
+	}
+	database, err := sql.Open("sqlite", filepath.Join(state, "waypost.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := database.ExecContext(t.Context(), `CREATE TABLE mailbox_fixture (value TEXT)`); err != nil {
+		t.Fatal(err)
+	}
+	if err := database.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	snapshot, err := mailboxDoctorSnapshot(t.Context(), state)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(snapshot) })
+	if !privateDoctorDirectory(snapshot) {
+		t.Fatal("mailbox snapshot directory is not private")
+	}
+	if _, err := os.Stat(filepath.Join(snapshot, "waypost.db")); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/cmd/punaro-adapter/main_test.go
+++ b/cmd/punaro-adapter/main_test.go
@@ -560,6 +560,44 @@ func TestMailboxDoctorSnapshotsLegacyAndWaypostDatabases(t *testing.T) {
 	}
 }
 
+func TestMailboxDoctorProtectsSnapshotDirectoryBeforeUse(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX private-directory fixture")
+	}
+	state := t.TempDir()
+	if err := os.Chmod(state, 0o700); err != nil { // #nosec G302 -- private mailbox fixture.
+		t.Fatal(err)
+	}
+	database, err := sql.Open("sqlite", filepath.Join(state, "waypost.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := database.ExecContext(t.Context(), `CREATE TABLE mailbox_fixture (value TEXT)`); err != nil {
+		t.Fatal(err)
+	}
+	if err := database.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	previous := mailboxDoctorSnapshotProtect
+	protected := ""
+	mailboxDoctorSnapshotProtect = func(path string) error {
+		protected = path
+		return errors.New("fixture protection failure")
+	}
+	t.Cleanup(func() { mailboxDoctorSnapshotProtect = previous })
+
+	if _, err := mailboxDoctorSnapshot(t.Context(), state); err == nil {
+		t.Fatal("snapshot protection failure was ignored")
+	}
+	if protected == "" {
+		t.Fatal("snapshot directory was not protected")
+	}
+	if _, err := os.Stat(protected); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("failed protected snapshot was not removed: %v", err)
+	}
+}
+
 func TestMailboxDoctorIsolationHonorsDeadline(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("POSIX blocking executable fixture")
@@ -930,12 +968,12 @@ func TestPluginDoctorValidatesAllAdaptersLauncherAndExactSkillTree(t *testing.T)
 		t.Fatal(err)
 	}
 	oldRelease, oldDigest, oldRuntimeDigest := adapterBuildRelease, adapterExpectedSkillSetDigest, adapterExpectedPluginRuntimeDigest
-	adapterBuildRelease, adapterExpectedSkillSetDigest, adapterExpectedPluginRuntimeDigest = "v0.1.0-alpha.4", digest, runtimeDigest
+	adapterBuildRelease, adapterExpectedSkillSetDigest, adapterExpectedPluginRuntimeDigest = "v0.1.0-alpha.5", digest, runtimeDigest
 	t.Cleanup(func() {
 		adapterBuildRelease, adapterExpectedSkillSetDigest, adapterExpectedPluginRuntimeDigest = oldRelease, oldDigest, oldRuntimeDigest
 	})
 	result := inspectAdapterPlugin(t.Context(), root)
-	if !result.Portable || !result.Codex || !result.Claude || !result.Launcher || result.Version != "v0.1.0-alpha.4" || result.SkillDigest != "sha256:"+digest {
+	if !result.Portable || !result.Codex || !result.Claude || !result.Launcher || result.Version != "v0.1.0-alpha.5" || result.SkillDigest != "sha256:"+digest {
 		t.Fatalf("plugin=%#v", result)
 	}
 	var helperOutput bytes.Buffer

--- a/cmd/punaro-release/main_test.go
+++ b/cmd/punaro-release/main_test.go
@@ -171,8 +171,8 @@ func TestBuildFactsBindsPluginSkillsGeneratedComposeAndMigrations(t *testing.T) 
 	if err != nil {
 		t.Fatal(err)
 	}
-	facts, err := buildFacts([]string{"--release", "v0.1.0-alpha.4", "--plugin-root", root})
-	if err != nil || facts.Release != "v0.1.0-alpha.4" || facts.ComposeSHA256 != operator.ComposeManifestSHA256() || len(facts.MigrationManifestSHA256) != 64 || len(facts.SkillSetSHA256) != 64 || len(facts.PluginRuntimeSHA256) != 64 {
+	facts, err := buildFacts([]string{"--release", "v0.1.0-alpha.5", "--plugin-root", root})
+	if err != nil || facts.Release != "v0.1.0-alpha.5" || facts.ComposeSHA256 != operator.ComposeManifestSHA256() || len(facts.MigrationManifestSHA256) != 64 || len(facts.SkillSetSHA256) != 64 || len(facts.PluginRuntimeSHA256) != 64 {
 		t.Fatalf("facts=%#v err=%v", facts, err)
 	}
 	if _, err := buildFacts([]string{"--release", "v0.1.0", "--plugin-root", root}); err == nil {

--- a/docs/doctor.md
+++ b/docs/doctor.md
@@ -40,6 +40,10 @@ accepts the legacy `mailbox.db`, flat membership array, and complete
 `mailbox_status` / `mailbox_recv` / `mailbox_ack` / `mailbox_wait` surface. Both database names
 in one configured state directory are ambiguous and fail closed; doctor never
 runs migration or chooses one on the operator's behalf.
+On Windows the disposable snapshot directory receives a protected,
+current-user-owned DACL before SQLite opens it, and the read-only SQLite URI
+uses canonical slash-separated drive paths. A snapshot that cannot satisfy
+either boundary fails closed without falling back to the live mailbox.
 Backup contents, mailbox state, and nested skill trees are traversed in bounded
 directory batches with total-entry ceilings and deadline checks between reads.
 Skill-set digests length-prefix every relative path and file body so arbitrary

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "punaro",
-  "version": "0.1.0-alpha.4",
+  "version": "0.1.0-alpha.5",
   "description": "Safely receive and reply to durable Punaro messages and handle explicitly authorized trusted attachments.",
   "author": {
     "name": "Punaro contributors",

--- a/scripts/test-install-adapter.sh
+++ b/scripts/test-install-adapter.sh
@@ -104,8 +104,8 @@ file_mode() {
 
 [ -x "$adapter" ] || { printf '%s\n' 'adapter binary was not installed' >&2; exit 1; }
 [ -x "$bootstrap" ] || { printf '%s\n' 'bootstrap binary was not installed' >&2; exit 1; }
-[ "$("$adapter" version)" = 'v0.1.0-alpha.4' ] || { printf '%s\n' 'adapter binary lacks the source release identity' >&2; exit 1; }
-[ "$("$bootstrap" version)" = 'v0.1.0-alpha.4' ] || { printf '%s\n' 'bootstrap binary lacks the source release identity' >&2; exit 1; }
+[ "$("$adapter" version)" = 'v0.1.0-alpha.5' ] || { printf '%s\n' 'adapter binary lacks the source release identity' >&2; exit 1; }
+[ "$("$bootstrap" version)" = 'v0.1.0-alpha.5' ] || { printf '%s\n' 'bootstrap binary lacks the source release identity' >&2; exit 1; }
 [ -d "$home/.local/state/punaro-bootstrap/current" ] || { printf '%s\n' 'bootstrap current slot was not seeded' >&2; exit 1; }
 [ -x "$attachment" ] || { printf '%s\n' 'attachment binary was not installed' >&2; exit 1; }
 [ -x "$memory" ] || { printf '%s\n' 'memory binary was not installed' >&2; exit 1; }


### PR DESCRIPTION
## Summary

- protect the disposable mailbox snapshot directory with an owner-only DACL before SQLite opens it on Windows
- generate canonical slash-separated Windows SQLite file URIs and fail closed when snapshot protection fails
- bump plugin/install expectations to v0.1.0-alpha.5 and document the diagnostic boundary

Contributes to #188.

## Verification

- test-first regression: protection failure and Windows URI behavior failed before implementation
- Windows-native snapshot ACL, URI, and real SQLite VACUUM tests passed on a fleet Windows host
- a patched read-only adapter doctor passed the real migrated Waypost MCP snapshot diagnostic on that host
- make plugin-validate deployment-lint release-gates
- make test test-race staticcheck security lint

No message bodies, credentials, or private configuration were used in the PR evidence.