### PR TITLE
Fix legacy Telegram relay mail cutover

### DIFF
--- a/internal/postgres/mail_cutover.go
+++ b/internal/postgres/mail_cutover.go
@@ -67,17 +67,20 @@ func canonicalMailCutoverManifest(request MailCutoverRequest) ([]byte, error) {
 	}
 	counts := []int64{manifest.Counts.Endpoints, manifest.Counts.Conversations, manifest.Counts.Memberships, manifest.Counts.Roles, manifest.Counts.RoleMemberships, manifest.Counts.RoleBindings, manifest.Counts.Messages, manifest.Counts.Deliveries, manifest.Counts.RecipientCursors, manifest.Counts.MessageIdempotency, manifest.Counts.ConversationIdempotency, manifest.Counts.ControlEvents, manifest.Counts.ControlIdempotency, manifest.Counts.RequestNonces, manifest.Counts.RoleProfiles, manifest.Counts.RoleProfileIdempotency, manifest.Counts.RateBuckets, manifest.Counts.DirectConversations, manifest.Counts.MessageFromRoles, manifest.Counts.DirectMessageIdempotency, manifest.Counts.TelegramClaims, manifest.Counts.TelegramParticipants, manifest.Counts.TelegramClaimEvents, manifest.Counts.DisplayNameIdempotency, manifest.Counts.TelegramClaimIdempotency}
 	hashes := []string{manifest.TableSHA256.Endpoints, manifest.TableSHA256.Conversations, manifest.TableSHA256.Memberships, manifest.TableSHA256.Roles, manifest.TableSHA256.RoleMemberships, manifest.TableSHA256.RoleBindings, manifest.TableSHA256.Messages, manifest.TableSHA256.Deliveries, manifest.TableSHA256.RecipientCursors, manifest.TableSHA256.MessageIdempotency, manifest.TableSHA256.ConversationIdempotency, manifest.TableSHA256.ControlEvents, manifest.TableSHA256.ControlIdempotency, manifest.TableSHA256.RequestNonces, manifest.TableSHA256.RoleProfiles, manifest.TableSHA256.RoleProfileIdempotency, manifest.TableSHA256.RateBuckets, manifest.TableSHA256.DirectConversations, manifest.TableSHA256.MessageFromRoles, manifest.TableSHA256.DirectMessageIdempotency, manifest.TableSHA256.TelegramClaims, manifest.TableSHA256.TelegramParticipants, manifest.TableSHA256.TelegramClaimEvents, manifest.TableSHA256.DisplayNameIdempotency, manifest.TableSHA256.TelegramClaimIdempotency}
+	tables := []string{"mail_endpoints", "mail_conversations", "mail_memberships", "mail_roles", "mail_role_memberships", "mail_role_bindings", "mail_messages", "mail_deliveries", "mail_recipient_cursors", "mail_message_idempotency", "mail_conversation_idempotency", "mail_conversation_controls", "mail_conversation_control_idempotency", "mail_request_nonces", "mail_role_profiles", "mail_role_profile_idempotency", "mail_rate_buckets", "mail_direct_conversations", "mail_message_from_roles", "mail_direct_message_idempotency", "mail_telegram_claims", "mail_telegram_participants", "mail_telegram_claim_events", "mail_conversation_display_name_idempotency", "mail_telegram_claim_idempotency"}
 	if (manifest.Version < 1 || manifest.Version > 8) || manifest.SourceID != request.SourceID || manifest.Phase != relay.MigrationSourcePrepared || manifest.EpochID != request.EpochID || manifest.TargetIdentity != request.TargetIdentity || manifest.Fingerprint != request.SourceFingerprint {
 		return nil, errors.New("mail cutover manifest binding does not match")
 	}
-	parentRoleOnlyV3 := manifest.Version == 3 && manifest.Counts.ControlEvents == 0 && manifest.Counts.ControlIdempotency == 0 && manifest.TableSHA256.ControlEvents == "" && manifest.TableSHA256.ControlIdempotency == ""
 	for _, count := range counts {
 		if count < 0 {
 			return nil, errors.New("mail cutover manifest count is invalid")
 		}
 	}
 	for index, hash := range hashes {
-		if ((manifest.Version == 1 && index >= 3 && index <= 5) || ((manifest.Version <= 2 || parentRoleOnlyV3) && index >= 11 && index <= 12) || (manifest.Version < 4 && index >= 14) || (manifest.Version < 5 && index >= 16) || (manifest.Version < 6 && index >= 17) || (manifest.Version < 7 && index >= 20) || (manifest.Version < 8 && index >= 24)) && hash == "" {
+		if !relay.MigrationSourceTablePresent(manifest, tables[index]) {
+			if hash != "" || counts[index] != 0 {
+				return nil, errors.New("mail cutover manifest absent table evidence is invalid")
+			}
 			continue
 		}
 		if !mailCutoverDigestPattern.MatchString(hash) {

--- a/internal/postgres/mail_cutover_import.go
+++ b/internal/postgres/mail_cutover_import.go
@@ -333,7 +333,7 @@ func canonicalizeStagedPayload(payload []byte) ([]byte, error) {
 }
 
 func mailCutoverTableEvidence(manifest relay.MigrationSourceManifest, table string) (int64, string) {
-	if (manifest.Version == 1 && (table == "mail_roles" || table == "mail_role_memberships" || table == "mail_role_bindings")) || (manifest.Version <= 2 && (table == "mail_conversation_controls" || table == "mail_conversation_control_idempotency")) || (manifest.Version < 4 && (table == "mail_role_profiles" || table == "mail_role_profile_idempotency")) || (manifest.Version < 5 && table == "mail_rate_buckets") || (manifest.Version < 6 && (table == "mail_direct_conversations" || table == "mail_message_from_roles" || table == "mail_direct_message_idempotency")) || (manifest.Version < 7 && (table == "mail_telegram_claims" || table == "mail_telegram_participants" || table == "mail_telegram_claim_events" || table == "mail_conversation_display_name_idempotency")) || (manifest.Version < 8 && table == "mail_telegram_claim_idempotency") {
+	if !relay.MigrationSourceTablePresent(manifest, table) {
 		return 0, emptyMailCutoverDigest
 	}
 	switch table {

--- a/internal/postgres/mail_cutover_test.go
+++ b/internal/postgres/mail_cutover_test.go
@@ -90,6 +90,31 @@ func TestMailCutoverRequestValidation(t *testing.T) {
 	if len(current.Manifest) > 8192 {
 		t.Fatalf("current v7 manifest is %d bytes, want <= 8192", len(current.Manifest))
 	}
+	legacyTelegram := valid
+	legacyTelegramManifest := currentManifest
+	legacyTelegramManifest.TableSHA256.RoleProfiles = ""
+	legacyTelegramManifest.TableSHA256.RoleProfileIdempotency = ""
+	legacyTelegramManifest.TableSHA256.RateBuckets = ""
+	legacyTelegramManifest.TableSHA256.DirectConversations = ""
+	legacyTelegramManifest.TableSHA256.MessageFromRoles = ""
+	legacyTelegramManifest.TableSHA256.DirectMessageIdempotency = ""
+	legacyTelegramManifest.TableSHA256.DisplayNameIdempotency = ""
+	legacyTelegramManifest.TableSHA256.TelegramClaimIdempotency = ""
+	legacyTelegram.Manifest, _ = json.Marshal(legacyTelegramManifest)
+	legacyTelegramDigest := sha256.Sum256(legacyTelegram.Manifest)
+	legacyTelegram.ManifestSHA256 = hex.EncodeToString(legacyTelegramDigest[:])
+	if err := legacyTelegram.Validate(); err != nil {
+		t.Fatalf("legacy Telegram branch request rejected: %v", err)
+	}
+	legacyTelegramInvalid := legacyTelegram
+	legacyTelegramInvalidManifest := legacyTelegramManifest
+	legacyTelegramInvalidManifest.Counts.DirectConversations = 1
+	legacyTelegramInvalid.Manifest, _ = json.Marshal(legacyTelegramInvalidManifest)
+	legacyTelegramInvalidDigest := sha256.Sum256(legacyTelegramInvalid.Manifest)
+	legacyTelegramInvalid.ManifestSHA256 = hex.EncodeToString(legacyTelegramInvalidDigest[:])
+	if err := legacyTelegramInvalid.Validate(); err == nil {
+		t.Fatal("legacy Telegram branch accepted nonzero evidence for an absent table")
+	}
 	legacy := valid
 	legacyManifest := manifest
 	legacyManifest.Version = 1

--- a/internal/postgres/mail_cutover_test.go
+++ b/internal/postgres/mail_cutover_test.go
@@ -99,7 +99,9 @@ func TestMailCutoverRequestValidation(t *testing.T) {
 	legacyTelegramManifest.TableSHA256.MessageFromRoles = ""
 	legacyTelegramManifest.TableSHA256.DirectMessageIdempotency = ""
 	legacyTelegramManifest.TableSHA256.DisplayNameIdempotency = ""
-	legacyTelegramManifest.TableSHA256.TelegramClaimIdempotency = ""
+	legacyTelegramManifest.Counts.TelegramClaimIdempotency = legacyTelegramManifest.Counts.TelegramClaims
+	emptyDigest := sha256.Sum256(nil)
+	legacyTelegramManifest.TableSHA256.TelegramClaimIdempotency = hex.EncodeToString(emptyDigest[:])
 	legacyTelegram.Manifest, _ = json.Marshal(legacyTelegramManifest)
 	legacyTelegramDigest := sha256.Sum256(legacyTelegram.Manifest)
 	legacyTelegram.ManifestSHA256 = hex.EncodeToString(legacyTelegramDigest[:])

--- a/internal/relay/migration_batch.go
+++ b/internal/relay/migration_batch.go
@@ -213,6 +213,12 @@ func ReadMigrationSourceBatch(ctx context.Context, path, table, afterKey string,
 	if !MigrationSourceTablePresent(manifest, table) {
 		return MigrationSourceBatch{Done: true}, nil
 	}
+	source := migrationTableSpecForVersion(spec.source, manifest.Version)
+	selectColumns, sourceTable, sourceOrder := migrationSourceQuery(source, IsLegacyTelegramMigrationSource(manifest))
+	queryKeyColumns := spec.keyColumns
+	if IsLegacyTelegramMigrationSource(manifest) && table == "mail_telegram_claim_idempotency" {
+		queryKeyColumns = []string{"requested_by_machine", "idempotency_key"}
+	}
 	var keyValues []any
 	where := ""
 	if afterKey != "" {
@@ -228,24 +234,23 @@ func ReadMigrationSourceBatch(ctx context.Context, path, table, afterKey string,
 				return MigrationSourceBatch{}, errors.New("relay migration resume key is invalid")
 			}
 			keyValues[index] = part
-			predicates[index] = spec.keyColumns[index] + "=?"
+			predicates[index] = queryKeyColumns[index] + "=?"
 			placeholders[index] = "?"
 		}
 		var present int
 		// #nosec G201 -- identifiers come only from migrationBatchSpecs.
-		exactQuery := fmt.Sprintf("SELECT 1 FROM %s WHERE %s LIMIT 1", spec.source.name, strings.Join(predicates, " AND "))
+		exactQuery := fmt.Sprintf("SELECT 1 FROM %s WHERE %s LIMIT 1", sourceTable, strings.Join(predicates, " AND "))
 		if err := tx.QueryRowContext(ctx, exactQuery, keyValues...).Scan(&present); err != nil || present != 1 { // #nosec G202 -- fragments come only from migrationBatchSpecs.
 			return MigrationSourceBatch{}, errors.New("relay migration resume key is unavailable")
 		}
 		if len(parts) == 1 {
-			where = " WHERE " + spec.keyColumns[0] + ">?"
+			where = " WHERE " + queryKeyColumns[0] + ">?"
 		} else {
-			where = " WHERE (" + strings.Join(spec.keyColumns, ",") + ")>(" + strings.Join(placeholders, ",") + ")"
+			where = " WHERE (" + strings.Join(queryKeyColumns, ",") + ")>(" + strings.Join(placeholders, ",") + ")"
 		}
 	}
-	source := migrationTableSpecForVersion(spec.source, manifest.Version)
 	// #nosec G201 -- fragments come only from migrationBatchSpecs and frozen parent column lists.
-	query := fmt.Sprintf("SELECT %s FROM %s%s ORDER BY %s LIMIT ?", source.columns, source.name, where, source.order)
+	query := fmt.Sprintf("SELECT %s FROM %s%s ORDER BY %s LIMIT ?", selectColumns, sourceTable, where, sourceOrder)
 	arguments := make([]any, 0, len(keyValues)+1)
 	arguments = append(arguments, keyValues...)
 	arguments = append(arguments, limit+1)

--- a/internal/relay/migration_batch.go
+++ b/internal/relay/migration_batch.go
@@ -210,8 +210,7 @@ func ReadMigrationSourceBatch(ctx context.Context, path, table, afterKey string,
 	if manifest.Phase != MigrationSourcePrepared {
 		return MigrationSourceBatch{}, errors.New("relay migration source is not prepared")
 	}
-	parentRoleOnlyV3 := manifest.Version == 3 && manifest.Counts.ControlEvents == 0 && manifest.Counts.ControlIdempotency == 0 && manifest.TableSHA256.ControlEvents == "" && manifest.TableSHA256.ControlIdempotency == ""
-	if (manifest.Version == 1 && (table == "mail_roles" || table == "mail_role_memberships" || table == "mail_role_bindings")) || ((manifest.Version <= 2 || parentRoleOnlyV3) && (table == "mail_conversation_controls" || table == "mail_conversation_control_idempotency")) || (manifest.Version < 4 && (table == "mail_role_profiles" || table == "mail_role_profile_idempotency")) || (manifest.Version < 5 && table == "mail_rate_buckets") || (manifest.Version < 6 && (table == "mail_direct_conversations" || table == "mail_message_from_roles" || table == "mail_direct_message_idempotency")) || (manifest.Version < 7 && (table == "mail_telegram_claims" || table == "mail_telegram_participants" || table == "mail_telegram_claim_events" || table == "mail_conversation_display_name_idempotency")) || (manifest.Version < 8 && table == "mail_telegram_claim_idempotency") {
+	if !MigrationSourceTablePresent(manifest, table) {
 		return MigrationSourceBatch{Done: true}, nil
 	}
 	var keyValues []any

--- a/internal/relay/migration_source.go
+++ b/internal/relay/migration_source.go
@@ -111,6 +111,55 @@ type MigrationSourceManifest struct {
 	lastTransition          string
 }
 
+// IsLegacyTelegramMigrationSource identifies the exact v7-shaped predecessor
+// branch that carried Telegram claims and current message metadata without the
+// later profile, rate-limit, direct-message, rename-idempotency, and
+// claim-idempotency tables.
+func IsLegacyTelegramMigrationSource(manifest MigrationSourceManifest) bool {
+	return manifest.Version == 7 &&
+		manifest.TableSHA256.TelegramClaims != "" && manifest.TableSHA256.TelegramParticipants != "" && manifest.TableSHA256.TelegramClaimEvents != "" &&
+		manifest.Counts.RoleProfiles == 0 && manifest.TableSHA256.RoleProfiles == "" &&
+		manifest.Counts.RoleProfileIdempotency == 0 && manifest.TableSHA256.RoleProfileIdempotency == "" &&
+		manifest.Counts.RateBuckets == 0 && manifest.TableSHA256.RateBuckets == "" &&
+		manifest.Counts.DirectConversations == 0 && manifest.TableSHA256.DirectConversations == "" &&
+		manifest.Counts.MessageFromRoles == 0 && manifest.TableSHA256.MessageFromRoles == "" &&
+		manifest.Counts.DirectMessageIdempotency == 0 && manifest.TableSHA256.DirectMessageIdempotency == "" &&
+		manifest.Counts.DisplayNameIdempotency == 0 && manifest.TableSHA256.DisplayNameIdempotency == "" &&
+		manifest.Counts.TelegramClaimIdempotency == 0 && manifest.TableSHA256.TelegramClaimIdempotency == ""
+}
+
+// MigrationSourceTablePresent reports whether one canonical cutover table is
+// represented by the source schema rather than by an empty destination table.
+func MigrationSourceTablePresent(manifest MigrationSourceManifest, table string) bool {
+	legacyTelegram := IsLegacyTelegramMigrationSource(manifest)
+	if legacyTelegram {
+		switch table {
+		case "mail_role_profiles", "mail_role_profile_idempotency", "mail_rate_buckets", "mail_direct_conversations", "mail_message_from_roles", "mail_direct_message_idempotency", "mail_conversation_display_name_idempotency", "mail_telegram_claim_idempotency":
+			return false
+		}
+	}
+	parentRoleOnlyV3 := manifest.Version == 3 && manifest.Counts.ControlEvents == 0 && manifest.Counts.ControlIdempotency == 0 && manifest.TableSHA256.ControlEvents == "" && manifest.TableSHA256.ControlIdempotency == ""
+	if manifest.Version == 1 && (table == "mail_roles" || table == "mail_role_memberships" || table == "mail_role_bindings") {
+		return false
+	}
+	if (manifest.Version <= 2 || parentRoleOnlyV3) && (table == "mail_conversation_controls" || table == "mail_conversation_control_idempotency") {
+		return false
+	}
+	if manifest.Version < 4 && (table == "mail_role_profiles" || table == "mail_role_profile_idempotency") {
+		return false
+	}
+	if manifest.Version < 5 && table == "mail_rate_buckets" {
+		return false
+	}
+	if manifest.Version < 6 && (table == "mail_direct_conversations" || table == "mail_message_from_roles" || table == "mail_direct_message_idempotency") {
+		return false
+	}
+	if manifest.Version < 7 && (table == "mail_telegram_claims" || table == "mail_telegram_participants" || table == "mail_telegram_claim_events" || table == "mail_conversation_display_name_idempotency") {
+		return false
+	}
+	return manifest.Version >= 8 || table != "mail_telegram_claim_idempotency"
+}
+
 type migrationTableSpec struct {
 	name, columns, order string
 }
@@ -149,6 +198,11 @@ var v5MigrationTableSpecs = withParentConversationAndMessageColumns(migrationTab
 var v6MigrationTableSpecs = withParentConversationAndMessageColumns(migrationTableSpecs[:20])
 var v7MigrationTableSpecs = append([]migrationTableSpec(nil), migrationTableSpecs[:24]...)
 
+var legacyTelegramV7MigrationTableSpecs = func() []migrationTableSpec {
+	specs := append([]migrationTableSpec(nil), migrationTableSpecs[:14]...)
+	return append(specs, migrationTableSpecs[20:23]...)
+}()
+
 var roleMigrationTableSpecs = withParentConversationAndMessageColumns(func() []migrationTableSpec {
 	specs := append([]migrationTableSpec(nil), migrationTableSpecs[:11]...)
 	return append(specs, migrationTableSpecs[13])
@@ -180,6 +234,7 @@ var legacyMigrationTableSpecs = []migrationTableSpec{
 }
 
 const v7MigrationSourceSchema = "punaro-relay-sqlite-v7:endpoints;conversations;memberships;roles;role_memberships;role_bindings;messages;deliveries;recipient_cursors;idempotency;conversation_idempotency;conversation_controls;conversation_control_idempotency;request_nonces;role_profiles;role_profile_idempotency;rate_buckets;direct_conversations;message_from_roles;direct_message_idempotency;telegram_claims;telegram_participants;telegram_claim_events;conversation_display_name_idempotency"
+const legacyTelegramV7MigrationSourceSchema = "punaro-relay-sqlite-v7-legacy-telegram:endpoints;conversations;memberships;roles;role_memberships;role_bindings;messages;deliveries;recipient_cursors;idempotency;conversation_idempotency;conversation_controls;conversation_control_idempotency;request_nonces;telegram_claims;telegram_participants;telegram_claim_events"
 const migrationSourceSchema = v7MigrationSourceSchema + ";telegram_claim_idempotency"
 const v6MigrationSourceSchema = "punaro-relay-sqlite-v6:endpoints;conversations;memberships;roles;role_memberships;role_bindings;messages;deliveries;recipient_cursors;idempotency;conversation_idempotency;conversation_controls;conversation_control_idempotency;request_nonces;role_profiles;role_profile_idempotency;rate_buckets;direct_conversations;message_from_roles;direct_message_idempotency"
 const v5MigrationSourceSchema = "punaro-relay-sqlite-v5:endpoints;conversations;memberships;roles;role_memberships;role_bindings;messages;deliveries;recipient_cursors;idempotency;conversation_idempotency;conversation_controls;conversation_control_idempotency;request_nonces;role_profiles;role_profile_idempotency;rate_buckets"
@@ -238,7 +293,7 @@ func CheckMigrationSourceEnrollmentCoverage(ctx context.Context, path, enrollmen
 	}
 	for rows.Next() {
 		var endpoint, machineID string
-		if err := rows.Scan(&endpoint, &machineID); err != nil || !authenticator.AllowsEndpoint(machineID, endpoint) {
+		if err := rows.Scan(&endpoint, &machineID); err != nil || (!authenticator.AllowsEndpoint(machineID, endpoint) && machineID != retiredMigrationMachineID(endpoint)) {
 			_ = rows.Close()
 			return errors.New("relay migration enrollment does not cover every endpoint")
 		}
@@ -296,6 +351,11 @@ func PrepareMigrationSource(ctx context.Context, path, epochID, targetIdentity, 
 		if current.Phase != MigrationSourceActive || current.Fingerprint != expectedFingerprint {
 			return MigrationSourceManifest{}, errors.New("relay migration source changed before preparation")
 		}
+		if IsLegacyTelegramMigrationSource(current) {
+			if err := repairLegacyTelegramMigrationSource(ctx, conn); err != nil {
+				return MigrationSourceManifest{}, err
+			}
+		}
 		if _, err := conn.ExecContext(ctx, `UPDATE endpoints SET lease_until=?,ownership_generation=ownership_generation+1,
 			consumer_id=NULL,consumer_generation=consumer_generation+CASE WHEN consumer_id IS NULL THEN 0 ELSE 1 END,consumer_lease_until=NULL`, now.UTC().UnixMilli()); err != nil {
 			return MigrationSourceManifest{}, errors.New("relay migration endpoint fencing failed")
@@ -311,6 +371,11 @@ func PrepareMigrationSource(ctx context.Context, path, epochID, targetIdentity, 
 			lease_generation=lease_generation+CASE WHEN lease_token IS NULL THEN 0 ELSE 1 END,
 			ownership_generation=NULL,consumer_generation=NULL,lease_until=NULL`); err != nil {
 			return MigrationSourceManifest{}, errors.New("relay migration delivery fencing failed")
+		}
+		if IsLegacyTelegramMigrationSource(current) {
+			if err := verifyRepairedLegacyTelegramMigrationSource(ctx, conn); err != nil {
+				return MigrationSourceManifest{}, err
+			}
 		}
 		prepared, err := inspectMigrationSource(ctx, conn)
 		if err != nil {
@@ -331,6 +396,72 @@ func PrepareMigrationSource(ctx context.Context, path, epochID, targetIdentity, 
 		prepared.lastTransition = "prepared"
 		return prepared, nil
 	})
+}
+
+func retiredMigrationMachineID(endpoint string) string {
+	digest := sha256.Sum256([]byte(endpoint))
+	return "migration-retired-" + hex.EncodeToString(digest[:])
+}
+
+func repairLegacyTelegramMigrationSource(ctx context.Context, conn *sql.Conn) error {
+	rows, err := conn.QueryContext(ctx, `WITH referenced(endpoint) AS (
+		SELECT endpoint FROM memberships
+		UNION SELECT from_endpoint FROM messages
+		UNION SELECT recipient_endpoint FROM deliveries WHERE substr(recipient_endpoint,1,6)<>char(30)||'role:'
+		UNION SELECT recipient_endpoint FROM recipient_cursors WHERE substr(recipient_endpoint,1,6)<>char(30)||'role:'
+		UNION SELECT actor_endpoint FROM conversation_controls
+		UNION SELECT member_endpoint FROM conversation_controls
+		UNION SELECT session_endpoint FROM role_bindings
+		UNION SELECT requested_by_endpoint FROM telegram_claims
+		UNION SELECT actor_endpoint FROM telegram_claim_events
+		UNION SELECT in_reply_to_endpoint FROM messages WHERE in_reply_to_endpoint IS NOT NULL
+	)
+	SELECT referenced.endpoint,COALESCE(min(role_bindings.machine_id),''),count(DISTINCT role_bindings.machine_id)
+	FROM referenced LEFT JOIN endpoints ON endpoints.endpoint=referenced.endpoint
+	LEFT JOIN role_bindings ON role_bindings.session_endpoint=referenced.endpoint
+	WHERE endpoints.endpoint IS NULL GROUP BY referenced.endpoint ORDER BY referenced.endpoint COLLATE BINARY`)
+	if err != nil {
+		return errors.New("relay migration legacy endpoint repair is unavailable")
+	}
+	type missingEndpoint struct{ endpoint, bindingMachine string }
+	var missing []missingEndpoint
+	for rows.Next() {
+		var endpoint, bindingMachine string
+		var bindingMachines int
+		if err := rows.Scan(&endpoint, &bindingMachine, &bindingMachines); err != nil || !ValidEndpoint(endpoint) || bindingMachines > 1 || bindingMachine != "" && !ValidMachineID(bindingMachine) {
+			_ = rows.Close()
+			return errors.New("relay migration legacy endpoint repair is ambiguous")
+		}
+		missing = append(missing, missingEndpoint{endpoint: endpoint, bindingMachine: bindingMachine})
+	}
+	if err := rows.Close(); err != nil || rows.Err() != nil {
+		return errors.New("relay migration legacy endpoint repair is unavailable")
+	}
+	for _, item := range missing {
+		machineID := item.bindingMachine
+		if machineID == "" {
+			machineID = retiredMigrationMachineID(item.endpoint)
+		}
+		if _, err := conn.ExecContext(ctx, `INSERT INTO endpoints(endpoint,machine_id,lease_until,ownership_generation,consumer_id,consumer_generation,consumer_lease_until) VALUES(?,?,0,1,NULL,0,NULL)`, item.endpoint, machineID); err != nil {
+			return errors.New("relay migration legacy endpoint repair cannot be persisted")
+		}
+	}
+	return nil
+}
+
+func verifyRepairedLegacyTelegramMigrationSource(ctx context.Context, q migrationQueryer) error {
+	var invalid bool
+	err := q.QueryRowContext(ctx, `SELECT
+		EXISTS(SELECT 1 FROM memberships m LEFT JOIN endpoints e ON e.endpoint=m.endpoint WHERE e.endpoint IS NULL)
+		OR EXISTS(SELECT 1 FROM messages m LEFT JOIN endpoints e ON e.endpoint=m.from_endpoint WHERE e.endpoint IS NULL)
+		OR EXISTS(SELECT 1 FROM deliveries d LEFT JOIN endpoints e ON e.endpoint=d.recipient_endpoint LEFT JOIN roles r ON substr(d.recipient_endpoint,7)=r.role WHERE (substr(d.recipient_endpoint,1,6)=char(30)||'role:' AND r.role IS NULL) OR (substr(d.recipient_endpoint,1,6)<>char(30)||'role:' AND e.endpoint IS NULL))
+		OR EXISTS(SELECT 1 FROM recipient_cursors c LEFT JOIN endpoints e ON e.endpoint=c.recipient_endpoint LEFT JOIN roles r ON substr(c.recipient_endpoint,7)=r.role WHERE (substr(c.recipient_endpoint,1,6)=char(30)||'role:' AND r.role IS NULL) OR (substr(c.recipient_endpoint,1,6)<>char(30)||'role:' AND e.endpoint IS NULL))
+		OR EXISTS(SELECT 1 FROM deliveries WHERE lease_machine_id IS NOT NULL OR lease_token IS NOT NULL OR ownership_generation IS NOT NULL OR consumer_generation IS NOT NULL OR lease_until IS NOT NULL)
+		OR EXISTS(SELECT 1 FROM role_bindings b LEFT JOIN roles r ON r.role=b.role LEFT JOIN endpoints e ON e.endpoint=b.session_endpoint WHERE r.role IS NULL OR e.endpoint IS NULL OR r.machine_id<>b.machine_id OR e.machine_id<>b.machine_id OR e.ownership_generation<>b.ownership_generation)`).Scan(&invalid)
+	if err != nil || invalid {
+		return errors.New("relay migration legacy source repair is incomplete")
+	}
+	return nil
 }
 
 // AbortPreparedMigrationSource reopens SQLite only before the permanent retire
@@ -467,6 +598,7 @@ func inspectMigrationSource(ctx context.Context, q migrationQueryer) (MigrationS
 	}
 	manifest := MigrationSourceManifest{Version: 3}
 	roleOnly := false
+	legacyTelegram := false
 	tableSpecs, schema := v3MigrationTableSpecs, v3MigrationSourceSchema
 	switch {
 	case roleTables == 0:
@@ -478,6 +610,14 @@ func inspectMigrationSource(ctx context.Context, q migrationQueryer) (MigrationS
 		roleOnly = true
 		manifest.Version = 2
 		tableSpecs, schema = roleMigrationTableSpecs, roleMigrationSourceSchema
+	case telegramTables == 3 && claimIdempotencyTables == 0 && profileTables == 0 && rateBucketTables == 0 && directTables == 0:
+		// The Telegram topic-claim branch was deployed from a supported
+		// predecessor before the later profile, rate-limit, direct-message,
+		// rename-idempotency, and claim-idempotency tables converged on main.
+		// Its conversation/message columns and Telegram tables are v7-shaped.
+		legacyTelegram = true
+		manifest.Version = 7
+		tableSpecs, schema = legacyTelegramV7MigrationTableSpecs, legacyTelegramV7MigrationSourceSchema
 	case claimIdempotencyTables == 1 && telegramTables == 3:
 		manifest.Version = 8
 		tableSpecs, schema = migrationTableSpecs, migrationSourceSchema
@@ -522,7 +662,7 @@ func inspectMigrationSource(ctx context.Context, q migrationQueryer) (MigrationS
 	if manifest.lastTransition != "" && manifest.lastTransition != "prepared" && manifest.lastTransition != "aborted" && manifest.lastTransition != "retired" {
 		return MigrationSourceManifest{}, errors.New("relay migration transition journal is invalid")
 	}
-	if err := verifyMigrationSourceSchemaVersion(ctx, q, manifest.Version, controlTables == 2, profileTables == 2, rateBucketTables == 1, directTables == 3); err != nil {
+	if err := verifyMigrationSourceSchemaVersion(ctx, q, manifest.Version, controlTables == 2, profileTables == 2, rateBucketTables == 1, directTables == 3, legacyTelegram); err != nil {
 		return MigrationSourceManifest{}, err
 	}
 	overall := sha256.New()
@@ -599,11 +739,11 @@ func conversationDisplayNameTypeCheck(version int) string {
 	return " OR (display_name IS NOT NULL AND typeof(display_name)<>'text')"
 }
 
-func verifyMigrationSourceSchemaVersion(ctx context.Context, q migrationQueryer, version int, controls, profiles, rateBuckets, direct bool) error {
+func verifyMigrationSourceSchemaVersion(ctx context.Context, q migrationQueryer, version int, controls, profiles, rateBuckets, direct, legacyTelegram bool) error {
 	if version == 1 {
 		return verifyLegacyMigrationSourceSchema(ctx, q)
 	}
-	return verifyMigrationSourceSchema(ctx, q, version, controls, profiles, rateBuckets, direct)
+	return verifyMigrationSourceSchema(ctx, q, version, controls, profiles, rateBuckets, direct, legacyTelegram)
 }
 
 func verifyLegacyMigrationSourceSchema(ctx context.Context, q migrationQueryer) error {
@@ -639,7 +779,7 @@ func verifyLegacyMigrationSourceSchema(ctx context.Context, q migrationQueryer) 
 	return foreignKeys.Close()
 }
 
-func verifyMigrationSourceSchema(ctx context.Context, q migrationQueryer, version int, controls, profiles, rateBuckets, direct bool) error {
+func verifyMigrationSourceSchema(ctx context.Context, q migrationQueryer, version int, controls, profiles, rateBuckets, direct, legacyTelegram bool) error {
 	rows, err := q.QueryContext(ctx, `SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%' ORDER BY name`)
 	if err != nil {
 		return errors.New("relay migration source schema is unavailable")
@@ -656,6 +796,8 @@ func verifyMigrationSourceSchema(ctx context.Context, q migrationQueryer, versio
 	names = filterOperationalQuotaTables(names)
 	want := []string{"conversation_control_idempotency", "conversation_controls", "conversation_display_name_idempotency", "conversation_idempotency", "conversations", "deliveries", "endpoints", "idempotency", "memberships", "messages", "recipient_cursors", "relay_migration_control", "request_nonces", "role_bindings", "role_memberships", "roles", "telegram_claim_events", "telegram_claim_idempotency", "telegram_claims", "telegram_participants"}
 	switch {
+	case legacyTelegram:
+		want = []string{"conversation_control_idempotency", "conversation_controls", "conversation_idempotency", "conversations", "deliveries", "endpoints", "idempotency", "memberships", "messages", "recipient_cursors", "relay_migration_control", "request_nonces", "role_bindings", "role_memberships", "roles", "telegram_claim_events", "telegram_claims", "telegram_participants"}
 	case direct:
 		want = []string{"conversation_control_idempotency", "conversation_controls", "conversation_display_name_idempotency", "conversation_idempotency", "conversations", "deliveries", "direct_conversations", "direct_message_idempotency", "endpoints", "idempotency", "memberships", "message_from_roles", "messages", "rate_buckets", "recipient_cursors", "relay_migration_control", "request_nonces", "role_bindings", "role_memberships", "role_profile_idempotency", "role_profiles", "roles", "telegram_claim_events", "telegram_claim_idempotency", "telegram_claims", "telegram_participants"}
 	case rateBuckets:
@@ -732,6 +874,10 @@ func verifyMigrationSourceSchema(ctx context.Context, q migrationQueryer, versio
 		delete(expectedColumns, "message_from_roles")
 		delete(expectedColumns, "direct_message_idempotency")
 	}
+	if legacyTelegram {
+		delete(expectedColumns, "conversation_display_name_idempotency")
+		expectedColumns["messages"] = append(expectedColumns["messages"], "to_role:TEXT:0:0:-")
+	}
 	if version < 8 {
 		delete(expectedColumns, "telegram_claim_idempotency")
 	}
@@ -803,6 +949,9 @@ func verifyMigrationSourceSchema(ctx context.Context, q migrationQueryer, versio
 		delete(expectedForeignKeys, "direct_conversations")
 		delete(expectedForeignKeys, "message_from_roles")
 		delete(expectedForeignKeys, "direct_message_idempotency")
+	}
+	if legacyTelegram {
+		delete(expectedForeignKeys, "conversation_display_name_idempotency")
 	}
 	if version < 8 {
 		delete(expectedForeignKeys, "telegram_claim_idempotency")
@@ -892,6 +1041,16 @@ func verifyMigrationSourceSchema(ctx context.Context, q migrationQueryer, versio
 		filtered := expectedIndexes[:0]
 		for _, index := range expectedIndexes {
 			if strings.HasPrefix(index, "telegram_") || strings.HasPrefix(index, "conversation_display_name_idempotency:") {
+				continue
+			}
+			filtered = append(filtered, index)
+		}
+		expectedIndexes = filtered
+	}
+	if legacyTelegram {
+		filtered := expectedIndexes[:0]
+		for _, index := range expectedIndexes {
+			if strings.HasPrefix(index, "conversation_display_name_idempotency:") || index == "telegram_claims:1:c:0:requested_by_machine,idempotency_key" {
 				continue
 			}
 			filtered = append(filtered, index)
@@ -998,6 +1157,9 @@ func verifyMigrationSourceSchema(ctx context.Context, q migrationQueryer, versio
 	if version < 7 {
 		wantTriggers -= 12
 	}
+	if legacyTelegram {
+		wantTriggers -= 3
+	}
 	var quotaTables int
 	if err := q.QueryRowContext(ctx, `SELECT count(*) FROM sqlite_master WHERE type='table' AND name IN ('pending_quota_recipients','pending_quota_install','delivery_terminals')`).Scan(&quotaTables); err != nil || quotaTables != 0 && quotaTables != 2 && quotaTables != 3 {
 		return errors.New("relay migration source schema is unavailable")
@@ -1102,6 +1264,29 @@ func verifyMigrationSourceSchema(ctx context.Context, q migrationQueryer, versio
 		OR EXISTS (SELECT 1 FROM role_profile_idempotency AS retry LEFT JOIN role_profiles AS profile ON profile.role=retry.role WHERE profile.role IS NULL
 			OR typeof(retry.machine_id)<>'text' OR typeof(retry.key)<>'text' OR typeof(retry.request_hash)<>'text' OR typeof(retry.role)<>'text'
 			OR (retry.display_name IS NOT NULL AND typeof(retry.display_name)<>'text') OR typeof(retry.direct_addressable)<>'integer' OR typeof(retry.updated_at)<>'integer' OR typeof(retry.created_at)<>'integer')`
+	}
+	if legacyTelegram {
+		for _, clause := range []string{
+			"\n        OR EXISTS (SELECT 1 FROM memberships AS membership LEFT JOIN endpoints AS endpoint ON endpoint.endpoint=membership.endpoint WHERE endpoint.endpoint IS NULL)",
+			"\n        OR EXISTS (SELECT 1 FROM messages AS message LEFT JOIN endpoints AS endpoint ON endpoint.endpoint=message.from_endpoint WHERE endpoint.endpoint IS NULL)",
+		} {
+			logicalStateQuery = strings.ReplaceAll(logicalStateQuery, clause, "")
+		}
+		logicalStateQuery = strings.Replace(logicalStateQuery,
+			`OR EXISTS (SELECT 1 FROM deliveries WHERE lease_generation<0 OR (lease_token IS NOT NULL AND (ownership_generation<1 OR consumer_generation<0)) OR (acked_at IS NOT NULL AND lease_token IS NOT NULL) OR ((lease_machine_id IS NULL OR lease_token IS NULL OR ownership_generation IS NULL OR consumer_generation IS NULL OR lease_until IS NULL) AND NOT (lease_machine_id IS NULL AND lease_token IS NULL AND ownership_generation IS NULL AND consumer_generation IS NULL AND lease_until IS NULL)))`,
+			`OR EXISTS (SELECT 1 FROM deliveries WHERE lease_generation<0)`, 1)
+		logicalStateQuery = strings.Replace(logicalStateQuery,
+			`OR EXISTS (SELECT 1 FROM deliveries AS delivery LEFT JOIN endpoints AS endpoint ON endpoint.endpoint=delivery.recipient_endpoint LEFT JOIN roles AS role ON substr(delivery.recipient_endpoint,7)=role.role WHERE (substr(delivery.recipient_endpoint,1,6)=char(30)||'role:' AND role.role IS NULL) OR (substr(delivery.recipient_endpoint,1,6)<>char(30)||'role:' AND endpoint.endpoint IS NULL))`,
+			`OR EXISTS (SELECT 1 FROM deliveries AS delivery LEFT JOIN roles AS role ON substr(delivery.recipient_endpoint,7)=role.role WHERE substr(delivery.recipient_endpoint,1,6)=char(30)||'role:' AND role.role IS NULL)`, 1)
+		logicalStateQuery = strings.Replace(logicalStateQuery,
+			`OR EXISTS (SELECT 1 FROM recipient_cursors AS cursor LEFT JOIN endpoints AS endpoint ON endpoint.endpoint=cursor.recipient_endpoint LEFT JOIN roles AS role ON substr(cursor.recipient_endpoint,7)=role.role WHERE (substr(cursor.recipient_endpoint,1,6)=char(30)||'role:' AND role.role IS NULL) OR (substr(cursor.recipient_endpoint,1,6)<>char(30)||'role:' AND endpoint.endpoint IS NULL))`,
+			`OR EXISTS (SELECT 1 FROM recipient_cursors AS cursor LEFT JOIN roles AS role ON substr(cursor.recipient_endpoint,7)=role.role WHERE substr(cursor.recipient_endpoint,1,6)=char(30)||'role:' AND role.role IS NULL)`, 1)
+		logicalStateQuery = strings.Replace(logicalStateQuery,
+			`OR endpoint.machine_id<>binding.machine_id OR endpoint.ownership_generation<>binding.ownership_generation)`,
+			`OR (endpoint.endpoint IS NOT NULL AND endpoint.machine_id<>binding.machine_id))`, 1)
+		logicalStateQuery += `
+		OR EXISTS (SELECT 1 FROM messages WHERE to_role IS NOT NULL)
+		OR EXISTS (SELECT 1 FROM telegram_claims GROUP BY requested_by_machine,idempotency_key HAVING count(*)>1)`
 	}
 	if !controls {
 		for _, clause := range []string{

--- a/internal/relay/migration_source.go
+++ b/internal/relay/migration_source.go
@@ -293,7 +293,12 @@ func CheckMigrationSourceEnrollmentCoverage(ctx context.Context, path, enrollmen
 	}
 	for rows.Next() {
 		var endpoint, machineID string
-		if err := rows.Scan(&endpoint, &machineID); err != nil || (!authenticator.AllowsEndpoint(machineID, endpoint) && machineID != retiredMigrationMachineID(endpoint)) {
+		if err := rows.Scan(&endpoint, &machineID); err != nil {
+			_ = rows.Close()
+			return errors.New("relay migration enrollment does not cover every endpoint")
+		}
+		retiredRepairEndpoint := IsLegacyTelegramMigrationSource(manifest) && (manifest.Phase == MigrationSourcePrepared || manifest.Phase == MigrationSourceRetired) && machineID == retiredMigrationMachineID(endpoint)
+		if !authenticator.AllowsEndpoint(machineID, endpoint) && !retiredRepairEndpoint {
 			_ = rows.Close()
 			return errors.New("relay migration enrollment does not cover every endpoint")
 		}
@@ -404,6 +409,20 @@ func retiredMigrationMachineID(endpoint string) string {
 }
 
 func repairLegacyTelegramMigrationSource(ctx context.Context, conn *sql.Conn) error {
+	existing, err := conn.QueryContext(ctx, `SELECT endpoint,machine_id FROM endpoints ORDER BY endpoint COLLATE BINARY`)
+	if err != nil {
+		return errors.New("relay migration legacy endpoint provenance is unavailable")
+	}
+	for existing.Next() {
+		var endpoint, machineID string
+		if err := existing.Scan(&endpoint, &machineID); err != nil || machineID == retiredMigrationMachineID(endpoint) {
+			_ = existing.Close()
+			return errors.New("relay migration legacy endpoint provenance is invalid")
+		}
+	}
+	if err := existing.Close(); err != nil || existing.Err() != nil {
+		return errors.New("relay migration legacy endpoint provenance is unavailable")
+	}
 	rows, err := conn.QueryContext(ctx, `WITH referenced(endpoint) AS (
 		SELECT endpoint FROM memberships
 		UNION SELECT from_endpoint FROM messages
@@ -1269,6 +1288,7 @@ func verifyMigrationSourceSchema(ctx context.Context, q migrationQueryer, versio
 		for _, clause := range []string{
 			"\n        OR EXISTS (SELECT 1 FROM memberships AS membership LEFT JOIN endpoints AS endpoint ON endpoint.endpoint=membership.endpoint WHERE endpoint.endpoint IS NULL)",
 			"\n        OR EXISTS (SELECT 1 FROM messages AS message LEFT JOIN endpoints AS endpoint ON endpoint.endpoint=message.from_endpoint WHERE endpoint.endpoint IS NULL)",
+			"\n\t\tOR EXISTS (SELECT 1 FROM conversation_controls AS control\n\t\t\tLEFT JOIN endpoints AS actor ON actor.endpoint=control.actor_endpoint\n\t\t\tLEFT JOIN endpoints AS member ON member.endpoint=control.member_endpoint\n\t\t\tWHERE actor.endpoint IS NULL OR member.endpoint IS NULL)",
 		} {
 			logicalStateQuery = strings.ReplaceAll(logicalStateQuery, clause, "")
 		}
@@ -1281,6 +1301,9 @@ func verifyMigrationSourceSchema(ctx context.Context, q migrationQueryer, versio
 		logicalStateQuery = strings.Replace(logicalStateQuery,
 			`OR EXISTS (SELECT 1 FROM recipient_cursors AS cursor LEFT JOIN endpoints AS endpoint ON endpoint.endpoint=cursor.recipient_endpoint LEFT JOIN roles AS role ON substr(cursor.recipient_endpoint,7)=role.role WHERE (substr(cursor.recipient_endpoint,1,6)=char(30)||'role:' AND role.role IS NULL) OR (substr(cursor.recipient_endpoint,1,6)<>char(30)||'role:' AND endpoint.endpoint IS NULL))`,
 			`OR EXISTS (SELECT 1 FROM recipient_cursors AS cursor LEFT JOIN roles AS role ON substr(cursor.recipient_endpoint,7)=role.role WHERE substr(cursor.recipient_endpoint,1,6)=char(30)||'role:' AND role.role IS NULL)`, 1)
+		logicalStateQuery = strings.Replace(logicalStateQuery,
+			`WHERE role.role IS NULL OR endpoint.endpoint IS NULL`,
+			`WHERE role.role IS NULL`, 1)
 		logicalStateQuery = strings.Replace(logicalStateQuery,
 			`OR endpoint.machine_id<>binding.machine_id OR endpoint.ownership_generation<>binding.ownership_generation)`,
 			`OR (endpoint.endpoint IS NOT NULL AND endpoint.machine_id<>binding.machine_id))`, 1)

--- a/internal/relay/migration_source.go
+++ b/internal/relay/migration_source.go
@@ -125,7 +125,7 @@ func IsLegacyTelegramMigrationSource(manifest MigrationSourceManifest) bool {
 		manifest.Counts.MessageFromRoles == 0 && manifest.TableSHA256.MessageFromRoles == "" &&
 		manifest.Counts.DirectMessageIdempotency == 0 && manifest.TableSHA256.DirectMessageIdempotency == "" &&
 		manifest.Counts.DisplayNameIdempotency == 0 && manifest.TableSHA256.DisplayNameIdempotency == "" &&
-		manifest.Counts.TelegramClaimIdempotency == 0 && manifest.TableSHA256.TelegramClaimIdempotency == ""
+		manifest.Counts.TelegramClaimIdempotency == manifest.Counts.TelegramClaims && validMigrationDigest(manifest.TableSHA256.TelegramClaimIdempotency)
 }
 
 // MigrationSourceTablePresent reports whether one canonical cutover table is
@@ -133,8 +133,11 @@ func IsLegacyTelegramMigrationSource(manifest MigrationSourceManifest) bool {
 func MigrationSourceTablePresent(manifest MigrationSourceManifest, table string) bool {
 	legacyTelegram := IsLegacyTelegramMigrationSource(manifest)
 	if legacyTelegram {
+		if table == "mail_telegram_claim_idempotency" {
+			return true
+		}
 		switch table {
-		case "mail_role_profiles", "mail_role_profile_idempotency", "mail_rate_buckets", "mail_direct_conversations", "mail_message_from_roles", "mail_direct_message_idempotency", "mail_conversation_display_name_idempotency", "mail_telegram_claim_idempotency":
+		case "mail_role_profiles", "mail_role_profile_idempotency", "mail_rate_buckets", "mail_direct_conversations", "mail_message_from_roles", "mail_direct_message_idempotency", "mail_conversation_display_name_idempotency":
 			return false
 		}
 	}
@@ -200,7 +203,8 @@ var v7MigrationTableSpecs = append([]migrationTableSpec(nil), migrationTableSpec
 
 var legacyTelegramV7MigrationTableSpecs = func() []migrationTableSpec {
 	specs := append([]migrationTableSpec(nil), migrationTableSpecs[:14]...)
-	return append(specs, migrationTableSpecs[20:23]...)
+	specs = append(specs, migrationTableSpecs[20:23]...)
+	return append(specs, migrationTableSpecs[24])
 }()
 
 var roleMigrationTableSpecs = withParentConversationAndMessageColumns(func() []migrationTableSpec {
@@ -234,7 +238,7 @@ var legacyMigrationTableSpecs = []migrationTableSpec{
 }
 
 const v7MigrationSourceSchema = "punaro-relay-sqlite-v7:endpoints;conversations;memberships;roles;role_memberships;role_bindings;messages;deliveries;recipient_cursors;idempotency;conversation_idempotency;conversation_controls;conversation_control_idempotency;request_nonces;role_profiles;role_profile_idempotency;rate_buckets;direct_conversations;message_from_roles;direct_message_idempotency;telegram_claims;telegram_participants;telegram_claim_events;conversation_display_name_idempotency"
-const legacyTelegramV7MigrationSourceSchema = "punaro-relay-sqlite-v7-legacy-telegram:endpoints;conversations;memberships;roles;role_memberships;role_bindings;messages;deliveries;recipient_cursors;idempotency;conversation_idempotency;conversation_controls;conversation_control_idempotency;request_nonces;telegram_claims;telegram_participants;telegram_claim_events"
+const legacyTelegramV7MigrationSourceSchema = "punaro-relay-sqlite-v7-legacy-telegram:endpoints;conversations;memberships;roles;role_memberships;role_bindings;messages;deliveries;recipient_cursors;idempotency;conversation_idempotency;conversation_controls;conversation_control_idempotency;request_nonces;telegram_claims;telegram_participants;telegram_claim_events;telegram_claim_idempotency-derived-from-telegram_claims"
 
 const legacyMigrationEndpointRepairsTable = "relay_migration_endpoint_repairs"
 const migrationSourceSchema = v7MigrationSourceSchema + ";telegram_claim_idempotency"
@@ -244,6 +248,13 @@ const v4MigrationSourceSchema = "punaro-relay-sqlite-v4:endpoints;conversations;
 const v3MigrationSourceSchema = "punaro-relay-sqlite-v3:endpoints;conversations;memberships;roles;role_memberships;role_bindings;messages;deliveries;recipient_cursors;idempotency;conversation_idempotency;conversation_controls;conversation_control_idempotency;request_nonces"
 const roleMigrationSourceSchema = "punaro-relay-sqlite-v3:endpoints;conversations;memberships;roles;role_memberships;role_bindings;messages;deliveries;recipient_cursors;idempotency;conversation_idempotency;request_nonces"
 const legacyMigrationSourceSchema = "punaro-relay-sqlite-v1:endpoints;conversations;memberships;messages;deliveries;recipient_cursors;idempotency;conversation_idempotency;request_nonces"
+
+func migrationSourceQuery(spec migrationTableSpec, legacyTelegram bool) (string, string, string) {
+	if legacyTelegram && spec.name == "telegram_claim_idempotency" {
+		return "requested_by_machine AS machine_id,idempotency_key AS key,request_hash,conversation_id,created_at", "telegram_claims", "requested_by_machine,idempotency_key"
+	}
+	return spec.columns, spec.name, spec.order
+}
 
 // InspectMigrationSource reads an existing source without creating, migrating,
 // checkpointing, or changing its logical cutover state.
@@ -765,7 +776,8 @@ func inspectMigrationSource(ctx context.Context, q migrationQueryer) (MigrationS
 	}
 	for _, spec := range tableSpecs {
 		tableHash := sha256.New()
-		query := fmt.Sprintf("SELECT %s FROM %s ORDER BY %s", spec.columns, spec.name, spec.order)
+		selectColumns, sourceTable, order := migrationSourceQuery(spec, legacyTelegram)
+		query := fmt.Sprintf("SELECT %s FROM %s ORDER BY %s", selectColumns, sourceTable, order)
 		rows, err := q.QueryContext(ctx, query) // #nosec G202 -- query fragments come only from the fixed migrationTableSpecs allowlist.
 		if err != nil {
 			return MigrationSourceManifest{}, errors.New("relay migration source rows are unavailable")

--- a/internal/relay/migration_source.go
+++ b/internal/relay/migration_source.go
@@ -94,21 +94,22 @@ type MigrationSourceHashes struct {
 // MigrationSourceManifest is a content-addressed logical view of one SQLite
 // relay. It never includes file bytes, page order, WAL state, or secrets.
 type MigrationSourceManifest struct {
-	Version                 int                   `json:"version"`
-	SourceID                string                `json:"source_id"`
-	Phase                   MigrationSourcePhase  `json:"phase"`
-	EpochID                 string                `json:"epoch_id,omitempty"`
-	TargetIdentity          string                `json:"target_identity,omitempty"`
-	Counts                  MigrationSourceCounts `json:"counts"`
-	TableSHA256             MigrationSourceHashes `json:"table_sha256"`
-	Fingerprint             string                `json:"fingerprint"`
-	ExpectedFingerprint     string                `json:"-"`
-	lastEpochID             string
-	lastTargetIdentity      string
-	lastExpectedFingerprint string
-	lastResultFingerprint   string
-	lastCutoff              int64
-	lastTransition          string
+	Version                     int                   `json:"version"`
+	SourceID                    string                `json:"source_id"`
+	Phase                       MigrationSourcePhase  `json:"phase"`
+	EpochID                     string                `json:"epoch_id,omitempty"`
+	TargetIdentity              string                `json:"target_identity,omitempty"`
+	Counts                      MigrationSourceCounts `json:"counts"`
+	TableSHA256                 MigrationSourceHashes `json:"table_sha256"`
+	Fingerprint                 string                `json:"fingerprint"`
+	ExpectedFingerprint         string                `json:"-"`
+	lastEpochID                 string
+	lastTargetIdentity          string
+	lastExpectedFingerprint     string
+	lastResultFingerprint       string
+	lastCutoff                  int64
+	lastTransition              string
+	legacyTelegramRepairLineage bool
 }
 
 // IsLegacyTelegramMigrationSource identifies the exact v7-shaped predecessor
@@ -126,6 +127,23 @@ func IsLegacyTelegramMigrationSource(manifest MigrationSourceManifest) bool {
 		manifest.Counts.DirectMessageIdempotency == 0 && manifest.TableSHA256.DirectMessageIdempotency == "" &&
 		manifest.Counts.DisplayNameIdempotency == 0 && manifest.TableSHA256.DisplayNameIdempotency == "" &&
 		manifest.Counts.TelegramClaimIdempotency == manifest.Counts.TelegramClaims && validMigrationDigest(manifest.TableSHA256.TelegramClaimIdempotency)
+}
+
+func isLegacyTelegramRepairLineage(manifest MigrationSourceManifest) bool {
+	return IsLegacyTelegramMigrationSource(manifest) || manifest.legacyTelegramRepairLineage
+}
+
+func legacyTelegramRepairJournalAllows(manifest MigrationSourceManifest) bool {
+	switch manifest.Phase {
+	case MigrationSourceActive:
+		return manifest.lastTransition == "aborted"
+	case MigrationSourcePrepared:
+		return manifest.lastTransition == "prepared"
+	case MigrationSourceRetired:
+		return manifest.lastTransition == "retired"
+	default:
+		return false
+	}
 }
 
 // MigrationSourceTablePresent reports whether one canonical cutover table is
@@ -373,7 +391,7 @@ func PrepareMigrationSource(ctx context.Context, path, epochID, targetIdentity, 
 		if current.Phase != MigrationSourceActive || current.Fingerprint != expectedFingerprint {
 			return MigrationSourceManifest{}, errors.New("relay migration source changed before preparation")
 		}
-		if IsLegacyTelegramMigrationSource(current) {
+		if isLegacyTelegramRepairLineage(current) {
 			if err := repairLegacyTelegramMigrationSource(ctx, conn, current); err != nil {
 				return MigrationSourceManifest{}, err
 			}
@@ -394,7 +412,7 @@ func PrepareMigrationSource(ctx context.Context, path, epochID, targetIdentity, 
 			ownership_generation=NULL,consumer_generation=NULL,lease_until=NULL`); err != nil {
 			return MigrationSourceManifest{}, errors.New("relay migration delivery fencing failed")
 		}
-		if IsLegacyTelegramMigrationSource(current) {
+		if isLegacyTelegramRepairLineage(current) {
 			if err := verifyRepairedLegacyTelegramMigrationSource(ctx, conn); err != nil {
 				return MigrationSourceManifest{}, err
 			}
@@ -434,7 +452,7 @@ func readLegacyMigrationEndpointRepairs(ctx context.Context, q migrationQueryer,
 	if tables == 0 {
 		return repairs, nil
 	}
-	journalAllowsRepairs := IsLegacyTelegramMigrationSource(manifest) && (manifest.Phase == MigrationSourcePrepared || manifest.Phase == MigrationSourceRetired || manifest.Phase == MigrationSourceActive && manifest.lastTransition == "aborted")
+	journalAllowsRepairs := isLegacyTelegramRepairLineage(manifest) && legacyTelegramRepairJournalAllows(manifest)
 	if !journalAllowsRepairs {
 		return nil, errors.New("relay migration legacy endpoint provenance is invalid")
 	}
@@ -698,6 +716,14 @@ func inspectMigrationSource(ctx context.Context, q migrationQueryer) (MigrationS
 	if claimIdempotencyTables == 1 && telegramTables != 3 {
 		return MigrationSourceManifest{}, errors.New("relay migration source schema is unavailable")
 	}
+	var repairTables, toRoleColumns int
+	if err := q.QueryRowContext(ctx, `SELECT count(*) FROM sqlite_master WHERE type='table' AND name=?`, legacyMigrationEndpointRepairsTable).Scan(&repairTables); err != nil || repairTables < 0 || repairTables > 1 {
+		return MigrationSourceManifest{}, errors.New("relay migration source schema is unavailable")
+	}
+	if err := q.QueryRowContext(ctx, `SELECT count(*) FROM pragma_table_info('messages') WHERE name='to_role'`).Scan(&toRoleColumns); err != nil || toRoleColumns < 0 || toRoleColumns > 1 {
+		return MigrationSourceManifest{}, errors.New("relay migration source schema is unavailable")
+	}
+	reopenedLegacyTelegram := repairTables == 1 && toRoleColumns == 1 && controlTables == 2 && profileTables == 2 && rateBucketTables == 1 && directTables == 3 && telegramTables == 3 && claimIdempotencyTables == 1
 	manifest := MigrationSourceManifest{Version: 3}
 	roleOnly := false
 	legacyTelegram := false
@@ -720,6 +746,10 @@ func inspectMigrationSource(ctx context.Context, q migrationQueryer) (MigrationS
 		legacyTelegram = true
 		manifest.Version = 7
 		tableSpecs, schema = legacyTelegramV7MigrationTableSpecs, legacyTelegramV7MigrationSourceSchema
+	case reopenedLegacyTelegram:
+		manifest.Version = 8
+		manifest.legacyTelegramRepairLineage = true
+		tableSpecs, schema = migrationTableSpecs, migrationSourceSchema+";legacy-telegram-repair-lineage"
 	case claimIdempotencyTables == 1 && telegramTables == 3:
 		manifest.Version = 8
 		tableSpecs, schema = migrationTableSpecs, migrationSourceSchema
@@ -764,7 +794,10 @@ func inspectMigrationSource(ctx context.Context, q migrationQueryer) (MigrationS
 	if manifest.lastTransition != "" && manifest.lastTransition != "prepared" && manifest.lastTransition != "aborted" && manifest.lastTransition != "retired" {
 		return MigrationSourceManifest{}, errors.New("relay migration transition journal is invalid")
 	}
-	if err := verifyMigrationSourceSchemaVersion(ctx, q, manifest.Version, controlTables == 2, profileTables == 2, rateBucketTables == 1, directTables == 3, legacyTelegram); err != nil {
+	if reopenedLegacyTelegram && !legacyTelegramRepairJournalAllows(manifest) {
+		return MigrationSourceManifest{}, errors.New("relay migration legacy endpoint provenance is invalid")
+	}
+	if err := verifyMigrationSourceSchemaVersion(ctx, q, manifest.Version, controlTables == 2, profileTables == 2, rateBucketTables == 1, directTables == 3, legacyTelegram, legacyTelegram || manifest.legacyTelegramRepairLineage); err != nil {
 		return MigrationSourceManifest{}, err
 	}
 	overall := sha256.New()
@@ -842,11 +875,11 @@ func conversationDisplayNameTypeCheck(version int) string {
 	return " OR (display_name IS NOT NULL AND typeof(display_name)<>'text')"
 }
 
-func verifyMigrationSourceSchemaVersion(ctx context.Context, q migrationQueryer, version int, controls, profiles, rateBuckets, direct, legacyTelegram bool) error {
+func verifyMigrationSourceSchemaVersion(ctx context.Context, q migrationQueryer, version int, controls, profiles, rateBuckets, direct, legacyTelegram, legacyTelegramRepairLineage bool) error {
 	if version == 1 {
 		return verifyLegacyMigrationSourceSchema(ctx, q)
 	}
-	return verifyMigrationSourceSchema(ctx, q, version, controls, profiles, rateBuckets, direct, legacyTelegram)
+	return verifyMigrationSourceSchema(ctx, q, version, controls, profiles, rateBuckets, direct, legacyTelegram, legacyTelegramRepairLineage)
 }
 
 func verifyLegacyMigrationSourceSchema(ctx context.Context, q migrationQueryer) error {
@@ -882,9 +915,9 @@ func verifyLegacyMigrationSourceSchema(ctx context.Context, q migrationQueryer) 
 	return foreignKeys.Close()
 }
 
-func verifyMigrationSourceSchema(ctx context.Context, q migrationQueryer, version int, controls, profiles, rateBuckets, direct, legacyTelegram bool) error {
+func verifyMigrationSourceSchema(ctx context.Context, q migrationQueryer, version int, controls, profiles, rateBuckets, direct, legacyTelegram, legacyTelegramRepairLineage bool) error {
 	var repairTables int
-	if err := q.QueryRowContext(ctx, `SELECT count(*) FROM sqlite_master WHERE type='table' AND name=?`, legacyMigrationEndpointRepairsTable).Scan(&repairTables); err != nil || repairTables < 0 || repairTables > 1 || repairTables == 1 && !legacyTelegram {
+	if err := q.QueryRowContext(ctx, `SELECT count(*) FROM sqlite_master WHERE type='table' AND name=?`, legacyMigrationEndpointRepairsTable).Scan(&repairTables); err != nil || repairTables < 0 || repairTables > 1 || repairTables == 1 && !legacyTelegramRepairLineage {
 		return errors.New("relay migration source schema is unavailable")
 	}
 	rows, err := q.QueryContext(ctx, `SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%' ORDER BY name`)
@@ -906,7 +939,7 @@ func verifyMigrationSourceSchema(ctx context.Context, q migrationQueryer, versio
 	case legacyTelegram:
 		want = []string{"conversation_control_idempotency", "conversation_controls", "conversation_idempotency", "conversations", "deliveries", "endpoints", "idempotency", "memberships", "messages", "recipient_cursors", "relay_migration_control", "request_nonces", "role_bindings", "role_memberships", "roles", "telegram_claim_events", "telegram_claims", "telegram_participants"}
 		if repairTables == 1 {
-			want = append(want[:11], append([]string{legacyMigrationEndpointRepairsTable}, want[11:]...)...)
+			want = append(want, legacyMigrationEndpointRepairsTable)
 		}
 	case direct:
 		want = []string{"conversation_control_idempotency", "conversation_controls", "conversation_display_name_idempotency", "conversation_idempotency", "conversations", "deliveries", "direct_conversations", "direct_message_idempotency", "endpoints", "idempotency", "memberships", "message_from_roles", "messages", "rate_buckets", "recipient_cursors", "relay_migration_control", "request_nonces", "role_bindings", "role_memberships", "role_profile_idempotency", "role_profiles", "roles", "telegram_claim_events", "telegram_claim_idempotency", "telegram_claims", "telegram_participants"}
@@ -916,6 +949,9 @@ func verifyMigrationSourceSchema(ctx context.Context, q migrationQueryer, versio
 		want = []string{"conversation_control_idempotency", "conversation_controls", "conversation_display_name_idempotency", "conversation_idempotency", "conversations", "deliveries", "endpoints", "idempotency", "memberships", "messages", "recipient_cursors", "relay_migration_control", "request_nonces", "role_bindings", "role_memberships", "role_profile_idempotency", "role_profiles", "roles", "telegram_claim_events", "telegram_claim_idempotency", "telegram_claims", "telegram_participants"}
 	case !controls:
 		want = []string{"conversation_display_name_idempotency", "conversation_idempotency", "conversations", "deliveries", "endpoints", "idempotency", "memberships", "messages", "recipient_cursors", "relay_migration_control", "request_nonces", "role_bindings", "role_memberships", "roles", "telegram_claim_events", "telegram_claim_idempotency", "telegram_claims", "telegram_participants"}
+	}
+	if legacyTelegramRepairLineage && !legacyTelegram {
+		want = append(want, legacyMigrationEndpointRepairsTable)
 	}
 	if version < 8 {
 		filtered := make([]string, 0, len(want))
@@ -937,6 +973,7 @@ func verifyMigrationSourceSchema(ctx context.Context, q migrationQueryer, versio
 		}
 		want = filtered
 	}
+	sort.Strings(want)
 	if strings.Join(names, "\x00") != strings.Join(want, "\x00") {
 		return errors.New("relay migration source has an unexpected schema")
 	}
@@ -989,6 +1026,8 @@ func verifyMigrationSourceSchema(ctx context.Context, q migrationQueryer, versio
 	}
 	if legacyTelegram {
 		delete(expectedColumns, "conversation_display_name_idempotency")
+	}
+	if legacyTelegramRepairLineage {
 		expectedColumns["messages"] = append(expectedColumns["messages"], "to_role:TEXT:0:0:-")
 	}
 	if version < 8 {
@@ -1408,8 +1447,11 @@ func verifyMigrationSourceSchema(ctx context.Context, q migrationQueryer, versio
 			`OR endpoint.machine_id<>binding.machine_id OR endpoint.ownership_generation<>binding.ownership_generation)`,
 			`OR (endpoint.endpoint IS NOT NULL AND endpoint.machine_id<>binding.machine_id))`, 1)
 		logicalStateQuery += `
-		OR EXISTS (SELECT 1 FROM messages WHERE to_role IS NOT NULL)
 		OR EXISTS (SELECT 1 FROM telegram_claims GROUP BY requested_by_machine,idempotency_key HAVING count(*)>1)`
+	}
+	if legacyTelegramRepairLineage {
+		logicalStateQuery += `
+		OR EXISTS (SELECT 1 FROM messages WHERE to_role IS NOT NULL)`
 	}
 	if !controls {
 		for _, clause := range []string{

--- a/internal/relay/migration_source.go
+++ b/internal/relay/migration_source.go
@@ -235,6 +235,8 @@ var legacyMigrationTableSpecs = []migrationTableSpec{
 
 const v7MigrationSourceSchema = "punaro-relay-sqlite-v7:endpoints;conversations;memberships;roles;role_memberships;role_bindings;messages;deliveries;recipient_cursors;idempotency;conversation_idempotency;conversation_controls;conversation_control_idempotency;request_nonces;role_profiles;role_profile_idempotency;rate_buckets;direct_conversations;message_from_roles;direct_message_idempotency;telegram_claims;telegram_participants;telegram_claim_events;conversation_display_name_idempotency"
 const legacyTelegramV7MigrationSourceSchema = "punaro-relay-sqlite-v7-legacy-telegram:endpoints;conversations;memberships;roles;role_memberships;role_bindings;messages;deliveries;recipient_cursors;idempotency;conversation_idempotency;conversation_controls;conversation_control_idempotency;request_nonces;telegram_claims;telegram_participants;telegram_claim_events"
+
+const legacyMigrationEndpointRepairsTable = "relay_migration_endpoint_repairs"
 const migrationSourceSchema = v7MigrationSourceSchema + ";telegram_claim_idempotency"
 const v6MigrationSourceSchema = "punaro-relay-sqlite-v6:endpoints;conversations;memberships;roles;role_memberships;role_bindings;messages;deliveries;recipient_cursors;idempotency;conversation_idempotency;conversation_controls;conversation_control_idempotency;request_nonces;role_profiles;role_profile_idempotency;rate_buckets;direct_conversations;message_from_roles;direct_message_idempotency"
 const v5MigrationSourceSchema = "punaro-relay-sqlite-v5:endpoints;conversations;memberships;roles;role_memberships;role_bindings;messages;deliveries;recipient_cursors;idempotency;conversation_idempotency;conversation_controls;conversation_control_idempotency;request_nonces;role_profiles;role_profile_idempotency;rate_buckets"
@@ -287,6 +289,10 @@ func CheckMigrationSourceEnrollmentCoverage(ctx context.Context, path, enrollmen
 	if err != nil {
 		return err
 	}
+	repairedOwners, err := readLegacyMigrationEndpointRepairs(ctx, tx, manifest)
+	if err != nil {
+		return err
+	}
 	rows, err := tx.QueryContext(ctx, `SELECT endpoint, machine_id FROM endpoints ORDER BY endpoint COLLATE BINARY`)
 	if err != nil {
 		return errors.New("relay migration endpoints are unavailable")
@@ -297,7 +303,7 @@ func CheckMigrationSourceEnrollmentCoverage(ctx context.Context, path, enrollmen
 			_ = rows.Close()
 			return errors.New("relay migration enrollment does not cover every endpoint")
 		}
-		retiredRepairEndpoint := IsLegacyTelegramMigrationSource(manifest) && (manifest.Phase == MigrationSourcePrepared || manifest.Phase == MigrationSourceRetired) && machineID == retiredMigrationMachineID(endpoint)
+		retiredRepairEndpoint := repairedOwners[endpoint] == machineID
 		if !authenticator.AllowsEndpoint(machineID, endpoint) && !retiredRepairEndpoint {
 			_ = rows.Close()
 			return errors.New("relay migration enrollment does not cover every endpoint")
@@ -357,7 +363,7 @@ func PrepareMigrationSource(ctx context.Context, path, epochID, targetIdentity, 
 			return MigrationSourceManifest{}, errors.New("relay migration source changed before preparation")
 		}
 		if IsLegacyTelegramMigrationSource(current) {
-			if err := repairLegacyTelegramMigrationSource(ctx, conn); err != nil {
+			if err := repairLegacyTelegramMigrationSource(ctx, conn, current); err != nil {
 				return MigrationSourceManifest{}, err
 			}
 		}
@@ -408,20 +414,81 @@ func retiredMigrationMachineID(endpoint string) string {
 	return "migration-retired-" + hex.EncodeToString(digest[:])
 }
 
-func repairLegacyTelegramMigrationSource(ctx context.Context, conn *sql.Conn) error {
+func readLegacyMigrationEndpointRepairs(ctx context.Context, q migrationQueryer, manifest MigrationSourceManifest) (map[string]string, error) {
+	var tables int
+	if err := q.QueryRowContext(ctx, `SELECT count(*) FROM sqlite_master WHERE type='table' AND name=?`, legacyMigrationEndpointRepairsTable).Scan(&tables); err != nil || tables < 0 || tables > 1 {
+		return nil, errors.New("relay migration legacy endpoint provenance is unavailable")
+	}
+	repairs := make(map[string]string)
+	if tables == 0 {
+		return repairs, nil
+	}
+	journalAllowsRepairs := IsLegacyTelegramMigrationSource(manifest) && (manifest.Phase == MigrationSourcePrepared || manifest.Phase == MigrationSourceRetired || manifest.Phase == MigrationSourceActive && manifest.lastTransition == "aborted")
+	if !journalAllowsRepairs {
+		return nil, errors.New("relay migration legacy endpoint provenance is invalid")
+	}
+	rows, err := q.QueryContext(ctx, `SELECT endpoint,machine_id FROM relay_migration_endpoint_repairs ORDER BY endpoint COLLATE BINARY`)
+	if err != nil {
+		return nil, errors.New("relay migration legacy endpoint provenance is unavailable")
+	}
+	for rows.Next() {
+		var endpoint, machineID string
+		if err := rows.Scan(&endpoint, &machineID); err != nil || !ValidEndpoint(endpoint) || machineID != retiredMigrationMachineID(endpoint) {
+			_ = rows.Close()
+			return nil, errors.New("relay migration legacy endpoint provenance is invalid")
+		}
+		repairs[endpoint] = machineID
+	}
+	if err := rows.Close(); err != nil || rows.Err() != nil {
+		return nil, errors.New("relay migration legacy endpoint provenance is unavailable")
+	}
+	return repairs, nil
+}
+
+func installLegacyMigrationEndpointRepairs(ctx context.Context, conn *sql.Conn) error {
+	if _, err := conn.ExecContext(ctx, `CREATE TABLE relay_migration_endpoint_repairs(endpoint TEXT PRIMARY KEY,machine_id TEXT NOT NULL) WITHOUT ROWID`); err != nil {
+		return errors.New("relay migration legacy endpoint provenance cannot be installed")
+	}
+	for _, operation := range []string{"INSERT", "UPDATE", "DELETE"} {
+		name := "relay_migration_guard_" + legacyMigrationEndpointRepairsTable + "_" + strings.ToLower(operation)
+		statement := fmt.Sprintf(`CREATE TRIGGER %s BEFORE %s ON %s
+			WHEN COALESCE((SELECT phase FROM relay_migration_control WHERE singleton=1), 'missing') <> 'active'
+			BEGIN SELECT RAISE(ABORT, 'relay migration source is not writable'); END`, name, operation, legacyMigrationEndpointRepairsTable) // #nosec G201 -- identifiers come only from fixed internal constants.
+		if _, err := conn.ExecContext(ctx, statement); err != nil { // #nosec G202 -- identifiers come only from fixed internal constants.
+			return errors.New("relay migration legacy endpoint provenance cannot be installed")
+		}
+	}
+	return nil
+}
+
+func repairLegacyTelegramMigrationSource(ctx context.Context, conn *sql.Conn, manifest MigrationSourceManifest) error {
+	repairs, err := readLegacyMigrationEndpointRepairs(ctx, conn, manifest)
+	if err != nil {
+		return err
+	}
 	existing, err := conn.QueryContext(ctx, `SELECT endpoint,machine_id FROM endpoints ORDER BY endpoint COLLATE BINARY`)
 	if err != nil {
 		return errors.New("relay migration legacy endpoint provenance is unavailable")
 	}
 	for existing.Next() {
 		var endpoint, machineID string
-		if err := existing.Scan(&endpoint, &machineID); err != nil || machineID == retiredMigrationMachineID(endpoint) {
+		if err := existing.Scan(&endpoint, &machineID); err != nil || machineID == retiredMigrationMachineID(endpoint) && repairs[endpoint] != machineID {
 			_ = existing.Close()
 			return errors.New("relay migration legacy endpoint provenance is invalid")
 		}
+		delete(repairs, endpoint)
 	}
-	if err := existing.Close(); err != nil || existing.Err() != nil {
+	if err := existing.Close(); err != nil || existing.Err() != nil || len(repairs) != 0 {
 		return errors.New("relay migration legacy endpoint provenance is unavailable")
+	}
+	var repairTables int
+	if err := conn.QueryRowContext(ctx, `SELECT count(*) FROM sqlite_master WHERE type='table' AND name=?`, legacyMigrationEndpointRepairsTable).Scan(&repairTables); err != nil {
+		return errors.New("relay migration legacy endpoint provenance is unavailable")
+	}
+	if repairTables == 0 {
+		if err := installLegacyMigrationEndpointRepairs(ctx, conn); err != nil {
+			return err
+		}
 	}
 	rows, err := conn.QueryContext(ctx, `WITH referenced(endpoint) AS (
 		SELECT endpoint FROM memberships
@@ -463,6 +530,11 @@ func repairLegacyTelegramMigrationSource(ctx context.Context, conn *sql.Conn) er
 		}
 		if _, err := conn.ExecContext(ctx, `INSERT INTO endpoints(endpoint,machine_id,lease_until,ownership_generation,consumer_id,consumer_generation,consumer_lease_until) VALUES(?,?,0,1,NULL,0,NULL)`, item.endpoint, machineID); err != nil {
 			return errors.New("relay migration legacy endpoint repair cannot be persisted")
+		}
+		if item.bindingMachine == "" {
+			if _, err := conn.ExecContext(ctx, `INSERT INTO relay_migration_endpoint_repairs(endpoint,machine_id) VALUES(?,?)`, item.endpoint, machineID); err != nil {
+				return errors.New("relay migration legacy endpoint provenance cannot be persisted")
+			}
 		}
 	}
 	return nil
@@ -799,6 +871,10 @@ func verifyLegacyMigrationSourceSchema(ctx context.Context, q migrationQueryer) 
 }
 
 func verifyMigrationSourceSchema(ctx context.Context, q migrationQueryer, version int, controls, profiles, rateBuckets, direct, legacyTelegram bool) error {
+	var repairTables int
+	if err := q.QueryRowContext(ctx, `SELECT count(*) FROM sqlite_master WHERE type='table' AND name=?`, legacyMigrationEndpointRepairsTable).Scan(&repairTables); err != nil || repairTables < 0 || repairTables > 1 || repairTables == 1 && !legacyTelegram {
+		return errors.New("relay migration source schema is unavailable")
+	}
 	rows, err := q.QueryContext(ctx, `SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%' ORDER BY name`)
 	if err != nil {
 		return errors.New("relay migration source schema is unavailable")
@@ -817,6 +893,9 @@ func verifyMigrationSourceSchema(ctx context.Context, q migrationQueryer, versio
 	switch {
 	case legacyTelegram:
 		want = []string{"conversation_control_idempotency", "conversation_controls", "conversation_idempotency", "conversations", "deliveries", "endpoints", "idempotency", "memberships", "messages", "recipient_cursors", "relay_migration_control", "request_nonces", "role_bindings", "role_memberships", "roles", "telegram_claim_events", "telegram_claims", "telegram_participants"}
+		if repairTables == 1 {
+			want = append(want[:11], append([]string{legacyMigrationEndpointRepairsTable}, want[11:]...)...)
+		}
 	case direct:
 		want = []string{"conversation_control_idempotency", "conversation_controls", "conversation_display_name_idempotency", "conversation_idempotency", "conversations", "deliveries", "direct_conversations", "direct_message_idempotency", "endpoints", "idempotency", "memberships", "message_from_roles", "messages", "rate_buckets", "recipient_cursors", "relay_migration_control", "request_nonces", "role_bindings", "role_memberships", "role_profile_idempotency", "role_profiles", "roles", "telegram_claim_events", "telegram_claim_idempotency", "telegram_claims", "telegram_participants"}
 	case rateBuckets:
@@ -876,6 +955,9 @@ func verifyMigrationSourceSchema(ctx context.Context, q migrationQueryer, versio
 		"direct_conversations":                  {"role_low:TEXT:1:1:-", "role_high:TEXT:1:2:-", "conversation_id:TEXT:1:0:-", "created_at:INTEGER:1:0:-"},
 		"message_from_roles":                    {"message_id:TEXT:0:1:-", "from_role:TEXT:1:0:-"},
 		"direct_message_idempotency":            {"machine_id:TEXT:1:1:-", "key:TEXT:1:2:-", "request_hash:TEXT:1:0:-", "from_role:TEXT:1:0:-", "to_role:TEXT:1:0:-", "conversation_id:TEXT:1:0:-", "message_id:TEXT:1:0:-", "sequence:INTEGER:1:0:-", "created_at:INTEGER:1:0:-"},
+	}
+	if repairTables == 1 {
+		expectedColumns[legacyMigrationEndpointRepairsTable] = []string{"endpoint:TEXT:1:1:-", "machine_id:TEXT:1:0:-"}
 	}
 	if !controls {
 		delete(expectedColumns, "conversation_controls")
@@ -1076,6 +1158,9 @@ func verifyMigrationSourceSchema(ctx context.Context, q migrationQueryer, versio
 		}
 		expectedIndexes = filtered
 	}
+	if repairTables == 1 {
+		expectedIndexes = append(expectedIndexes, legacyMigrationEndpointRepairsTable+":1:pk:0:endpoint")
+	}
 	var actualIndexes []string
 	for table := range expectedColumns {
 		indexes, err := q.QueryContext(ctx, fmt.Sprintf("PRAGMA index_list(%s)", table)) // #nosec G202 -- table comes only from the fixed expectedColumns allowlist.
@@ -1172,6 +1257,9 @@ func verifyMigrationSourceSchema(ctx context.Context, q migrationQueryer, versio
 	}
 	if version < 8 {
 		wantTriggers -= 3
+	}
+	if repairTables == 1 {
+		wantTriggers += 3
 	}
 	if version < 7 {
 		wantTriggers -= 12

--- a/internal/relay/migration_source_test.go
+++ b/internal/relay/migration_source_test.go
@@ -1260,19 +1260,19 @@ func TestPrepareLegacyTelegramBranchRepairsDerivedOperationalState(t *testing.T)
 	if err != nil || aborted.Phase != MigrationSourceActive {
 		t.Fatalf("abort repaired legacy source=%#v err=%v", aborted, err)
 	}
-	db, err = openMigrationSourceDatabase(path, false)
+	reopened, err := Open(path)
 	if err != nil {
+		t.Fatalf("reopen aborted legacy source: %v", err)
+	}
+	if err := reopened.ConsumeRequestNonce("machine-a", "post-abort-write", now, now.Add(time.Hour)); err != nil {
+		_ = reopened.Close()
 		t.Fatal(err)
 	}
-	if _, err := db.ExecContext(ctx, `INSERT INTO request_nonces(machine_id,nonce,expires_at) VALUES('machine-a','post-abort-write',?)`, now.Add(time.Hour).UnixMilli()); err != nil {
-		_ = db.Close()
-		t.Fatal(err)
-	}
-	if err := db.Close(); err != nil {
+	if err := reopened.Close(); err != nil {
 		t.Fatal(err)
 	}
 	active, err := InspectMigrationSource(ctx, path)
-	if err != nil || active.Phase != MigrationSourceActive || active.Fingerprint == aborted.Fingerprint {
+	if err != nil || active.Version != 8 || active.Phase != MigrationSourceActive || active.Fingerprint == aborted.Fingerprint || !active.legacyTelegramRepairLineage {
 		t.Fatalf("inspect written aborted legacy source=%#v err=%v", active, err)
 	}
 	if err := CheckMigrationSourceEnrollmentCoverage(ctx, path, enrollment); err != nil {
@@ -1281,6 +1281,10 @@ func TestPrepareLegacyTelegramBranchRepairsDerivedOperationalState(t *testing.T)
 	retried, err := PrepareMigrationSource(ctx, path, uuid.NewString(), prepared.TargetIdentity, active.Fingerprint, now.Add(2*time.Minute))
 	if err != nil || retried.Phase != MigrationSourcePrepared {
 		t.Fatalf("retry repaired legacy source=%#v err=%v", retried, err)
+	}
+	reopenedPrepared, err := InspectMigrationSource(ctx, path)
+	if err != nil || reopenedPrepared.Version != 8 || reopenedPrepared.Phase != MigrationSourcePrepared || reopenedPrepared.Fingerprint != retried.Fingerprint || !reopenedPrepared.legacyTelegramRepairLineage {
+		t.Fatalf("inspect retried reopened legacy source=%#v err=%v", reopenedPrepared, err)
 	}
 }
 

--- a/internal/relay/migration_source_test.go
+++ b/internal/relay/migration_source_test.go
@@ -1225,6 +1225,32 @@ func TestPrepareLegacyTelegramBranchRepairsDerivedOperationalState(t *testing.T)
 	if err := CheckMigrationSourceEnrollmentCoverage(ctx, path, uncoveredBinding); err == nil {
 		t.Fatal("repaired binding endpoint bypassed enrollment authority")
 	}
+	aborted, err := AbortPreparedMigrationSource(ctx, path, prepared.EpochID, prepared.TargetIdentity, prepared.Fingerprint)
+	if err != nil || aborted.Phase != MigrationSourceActive {
+		t.Fatalf("abort repaired legacy source=%#v err=%v", aborted, err)
+	}
+	db, err = openMigrationSourceDatabase(path, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.ExecContext(ctx, `INSERT INTO request_nonces(machine_id,nonce,expires_at) VALUES('machine-a','post-abort-write',?)`, now.Add(time.Hour).UnixMilli()); err != nil {
+		_ = db.Close()
+		t.Fatal(err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatal(err)
+	}
+	active, err := InspectMigrationSource(ctx, path)
+	if err != nil || active.Phase != MigrationSourceActive || active.Fingerprint == aborted.Fingerprint {
+		t.Fatalf("inspect written aborted legacy source=%#v err=%v", active, err)
+	}
+	if err := CheckMigrationSourceEnrollmentCoverage(ctx, path, enrollment); err != nil {
+		t.Fatalf("durable repair provenance failed enrollment after abort: %v", err)
+	}
+	retried, err := PrepareMigrationSource(ctx, path, uuid.NewString(), prepared.TargetIdentity, active.Fingerprint, now.Add(2*time.Minute))
+	if err != nil || retried.Phase != MigrationSourcePrepared {
+		t.Fatalf("retry repaired legacy source=%#v err=%v", retried, err)
+	}
 }
 
 func TestPrepareLegacyTelegramBranchRejectsPreexistingRetiredOwner(t *testing.T) {

--- a/internal/relay/migration_source_test.go
+++ b/internal/relay/migration_source_test.go
@@ -1018,6 +1018,236 @@ func TestInspectMigrationSourceAcceptsPreparedParentV6WithoutTelegramTables(t *t
 	}
 }
 
+func TestInspectMigrationSourceAcceptsLegacyTelegramBranchSchema(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	now := time.Date(2026, time.August, 25, 15, 0, 0, 0, time.UTC)
+	path := filepath.Join(t.TempDir(), "relay.db")
+	store, err := Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.AdvertiseEndpoints("machine-a", []string{"agent/a"}, now, time.Hour); err != nil {
+		_ = store.Close()
+		t.Fatal(err)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatal(err)
+	}
+	db, err := openMigrationSourceDatabase(path, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, statement := range []string{
+		`DROP INDEX telegram_claims_machine_key`,
+		`DROP TABLE telegram_claim_idempotency`,
+		`DROP TABLE conversation_display_name_idempotency`,
+		`DROP TABLE direct_message_idempotency`,
+		`DROP TABLE message_from_roles`,
+		`DROP TABLE direct_conversations`,
+		`DROP TABLE rate_buckets`,
+		`DROP TABLE role_profile_idempotency`,
+		`DROP TABLE role_profiles`,
+		`ALTER TABLE messages ADD COLUMN to_role TEXT`,
+	} {
+		if _, err := db.ExecContext(ctx, statement); err != nil {
+			_ = db.Close()
+			t.Fatal(err)
+		}
+	}
+	if err := db.Close(); err != nil {
+		t.Fatal(err)
+	}
+	inspected, err := InspectMigrationSource(ctx, path)
+	if err != nil || inspected.Version != 7 || inspected.Phase != MigrationSourceActive || inspected.TableSHA256.TelegramClaims == "" || inspected.TableSHA256.DirectConversations != "" || inspected.TableSHA256.DisplayNameIdempotency != "" {
+		t.Fatalf("legacy Telegram branch inspect=%#v err=%v", inspected, err)
+	}
+	prepared, err := PrepareMigrationSource(ctx, path, uuid.NewString(), strings.Repeat("d", 64), inspected.Fingerprint, now.Add(time.Minute))
+	if err != nil || prepared.Phase != MigrationSourcePrepared || prepared.Version != 7 {
+		t.Fatalf("legacy Telegram branch prepare=%#v err=%v", prepared, err)
+	}
+	for _, table := range []string{"mail_role_profiles", "mail_rate_buckets", "mail_direct_conversations", "mail_conversation_display_name_idempotency", "mail_telegram_claim_idempotency"} {
+		batch, err := ReadMigrationSourceBatch(ctx, path, table, "", 10)
+		if err != nil || len(batch.Rows) != 0 || !batch.Done {
+			t.Fatalf("legacy Telegram branch absent table %s batch=%#v err=%v", table, batch, err)
+		}
+	}
+	telegram, err := ReadMigrationSourceBatch(ctx, path, "mail_telegram_claims", "", 10)
+	if err != nil || len(telegram.Rows) != 0 || !telegram.Done {
+		t.Fatalf("legacy Telegram branch claim batch=%#v err=%v", telegram, err)
+	}
+}
+
+func TestInspectMigrationSourceRejectsPopulatedRetiredToRoleColumn(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	now := time.Date(2026, time.August, 25, 15, 0, 0, 0, time.UTC)
+	path := filepath.Join(t.TempDir(), "relay.db")
+	store, err := Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.AdvertiseEndpoints("machine-a", []string{"agent/a"}, now, time.Hour); err != nil {
+		_ = store.Close()
+		t.Fatal(err)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatal(err)
+	}
+	db, err := openMigrationSourceDatabase(path, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, statement := range []string{
+		`DROP INDEX telegram_claims_machine_key`,
+		`DROP TABLE telegram_claim_idempotency`, `DROP TABLE conversation_display_name_idempotency`,
+		`DROP TABLE direct_message_idempotency`, `DROP TABLE message_from_roles`, `DROP TABLE direct_conversations`,
+		`DROP TABLE rate_buckets`, `DROP TABLE role_profile_idempotency`, `DROP TABLE role_profiles`,
+		`ALTER TABLE messages ADD COLUMN to_role TEXT`,
+		`INSERT INTO conversations(id,next_sequence,created_at) VALUES('11111111-1111-4111-8111-111111111111',1,1)`,
+		`INSERT INTO messages(id,conversation_id,sequence,from_endpoint,body,created_at,to_role) VALUES('22222222-2222-4222-8222-222222222222','11111111-1111-4111-8111-111111111111',1,'agent/a','body',1,'role/machine-a/legacy')`,
+	} {
+		if _, err := db.ExecContext(ctx, statement); err != nil {
+			_ = db.Close()
+			t.Fatal(err)
+		}
+	}
+	if err := db.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := InspectMigrationSource(ctx, path); err == nil {
+		t.Fatal("populated retired messages.to_role was accepted")
+	}
+}
+
+func TestPrepareLegacyTelegramBranchRepairsDerivedOperationalState(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	now := time.Date(2026, time.August, 25, 15, 30, 0, 0, time.UTC)
+	path := filepath.Join(t.TempDir(), "relay.db")
+	store, err := Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.AdvertiseEndpoints("machine-a", []string{"agent/a"}, now, time.Hour); err != nil {
+		_ = store.Close()
+		t.Fatal(err)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatal(err)
+	}
+	db, err := openMigrationSourceDatabase(path, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	conversationID := "11111111-1111-4111-8111-111111111111"
+	messageID := "22222222-2222-4222-8222-222222222222"
+	deliveryID := "33333333-3333-4333-8333-333333333333"
+	for _, statement := range []string{
+		`DROP INDEX telegram_claims_machine_key`, `DROP TABLE telegram_claim_idempotency`, `DROP TABLE conversation_display_name_idempotency`,
+		`DROP TABLE direct_message_idempotency`, `DROP TABLE message_from_roles`, `DROP TABLE direct_conversations`,
+		`DROP TABLE rate_buckets`, `DROP TABLE role_profile_idempotency`, `DROP TABLE role_profiles`,
+		`ALTER TABLE messages ADD COLUMN to_role TEXT`,
+		`INSERT INTO conversations(id,next_sequence,created_at,display_name) VALUES('` + conversationID + `',1,1,'legacy')`,
+		`INSERT INTO memberships(conversation_id,endpoint,capabilities) VALUES('` + conversationID + `','legacy/member',3)`,
+		`INSERT INTO messages(id,conversation_id,sequence,from_endpoint,body,created_at) VALUES('` + messageID + `','` + conversationID + `',1,'legacy/sender','body',1)`,
+		`INSERT INTO idempotency(machine_id,key,request_hash,message_id,created_at) VALUES('machine-a','legacy-message','` + strings.Repeat("a", 64) + `','` + messageID + `',1)`,
+		`INSERT INTO deliveries(id,message_id,recipient_endpoint,lease_machine_id,lease_token,lease_generation,ownership_generation,consumer_generation,lease_until,acked_at) VALUES('` + deliveryID + `','` + messageID + `','legacy/member','machine-a','` + strings.Repeat("b", 64) + `',2,NULL,NULL,2,3)`,
+		`INSERT INTO recipient_cursors(recipient_endpoint,conversation_id,sequence) VALUES('legacy/member','` + conversationID + `',1)`,
+		`INSERT INTO roles(role,machine_id) VALUES('role/machine-a/reviewer','machine-a')`,
+		`INSERT INTO role_bindings(role,session_endpoint,machine_id,ownership_generation,lease_until) VALUES('role/machine-a/reviewer','agent/a','machine-a',99,2)`,
+	} {
+		if _, err := db.ExecContext(ctx, statement); err != nil {
+			_ = db.Close()
+			t.Fatal(err)
+		}
+	}
+	if err := db.Close(); err != nil {
+		t.Fatal(err)
+	}
+	inspected, err := InspectMigrationSource(ctx, path)
+	if err != nil || !IsLegacyTelegramMigrationSource(inspected) {
+		t.Fatalf("inspect repairable legacy source=%#v err=%v", inspected, err)
+	}
+	prepared, err := PrepareMigrationSource(ctx, path, uuid.NewString(), strings.Repeat("e", 64), inspected.Fingerprint, now.Add(time.Minute))
+	if err != nil || prepared.Phase != MigrationSourcePrepared || prepared.Counts.Endpoints != inspected.Counts.Endpoints+2 {
+		t.Fatalf("prepare repairable legacy source=%#v err=%v", prepared, err)
+	}
+	db, err = openMigrationSourceDatabase(path, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, endpoint := range []string{"legacy/member", "legacy/sender"} {
+		var machineID string
+		if err := db.QueryRowContext(ctx, `SELECT machine_id FROM endpoints WHERE endpoint=?`, endpoint).Scan(&machineID); err != nil || machineID != retiredMigrationMachineID(endpoint) {
+			_ = db.Close()
+			t.Fatalf("retired endpoint %s machine=%q err=%v", endpoint, machineID, err)
+		}
+	}
+	var leased, mismatched int
+	if err := db.QueryRowContext(ctx, `SELECT count(*) FROM deliveries WHERE lease_machine_id IS NOT NULL OR lease_token IS NOT NULL OR ownership_generation IS NOT NULL OR consumer_generation IS NOT NULL OR lease_until IS NOT NULL`).Scan(&leased); err != nil {
+		_ = db.Close()
+		t.Fatal(err)
+	}
+	if err := db.QueryRowContext(ctx, `SELECT count(*) FROM role_bindings b JOIN endpoints e ON e.endpoint=b.session_endpoint WHERE b.ownership_generation<>e.ownership_generation`).Scan(&mismatched); err != nil {
+		_ = db.Close()
+		t.Fatal(err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if leased != 0 || mismatched != 0 {
+		t.Fatalf("prepared repair left leased=%d mismatched=%d", leased, mismatched)
+	}
+	enrollment := `[{"id":"machine-a","public_key":"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA","endpoints":["agent/a"]}]`
+	if err := CheckMigrationSourceEnrollmentCoverage(ctx, path, enrollment); err != nil {
+		t.Fatalf("retired tombstones failed enrollment coverage: %v", err)
+	}
+}
+
+func TestInspectMigrationSourceRejectsLegacyTelegramDuplicateClaimRetries(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	now := time.Date(2026, time.August, 25, 16, 0, 0, 0, time.UTC)
+	path := filepath.Join(t.TempDir(), "relay.db")
+	store, err := Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.AdvertiseEndpoints("machine-telegram", []string{TelegramGatewayEndpoint}, now, time.Hour); err != nil {
+		_ = store.Close()
+		t.Fatal(err)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatal(err)
+	}
+	db, err := openMigrationSourceDatabase(path, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, statement := range []string{
+		`DROP INDEX telegram_claims_machine_key`, `DROP TABLE telegram_claim_idempotency`, `DROP TABLE conversation_display_name_idempotency`,
+		`DROP TABLE direct_message_idempotency`, `DROP TABLE message_from_roles`, `DROP TABLE direct_conversations`,
+		`DROP TABLE rate_buckets`, `DROP TABLE role_profile_idempotency`, `DROP TABLE role_profiles`,
+		`ALTER TABLE messages ADD COLUMN to_role TEXT`,
+		`INSERT INTO conversations(id,next_sequence,created_at) VALUES('11111111-1111-4111-8111-111111111111',0,1),('22222222-2222-4222-8222-222222222222',0,2)`,
+		`INSERT INTO telegram_claims(conversation_id,status,requested_by_machine,requested_by_endpoint,idempotency_key,request_hash,created_at) VALUES
+			('11111111-1111-4111-8111-111111111111','pending','machine-telegram','telegram/primary','duplicate-key','` + strings.Repeat("a", 64) + `',1),
+			('22222222-2222-4222-8222-222222222222','pending','machine-telegram','telegram/primary','duplicate-key','` + strings.Repeat("b", 64) + `',2)`,
+	} {
+		if _, err := db.ExecContext(ctx, statement); err != nil {
+			_ = db.Close()
+			t.Fatal(err)
+		}
+	}
+	if err := db.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := InspectMigrationSource(ctx, path); err == nil {
+		t.Fatal("legacy Telegram source with duplicate claim retry keys was accepted")
+	}
+}
+
 func TestInspectMigrationSourceAcceptsPreparedParentWithoutDirectMessages(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()

--- a/internal/relay/migration_source_test.go
+++ b/internal/relay/migration_source_test.go
@@ -1025,7 +1025,7 @@ func TestInspectMigrationSourceAcceptsPreparedParentV6WithoutTelegramTables(t *t
 	}
 }
 
-func TestInspectMigrationSourceAcceptsLegacyTelegramBranchSchema(t *testing.T) {
+func TestInspectMigrationSourceAcceptsLegacyTelegramBranchSchemaAndBackfillsClaimReplayBoundary(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
 	now := time.Date(2026, time.August, 25, 15, 0, 0, 0, time.UTC)
@@ -1038,6 +1038,10 @@ func TestInspectMigrationSourceAcceptsLegacyTelegramBranchSchema(t *testing.T) {
 		_ = store.Close()
 		t.Fatal(err)
 	}
+	if err := store.AdvertiseEndpoints("machine-telegram", []string{TelegramGatewayEndpoint}, now, time.Hour); err != nil {
+		_ = store.Close()
+		t.Fatal(err)
+	}
 	if err := store.Close(); err != nil {
 		t.Fatal(err)
 	}
@@ -1045,6 +1049,9 @@ func TestInspectMigrationSourceAcceptsLegacyTelegramBranchSchema(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	conversationID := "11111111-1111-4111-8111-111111111111"
+	otherConversationID := "22222222-2222-4222-8222-222222222222"
+	requestHash := telegramClaimRequestHash(conversationID)
 	for _, statement := range []string{
 		`DROP INDEX telegram_claims_machine_key`,
 		`DROP TABLE telegram_claim_idempotency`,
@@ -1056,6 +1063,8 @@ func TestInspectMigrationSourceAcceptsLegacyTelegramBranchSchema(t *testing.T) {
 		`DROP TABLE role_profile_idempotency`,
 		`DROP TABLE role_profiles`,
 		`ALTER TABLE messages ADD COLUMN to_role TEXT`,
+		`INSERT INTO conversations(id,next_sequence,created_at,display_name) VALUES('` + conversationID + `',0,1,'legacy')`,
+		`INSERT INTO telegram_claims(conversation_id,status,requested_by_machine,requested_by_endpoint,idempotency_key,request_hash,created_at) VALUES('` + conversationID + `','pending','machine-telegram','` + TelegramGatewayEndpoint + `','legacy-claim-key','` + requestHash + `',1)`,
 	} {
 		if _, err := db.ExecContext(ctx, statement); err != nil {
 			_ = db.Close()
@@ -1066,22 +1075,44 @@ func TestInspectMigrationSourceAcceptsLegacyTelegramBranchSchema(t *testing.T) {
 		t.Fatal(err)
 	}
 	inspected, err := InspectMigrationSource(ctx, path)
-	if err != nil || inspected.Version != 7 || inspected.Phase != MigrationSourceActive || inspected.TableSHA256.TelegramClaims == "" || inspected.TableSHA256.DirectConversations != "" || inspected.TableSHA256.DisplayNameIdempotency != "" {
+	if err != nil || inspected.Version != 7 || inspected.Phase != MigrationSourceActive || inspected.Counts.TelegramClaims != 1 || inspected.Counts.TelegramClaimIdempotency != 1 || inspected.TableSHA256.TelegramClaimIdempotency == "" || inspected.TableSHA256.DirectConversations != "" || inspected.TableSHA256.DisplayNameIdempotency != "" {
 		t.Fatalf("legacy Telegram branch inspect=%#v err=%v", inspected, err)
 	}
 	prepared, err := PrepareMigrationSource(ctx, path, uuid.NewString(), strings.Repeat("d", 64), inspected.Fingerprint, now.Add(time.Minute))
 	if err != nil || prepared.Phase != MigrationSourcePrepared || prepared.Version != 7 {
 		t.Fatalf("legacy Telegram branch prepare=%#v err=%v", prepared, err)
 	}
-	for _, table := range []string{"mail_role_profiles", "mail_rate_buckets", "mail_direct_conversations", "mail_conversation_display_name_idempotency", "mail_telegram_claim_idempotency"} {
+	for _, table := range []string{"mail_role_profiles", "mail_rate_buckets", "mail_direct_conversations", "mail_conversation_display_name_idempotency"} {
 		batch, err := ReadMigrationSourceBatch(ctx, path, table, "", 10)
 		if err != nil || len(batch.Rows) != 0 || !batch.Done {
 			t.Fatalf("legacy Telegram branch absent table %s batch=%#v err=%v", table, batch, err)
 		}
 	}
 	telegram, err := ReadMigrationSourceBatch(ctx, path, "mail_telegram_claims", "", 10)
-	if err != nil || len(telegram.Rows) != 0 || !telegram.Done {
+	if err != nil || len(telegram.Rows) != 1 || !telegram.Done {
 		t.Fatalf("legacy Telegram branch claim batch=%#v err=%v", telegram, err)
+	}
+	derived, err := ReadMigrationSourceBatch(ctx, path, "mail_telegram_claim_idempotency", "", 10)
+	if err != nil || len(derived.Rows) != 1 || !derived.Done {
+		t.Fatalf("legacy Telegram branch derived claim retry batch=%#v err=%v", derived, err)
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(derived.Rows[0].Payload, &payload); err != nil {
+		t.Fatal(err)
+	}
+	if payload["machine_id"] != "machine-telegram" || payload["key"] != "legacy-claim-key" || payload["conversation_id"] != conversationID || payload["request_hash"] != requestHash || payload["request_hash"] == telegramClaimRequestHash(otherConversationID) {
+		t.Fatalf("derived claim retry lost cross-conversation boundary: %#v", payload)
+	}
+	hasher, err := NewMigrationTableHasher("mail_telegram_claim_idempotency")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := hasher.Add(derived.Rows[0]); err != nil {
+		t.Fatal(err)
+	}
+	count, digest := hasher.Evidence()
+	if count != prepared.Counts.TelegramClaimIdempotency || digest != prepared.TableSHA256.TelegramClaimIdempotency {
+		t.Fatalf("derived claim retry evidence count=%d digest=%s manifest=%#v", count, digest, prepared)
 	}
 }
 

--- a/internal/relay/migration_source_test.go
+++ b/internal/relay/migration_source_test.go
@@ -375,6 +375,13 @@ func TestCheckMigrationSourceEnrollmentCoverage(t *testing.T) {
 	if err := CheckMigrationSourceEnrollmentCoverage(ctx, path, reassigned); err == nil {
 		t.Fatal("another machine's authority was accepted for the persisted endpoint owner")
 	}
+	retiredEndpoint := "agent/retired"
+	if _, err := store.db.ExecContext(ctx, `INSERT INTO endpoints(endpoint,machine_id,lease_until,ownership_generation,consumer_id,consumer_generation,consumer_lease_until) VALUES(?,?,0,1,NULL,0,NULL)`, retiredEndpoint, retiredMigrationMachineID(retiredEndpoint)); err != nil {
+		t.Fatal(err)
+	}
+	if err := CheckMigrationSourceEnrollmentCoverage(ctx, path, covered); err == nil {
+		t.Fatal("current source accepted an uncovered endpoint with a fabricated retired migration owner")
+	}
 }
 
 func TestMigrationSourceRefusesOutOfRangeRoleCapabilities(t *testing.T) {
@@ -1143,6 +1150,10 @@ func TestPrepareLegacyTelegramBranchRepairsDerivedOperationalState(t *testing.T)
 	conversationID := "11111111-1111-4111-8111-111111111111"
 	messageID := "22222222-2222-4222-8222-222222222222"
 	deliveryID := "33333333-3333-4333-8333-333333333333"
+	controlID := "44444444-4444-4444-8444-444444444444"
+	controlActor := "legacy/control-actor"
+	controlMember := "legacy/control-member"
+	controlHash := ControlRequestHash(ControlInput{ConversationID: conversationID, ActorEndpoint: controlActor, Operation: ControlRemoveMember, Member: Member{Endpoint: controlMember}})
 	for _, statement := range []string{
 		`DROP INDEX telegram_claims_machine_key`, `DROP TABLE telegram_claim_idempotency`, `DROP TABLE conversation_display_name_idempotency`,
 		`DROP TABLE direct_message_idempotency`, `DROP TABLE message_from_roles`, `DROP TABLE direct_conversations`,
@@ -1155,7 +1166,9 @@ func TestPrepareLegacyTelegramBranchRepairsDerivedOperationalState(t *testing.T)
 		`INSERT INTO deliveries(id,message_id,recipient_endpoint,lease_machine_id,lease_token,lease_generation,ownership_generation,consumer_generation,lease_until,acked_at) VALUES('` + deliveryID + `','` + messageID + `','legacy/member','machine-a','` + strings.Repeat("b", 64) + `',2,NULL,NULL,2,3)`,
 		`INSERT INTO recipient_cursors(recipient_endpoint,conversation_id,sequence) VALUES('legacy/member','` + conversationID + `',1)`,
 		`INSERT INTO roles(role,machine_id) VALUES('role/machine-a/reviewer','machine-a')`,
-		`INSERT INTO role_bindings(role,session_endpoint,machine_id,ownership_generation,lease_until) VALUES('role/machine-a/reviewer','agent/a','machine-a',99,2)`,
+		`INSERT INTO role_bindings(role,session_endpoint,machine_id,ownership_generation,lease_until) VALUES('role/machine-a/reviewer','legacy/binding','machine-a',99,2)`,
+		`INSERT INTO conversation_controls(id,conversation_id,actor_endpoint,operation,member_endpoint,member_capabilities,created_at) VALUES('` + controlID + `','` + conversationID + `','` + controlActor + `','remove_member','` + controlMember + `',0,1)`,
+		`INSERT INTO conversation_control_idempotency(machine_id,key,request_hash,control_id,created_at) VALUES('machine-a','legacy-control','` + controlHash + `','` + controlID + `',1)`,
 	} {
 		if _, err := db.ExecContext(ctx, statement); err != nil {
 			_ = db.Close()
@@ -1170,19 +1183,24 @@ func TestPrepareLegacyTelegramBranchRepairsDerivedOperationalState(t *testing.T)
 		t.Fatalf("inspect repairable legacy source=%#v err=%v", inspected, err)
 	}
 	prepared, err := PrepareMigrationSource(ctx, path, uuid.NewString(), strings.Repeat("e", 64), inspected.Fingerprint, now.Add(time.Minute))
-	if err != nil || prepared.Phase != MigrationSourcePrepared || prepared.Counts.Endpoints != inspected.Counts.Endpoints+2 {
+	if err != nil || prepared.Phase != MigrationSourcePrepared || prepared.Counts.Endpoints != inspected.Counts.Endpoints+5 {
 		t.Fatalf("prepare repairable legacy source=%#v err=%v", prepared, err)
 	}
 	db, err = openMigrationSourceDatabase(path, true)
 	if err != nil {
 		t.Fatal(err)
 	}
-	for _, endpoint := range []string{"legacy/member", "legacy/sender"} {
+	for _, endpoint := range []string{"legacy/member", "legacy/sender", controlActor, controlMember} {
 		var machineID string
 		if err := db.QueryRowContext(ctx, `SELECT machine_id FROM endpoints WHERE endpoint=?`, endpoint).Scan(&machineID); err != nil || machineID != retiredMigrationMachineID(endpoint) {
 			_ = db.Close()
 			t.Fatalf("retired endpoint %s machine=%q err=%v", endpoint, machineID, err)
 		}
+	}
+	var bindingMachine string
+	if err := db.QueryRowContext(ctx, `SELECT machine_id FROM endpoints WHERE endpoint='legacy/binding'`).Scan(&bindingMachine); err != nil || bindingMachine != "machine-a" {
+		_ = db.Close()
+		t.Fatalf("binding repair machine=%q err=%v", bindingMachine, err)
 	}
 	var leased, mismatched int
 	if err := db.QueryRowContext(ctx, `SELECT count(*) FROM deliveries WHERE lease_machine_id IS NOT NULL OR lease_token IS NOT NULL OR ownership_generation IS NOT NULL OR consumer_generation IS NOT NULL OR lease_until IS NOT NULL`).Scan(&leased); err != nil {
@@ -1199,9 +1217,61 @@ func TestPrepareLegacyTelegramBranchRepairsDerivedOperationalState(t *testing.T)
 	if leased != 0 || mismatched != 0 {
 		t.Fatalf("prepared repair left leased=%d mismatched=%d", leased, mismatched)
 	}
-	enrollment := `[{"id":"machine-a","public_key":"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA","endpoints":["agent/a"]}]`
+	enrollment := `[{"id":"machine-a","public_key":"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA","endpoints":["agent/a","legacy/binding"]}]`
 	if err := CheckMigrationSourceEnrollmentCoverage(ctx, path, enrollment); err != nil {
 		t.Fatalf("retired tombstones failed enrollment coverage: %v", err)
+	}
+	uncoveredBinding := `[{"id":"machine-a","public_key":"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA","endpoints":["agent/a"]}]`
+	if err := CheckMigrationSourceEnrollmentCoverage(ctx, path, uncoveredBinding); err == nil {
+		t.Fatal("repaired binding endpoint bypassed enrollment authority")
+	}
+}
+
+func TestPrepareLegacyTelegramBranchRejectsPreexistingRetiredOwner(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	now := time.Date(2026, time.August, 25, 15, 45, 0, 0, time.UTC)
+	path := filepath.Join(t.TempDir(), "relay.db")
+	store, err := Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.AdvertiseEndpoints("machine-a", []string{"agent/a"}, now, time.Hour); err != nil {
+		_ = store.Close()
+		t.Fatal(err)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatal(err)
+	}
+	db, err := openMigrationSourceDatabase(path, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, statement := range []string{
+		`DROP INDEX telegram_claims_machine_key`, `DROP TABLE telegram_claim_idempotency`, `DROP TABLE conversation_display_name_idempotency`,
+		`DROP TABLE direct_message_idempotency`, `DROP TABLE message_from_roles`, `DROP TABLE direct_conversations`,
+		`DROP TABLE rate_buckets`, `DROP TABLE role_profile_idempotency`, `DROP TABLE role_profiles`,
+		`ALTER TABLE messages ADD COLUMN to_role TEXT`,
+	} {
+		if _, err := db.ExecContext(ctx, statement); err != nil {
+			_ = db.Close()
+			t.Fatal(err)
+		}
+	}
+	fabricatedEndpoint := "legacy/fabricated"
+	if _, err := db.ExecContext(ctx, `INSERT INTO endpoints(endpoint,machine_id,lease_until,ownership_generation,consumer_id,consumer_generation,consumer_lease_until) VALUES(?,?,0,1,NULL,0,NULL)`, fabricatedEndpoint, retiredMigrationMachineID(fabricatedEndpoint)); err != nil {
+		_ = db.Close()
+		t.Fatal(err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatal(err)
+	}
+	inspected, err := InspectMigrationSource(ctx, path)
+	if err != nil || !IsLegacyTelegramMigrationSource(inspected) {
+		t.Fatalf("inspect fabricated legacy source=%#v err=%v", inspected, err)
+	}
+	if _, err := PrepareMigrationSource(ctx, path, uuid.NewString(), strings.Repeat("f", 64), inspected.Fingerprint, now.Add(time.Minute)); err == nil {
+		t.Fatal("legacy source accepted a pre-existing deterministic retired owner")
 	}
 }
 


### PR DESCRIPTION
## Summary
- recognize the exact deployed legacy Telegram SQLite schema without weakening current-schema validation
- repair derived orphan endpoints, stale delivery leases, and role-generation drift atomically during the existing irreversible prepare boundary
- preserve sparse-table evidence through batching and PostgreSQL manifest validation, while rejecting populated retired target-role data and duplicate claim retry keys

## Validation
- focused RED-to-GREEN legacy schema, repair, fail-closed, and manifest tests
- repository-wide make test
- race, staticcheck, govulncheck, gosec, gitleaks, vet, golangci, Windows build
- plugin, deployment, and release gates
- patched operator mail cutover dry-run succeeded read-only against the stopped live migration copy

Pioneer review is currently unavailable because pioneer doctor reports PI_MODELS_CONFIG_INVALID; no Pi configuration was inspected or bypassed. Bugbot quota absence is owner-waived.