### PR TITLE
Complete alpha.8 doctor and selected-client updates

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "punaro",
   "displayName": "Punaro",
-  "version": "0.1.0-alpha.7",
+  "version": "0.1.0-alpha.8",
   "description": "Safely receive and reply to durable Punaro messages and handle explicitly authorized trusted attachments.",
   "author": {
     "name": "Punaro contributors",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "punaro",
-  "version": "0.1.0-alpha.7",
+  "version": "0.1.0-alpha.8",
   "description": "Safely receive and reply to durable Punaro messages and handle explicitly authorized trusted attachments.",
   "author": {
     "name": "Punaro contributors",

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -100,6 +100,8 @@ jobs:
 
       - run: go test ./cmd/punaro-memory -run '^TestWindows'
 
+      - run: go test ./cmd/punaro-enroll -run '^TestWindows'
+
       - run: go test ./internal/memoryclient -run '^TestWindows'
       - name: Build release artifacts on Windows
         shell: bash

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -286,6 +286,15 @@ Punaro separates four principals:
 | Role | `role/plan-reviewer` or `role/<machine>/<slug>` | A durable conversation identity owned by one enrolled machine and bound to one live endpoint at a time. Canonical `role/<machine>/<slug>` handles are opt-in public addresses; legacy names remain valid conversation members until explicitly registered. |
 | Conversation | `conv_01…` | The durable room/thread which has members and messages. |
 
+Enrollment templates are server-owned authorization choices, not client
+labels. A `trusted-agent` template expands only the exact confirmed project or
+all-project capability grants. A `service` template expands to an exactly empty
+grant set and creates a revocable device principal that can authenticate only
+routes requiring no capability grant, such as server doctor probes. Template,
+scope, and grants are bound into the owner-confirmed preview hash and pending
+enrollment; `service` cannot be combined with project scope, all-project scope,
+or legacy exchange.
+
 An endpoint belongs to exactly one currently connected machine lease. A machine
 can only advertise endpoints in its configured namespace (for example,
 `agent/`) and only after local attachment is confirmed. A machine may instead
@@ -1997,6 +2006,14 @@ The implementation is not internet-exposure-ready until these cases pass:
   signed release; it never supplies a URL, command, or unsigned `latest`
   pointer. `punaro-bootstrap update` verifies catalog/manifest signatures and
   exact artifact digests, then publishes `current`/`previous` slots.
+  Familiar client command names are installer-owned copies of one stable,
+  closed-allowlist dispatcher. On POSIX it replaces itself with the selected
+  signed-slot payload; on Windows it starts that exact payload with inherited
+  stdio and propagates its exit status. Built-in updates replace signed slot
+  artifacts, never these dispatcher copies. Doctor requires the adapter,
+  enrollment, memory, and trusted-attachment dispatchers to be regular,
+  byte-identical executables, while the client installer waits for every
+  Windows destination to become replaceable before overwriting it.
   Platform services launch `punaro-bootstrap run`, which supervises the
   current-slot adapter, requires a local ready signal within 60 seconds when a
   previous slot exists, rolls back once if the fresh catalog still allows that

--- a/cmd/punaro-adapter/client_launchers_windows_test.go
+++ b/cmd/punaro-adapter/client_launchers_windows_test.go
@@ -1,0 +1,27 @@
+//go:build windows
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestWindowsClientComponentLaunchersMustBeIdenticalRegularExecutables(t *testing.T) {
+	root := t.TempDir()
+	for _, component := range []string{"punaro-adapter.exe", "punaro-enroll.exe", "punaro-memory.exe", "punaro-trusted-attachment.exe"} {
+		if err := os.WriteFile(filepath.Join(root, component), []byte("stable-launcher"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if !clientComponentLaunchersMatch(t.Context(), root) {
+		t.Fatal("matching Windows client component launchers rejected")
+	}
+	if err := os.WriteFile(filepath.Join(root, "punaro-enroll.exe"), []byte("stale-enroll"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if clientComponentLaunchersMatch(t.Context(), root) {
+		t.Fatal("mixed Windows client component launchers accepted")
+	}
+}

--- a/cmd/punaro-adapter/doctor.go
+++ b/cmd/punaro-adapter/doctor.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bufio"
 	"context"
+	"crypto/sha256"
 	"database/sql"
 	"encoding/base64"
 	"encoding/json"
@@ -137,7 +138,10 @@ var (
 	adapterDoctorBootstrapProbe             = func(ctx context.Context, directory, bootstrapRelease string) (punarodiagnostic.Report, error) {
 		return bootstrap.IsolatedDoctor(ctx, bootstrap.DoctorRequest{Directory: directory, BootstrapRelease: bootstrapRelease})
 	}
-	adapterDoctorPluginProbe     = inspectAdapterPluginIsolated
+	adapterDoctorPluginProbe         = inspectAdapterPluginIsolated
+	adapterDoctorClientLauncherProbe = func(ctx context.Context) bool {
+		return clientComponentLaunchersMatch(ctx, defaultAdapterBinDirectory())
+	}
 	mailboxDoctorSnapshotProtect = protectMailboxDoctorSnapshot
 )
 
@@ -178,6 +182,7 @@ func runAdapterDoctor(args []string, stdout, stderr io.Writer) int {
 			punarodiagnostic.Unavailable("bootstrap_running_artifact", "repair_adapter_configuration"),
 			punarodiagnostic.Unavailable("bootstrap_supervisor", "repair_adapter_configuration"),
 			punarodiagnostic.Unavailable("installed_release", "repair_adapter_configuration"),
+			punarodiagnostic.Unavailable("client_component_launchers", "repair_adapter_configuration"),
 			punarodiagnostic.Unavailable("portable_plugin_registration", "repair_adapter_configuration"),
 			punarodiagnostic.Unavailable("codex_plugin_registration", "repair_adapter_configuration"),
 			punarodiagnostic.Unavailable("claude_plugin_registration", "repair_adapter_configuration"),
@@ -194,6 +199,7 @@ func runAdapterDoctor(args []string, stdout, stderr io.Writer) int {
 	checks := []punarodiagnostic.Check{
 		punarodiagnostic.Pass("adapter_configuration"),
 		punarodiagnostic.Pass("machine_credential_file"),
+		boolDoctorCheck(adapterDoctorClientLauncherProbe(ctx), "client_component_launchers", "reinstall_client_launchers"),
 		boolDoctorCheck(config.profileFile != "", "adapter_profile_file", "install_adapter_profile"),
 		boolDoctorCheck(config.identityFile != "", "client_identity_file", "install_client_identity"),
 	}
@@ -746,6 +752,57 @@ func defaultAdapterBootstrapDirectory() string {
 		return ""
 	}
 	return filepath.Join(home, ".local", "state", "punaro-bootstrap")
+}
+
+func defaultAdapterBinDirectory() string {
+	if runtime.GOOS == "windows" {
+		root := strings.TrimSpace(os.Getenv("LOCALAPPDATA"))
+		if root == "" {
+			return ""
+		}
+		return filepath.Join(root, "Punaro", "bin")
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	return filepath.Join(home, ".local", "bin")
+}
+
+func clientComponentLaunchersMatch(ctx context.Context, root string) bool {
+	if ctx == nil || ctx.Err() != nil || root == "" || !filepath.IsAbs(root) {
+		return false
+	}
+	var expected [sha256.Size]byte
+	for index, component := range []string{"punaro-adapter", "punaro-enroll", "punaro-memory", "punaro-trusted-attachment"} {
+		if runtime.GOOS == "windows" {
+			component += ".exe"
+		}
+		path := filepath.Join(root, component)
+		info, err := os.Lstat(path) // #nosec G703 -- closed component names below the installer-owned bin root.
+		if err != nil || !info.Mode().IsRegular() || info.Mode()&os.ModeSymlink != 0 || info.Size() < 1 || info.Size() > maximumMailboxDoctorBytes || runtime.GOOS != "windows" && info.Mode().Perm()&0o111 == 0 {
+			return false
+		}
+		file, err := os.Open(path) // #nosec G304,G703 -- closed component names below the installer-owned bin root.
+		if err != nil {
+			return false
+		}
+		hash := sha256.New()
+		copied, copyErr := io.Copy(hash, io.LimitReader(pluginDoctorContextReader{ctx: ctx, reader: file}, maximumMailboxDoctorBytes+1))
+		opened, statErr := file.Stat()
+		closeErr := file.Close()
+		if copyErr != nil || statErr != nil || closeErr != nil || !opened.Mode().IsRegular() || !os.SameFile(info, opened) || opened.Size() != info.Size() || copied != info.Size() {
+			return false
+		}
+		var digest [sha256.Size]byte
+		copy(digest[:], hash.Sum(nil))
+		if index == 0 {
+			expected = digest
+		} else if digest != expected {
+			return false
+		}
+	}
+	return true
 }
 
 func defaultAdapterBootstrapExecutable() string {

--- a/cmd/punaro-adapter/doctor.go
+++ b/cmd/punaro-adapter/doctor.go
@@ -35,6 +35,7 @@ const (
 	maximumAdapterDoctorTimeout         = 30 * time.Second
 	maximumMailboxDoctorOutput          = 64 << 10
 	maximumMailboxDoctorBytes           = 64 << 20
+	maximumClientLauncherBytes          = 8 << 20
 	maximumMailboxDoctorEndpoints       = 256
 	maximumBootstrapVersionOutput       = 256
 	maximumBootstrapReleaseDoctorOutput = 512
@@ -139,10 +140,11 @@ var (
 		return bootstrap.IsolatedDoctor(ctx, bootstrap.DoctorRequest{Directory: directory, BootstrapRelease: bootstrapRelease})
 	}
 	adapterDoctorPluginProbe         = inspectAdapterPluginIsolated
-	adapterDoctorClientLauncherProbe = func(ctx context.Context) bool {
-		return clientComponentLaunchersMatch(ctx, defaultAdapterBinDirectory())
+	adapterDoctorClientLauncherProbe = func(ctx context.Context) (bool, error) {
+		return inspectAdapterClientLaunchersIsolated(ctx, defaultAdapterBinDirectory())
 	}
-	mailboxDoctorSnapshotProtect = protectMailboxDoctorSnapshot
+	adapterDoctorClientLaunchersExecutable = os.Executable
+	mailboxDoctorSnapshotProtect           = protectMailboxDoctorSnapshot
 )
 
 func runAdapterDoctor(args []string, stdout, stderr io.Writer) int {
@@ -199,9 +201,14 @@ func runAdapterDoctor(args []string, stdout, stderr io.Writer) int {
 	checks := []punarodiagnostic.Check{
 		punarodiagnostic.Pass("adapter_configuration"),
 		punarodiagnostic.Pass("machine_credential_file"),
-		boolDoctorCheck(adapterDoctorClientLauncherProbe(ctx), "client_component_launchers", "reinstall_client_launchers"),
 		boolDoctorCheck(config.profileFile != "", "adapter_profile_file", "install_adapter_profile"),
 		boolDoctorCheck(config.identityFile != "", "client_identity_file", "install_client_identity"),
+	}
+	launchers, launcherErr := adapterDoctorClientLauncherProbe(ctx)
+	if launcherErr != nil {
+		checks = append(checks, punarodiagnostic.Unavailable("client_component_launchers", "reinstall_client_launchers"))
+	} else {
+		checks = append(checks, boolDoctorCheck(launchers, "client_component_launchers", "reinstall_client_launchers"))
 	}
 	mailbox, mailboxErr := adapterDoctorMailboxProbe(ctx, config)
 	if mailboxErr != nil {
@@ -780,7 +787,7 @@ func clientComponentLaunchersMatch(ctx context.Context, root string) bool {
 		}
 		path := filepath.Join(root, component)
 		info, err := os.Lstat(path) // #nosec G703 -- closed component names below the installer-owned bin root.
-		if err != nil || !info.Mode().IsRegular() || info.Mode()&os.ModeSymlink != 0 || info.Size() < 1 || info.Size() > maximumMailboxDoctorBytes || runtime.GOOS != "windows" && info.Mode().Perm()&0o111 == 0 {
+		if err != nil || !info.Mode().IsRegular() || info.Mode()&os.ModeSymlink != 0 || info.Size() < 1 || info.Size() > maximumClientLauncherBytes || runtime.GOOS != "windows" && info.Mode().Perm()&0o111 == 0 {
 			return false
 		}
 		file, err := os.Open(path) // #nosec G304,G703 -- closed component names below the installer-owned bin root.
@@ -788,7 +795,7 @@ func clientComponentLaunchersMatch(ctx context.Context, root string) bool {
 			return false
 		}
 		hash := sha256.New()
-		copied, copyErr := io.Copy(hash, io.LimitReader(pluginDoctorContextReader{ctx: ctx, reader: file}, maximumMailboxDoctorBytes+1))
+		copied, copyErr := io.Copy(hash, io.LimitReader(pluginDoctorContextReader{ctx: ctx, reader: file}, maximumClientLauncherBytes+1))
 		opened, statErr := file.Stat()
 		closeErr := file.Close()
 		if copyErr != nil || statErr != nil || closeErr != nil || !opened.Mode().IsRegular() || !os.SameFile(info, opened) || opened.Size() != info.Size() || copied != info.Size() {
@@ -803,6 +810,46 @@ func clientComponentLaunchersMatch(ctx context.Context, root string) bool {
 		}
 	}
 	return true
+}
+
+func inspectAdapterClientLaunchersIsolated(ctx context.Context, directory string) (bool, error) {
+	if ctx == nil || ctx.Err() != nil || directory == "" || !filepath.IsAbs(directory) {
+		return false, errors.New("client launcher diagnostic is unavailable")
+	}
+	executable, err := adapterDoctorClientLaunchersExecutable()
+	if err != nil {
+		return false, errors.New("client launcher diagnostic is unavailable")
+	}
+	command := exec.CommandContext(ctx, executable, "doctor-client-launchers-inspect", "--directory", directory) // #nosec G204,G702 -- os.Executable self helper with one explicit local directory.
+	command.Stdin = nil
+	command.Stderr = io.Discard
+	output := boundedDoctorOutput{maximum: 16}
+	command.Stdout = &output
+	if command.Run() != nil || ctx.Err() != nil || output.overflow {
+		return false, errors.New("client launcher diagnostic is unavailable")
+	}
+	switch strings.TrimSpace(output.buffer.String()) {
+	case "true":
+		return true, nil
+	case "false":
+		return false, nil
+	default:
+		return false, errors.New("client launcher diagnostic is unavailable")
+	}
+}
+
+func runAdapterClientLaunchersInspect(args []string, stdout io.Writer) int {
+	flags := flag.NewFlagSet("punaro-adapter doctor-client-launchers-inspect", flag.ContinueOnError)
+	flags.SetOutput(io.Discard)
+	directory := flags.String("directory", "", "installer-owned client bin directory")
+	if flags.Parse(args) != nil || flags.NArg() != 0 || *directory == "" || !filepath.IsAbs(*directory) {
+		return 2
+	}
+	_, err := fmt.Fprintln(stdout, clientComponentLaunchersMatch(context.Background(), *directory))
+	if err != nil {
+		return 1
+	}
+	return 0
 }
 
 func defaultAdapterBootstrapExecutable() string {

--- a/cmd/punaro-adapter/doctor_test_setup_test.go
+++ b/cmd/punaro-adapter/doctor_test_setup_test.go
@@ -8,9 +8,10 @@ import (
 )
 
 func init() {
-	// Production service and bootstrap-release inspection launch the current
-	// executable as deadline-isolated helpers. Unit tests call the direct
-	// implementations so the Go test binary cannot recursively launch itself.
+	// Production service, bootstrap, bootstrap-release, and client-launcher
+	// inspection launch the current executable as deadline-isolated helpers.
+	// Unit tests call the direct implementations so the Go test binary cannot
+	// recursively launch itself.
 	adapterDoctorServiceProbe = func(ctx context.Context, _ adapterConfig) (serviceDoctorResult, error) {
 		return inspectAdapterService(ctx), nil
 	}
@@ -19,5 +20,8 @@ func init() {
 	}
 	adapterDoctorBootstrapProbe = func(ctx context.Context, directory, bootstrapRelease string) (punarodiagnostic.Report, error) {
 		return bootstrap.Doctor(ctx, bootstrap.DoctorRequest{Directory: directory, BootstrapRelease: bootstrapRelease})
+	}
+	adapterDoctorClientLauncherProbe = func(ctx context.Context) (bool, error) {
+		return clientComponentLaunchersMatch(ctx, defaultAdapterBinDirectory()), nil
 	}
 }

--- a/cmd/punaro-adapter/main.go
+++ b/cmd/punaro-adapter/main.go
@@ -115,6 +115,8 @@ func main() {
 		os.Exit(runAdapterServiceInspect(os.Args[2:], os.Stdout))
 	case os.Args[1] == "doctor-bootstrap-release-inspect":
 		os.Exit(runAdapterBootstrapReleaseInspect(os.Args[2:], os.Stdout))
+	case os.Args[1] == "doctor-client-launchers-inspect":
+		os.Exit(runAdapterClientLaunchersInspect(os.Args[2:], os.Stdout))
 	case os.Args[1] == "version":
 		if adapterBuildRelease == "" {
 			os.Exit(1)

--- a/cmd/punaro-adapter/main_test.go
+++ b/cmd/punaro-adapter/main_test.go
@@ -325,6 +325,7 @@ func TestAdapterDoctorEmitsStrictHealthyReport(t *testing.T) {
 	adapterDoctorPluginProbe = func(context.Context, string) pluginDoctorResult {
 		return pluginDoctorResult{Portable: true, Codex: true, Claude: true, Launcher: true, Version: "v0.1.0-alpha.1", SkillDigest: "sha256:" + strings.Repeat("a", 64)}
 	}
+	adapterDoctorClientLauncherProbe = func(context.Context) bool { return true }
 	var stdout, stderr bytes.Buffer
 	if code := runAdapterDoctor(nil, &stdout, &stderr); code != 0 {
 		t.Fatalf("code=%d stdout=%q stderr=%q", code, stdout.String(), stderr.String())
@@ -968,12 +969,12 @@ func TestPluginDoctorValidatesAllAdaptersLauncherAndExactSkillTree(t *testing.T)
 		t.Fatal(err)
 	}
 	oldRelease, oldDigest, oldRuntimeDigest := adapterBuildRelease, adapterExpectedSkillSetDigest, adapterExpectedPluginRuntimeDigest
-	adapterBuildRelease, adapterExpectedSkillSetDigest, adapterExpectedPluginRuntimeDigest = "v0.1.0-alpha.7", digest, runtimeDigest
+	adapterBuildRelease, adapterExpectedSkillSetDigest, adapterExpectedPluginRuntimeDigest = "v0.1.0-alpha.8", digest, runtimeDigest
 	t.Cleanup(func() {
 		adapterBuildRelease, adapterExpectedSkillSetDigest, adapterExpectedPluginRuntimeDigest = oldRelease, oldDigest, oldRuntimeDigest
 	})
 	result := inspectAdapterPlugin(t.Context(), root)
-	if !result.Portable || !result.Codex || !result.Claude || !result.Launcher || result.Version != "v0.1.0-alpha.7" || result.SkillDigest != "sha256:"+digest {
+	if !result.Portable || !result.Codex || !result.Claude || !result.Launcher || result.Version != "v0.1.0-alpha.8" || result.SkillDigest != "sha256:"+digest {
 		t.Fatalf("plugin=%#v", result)
 	}
 	var helperOutput bytes.Buffer
@@ -1032,6 +1033,7 @@ func preserveAdapterDoctorDependencies(t *testing.T) {
 	relayProbe, notificationProbe, endpointProbe := adapterDoctorRelayProbe, adapterDoctorNotificationProbe, adapterDoctorEndpointProbe
 	mailboxProbe, serviceProbe := adapterDoctorMailboxProbe, adapterDoctorServiceProbe
 	bootstrapReleaseProbe, bootstrapProbe, pluginProbe := adapterDoctorBootstrapReleaseProbe, adapterDoctorBootstrapProbe, adapterDoctorPluginProbe
+	launcherProbe := adapterDoctorClientLauncherProbe
 	buildRelease := adapterBuildRelease
 	t.Cleanup(func() {
 		adapterDoctorConfigLoad = configLoad
@@ -1039,8 +1041,34 @@ func preserveAdapterDoctorDependencies(t *testing.T) {
 		adapterDoctorEndpointProbe = endpointProbe
 		adapterDoctorMailboxProbe, adapterDoctorServiceProbe = mailboxProbe, serviceProbe
 		adapterDoctorBootstrapReleaseProbe, adapterDoctorBootstrapProbe, adapterDoctorPluginProbe = bootstrapReleaseProbe, bootstrapProbe, pluginProbe
+		adapterDoctorClientLauncherProbe = launcherProbe
 		adapterBuildRelease = buildRelease
 	})
+}
+
+func TestClientComponentLaunchersMustBeIdenticalRegularExecutables(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX mode and symlink contract")
+	}
+	root := t.TempDir()
+	for _, component := range []string{"punaro-adapter", "punaro-enroll", "punaro-memory", "punaro-trusted-attachment"} {
+		path := filepath.Join(root, component)
+		if err := os.WriteFile(path, []byte("stable-launcher"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Chmod(path, 0o700); err != nil { // #nosec G302 -- private executable fixture.
+			t.Fatal(err)
+		}
+	}
+	if !clientComponentLaunchersMatch(t.Context(), root) {
+		t.Fatal("matching client component launchers rejected")
+	}
+	if err := os.WriteFile(filepath.Join(root, "punaro-enroll"), []byte("stale-enroll"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if clientComponentLaunchersMatch(t.Context(), root) {
+		t.Fatal("mixed client component launchers accepted")
+	}
 }
 
 func TestInspectAdapterBootstrapReleaseExecutesInstalledIdentity(t *testing.T) {

--- a/cmd/punaro-adapter/main_test.go
+++ b/cmd/punaro-adapter/main_test.go
@@ -325,7 +325,7 @@ func TestAdapterDoctorEmitsStrictHealthyReport(t *testing.T) {
 	adapterDoctorPluginProbe = func(context.Context, string) pluginDoctorResult {
 		return pluginDoctorResult{Portable: true, Codex: true, Claude: true, Launcher: true, Version: "v0.1.0-alpha.1", SkillDigest: "sha256:" + strings.Repeat("a", 64)}
 	}
-	adapterDoctorClientLauncherProbe = func(context.Context) bool { return true }
+	adapterDoctorClientLauncherProbe = func(context.Context) (bool, error) { return true, nil }
 	var stdout, stderr bytes.Buffer
 	if code := runAdapterDoctor(nil, &stdout, &stderr); code != 0 {
 		t.Fatalf("code=%d stdout=%q stderr=%q", code, stdout.String(), stderr.String())
@@ -403,6 +403,7 @@ func TestAdapterDoctorReportsIndependentRelayFailures(t *testing.T) {
 	adapterDoctorServiceProbe = func(context.Context, adapterConfig) (serviceDoctorResult, error) {
 		return serviceDoctorResult{Installed: true, Enabled: true, Running: true, Executable: true, ExitStatus: true, RestartState: true}, nil
 	}
+	adapterDoctorClientLauncherProbe = func(context.Context) (bool, error) { return true, nil }
 	var stdout, stderr bytes.Buffer
 	if code := runAdapterDoctor(nil, &stdout, &stderr); code != 1 || stderr.Len() != 0 {
 		t.Fatalf("code=%d stdout=%q stderr=%q", code, stdout.String(), stderr.String())
@@ -435,6 +436,7 @@ func TestAdapterDoctorRejectsStaleMachineAttachmentForCurrentEndpoint(t *testing
 		return adapter.DoctorProbeResult{Transport: true, Origin: true, Access: true, Enrolled: true, Protocol: true}, nil
 	}
 	adapterDoctorServiceProbe = func(context.Context, adapterConfig) (serviceDoctorResult, error) { return serviceDoctorResult{}, nil }
+	adapterDoctorClientLauncherProbe = func(context.Context) (bool, error) { return true, nil }
 	var stdout bytes.Buffer
 	if code := runAdapterDoctor(nil, &stdout, io.Discard); code != 1 {
 		t.Fatalf("code=%d report=%s", code, stdout.String())
@@ -1033,7 +1035,7 @@ func preserveAdapterDoctorDependencies(t *testing.T) {
 	relayProbe, notificationProbe, endpointProbe := adapterDoctorRelayProbe, adapterDoctorNotificationProbe, adapterDoctorEndpointProbe
 	mailboxProbe, serviceProbe := adapterDoctorMailboxProbe, adapterDoctorServiceProbe
 	bootstrapReleaseProbe, bootstrapProbe, pluginProbe := adapterDoctorBootstrapReleaseProbe, adapterDoctorBootstrapProbe, adapterDoctorPluginProbe
-	launcherProbe := adapterDoctorClientLauncherProbe
+	launcherProbe, launcherExecutable := adapterDoctorClientLauncherProbe, adapterDoctorClientLaunchersExecutable
 	buildRelease := adapterBuildRelease
 	t.Cleanup(func() {
 		adapterDoctorConfigLoad = configLoad
@@ -1042,6 +1044,7 @@ func preserveAdapterDoctorDependencies(t *testing.T) {
 		adapterDoctorMailboxProbe, adapterDoctorServiceProbe = mailboxProbe, serviceProbe
 		adapterDoctorBootstrapReleaseProbe, adapterDoctorBootstrapProbe, adapterDoctorPluginProbe = bootstrapReleaseProbe, bootstrapProbe, pluginProbe
 		adapterDoctorClientLauncherProbe = launcherProbe
+		adapterDoctorClientLaunchersExecutable = launcherExecutable
 		adapterBuildRelease = buildRelease
 	})
 }
@@ -1068,6 +1071,44 @@ func TestClientComponentLaunchersMustBeIdenticalRegularExecutables(t *testing.T)
 	}
 	if clientComponentLaunchersMatch(t.Context(), root) {
 		t.Fatal("mixed client component launchers accepted")
+	}
+}
+
+func TestRunAdapterClientLaunchersInspectEmitsOneBoundedBoolean(t *testing.T) {
+	root := t.TempDir()
+	for _, component := range []string{"punaro-adapter", "punaro-enroll", "punaro-memory", "punaro-trusted-attachment"} {
+		if runtime.GOOS == "windows" {
+			component += ".exe"
+		}
+		if err := os.WriteFile(filepath.Join(root, component), []byte("stable-launcher"), 0o700); err != nil { // #nosec G306 -- executable launcher fixture.
+			t.Fatal(err)
+		}
+	}
+	var stdout bytes.Buffer
+	if code := runAdapterClientLaunchersInspect([]string{"--directory", root}, &stdout); code != 0 || stdout.String() != "true\n" {
+		t.Fatalf("code=%d stdout=%q", code, stdout.String())
+	}
+	if code := runAdapterClientLaunchersInspect([]string{"--directory", "relative"}, io.Discard); code != 2 {
+		t.Fatalf("relative directory code=%d", code)
+	}
+}
+
+func TestAdapterClientLauncherIsolationHonorsDeadline(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX blocking executable fixture")
+	}
+	blocker := filepath.Join(t.TempDir(), "blocked-client-launcher-doctor")
+	if err := os.WriteFile(blocker, []byte("#!/bin/sh\nexec sleep 10\n"), 0o700); err != nil { // #nosec G306 -- private executable deadline fixture.
+		t.Fatal(err)
+	}
+	previous := adapterDoctorClientLaunchersExecutable
+	adapterDoctorClientLaunchersExecutable = func() (string, error) { return blocker, nil }
+	t.Cleanup(func() { adapterDoctorClientLaunchersExecutable = previous })
+	ctx, cancel := context.WithTimeout(t.Context(), 20*time.Millisecond)
+	defer cancel()
+	started := time.Now()
+	if matched, err := inspectAdapterClientLaunchersIsolated(ctx, t.TempDir()); err == nil || matched || time.Since(started) > time.Second {
+		t.Fatalf("matched=%v err=%v elapsed=%s", matched, err, time.Since(started))
 	}
 }
 

--- a/cmd/punaro-admin/main.go
+++ b/cmd/punaro-admin/main.go
@@ -123,6 +123,7 @@ func runClientAdd(args []string, stdout, stderr io.Writer) int {
 	machineID := flags.String("machine-id", "", "unique lowercase client machine ID")
 	binding := flags.String("client-binding", "", "client-generated opaque binding UUID")
 	allProjects := flags.Bool("all-projects", false, "grant dynamic current and future project access")
+	serviceOnly := flags.Bool("service", false, "create an identity with no API capability grants")
 	ttl := flags.Duration("ttl", 10*time.Minute, "single-use enrollment lifetime")
 	legacyPrincipal := flags.String("legacy-principal-id", "", "operator-approved legacy machine principal for exchange")
 	confirmed := flags.Bool("yes", false, "confirm the printed exact grant expansion")
@@ -131,7 +132,19 @@ func runClientAdd(args []string, stdout, stderr io.Writer) int {
 	if flags.Parse(args) != nil || *actor == "" || *name == "" || *machineID == "" || *binding == "" || flags.NArg() != 0 {
 		return 2
 	}
-	grants, previewHash, err := punaropostgres.PreviewTrustedAgentEnrollment(projects, *allProjects)
+	var grants []punaropostgres.GrantSpec
+	var previewHash string
+	var err error
+	template := "trusted-agent"
+	if *serviceOnly {
+		if len(projects) != 0 || *allProjects || *legacyPrincipal != "" {
+			return adminError(stderr, errors.New("service enrollment scope is ambiguous"))
+		}
+		template = "service"
+		grants, previewHash, err = punaropostgres.PreviewServiceEnrollment()
+	} else {
+		grants, previewHash, err = punaropostgres.PreviewTrustedAgentEnrollment(projects, *allProjects)
+	}
 	if err != nil {
 		return adminError(stderr, err)
 	}
@@ -139,7 +152,7 @@ func runClientAdd(args []string, stdout, stderr io.Writer) int {
 		Template    string                     `json:"template"`
 		PreviewHash string                     `json:"preview_hash"`
 		Grants      []punaropostgres.GrantSpec `json:"grants"`
-	}{Template: "trusted-agent", PreviewHash: previewHash, Grants: grants}
+	}{Template: template, PreviewHash: previewHash, Grants: grants}
 	if code := writeJSON(stdout, stderr, preview); code != 0 {
 		return code
 	}
@@ -156,7 +169,7 @@ func runClientAdd(args []string, stdout, stderr io.Writer) int {
 		return adminError(stderr, err)
 	}
 	defer func() { _ = admin.Close() }()
-	pending, err := admin.CreateEnrollment(context.Background(), *actor, punaropostgres.EnrollmentRequest{ClientBinding: *binding, MachineID: *machineID, Label: *name, ProjectIDs: projects, AllProjects: *allProjects, LegacyPrincipalID: *legacyPrincipal, TTL: *ttl}, previewHash)
+	pending, err := admin.CreateEnrollment(context.Background(), *actor, punaropostgres.EnrollmentRequest{ClientBinding: *binding, MachineID: *machineID, Label: *name, ProjectIDs: projects, AllProjects: *allProjects, ServiceOnly: *serviceOnly, LegacyPrincipalID: *legacyPrincipal, TTL: *ttl}, previewHash)
 	if err != nil {
 		return adminError(stderr, err)
 	}

--- a/cmd/punaro-admin/main_test.go
+++ b/cmd/punaro-admin/main_test.go
@@ -46,6 +46,20 @@ func TestClientAddPrintsExactPreviewBeforeOpeningAdministration(t *testing.T) {
 	}
 }
 
+func TestClientInvitePrintsServiceOnlyPreviewBeforeOpeningAdministration(t *testing.T) {
+	original := openAdminDatabase
+	t.Cleanup(func() { openAdminDatabase = original })
+	openAdminDatabase = func(_ context.Context, _ postgres.Config) (adminDatabase, error) {
+		t.Fatal("administration opened before confirmation")
+		return nil, nil
+	}
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"client", "invite", "--actor-principal-id", "11111111-1111-4111-8111-111111111111", "--name", "server doctor", "--machine-id", "server-doctor", "--client-binding", "22222222-2222-4222-8222-222222222222", "--service"}, &stdout, &stderr)
+	if code != 3 || !strings.Contains(stdout.String(), `"template": "service"`) || !strings.Contains(stdout.String(), `"grants": []`) || !strings.Contains(stdout.String(), `"preview_hash"`) || !strings.Contains(stderr.String(), "rerun with --yes") {
+		t.Fatalf("code=%d stdout=%q stderr=%q", code, stdout.String(), stderr.String())
+	}
+}
+
 func TestClientInviteAliasAndLifecycleCommands(t *testing.T) {
 	original := openAdminDatabase
 	t.Cleanup(func() { openAdminDatabase = original })

--- a/cmd/punaro-bootstrap/main.go
+++ b/cmd/punaro-bootstrap/main.go
@@ -197,6 +197,9 @@ func runSeedCheckout(args []string) error {
 	flags.SetOutput(io.Discard)
 	directory := flags.String("directory", "", "absolute private bootstrap directory")
 	adapter := flags.String("adapter", "", "absolute checkout adapter binary")
+	trustedAttachment := flags.String("trusted-attachment", "", "absolute checkout trusted-attachment binary")
+	memory := flags.String("memory", "", "absolute checkout memory binary")
+	enroll := flags.String("enroll", "", "absolute checkout enrollment binary")
 	keysFile := flags.String("keys-file", "", "release public key set")
 	if err := flags.Parse(args); err != nil {
 		return errors.New("bootstrap seed-checkout is invalid")
@@ -212,7 +215,9 @@ func runSeedCheckout(args []string) error {
 		}
 		keys = loaded
 	}
-	return bootstrap.SeedLocalCheckout(*directory, *adapter, keys)
+	return bootstrap.SeedLocalCheckoutArtifacts(*directory, bootstrap.LocalCheckoutArtifacts{
+		Adapter: *adapter, TrustedAttachment: *trustedAttachment, Memory: *memory, Enroll: *enroll,
+	}, keys)
 }
 
 func loadKeys(path string) (map[string]ed25519.PublicKey, error) {

--- a/cmd/punaro-bootstrap/main_test.go
+++ b/cmd/punaro-bootstrap/main_test.go
@@ -7,6 +7,7 @@ import (
 	"crypto/rand"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -61,6 +62,36 @@ func TestBootstrapCLIRequiresAbsoluteDirectoryAndKeys(t *testing.T) {
 	}
 	if err := run([]string{"update", "--directory", abs, "--keys-file", "keys.json"}); err == nil {
 		t.Fatal("relative keys file accepted")
+	}
+}
+
+func TestBootstrapCLISeedCheckoutPublishesAllLocalClientArtifacts(t *testing.T) {
+	root := t.TempDir()
+	state := filepath.Join(root, "state")
+	if err := os.Mkdir(state, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	components := []string{"punaro-adapter", "punaro-trusted-attachment", "punaro-memory", "punaro-enroll"}
+	args := []string{"seed-checkout", "--directory", state}
+	for _, component := range components {
+		path := filepath.Join(root, component)
+		if err := os.WriteFile(path, []byte(component), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		args = append(args, "--"+strings.TrimPrefix(component, "punaro-"), path)
+	}
+	if err := run(args); err != nil {
+		t.Fatal(err)
+	}
+	for _, component := range components {
+		name := fmt.Sprintf("%s-%s-%s", component, runtime.GOOS, runtime.GOARCH)
+		if runtime.GOOS == "windows" {
+			name += ".exe"
+		}
+		body, err := os.ReadFile(filepath.Join(state, "current", name)) // #nosec G304 -- closed test component names under t.TempDir.
+		if err != nil || string(body) != component {
+			t.Fatalf("selected local artifact %s body=%q err=%v", name, body, err)
+		}
 	}
 }
 

--- a/cmd/punaro-enroll/main.go
+++ b/cmd/punaro-enroll/main.go
@@ -379,7 +379,7 @@ func loadMaterial(path string) (enrollmentMaterial, error) {
 		return enrollmentMaterial{}, errors.New("invalid enrollment material")
 	}
 	var preview enrollmentPreview
-	if err := decodeExact(records[0], &preview, "template", "preview_hash", "grants"); err != nil || preview.Template != "trusted-agent" || !validPreviewHash(preview.PreviewHash) || !validGrantPreview(preview.Grants) {
+	if err := decodeExact(records[0], &preview, "template", "preview_hash", "grants"); err != nil || !validEnrollmentPreview(preview) {
 		return enrollmentMaterial{}, errors.New("invalid enrollment material")
 	}
 	envelope, err := decodeEnrollmentEnvelope(records[1])
@@ -391,7 +391,7 @@ func loadMaterial(path string) (enrollmentMaterial, error) {
 
 func decodeEnrollmentEnvelope(raw []byte) (enrollmentEnvelope, error) {
 	var envelope enrollmentEnvelope
-	if err := decodeExact(raw, &envelope, "enrollment_id", "client_binding", "code", "expires_at", "preview_hash", "grants"); err != nil || !validMaterial(enrollmentMaterial{EnrollmentID: envelope.EnrollmentID, ClientBinding: envelope.ClientBinding, Code: envelope.Code}) || envelope.ExpiresAt.IsZero() || !validPreviewHash(envelope.PreviewHash) || !validGrantPreview(envelope.Grants) {
+	if err := decodeExact(raw, &envelope, "enrollment_id", "client_binding", "code", "expires_at", "preview_hash", "grants"); err != nil || !validMaterial(enrollmentMaterial{EnrollmentID: envelope.EnrollmentID, ClientBinding: envelope.ClientBinding, Code: envelope.Code}) || envelope.ExpiresAt.IsZero() || !validPreviewHash(envelope.PreviewHash) || !validGrantPreview(envelope.Grants, true) {
 		return enrollmentEnvelope{}, errors.New("invalid enrollment material")
 	}
 	return envelope, nil
@@ -427,9 +427,23 @@ func validPreviewHash(value string) bool {
 	return err == nil && len(decoded) == 32 && hex.EncodeToString(decoded) == value
 }
 
-func validGrantPreview(rawGrants []json.RawMessage) bool {
-	if len(rawGrants) == 0 {
+func validEnrollmentPreview(preview enrollmentPreview) bool {
+	if !validPreviewHash(preview.PreviewHash) {
 		return false
+	}
+	switch preview.Template {
+	case "trusted-agent":
+		return validGrantPreview(preview.Grants, false)
+	case "service":
+		return len(preview.Grants) == 0
+	default:
+		return false
+	}
+}
+
+func validGrantPreview(rawGrants []json.RawMessage, allowEmpty bool) bool {
+	if len(rawGrants) == 0 {
+		return allowEmpty
 	}
 	for _, raw := range rawGrants {
 		var grant enrollmentGrantPreview

--- a/cmd/punaro-enroll/main.go
+++ b/cmd/punaro-enroll/main.go
@@ -112,20 +112,37 @@ func main() { os.Exit(run(os.Args[1:], os.Stdout, os.Stderr)) }
 
 func run(args []string, stdout, stderr io.Writer) int {
 	if len(args) == 0 {
-		_, _ = fmt.Fprintln(stderr, "usage: punaro-enroll prepare|redeem|recover")
+		_, _ = fmt.Fprintln(stderr, "usage: punaro-enroll prepare|protect-material|redeem|recover")
 		return 2
 	}
 	switch args[0] {
 	case "prepare":
 		return runPrepare(args[1:], stdout, stderr)
+	case "protect-material":
+		return runProtectMaterial(args[1:], stdout, stderr)
 	case "redeem":
 		return runRedeem(args[1:], stdout, stderr, false)
 	case "recover":
 		return runRedeem(args[1:], stdout, stderr, true)
 	default:
-		_, _ = fmt.Fprintln(stderr, "usage: punaro-enroll prepare|redeem|recover")
+		_, _ = fmt.Fprintln(stderr, "usage: punaro-enroll prepare|protect-material|redeem|recover")
 		return 2
 	}
+}
+
+func runProtectMaterial(args []string, stdout, stderr io.Writer) int {
+	flags := flag.NewFlagSet("protect-material", flag.ContinueOnError)
+	flags.SetOutput(io.Discard)
+	path := flags.String("file", "", "absolute transferred enrollment-material file")
+	if flags.Parse(args) != nil || flags.NArg() != 0 || *path == "" {
+		return invalid(stderr)
+	}
+	if protectEnrollmentMaterial(*path) != nil {
+		_, _ = fmt.Fprintln(stderr, "punaro-enroll protect-material failed")
+		return 1
+	}
+	_, _ = fmt.Fprintln(stdout, "enrollment material protected")
+	return 0
 }
 
 func runPrepare(args []string, stdout, stderr io.Writer) int {

--- a/cmd/punaro-enroll/main_test.go
+++ b/cmd/punaro-enroll/main_test.go
@@ -625,6 +625,24 @@ func TestEnrollmentMaterialAcceptsExactServiceAdminOutput(t *testing.T) {
 	}
 }
 
+func TestProtectMaterialTightensTransferredFileWithoutReadingIt(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "enrollment-material.json")
+	want := []byte("private enrollment material")
+	if err := os.WriteFile(path, want, 0o644); err != nil { // #nosec G306 -- deliberately models a transferred file with an inherited broad mode.
+		t.Fatal(err)
+	}
+	var stdout, stderr bytes.Buffer
+	if code := run([]string{"protect-material", "--file", path}, &stdout, &stderr); code != 0 || stdout.String() != "enrollment material protected\n" || stderr.Len() != 0 {
+		t.Fatalf("code=%d stdout=%q stderr=%q", code, stdout.String(), stderr.String())
+	}
+	if _, err := readPrivate(path, maxEnrollmentMaterial); err != nil {
+		t.Fatalf("protected material remained unreadable: %v", err)
+	}
+	if got, err := os.ReadFile(path); err != nil || !bytes.Equal(got, want) { // #nosec G304 -- fixed child of t.TempDir verifies that permission repair did not rewrite contents.
+		t.Fatalf("protected material content changed: got=%q err=%v", got, err)
+	}
+}
+
 func TestEnrollmentMaterialAcceptsExactAdminOutputAtProjectLimit(t *testing.T) {
 	projectIDs := make([]string, 100)
 	for i := range projectIDs {

--- a/cmd/punaro-enroll/main_test.go
+++ b/cmd/punaro-enroll/main_test.go
@@ -600,6 +600,31 @@ func TestEnrollmentMaterialAcceptsStrictAdminEnvelope(t *testing.T) {
 	}
 }
 
+func TestEnrollmentMaterialAcceptsExactServiceAdminOutput(t *testing.T) {
+	grants, previewHash, err := punaropostgres.PreviewServiceEnrollment()
+	if err != nil {
+		t.Fatal(err)
+	}
+	preview := struct {
+		Template    string                     `json:"template"`
+		PreviewHash string                     `json:"preview_hash"`
+		Grants      []punaropostgres.GrantSpec `json:"grants"`
+	}{Template: "service", PreviewHash: previewHash, Grants: grants}
+	pending := punaropostgres.PendingEnrollment{ID: "33333333-3333-4333-8333-333333333333", ClientBinding: "44444444-4444-4444-8444-444444444444", Code: strings.Repeat("A", 43), ExpiresAt: time.Date(2030, 1, 2, 3, 4, 5, 0, time.UTC), PreviewHash: previewHash, Grants: grants}
+	previewRaw, err := json.MarshalIndent(preview, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	pendingRaw, err := json.MarshalIndent(pending, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	material, err := loadMaterial(writeTestMaterial(t, string(append(append(previewRaw, '\n'), append(pendingRaw, '\n')...))))
+	if err != nil || material.EnrollmentID != pending.ID {
+		t.Fatalf("service admin output material=%#v err=%v", material, err)
+	}
+}
+
 func TestEnrollmentMaterialAcceptsExactAdminOutputAtProjectLimit(t *testing.T) {
 	projectIDs := make([]string, 100)
 	for i := range projectIDs {

--- a/cmd/punaro-enroll/private_file_unix.go
+++ b/cmd/punaro-enroll/private_file_unix.go
@@ -143,6 +143,48 @@ func readPrivate(path string, maximum int) ([]byte, error) {
 	}
 	return raw, nil
 }
+
+func protectEnrollmentMaterial(path string) error {
+	if !filepath.IsAbs(path) || filepath.Clean(path) != path {
+		return errors.New("unsafe enrollment material")
+	}
+	before, err := os.Lstat(path)
+	if err != nil {
+		return err
+	}
+	if !before.Mode().IsRegular() || before.Mode()&os.ModeSymlink != 0 || !ownedByCurrentUser(before) || before.Size() < 1 || before.Size() > maxEnrollmentMaterial {
+		return errors.New("unsafe enrollment material")
+	}
+	// Open without following a replacement link. O_NONBLOCK prevents a raced
+	// FIFO from blocking before the post-open type and identity checks.
+	fd, err := unix.Open(path, unix.O_RDONLY|unix.O_CLOEXEC|unix.O_NOFOLLOW|unix.O_NONBLOCK, 0)
+	if err != nil {
+		return err
+	}
+	file := os.NewFile(uintptr(fd), path) // #nosec G115 -- unix.Open returns a non-negative descriptor for os.NewFile.
+	opened, err := file.Stat()
+	if err != nil || !opened.Mode().IsRegular() || !ownedByCurrentUser(opened) || opened.Size() < 1 || opened.Size() > maxEnrollmentMaterial || !os.SameFile(before, opened) {
+		_ = file.Close()
+		return errors.New("enrollment material changed while opening")
+	}
+	if err := unix.Fchmod(fd, 0o600); err != nil {
+		_ = file.Close()
+		return err
+	}
+	if err := file.Sync(); err != nil {
+		_ = file.Close()
+		return err
+	}
+	if err := file.Close(); err != nil {
+		return err
+	}
+	after, err := os.Lstat(path)
+	if err != nil || !os.SameFile(opened, after) || !privateFile(after) || after.Size() < 1 || after.Size() > maxEnrollmentMaterial {
+		return errors.New("protected enrollment material could not be verified")
+	}
+	return syncPrivateDirectory(filepath.Dir(path))
+}
+
 func writePrivateNew(path string, raw []byte) error {
 	if len(raw) == 0 || !filepath.IsAbs(path) {
 		return errors.New("unsafe private file")

--- a/cmd/punaro-enroll/private_file_windows.go
+++ b/cmd/punaro-enroll/private_file_windows.go
@@ -161,6 +161,64 @@ func readPrivate(path string, maximum int) ([]byte, error) {
 	}
 	return raw, nil
 }
+
+func protectEnrollmentMaterial(path string) error {
+	if !filepath.IsAbs(path) || filepath.Clean(path) != path {
+		return errors.New("unsafe enrollment material")
+	}
+	before, err := os.Lstat(path)
+	if err != nil {
+		return err
+	}
+	if !before.Mode().IsRegular() || before.Mode()&os.ModeSymlink != 0 || before.Size() < 1 || before.Size() > maxEnrollmentMaterial {
+		return errors.New("unsafe enrollment material")
+	}
+	name, err := windows.UTF16PtrFromString(path)
+	if err != nil {
+		return err
+	}
+	handle, err := windows.CreateFile(
+		name,
+		windows.GENERIC_READ|windows.GENERIC_WRITE|windows.WRITE_DAC|windows.WRITE_OWNER,
+		windows.FILE_SHARE_READ,
+		nil,
+		windows.OPEN_EXISTING,
+		windows.FILE_ATTRIBUTE_NORMAL|windows.FILE_FLAG_OPEN_REPARSE_POINT,
+		0,
+	) // #nosec G304 -- explicit absolute transfer path is opened without following a final reparse point.
+	if err != nil {
+		return err
+	}
+	file := os.NewFile(uintptr(handle), path)
+	opened, err := file.Stat()
+	var details windows.ByHandleFileInformation
+	if detailsErr := windows.GetFileInformationByHandle(handle, &details); err != nil || detailsErr != nil || details.FileAttributes&windows.FILE_ATTRIBUTE_REPARSE_POINT != 0 || details.FileAttributes&windows.FILE_ATTRIBUTE_DIRECTORY != 0 || !opened.Mode().IsRegular() || opened.Size() < 1 || opened.Size() > maxEnrollmentMaterial || !os.SameFile(before, opened) {
+		_ = file.Close()
+		return errors.New("enrollment material changed while opening")
+	}
+	user, acl, err := currentUserFullControlACL()
+	if err != nil {
+		_ = file.Close()
+		return err
+	}
+	if err := windows.SetSecurityInfo(handle, windows.SE_FILE_OBJECT, windows.OWNER_SECURITY_INFORMATION|windows.DACL_SECURITY_INFORMATION|windows.PROTECTED_DACL_SECURITY_INFORMATION, user, nil, acl, nil); err != nil {
+		_ = file.Close()
+		return err
+	}
+	if err := file.Sync(); err != nil {
+		_ = file.Close()
+		return err
+	}
+	if err := file.Close(); err != nil {
+		return err
+	}
+	after, err := os.Lstat(path)
+	if err != nil || !after.Mode().IsRegular() || after.Size() < 1 || after.Size() > maxEnrollmentMaterial || !os.SameFile(opened, after) || !privateWindowsACL(path) {
+		return errors.New("protected enrollment material could not be verified")
+	}
+	return syncPrivateDirectory(filepath.Dir(path))
+}
+
 func writePrivateNew(path string, raw []byte) error {
 	if len(raw) == 0 || !filepath.IsAbs(path) {
 		return errors.New("unsafe private file")
@@ -359,10 +417,18 @@ func privateWindowsACL(path string) bool {
 var protectWindowsPath = protectWindowsPathImpl
 
 func protectWindowsPathImpl(path string) error {
+	user, acl, err := currentUserFullControlACL()
+	if err != nil {
+		return err
+	}
+	return windows.SetNamedSecurityInfo(path, windows.SE_FILE_OBJECT, windows.OWNER_SECURITY_INFORMATION|windows.DACL_SECURITY_INFORMATION|windows.PROTECTED_DACL_SECURITY_INFORMATION, user, nil, acl, nil)
+}
+
+func currentUserFullControlACL() (*windows.SID, *windows.ACL, error) {
 	token := windows.GetCurrentProcessToken()
 	user, err := token.GetTokenUser()
 	if err != nil || user.User.Sid == nil {
-		return errors.New("current user is unavailable")
+		return nil, nil, errors.New("current user is unavailable")
 	}
 	acl, err := windows.ACLFromEntries([]windows.EXPLICIT_ACCESS{{
 		// Use the expanded file FullControl mask rather than GENERIC_ALL so the
@@ -372,7 +438,7 @@ func protectWindowsPathImpl(path string) error {
 		Trustee:           windows.TRUSTEE{TrusteeForm: windows.TRUSTEE_IS_SID, TrusteeValue: windows.TrusteeValueFromSID(user.User.Sid)},
 	}}, nil)
 	if err != nil {
-		return err
+		return nil, nil, err
 	}
-	return windows.SetNamedSecurityInfo(path, windows.SE_FILE_OBJECT, windows.OWNER_SECURITY_INFORMATION|windows.DACL_SECURITY_INFORMATION|windows.PROTECTED_DACL_SECURITY_INFORMATION, user.User.Sid, nil, acl, nil)
+	return user.User.Sid, acl, nil
 }

--- a/cmd/punaro-enroll/private_file_windows.go
+++ b/cmd/punaro-enroll/private_file_windows.go
@@ -216,7 +216,7 @@ func protectEnrollmentMaterial(path string) error {
 	if err != nil || !after.Mode().IsRegular() || after.Size() < 1 || after.Size() > maxEnrollmentMaterial || !os.SameFile(opened, after) || !privateWindowsACL(path) {
 		return errors.New("protected enrollment material could not be verified")
 	}
-	return syncPrivateDirectory(filepath.Dir(path))
+	return nil
 }
 
 func writePrivateNew(path string, raw []byte) error {

--- a/cmd/punaro-enroll/private_file_windows_test.go
+++ b/cmd/punaro-enroll/private_file_windows_test.go
@@ -55,6 +55,25 @@ func TestWindowsPrivateDACL(t *testing.T) {
 	}
 }
 
+func TestWindowsProtectTransferredMaterialReplacesInheritedACLWithOneACE(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "enrollment-material.json")
+	if err := os.WriteFile(path, []byte("private enrollment material"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if privateWindowsACL(path) {
+		t.Skip("temporary file already has an exclusive DACL")
+	}
+	if _, err := readPrivate(path, maxEnrollmentMaterial); err == nil {
+		t.Fatal("inherited transfer ACL was accepted before remediation")
+	}
+	if err := protectEnrollmentMaterial(path); err != nil {
+		t.Fatal(err)
+	}
+	if !privateWindowsACL(path) {
+		t.Fatal("remediated enrollment material does not have one exclusive current-user ACE")
+	}
+}
+
 func TestReservedStateFileNameRejectsWindowsAliases(t *testing.T) {
 	for _, name := range []string{redemptionJournalName, strings.ToUpper(redemptionJournalName), redemptionJournalName + ".", redemptionJournalName + " "} {
 		if !reservedStateFileName(name) {

--- a/cmd/punaro-enroll/private_file_windows_test.go
+++ b/cmd/punaro-enroll/private_file_windows_test.go
@@ -66,6 +66,9 @@ func TestWindowsProtectTransferredMaterialReplacesInheritedACLWithOneACE(t *test
 	if _, err := readPrivate(path, maxEnrollmentMaterial); err == nil {
 		t.Fatal("inherited transfer ACL was accepted before remediation")
 	}
+	previousSync := syncPrivateDirectory
+	syncPrivateDirectory = func(string) error { return errors.New("parent is not writable") }
+	t.Cleanup(func() { syncPrivateDirectory = previousSync })
 	if err := protectEnrollmentMaterial(path); err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/punaro-launcher/execute_unix.go
+++ b/cmd/punaro-launcher/execute_unix.go
@@ -1,0 +1,13 @@
+//go:build !windows
+
+package main
+
+import (
+	"os"
+	"syscall"
+)
+
+func executeSelectedComponent(path string, arguments []string) (int, error) {
+	argv := append([]string{path}, arguments...)
+	return 1, syscall.Exec(path, argv, os.Environ()) // #nosec G204,G702 -- path uses the launcher's closed component allowlist.
+}

--- a/cmd/punaro-launcher/execute_windows.go
+++ b/cmd/punaro-launcher/execute_windows.go
@@ -1,0 +1,26 @@
+//go:build windows
+
+package main
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+)
+
+func executeSelectedComponent(path string, arguments []string) (int, error) {
+	// #nosec G204,G702 -- path uses the launcher's closed component allowlist.
+	command := exec.Command(path, arguments...) //nolint:noctx // Windows child lifetime intentionally matches the dispatcher process; path uses the closed component allowlist.
+	command.Stdin = os.Stdin
+	command.Stdout = os.Stdout
+	command.Stderr = os.Stderr
+	command.Env = os.Environ()
+	if err := command.Run(); err != nil {
+		var exitError *exec.ExitError
+		if errors.As(err, &exitError) {
+			return exitError.ExitCode(), nil
+		}
+		return 1, err
+	}
+	return 0, nil
+}

--- a/cmd/punaro-launcher/main.go
+++ b/cmd/punaro-launcher/main.go
@@ -1,0 +1,86 @@
+// punaro-launcher is the stable installer-owned dispatcher for signed client
+// components. The familiar command names are copies of this binary; payloads
+// always execute from the selected bootstrap slot.
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"os/signal"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+var allowedComponents = map[string]struct{}{
+	"punaro-adapter":            {},
+	"punaro-enroll":             {},
+	"punaro-memory":             {},
+	"punaro-trusted-attachment": {},
+}
+
+func main() {
+	os.Exit(run())
+}
+
+func run() int {
+	path, err := selectedComponentPath(runtime.GOOS, runtime.GOARCH, userHome(), os.Getenv("LOCALAPPDATA"), filepath.Base(os.Args[0]))
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "punaro launcher: selected component is unavailable; run the Punaro client installer or bootstrap doctor")
+		return 1
+	}
+	info, err := os.Lstat(path) // #nosec G703 -- path is constrained to one allowlisted component below the private bootstrap root.
+	if err != nil || !info.Mode().IsRegular() || runtime.GOOS != "windows" && info.Mode().Perm()&0o111 == 0 {
+		fmt.Fprintln(os.Stderr, "punaro launcher: selected component is unavailable; run the Punaro client installer or bootstrap doctor")
+		return 1
+	}
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
+	defer stop()
+	command := exec.CommandContext(ctx, path, os.Args[1:]...) // #nosec G204,G702 -- executable path uses a closed component allowlist.
+	command.Stdin = os.Stdin
+	command.Stdout = os.Stdout
+	command.Stderr = os.Stderr
+	command.Env = os.Environ()
+	if err := command.Run(); err != nil {
+		var exitError *exec.ExitError
+		if errors.As(err, &exitError) {
+			return exitError.ExitCode()
+		}
+		fmt.Fprintln(os.Stderr, "punaro launcher: selected component could not start")
+		return 1
+	}
+	return 0
+}
+
+func userHome() string {
+	home, _ := os.UserHomeDir()
+	return home
+}
+
+func selectedComponentPath(goos, goarch, home, localAppData, invoked string) (string, error) {
+	component := strings.TrimSuffix(filepath.Base(invoked), ".exe")
+	if _, ok := allowedComponents[component]; !ok || (goarch != "amd64" && goarch != "arm64") {
+		return "", errors.New("unsupported component")
+	}
+	name := component + "-" + goos + "-" + goarch
+	var root string
+	switch goos {
+	case "darwin", "linux":
+		if !filepath.IsAbs(home) {
+			return "", errors.New("home is unavailable")
+		}
+		root = filepath.Join(home, ".local", "state", "punaro-bootstrap")
+	case "windows":
+		if !filepath.IsAbs(localAppData) {
+			return "", errors.New("local app data is unavailable")
+		}
+		root = filepath.Join(localAppData, "Punaro", "bootstrap")
+		name += ".exe"
+	default:
+		return "", errors.New("unsupported platform")
+	}
+	return filepath.Join(root, "current", name), nil
+}

--- a/cmd/punaro-launcher/main.go
+++ b/cmd/punaro-launcher/main.go
@@ -4,12 +4,9 @@
 package main
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"os"
-	"os/exec"
-	"os/signal"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -37,22 +34,12 @@ func run() int {
 		fmt.Fprintln(os.Stderr, "punaro launcher: selected component is unavailable; run the Punaro client installer or bootstrap doctor")
 		return 1
 	}
-	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
-	defer stop()
-	command := exec.CommandContext(ctx, path, os.Args[1:]...) // #nosec G204,G702 -- executable path uses a closed component allowlist.
-	command.Stdin = os.Stdin
-	command.Stdout = os.Stdout
-	command.Stderr = os.Stderr
-	command.Env = os.Environ()
-	if err := command.Run(); err != nil {
-		var exitError *exec.ExitError
-		if errors.As(err, &exitError) {
-			return exitError.ExitCode()
-		}
+	code, err := executeSelectedComponent(path, os.Args[1:])
+	if err != nil {
 		fmt.Fprintln(os.Stderr, "punaro launcher: selected component could not start")
 		return 1
 	}
-	return 0
+	return code
 }
 
 func userHome() string {

--- a/cmd/punaro-launcher/main_test.go
+++ b/cmd/punaro-launcher/main_test.go
@@ -1,0 +1,26 @@
+package main
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestSelectedComponentPathUsesOnlyKnownCommandsAndPlatformSlot(t *testing.T) {
+	home := filepath.Join(string(filepath.Separator), "Users", "operator")
+	path, err := selectedComponentPath("darwin", "arm64", home, "", "punaro-enroll")
+	want := filepath.Join(home, ".local", "state", "punaro-bootstrap", "current", "punaro-enroll-darwin-arm64")
+	if err != nil || path != want {
+		t.Fatalf("path=%q want=%q err=%v", path, want, err)
+	}
+	localAppData := filepath.Join(string(filepath.Separator), "Users", "operator", "AppData", "Local")
+	path, err = selectedComponentPath("windows", "amd64", home, localAppData, "punaro-memory.exe")
+	want = filepath.Join(localAppData, "Punaro", "bootstrap", "current", "punaro-memory-windows-amd64.exe")
+	if err != nil || path != want {
+		t.Fatalf("path=%q want=%q err=%v", path, want, err)
+	}
+	for _, invoked := range []string{"punaro-bootstrap", "punaro-keygen", "punaro-enroll;touch", ""} {
+		if _, err := selectedComponentPath("linux", "amd64", home, "", invoked); err == nil {
+			t.Fatalf("unknown command %q accepted", invoked)
+		}
+	}
+}

--- a/cmd/punaro-release/main_test.go
+++ b/cmd/punaro-release/main_test.go
@@ -171,8 +171,8 @@ func TestBuildFactsBindsPluginSkillsGeneratedComposeAndMigrations(t *testing.T) 
 	if err != nil {
 		t.Fatal(err)
 	}
-	facts, err := buildFacts([]string{"--release", "v0.1.0-alpha.7", "--plugin-root", root})
-	if err != nil || facts.Release != "v0.1.0-alpha.7" || facts.ComposeSHA256 != operator.ComposeManifestSHA256() || len(facts.MigrationManifestSHA256) != 64 || len(facts.SkillSetSHA256) != 64 || len(facts.PluginRuntimeSHA256) != 64 {
+	facts, err := buildFacts([]string{"--release", "v0.1.0-alpha.8", "--plugin-root", root})
+	if err != nil || facts.Release != "v0.1.0-alpha.8" || facts.ComposeSHA256 != operator.ComposeManifestSHA256() || len(facts.MigrationManifestSHA256) != 64 || len(facts.SkillSetSHA256) != 64 || len(facts.PluginRuntimeSHA256) != 64 {
 		t.Fatalf("facts=%#v err=%v", facts, err)
 	}
 	if _, err := buildFacts([]string{"--release", "v0.1.0", "--plugin-root", root}); err == nil {

--- a/cmd/punaro/main.go
+++ b/cmd/punaro/main.go
@@ -193,6 +193,7 @@ type serverDoctorState struct {
 	CatalogSequence       int64
 	Protocol              int64
 	InstalledRelease      knownDoctorBool
+	OperatorBinaryRelease knownDoctorBool
 	RunningImage          knownDoctorBool
 	ComposeBinding        knownDoctorBool
 	MigrationBinding      knownDoctorBool
@@ -722,7 +723,7 @@ func unavailableServerDoctorChecks(gatewayColocated bool) []punarodiagnostic.Che
 		"access_admission", "administration_listener_private", "application_credential_file", "attachment_blob_containment", "attachment_blob_directory",
 		"backup_directory", "backup_freshness", "blob_storage_private", "compose_manifest_binding", "compose_override", "daemon_environment", "data_directory",
 		"database_connection", "database_listener_private", "database_owner", "database_pair", "database_schema",
-		"health_endpoint", "health_listener_private", "host_update_stage", "image_digest_binding", "installed_release", "installation_directory", "installation_paths", "machine_identity",
+		"health_endpoint", "health_listener_private", "host_update_stage", "image_digest_binding", "installed_release", "operator_binary_release", "installation_directory", "installation_paths", "machine_identity",
 		"maintenance_fence", "migration_manifest_binding", "owner_credential_file", "postgres_major", "readiness_endpoint", "recovery_receipt", "relay_enrollment",
 		"relay_protocol", "running_image", "storage_capacity", "storage_credential_isolation", "storage_directory_separation", "tunnel_origin", "tunnel_route",
 		"update_recovery", "update_transaction", "verified_backup",
@@ -756,6 +757,7 @@ func diagnoseServer(ctx context.Context, installation operator.Installation, mac
 	identity.Protocol = extended.Protocol
 	identity.Capabilities = serverDoctorCapabilities(installation)
 	checks = appendKnownServerCheck(checks, "installed_release", "install_signed_release", extended.InstalledRelease)
+	checks = appendKnownServerCheck(checks, "operator_binary_release", "install_release_operator_binary", extended.OperatorBinaryRelease)
 	if extended.MachineID == "" {
 		checks = append(checks, punarodiagnostic.Fail("machine_identity", "configure_server_machine_identity"))
 	} else {

--- a/cmd/punaro/main_test.go
+++ b/cmd/punaro/main_test.go
@@ -1609,6 +1609,44 @@ func TestServerDoctorRequiresReleasePostgreSQLMajor(t *testing.T) {
 	}
 }
 
+func TestServerDoctorInspectsRunningImageFromInstallationDirectory(t *testing.T) {
+	directory := t.TempDir()
+	original := serverDoctorRunningImageCommand
+	t.Cleanup(func() { serverDoctorRunningImageCommand = original })
+	var calls int
+	serverDoctorRunningImageCommand = func(_ context.Context, actualDirectory, executable string, arguments ...string) (string, bool) {
+		calls++
+		if actualDirectory != directory || executable != "docker" {
+			t.Fatalf("directory=%q executable=%q", actualDirectory, executable)
+		}
+		switch arguments[0] {
+		case "compose":
+			return "punaro-container\n", true
+		case "inspect":
+			return cliTestImage + "\n", true
+		default:
+			t.Fatalf("arguments=%q", arguments)
+			return "", false
+		}
+	}
+	state := inspectRunningImage(t.Context(), operator.Installation{
+		Directory:        directory,
+		Image:            cliTestImage,
+		OwnerPrincipalID: "11111111-1111-4111-8111-111111111111",
+	})
+	if !state.Known || !state.OK || calls != 2 {
+		t.Fatalf("running image state=%#v calls=%d", state, calls)
+	}
+}
+
+func TestServerDoctorCommandUsesRequestedWorkingDirectory(t *testing.T) {
+	directory := t.TempDir()
+	command := newServerDoctorCommand(t.Context(), directory, "docker", "version")
+	if command.Dir != directory {
+		t.Fatalf("command directory=%q want=%q", command.Dir, directory)
+	}
+}
+
 func TestServerDoctorProfileLoadsOnlyProtectedLeastPrivilegeInputs(t *testing.T) {
 	root := t.TempDir()
 	if runtime.GOOS != "windows" {

--- a/cmd/punaro/main_test.go
+++ b/cmd/punaro/main_test.go
@@ -503,7 +503,7 @@ func TestServerDoctorDeadlineIncludesInstallationLoad(t *testing.T) {
 func healthyServerDoctorState() serverDoctorState {
 	return serverDoctorState{
 		MachineID: "punaro-lxc", Release: "v0.1.0-alpha.1", ReleaseSequence: 1, CatalogSequence: 1, Protocol: 1,
-		InstalledRelease: knownDoctorBool{Known: true, OK: true}, RunningImage: knownDoctorBool{Known: true, OK: true},
+		InstalledRelease: knownDoctorBool{Known: true, OK: true}, OperatorBinaryRelease: knownDoctorBool{Known: true, OK: true}, RunningImage: knownDoctorBool{Known: true, OK: true},
 		ComposeBinding: knownDoctorBool{Known: true, OK: true}, MigrationBinding: knownDoctorBool{Known: true, OK: true},
 		PostgresMajor: 18, ExpectedPostgresMajor: 18, PostgresKnown: true, Storage: knownDoctorBool{Known: true, OK: true},
 		BackupAvailable: knownDoctorBool{Known: true, OK: true}, BackupFresh: knownDoctorBool{Known: true, OK: true},
@@ -1379,6 +1379,7 @@ func TestDoctorClassifiesEveryExtendedServerDependency(t *testing.T) {
 	state.ReleaseSequence = 2
 	state.CatalogSequence = 4
 	state.InstalledRelease.OK = false
+	state.OperatorBinaryRelease.OK = false
 	state.RunningImage.OK = false
 	state.ComposeBinding.OK = false
 	state.MigrationBinding.Known = false
@@ -1419,7 +1420,7 @@ func TestDoctorClassifiesEveryExtendedServerDependency(t *testing.T) {
 		t.Fatalf("identity=%#v", report.Identity)
 	}
 	want := map[string]punarodiagnostic.Status{
-		"installed_release": "fail", "running_image": "fail", "compose_manifest_binding": "fail",
+		"installed_release": "fail", "operator_binary_release": "fail", "running_image": "fail", "compose_manifest_binding": "fail",
 		"migration_manifest_binding": "unavailable", "postgres_major": "unavailable", "storage_capacity": "fail",
 		"verified_backup": "fail", "backup_freshness": "unavailable", "update_transaction": "fail", "recovery_receipt": "unavailable", "update_recovery": "fail",
 		"database_listener_private": "fail", "health_listener_private": "fail", "administration_listener_private": "fail",
@@ -1636,6 +1637,51 @@ func TestServerDoctorInspectsRunningImageFromInstallationDirectory(t *testing.T)
 	})
 	if !state.Known || !state.OK || calls != 2 {
 		t.Fatalf("running image state=%#v calls=%d", state, calls)
+	}
+}
+
+func TestServerDoctorRunningImageDistinguishesMismatchAndUnavailable(t *testing.T) {
+	original := serverDoctorRunningImageCommand
+	t.Cleanup(func() { serverDoctorRunningImageCommand = original })
+	installation := operator.Installation{
+		Directory:        t.TempDir(),
+		Image:            cliTestImage,
+		OwnerPrincipalID: "11111111-1111-4111-8111-111111111111",
+	}
+	serverDoctorRunningImageCommand = func(_ context.Context, _ string, _ string, arguments ...string) (string, bool) {
+		if arguments[0] == "compose" {
+			return "punaro-container\n", true
+		}
+		return "ghcr.io/rock3r/punaro@sha256:" + strings.Repeat("b", 64) + "\n", true
+	}
+	if state := inspectRunningImage(t.Context(), installation); !state.Known || state.OK {
+		t.Fatalf("mismatched running image state=%#v", state)
+	}
+	serverDoctorRunningImageCommand = func(context.Context, string, string, ...string) (string, bool) {
+		return "", false
+	}
+	if state := inspectRunningImage(t.Context(), installation); state.Known || state.OK {
+		t.Fatalf("unavailable running image state=%#v", state)
+	}
+}
+
+func TestOperatorBinaryReleaseFollowsDurableUpdateOutcome(t *testing.T) {
+	transaction := punaropostgres.UpdateTransaction{UpdateRequest: punaropostgres.UpdateRequest{SourceRelease: "v0.1.0-alpha.7", TargetRelease: "v0.1.0-alpha.8"}, Phase: punaropostgres.UpdateCommitted}
+	if state := operatorBinaryReleaseState("v0.1.0-alpha.7", transaction, true); !state.Known || state.OK {
+		t.Fatalf("stale committed operator state=%#v", state)
+	}
+	if state := operatorBinaryReleaseState("v0.1.0-alpha.8", transaction, true); !state.Known || !state.OK {
+		t.Fatalf("updated committed operator state=%#v", state)
+	}
+	transaction.Phase = punaropostgres.UpdateRecovered
+	if state := operatorBinaryReleaseState("v0.1.0-alpha.7", transaction, true); !state.Known || !state.OK {
+		t.Fatalf("recovered source operator state=%#v", state)
+	}
+	if state := operatorBinaryReleaseState("", punaropostgres.UpdateTransaction{}, false); state.Known || state.OK {
+		t.Fatalf("unidentified fresh operator state=%#v", state)
+	}
+	if state := operatorBinaryReleaseState("v0.1.0-alpha.8", punaropostgres.UpdateTransaction{}, false); !state.Known || !state.OK {
+		t.Fatalf("fresh identified operator state=%#v", state)
 	}
 }
 

--- a/cmd/punaro/server_doctor.go
+++ b/cmd/punaro/server_doctor.go
@@ -555,7 +555,7 @@ func inspectServerDoctorState(parent context.Context, installation operator.Inst
 		state.AdminPrivate = known(listenerErr == nil, private)
 		_ = administration.Close()
 	}
-	state.UpdateTransaction, state.RecoveryReceipt, state.UpdateRecovery = inspectUpdateState(ctx, installation)
+	state.UpdateTransaction, state.RecoveryReceipt, state.UpdateRecovery, state.OperatorBinaryRelease = inspectUpdateState(ctx, installation)
 	return state
 }
 
@@ -1095,31 +1095,46 @@ func serverGatewaySystemdExecStartBound(body string) bool {
 	return fields["path"] == executable && fields["argv[]"] == executable
 }
 
-func inspectUpdateState(parent context.Context, installation operator.Installation) (knownDoctorBool, knownDoctorBool, knownDoctorBool) {
+func inspectUpdateState(parent context.Context, installation operator.Installation) (knownDoctorBool, knownDoctorBool, knownDoctorBool, knownDoctorBool) {
 	admin, err := openServerDoctorAdministration(parent, installation.OwnerDSNFile)
 	if err != nil {
-		return knownDoctorBool{}, knownDoctorBool{}, knownDoctorBool{}
+		return knownDoctorBool{}, knownDoctorBool{}, knownDoctorBool{}, knownDoctorBool{}
 	}
 	defer func() { _ = admin.Close() }()
 	transaction, err := admin.LatestUpdate(parent)
 	if errors.Is(err, punaropostgres.ErrNotFound) {
-		return known(true, true), serverDoctorRecoveryReceiptCheck(parent, serverDoctorRecoveryReceiptRequest{Directory: installation.Directory, ExpectAbsent: true}), known(true, true)
+		return known(true, true), serverDoctorRecoveryReceiptCheck(parent, serverDoctorRecoveryReceiptRequest{Directory: installation.Directory, ExpectAbsent: true}), known(true, true), operatorBinaryReleaseState(serverBuildRelease, punaropostgres.UpdateTransaction{}, false)
 	}
 	if err != nil {
-		return knownDoctorBool{}, knownDoctorBool{}, knownDoctorBool{}
+		return knownDoctorBool{}, knownDoctorBool{}, knownDoctorBool{}, knownDoctorBool{}
 	}
+	operatorRelease := operatorBinaryReleaseState(serverBuildRelease, transaction, true)
 	terminal := transaction.Phase == punaropostgres.UpdateCommitted || transaction.Phase == punaropostgres.UpdateRecovered || transaction.Phase == punaropostgres.UpdateAborted
 	if transaction.Phase == punaropostgres.UpdateCommitted && serverBuildRelease != "" {
 		terminal = transaction.TargetRelease == serverBuildRelease && transaction.TargetImage == installation.Image && transaction.ComposeSHA256 == serverBuildComposeSHA256 && transaction.MigrationManifestSHA256 == serverBuildMigrationSHA256
 	}
 	if terminal {
-		return known(true, true), serverDoctorRecoveryReceiptCheck(parent, serverDoctorRecoveryReceiptRequest{Directory: installation.Directory, ExpectAbsent: true}), known(true, true)
+		return known(true, true), serverDoctorRecoveryReceiptCheck(parent, serverDoctorRecoveryReceiptRequest{Directory: installation.Directory, ExpectAbsent: true}), known(true, true), operatorRelease
 	}
 	if !updatePhaseRequiresRecoveryReceipt(transaction.Phase) {
-		return known(true, false), serverDoctorRecoveryReceiptCheck(parent, serverDoctorRecoveryReceiptRequest{Directory: installation.Directory, ExpectAbsent: true}), known(true, false)
+		return known(true, false), serverDoctorRecoveryReceiptCheck(parent, serverDoctorRecoveryReceiptRequest{Directory: installation.Directory, ExpectAbsent: true}), known(true, false), operatorRelease
 	}
 	receipt := serverDoctorRecoveryReceiptRequest{Directory: installation.Directory, UpdateID: transaction.UpdateID, BackupID: transaction.BackupID, TargetRelease: transaction.TargetRelease, ManifestSHA256: transaction.BackupManifestSHA256}
-	return known(true, false), serverDoctorRecoveryReceiptCheck(parent, receipt), known(true, false)
+	return known(true, false), serverDoctorRecoveryReceiptCheck(parent, receipt), known(true, false), operatorRelease
+}
+
+func operatorBinaryReleaseState(release string, transaction punaropostgres.UpdateTransaction, found bool) knownDoctorBool {
+	if release == "" {
+		return knownDoctorBool{}
+	}
+	if !found {
+		return known(true, true)
+	}
+	expected := transaction.SourceRelease
+	if transaction.Phase == punaropostgres.UpdateCommitted {
+		expected = transaction.TargetRelease
+	}
+	return known(expected != "", release == expected)
 }
 
 func updatePhaseRequiresRecoveryReceipt(phase punaropostgres.UpdatePhase) bool {

--- a/cmd/punaro/server_doctor.go
+++ b/cmd/punaro/server_doctor.go
@@ -108,6 +108,7 @@ var (
 	serverDoctorProfileExecutable         = os.Executable
 	serverDoctorRecoveryReceiptCheck      = isolatedServerDoctorRecoveryReceipt
 	serverDoctorRecoveryReceiptExecutable = os.Executable
+	serverDoctorRunningImageCommand       = boundedCommandInDirectory
 )
 
 func isolatedServerDoctorProfile(ctx context.Context, path string) (serverDoctorProfile, error) {
@@ -707,11 +708,11 @@ func inspectRunningImage(parent context.Context, installation operator.Installat
 	if err != nil {
 		return knownDoctorBool{}
 	}
-	container, ok := boundedCommand(parent, "docker", "compose", "--project-name", project, "--env-file", operator.EnvFile(installation.Directory), "-f", operator.OverrideFile(installation.Directory), "ps", "--quiet", "punarod")
+	container, ok := serverDoctorRunningImageCommand(parent, installation.Directory, "docker", "compose", "--project-name", project, "--env-file", operator.EnvFile(installation.Directory), "-f", operator.OverrideFile(installation.Directory), "ps", "--quiet", "punarod")
 	if !ok || strings.TrimSpace(container) == "" || strings.Contains(strings.TrimSpace(container), "\n") {
 		return known(ok, false)
 	}
-	image, ok := boundedCommand(parent, "docker", "inspect", "--format", "{{.Config.Image}}", strings.TrimSpace(container))
+	image, ok := serverDoctorRunningImageCommand(parent, installation.Directory, "docker", "inspect", "--format", "{{.Config.Image}}", strings.TrimSpace(container))
 	return known(ok, strings.TrimSpace(image) == installation.Image)
 }
 
@@ -1133,13 +1134,21 @@ func updatePhaseRequiresRecoveryReceipt(phase punaropostgres.UpdatePhase) bool {
 }
 
 func boundedCommand(parent context.Context, executable string, arguments ...string) (string, bool) {
-	return boundedCommandLimit(parent, serverDoctorOutputLimit, executable, arguments...)
+	return boundedCommandLimitInDirectory(parent, serverDoctorOutputLimit, "", executable, arguments...)
 }
 
 func boundedCommandLimit(parent context.Context, maximum int, executable string, arguments ...string) (string, bool) {
+	return boundedCommandLimitInDirectory(parent, maximum, "", executable, arguments...)
+}
+
+func boundedCommandInDirectory(parent context.Context, directory, executable string, arguments ...string) (string, bool) {
+	return boundedCommandLimitInDirectory(parent, serverDoctorOutputLimit, directory, executable, arguments...)
+}
+
+func boundedCommandLimitInDirectory(parent context.Context, maximum int, directory, executable string, arguments ...string) (string, bool) {
 	ctx, cancel := context.WithTimeout(parent, serverDoctorCommandTimeout)
 	defer cancel()
-	command := exec.CommandContext(ctx, executable, arguments...) // #nosec G204 -- fixed audited executable and structured arguments.
+	command := newServerDoctorCommand(ctx, directory, executable, arguments...)
 	command.Stdin = nil
 	command.Stderr = io.Discard
 	output := boundedServerDoctorOutput{maximum: maximum}
@@ -1148,4 +1157,10 @@ func boundedCommandLimit(parent context.Context, maximum int, executable string,
 		return "", false
 	}
 	return output.buffer.String(), true
+}
+
+func newServerDoctorCommand(ctx context.Context, directory, executable string, arguments ...string) *exec.Cmd {
+	command := exec.CommandContext(ctx, executable, arguments...) // #nosec G204 -- fixed audited executable and structured arguments.
+	command.Dir = directory
+	return command
 }

--- a/docs/agent-plugin.md
+++ b/docs/agent-plugin.md
@@ -7,9 +7,9 @@ Codex and Claude Code plugin. All forms expose the same three skills:
 - `punaro-reply` replies through the enrolled local Punaro adapter.
 - `punaro-attachment` handles one explicitly authorized trusted attachment.
 
-The plugin's package-relative POSIX and Windows launchers start the
-installer-owned `punaro-adapter mailbox-mcp` binary from its supported absolute
-location. The wrapper reads the same owner-only `adapter.env` profile as the
+The plugin's package-relative POSIX and Windows launchers start
+`punaro-adapter mailbox-mcp` from the bootstrap's selected signed slot. The
+wrapper reads the same owner-only `adapter.env` profile as the
 adapter and launches `waypost mcp` with its configured binary and state
 directory. The same launcher remains compatible with a configured legacy
 `agent-mailbox` during a rolling migration. The plugin does not install Punaro, enroll a machine, provision
@@ -18,9 +18,10 @@ credentials, select a relay, or change any local routing.
 ## Prerequisites
 
 Complete the supported [client installation](installation.md) first. The
-launchers use `~/.local/bin/punaro-adapter` on macOS and Linux and
-`%LOCALAPPDATA%\Punaro\bin\punaro-adapter.exe` on Windows; they do not depend on
-the agent application's inherited `PATH`. The wrapper uses the Waypost binary
+launchers resolve `current/punaro-adapter-OS-ARCH` below the private bootstrap
+directory (`~/.local/state/punaro-bootstrap` or
+`%LOCALAPPDATA%\Punaro\bootstrap`); they do not depend on the agent
+application's inherited `PATH` or a stale fixed payload. The wrapper uses the Waypost binary
 and mailbox state directory recorded by that installation. Its MCP server must
 provide `waypost_status`, `waypost_recv`, and `waypost_ack`; doctor also accepts
 the complete legacy `mailbox_*` surface while that host awaits migration. Trusted

--- a/docs/agent-plugin.md
+++ b/docs/agent-plugin.md
@@ -7,22 +7,25 @@ Codex and Claude Code plugin. All forms expose the same three skills:
 - `punaro-reply` replies through the enrolled local Punaro adapter.
 - `punaro-attachment` handles one explicitly authorized trusted attachment.
 
-The plugin's package-relative POSIX and Windows launchers start
-`punaro-adapter mailbox-mcp` from the bootstrap's selected signed slot. The
-wrapper reads the same owner-only `adapter.env` profile as the
-adapter and launches `waypost mcp` with its configured binary and state
-directory. The same launcher remains compatible with a configured legacy
+The plugin's package-relative launchers start `punaro-adapter mailbox-mcp`
+from the bootstrap's selected signed slot. POSIX launchers resolve that slot
+directly; Windows launchers use the stable installer-owned dispatcher in
+`%LOCALAPPDATA%\Punaro\bin`, which performs the same closed selected-slot
+dispatch without starting PowerShell. The wrapper reads the same owner-only
+`adapter.env` profile as the adapter and launches `waypost mcp` with its
+configured binary and state directory. The same launcher remains compatible with a configured legacy
 `agent-mailbox` during a rolling migration. The plugin does not install Punaro, enroll a machine, provision
 credentials, select a relay, or change any local routing.
 
 ## Prerequisites
 
 Complete the supported [client installation](installation.md) first. The
-launchers resolve `current/punaro-adapter-OS-ARCH` below the private bootstrap
-directory (`~/.local/state/punaro-bootstrap` or
-`%LOCALAPPDATA%\Punaro\bootstrap`); they do not depend on the agent
-application's inherited `PATH` or a stale fixed payload. The wrapper uses the Waypost binary
-and mailbox state directory recorded by that installation. Its MCP server must
+launchers resolve the selected adapter below the private bootstrap directory
+(`~/.local/state/punaro-bootstrap` or `%LOCALAPPDATA%\Punaro\bootstrap`),
+directly on POSIX and through
+`%LOCALAPPDATA%\Punaro\bin\punaro-adapter.exe` on Windows; they do not depend on
+the agent application's inherited `PATH` or a stale fixed payload. The wrapper
+uses the Waypost binary and mailbox state directory recorded by that installation. Its MCP server must
 provide `waypost_status`, `waypost_recv`, and `waypost_ack`; doctor also accepts
 the complete legacy `mailbox_*` surface while that host awaits migration. Trusted
 attachment operations additionally require the operator-installed

--- a/docs/doctor.md
+++ b/docs/doctor.md
@@ -335,7 +335,10 @@ registration files to match the digest embedded by the release builder.
 `client_component_launchers` requires the stable adapter, enrollment, memory,
 and trusted-attachment dispatchers to be regular executable copies of the same
 installer build. This catches mixed fixed payloads left by older installers;
-the dispatchers always execute the selected signed-slot artifacts.
+the dispatchers always execute the selected signed-slot artifacts. Hashing is
+performed in a deadline-isolated helper with an 8 MiB bound per launcher; a
+stalled helper is reported as required-unavailable rather than outliving the
+shared doctor deadline.
 
 The adapter inspects and runs `version` on the fixed installer-owned
 `punaro-bootstrap` executable in a deadline-isolated child and passes that

--- a/docs/doctor.md
+++ b/docs/doctor.md
@@ -315,6 +315,7 @@ Service, release, and plugin state: `adapter_service_installed`,
 `adapter_service_executable`, `adapter_service_last_exit`,
 `adapter_service_restart_state`, `bootstrap_selected_artifact`,
 `bootstrap_running_artifact`, `bootstrap_supervisor`, `installed_release`,
+`client_component_launchers`,
 `portable_plugin_registration`, `codex_plugin_registration`,
 `claude_plugin_registration`, `plugin_launcher`, `plugin_version`,
 `skill_set_parity`.
@@ -322,6 +323,11 @@ Service, release, and plugin state: `adapter_service_installed`,
 `plugin_launcher` requires the platform launcher to be a safe executable and
 requires the exact bytes of both POSIX/Windows launchers and both MCP
 registration files to match the digest embedded by the release builder.
+
+`client_component_launchers` requires the stable adapter, enrollment, memory,
+and trusted-attachment dispatchers to be regular executable copies of the same
+installer build. This catches mixed fixed payloads left by older installers;
+the dispatchers always execute the selected signed-slot artifacts.
 
 The adapter inspects and runs `version` on the fixed installer-owned
 `punaro-bootstrap` executable in a deadline-isolated child and passes that
@@ -474,6 +480,7 @@ operator explicitly approves that separate action.
   `repair_mailbox_mcp`, `repair_mailbox_state_directory`,
   `repair_plugin_registration`, `repair_codex_plugin_registration`,
   `repair_claude_plugin_registration`, `repair_plugin_launcher`,
+  `reinstall_client_launchers`,
   `repair_bootstrap_directory`, `repair_bootstrap_lock_state`,
   `repair_bootstrap_state`, and `repair_previous_slot` mean stop and use the
   reviewed installer or documented bootstrap recovery path. Do not weaken

--- a/docs/doctor.md
+++ b/docs/doctor.md
@@ -216,7 +216,8 @@ Installation and provenance: `installation_configuration`,
 `attachment_blob_containment`, `storage_directory_separation`,
 `storage_credential_isolation`, `daemon_environment`, `compose_override`,
 `compose_manifest_binding`, `migration_manifest_binding`,
-`image_digest_binding`, `installed_release`, `running_image`,
+`image_digest_binding`, `installed_release`, `operator_binary_release`,
+`running_image`,
 `machine_identity`.
 
 For native release artifacts, `installed_release` compares the exact
@@ -226,6 +227,13 @@ it binds the release-tagged repository identity known at build time and
 requires the installation to use a digest-pinned image from that exact
 repository. Compose manifest hashing runs in a deadline-isolated helper, so a
 stalled mounted file cannot extend the total doctor timeout.
+
+`operator_binary_release` checks the host-side `punaro` executable against the
+latest durable update outcome: a committed transaction requires the target
+release, while an incomplete, aborted, or recovered transaction requires the
+source release. A fresh installation with no transaction accepts its identified
+release. Missing build identity or unavailable update state reports
+`unavailable`; drift reports `install_release_operator_binary`.
 
 Database, storage, and update recovery: `database_connection`,
 `database_listener_private`, `administration_listener_private`,
@@ -453,7 +461,8 @@ operator explicitly approves that separate action.
   `install_matching_plugin`, `install_matching_release`,
   `install_matching_skill_set`, `install_platform_release`,
   `install_release_keys`, `install_second_signed_release`,
-  `install_signed_release`, `install_unblocked_release`,
+  `install_release_operator_binary`, `install_signed_release`,
+  `install_unblocked_release`,
   `repair_release_catalog`, `repair_release_manifest`,
   `repair_release_origin`,
   `reinstall_release_compose_manifest`,

--- a/docs/github-releases.md
+++ b/docs/github-releases.md
@@ -136,6 +136,12 @@ Only the offline-signature publisher can make those stable assets visible.
    Set `supported_from` to the comma-separated installed releases that
    may upgrade directly to this release; this is required for rolling fleet
    transitions after the first release.
+
+   Alpha.8 introduces the selected-component dispatcher and the full local
+   checkout slot. Dispatch `v0.1.0-alpha.8` with
+   `minimum_bootstrap_release=v0.1.0-alpha.8`; upgrading from an older fixed
+   bootstrap requires one client-installer handoff before built-in updates can
+   safely manage every selected component.
 3. Wait for the draft release to appear. The live `catalog` prerelease is not
    touched by the unsigned workflow.
 4. Generate the offline key once, on an air-gapped or owner-only machine, and

--- a/docs/github-releases.md
+++ b/docs/github-releases.md
@@ -77,6 +77,12 @@ release-named identity is embedded metadata, not a pushed tag. It then builds:
   `linux/arm64`, and `windows/amd64`
 - `punaro`, `punaro-telegram`, and `punaro-relay-adopt-prepare` for Linux
 
+The Linux `punaro-linux-{amd64,arm64}` artifact is also the supported
+host-operator handoff for a server update. Operators verify its manifest
+signature and manifest-bound length/digest before an atomic root-owned install;
+server doctor then checks `operator_binary_release` against the durable update
+outcome.
+
 Darwin adapter builds use `CGO_ENABLED=1` so the supported ACL path is compiled
 in. The workflow then writes unsigned `punaro-release.json` and
 `punaro-catalog.json` and creates a **draft** GitHub Release. The private

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -527,6 +527,13 @@ For a legacy exchange the owner also supplies the exact content-free
 `--legacy-principal-id` from `punaro-admin legacy list`; the new machine ID must
 remain the existing registered machine ID.
 
+For a non-agent service probe such as server doctor, the owner uses
+`--service` instead of `--project` or `--all-projects`. Its exact preview has an
+empty `grants` array and grants no project, conversation, memory, attachment,
+or installation capability. `--service` is mutually exclusive with project
+scope and legacy exchange; the resulting device credential authenticates only
+routes that require no capability grant.
+
 Redeem that protected file on the client:
 
 ```sh

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -534,6 +534,24 @@ or installation capability. `--service` is mutually exclusive with project
 scope and legacy exchange; the resulting device credential authenticates only
 routes that require no capability grant.
 
+Windows file transfer tools commonly leave the destination with an inherited
+ACL. Before redemption, tighten that exact transferred file without displaying
+or parsing its contents:
+
+```powershell
+punaro-enroll protect-material `
+  --file C:\absolute\private\enrollment-material.json
+```
+
+The command accepts only an absolute regular file within the enrollment size
+bound, refuses a directory, reparse point, or replacement race, and replaces
+the inherited ACL with exactly one protected FullControl ACE for the current
+user. It does not weaken or modify parent directories. `redeem` then performs
+the normal strict private-file and enrollment-document validation. On
+macOS/Linux the same command is available when a transfer tool has broadened
+the mode; it verifies current-user ownership and changes only that exact file
+to `0600`.
+
 Redeem that protected file on the client:
 
 ```sh

--- a/docs/operator-guide.md
+++ b/docs/operator-guide.md
@@ -704,6 +704,22 @@ schema-range, rollback-floor, and PostgreSQL-major values match the target
 release. The file must be an absolute private regular file. On the first update
 from an installation without a release-name lock, supply the current release:
 
+The supported host-binary handoff starts from one downloaded target-release
+directory containing `punaro-release.json`, `punaro-release.sig`, and every
+native artifact named by that manifest, plus the independently configured
+public release key. First verify the detached manifest signature with the
+trusted `punaro-release verify` tool, then verify the complete artifact
+directory against that verified manifest with `punaro-release
+verify-artifacts`. Select the matching verified `punaro-linux-ARCH` artifact
+and install it through a
+root-owned `0755` temporary file in `/usr/local/bin` and an atomic same-directory
+rename to `/usr/local/bin/punaro`; do not overwrite it from an unverified
+download stream. Confirm `punaro version` names the target before starting the
+update. After the durable transaction reaches its terminal outcome, server
+doctor must report `operator_binary_release` passing for that outcome. A
+failure uses remediation `install_release_operator_binary`; it never authorizes
+doctor to replace the executable itself.
+
 ```sh
 punaro update \
   --directory /absolute/private/punaro-installation \

--- a/docs/operator-guide.md
+++ b/docs/operator-guide.md
@@ -170,8 +170,8 @@ database and investigate. The digest-pinned `make test-postgres` stack is epheme
 test infrastructure, publishes no database port, and deletes its volume on
 exit.
 
-The current binary requires schema version 49 and supports an intact schema
-from version 10 through 49 as an update boundary. Versions 10 through 48 are
+The current binary requires schema version 57 and supports an intact schema
+from version 10 through 57 as an update boundary. Versions 10 through 56 are
 reported as `upgrade_required`; versions below the compatibility floor, newer
 versions, and damaged objects are `incompatible`. The embedded manifest and
 target release metadata are authoritative; check them instead of assuming a
@@ -182,7 +182,9 @@ relay invocation capability, migration 44 adds client lifecycle authority,
 migration 45 adds opt-in canonical role profiles, migration 46 adds durable
 mail rate-limit buckets, migration 47 adds idempotent direct-role
 conversations, migration 48 adds explicit pending-delivery capacity
-counters, and migration 49 adds content-free terminal delivery metadata.
+counters, migration 49 adds content-free terminal delivery metadata, and
+migrations 50 through 57 add conversation display names, Telegram topic-claim
+cutover tables, and their idempotency and machine-key fences.
 After migration 48, `punaro relay reconcile-capacity
 --directory DIR --yes` rebuilds those counters from pending deliveries if
 startup readiness reports inconsistency. Ordinary SQLite `Open` and PostgreSQL
@@ -206,7 +208,7 @@ consume the mail budget indefinitely.
 
 SQLite remains the default active relay. Maintainers may explicitly select an
 empty PostgreSQL relay with `PUNARO_RELAY_STORE=postgres` only after completing
-the supported update through the exact current schema (currently v49). This selector does not import the SQLite file,
+the supported update through the exact current schema (currently v57). This selector does not import the SQLite file,
 does not dual-write, and is incompatible with the superseded directory and
 attachment routes. Do not point an established installation at an empty
 PostgreSQL relay as a migration shortcut; the verified one-shot mail cutover is
@@ -216,7 +218,7 @@ again while retaining both stores unchanged.
 ### One-shot mail cutover
 
 First complete the supported update through the exact current schema (currently
-v49); the preview and execution both fail closed on any runtime-compatible older schema before
+v57); the preview and execution both fail closed on any runtime-compatible older schema before
 inspecting or preparing SQLite. Then stop ordinary operator changes, confirm every intended legacy machine is
 `migrated` or explicitly `retired`, and run the read-only preview:
 

--- a/internal/bootstrap/doctor.go
+++ b/internal/bootstrap/doctor.go
@@ -5,6 +5,7 @@ import (
 	"crypto/ed25519"
 	"crypto/sha256"
 	"encoding/hex"
+	"encoding/json"
 	"errors"
 	"io"
 	"os"
@@ -660,13 +661,69 @@ func verifySignedSlot(ctx context.Context, directory string, manifest punarorele
 }
 
 func verifyLocalCheckoutSlot(ctx context.Context, directory, goos, goarch, expectedDigest string) (string, bool) {
-	name := artifactName(adapterComponent, goos, goarch)
-	entries, ok := readDoctorDirectoryEntries(ctx, directory, 2)
-	if !ok || len(entries) != 2 {
+	adapterName := artifactName(adapterComponent, goos, goarch)
+	stateBody, stateExists, stateErr := doctorReadOptionalState(ctx, filepath.Join(directory, localCheckoutStateFile), maximumDoctorStateBytes)
+	if stateErr != nil {
 		return "", false
 	}
-	digest, ok := hashExactArtifact(ctx, filepath.Join(directory, name), -1, 0o755)
-	return digest, ok && digest == expectedDigest
+	if !stateExists {
+		entries, ok := readDoctorDirectoryEntries(ctx, directory, 2)
+		if !ok || len(entries) != 2 {
+			return "", false
+		}
+		digest, ok := hashExactArtifact(ctx, filepath.Join(directory, adapterName), -1, 0o755)
+		return digest, ok && digest == expectedDigest
+	}
+	state, ok := parseLocalCheckoutState(stateBody, goos, goarch)
+	if !ok || state.Artifacts[adapterName] != expectedDigest {
+		return "", false
+	}
+	entries, ok := readDoctorDirectoryEntries(ctx, directory, len(state.Artifacts)+2)
+	if !ok || len(entries) != len(state.Artifacts)+2 {
+		return "", false
+	}
+	for _, entry := range entries {
+		if entry.Name() == slotRecord || entry.Name() == localCheckoutStateFile {
+			continue
+		}
+		expected, found := state.Artifacts[entry.Name()]
+		if !found {
+			return "", false
+		}
+		digest, valid := hashExactArtifact(ctx, filepath.Join(directory, entry.Name()), -1, 0o755)
+		if !valid || digest != expected {
+			return "", false
+		}
+	}
+	return expectedDigest, true
+}
+
+func parseLocalCheckoutState(body []byte, goos, goarch string) (localCheckoutState, bool) {
+	if rejectDuplicateJSONFields(body) != nil {
+		return localCheckoutState{}, false
+	}
+	decoder := json.NewDecoder(strings.NewReader(string(body)))
+	decoder.DisallowUnknownFields()
+	var state localCheckoutState
+	if decoder.Decode(&state) != nil {
+		return localCheckoutState{}, false
+	}
+	var trailing any
+	if !errors.Is(decoder.Decode(&trailing), io.EOF) || state.Schema != 1 || len(state.Artifacts) < 1 || len(state.Artifacts) > 4 {
+		return localCheckoutState{}, false
+	}
+	allowed := map[string]struct{}{
+		artifactName(adapterComponent, goos, goarch):            {},
+		artifactName("punaro-trusted-attachment", goos, goarch): {},
+		artifactName("punaro-memory", goos, goarch):             {},
+		artifactName("punaro-enroll", goos, goarch):             {},
+	}
+	for name, digest := range state.Artifacts {
+		if _, found := allowed[name]; !found || !validManifestDigest(digest) {
+			return localCheckoutState{}, false
+		}
+	}
+	return state, true
 }
 
 func readDoctorDirectoryEntries(ctx context.Context, directory string, maximum int) ([]os.DirEntry, bool) {

--- a/internal/bootstrap/doctor_test.go
+++ b/internal/bootstrap/doctor_test.go
@@ -128,6 +128,40 @@ func TestDoctorDetectsArtifactTamperAndDoesNotRepairInvalidJournal(t *testing.T)
 	}
 }
 
+func TestVerifyLocalCheckoutSlotAcceptsAndProtectsClientArtifacts(t *testing.T) {
+	directory := privateDir(t)
+	artifacts := LocalCheckoutArtifacts{}
+	for component, target := range map[string]*string{
+		adapterComponent:            &artifacts.Adapter,
+		"punaro-trusted-attachment": &artifacts.TrustedAttachment,
+		"punaro-memory":             &artifacts.Memory,
+		"punaro-enroll":             &artifacts.Enroll,
+	} {
+		path := filepath.Join(t.TempDir(), component)
+		if err := os.WriteFile(path, []byte(component+"-body"), 0o700); err != nil { // #nosec G306 -- private executable fixture.
+			t.Fatal(err)
+		}
+		*target = path
+	}
+	if err := SeedLocalCheckoutArtifacts(directory, artifacts, nil); err != nil {
+		t.Fatal(err)
+	}
+	slot, err := readSlot(filepath.Join(directory, currentSlot))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := verifyLocalCheckoutSlot(t.Context(), filepath.Join(directory, currentSlot), runtime.GOOS, runtime.GOARCH, slot.ManifestSHA256); !ok {
+		t.Fatal("seeded client artifacts failed local checkout verification")
+	}
+	memory := filepath.Join(directory, currentSlot, artifactName("punaro-memory", runtime.GOOS, runtime.GOARCH))
+	if err := os.WriteFile(memory, []byte("tampered"), 0o755); err != nil { // #nosec G306 -- private executable fixture.
+		t.Fatal(err)
+	}
+	if _, ok := verifyLocalCheckoutSlot(t.Context(), filepath.Join(directory, currentSlot), runtime.GOOS, runtime.GOARCH, slot.ManifestSHA256); ok {
+		t.Fatal("tampered client artifact passed local checkout verification")
+	}
+}
+
 func TestDoctorCancellationProducesExplicitPartialFailureWithoutMutation(t *testing.T) {
 	origin := newSignedOrigin(t, originSpec{payload: testArtifact, goos: runtime.GOOS, goarch: runtime.GOARCH})
 	directory := privateDir(t)

--- a/internal/bootstrap/run.go
+++ b/internal/bootstrap/run.go
@@ -37,7 +37,13 @@ const (
 	recoveryPreviousFailed = "previous-unhealthy"
 	recoveryCurrentExited  = "current-exited"
 	directoryKeysFile      = "release.pub"
+	localCheckoutStateFile = "checkout.json"
 )
+
+type localCheckoutState struct {
+	Schema    int64             `json:"schema"`
+	Artifacts map[string]string `json:"artifacts"`
+}
 
 // ErrRecoveryOnly means normal child restarts are disabled until host-local recovery.
 var ErrRecoveryOnly = errors.New("bootstrap is recovery-only")
@@ -1076,12 +1082,43 @@ func enterRecoveryOnly(directory, reason string, started slotState) error {
 	return writeRecoveryRecord(directory, reason)
 }
 
-// SeedLocalCheckout publishes a host-local adapter from a reviewed checkout
-// into the current slot. It is not a signed update and cannot be used as an
-// automatic rollback target.
+// LocalCheckoutArtifacts are the installer-built client artifacts published
+// into a development checkout slot before the first signed update.
+type LocalCheckoutArtifacts struct {
+	Adapter           string
+	TrustedAttachment string
+	Memory            string
+	Enroll            string
+}
+
+// SeedLocalCheckout publishes a host-local adapter from a reviewed checkout.
 func SeedLocalCheckout(directory, adapterPath string, keys map[string]ed25519.PublicKey) error {
-	if directory == "" || !filepath.IsAbs(directory) || adapterPath == "" || !filepath.IsAbs(adapterPath) {
+	return SeedLocalCheckoutArtifacts(directory, LocalCheckoutArtifacts{Adapter: adapterPath}, keys)
+}
+
+// SeedLocalCheckoutArtifacts publishes host-local client artifacts from a
+// reviewed checkout into the current slot. It is not a signed update and
+// cannot be used as an automatic rollback target.
+func SeedLocalCheckoutArtifacts(directory string, artifacts LocalCheckoutArtifacts, keys map[string]ed25519.PublicKey) error {
+	if directory == "" || !filepath.IsAbs(directory) || artifacts.Adapter == "" || !filepath.IsAbs(artifacts.Adapter) {
 		return errors.New("bootstrap directory is invalid")
+	}
+	paths := map[string]string{
+		adapterComponent:            artifacts.Adapter,
+		"punaro-trusted-attachment": artifacts.TrustedAttachment,
+		"punaro-memory":             artifacts.Memory,
+		"punaro-enroll":             artifacts.Enroll,
+	}
+	for component, path := range paths {
+		if component == adapterComponent || path != "" {
+			if path == "" || !filepath.IsAbs(path) {
+				return errors.New("bootstrap artifact is invalid")
+			}
+			info, err := os.Lstat(path) // #nosec G703 -- operator-selected checkout artifact.
+			if err != nil || !info.Mode().IsRegular() {
+				return errors.New("bootstrap artifact is invalid")
+			}
+		}
 	}
 	if err := prepareDirectory(directory); err != nil {
 		return err
@@ -1123,11 +1160,7 @@ func SeedLocalCheckout(directory, adapterPath string, keys map[string]ed25519.Pu
 			}
 		}
 	}
-	info, err := os.Lstat(adapterPath) // #nosec G703 -- operator-selected checkout adapter.
-	if err != nil || !info.Mode().IsRegular() {
-		return errors.New("bootstrap adapter is invalid")
-	}
-	body, err := os.ReadFile(adapterPath) // #nosec G304 -- operator-selected checkout adapter.
+	body, err := os.ReadFile(artifacts.Adapter) // #nosec G304 -- operator-selected checkout adapter.
 	if err != nil {
 		return errors.New("bootstrap adapter is invalid")
 	}
@@ -1142,6 +1175,29 @@ func SeedLocalCheckout(directory, adapterPath string, keys map[string]ed25519.Pu
 	}
 	name := artifactName(adapterComponent, runtime.GOOS, runtime.GOARCH)
 	if err := writeAtomic(filepath.Join(candidate, name), body, 0o755); err != nil {
+		return err
+	}
+	artifactDigests := map[string]string{name: digest}
+	for component, path := range paths {
+		if component == adapterComponent || path == "" {
+			continue
+		}
+		artifactBody, err := os.ReadFile(path) // #nosec G304 -- operator-selected checkout artifact.
+		if err != nil {
+			return errors.New("bootstrap artifact is invalid")
+		}
+		artifactFileName := artifactName(component, runtime.GOOS, runtime.GOARCH)
+		if err := writeAtomic(filepath.Join(candidate, artifactFileName), artifactBody, 0o755); err != nil {
+			return err
+		}
+		artifactSum := sha256.Sum256(artifactBody)
+		artifactDigests[artifactFileName] = hex.EncodeToString(artifactSum[:])
+	}
+	checkoutState, err := json.Marshal(localCheckoutState{Schema: 1, Artifacts: artifactDigests})
+	if err != nil {
+		return err
+	}
+	if err := writeAtomic(filepath.Join(candidate, localCheckoutStateFile), checkoutState, 0o600); err != nil {
 		return err
 	}
 	record, err := json.Marshal(slotState{Schema: 1, Release: localCheckoutRelease, Sequence: 1, ManifestSHA256: digest})

--- a/internal/diagnostic/fleet.go
+++ b/internal/diagnostic/fleet.go
@@ -37,7 +37,7 @@ var requiredComponentCheckCodes = map[Component][]string{
 		"backup_directory", "backup_freshness", "blob_storage_private", "compose_manifest_binding", "compose_override", "daemon_environment", "data_directory",
 		"database_connection", "database_listener_private", "database_owner", "database_pair", "database_schema", "gateway_release", "gateway_service_enabled",
 		"gateway_service_executable", "gateway_service_installed", "gateway_service_last_exit", "gateway_service_restart_state", "gateway_service_running", "health_endpoint",
-		"health_listener_private", "host_update_stage", "image_digest_binding", "installed_release", "installation_configuration", "installation_directory", "machine_identity",
+		"health_listener_private", "host_update_stage", "image_digest_binding", "installed_release", "operator_binary_release", "installation_configuration", "installation_directory", "machine_identity",
 		"installation_paths", "maintenance_fence", "migration_manifest_binding", "owner_credential_file", "postgres_major", "readiness_endpoint", "recovery_receipt", "relay_enrollment",
 		"relay_protocol", "running_image", "storage_capacity", "storage_credential_isolation", "storage_directory_separation", "tunnel_origin", "tunnel_route",
 		"update_recovery", "update_transaction", "verified_backup",

--- a/internal/diagnostic/fleet.go
+++ b/internal/diagnostic/fleet.go
@@ -45,7 +45,7 @@ var requiredComponentCheckCodes = map[Component][]string{
 	ComponentAdapter: {
 		"adapter_configuration", "adapter_data_directory", "adapter_profile_file", "adapter_service_enabled", "adapter_service_executable", "adapter_service_installed",
 		"adapter_service_last_exit", "adapter_service_restart_state", "adapter_service_running", "bootstrap_running_artifact", "bootstrap_selected_artifact", "bootstrap_supervisor",
-		"claude_plugin_registration", "client_identity_file", "codex_plugin_registration", "endpoint_attachment", "expired_endpoint_bindings", "expired_role_bindings",
+		"claude_plugin_registration", "client_component_launchers", "client_identity_file", "codex_plugin_registration", "endpoint_attachment", "expired_endpoint_bindings", "expired_role_bindings",
 		"installed_release", "installer_path_aliases", "machine_credential_file", "mailbox_executable", "mailbox_mcp", "mailbox_state_directory", "notification_access",
 		"notification_enrollment", "notification_origin", "notification_protocol", "notification_transport", "plugin_launcher", "plugin_version", "portable_plugin_registration",
 		"relay_access", "relay_enrollment", "relay_origin", "relay_protocol", "relay_transport", "skill_set_parity",

--- a/internal/diagnostic/fleet_test.go
+++ b/internal/diagnostic/fleet_test.go
@@ -35,6 +35,28 @@ func TestFleetRejectsReportsMissingComponentSpecificChecks(t *testing.T) {
 	}
 }
 
+func TestFleetRejectsAdapterReportMissingClientComponentLaunchers(t *testing.T) {
+	report := mustFleetInput(t, ComponentAdapter, Identity{MachineID: "mac-studio", Release: "v0.1.0-alpha.2", ReleaseSequence: 2, Protocol: 1, Platform: "darwin-arm64", PluginVersion: "v0.1.0-alpha.2", SkillSetDigest: "sha256:" + digestA})
+	checks := make([]Check, 0, len(report.Checks)-1)
+	for _, check := range report.Checks {
+		if check.Code != "client_component_launchers" {
+			checks = append(checks, check)
+		}
+	}
+	incomplete, err := New(ComponentAdapter, report.Identity, checks)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = AggregateFleet([]Report{incomplete}, FleetPolicy{
+		Expected:        []FleetTarget{{MachineID: "mac-studio", Component: ComponentAdapter}},
+		CatalogSequence: 2,
+		Catalog:         map[string]int64{"v0.1.0-alpha.2": 2},
+	})
+	if err == nil {
+		t.Fatal("adapter report without client_component_launchers was accepted")
+	}
+}
+
 func TestFleetDetectsMissingDuplicateCatalogAndCompatibilitySkew(t *testing.T) {
 	reports := []Report{
 		mustFleetInput(t, ComponentServer, Identity{MachineID: "punaro-lxc", Release: "v0.1.0-alpha.2", ReleaseSequence: 2, Protocol: 2, StorageSchema: 44, Platform: "linux-arm64"}),

--- a/internal/postgres/device_auth.go
+++ b/internal/postgres/device_auth.go
@@ -83,6 +83,17 @@ func PreviewTrustedAgentEnrollment(projectIDs []string, allProjects bool) ([]Gra
 	if err != nil {
 		return nil, "", err
 	}
+	return previewEnrollment(grants)
+}
+
+// PreviewServiceEnrollment returns an explicitly empty capability expansion
+// for service identities that authenticate health checks but need no API
+// authority of their own.
+func PreviewServiceEnrollment() ([]GrantSpec, string, error) {
+	return previewEnrollment([]GrantSpec{})
+}
+
+func previewEnrollment(grants []GrantSpec) ([]GrantSpec, string, error) {
 	body, err := json.Marshal(grants)
 	if err != nil {
 		return nil, "", errors.New("enrollment preview cannot be encoded")
@@ -98,6 +109,7 @@ type EnrollmentRequest struct {
 	Label             string
 	ProjectIDs        []string
 	AllProjects       bool
+	ServiceOnly       bool
 	LegacyPrincipalID string
 	TTL               time.Duration
 	CredentialTTL     time.Duration
@@ -108,6 +120,12 @@ type EnrollmentRequest struct {
 func (r EnrollmentRequest) Validate() error {
 	if !validOpaqueID(r.ClientBinding) || !validLifecycleMachineID(r.MachineID) || !validDisplayName(r.Label) || len(r.ProjectIDs) > maxEnrollmentProjects || r.TTL < minEnrollmentTTL || r.TTL > maxEnrollmentTTL || r.CredentialTTL != 0 || !r.ExpiresAt.IsZero() || (r.LegacyPrincipalID != "" && !validOpaqueID(r.LegacyPrincipalID)) {
 		return errors.New("invalid enrollment request")
+	}
+	if r.ServiceOnly {
+		if len(r.ProjectIDs) != 0 || r.AllProjects || r.LegacyPrincipalID != "" {
+			return errors.New("invalid enrollment request")
+		}
+		return nil
 	}
 	_, err := TrustedAgentGrantPreview(r.ProjectIDs, r.AllProjects)
 	return err

--- a/internal/postgres/device_auth_integration_test.go
+++ b/internal/postgres/device_auth_integration_test.go
@@ -72,23 +72,6 @@ func testDeviceAuthIntegration(ctx context.Context, t *testing.T, app *Database,
 	if err != nil {
 		t.Fatal(err)
 	}
-	serviceRequest := EnrollmentRequest{ClientBinding: uuid.NewString(), MachineID: "server-doctor", Label: "server doctor", ServiceOnly: true, TTL: 10 * time.Minute}
-	serviceGrants, serviceHash, err := PreviewServiceEnrollment()
-	if err != nil || len(serviceGrants) != 0 {
-		t.Fatalf("service preview=%#v hash=%q err=%v", serviceGrants, serviceHash, err)
-	}
-	servicePending, err := admin.CreateEnrollment(ctx, owner.ID, serviceRequest, serviceHash)
-	if err != nil || len(servicePending.Grants) != 0 {
-		t.Fatalf("service pending=%#v err=%v", servicePending, err)
-	}
-	serviceCredential, err := app.RedeemEnrollment(ctx, RedeemEnrollment{EnrollmentID: servicePending.ID, ClientBinding: serviceRequest.ClientBinding, Code: servicePending.Code, IdempotencyKey: uuid.NewString()})
-	if err != nil {
-		t.Fatal(err)
-	}
-	var serviceGrantCount int
-	if err := ownerDB.QueryRowContext(ctx, `SELECT count(*) FROM auth.capability_grants WHERE principal_id = $1`, serviceCredential.PrincipalID).Scan(&serviceGrantCount); err != nil || serviceGrantCount != 0 {
-		t.Fatalf("service grant count=%d err=%v", serviceGrantCount, err)
-	}
 	request := EnrollmentRequest{ClientBinding: uuid.NewString(), MachineID: "laptop", Label: "laptop", ProjectIDs: []string{project.ProjectID}, TTL: 10 * time.Minute}
 	preview, previewHash, err := PreviewTrustedAgentEnrollment(request.ProjectIDs, request.AllProjects)
 	if err != nil || len(preview) == 0 || previewHash == "" {
@@ -571,5 +554,23 @@ WHERE id = $1`, legacyPending.ID, uuid.NewString(), owner.ID, credential.LookupI
 	}
 	if resolvedPublicKey, err := app.ResolveMigratedLegacyPublicKey(ctx, legacyAuthenticated); err != nil || !bytes.Equal(resolvedPublicKey, legacyPublic) {
 		t.Fatalf("migrated relay authority failed after legacy disable: key=%x err=%v", resolvedPublicKey, err)
+	}
+
+	serviceRequest := EnrollmentRequest{ClientBinding: uuid.NewString(), MachineID: "server-doctor", Label: "server doctor", ServiceOnly: true, TTL: 10 * time.Minute}
+	serviceGrants, serviceHash, err := PreviewServiceEnrollment()
+	if err != nil || len(serviceGrants) != 0 {
+		t.Fatalf("service preview=%#v hash=%q err=%v", serviceGrants, serviceHash, err)
+	}
+	servicePending, err := admin.CreateEnrollment(ctx, owner.ID, serviceRequest, serviceHash)
+	if err != nil || len(servicePending.Grants) != 0 {
+		t.Fatalf("service pending=%#v err=%v", servicePending, err)
+	}
+	serviceCredential, err := app.RedeemEnrollment(ctx, RedeemEnrollment{EnrollmentID: servicePending.ID, ClientBinding: serviceRequest.ClientBinding, Code: servicePending.Code, IdempotencyKey: uuid.NewString()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var serviceGrantCount int
+	if err := ownerDB.QueryRowContext(ctx, `SELECT count(*) FROM auth.capability_grants WHERE principal_id = $1`, serviceCredential.PrincipalID).Scan(&serviceGrantCount); err != nil || serviceGrantCount != 0 {
+		t.Fatalf("service grant count=%d err=%v", serviceGrantCount, err)
 	}
 }

--- a/internal/postgres/device_auth_integration_test.go
+++ b/internal/postgres/device_auth_integration_test.go
@@ -72,6 +72,23 @@ func testDeviceAuthIntegration(ctx context.Context, t *testing.T, app *Database,
 	if err != nil {
 		t.Fatal(err)
 	}
+	serviceRequest := EnrollmentRequest{ClientBinding: uuid.NewString(), MachineID: "server-doctor", Label: "server doctor", ServiceOnly: true, TTL: 10 * time.Minute}
+	serviceGrants, serviceHash, err := PreviewServiceEnrollment()
+	if err != nil || len(serviceGrants) != 0 {
+		t.Fatalf("service preview=%#v hash=%q err=%v", serviceGrants, serviceHash, err)
+	}
+	servicePending, err := admin.CreateEnrollment(ctx, owner.ID, serviceRequest, serviceHash)
+	if err != nil || len(servicePending.Grants) != 0 {
+		t.Fatalf("service pending=%#v err=%v", servicePending, err)
+	}
+	serviceCredential, err := app.RedeemEnrollment(ctx, RedeemEnrollment{EnrollmentID: servicePending.ID, ClientBinding: serviceRequest.ClientBinding, Code: servicePending.Code, IdempotencyKey: uuid.NewString()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var serviceGrantCount int
+	if err := ownerDB.QueryRowContext(ctx, `SELECT count(*) FROM auth.capability_grants WHERE principal_id = $1`, serviceCredential.PrincipalID).Scan(&serviceGrantCount); err != nil || serviceGrantCount != 0 {
+		t.Fatalf("service grant count=%d err=%v", serviceGrantCount, err)
+	}
 	request := EnrollmentRequest{ClientBinding: uuid.NewString(), MachineID: "laptop", Label: "laptop", ProjectIDs: []string{project.ProjectID}, TTL: 10 * time.Minute}
 	preview, previewHash, err := PreviewTrustedAgentEnrollment(request.ProjectIDs, request.AllProjects)
 	if err != nil || len(preview) == 0 || previewHash == "" {

--- a/internal/postgres/device_auth_store.go
+++ b/internal/postgres/device_auth_store.go
@@ -307,7 +307,14 @@ func (a *Administration) CreateEnrollment(ctx context.Context, actorPrincipalID 
 	if err := a.requireClientLifecycleSchema(ctx); err != nil {
 		return PendingEnrollment{}, err
 	}
-	grants, previewHash, err := PreviewTrustedAgentEnrollment(request.ProjectIDs, request.AllProjects)
+	var grants []GrantSpec
+	var previewHash string
+	var err error
+	if request.ServiceOnly {
+		grants, previewHash, err = PreviewServiceEnrollment()
+	} else {
+		grants, previewHash, err = PreviewTrustedAgentEnrollment(request.ProjectIDs, request.AllProjects)
+	}
 	if err != nil || subtle.ConstantTimeCompare([]byte(previewHash), []byte(confirmedPreviewHash)) != 1 {
 		return PendingEnrollment{}, errors.New("enrollment preview was not confirmed")
 	}

--- a/internal/postgres/device_auth_test.go
+++ b/internal/postgres/device_auth_test.go
@@ -47,6 +47,30 @@ func TestTrustedAgentGrantPreviewIsExactAndNonAdministrative(t *testing.T) {
 	}
 }
 
+func TestServiceEnrollmentGrantPreviewIsEmptyAndStable(t *testing.T) {
+	first, firstHash, err := PreviewServiceEnrollment()
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, secondHash, err := PreviewServiceEnrollment()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(first) != 0 || len(second) != 0 || firstHash == "" || firstHash != secondHash {
+		t.Fatalf("service previews=%#v %#v hashes=%q %q", first, second, firstHash, secondHash)
+	}
+	request := EnrollmentRequest{
+		ClientBinding: testPrincipalB,
+		MachineID:     "server-doctor",
+		Label:         "server doctor",
+		ServiceOnly:   true,
+		TTL:           10 * time.Minute,
+	}
+	if err := request.Validate(); err != nil {
+		t.Fatalf("service-only request rejected: %v", err)
+	}
+}
+
 func TestDeviceCredentialEncodingHasOpaqueLookupAnd256BitSecret(t *testing.T) {
 	encoded, lookupID, digest, err := newDeviceCredential()
 	if err != nil {

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "punaro",
-  "version": "0.1.0-alpha.7",
+  "version": "0.1.0-alpha.8",
   "description": "Safely receive and reply to durable Punaro messages and handle explicitly authorized trusted attachments.",
   "author": {
     "name": "Punaro contributors",

--- a/scripts/install-adapter.sh
+++ b/scripts/install-adapter.sh
@@ -284,17 +284,18 @@ fi
 	go build -trimpath -buildvcs=true -o "$build_dir/punaro-memory" ./cmd/punaro-memory
 	go build -trimpath -buildvcs=true -o "$build_dir/punaro-enroll" ./cmd/punaro-enroll
 	go build -trimpath -buildvcs=true -o "$build_dir/punaro-keygen" ./cmd/punaro-keygen
+	go build -trimpath -buildvcs=true -o "$build_dir/punaro-launcher" ./cmd/punaro-launcher
 )
 install -m 700 "$build_dir/punaro-adapter" "$bin_dir/punaro-adapter"
 install -m 700 "$build_dir/punaro-bootstrap" "$bin_dir/punaro-bootstrap"
 if [ -n "$keys_file" ]; then
-	"$bin_dir/punaro-bootstrap" seed-checkout --directory "$bootstrap_dir" --adapter "$bin_dir/punaro-adapter" --keys-file "$keys_file"
+	"$bin_dir/punaro-bootstrap" seed-checkout --directory "$bootstrap_dir" --adapter "$bin_dir/punaro-adapter" --trusted-attachment "$build_dir/punaro-trusted-attachment" --memory "$build_dir/punaro-memory" --enroll "$build_dir/punaro-enroll" --keys-file "$keys_file"
 else
-	"$bin_dir/punaro-bootstrap" seed-checkout --directory "$bootstrap_dir" --adapter "$bin_dir/punaro-adapter"
+	"$bin_dir/punaro-bootstrap" seed-checkout --directory "$bootstrap_dir" --adapter "$bin_dir/punaro-adapter" --trusted-attachment "$build_dir/punaro-trusted-attachment" --memory "$build_dir/punaro-memory" --enroll "$build_dir/punaro-enroll"
 fi
-install -m 700 "$build_dir/punaro-trusted-attachment" "$bin_dir/punaro-trusted-attachment"
-install -m 700 "$build_dir/punaro-memory" "$bin_dir/punaro-memory"
-install -m 700 "$build_dir/punaro-enroll" "$bin_dir/punaro-enroll"
+for component in punaro-adapter punaro-trusted-attachment punaro-memory punaro-enroll; do
+	install -m 700 "$build_dir/punaro-launcher" "$bin_dir/$component"
+done
 
 if [ -e "$key_file" ] || [ -L "$key_file" ]; then
 	regular_private_file "$key_file" || fail 'existing machine key must be a non-symlink regular 0600 file'

--- a/scripts/install-client.ps1
+++ b/scripts/install-client.ps1
@@ -376,7 +376,10 @@ if ($null -ne $existingAdapterTask -and $existingAdapterTask.State -eq 'Running'
 
 try {
 Stop-PunaroOrphanAdapter -BootstrapDirectory $bootstrapDir
-Wait-PunaroReplaceableBinary -Path (Join-Path $binDir 'punaro-adapter.exe')
+$dispatcherComponents = @('punaro-adapter.exe', 'punaro-trusted-attachment.exe', 'punaro-memory.exe', 'punaro-enroll.exe')
+foreach ($component in $dispatcherComponents) {
+    Wait-PunaroReplaceableBinary -Path (Join-Path $binDir $component)
+}
 Wait-PunaroReplaceableBinary -Path (Join-Path $binDir 'punaro-bootstrap.exe')
 Build-PunaroBinary -Package (Join-Path $repoDir 'cmd\punaro-adapter') -Output (Join-Path $binDir 'punaro-adapter.exe') -LdFlags "-X main.adapterBuildRelease=$sourceRelease -X main.adapterExpectedSkillSetDigest=$skillSha256 -X main.adapterExpectedPluginRuntimeDigest=$pluginRuntimeSha256"
 Build-PunaroBinary -Package (Join-Path $repoDir 'cmd\punaro-bootstrap') -Output (Join-Path $binDir 'punaro-bootstrap.exe') -LdFlags "-X main.bootstrapBuildRelease=$sourceRelease"
@@ -400,7 +403,11 @@ Invoke-Program -Program (Join-Path $binDir 'punaro-bootstrap.exe') -Arguments $s
 $launcherBuild = Join-Path $root ("punaro-launcher-" + [Guid]::NewGuid().ToString('N') + '.exe')
 try {
     Build-PunaroBinary -Package (Join-Path $repoDir 'cmd\punaro-launcher') -Output $launcherBuild
-    foreach ($component in @('punaro-adapter.exe', 'punaro-trusted-attachment.exe', 'punaro-memory.exe', 'punaro-enroll.exe')) {
+    foreach ($component in $dispatcherComponents) {
+        $destination = Join-Path $binDir $component
+        Wait-PunaroReplaceableBinary -Path $destination
+    }
+    foreach ($component in $dispatcherComponents) {
         $destination = Join-Path $binDir $component
         [System.IO.File]::Copy($launcherBuild, $destination, $true)
         Protect-PunaroPath -Path $destination

--- a/scripts/install-client.ps1
+++ b/scripts/install-client.ps1
@@ -384,13 +384,30 @@ Build-PunaroBinary -Package (Join-Path $repoDir 'cmd\punaro-trusted-attachment')
 Build-PunaroBinary -Package (Join-Path $repoDir 'cmd\punaro-memory') -Output (Join-Path $binDir 'punaro-memory.exe')
 Build-PunaroBinary -Package (Join-Path $repoDir 'cmd\punaro-enroll') -Output (Join-Path $binDir 'punaro-enroll.exe')
 Build-PunaroBinary -Package (Join-Path $repoDir 'cmd\punaro-keygen') -Output (Join-Path $binDir 'punaro-keygen.exe')
-$seedArguments = @('seed-checkout', '--directory', $bootstrapDir, '--adapter', (Join-Path $binDir 'punaro-adapter.exe'))
+$seedArguments = @(
+    'seed-checkout', '--directory', $bootstrapDir,
+    '--adapter', (Join-Path $binDir 'punaro-adapter.exe'),
+    '--trusted-attachment', (Join-Path $binDir 'punaro-trusted-attachment.exe'),
+    '--memory', (Join-Path $binDir 'punaro-memory.exe'),
+    '--enroll', (Join-Path $binDir 'punaro-enroll.exe')
+)
 if (-not [string]::IsNullOrWhiteSpace($KeysFile)) {
     $resolvedKeys = [System.IO.Path]::GetFullPath($KeysFile)
     Get-RegularFile -Path $resolvedKeys -Label 'release keys file' | Out-Null
     $seedArguments += @('--keys-file', $resolvedKeys)
 }
 Invoke-Program -Program (Join-Path $binDir 'punaro-bootstrap.exe') -Arguments $seedArguments -Description 'bootstrap checkout seed'
+$launcherBuild = Join-Path $root ("punaro-launcher-" + [Guid]::NewGuid().ToString('N') + '.exe')
+try {
+    Build-PunaroBinary -Package (Join-Path $repoDir 'cmd\punaro-launcher') -Output $launcherBuild
+    foreach ($component in @('punaro-adapter.exe', 'punaro-trusted-attachment.exe', 'punaro-memory.exe', 'punaro-enroll.exe')) {
+        $destination = Join-Path $binDir $component
+        [System.IO.File]::Copy($launcherBuild, $destination, $true)
+        Protect-PunaroPath -Path $destination
+    }
+} finally {
+    if (Test-Path -LiteralPath $launcherBuild) { [System.IO.File]::Delete($launcherBuild) }
+}
 foreach ($name in @('Run-PunaroAdapter.ps1', 'Import-PunaroEnvironment.ps1')) {
     $source = Join-Path $repoDir "deploy\windows\$name"
     $destination = Join-Path $root $name

--- a/scripts/punaro-plugin-mcp
+++ b/scripts/punaro-plugin-mcp
@@ -34,6 +34,16 @@ if [ -z "$user_home" ]; then
 	esac
 fi
 
-adapter="$user_home/.local/bin/punaro-adapter"
-[ -f "$adapter" ] && [ ! -L "$adapter" ] && [ -x "$adapter" ] || fail "installed adapter is unavailable at $adapter; run the Punaro client installer first"
+case "$(uname -s)" in
+	Darwin) adapter_os=darwin ;;
+	Linux) adapter_os=linux ;;
+	*) fail 'this launcher supports macOS and Linux' ;;
+esac
+case "$(uname -m)" in
+	x86_64|amd64) adapter_arch=amd64 ;;
+	arm64|aarch64) adapter_arch=arm64 ;;
+	*) fail 'this launcher does not support the current architecture' ;;
+esac
+adapter="$user_home/.local/state/punaro-bootstrap/current/punaro-adapter-$adapter_os-$adapter_arch"
+[ -f "$adapter" ] && [ ! -L "$adapter" ] && [ -x "$adapter" ] || fail "selected adapter is unavailable; run the Punaro client installer or bootstrap doctor"
 exec "$adapter" mailbox-mcp

--- a/scripts/punaro-plugin-mcp.cmd
+++ b/scripts/punaro-plugin-mcp.cmd
@@ -4,9 +4,16 @@ if "%LOCALAPPDATA%"=="" (
   echo punaro plugin: LOCALAPPDATA is unavailable 1>&2
   exit /b 1
 )
-set "PUNARO_PLUGIN_ADAPTER=%LOCALAPPDATA%\Punaro\bin\punaro-adapter.exe"
-if not exist "%PUNARO_PLUGIN_ADAPTER%" (
-  echo punaro plugin: installed adapter is unavailable at "%PUNARO_PLUGIN_ADAPTER%"; run the Punaro client installer first 1>&2
+if /I "%PROCESSOR_ARCHITECTURE%"=="AMD64" set "PUNARO_PLUGIN_ARCH=amd64"
+if /I "%PROCESSOR_ARCHITECTURE%"=="ARM64" set "PUNARO_PLUGIN_ARCH=arm64"
+if not defined PUNARO_PLUGIN_ARCH (
+  echo punaro plugin: this launcher does not support the current architecture 1>&2
+  exit /b 1
+)
+set "PUNARO_PLUGIN_ADAPTER=%LOCALAPPDATA%\Punaro\bootstrap\current\punaro-adapter-windows-%PUNARO_PLUGIN_ARCH%.exe"
+powershell.exe -NoLogo -NoProfile -NonInteractive -Command "$item = Get-Item -LiteralPath $env:PUNARO_PLUGIN_ADAPTER -Force -ErrorAction Stop; if ($item.PSIsContainer -or ($item.Attributes -band [IO.FileAttributes]::ReparsePoint)) { exit 1 }" >nul 2>&1
+if errorlevel 1 (
+  echo punaro plugin: selected adapter is unavailable; run the Punaro client installer or bootstrap doctor 1>&2
   exit /b 1
 )
 "%PUNARO_PLUGIN_ADAPTER%" mailbox-mcp

--- a/scripts/punaro-plugin-mcp.cmd
+++ b/scripts/punaro-plugin-mcp.cmd
@@ -4,15 +4,8 @@ if "%LOCALAPPDATA%"=="" (
   echo punaro plugin: LOCALAPPDATA is unavailable 1>&2
   exit /b 1
 )
-if /I "%PROCESSOR_ARCHITECTURE%"=="AMD64" set "PUNARO_PLUGIN_ARCH=amd64"
-if /I "%PROCESSOR_ARCHITECTURE%"=="ARM64" set "PUNARO_PLUGIN_ARCH=arm64"
-if not defined PUNARO_PLUGIN_ARCH (
-  echo punaro plugin: this launcher does not support the current architecture 1>&2
-  exit /b 1
-)
-set "PUNARO_PLUGIN_ADAPTER=%LOCALAPPDATA%\Punaro\bootstrap\current\punaro-adapter-windows-%PUNARO_PLUGIN_ARCH%.exe"
-powershell.exe -NoLogo -NoProfile -NonInteractive -Command "$item = Get-Item -LiteralPath $env:PUNARO_PLUGIN_ADAPTER -Force -ErrorAction Stop; if ($item.PSIsContainer -or ($item.Attributes -band [IO.FileAttributes]::ReparsePoint)) { exit 1 }" >nul 2>&1
-if errorlevel 1 (
+set "PUNARO_PLUGIN_ADAPTER=%LOCALAPPDATA%\Punaro\bin\punaro-adapter.exe"
+if not exist "%PUNARO_PLUGIN_ADAPTER%" (
   echo punaro plugin: selected adapter is unavailable; run the Punaro client installer or bootstrap doctor 1>&2
   exit /b 1
 )

--- a/scripts/test-agent-plugin.py
+++ b/scripts/test-agent-plugin.py
@@ -149,8 +149,8 @@ def validate_skills() -> None:
         if "set --" in posix_launcher:
             raise ValidationError(f"POSIX skill launcher must preserve forwarded arguments: {skill_name}/{command}")
         windows_launcher = (skill_root / "scripts" / f"{command}.cmd").read_text(encoding="utf-8")
-        if f"%LOCALAPPDATA%\\Punaro\\bootstrap\\current\\{command}-windows-%PUNARO_SKILL_ARCH%.exe" not in windows_launcher or "\\Punaro\\bin\\" in windows_launcher or "%PATH%" in windows_launcher:
-            raise ValidationError(f"Windows skill launcher must use the selected bootstrap slot: {skill_name}/{command}")
+        if f"%LOCALAPPDATA%\\Punaro\\bin\\{command}.exe" not in windows_launcher or "powershell.exe" in windows_launcher.lower() or "\\bootstrap\\current\\" in windows_launcher or "%PATH%" in windows_launcher:
+            raise ValidationError(f"Windows skill launcher must use the stable installer-owned dispatcher: {skill_name}/{command}")
 
     if os.name == "posix":
         with tempfile.TemporaryDirectory(prefix="punaro-skill-launchers-") as fixture:
@@ -198,6 +198,9 @@ def validate_mcp() -> dict[str, Any]:
             raise ValidationError(f"mailbox launcher must be a regular package file: {launcher.name}")
     if not os.access(ROOT / "scripts/punaro-plugin-mcp", os.X_OK):
         raise ValidationError("POSIX mailbox launcher must be executable")
+    windows_launcher = (ROOT / "scripts/punaro-plugin-mcp.cmd").read_text(encoding="utf-8")
+    if "%LOCALAPPDATA%\\Punaro\\bin\\punaro-adapter.exe" not in windows_launcher or "powershell.exe" in windows_launcher.lower() or "\\bootstrap\\current\\" in windows_launcher or "%PATH%" in windows_launcher:
+        raise ValidationError("Windows mailbox launcher must use the stable installer-owned dispatcher")
     return config
 
 

--- a/scripts/test-agent-plugin.py
+++ b/scripts/test-agent-plugin.py
@@ -144,21 +144,23 @@ def validate_skills() -> None:
         if not os.access(skill_root / "scripts" / command, os.X_OK):
             raise ValidationError(f"POSIX skill launcher must be executable: {skill_name}/{command}")
         posix_launcher = (skill_root / "scripts" / command).read_text(encoding="utf-8")
-        if f'.local/bin/{command}' not in posix_launcher or "PATH" in posix_launcher:
-            raise ValidationError(f"POSIX skill launcher must use the installer-owned path: {skill_name}/{command}")
+        if f'.local/state/punaro-bootstrap/current/{command}-$adapter_os-$adapter_arch' not in posix_launcher or ".local/bin/" in posix_launcher or "PATH" in posix_launcher:
+            raise ValidationError(f"POSIX skill launcher must use the selected bootstrap slot: {skill_name}/{command}")
         if "set --" in posix_launcher:
             raise ValidationError(f"POSIX skill launcher must preserve forwarded arguments: {skill_name}/{command}")
         windows_launcher = (skill_root / "scripts" / f"{command}.cmd").read_text(encoding="utf-8")
-        if f"%LOCALAPPDATA%\\Punaro\\bin\\{command}.exe" not in windows_launcher or "%PATH%" in windows_launcher:
-            raise ValidationError(f"Windows skill launcher must use the installer-owned path: {skill_name}/{command}")
+        if f"%LOCALAPPDATA%\\Punaro\\bootstrap\\current\\{command}-windows-%PUNARO_SKILL_ARCH%.exe" not in windows_launcher or "\\Punaro\\bin\\" in windows_launcher or "%PATH%" in windows_launcher:
+            raise ValidationError(f"Windows skill launcher must use the selected bootstrap slot: {skill_name}/{command}")
 
     if os.name == "posix":
         with tempfile.TemporaryDirectory(prefix="punaro-skill-launchers-") as fixture:
             home = Path(fixture)
-            bin_dir = home / ".local" / "bin"
-            bin_dir.mkdir(parents=True)
+            slot_dir = home / ".local" / "state" / "punaro-bootstrap" / "current"
+            slot_dir.mkdir(parents=True)
+            platform_os = "darwin" if os.uname().sysname == "Darwin" else "linux"
+            platform_arch = "arm64" if os.uname().machine in {"arm64", "aarch64"} else "amd64"
             for skill_name, command in SKILL_LAUNCHERS.items():
-                installed = bin_dir / command
+                installed = slot_dir / f"{command}-{platform_os}-{platform_arch}"
                 installed.write_text("#!/bin/sh\nprintf '%s\\n' \"$*\"\n", encoding="utf-8")
                 installed.chmod(0o700)
                 launcher = skills_root / skill_name / "scripts" / command

--- a/scripts/test-install-adapter.sh
+++ b/scripts/test-install-adapter.sh
@@ -34,7 +34,7 @@ grep -Fq -- '--keys-file' "$repo_dir/scripts/install-adapter.sh" || {
 	printf '%s\n' 'installer must accept --keys-file so signed slots can roll back' >&2
 	exit 1
 }
-grep -Fq 'seed-checkout --directory "$bootstrap_dir" --adapter "$bin_dir/punaro-adapter" --keys-file "$keys_file"' "$repo_dir/scripts/install-adapter.sh" || {
+grep -Fq 'seed-checkout --directory "$bootstrap_dir" --adapter "$bin_dir/punaro-adapter" --trusted-attachment "$build_dir/punaro-trusted-attachment" --memory "$build_dir/punaro-memory" --enroll "$build_dir/punaro-enroll" --keys-file "$keys_file"' "$repo_dir/scripts/install-adapter.sh" || {
 	printf '%s\n' 'installer must persist release keys during seed-checkout' >&2
 	exit 1
 }
@@ -104,8 +104,8 @@ file_mode() {
 
 [ -x "$adapter" ] || { printf '%s\n' 'adapter binary was not installed' >&2; exit 1; }
 [ -x "$bootstrap" ] || { printf '%s\n' 'bootstrap binary was not installed' >&2; exit 1; }
-[ "$("$adapter" version)" = 'v0.1.0-alpha.7' ] || { printf '%s\n' 'adapter binary lacks the source release identity' >&2; exit 1; }
-[ "$("$bootstrap" version)" = 'v0.1.0-alpha.7' ] || { printf '%s\n' 'bootstrap binary lacks the source release identity' >&2; exit 1; }
+[ "$(HOME="$home" "$adapter" version)" = 'v0.1.0-alpha.8' ] || { printf '%s\n' 'adapter binary lacks the source release identity' >&2; exit 1; }
+[ "$("$bootstrap" version)" = 'v0.1.0-alpha.8' ] || { printf '%s\n' 'bootstrap binary lacks the source release identity' >&2; exit 1; }
 [ -d "$home/.local/state/punaro-bootstrap/current" ] || { printf '%s\n' 'bootstrap current slot was not seeded' >&2; exit 1; }
 [ -x "$attachment" ] || { printf '%s\n' 'attachment binary was not installed' >&2; exit 1; }
 [ -x "$memory" ] || { printf '%s\n' 'memory binary was not installed' >&2; exit 1; }
@@ -136,6 +136,11 @@ grep -Fq '"endpoint_prefixes":["agent/macbook/"]' "$enrollment"
 grep -Fq 'group create --group group/punaro-attached' "$mailbox_log"
 HOME="$home" PUNARO_TEST_MAILBOX_LOG="$mailbox_log" "$repo_dir/scripts/punaro-plugin-mcp"
 grep -Fq -- "--state-dir $mailbox_state mcp" "$mailbox_log"
+mv "$adapter" "$adapter.fixed-before-slot-test"
+printf '%s\n' '#!/bin/sh' 'exit 88' >"$adapter"
+chmod 700 "$adapter"
+HOME="$home" PUNARO_TEST_MAILBOX_LOG="$mailbox_log" "$repo_dir/scripts/punaro-plugin-mcp"
+mv "$adapter.fixed-before-slot-test" "$adapter"
 grep -Fq '"id":"macbook"' "$fixture_dir/first.out"
 if grep -Fq 'PUNARO_CF_ACCESS_CLIENT_SECRET' "$fixture_dir/first.out"; then
 	printf '%s\n' 'installer output must not solicit or print Access secrets' >&2

--- a/scripts/test-install-client-windows.ps1
+++ b/scripts/test-install-client-windows.ps1
@@ -19,6 +19,16 @@ $installer = [System.IO.File]::ReadAllText((Join-Path $repoDir 'scripts\install-
 foreach ($expected in @('LogonType Interactive', 'ExecutionTimeLimit ([TimeSpan]::Zero)', 'RestartCount', 'RepetitionInterval', 'RepetitionDuration', '-WindowStyle Hidden', '-Hidden', 'SetAccessRuleProtection($true, $false)', '-ExecutionPolicy Bypass', 'ForEach-Object { $_.address }', 'punaro-trusted-attachment.exe', 'punaro-memory.exe', 'punaro-enroll.exe', 'agent-mailbox', '[string]$AgentMailboxBin', '$mailboxIsWaypost', 'AgentGuidanceDir', 'AllowLanHttp', 'PUNARO_ADAPTER_TRUSTED_LAN_CIDR')) {
     if (-not $installer.Contains($expected)) { throw "Windows installer is missing required behavior: $expected" }
 }
+$dispatcherWait = 'Wait-PunaroReplaceableBinary -Path $destination'
+$dispatcherCopy = '[System.IO.File]::Copy($launcherBuild, $destination, $true)'
+if ($installer.IndexOf($dispatcherWait, [System.StringComparison]::Ordinal) -lt 0 -or $installer.IndexOf($dispatcherWait, [System.StringComparison]::Ordinal) -gt $installer.IndexOf($dispatcherCopy, [System.StringComparison]::Ordinal)) {
+    throw 'Windows installer must wait for every dispatcher destination before replacing any dispatcher'
+}
+$initialDispatcherWait = 'Wait-PunaroReplaceableBinary -Path (Join-Path $binDir $component)'
+$firstBinaryBuild = 'Build-PunaroBinary -Package'
+if ($installer.IndexOf($initialDispatcherWait, [System.StringComparison]::Ordinal) -lt 0 -or $installer.IndexOf($initialDispatcherWait, [System.StringComparison]::Ordinal) -gt $installer.IndexOf($firstBinaryBuild, [System.StringComparison]::Ordinal)) {
+    throw 'Windows installer must wait for all installed dispatchers before building over their destinations'
+}
 $allScripts = ($paths | ForEach-Object { [System.IO.File]::ReadAllText($_) }) -join "`n"
 if (-not $allScripts.Contains('existing Punaro guidance predates trusted attachments')) {
     throw 'Windows guidance installer does not fail closed on retired guidance'

--- a/scripts/test-install-client-windows.ps1
+++ b/scripts/test-install-client-windows.ps1
@@ -116,6 +116,14 @@ try {
     }
     & (Join-Path $repoDir 'scripts\punaro-plugin-mcp.cmd')
     if ($LASTEXITCODE -ne 0) { throw 'Windows plugin launcher could not start the installer-owned adapter' }
+    $fixedAdapter = Join-Path $root 'bin\punaro-adapter.exe'
+    $savedFixedAdapter = $fixedAdapter + '.fixed-before-slot-test'
+    [System.IO.File]::Move($fixedAdapter, $savedFixedAdapter)
+    [System.IO.File]::WriteAllText($fixedAdapter, 'stale fixed adapter', [System.Text.Encoding]::ASCII)
+    & (Join-Path $repoDir 'scripts\punaro-plugin-mcp.cmd')
+    if ($LASTEXITCODE -ne 0) { throw 'Windows plugin launcher did not use the selected bootstrap slot' }
+    [System.IO.File]::Delete($fixedAdapter)
+    [System.IO.File]::Move($savedFixedAdapter, $fixedAdapter)
     foreach ($path in @((Join-Path $root 'bin\punaro-attachment.exe'), (Join-Path $root 'bin\punaro-directory.exe'), (Join-Path $root 'bin\punaro-dpapi.exe'), (Join-Path $root 'Run-PunaroAttachment.ps1'))) {
         if (Test-Path -LiteralPath $path) { throw "Windows client installer must not create retired attachment artifact $path" }
     }

--- a/scripts/test-install-client-windows.ps1
+++ b/scripts/test-install-client-windows.ps1
@@ -117,12 +117,10 @@ try {
     & (Join-Path $repoDir 'scripts\punaro-plugin-mcp.cmd')
     if ($LASTEXITCODE -ne 0) { throw 'Windows plugin launcher could not start the installer-owned adapter' }
     $fixedAdapter = Join-Path $root 'bin\punaro-adapter.exe'
-    $savedFixedAdapter = $fixedAdapter + '.fixed-before-slot-test'
+    $savedFixedAdapter = $fixedAdapter + '.dispatcher-presence-test'
     [System.IO.File]::Move($fixedAdapter, $savedFixedAdapter)
-    [System.IO.File]::WriteAllText($fixedAdapter, 'stale fixed adapter', [System.Text.Encoding]::ASCII)
     & (Join-Path $repoDir 'scripts\punaro-plugin-mcp.cmd')
-    if ($LASTEXITCODE -ne 0) { throw 'Windows plugin launcher did not use the selected bootstrap slot' }
-    [System.IO.File]::Delete($fixedAdapter)
+    if ($LASTEXITCODE -eq 0) { throw 'Windows plugin launcher did not require the stable selected-slot dispatcher' }
     [System.IO.File]::Move($savedFixedAdapter, $fixedAdapter)
     foreach ($path in @((Join-Path $root 'bin\punaro-attachment.exe'), (Join-Path $root 'bin\punaro-directory.exe'), (Join-Path $root 'bin\punaro-dpapi.exe'), (Join-Path $root 'Run-PunaroAttachment.ps1'))) {
         if (Test-Path -LiteralPath $path) { throw "Windows client installer must not create retired attachment artifact $path" }

--- a/scripts/verify-deployment-files.sh
+++ b/scripts/verify-deployment-files.sh
@@ -32,8 +32,9 @@ macos_import_script=scripts/import-macos-signing-cert.sh
 macos_sign_test=scripts/test-sign-notarize-macos.sh
 doctor_docs=docs/doctor.md
 operator_guide=docs/operator-guide.md
+installation_docs=docs/installation.md
 
-for path in "$unit" "$example" "$launch_agent" "$adapter_installer" "$client_installer" "$adapter_installer_test" "$server_installer" "$server_installer_test" "$attachment_relay_configurer" "$attachment_relay_configurer_test" "$agent_guidance_installer" "$agent_guidance_installer_test" "$windows_client_installer" "$windows_guidance_installer" "$windows_client_installer_test" "$windows_adapter_runner" "$windows_environment_importer" "$production_compose_verifier" "$production_compose_test" "$production_compose_bootstrap_test" "$memory_onboarding_e2e_test" "$release_artifact_builder" "$release_candidate_tag_generator" "$release_candidate_tag_test" "$release_assemble_test" "$release_publish_test" "$macos_sign_script" "$macos_import_script" "$macos_sign_test" "$doctor_docs" "$operator_guide" scripts/production-compose deploy/compose/postgres-bootstrap.sh deploy/compose/postgres-entrypoint.sh docker-compose.memory-onboarding-e2e.yml .github/workflows/release.yml .github/workflows/macos-notarize.yml deploy/macos/hardened-runtime.entitlements; do
+for path in "$unit" "$example" "$launch_agent" "$adapter_installer" "$client_installer" "$adapter_installer_test" "$server_installer" "$server_installer_test" "$attachment_relay_configurer" "$attachment_relay_configurer_test" "$agent_guidance_installer" "$agent_guidance_installer_test" "$windows_client_installer" "$windows_guidance_installer" "$windows_client_installer_test" "$windows_adapter_runner" "$windows_environment_importer" "$production_compose_verifier" "$production_compose_test" "$production_compose_bootstrap_test" "$memory_onboarding_e2e_test" "$release_artifact_builder" "$release_candidate_tag_generator" "$release_candidate_tag_test" "$release_assemble_test" "$release_publish_test" "$macos_sign_script" "$macos_import_script" "$macos_sign_test" "$doctor_docs" "$operator_guide" "$installation_docs" scripts/production-compose deploy/compose/postgres-bootstrap.sh deploy/compose/postgres-entrypoint.sh docker-compose.memory-onboarding-e2e.yml .github/workflows/release.yml .github/workflows/macos-notarize.yml deploy/macos/hardened-runtime.entitlements; do
 	if [ ! -f "$path" ]; then
 		printf '%s\n' "missing adapter deployment artifact: $path" >&2
 		exit 1
@@ -177,6 +178,18 @@ if ! grep -Fq 'cygpath -w "$repo_dir"' "$release_artifact_builder"; then
 fi
 if ! grep -Fq 'Build release artifacts on Windows' .github/workflows/quality.yml; then
 	printf '%s\n' 'quality workflow must exercise the release artifact builder on Windows' >&2
+	exit 1
+fi
+if ! grep -Fq "go test ./cmd/punaro-enroll -run '^TestWindows'" .github/workflows/quality.yml; then
+	printf '%s\n' 'quality workflow must exercise enrollment DACL tests on Windows' >&2
+	exit 1
+fi
+if ! grep -Fq 'punaro-enroll protect-material' "$installation_docs"; then
+	printf '%s\n' 'installation documentation omits the protected Windows enrollment-transfer remediation' >&2
+	exit 1
+fi
+if ! grep -Fq 'operator_binary_release' "$doctor_docs"; then
+	printf '%s\n' 'doctor documentation omits the host operator-binary release check' >&2
 	exit 1
 fi
 "$release_assemble_test"

--- a/scripts/verify-deployment-files.sh
+++ b/scripts/verify-deployment-files.sh
@@ -31,13 +31,20 @@ macos_sign_script=scripts/sign-notarize-macos.sh
 macos_import_script=scripts/import-macos-signing-cert.sh
 macos_sign_test=scripts/test-sign-notarize-macos.sh
 doctor_docs=docs/doctor.md
+operator_guide=docs/operator-guide.md
 
-for path in "$unit" "$example" "$launch_agent" "$adapter_installer" "$client_installer" "$adapter_installer_test" "$server_installer" "$server_installer_test" "$attachment_relay_configurer" "$attachment_relay_configurer_test" "$agent_guidance_installer" "$agent_guidance_installer_test" "$windows_client_installer" "$windows_guidance_installer" "$windows_client_installer_test" "$windows_adapter_runner" "$windows_environment_importer" "$production_compose_verifier" "$production_compose_test" "$production_compose_bootstrap_test" "$memory_onboarding_e2e_test" "$release_artifact_builder" "$release_candidate_tag_generator" "$release_candidate_tag_test" "$release_assemble_test" "$release_publish_test" "$macos_sign_script" "$macos_import_script" "$macos_sign_test" "$doctor_docs" scripts/production-compose deploy/compose/postgres-bootstrap.sh deploy/compose/postgres-entrypoint.sh docker-compose.memory-onboarding-e2e.yml .github/workflows/release.yml .github/workflows/macos-notarize.yml deploy/macos/hardened-runtime.entitlements; do
+for path in "$unit" "$example" "$launch_agent" "$adapter_installer" "$client_installer" "$adapter_installer_test" "$server_installer" "$server_installer_test" "$attachment_relay_configurer" "$attachment_relay_configurer_test" "$agent_guidance_installer" "$agent_guidance_installer_test" "$windows_client_installer" "$windows_guidance_installer" "$windows_client_installer_test" "$windows_adapter_runner" "$windows_environment_importer" "$production_compose_verifier" "$production_compose_test" "$production_compose_bootstrap_test" "$memory_onboarding_e2e_test" "$release_artifact_builder" "$release_candidate_tag_generator" "$release_candidate_tag_test" "$release_assemble_test" "$release_publish_test" "$macos_sign_script" "$macos_import_script" "$macos_sign_test" "$doctor_docs" "$operator_guide" scripts/production-compose deploy/compose/postgres-bootstrap.sh deploy/compose/postgres-entrypoint.sh docker-compose.memory-onboarding-e2e.yml .github/workflows/release.yml .github/workflows/macos-notarize.yml deploy/macos/hardened-runtime.entitlements; do
 	if [ ! -f "$path" ]; then
 		printf '%s\n' "missing adapter deployment artifact: $path" >&2
 		exit 1
 	fi
 done
+
+latest_schema=$(find internal/postgres/migrations -type f -name '[0-9][0-9][0-9]_*.sql' -print | sed 's|.*/||; s|_.*||' | sort -n | tail -1 | sed 's/^0*//')
+if [ -z "$latest_schema" ] || ! grep -Fq "currently v$latest_schema" "$operator_guide"; then
+	printf '%s\n' "operator guide does not identify the current schema as v$latest_schema" >&2
+	exit 1
+fi
 
 for executable in "$adapter_installer" "$client_installer" "$adapter_installer_test" "$server_installer" "$server_installer_test" "$attachment_relay_configurer" "$attachment_relay_configurer_test" "$agent_guidance_installer" "$agent_guidance_installer_test" "$windows_client_installer_test" "$production_compose_verifier" "$production_compose_test" "$production_compose_bootstrap_test" "$memory_onboarding_e2e_test" "$release_artifact_builder" "$release_candidate_tag_generator" "$release_candidate_tag_test" "$release_assemble_test" "$release_publish_test" "$macos_sign_script" "$macos_import_script" "$macos_sign_test" scripts/production-compose deploy/compose/postgres-bootstrap.sh deploy/compose/postgres-entrypoint.sh; do
 	if [ ! -x "$executable" ]; then

--- a/skills/punaro-attachment/SKILL.md
+++ b/skills/punaro-attachment/SKILL.md
@@ -19,8 +19,9 @@ the retired v2/v3 controller.
 
 Before the first trusted-attachment operation in a task, or after a local,
 relay, service, or authorization failure, run the installed adapter's read-only
-doctor from its installer-owned fixed path (`$HOME/.local/bin/punaro-adapter`
-on macOS/Linux or `%LOCALAPPDATA%\Punaro\bin\punaro-adapter.exe` on Windows).
+doctor through its stable installer-owned dispatcher (`$HOME/.local/bin/punaro-adapter`
+on macOS/Linux or `%LOCALAPPDATA%\Punaro\bin\punaro-adapter.exe` on Windows),
+which resolves the adapter from the selected signed bootstrap slot.
 Resolve the plugin root as the directory two levels above this `SKILL.md` and
 pass its absolute path with `--plugin-root`; never discover the adapter through
 `PATH`.

--- a/skills/punaro-attachment/scripts/punaro-trusted-attachment
+++ b/skills/punaro-attachment/scripts/punaro-trusted-attachment
@@ -45,6 +45,16 @@ if [ -z "$user_home" ]; then
 	esac
 fi
 
-client="$user_home/.local/bin/punaro-trusted-attachment"
-[ -f "$client" ] && [ ! -L "$client" ] && [ -x "$client" ] || fail "installed trusted-attachment client is unavailable at $client; run the Punaro client installer first"
+case "$(uname -s)" in
+Darwin) adapter_os=darwin ;;
+Linux) adapter_os=linux ;;
+*) fail 'this launcher supports macOS and Linux' ;;
+esac
+case "$(uname -m)" in
+x86_64|amd64) adapter_arch=amd64 ;;
+arm64|aarch64) adapter_arch=arm64 ;;
+*) fail 'this launcher does not support the current architecture' ;;
+esac
+client="$user_home/.local/state/punaro-bootstrap/current/punaro-trusted-attachment-$adapter_os-$adapter_arch"
+[ -f "$client" ] && [ ! -L "$client" ] && [ -x "$client" ] || fail 'selected trusted-attachment client is unavailable; run the Punaro client installer or bootstrap doctor'
 exec "$client" "$@"

--- a/skills/punaro-attachment/scripts/punaro-trusted-attachment.cmd
+++ b/skills/punaro-attachment/scripts/punaro-trusted-attachment.cmd
@@ -4,15 +4,8 @@ if "%LOCALAPPDATA%"=="" (
   echo punaro attachment skill: LOCALAPPDATA is unavailable 1>&2
   exit /b 1
 )
-if /I "%PROCESSOR_ARCHITECTURE%"=="AMD64" set "PUNARO_SKILL_ARCH=amd64"
-if /I "%PROCESSOR_ARCHITECTURE%"=="ARM64" set "PUNARO_SKILL_ARCH=arm64"
-if not defined PUNARO_SKILL_ARCH (
-  echo punaro attachment skill: this launcher does not support the current architecture 1>&2
-  exit /b 1
-)
-set "PUNARO_SKILL_ATTACHMENT=%LOCALAPPDATA%\Punaro\bootstrap\current\punaro-trusted-attachment-windows-%PUNARO_SKILL_ARCH%.exe"
-powershell.exe -NoLogo -NoProfile -NonInteractive -Command "$item = Get-Item -LiteralPath $env:PUNARO_SKILL_ATTACHMENT -Force -ErrorAction Stop; if ($item.PSIsContainer -or ($item.Attributes -band [IO.FileAttributes]::ReparsePoint)) { exit 1 }" >nul 2>&1
-if errorlevel 1 (
+set "PUNARO_SKILL_ATTACHMENT=%LOCALAPPDATA%\Punaro\bin\punaro-trusted-attachment.exe"
+if not exist "%PUNARO_SKILL_ATTACHMENT%" (
   echo punaro attachment skill: selected trusted-attachment client is unavailable; run the Punaro client installer or bootstrap doctor 1>&2
   exit /b 1
 )

--- a/skills/punaro-attachment/scripts/punaro-trusted-attachment.cmd
+++ b/skills/punaro-attachment/scripts/punaro-trusted-attachment.cmd
@@ -4,9 +4,16 @@ if "%LOCALAPPDATA%"=="" (
   echo punaro attachment skill: LOCALAPPDATA is unavailable 1>&2
   exit /b 1
 )
-set "PUNARO_SKILL_ATTACHMENT=%LOCALAPPDATA%\Punaro\bin\punaro-trusted-attachment.exe"
-if not exist "%PUNARO_SKILL_ATTACHMENT%" (
-  echo punaro attachment skill: installed trusted-attachment client is unavailable at "%PUNARO_SKILL_ATTACHMENT%"; run the Punaro client installer first 1>&2
+if /I "%PROCESSOR_ARCHITECTURE%"=="AMD64" set "PUNARO_SKILL_ARCH=amd64"
+if /I "%PROCESSOR_ARCHITECTURE%"=="ARM64" set "PUNARO_SKILL_ARCH=arm64"
+if not defined PUNARO_SKILL_ARCH (
+  echo punaro attachment skill: this launcher does not support the current architecture 1>&2
+  exit /b 1
+)
+set "PUNARO_SKILL_ATTACHMENT=%LOCALAPPDATA%\Punaro\bootstrap\current\punaro-trusted-attachment-windows-%PUNARO_SKILL_ARCH%.exe"
+powershell.exe -NoLogo -NoProfile -NonInteractive -Command "$item = Get-Item -LiteralPath $env:PUNARO_SKILL_ATTACHMENT -Force -ErrorAction Stop; if ($item.PSIsContainer -or ($item.Attributes -band [IO.FileAttributes]::ReparsePoint)) { exit 1 }" >nul 2>&1
+if errorlevel 1 (
+  echo punaro attachment skill: selected trusted-attachment client is unavailable; run the Punaro client installer or bootstrap doctor 1>&2
   exit /b 1
 )
 "%PUNARO_SKILL_ATTACHMENT%" %*

--- a/skills/punaro-mailbox/scripts/punaro-adapter
+++ b/skills/punaro-mailbox/scripts/punaro-adapter
@@ -45,6 +45,16 @@ if [ -z "$user_home" ]; then
 	esac
 fi
 
-adapter="$user_home/.local/bin/punaro-adapter"
-[ -f "$adapter" ] && [ ! -L "$adapter" ] && [ -x "$adapter" ] || fail "installed adapter is unavailable at $adapter; run the Punaro client installer first"
+case "$(uname -s)" in
+Darwin) adapter_os=darwin ;;
+Linux) adapter_os=linux ;;
+*) fail 'this launcher supports macOS and Linux' ;;
+esac
+case "$(uname -m)" in
+x86_64|amd64) adapter_arch=amd64 ;;
+arm64|aarch64) adapter_arch=arm64 ;;
+*) fail 'this launcher does not support the current architecture' ;;
+esac
+adapter="$user_home/.local/state/punaro-bootstrap/current/punaro-adapter-$adapter_os-$adapter_arch"
+[ -f "$adapter" ] && [ ! -L "$adapter" ] && [ -x "$adapter" ] || fail 'selected adapter is unavailable; run the Punaro client installer or bootstrap doctor'
 exec "$adapter" "$@"

--- a/skills/punaro-mailbox/scripts/punaro-adapter.cmd
+++ b/skills/punaro-mailbox/scripts/punaro-adapter.cmd
@@ -4,15 +4,8 @@ if "%LOCALAPPDATA%"=="" (
   echo punaro mailbox skill: LOCALAPPDATA is unavailable 1>&2
   exit /b 1
 )
-if /I "%PROCESSOR_ARCHITECTURE%"=="AMD64" set "PUNARO_SKILL_ARCH=amd64"
-if /I "%PROCESSOR_ARCHITECTURE%"=="ARM64" set "PUNARO_SKILL_ARCH=arm64"
-if not defined PUNARO_SKILL_ARCH (
-  echo punaro mailbox skill: this launcher does not support the current architecture 1>&2
-  exit /b 1
-)
-set "PUNARO_SKILL_ADAPTER=%LOCALAPPDATA%\Punaro\bootstrap\current\punaro-adapter-windows-%PUNARO_SKILL_ARCH%.exe"
-powershell.exe -NoLogo -NoProfile -NonInteractive -Command "$item = Get-Item -LiteralPath $env:PUNARO_SKILL_ADAPTER -Force -ErrorAction Stop; if ($item.PSIsContainer -or ($item.Attributes -band [IO.FileAttributes]::ReparsePoint)) { exit 1 }" >nul 2>&1
-if errorlevel 1 (
+set "PUNARO_SKILL_ADAPTER=%LOCALAPPDATA%\Punaro\bin\punaro-adapter.exe"
+if not exist "%PUNARO_SKILL_ADAPTER%" (
   echo punaro mailbox skill: selected adapter is unavailable; run the Punaro client installer or bootstrap doctor 1>&2
   exit /b 1
 )

--- a/skills/punaro-mailbox/scripts/punaro-adapter.cmd
+++ b/skills/punaro-mailbox/scripts/punaro-adapter.cmd
@@ -4,9 +4,16 @@ if "%LOCALAPPDATA%"=="" (
   echo punaro mailbox skill: LOCALAPPDATA is unavailable 1>&2
   exit /b 1
 )
-set "PUNARO_SKILL_ADAPTER=%LOCALAPPDATA%\Punaro\bin\punaro-adapter.exe"
-if not exist "%PUNARO_SKILL_ADAPTER%" (
-  echo punaro mailbox skill: installed adapter is unavailable at "%PUNARO_SKILL_ADAPTER%"; run the Punaro client installer first 1>&2
+if /I "%PROCESSOR_ARCHITECTURE%"=="AMD64" set "PUNARO_SKILL_ARCH=amd64"
+if /I "%PROCESSOR_ARCHITECTURE%"=="ARM64" set "PUNARO_SKILL_ARCH=arm64"
+if not defined PUNARO_SKILL_ARCH (
+  echo punaro mailbox skill: this launcher does not support the current architecture 1>&2
+  exit /b 1
+)
+set "PUNARO_SKILL_ADAPTER=%LOCALAPPDATA%\Punaro\bootstrap\current\punaro-adapter-windows-%PUNARO_SKILL_ARCH%.exe"
+powershell.exe -NoLogo -NoProfile -NonInteractive -Command "$item = Get-Item -LiteralPath $env:PUNARO_SKILL_ADAPTER -Force -ErrorAction Stop; if ($item.PSIsContainer -or ($item.Attributes -band [IO.FileAttributes]::ReparsePoint)) { exit 1 }" >nul 2>&1
+if errorlevel 1 (
+  echo punaro mailbox skill: selected adapter is unavailable; run the Punaro client installer or bootstrap doctor 1>&2
   exit /b 1
 )
 "%PUNARO_SKILL_ADAPTER%" %*

--- a/skills/punaro-reply/scripts/punaro-adapter
+++ b/skills/punaro-reply/scripts/punaro-adapter
@@ -45,6 +45,16 @@ if [ -z "$user_home" ]; then
 	esac
 fi
 
-adapter="$user_home/.local/bin/punaro-adapter"
-[ -f "$adapter" ] && [ ! -L "$adapter" ] && [ -x "$adapter" ] || fail "installed adapter is unavailable at $adapter; run the Punaro client installer first"
+case "$(uname -s)" in
+Darwin) adapter_os=darwin ;;
+Linux) adapter_os=linux ;;
+*) fail 'this launcher supports macOS and Linux' ;;
+esac
+case "$(uname -m)" in
+x86_64|amd64) adapter_arch=amd64 ;;
+arm64|aarch64) adapter_arch=arm64 ;;
+*) fail 'this launcher does not support the current architecture' ;;
+esac
+adapter="$user_home/.local/state/punaro-bootstrap/current/punaro-adapter-$adapter_os-$adapter_arch"
+[ -f "$adapter" ] && [ ! -L "$adapter" ] && [ -x "$adapter" ] || fail 'selected adapter is unavailable; run the Punaro client installer or bootstrap doctor'
 exec "$adapter" "$@"

--- a/skills/punaro-reply/scripts/punaro-adapter.cmd
+++ b/skills/punaro-reply/scripts/punaro-adapter.cmd
@@ -4,15 +4,8 @@ if "%LOCALAPPDATA%"=="" (
   echo punaro reply skill: LOCALAPPDATA is unavailable 1>&2
   exit /b 1
 )
-if /I "%PROCESSOR_ARCHITECTURE%"=="AMD64" set "PUNARO_SKILL_ARCH=amd64"
-if /I "%PROCESSOR_ARCHITECTURE%"=="ARM64" set "PUNARO_SKILL_ARCH=arm64"
-if not defined PUNARO_SKILL_ARCH (
-  echo punaro reply skill: this launcher does not support the current architecture 1>&2
-  exit /b 1
-)
-set "PUNARO_SKILL_ADAPTER=%LOCALAPPDATA%\Punaro\bootstrap\current\punaro-adapter-windows-%PUNARO_SKILL_ARCH%.exe"
-powershell.exe -NoLogo -NoProfile -NonInteractive -Command "$item = Get-Item -LiteralPath $env:PUNARO_SKILL_ADAPTER -Force -ErrorAction Stop; if ($item.PSIsContainer -or ($item.Attributes -band [IO.FileAttributes]::ReparsePoint)) { exit 1 }" >nul 2>&1
-if errorlevel 1 (
+set "PUNARO_SKILL_ADAPTER=%LOCALAPPDATA%\Punaro\bin\punaro-adapter.exe"
+if not exist "%PUNARO_SKILL_ADAPTER%" (
   echo punaro reply skill: selected adapter is unavailable; run the Punaro client installer or bootstrap doctor 1>&2
   exit /b 1
 )

--- a/skills/punaro-reply/scripts/punaro-adapter.cmd
+++ b/skills/punaro-reply/scripts/punaro-adapter.cmd
@@ -4,9 +4,16 @@ if "%LOCALAPPDATA%"=="" (
   echo punaro reply skill: LOCALAPPDATA is unavailable 1>&2
   exit /b 1
 )
-set "PUNARO_SKILL_ADAPTER=%LOCALAPPDATA%\Punaro\bin\punaro-adapter.exe"
-if not exist "%PUNARO_SKILL_ADAPTER%" (
-  echo punaro reply skill: installed adapter is unavailable at "%PUNARO_SKILL_ADAPTER%"; run the Punaro client installer first 1>&2
+if /I "%PROCESSOR_ARCHITECTURE%"=="AMD64" set "PUNARO_SKILL_ARCH=amd64"
+if /I "%PROCESSOR_ARCHITECTURE%"=="ARM64" set "PUNARO_SKILL_ARCH=arm64"
+if not defined PUNARO_SKILL_ARCH (
+  echo punaro reply skill: this launcher does not support the current architecture 1>&2
+  exit /b 1
+)
+set "PUNARO_SKILL_ADAPTER=%LOCALAPPDATA%\Punaro\bootstrap\current\punaro-adapter-windows-%PUNARO_SKILL_ARCH%.exe"
+powershell.exe -NoLogo -NoProfile -NonInteractive -Command "$item = Get-Item -LiteralPath $env:PUNARO_SKILL_ADAPTER -Force -ErrorAction Stop; if ($item.PSIsContainer -or ($item.Attributes -band [IO.FileAttributes]::ReparsePoint)) { exit 1 }" >nul 2>&1
+if errorlevel 1 (
+  echo punaro reply skill: selected adapter is unavailable; run the Punaro client installer or bootstrap doctor 1>&2
   exit /b 1
 )
 "%PUNARO_SKILL_ADAPTER%" %*


### PR DESCRIPTION
## Summary

- add stable client dispatchers that always execute the selected signed bootstrap slot, seed and integrity-check every local client component, and update portable plugin and skill launchers
- add explicit service-only device enrollment for least-privilege server diagnostics
- make server doctor inspect the running Compose image from the installation directory and add the missing client-launcher diagnostic
- update alpha.8 manifests, release guidance, operator documentation, doctor documentation, installers, and all three Punaro skills

Addresses #188.

## Verification

- `make test test-race staticcheck security lint`
- all five fresh GitHub Actions jobs passed, including complete product E2E, PostgreSQL integration, and Windows client build
- Windows cross-builds passed for adapter, enrollment, and dispatcher binaries
- govulncheck found zero reachable vulnerabilities, gosec found zero issues, and gitleaks found no leaks
- GitHub verified the final commit SSH signature
- Pioneer reviewed the immutable full PR range outside the outer sandbox and gave unconditional approval with no actionable findings

## Review disposition

The three prior Pioneer findings covering DESIGN invariants, replaceability waits for all Windows dispatchers, and direct doctor-test launcher probe overrides are closed and regression-tested.