### PR TITLE
Fix Windows bootstrap replacement for alpha.9

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "punaro",
   "displayName": "Punaro",
-  "version": "0.1.0-alpha.8",
+  "version": "0.1.0-alpha.9",
   "description": "Safely receive and reply to durable Punaro messages and handle explicitly authorized trusted attachments.",
   "author": {
     "name": "Punaro contributors",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "punaro",
-  "version": "0.1.0-alpha.8",
+  "version": "0.1.0-alpha.9",
   "description": "Safely receive and reply to durable Punaro messages and handle explicitly authorized trusted attachments.",
   "author": {
     "name": "Punaro contributors",

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -2013,7 +2013,14 @@ The implementation is not internet-exposure-ready until these cases pass:
   artifacts, never these dispatcher copies. Doctor requires the adapter,
   enrollment, memory, and trusted-attachment dispatchers to be regular,
   byte-identical executables, while the client installer waits for every
-  Windows destination to become replaceable before overwriting it.
+  Windows destination to become replaceable before overwriting it. When that
+  installer replaces an enabled repeating Windows task, it disables the task
+  for the complete replacement critical section, stops instances even if they
+  started while the fence was acquired, and restores the prior enabled/running
+  state on failure. A restoration failure is reported together with the original
+  installation error. It terminates only processes whose verified image is the
+  exact fixed bootstrap path, confirms their bounded exit, and then applies the
+  same replaceability fence.
   Platform services launch `punaro-bootstrap run`, which supervises the
   current-slot adapter, requires a local ready signal within 60 seconds when a
   previous slot exists, rolls back once if the fresh catalog still allows that

--- a/cmd/punaro-adapter/main_test.go
+++ b/cmd/punaro-adapter/main_test.go
@@ -971,12 +971,12 @@ func TestPluginDoctorValidatesAllAdaptersLauncherAndExactSkillTree(t *testing.T)
 		t.Fatal(err)
 	}
 	oldRelease, oldDigest, oldRuntimeDigest := adapterBuildRelease, adapterExpectedSkillSetDigest, adapterExpectedPluginRuntimeDigest
-	adapterBuildRelease, adapterExpectedSkillSetDigest, adapterExpectedPluginRuntimeDigest = "v0.1.0-alpha.8", digest, runtimeDigest
+	adapterBuildRelease, adapterExpectedSkillSetDigest, adapterExpectedPluginRuntimeDigest = "v0.1.0-alpha.9", digest, runtimeDigest
 	t.Cleanup(func() {
 		adapterBuildRelease, adapterExpectedSkillSetDigest, adapterExpectedPluginRuntimeDigest = oldRelease, oldDigest, oldRuntimeDigest
 	})
 	result := inspectAdapterPlugin(t.Context(), root)
-	if !result.Portable || !result.Codex || !result.Claude || !result.Launcher || result.Version != "v0.1.0-alpha.8" || result.SkillDigest != "sha256:"+digest {
+	if !result.Portable || !result.Codex || !result.Claude || !result.Launcher || result.Version != "v0.1.0-alpha.9" || result.SkillDigest != "sha256:"+digest {
 		t.Fatalf("plugin=%#v", result)
 	}
 	var helperOutput bytes.Buffer

--- a/cmd/punaro-release/main_test.go
+++ b/cmd/punaro-release/main_test.go
@@ -171,8 +171,8 @@ func TestBuildFactsBindsPluginSkillsGeneratedComposeAndMigrations(t *testing.T) 
 	if err != nil {
 		t.Fatal(err)
 	}
-	facts, err := buildFacts([]string{"--release", "v0.1.0-alpha.8", "--plugin-root", root})
-	if err != nil || facts.Release != "v0.1.0-alpha.8" || facts.ComposeSHA256 != operator.ComposeManifestSHA256() || len(facts.MigrationManifestSHA256) != 64 || len(facts.SkillSetSHA256) != 64 || len(facts.PluginRuntimeSHA256) != 64 {
+	facts, err := buildFacts([]string{"--release", "v0.1.0-alpha.9", "--plugin-root", root})
+	if err != nil || facts.Release != "v0.1.0-alpha.9" || facts.ComposeSHA256 != operator.ComposeManifestSHA256() || len(facts.MigrationManifestSHA256) != 64 || len(facts.SkillSetSHA256) != 64 || len(facts.PluginRuntimeSHA256) != 64 {
 		t.Fatalf("facts=%#v err=%v", facts, err)
 	}
 	if _, err := buildFacts([]string{"--release", "v0.1.0", "--plugin-root", root}); err == nil {

--- a/docs/github-releases.md
+++ b/docs/github-releases.md
@@ -148,6 +148,12 @@ Only the offline-signature publisher can make those stable assets visible.
    `minimum_bootstrap_release=v0.1.0-alpha.8`; upgrading from an older fixed
    bootstrap requires one client-installer handoff before built-in updates can
    safely manage every selected component.
+
+   Alpha.9 fixes the Windows client-installer handoff without changing the
+   signed-slot or fixed-bootstrap protocol. Dispatch `v0.1.0-alpha.9` with
+   `minimum_bootstrap_release=v0.1.0-alpha.8` and
+   `supported_from=v0.1.0-alpha.8`; alpha.8 clients can use the built-in signed
+   update, while the alpha.9 checkout supplies the corrected Windows installer.
 3. Wait for the draft release to appear. The live `catalog` prerelease is not
    touched by the unsigned workflow.
 4. Generate the offline key once, on an air-gapped or owner-only machine, and

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -182,6 +182,23 @@ Get-ScheduledTask -TaskName 'Punaro Adapter'
   --plugin-root C:\absolute\installed\punaro-plugin
 ```
 
+When reinstalling over an enabled repeating task, the installer disables it
+for the complete replacement critical section. It then stops every task instance,
+including one that started while the disable fence was being acquired, and every
+process using the exact installed bootstrap image before replacing any managed
+executable. It verifies process image identity and bounded exit first, restores
+the prior enabled and running state on failure, reports restoration failures with
+the original installer error, and does not terminate unrelated processes or
+weaken the binary replaceability fence.
+
+An alpha.8 failure may leave that bootstrap image running after the scheduled
+task has already returned to **Ready**. When the enabled repeating task still
+exists, alpha.9 fences it and terminates only the process whose image is exactly
+`%LOCALAPPDATA%\Punaro\bin\punaro-bootstrap.exe`. If that task definition no
+longer exists or is deliberately disabled, verify and stop that exact image
+manually before rerunning the installer. Do not disable the replaceability fence
+or terminate by name.
+
 The installer also builds `%LOCALAPPDATA%\Punaro\bin\punaro-trusted-attachment.exe`.
 After ordinary device enrollment, the operator separately provisions its fixed
 HTTPS origin, protected credential file, project UUID, and safe download root.

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "punaro",
-  "version": "0.1.0-alpha.8",
+  "version": "0.1.0-alpha.9",
   "description": "Safely receive and reply to durable Punaro messages and handle explicitly authorized trusted attachments.",
   "author": {
     "name": "Punaro contributors",

--- a/scripts/install-client.ps1
+++ b/scripts/install-client.ps1
@@ -44,9 +44,9 @@ function Get-PunaroProcessImage($Process) {
     return $image
 }
 
-function Get-PunaroMatchingAdapterPids([string]$WantPath) {
-    try { $listed = @(Get-Process -ErrorAction Stop) } catch { Stop-Install 'could not enumerate processes to recover run.pid' }
-    if ($listed.Count -eq 0) { Stop-Install 'could not enumerate processes to recover run.pid' }
+function Get-PunaroMatchingProcessPids([string]$WantPath) {
+    try { $listed = @(Get-Process -ErrorAction Stop) } catch { Stop-Install 'could not enumerate process images safely' }
+    if ($listed.Count -eq 0) { Stop-Install 'could not enumerate process images safely' }
     $usable = 0
     $matches = @()
     foreach ($proc in $listed) {
@@ -58,11 +58,11 @@ function Get-PunaroMatchingAdapterPids([string]$WantPath) {
             $matches += $proc.Id
         }
     }
-    if ($usable -eq 0) { Stop-Install 'could not enumerate processes to recover run.pid' }
+    if ($usable -eq 0) { Stop-Install 'could not enumerate process images safely' }
     return $matches
 }
 
-function Stop-PunaroMatchingAdapter([int]$ProcessId, [string]$WantPath, [switch]$RequireImage) {
+function Stop-PunaroMatchingProcess([int]$ProcessId, [string]$WantPath, [switch]$RequireImage) {
     $proc = Get-Process -Id $ProcessId -ErrorAction SilentlyContinue
     if ($null -eq $proc) { return }
     $image = Get-PunaroProcessImage $proc
@@ -72,6 +72,8 @@ function Stop-PunaroMatchingAdapter([int]$ProcessId, [string]$WantPath, [switch]
     }
     $got = [System.IO.Path]::GetFullPath($image)
     if (-not $WantPath.Equals($got, [System.StringComparison]::OrdinalIgnoreCase)) { return }
+    # Revalidate immediately before termination; Windows has no atomic
+    # path-bound process-stop primitive that also eliminates PID reuse.
     Stop-Process -Id $ProcessId -Force -ErrorAction SilentlyContinue
     $deadline = (Get-Date).AddSeconds(5)
     do {
@@ -79,8 +81,16 @@ function Stop-PunaroMatchingAdapter([int]$ProcessId, [string]$WantPath, [switch]
         $proc = Get-Process -Id $ProcessId -ErrorAction SilentlyContinue
     } while ($null -ne $proc -and (Get-Date) -lt $deadline)
     if ($null -ne (Get-Process -Id $ProcessId -ErrorAction SilentlyContinue)) {
-        Stop-Install 'could not stop a matching Punaro adapter'
+        Stop-Install 'could not stop a matching Punaro process'
     }
+}
+
+function Stop-PunaroMatchingProcesses([string]$WantPath) {
+    foreach ($matchPid in @(Get-PunaroMatchingProcessPids $WantPath)) {
+        Stop-PunaroMatchingProcess $matchPid $WantPath
+    }
+    $remaining = @(Get-PunaroMatchingProcessPids $WantPath)
+    if ($remaining.Count -gt 0) { Stop-Install 'could not stop a matching Punaro process' }
 }
 
 function Stop-PunaroOrphanAdapter([string]$BootstrapDirectory) {
@@ -110,14 +120,10 @@ function Stop-PunaroOrphanAdapter([string]$BootstrapDirectory) {
     $want = [System.IO.Path]::GetFullPath($orphanPath)
     # A starting marker (pid 0) is recovered by identity-killing matching adapter images.
     if ($starting -and $orphanPid -le 0) {
-        foreach ($matchPid in @(Get-PunaroMatchingAdapterPids $want)) {
-            Stop-PunaroMatchingAdapter $matchPid $want
-        }
-        $remaining = @(Get-PunaroMatchingAdapterPids $want)
-        if ($remaining.Count -gt 0) { Stop-Install 'could not stop a matching Punaro adapter' }
+        Stop-PunaroMatchingProcesses $want
         return
     }
-    Stop-PunaroMatchingAdapter $orphanPid $want -RequireImage
+    Stop-PunaroMatchingProcess $orphanPid $want -RequireImage
 }
 
 function Wait-PunaroReplaceableBinary([string]$Path) {
@@ -351,10 +357,13 @@ if ([string]::IsNullOrWhiteSpace($MailboxStateDir)) {
 }
 $MailboxStateDir = Get-FullPath $MailboxStateDir
 
+$fixedBootstrapPath = [System.IO.Path]::GetFullPath((Join-Path $binDir 'punaro-bootstrap.exe'))
 $adapterTaskName = 'Punaro Adapter'
 $adapterTaskWasRunning = $false
 $adapterTaskRestored = $false
 $adapterTaskWasDisabled = $false
+$adapterTaskTemporarilyDisabled = $false
+$installFailure = $null
 $existingAdapterTask = Get-ScheduledTask -TaskName $adapterTaskName -ErrorAction SilentlyContinue
 $hadRepeatTrigger = Test-PunaroRepeatTrigger $existingAdapterTask
 if ($null -ne $existingAdapterTask -and $existingAdapterTask.State -eq 'Disabled') {
@@ -363,6 +372,14 @@ if ($null -ne $existingAdapterTask -and $existingAdapterTask.State -eq 'Disabled
 }
 if ($null -ne $existingAdapterTask -and $existingAdapterTask.State -eq 'Running') {
     $adapterTaskWasRunning = $true
+}
+
+try {
+if ($null -ne $existingAdapterTask -and -not $adapterTaskWasDisabled -and ($adapterTaskWasRunning -or $hadRepeatTrigger)) {
+    Disable-ScheduledTask -TaskName $adapterTaskName
+    $adapterTaskTemporarilyDisabled = $true
+}
+if ($adapterTaskTemporarilyDisabled) {
     Stop-ScheduledTask -TaskName $adapterTaskName
     $deadline = (Get-Date).AddSeconds(30)
     do {
@@ -373,16 +390,23 @@ if ($null -ne $existingAdapterTask -and $existingAdapterTask.State -eq 'Running'
         Stop-Install 'could not stop the running Punaro Adapter task before replacing bootstrap'
     }
 }
-
-try {
+if ($adapterTaskTemporarilyDisabled) {
+    $existingAdapterTask = Get-ScheduledTask -TaskName $adapterTaskName -ErrorAction SilentlyContinue
+    if ($null -eq $existingAdapterTask -or $existingAdapterTask.State -ne 'Disabled') {
+        Stop-Install 'could not disable the Punaro Adapter task during binary replacement'
+    }
+}
 Stop-PunaroOrphanAdapter -BootstrapDirectory $bootstrapDir
+if ($adapterTaskTemporarilyDisabled) {
+    Stop-PunaroMatchingProcesses $fixedBootstrapPath
+}
 $dispatcherComponents = @('punaro-adapter.exe', 'punaro-trusted-attachment.exe', 'punaro-memory.exe', 'punaro-enroll.exe')
 foreach ($component in $dispatcherComponents) {
     Wait-PunaroReplaceableBinary -Path (Join-Path $binDir $component)
 }
-Wait-PunaroReplaceableBinary -Path (Join-Path $binDir 'punaro-bootstrap.exe')
+Wait-PunaroReplaceableBinary -Path $fixedBootstrapPath
 Build-PunaroBinary -Package (Join-Path $repoDir 'cmd\punaro-adapter') -Output (Join-Path $binDir 'punaro-adapter.exe') -LdFlags "-X main.adapterBuildRelease=$sourceRelease -X main.adapterExpectedSkillSetDigest=$skillSha256 -X main.adapterExpectedPluginRuntimeDigest=$pluginRuntimeSha256"
-Build-PunaroBinary -Package (Join-Path $repoDir 'cmd\punaro-bootstrap') -Output (Join-Path $binDir 'punaro-bootstrap.exe') -LdFlags "-X main.bootstrapBuildRelease=$sourceRelease"
+Build-PunaroBinary -Package (Join-Path $repoDir 'cmd\punaro-bootstrap') -Output $fixedBootstrapPath -LdFlags "-X main.bootstrapBuildRelease=$sourceRelease"
 Build-PunaroBinary -Package (Join-Path $repoDir 'cmd\punaro-trusted-attachment') -Output (Join-Path $binDir 'punaro-trusted-attachment.exe')
 Build-PunaroBinary -Package (Join-Path $repoDir 'cmd\punaro-memory') -Output (Join-Path $binDir 'punaro-memory.exe')
 Build-PunaroBinary -Package (Join-Path $repoDir 'cmd\punaro-enroll') -Output (Join-Path $binDir 'punaro-enroll.exe')
@@ -399,7 +423,7 @@ if (-not [string]::IsNullOrWhiteSpace($KeysFile)) {
     Get-RegularFile -Path $resolvedKeys -Label 'release keys file' | Out-Null
     $seedArguments += @('--keys-file', $resolvedKeys)
 }
-Invoke-Program -Program (Join-Path $binDir 'punaro-bootstrap.exe') -Arguments $seedArguments -Description 'bootstrap checkout seed'
+Invoke-Program -Program $fixedBootstrapPath -Arguments $seedArguments -Description 'bootstrap checkout seed'
 $launcherBuild = Join-Path $root ("punaro-launcher-" + [Guid]::NewGuid().ToString('N') + '.exe')
 try {
     Build-PunaroBinary -Package (Join-Path $repoDir 'cmd\punaro-launcher') -Output $launcherBuild
@@ -497,10 +521,10 @@ $settings.RestartInterval = [TimeSpan]::FromMinutes(1)
 Register-ScheduledTask -TaskName $adapterTaskName -Action $action -Trigger $triggers -Principal $principal -Settings $settings -Description 'Punaro local mailbox adapter' -Force | Out-Null
 if ($Enable -or $adapterTaskWasRunning) {
     Start-ScheduledTask -TaskName $adapterTaskName
-    $adapterTaskRestored = $true
 } elseif ($adapterTaskWasDisabled) {
     Disable-ScheduledTask -TaskName $adapterTaskName
 }
+$adapterTaskRestored = $true
 
 if (-not [string]::IsNullOrWhiteSpace($AgentGuidanceDir)) {
     & (Join-Path $repoDir 'scripts\install-agent-guidance.ps1') -Directory $AgentGuidanceDir
@@ -512,8 +536,21 @@ Get-Content -LiteralPath $enrollmentFile
 Write-Output 'Next: add this machine''s distinct Access token pair to adapter.env; bind and attach desired aliases; then rerun with -Enable.'
 Write-Output 'After device-credential enrollment, use punaro-trusted-attachment.exe with a protected credential file and safe download root.'
 Write-Output 'Run punaro-enroll.exe prepare before the server owner issues the one-time enrollment for this device; redeem only a protected enrollment-material file.'
+} catch {
+    $installFailure = $_
+    throw
 } finally {
-    if ($adapterTaskWasRunning -and -not $adapterTaskRestored) {
-        Start-ScheduledTask -TaskName $adapterTaskName -ErrorAction SilentlyContinue
+    if ($adapterTaskTemporarilyDisabled -and -not $adapterTaskRestored) {
+        try {
+            Enable-ScheduledTask -TaskName $adapterTaskName -ErrorAction Stop
+            if ($adapterTaskWasRunning) {
+                Start-ScheduledTask -TaskName $adapterTaskName -ErrorAction Stop
+            }
+        } catch {
+            if ($null -ne $installFailure) {
+                throw "$($installFailure.Exception.Message); additionally could not restore the Punaro Adapter task: $($_.Exception.Message)"
+            }
+            throw
+        }
     }
 }

--- a/scripts/test-install-adapter.sh
+++ b/scripts/test-install-adapter.sh
@@ -104,8 +104,8 @@ file_mode() {
 
 [ -x "$adapter" ] || { printf '%s\n' 'adapter binary was not installed' >&2; exit 1; }
 [ -x "$bootstrap" ] || { printf '%s\n' 'bootstrap binary was not installed' >&2; exit 1; }
-[ "$(HOME="$home" "$adapter" version)" = 'v0.1.0-alpha.8' ] || { printf '%s\n' 'adapter binary lacks the source release identity' >&2; exit 1; }
-[ "$("$bootstrap" version)" = 'v0.1.0-alpha.8' ] || { printf '%s\n' 'bootstrap binary lacks the source release identity' >&2; exit 1; }
+[ "$(HOME="$home" "$adapter" version)" = 'v0.1.0-alpha.9' ] || { printf '%s\n' 'adapter binary lacks the source release identity' >&2; exit 1; }
+[ "$("$bootstrap" version)" = 'v0.1.0-alpha.9' ] || { printf '%s\n' 'bootstrap binary lacks the source release identity' >&2; exit 1; }
 [ -d "$home/.local/state/punaro-bootstrap/current" ] || { printf '%s\n' 'bootstrap current slot was not seeded' >&2; exit 1; }
 [ -x "$attachment" ] || { printf '%s\n' 'attachment binary was not installed' >&2; exit 1; }
 [ -x "$memory" ] || { printf '%s\n' 'memory binary was not installed' >&2; exit 1; }

--- a/scripts/test-install-client-windows.ps1
+++ b/scripts/test-install-client-windows.ps1
@@ -64,11 +64,41 @@ try {
     $global:punaroRegisteredTriggers = $null
     $global:punaroExistingTask = $null
     $global:punaroDisableTaskCalled = $false
+    $global:punaroEnableTaskCalled = $false
     $global:punaroStartTaskCalled = $false
+    $global:punaroStopTaskCalled = $false
+    $global:punaroStopTaskFailure = $false
+    $global:punaroDisableStateFailure = $false
+    $global:punaroTaskStartsDuringDisable = $false
+    $global:punaroEnableTaskFailure = $false
     function Get-ScheduledTask { param([string]$TaskName) return $global:punaroExistingTask }
-    function Disable-ScheduledTask { param([string]$TaskName) $global:punaroDisableTaskCalled = $true }
-    function Start-ScheduledTask { param([string]$TaskName) $global:punaroStartTaskCalled = $true }
-    function Stop-ScheduledTask { param([string]$TaskName) }
+    function Disable-ScheduledTask {
+        param([string]$TaskName)
+        $global:punaroDisableTaskCalled = $true
+        if ($null -ne $global:punaroExistingTask -and $global:punaroTaskStartsDuringDisable) {
+            $global:punaroExistingTask.State = 'Running'
+        } elseif ($null -ne $global:punaroExistingTask -and -not $global:punaroDisableStateFailure) {
+            $global:punaroExistingTask.State = 'Disabled'
+        }
+    }
+    function Enable-ScheduledTask {
+        param([string]$TaskName, [string]$ErrorAction)
+        $global:punaroEnableTaskCalled = $true
+        if ($global:punaroEnableTaskFailure) { throw 'simulated scheduled task restore failure' }
+        if ($null -ne $global:punaroExistingTask) { $global:punaroExistingTask.State = 'Ready' }
+    }
+    function Start-ScheduledTask { param([string]$TaskName, [string]$ErrorAction) $global:punaroStartTaskCalled = $true }
+    function Stop-ScheduledTask {
+        param([string]$TaskName)
+        $global:punaroStopTaskCalled = $true
+        if (-not $global:punaroDisableTaskCalled) {
+            throw 'simulated repeating task retriggered before replacement fence'
+        }
+        if ($global:punaroStopTaskFailure) { throw 'simulated scheduled task stop failure' }
+        if ($null -ne $global:punaroExistingTask -and -not $global:punaroDisableStateFailure) {
+            $global:punaroExistingTask.State = 'Disabled'
+        }
+    }
     function New-ScheduledTaskAction { param([string]$Execute, [string]$Argument) return [pscustomobject]@{ Execute = $Execute; Argument = $Argument } }
     function New-ScheduledTaskTrigger {
         param(
@@ -139,6 +169,106 @@ try {
     if (@($global:punaroRegisteredTriggers | Where-Object { $_.Once }).Count -ne 0 -or $global:punaroStartTaskCalled) {
         throw 'Windows client installer armed or started a fresh adapter without -Enable'
     }
+    $fixedBootstrap = Join-Path $root 'bin\punaro-bootstrap.exe'
+    $savedFixedBootstrap = $fixedBootstrap + '.service-parent-test'
+    $decoyBootstrapDirectory = Join-Path $fixture 'decoy'
+    [System.IO.Directory]::CreateDirectory($decoyBootstrapDirectory) | Out-Null
+    $decoyBootstrap = Join-Path $decoyBootstrapDirectory 'punaro-bootstrap.exe'
+    $pingExecutable = Join-Path $env:SystemRoot 'System32\PING.EXE'
+    [System.IO.File]::Move($fixedBootstrap, $savedFixedBootstrap)
+    [System.IO.File]::Copy($pingExecutable, $fixedBootstrap)
+    [System.IO.File]::Copy($pingExecutable, $decoyBootstrap)
+    $fakeBootstrapProcess = Start-Process -FilePath $fixedBootstrap -ArgumentList @('-t', '127.0.0.1') -PassThru -WindowStyle Hidden
+    $decoyBootstrapProcess = Start-Process -FilePath $decoyBootstrap -ArgumentList @('-t', '127.0.0.1') -PassThru -WindowStyle Hidden
+    try {
+        Start-Sleep -Milliseconds 500
+        if ($fakeBootstrapProcess.HasExited -or $decoyBootstrapProcess.HasExited) { throw 'Windows installer regression fixture bootstrap exited early' }
+        $global:punaroDisableTaskCalled = $false
+        $global:punaroExistingTask = [pscustomobject]@{ State = 'Running'; Triggers = @() }
+        & (Join-Path $repoDir 'scripts\install-client.ps1') -RelayUrl 'https://relay.example.test' -MachineId 'windows-test' -AgentMailboxBin $mailbox -AgentGuidanceDir $project
+        if ($LASTEXITCODE -ne 0) { throw 'Windows client installer failed while replacing a stopped task bootstrap parent' }
+        if (-not $global:punaroDisableTaskCalled) { throw 'Windows client installer did not fence the repeating task before stopping it' }
+        $fakeBootstrapProcess.Refresh()
+        if (-not $fakeBootstrapProcess.HasExited) { throw 'Windows client installer left the stopped task bootstrap parent running' }
+        $decoyBootstrapProcess.Refresh()
+        if ($decoyBootstrapProcess.HasExited) { throw 'Windows client installer stopped a different-path bootstrap process' }
+    } finally {
+        foreach ($fixtureProcess in @($fakeBootstrapProcess, $decoyBootstrapProcess)) {
+            if ($null -ne $fixtureProcess) {
+                $fixtureProcess.Refresh()
+                if (-not $fixtureProcess.HasExited) { Stop-Process -Id $fixtureProcess.Id -Force -ErrorAction SilentlyContinue }
+            }
+        }
+        if (Test-Path -LiteralPath $savedFixedBootstrap -PathType Leaf) {
+            if (Test-Path -LiteralPath $fixedBootstrap) { Remove-Item -LiteralPath $fixedBootstrap -Force }
+            [System.IO.File]::Move($savedFixedBootstrap, $fixedBootstrap)
+        }
+        $global:punaroExistingTask = $null
+    }
+    $global:punaroDisableTaskCalled = $false
+    $global:punaroEnableTaskCalled = $false
+    $global:punaroStartTaskCalled = $false
+    $global:punaroStopTaskFailure = $true
+    $global:punaroExistingTask = [pscustomobject]@{ State = 'Running'; Triggers = @() }
+    $stopFailureRestored = $false
+    try {
+        & (Join-Path $repoDir 'scripts\install-client.ps1') -RelayUrl 'https://relay.example.test' -MachineId 'windows-test' -AgentMailboxBin $mailbox -AgentGuidanceDir $project
+    } catch {
+        if ($_.Exception.Message.Contains('simulated scheduled task stop failure')) { $stopFailureRestored = $true } else { throw }
+    }
+    if (-not $stopFailureRestored -or -not $global:punaroDisableTaskCalled -or -not $global:punaroEnableTaskCalled -or -not $global:punaroStartTaskCalled) {
+        throw 'Windows client installer did not restore a temporarily disabled running task after failure'
+    }
+    $global:punaroStopTaskFailure = $false
+    $global:punaroDisableTaskCalled = $false
+    $global:punaroEnableTaskCalled = $false
+    $global:punaroStartTaskCalled = $false
+    $global:punaroStopTaskCalled = $false
+    $global:punaroRegisteredTriggers = $null
+    $repeat = [pscustomobject]@{ Repetition = [pscustomobject]@{ Interval = 'PT1M' } }
+    $global:punaroExistingTask = [pscustomobject]@{ State = 'Ready'; Triggers = @($repeat) }
+    $global:punaroTaskStartsDuringDisable = $true
+    & (Join-Path $repoDir 'scripts\install-client.ps1') -RelayUrl 'https://relay.example.test' -MachineId 'windows-test' -AgentMailboxBin $mailbox -AgentGuidanceDir $project
+    if ($LASTEXITCODE -ne 0) { throw 'Windows client installer failed to reinstall over an idle repeating task' }
+    if (-not $global:punaroDisableTaskCalled) { throw 'Windows client installer did not fence an idle repeating task during replacement' }
+    if (-not $global:punaroStopTaskCalled) { throw 'Windows client installer did not stop a repeating task instance that started while the replacement fence was acquired' }
+    if ($global:punaroEnableTaskCalled -or $global:punaroStartTaskCalled) { throw 'Windows client installer changed idle repeating task runtime state during successful replacement' }
+    if (@($global:punaroRegisteredTriggers | Where-Object { $_.Once }).Count -ne 1) {
+        throw 'Windows client installer did not preserve the repeating trigger for an idle task'
+    }
+    $global:punaroTaskStartsDuringDisable = $false
+    $global:punaroDisableTaskCalled = $false
+    $global:punaroEnableTaskCalled = $false
+    $global:punaroStartTaskCalled = $false
+    $global:punaroDisableStateFailure = $true
+    $global:punaroExistingTask = [pscustomobject]@{ State = 'Ready'; Triggers = @($repeat) }
+    $disableFenceFailedClosed = $false
+    try {
+        & (Join-Path $repoDir 'scripts\install-client.ps1') -RelayUrl 'https://relay.example.test' -MachineId 'windows-test' -AgentMailboxBin $mailbox -AgentGuidanceDir $project
+    } catch {
+        if ($_.Exception.Message.Contains('could not disable the Punaro Adapter task during binary replacement')) { $disableFenceFailedClosed = $true } else { throw }
+    }
+    if (-not $disableFenceFailedClosed -or -not $global:punaroDisableTaskCalled -or -not $global:punaroEnableTaskCalled -or $global:punaroStartTaskCalled) {
+        throw 'Windows client installer did not fail closed and restore an idle repeating task when its replacement fence failed'
+    }
+    $global:punaroDisableTaskCalled = $false
+    $global:punaroEnableTaskCalled = $false
+    $global:punaroStartTaskCalled = $false
+    $global:punaroDisableStateFailure = $true
+    $global:punaroEnableTaskFailure = $true
+    $global:punaroExistingTask = [pscustomobject]@{ State = 'Ready'; Triggers = @($repeat) }
+    $restoreFailurePreservedContext = $false
+    try {
+        & (Join-Path $repoDir 'scripts\install-client.ps1') -RelayUrl 'https://relay.example.test' -MachineId 'windows-test' -AgentMailboxBin $mailbox -AgentGuidanceDir $project
+    } catch {
+        $restoreFailurePreservedContext = $_.Exception.Message.Contains('could not disable the Punaro Adapter task during binary replacement') -and $_.Exception.Message.Contains('simulated scheduled task restore failure') -and -not $_.Exception.Message.Contains('punaro installer: punaro installer:')
+    }
+    if (-not $restoreFailurePreservedContext -or -not $global:punaroDisableTaskCalled -or -not $global:punaroEnableTaskCalled -or $global:punaroStartTaskCalled) {
+        throw 'Windows client installer did not report task restoration failure with the original installation error context'
+    }
+    $global:punaroEnableTaskFailure = $false
+    $global:punaroDisableStateFailure = $false
+    $global:punaroExistingTask = $null
     $global:punaroRegisteredTriggers = $null
     $global:punaroStartTaskCalled = $false
     & (Join-Path $repoDir 'scripts\install-client.ps1') -RelayUrl 'https://relay.example.test' -MachineId 'windows-test' -AgentMailboxBin $mailbox -AgentGuidanceDir $project -Enable

--- a/scripts/test-install-client-windows.sh
+++ b/scripts/test-install-client-windows.sh
@@ -41,16 +41,20 @@ for expected in \
 	'KeysFile' \
 	'--keys-file' \
 	'Stop-ScheduledTask' \
+	'Disable-ScheduledTask' \
+	'Enable-ScheduledTask' \
 	'Get-ScheduledTask' \
 	'could not stop the running Punaro Adapter task' \
+	'could not disable the Punaro Adapter task during binary replacement' \
+	'additionally could not restore the Punaro Adapter task' \
 	'Wait-PunaroReplaceableBinary' \
 	'Stop-PunaroOrphanAdapter' \
 	'run.pid is invalid' \
 	'PathType Leaf' \
 	'starting marker' \
-	'could not enumerate processes to recover run.pid' \
+	'could not enumerate process images safely' \
 	'run.pid image is unverifiable' \
-	'could not stop a matching Punaro adapter' \
+	'could not stop a matching Punaro process' \
 	'run.pid' \
 	'FileShare]::None' \
 	'main.adapterBuildRelease' \


### PR DESCRIPTION
## Summary

- stop only exact-image fixed bootstrap processes after fencing the enabled Windows scheduled task
- disable the task for the complete replacement critical section and stop instances even if a repeat trigger starts one during fence acquisition
- keep process enumeration, image revalidation, bounded exit, and binary replaceability fail closed
- restore prior enabled/running state on failure and report restoration failures together with the original installer error
- add real Windows RED/GREEN regressions, including a same-basename different-path negative control and leak-free cleanup
- bump all plugin manifests and current release fixtures to `v0.1.0-alpha.9`
- document alpha.9 release inputs, alpha.8 recovery, and the installer process/task invariants

Closes #197.
Blocks the remaining live fleet validation in #188 until merged and released.

## Validation

- RED on Mattone with alpha.8: exact installed bootstrap remained locked and installer failed at its replaceability fence
- GREEN on Mattone: exact installed bootstrap stopped, same-basename different-path decoy survived, full PowerShell installer suite passed
- RED/GREEN on Mattone for Ready-to-Running repeat-trigger race, disable-fence failure, enabled-idle restoration without Start, restoration failure context, and single-prefix combined diagnostic
- `make test test-race staticcheck security lint`
- govulncheck: 0 reachable vulnerabilities
- gosec: 0 issues
- gitleaks: no leaks
- Windows cross-build and deployment verifier passed
- final Pioneer immutable closure reviews ran outside the outer sandbox and gave unconditional approval

## Release

After merge, publish signed `v0.1.0-alpha.9` with sequence/catalog sequence 9, `minimum_bootstrap_release=v0.1.0-alpha.8`, and `supported_from=v0.1.0-alpha.8`.
