### PR TITLE
feat(canopi): add multi-provider adapters

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ PUNARO_TRUSTED_ATTACHMENT_OUTPUT ?= ./bin/punaro-trusted-attachment
 PUNARO_MEMORY_OUTPUT ?= ./bin/punaro-memory
 CANOPI_OUTPUT ?= ./bin/canopi
 CANOPI_CLAUDE_HOOK_OUTPUT ?= ./bin/canopi-claude-hook
+CANOPI_PROVIDER_HOOK_OUTPUT ?= ./bin/canopi-provider-hook
 CANOPI_SIM_OUTPUT ?= ./bin/canopi-sim
 
 operator-binary:
@@ -22,9 +23,11 @@ memory-client:
 canopi-binaries:
 	mkdir -p "$$(dirname "$(CANOPI_OUTPUT)")"
 	mkdir -p "$$(dirname "$(CANOPI_CLAUDE_HOOK_OUTPUT)")"
+	mkdir -p "$$(dirname "$(CANOPI_PROVIDER_HOOK_OUTPUT)")"
 	mkdir -p "$$(dirname "$(CANOPI_SIM_OUTPUT)")"
 	go build -trimpath -o "$(CANOPI_OUTPUT)" ./cmd/canopi
 	go build -trimpath -o "$(CANOPI_CLAUDE_HOOK_OUTPUT)" ./cmd/canopi-claude-hook
+	go build -trimpath -o "$(CANOPI_PROVIDER_HOOK_OUTPUT)" ./cmd/canopi-provider-hook
 	go build -trimpath -o "$(CANOPI_SIM_OUTPUT)" ./cmd/canopi-sim
 
 release-artifacts:

--- a/README.md
+++ b/README.md
@@ -8,10 +8,10 @@ operator.
 
 Punaro now also contains the first end-to-end MVP of **Canopi** (provisional
 name), its “what are my agents doing?” surface: normalized lifecycle events,
-multi-machine current state, an 800x480 monochrome renderer, a Claude Code
-adapter, simulator, and XIAO e-paper firmware path. Canopi is independently
-deployable and its event protocol does not depend on Punaro transport. See the
-[Canopi guide](docs/canopi.md).
+multi-machine current state, an 800x480 monochrome renderer, Claude Code,
+Codex/ChatGPT, Pi, and Grok Build adapters, a simulator, and XIAO e-paper
+firmware path. Canopi is independently deployable and its event protocol does
+not depend on Punaro transport. See the [Canopi guide](docs/canopi.md).
 
 ![Canopi MVP e-paper dashboard](artifacts/canopi-implementation.png)
 

--- a/canopi/providers/codex-hooks.example.json
+++ b/canopi/providers/codex-hooks.example.json
@@ -1,0 +1,12 @@
+{
+  "hooks": {
+    "SessionStart": [{ "hooks": [{ "type": "command", "command": "/absolute/path/to/canopi-provider-hook codex relay", "timeout": 1 }] }],
+    "UserPromptSubmit": [{ "hooks": [{ "type": "command", "command": "/absolute/path/to/canopi-provider-hook codex relay", "timeout": 1 }] }],
+    "PreToolUse": [{ "hooks": [{ "type": "command", "command": "/absolute/path/to/canopi-provider-hook codex relay", "timeout": 1 }] }],
+    "PostToolUse": [{ "hooks": [{ "type": "command", "command": "/absolute/path/to/canopi-provider-hook codex relay", "timeout": 1 }] }],
+    "PermissionRequest": [{ "hooks": [{ "type": "command", "command": "/absolute/path/to/canopi-provider-hook codex relay", "timeout": 1 }] }],
+    "SubagentStart": [{ "hooks": [{ "type": "command", "command": "/absolute/path/to/canopi-provider-hook codex relay", "timeout": 1 }] }],
+    "SubagentStop": [{ "hooks": [{ "type": "command", "command": "/absolute/path/to/canopi-provider-hook codex relay", "timeout": 1 }] }],
+    "Stop": [{ "hooks": [{ "type": "command", "command": "/absolute/path/to/canopi-provider-hook codex relay", "timeout": 1 }] }]
+  }
+}

--- a/canopi/providers/grok-build-hooks.example.json
+++ b/canopi/providers/grok-build-hooks.example.json
@@ -1,0 +1,13 @@
+{
+  "description": "Canopi lifecycle reporting for Grok Build. Replace the absolute executable path before installing.",
+  "hooks": {
+    "SessionStart": [{ "hooks": [{ "type": "command", "command": "/absolute/path/to/canopi-provider-hook grok", "async": true, "timeout": 30 }] }],
+    "UserPromptSubmit": [{ "hooks": [{ "type": "command", "command": "/absolute/path/to/canopi-provider-hook grok", "async": true, "timeout": 30 }] }],
+    "PreToolUse": [{ "hooks": [{ "type": "command", "command": "/absolute/path/to/canopi-provider-hook grok", "async": true, "timeout": 30 }] }],
+    "PostToolUse": [{ "hooks": [{ "type": "command", "command": "/absolute/path/to/canopi-provider-hook grok", "async": true, "timeout": 30 }] }],
+    "Notification": [{ "hooks": [{ "type": "command", "command": "/absolute/path/to/canopi-provider-hook grok", "async": true, "timeout": 30 }] }],
+    "SubagentStart": [{ "hooks": [{ "type": "command", "command": "/absolute/path/to/canopi-provider-hook grok", "async": true, "timeout": 30 }] }],
+    "SubagentStop": [{ "hooks": [{ "type": "command", "command": "/absolute/path/to/canopi-provider-hook grok", "async": true, "timeout": 30 }] }],
+    "Stop": [{ "hooks": [{ "type": "command", "command": "/absolute/path/to/canopi-provider-hook grok", "async": true, "timeout": 30 }] }]
+  }
+}

--- a/canopi/providers/pi/canopi.ts
+++ b/canopi/providers/pi/canopi.ts
@@ -1,0 +1,87 @@
+// Canopi's Pi 0.84.3 extension. It retains no prompt, transcript, system
+// prompt, tool input, tool result, or assistant message: the only child input
+// is the normalized lifecycle event below.
+import { randomUUID } from "node:crypto";
+import { spawn } from "node:child_process";
+
+type CanopiState = "working" | "waiting_for_user" | "done";
+
+type CanopiEvent = {
+  spec_version: 1;
+  event_id: string;
+  source: "pi";
+  machine: { id: string; label: string };
+  session_id: string;
+  agent_instance_id: string;
+  state: CanopiState;
+  waiting_reason?: "other";
+  activity_at: string;
+  emitted_at: string;
+  task: { title: string; repository?: string };
+  metadata: { hook: string };
+};
+
+function configured(): boolean {
+  return Boolean(
+    process.env.CANOPI_ENDPOINT &&
+      process.env.CANOPI_TOKEN_FILE &&
+      process.env.CANOPI_MACHINE_ID &&
+      process.env.CANOPI_PROVIDER_HOOK,
+  );
+}
+
+function report(sessionID: string, hook: string, state: CanopiState): void {
+  if (!configured()) return;
+  const now = new Date().toISOString();
+  const machineID = process.env.CANOPI_MACHINE_ID!;
+  const title = process.env.CANOPI_TASK_TITLE || "Pi";
+  const repository = process.env.CANOPI_REPOSITORY;
+  const event: CanopiEvent = {
+    spec_version: 1,
+    event_id: `pi:${randomUUID()}`,
+    source: "pi",
+    machine: { id: machineID, label: process.env.CANOPI_MACHINE_LABEL || machineID },
+    session_id: sessionID,
+    agent_instance_id: sessionID,
+    state,
+    activity_at: now,
+    emitted_at: now,
+    task: repository ? { title, repository } : { title },
+    metadata: { hook },
+  };
+  if (state === "waiting_for_user") event.waiting_reason = "other";
+
+  // Pi awaits lifecycle handlers, so never await local queue publication here.
+  // The durable Canopi worker performs all network delivery after the child has
+  // recorded the normalized event in its protected local spool.
+  try {
+    const child = spawn(process.env.CANOPI_PROVIDER_HOOK!, ["pi", "emit"], {
+      detached: true,
+      stdio: ["pipe", "ignore", "ignore"],
+      windowsHide: true,
+    });
+    // A missing executable is reported asynchronously by Node; consume that
+    // failure so monitoring can never turn into an unhandled Pi extension
+    // error. The local supervisor will be retried on the next lifecycle edge.
+    child.on("error", () => {});
+    child.stdin?.end(JSON.stringify(event));
+    child.unref();
+  } catch {
+    // Extensions must not interfere with Pi when local monitoring fails.
+  }
+}
+
+export default function (pi: any): void {
+  pi.on("session_start", (_event: unknown, ctx: any) => {
+    report(ctx.sessionManager.getSessionId(), "session_start", "working");
+  });
+  pi.on("agent_start", (_event: unknown, ctx: any) => {
+    report(ctx.sessionManager.getSessionId(), "agent_start", "working");
+  });
+  pi.on("agent_settled", (_event: unknown, ctx: any) => {
+    report(ctx.sessionManager.getSessionId(), "agent_settled", "waiting_for_user");
+  });
+  pi.on("session_shutdown", (_event: unknown, ctx: any) => {
+    report(ctx.sessionManager.getSessionId(), "session_shutdown", "done");
+  });
+}

--- a/cmd/canopi-claude-hook/main_test.go
+++ b/cmd/canopi-claude-hook/main_test.go
@@ -161,7 +161,7 @@ func TestClaudeHookDeliversToCollectorAndRendersDashboard(t *testing.T) {
 	if len(store.Snapshot(time.Now()).Agents) != 1 {
 		t.Fatalf("collector agents = %d, want 1", len(store.Snapshot(time.Now()).Agents))
 	}
-	request, err := http.NewRequest(http.MethodGet, collector.URL+"/v1/render/800x480.png", nil)
+	request, err := http.NewRequestWithContext(t.Context(), http.MethodGet, collector.URL+"/v1/render/800x480.png", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -170,7 +170,7 @@ func TestClaudeHookDeliversToCollectorAndRendersDashboard(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer response.Body.Close()
+	defer func() { _ = response.Body.Close() }()
 	if response.StatusCode != http.StatusOK || response.Header.Get("Content-Type") != "image/png" {
 		t.Fatalf("render response = %d %q", response.StatusCode, response.Header.Get("Content-Type"))
 	}

--- a/cmd/canopi-claude-hook/main_test.go
+++ b/cmd/canopi-claude-hook/main_test.go
@@ -3,12 +3,16 @@ package main
 import (
 	"bytes"
 	"errors"
+	"image/png"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"testing"
 	"time"
 
 	"github.com/rock3r/punaro/canopi/protocol"
+	"github.com/rock3r/punaro/internal/canopi"
 	"github.com/rock3r/punaro/internal/canopiadapter"
 )
 
@@ -119,5 +123,62 @@ func TestHookUsesInvocationTimeBeforeInputProcessing(t *testing.T) {
 	}
 	if !event.ActivityAt.Equal(invokedAt.UTC()) || !event.EmittedAt.Equal(invokedAt.UTC()) {
 		t.Fatalf("event timestamps = %s/%s, want invocation time %s", event.ActivityAt, event.EmittedAt, invokedAt.UTC())
+	}
+}
+
+func TestClaudeHookDeliversToCollectorAndRendersDashboard(t *testing.T) {
+	store := canopi.NewStore(canopi.DefaultConfig())
+	handler, err := canopi.NewHandler(canopi.HandlerConfig{
+		Store:  store,
+		Token:  "test-token-123456",
+		Render: canopi.RenderConfig{Width: 800, Height: 480, Grid: canopi.GridConfig{Columns: 2, Rows: 6}, RelativeTimeBucket: time.Minute, Title: "CANOPI"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	collector := httptest.NewServer(handler)
+	t.Cleanup(collector.Close)
+	tokenPath := filepath.Join(t.TempDir(), "token")
+	if err := os.WriteFile(tokenPath, []byte("test-token-123456\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	environment := map[string]string{
+		"CANOPI_ENDPOINT":   collector.URL,
+		"CANOPI_TOKEN_FILE": tokenPath,
+		"CANOPI_MACHINE_ID": "studio-m2",
+		"CANOPI_SPOOL_DIR":  filepath.Join(t.TempDir(), "spool"),
+	}
+	if err := runPrepare(func(key string) string { return environment[key] }); err != nil {
+		t.Fatal(err)
+	}
+	raw := []byte(`{"session_id":"claude-session","cwd":"/src/punaro","hook_event_name":"PermissionRequest","tool_input":{"command":"private"}}`)
+	if err := runHookAt(bytes.NewReader(raw), func(key string) string { return environment[key] }, func() error { return nil }, time.Now()); err != nil {
+		t.Fatal(err)
+	}
+	if err := runDelivery(func(key string) string { return environment[key] }); err != nil {
+		t.Fatal(err)
+	}
+	if len(store.Snapshot(time.Now()).Agents) != 1 {
+		t.Fatalf("collector agents = %d, want 1", len(store.Snapshot(time.Now()).Agents))
+	}
+	request, err := http.NewRequest(http.MethodGet, collector.URL+"/v1/render/800x480.png", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	request.Header.Set("Authorization", "Bearer test-token-123456")
+	response, err := http.DefaultClient.Do(request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer response.Body.Close()
+	if response.StatusCode != http.StatusOK || response.Header.Get("Content-Type") != "image/png" {
+		t.Fatalf("render response = %d %q", response.StatusCode, response.Header.Get("Content-Type"))
+	}
+	config, err := png.DecodeConfig(response.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if config.Width != 800 || config.Height != 480 {
+		t.Fatalf("render dimensions = %dx%d, want 800x480", config.Width, config.Height)
 	}
 }

--- a/cmd/canopi-provider-hook/main.go
+++ b/cmd/canopi-provider-hook/main.go
@@ -174,7 +174,7 @@ func spawnDetached(selected provider) error {
 	if err != nil {
 		return err
 	}
-	command := exec.CommandContext(context.Background(), executable, string(selected), "supervise") // #nosec G204 -- the executable and provider values are fixed by this binary.
+	command := exec.CommandContext(context.Background(), executable, string(selected), "supervise") // #nosec G204,G702 -- the executable is this binary and the provider is validated by parseProvider.
 	command.Stdout = io.Discard
 	command.Stderr = io.Discard
 	if err := command.Start(); err != nil {
@@ -188,7 +188,7 @@ func relayHookDetached(selected provider) error {
 	if err != nil {
 		return err
 	}
-	command := exec.CommandContext(context.Background(), executable, string(selected), "hook") // #nosec G204 -- the executable and provider values are fixed by this binary.
+	command := exec.CommandContext(context.Background(), executable, string(selected), "hook") // #nosec G204,G702 -- the executable is this binary and the provider is validated by parseProvider.
 	command.Stdin = os.Stdin
 	command.Stdout = io.Discard
 	command.Stderr = io.Discard

--- a/cmd/canopi-provider-hook/main.go
+++ b/cmd/canopi-provider-hook/main.go
@@ -1,0 +1,254 @@
+// canopi-provider-hook is the shared durable local runner for Codex, Grok
+// Build, and Pi integrations. Provider-facing invocations only publish a
+// privacy-safe normalized event to a local spool; delivery happens later.
+package main
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/rock3r/punaro/canopi/protocol"
+	"github.com/rock3r/punaro/internal/canopiadapter"
+	"github.com/rock3r/punaro/internal/canopicredential"
+)
+
+const maxHookBytes = 1 << 20
+
+type provider string
+
+const (
+	providerCodex provider = "codex"
+	providerGrok  provider = "grok"
+	providerPi    provider = "pi"
+)
+
+func main() {
+	if len(os.Args) < 2 {
+		os.Exit(2)
+	}
+	selected, ok := parseProvider(os.Args[1])
+	if !ok {
+		os.Exit(2)
+	}
+	command := "hook"
+	if len(os.Args) == 3 {
+		command = os.Args[2]
+	}
+	switch command {
+	case "prepare":
+		if runPrepare(selected, os.Getenv) != nil {
+			os.Exit(1)
+		}
+	case "supervise":
+		_ = runSupervisor(selected, os.Getenv)
+	case "deliver":
+		_ = runDelivery(selected, os.Getenv)
+	case "emit":
+		if runEmit(selected, os.Stdin, os.Getenv, func() error { return spawnDetached(selected) }) != nil {
+			os.Exit(1)
+		}
+	case "relay":
+		// Codex 0.142.4 parses async hooks but reports that they are not yet
+		// supported. This synchronous parent only hands its stdin to a detached
+		// child and always returns; the child performs all parsing and spool I/O.
+		// A launch failure must never add a provider-visible failure or delay.
+		_ = relayHookDetached(selected)
+	case "hook":
+		if selected == providerPi || runHook(selected, os.Stdin, os.Getenv, func() error { return spawnDetached(selected) }) != nil {
+			os.Exit(1)
+		}
+	default:
+		os.Exit(2)
+	}
+}
+
+func parseProvider(value string) (provider, bool) {
+	switch provider(value) {
+	case providerCodex, providerGrok, providerPi:
+		return provider(value), true
+	default:
+		return "", false
+	}
+}
+
+func runPrepare(selected provider, getenv func(string) string) error {
+	spool, err := deliverySpool(selected, getenv)
+	if err != nil {
+		return err
+	}
+	return spool.Prepare()
+}
+
+func runHook(selected provider, input io.Reader, getenv func(string) string, spawn func() error) error {
+	return runHookAt(selected, input, getenv, spawn, time.Now())
+}
+
+func runHookAt(selected provider, input io.Reader, getenv func(string) string, spawn func() error, invokedAt time.Time) error {
+	if !configured(getenv) {
+		return nil
+	}
+	raw, err := readBounded(input)
+	if err != nil {
+		return err
+	}
+	config := canopiadapter.AdapterConfig{
+		MachineID:    getenv("CANOPI_MACHINE_ID"),
+		MachineLabel: getenv("CANOPI_MACHINE_LABEL"),
+		TaskTitle:    getenv("CANOPI_TASK_TITLE"),
+		Repository:   getenv("CANOPI_REPOSITORY"),
+	}
+	var event protocol.Event
+	var emit bool
+	switch selected {
+	case providerCodex:
+		event, emit, err = canopiadapter.MapCodexHook(raw, config, invokedAt)
+	case providerGrok:
+		event, emit, err = canopiadapter.MapGrokHook(raw, config, invokedAt)
+	default:
+		return errors.New("provider command hooks are unsupported for this provider")
+	}
+	if err != nil {
+		return err
+	}
+	if !emit {
+		return nil
+	}
+	return enqueueAndKick(selected, event, getenv, spawn)
+}
+
+func runEmit(selected provider, input io.Reader, getenv func(string) string, spawn func() error) error {
+	if !configured(getenv) {
+		return nil
+	}
+	raw, err := readBounded(input)
+	if err != nil {
+		return err
+	}
+	event, err := protocol.DecodeEvent(strings.NewReader(string(raw)), 64<<10)
+	if err != nil {
+		return err
+	}
+	if event.Source != sourceForProvider(selected) {
+		return errors.New("normalized event source does not match provider")
+	}
+	return enqueueAndKick(selected, event, getenv, spawn)
+}
+
+func readBounded(input io.Reader) ([]byte, error) {
+	raw, err := io.ReadAll(io.LimitReader(input, maxHookBytes+1))
+	if err != nil {
+		return nil, err
+	}
+	if len(raw) > maxHookBytes {
+		return nil, errors.New("provider hook payload exceeds Canopi limit")
+	}
+	return raw, nil
+}
+
+func configured(getenv func(string) string) bool {
+	return getenv("CANOPI_ENDPOINT") != "" && getenv("CANOPI_TOKEN_FILE") != "" && getenv("CANOPI_MACHINE_ID") != ""
+}
+
+func enqueueAndKick(selected provider, event protocol.Event, getenv func(string) string, spawn func() error) error {
+	spool, err := deliverySpool(selected, getenv)
+	if err != nil {
+		return err
+	}
+	if err := spool.Enqueue(event); err != nil {
+		_ = spawn()
+		return err
+	}
+	_ = spawn()
+	return nil
+}
+
+func spawnDetached(selected provider) error {
+	executable, err := os.Executable()
+	if err != nil {
+		return err
+	}
+	command := exec.CommandContext(context.Background(), executable, string(selected), "supervise") // #nosec G204 -- the executable and provider values are fixed by this binary.
+	command.Stdout = io.Discard
+	command.Stderr = io.Discard
+	if err := command.Start(); err != nil {
+		return err
+	}
+	return command.Process.Release()
+}
+
+func relayHookDetached(selected provider) error {
+	executable, err := os.Executable()
+	if err != nil {
+		return err
+	}
+	command := exec.CommandContext(context.Background(), executable, string(selected), "hook") // #nosec G204 -- the executable and provider values are fixed by this binary.
+	command.Stdin = os.Stdin
+	command.Stdout = io.Discard
+	command.Stderr = io.Discard
+	if err := command.Start(); err != nil {
+		return err
+	}
+	return command.Process.Release()
+}
+
+func runDelivery(selected provider, getenv func(string) string) error {
+	spool, err := deliverySpool(selected, getenv)
+	if err != nil {
+		return err
+	}
+	token, err := canopicredential.ReadToken(getenv("CANOPI_TOKEN_FILE"))
+	if err != nil {
+		return err
+	}
+	client := &http.Client{Timeout: 750 * time.Millisecond}
+	return spool.Drain(context.Background(), func(ctx context.Context, event protocol.Event) error {
+		return canopiadapter.Deliver(ctx, client, getenv("CANOPI_ENDPOINT"), token, event)
+	})
+}
+
+func runSupervisor(selected provider, getenv func(string) string) error {
+	spool, err := deliverySpool(selected, getenv)
+	if err != nil {
+		return err
+	}
+	token, err := canopicredential.ReadToken(getenv("CANOPI_TOKEN_FILE"))
+	if err != nil {
+		return err
+	}
+	client := &http.Client{Timeout: 750 * time.Millisecond}
+	return spool.Serve(context.Background(), func(ctx context.Context, event protocol.Event) error {
+		return canopiadapter.Deliver(ctx, client, getenv("CANOPI_ENDPOINT"), token, event)
+	})
+}
+
+func deliverySpool(selected provider, getenv func(string) string) (canopiadapter.Spool, error) {
+	directory := strings.TrimSpace(getenv("CANOPI_SPOOL_DIR"))
+	if directory == "" {
+		tokenFile := strings.TrimSpace(getenv("CANOPI_TOKEN_FILE"))
+		if !filepath.IsAbs(tokenFile) {
+			return canopiadapter.Spool{}, os.ErrInvalid
+		}
+		directory = filepath.Join(filepath.Dir(tokenFile), "canopi-"+string(selected)+"-spool")
+	}
+	return canopiadapter.Spool{Directory: directory}, nil
+}
+
+func sourceForProvider(selected provider) protocol.Source {
+	switch selected {
+	case providerCodex:
+		return protocol.SourceCodex
+	case providerGrok:
+		return protocol.SourceGrokBuild
+	case providerPi:
+		return protocol.SourcePi
+	default:
+		return protocol.SourceOther
+	}
+}

--- a/cmd/canopi-provider-hook/main_test.go
+++ b/cmd/canopi-provider-hook/main_test.go
@@ -1,0 +1,413 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"image/png"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/rock3r/punaro/canopi/protocol"
+	"github.com/rock3r/punaro/internal/canopi"
+	"github.com/rock3r/punaro/internal/canopiadapter"
+)
+
+func TestProviderHookQueuesCodexAndGrokWithoutForwardingProviderContent(t *testing.T) {
+	for _, fixture := range []struct {
+		name     string
+		provider provider
+		raw      string
+		want     protocol.Source
+	}{
+		{name: "Codex", provider: providerCodex, raw: `{"session_id":"thread-1","cwd":"/src/punaro","hook_event_name":"PermissionRequest","tool_input":{"command":"private command"}}`, want: protocol.SourceCodex},
+		{name: "Grok", provider: providerGrok, raw: `{"sessionId":"thread-1","cwd":"/src/punaro","hookEventName":"Notification","notificationType":"idle_prompt","lastAssistantMessage":"private answer"}`, want: protocol.SourceGrokBuild},
+	} {
+		t.Run(fixture.name, func(t *testing.T) {
+			environment := testProviderEnvironment(t)
+			if err := runPrepare(fixture.provider, func(key string) string { return environment[key] }); err != nil {
+				t.Fatal(err)
+			}
+			if err := runHookAt(fixture.provider, bytes.NewBufferString(fixture.raw), func(key string) string { return environment[key] }, func() error { return nil }, time.Now()); err != nil {
+				t.Fatal(err)
+			}
+			spool := canopiadapter.Spool{Directory: environment["CANOPI_SPOOL_DIR"]}
+			var events []protocol.Event
+			if err := spool.Drain(t.Context(), func(_ context.Context, event protocol.Event) error {
+				events = append(events, event)
+				return nil
+			}); err != nil {
+				t.Fatal(err)
+			}
+			if len(events) != 1 || events[0].Source != fixture.want {
+				t.Fatalf("events = %+v", events)
+			}
+		})
+	}
+}
+
+func TestProviderHookQueuesNormalizedPiExtensionEvent(t *testing.T) {
+	environment := testProviderEnvironment(t)
+	if err := runPrepare(providerPi, func(key string) string { return environment[key] }); err != nil {
+		t.Fatal(err)
+	}
+	event, err := canopiadapter.MapPiLifecycle("pi-session-1", "agent_start", protocol.StateWorking, "", canopiadapter.AdapterConfig{MachineID: "studio-m2", TaskTitle: "Punaro / tests"}, time.Now())
+	if err != nil {
+		t.Fatal(err)
+	}
+	payload, err := json.Marshal(event)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := runEmit(providerPi, bytes.NewReader(payload), func(key string) string { return environment[key] }, func() error { return nil }); err != nil {
+		t.Fatal(err)
+	}
+	spool := canopiadapter.Spool{Directory: environment["CANOPI_SPOOL_DIR"]}
+	if got, err := spool.Pending(); err != nil || got != 1 {
+		t.Fatalf("pending events = %d, %v", got, err)
+	}
+}
+
+func TestProviderHookExamplesArePrivacySafeAndMapToSupportedLifecycles(t *testing.T) {
+	for _, fixture := range []struct {
+		name     string
+		path     string
+		provider provider
+		events   []string
+	}{
+		{name: "Codex", path: filepath.Join("..", "..", "canopi", "providers", "codex-hooks.example.json"), provider: providerCodex, events: []string{"SessionStart", "UserPromptSubmit", "PreToolUse", "PostToolUse", "PermissionRequest", "SubagentStart", "SubagentStop", "Stop"}},
+		{name: "Grok Build", path: filepath.Join("..", "..", "canopi", "providers", "grok-build-hooks.example.json"), provider: providerGrok, events: []string{"SessionStart", "UserPromptSubmit", "PreToolUse", "PostToolUse", "Notification", "SubagentStart", "SubagentStop", "Stop"}},
+	} {
+		t.Run(fixture.name, func(t *testing.T) {
+			payload, err := os.ReadFile(fixture.path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if strings.Contains(string(payload), "tool_input") || strings.Contains(string(payload), "transcript") {
+				t.Fatal("example config interpolates private provider content")
+			}
+			var parsed struct {
+				Hooks map[string]json.RawMessage `json:"hooks"`
+			}
+			if err := json.Unmarshal(payload, &parsed); err != nil {
+				t.Fatal(err)
+			}
+			for _, event := range fixture.events {
+				if _, ok := parsed.Hooks[event]; !ok {
+					t.Fatalf("missing lifecycle hook %q", event)
+				}
+			}
+		})
+	}
+}
+
+func TestCodexHookExampleLoadsInInstalledCodex(t *testing.T) {
+	codexPath, err := exec.LookPath("codex")
+	if err != nil {
+		t.Skip("Codex CLI is not installed on this test host")
+	}
+	project := t.TempDir()
+	if err := os.Mkdir(filepath.Join(project, ".git"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(filepath.Join(project, ".codex"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	payload, err := os.ReadFile(filepath.Join("..", "..", "canopi", "providers", "codex-hooks.example.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(project, ".codex", "hooks.json"), payload, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	codexHome := t.TempDir()
+	if err := os.WriteFile(filepath.Join(codexHome, "hooks.json"), payload, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	context, cancel := context.WithTimeout(t.Context(), 15*time.Second)
+	defer cancel()
+	command := exec.CommandContext(context, codexPath, "app-server", "--enable", "hooks", "--stdio") // #nosec G204 -- the resolved installed Codex path is a host contract test input.
+	command.Dir = project
+	command.Env = append(os.Environ(), "CODEX_HOME="+codexHome)
+	stdin, err := command.StdinPipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	stdout, err := command.StdoutPipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	var stderr bytes.Buffer
+	command.Stderr = &stderr
+	if err := command.Start(); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		_ = stdin.Close()
+		_ = command.Process.Kill()
+		_ = command.Wait()
+	})
+	encoder := json.NewEncoder(stdin)
+	if err := encoder.Encode(map[string]any{"id": 1, "method": "initialize", "params": map[string]any{"clientInfo": map[string]string{"name": "canopi-contract-test", "version": "1"}, "capabilities": map[string]any{"experimentalApi": true}}}); err != nil {
+		t.Fatal(err)
+	}
+	scanner := bufio.NewScanner(stdout)
+	if _, err := waitForJSONRPCResponse(scanner, 1); err != nil {
+		t.Fatalf("initialize Codex app server: %v; stderr=%s", err, stderr.String())
+	}
+	if err := encoder.Encode(map[string]any{"id": 2, "method": "hooks/list", "params": map[string]any{"cwds": []string{project}}}); err != nil {
+		t.Fatal(err)
+	}
+	response, err := waitForJSONRPCResponse(scanner, 2)
+	if err != nil {
+		t.Fatalf("list Codex hooks: %v; stderr=%s", err, stderr.String())
+	}
+	result, _ := response["result"].(map[string]any)
+	data, _ := result["data"].([]any)
+	if len(data) != 1 {
+		t.Fatalf("Codex hook data = %#v", result["data"])
+	}
+	entry, _ := data[0].(map[string]any)
+	if errors, _ := entry["errors"].([]any); len(errors) != 0 {
+		t.Fatalf("Codex rejected example hooks: %#v", errors)
+	}
+	hooks, _ := entry["hooks"].([]any)
+	if len(hooks) != 8 {
+		t.Fatalf("Codex loaded %d hooks, want 8: %#v; result=%#v", len(hooks), hooks, result)
+	}
+}
+
+func TestGrokBuildHookExampleLoadsInInstalledInspector(t *testing.T) {
+	grokPath, err := exec.LookPath("grok")
+	if err != nil {
+		t.Skip("Grok Build CLI is not installed on this test host")
+	}
+	gitPath, err := exec.LookPath("git")
+	if err != nil {
+		t.Skip("git is not installed on this test host")
+	}
+	project := t.TempDir()
+	if output, err := exec.Command(gitPath, "init", "--quiet", project).CombinedOutput(); err != nil { // #nosec G204 -- fixed local git initialization in a temporary contract-test project.
+		t.Fatalf("initialize temporary Grok Build project: %v: %s", err, output)
+	}
+	payload, err := os.ReadFile(filepath.Join("..", "..", "canopi", "providers", "grok-build-hooks.example.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	home := t.TempDir()
+	hooksDirectory := filepath.Join(home, ".grok", "hooks")
+	if err := os.MkdirAll(hooksDirectory, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(hooksDirectory, "canopi.json"), payload, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	context, cancel := context.WithTimeout(t.Context(), 15*time.Second)
+	defer cancel()
+	command := exec.CommandContext(context, grokPath, "inspect", "--json") // #nosec G204 -- the resolved installed Grok Build path is a host contract test input.
+	command.Dir = project
+	command.Env = append(os.Environ(), "HOME="+home, "GROK_HOME="+filepath.Join(home, ".grok"))
+	output, err := command.Output()
+	if err != nil {
+		t.Fatalf("Grok Build inspect: %v", err)
+	}
+	var inspected struct {
+		Hooks []any `json:"hooks"`
+	}
+	if err := json.Unmarshal(output, &inspected); err != nil {
+		t.Fatalf("decode Grok Build inspect output: %v", err)
+	}
+	if len(inspected.Hooks) != 8 {
+		t.Fatalf("Grok Build loaded %d hooks, want 8: %s", len(inspected.Hooks), output)
+	}
+}
+
+func TestPiExtensionEmitsSessionStartToCollector(t *testing.T) {
+	piPath, err := exec.LookPath("pi")
+	if err != nil {
+		t.Skip("Pi is not installed on this test host")
+	}
+	goPath, err := exec.LookPath("go")
+	if err != nil {
+		t.Skip("Go is not installed on this test host")
+	}
+	root, err := filepath.Abs(filepath.Join("..", ".."))
+	if err != nil {
+		t.Fatal(err)
+	}
+	collector, store := testCollector(t)
+	outputPath := filepath.Join(t.TempDir(), "canopi-provider-hook")
+	buildContext, cancelBuild := context.WithTimeout(t.Context(), 30*time.Second)
+	defer cancelBuild()
+	build := exec.CommandContext(buildContext, goPath, "build", "-trimpath", "-o", outputPath, "./cmd/canopi-provider-hook") // #nosec G204 -- fixed local build inputs for the Pi host contract test.
+	build.Dir = root
+	if output, err := build.CombinedOutput(); err != nil {
+		t.Fatalf("build Pi provider runner: %v: %s", err, output)
+	}
+	tokenPath := filepath.Join(t.TempDir(), "token")
+	if err := os.WriteFile(tokenPath, []byte("test-token-123456\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	environment := append(os.Environ(),
+		"CANOPI_ENDPOINT="+collector.URL,
+		"CANOPI_TOKEN_FILE="+tokenPath,
+		"CANOPI_MACHINE_ID=pi-contract-test",
+		"CANOPI_SPOOL_DIR="+filepath.Join(t.TempDir(), "spool"),
+		"CANOPI_PROVIDER_HOOK="+outputPath,
+		"PI_CODING_AGENT_DIR="+t.TempDir(),
+	)
+	prepare := exec.Command(outputPath, "pi", "prepare") // #nosec G204 -- fixed provider runner built above.
+	prepare.Env = environment
+	if output, err := prepare.CombinedOutput(); err != nil {
+		t.Fatalf("prepare Pi spool: %v: %s", err, output)
+	}
+	extensionPath := filepath.Join(root, "canopi", "providers", "pi", "canopi.ts")
+	piContext, cancelPi := context.WithTimeout(t.Context(), 12*time.Second)
+	defer cancelPi()
+	pi := exec.CommandContext(piContext, piPath, "--offline", "--no-session", "--mode", "rpc", "--extension", extensionPath) // #nosec G204 -- fixed installed Pi path and repository extension path in a host contract test.
+	pi.Dir = root
+	pi.Env = environment
+	var stdout, stderr bytes.Buffer
+	pi.Stdout = &stdout
+	pi.Stderr = &stderr
+	if err := pi.Start(); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		_ = pi.Process.Kill()
+		_ = pi.Wait()
+	})
+	deadline := time.NewTimer(5 * time.Second)
+	defer deadline.Stop()
+	tick := time.NewTicker(25 * time.Millisecond)
+	defer tick.Stop()
+	for {
+		if agents := store.Snapshot(time.Now()).Agents; len(agents) == 1 {
+			if agents[0].Source != protocol.SourcePi || agents[0].State != protocol.StateWorking {
+				t.Fatalf("Pi collector state = %+v", agents[0])
+			}
+			return
+		}
+		select {
+		case <-deadline.C:
+			t.Fatalf("Pi extension did not reach collector; stdout=%s stderr=%s", stdout.String(), stderr.String())
+		case <-tick.C:
+		}
+	}
+}
+
+func waitForJSONRPCResponse(scanner *bufio.Scanner, id int) (map[string]any, error) {
+	for scanner.Scan() {
+		var message map[string]any
+		if err := json.Unmarshal(scanner.Bytes(), &message); err != nil {
+			continue
+		}
+		if messageID, ok := message["id"].(float64); ok && int(messageID) == id {
+			return message, nil
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+	return nil, errors.New("Codex app server closed before its response")
+}
+
+func TestProvidersDeliverARealLifecycleToCollectorAndRender(t *testing.T) {
+	collector, store := testCollector(t)
+	for _, fixture := range []struct {
+		name     string
+		provider provider
+		raw      string
+		emit     bool
+	}{
+		{name: "Codex", provider: providerCodex, raw: `{"session_id":"codex-session","cwd":"/src/punaro","hook_event_name":"PermissionRequest","tool_input":{"command":"private"}}`},
+		{name: "Grok", provider: providerGrok, raw: `{"sessionId":"grok-session","cwd":"/src/punaro","hookEventName":"Notification","notificationType":"idle_prompt","lastAssistantMessage":"private"}`},
+		{name: "Pi", provider: providerPi, emit: true},
+	} {
+		t.Run(fixture.name, func(t *testing.T) {
+			environment := testProviderEnvironment(t)
+			environment["CANOPI_ENDPOINT"] = collector.URL
+			if err := os.WriteFile(environment["CANOPI_TOKEN_FILE"], []byte("test-token-123456\n"), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			if err := runPrepare(fixture.provider, func(key string) string { return environment[key] }); err != nil {
+				t.Fatal(err)
+			}
+			if fixture.emit {
+				event, err := canopiadapter.MapPiLifecycle("pi-session", "agent_settled", protocol.StateWaitingForUser, protocol.WaitingReasonOther, canopiadapter.AdapterConfig{MachineID: "studio-m2"}, time.Now())
+				if err != nil {
+					t.Fatal(err)
+				}
+				payload, err := json.Marshal(event)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if err := runEmit(fixture.provider, bytes.NewReader(payload), func(key string) string { return environment[key] }, func() error { return nil }); err != nil {
+					t.Fatal(err)
+				}
+			} else if err := runHookAt(fixture.provider, bytes.NewBufferString(fixture.raw), func(key string) string { return environment[key] }, func() error { return nil }, time.Now()); err != nil {
+				t.Fatal(err)
+			}
+			if err := runDelivery(fixture.provider, func(key string) string { return environment[key] }); err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+	if len(store.Snapshot(time.Now()).Agents) != 3 {
+		t.Fatalf("collector agents = %d, want 3", len(store.Snapshot(time.Now()).Agents))
+	}
+	request, err := http.NewRequest(http.MethodGet, collector.URL+"/v1/render/800x480.png", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	request.Header.Set("Authorization", "Bearer test-token-123456")
+	response, err := http.DefaultClient.Do(request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer response.Body.Close()
+	if response.StatusCode != http.StatusOK || response.Header.Get("Content-Type") != "image/png" {
+		t.Fatalf("render response = %d %q", response.StatusCode, response.Header.Get("Content-Type"))
+	}
+	config, err := png.DecodeConfig(response.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if config.Width != 800 || config.Height != 480 {
+		t.Fatalf("render dimensions = %dx%d, want 800x480", config.Width, config.Height)
+	}
+}
+
+func testCollector(t *testing.T) (*httptest.Server, *canopi.Store) {
+	t.Helper()
+	store := canopi.NewStore(canopi.DefaultConfig())
+	handler, err := canopi.NewHandler(canopi.HandlerConfig{
+		Store:  store,
+		Token:  "test-token-123456",
+		Render: canopi.RenderConfig{Width: 800, Height: 480, Grid: canopi.GridConfig{Columns: 2, Rows: 6}, RelativeTimeBucket: time.Minute, Title: "CANOPI"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+	return server, store
+}
+
+func testProviderEnvironment(t *testing.T) map[string]string {
+	t.Helper()
+	return map[string]string{
+		"CANOPI_ENDPOINT":   "http://canopi.test",
+		"CANOPI_TOKEN_FILE": filepath.Join(t.TempDir(), "token"),
+		"CANOPI_MACHINE_ID": "studio-m2",
+		"CANOPI_SPOOL_DIR":  filepath.Join(t.TempDir(), "spool"),
+	}
+}

--- a/cmd/canopi-provider-hook/main_test.go
+++ b/cmd/canopi-provider-hook/main_test.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"image/png"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -125,11 +126,11 @@ func TestCodexHookExampleLoadsInInstalledCodex(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(filepath.Join(project, ".codex", "hooks.json"), payload, 0o600); err != nil {
+	if err := os.WriteFile(filepath.Join(project, ".codex", "hooks.json"), payload, 0o600); err != nil { // #nosec G703 -- project is created by this test with t.TempDir.
 		t.Fatal(err)
 	}
 	codexHome := t.TempDir()
-	if err := os.WriteFile(filepath.Join(codexHome, "hooks.json"), payload, 0o600); err != nil {
+	if err := os.WriteFile(filepath.Join(codexHome, "hooks.json"), payload, 0o600); err != nil { // #nosec G703 -- codexHome is created by this test with t.TempDir.
 		t.Fatal(err)
 	}
 	context, cancel := context.WithTimeout(t.Context(), 15*time.Second)
@@ -195,7 +196,7 @@ func TestGrokBuildHookExampleLoadsInInstalledInspector(t *testing.T) {
 		t.Skip("git is not installed on this test host")
 	}
 	project := t.TempDir()
-	if output, err := exec.Command(gitPath, "init", "--quiet", project).CombinedOutput(); err != nil { // #nosec G204 -- fixed local git initialization in a temporary contract-test project.
+	if output, err := exec.CommandContext(t.Context(), gitPath, "init", "--quiet", project).CombinedOutput(); err != nil { // #nosec G204 -- fixed local git initialization in a temporary contract-test project.
 		t.Fatalf("initialize temporary Grok Build project: %v: %s", err, output)
 	}
 	payload, err := os.ReadFile(filepath.Join("..", "..", "canopi", "providers", "grok-build-hooks.example.json"))
@@ -207,7 +208,7 @@ func TestGrokBuildHookExampleLoadsInInstalledInspector(t *testing.T) {
 	if err := os.MkdirAll(hooksDirectory, 0o700); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(filepath.Join(hooksDirectory, "canopi.json"), payload, 0o600); err != nil {
+	if err := os.WriteFile(filepath.Join(hooksDirectory, "canopi.json"), payload, 0o600); err != nil { // #nosec G703 -- hooksDirectory is created by this test with t.TempDir.
 		t.Fatal(err)
 	}
 	context, cancel := context.WithTimeout(t.Context(), 15*time.Second)
@@ -243,7 +244,7 @@ func TestPiExtensionEmitsSessionStartToCollector(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	collector, store := testCollector(t)
+	collector, _, observed := testCollectorWithEvents(t)
 	outputPath := filepath.Join(t.TempDir(), "canopi-provider-hook")
 	buildContext, cancelBuild := context.WithTimeout(t.Context(), 30*time.Second)
 	defer cancelBuild()
@@ -264,7 +265,7 @@ func TestPiExtensionEmitsSessionStartToCollector(t *testing.T) {
 		"CANOPI_PROVIDER_HOOK="+outputPath,
 		"PI_CODING_AGENT_DIR="+t.TempDir(),
 	)
-	prepare := exec.Command(outputPath, "pi", "prepare") // #nosec G204 -- fixed provider runner built above.
+	prepare := exec.CommandContext(t.Context(), outputPath, "pi", "prepare") // #nosec G204 -- fixed provider runner built above.
 	prepare.Env = environment
 	if output, err := prepare.CombinedOutput(); err != nil {
 		t.Fatalf("prepare Pi spool: %v: %s", err, output)
@@ -290,13 +291,11 @@ func TestPiExtensionEmitsSessionStartToCollector(t *testing.T) {
 	tick := time.NewTicker(25 * time.Millisecond)
 	defer tick.Stop()
 	for {
-		if agents := store.Snapshot(time.Now()).Agents; len(agents) == 1 {
-			if agents[0].Source != protocol.SourcePi || agents[0].State != protocol.StateWorking {
-				t.Fatalf("Pi collector state = %+v", agents[0])
-			}
-			return
-		}
 		select {
+		case event := <-observed:
+			if event.Source == protocol.SourcePi && event.Metadata["hook"] == "session_start" && event.State == protocol.StateWorking {
+				return
+			}
 		case <-deadline.C:
 			t.Fatalf("Pi extension did not reach collector; stdout=%s stderr=%s", stdout.String(), stderr.String())
 		case <-tick.C:
@@ -364,7 +363,7 @@ func TestProvidersDeliverARealLifecycleToCollectorAndRender(t *testing.T) {
 	if len(store.Snapshot(time.Now()).Agents) != 3 {
 		t.Fatalf("collector agents = %d, want 3", len(store.Snapshot(time.Now()).Agents))
 	}
-	request, err := http.NewRequest(http.MethodGet, collector.URL+"/v1/render/800x480.png", nil)
+	request, err := http.NewRequestWithContext(t.Context(), http.MethodGet, collector.URL+"/v1/render/800x480.png", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -373,7 +372,7 @@ func TestProvidersDeliverARealLifecycleToCollectorAndRender(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer response.Body.Close()
+	defer func() { _ = response.Body.Close() }()
 	if response.StatusCode != http.StatusOK || response.Header.Get("Content-Type") != "image/png" {
 		t.Fatalf("render response = %d %q", response.StatusCode, response.Header.Get("Content-Type"))
 	}
@@ -388,6 +387,12 @@ func TestProvidersDeliverARealLifecycleToCollectorAndRender(t *testing.T) {
 
 func testCollector(t *testing.T) (*httptest.Server, *canopi.Store) {
 	t.Helper()
+	server, store, _ := testCollectorWithEvents(t)
+	return server, store
+}
+
+func testCollectorWithEvents(t *testing.T) (*httptest.Server, *canopi.Store, <-chan protocol.Event) {
+	t.Helper()
 	store := canopi.NewStore(canopi.DefaultConfig())
 	handler, err := canopi.NewHandler(canopi.HandlerConfig{
 		Store:  store,
@@ -397,9 +402,25 @@ func testCollector(t *testing.T) (*httptest.Server, *canopi.Store) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	server := httptest.NewServer(handler)
+	observed := make(chan protocol.Event, 16)
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		if request.Method == http.MethodPost && request.URL.Path == "/v1/events" {
+			payload, readErr := io.ReadAll(request.Body)
+			if readErr == nil {
+				var event protocol.Event
+				if json.Unmarshal(payload, &event) == nil {
+					select {
+					case observed <- event:
+					default:
+					}
+				}
+				request.Body = io.NopCloser(bytes.NewReader(payload))
+			}
+		}
+		handler.ServeHTTP(writer, request)
+	}))
 	t.Cleanup(server.Close)
-	return server, store
+	return server, store, observed
 }
 
 func testProviderEnvironment(t *testing.T) map[string]string {

--- a/docs/canopi.md
+++ b/docs/canopi.md
@@ -35,7 +35,8 @@ provider command hook -> bounded recoverable local spool -> detached retry worke
 
 - `canopi/protocol` is the versioned transport-neutral contract.
 - `cmd/canopi` is the collector, durable current-state store and renderer host.
-- `cmd/canopi-claude-hook` is the first real provider adapter.
+- `cmd/canopi-claude-hook` and `cmd/canopi-provider-hook` are durable local
+  provider adapters. The latter supports Codex, Grok Build, and Pi.
 - `cmd/canopi-sim` emits 19 realistic agents across three machines and moves
   one agent between working and permission-waiting with current activity times
   on successive ticks. Each process run scopes its event IDs independently.
@@ -73,8 +74,8 @@ optional repository, stable IDs, state, timestamps, and primitive allowlisted
 metadata leave the machine. Metadata may be omitted, while explicit JSON `null`
 is rejected to match the schema's object contract.
 
-The hook-facing Claude process performs no network I/O. It normalizes raw input
-only in memory and writes only the privacy-safe event to the local spool. The
+Provider-facing processes perform no network I/O. They normalize raw input only
+in memory and write only the privacy-safe event to the local spool. The
 complete event inode is hard-linked into its final queue name before any
 uncancellable file or directory sync begins. If Claude terminates a hook while
 sync is stalled, or the detached supervisor cannot be launched, that published
@@ -339,25 +340,99 @@ supervisor is the durable wake path: it keeps polling an empty spool, retries
 collector outages, and is restarted by the service manager if the worker
 crashes, so the final event of a quiet session does not depend on a later hook.
 
-## Pi evaluation
+## Codex, Grok Build, and Pi adapters
 
-Pi 0.84.2 type definitions were inspected directly rather than copied from the
-handoff. They expose `session_shutdown`, `agent_start`,
-`agent_end`, `agent_settled`, `turn_start`, `turn_end`, `tool_call`,
-`tool_result`, and tool-execution events.
+All four provider adapters use the same transport-neutral normalized event and
+the same owner-only local spool. They never pass prompts, transcripts, tool
+arguments, tool results, or assistant text to the collector. The provider
+process returns before any network delivery; the continuously supervised worker
+handles retries independently.
 
-`hsingjui/pi-hooks` was reviewed at commit
-`8250a856d4f892f0a8a640ac2f1241d1a000701b` (package version 0.0.1). It is a
-good reuse path for this MVP's `SessionStart`, `UserPromptSubmit`, tool, `Stop`,
-and `SessionEnd` command hooks, and its `Stop` payload includes
-`last_assistant_message`. It does not map Pi permission UI or notification
-events, supports command hooks only, and implements stop control best-effort.
-Therefore the next Pi slice should pin that reviewed commit for working/done
-reuse, then add a very small native Pi extension only if accurate
-waiting-for-user signals are required. Do not fork a full bespoke hook bridge.
+Build the shared runner and set the same non-secret environment in the shell or
+service that starts the coding agent:
 
-The protocol already reserves `pi`, `codex`, and `grok_build` sources, so those
-adapters need no collector changes.
+```sh
+go build -trimpath -o /absolute/bin/canopi-provider-hook ./cmd/canopi-provider-hook
+export CANOPI_ENDPOINT=https://canopi.example.internal:8443
+export CANOPI_TOKEN_FILE=/absolute/private/canopi.token
+export CANOPI_MACHINE_ID=studio-m2
+export CANOPI_MACHINE_LABEL=studio-m2
+export CANOPI_TASK_TITLE='Punaro / current task'
+export CANOPI_REPOSITORY='rock3r/punaro'
+```
+
+`CANOPI_SPOOL_DIR` is optional; if absent, each provider receives a distinct
+spool beside the token file. Run `prepare` once and keep the matching
+`supervise` command under the host service manager before enabling hooks:
+
+```sh
+/absolute/bin/canopi-provider-hook codex prepare
+/absolute/bin/canopi-provider-hook codex supervise
+```
+
+Use `grok` or `pi` in place of `codex` for their independent spool workers.
+The examples contain no secrets and use placeholder binary paths.
+
+### Codex / ChatGPT
+
+The Codex mapping was exercised against the installed Codex CLI 0.142.4 and
+its generated app-server schema. Copy
+`canopi/providers/codex-hooks.example.json` to
+`<repo>/.codex/hooks.json`, replace the absolute runner path, and inspect/trust
+the new hook definitions using Codex's `/hooks` UI before they run. This keeps
+the integration local to a repository rather than turning it on for every
+Codex project.
+
+That installed version parses `async` but explicitly skips async command hooks
+as unsupported. The committed example therefore uses a one-second synchronous
+relay command. It does only `fork/exec` and hands stdin to a detached child;
+the child performs parsing and queueing. Consequently unsupported `async`
+cannot silently disable reporting, and collector outages never hold up Codex.
+The current schema supports the eight configured events: session and prompt
+start, pre/post tool use, permission requests, subagent start/stop, and stop.
+
+### Grok Build
+
+The Grok Build adapter was exercised against the installed 1.0.5 inspector.
+Put `canopi/providers/grok-build-hooks.example.json` in an always-trusted
+global location such as `~/.grok/hooks/canopi.json`, replace the runner path,
+then confirm `grok inspect --json` reports eight hooks. A project-local
+`.grok/hooks/` copy also works only after explicitly trusting that project.
+
+Grok Build 1.0.5 currently loads the example's session, prompt, tool,
+notification, subagent, and stop events; it does not load a `PermissionRequest`
+entry. `Notification` with its supported `idle_prompt` / permission
+notification types supplies the waiting state. The mapper reads only its
+camel-case lifecycle identity fields (`sessionId`, `cwd`, event and optional
+agent type), never message content.
+
+### Pi
+
+Pi 0.84.3's installed TypeScript definitions were inspected directly. Its
+native extension lifecycle exposes `session_start`, `agent_start`,
+`agent_settled`, and `session_shutdown`; `agent_settled` means Pi has no
+automatic retry, compaction, or queued continuation left. Copy
+`canopi/providers/pi/canopi.ts` to Pi's trusted global extension directory
+(`~/.pi/agent/extensions/canopi.ts`) or load that file explicitly with
+`pi --extension /absolute/path/to/canopi.ts`. Also set:
+
+```sh
+export CANOPI_PROVIDER_HOOK=/absolute/bin/canopi-provider-hook
+```
+
+The extension sends only an already-normalized Pi event to
+`canopi-provider-hook pi emit` through a detached local child. Pi awaits
+extension callbacks, so child errors are consumed and monitoring cannot block
+or slow the agent. The end-to-end test starts the installed Pi offline with
+this extension and verifies its `session_start` event reaches the collector and
+renders at 800x480 without making a model call.
+
+`hsingjui/pi-hooks` was evaluated at commit
+`8250a856d4f892f0a8a640ac2f1241d1a000701b` (version 0.0.1). It is useful for
+general command hooks, but its working/done focus and `Stop` payload include
+`last_assistant_message`; it does not provide Pi's current settled lifecycle
+as a privacy-minimal normalized event. Canopi therefore uses the much smaller
+native extension above rather than forking that package.
 
 ## Panel firmware and exact hardware verification
 

--- a/internal/canopiadapter/claude.go
+++ b/internal/canopiadapter/claude.go
@@ -103,11 +103,15 @@ func MapClaudeHook(raw []byte, config AdapterConfig, now time.Time) (protocol.Ev
 }
 
 func newClaudeEventID() (string, error) {
+	return newProviderEventID(protocol.SourceClaudeCode)
+}
+
+func newProviderEventID(source protocol.Source) (string, error) {
 	var random [32]byte
 	if _, err := rand.Read(random[:]); err != nil {
-		return "", fmt.Errorf("generate Claude event ID: %w", err)
+		return "", fmt.Errorf("generate %s event ID: %w", source, err)
 	}
-	return "claude_code:" + hex.EncodeToString(random[:]), nil
+	return string(source) + ":" + hex.EncodeToString(random[:]), nil
 }
 
 func truncateRunes(value string, maximum int) string {

--- a/internal/canopiadapter/claude_test.go
+++ b/internal/canopiadapter/claude_test.go
@@ -199,3 +199,45 @@ func TestMapClaudeSubagentIncludesPrivacySafeAgentType(t *testing.T) {
 		t.Fatalf("subagent metadata/parent = %#v/%q", event.Metadata, event.ParentAgentInstanceID)
 	}
 }
+
+func TestMapCodexHookUsesItsCurrentClaudeCompatibleHookEnvelope(t *testing.T) {
+	raw := []byte(`{"session_id":"thread-1","cwd":"/src/punaro","hook_event_name":"PermissionRequest","tool_input":{"command":"private command"},"transcript_path":"/private/thread.jsonl"}`)
+	event, emit, err := MapCodexHook(raw, AdapterConfig{MachineID: "studio-m2", TaskTitle: "Punaro / tests"}, time.Now())
+	if err != nil || !emit {
+		t.Fatalf("MapCodexHook() = %+v, %t, %v", event, emit, err)
+	}
+	if event.Source != protocol.SourceCodex || event.State != protocol.StateWaitingForUser || event.WaitingReason != protocol.WaitingReasonPermission {
+		t.Fatalf("event = %+v", event)
+	}
+	encoded, _ := json.Marshal(event)
+	for _, private := range []string{"private command", "thread.jsonl", "tool_input"} {
+		if strings.Contains(string(encoded), private) {
+			t.Fatalf("normalized Codex event leaked %q: %s", private, encoded)
+		}
+	}
+}
+
+func TestMapGrokHookUsesCamelCaseEnvelopeWithoutPrivateContent(t *testing.T) {
+	raw := []byte(`{"sessionId":"session-1","cwd":"/src/punaro","hookEventName":"Notification","notificationType":"idle_prompt","lastAssistantMessage":"private answer"}`)
+	event, emit, err := MapGrokHook(raw, AdapterConfig{MachineID: "studio-m2", TaskTitle: "Punaro / tests"}, time.Now())
+	if err != nil || !emit {
+		t.Fatalf("MapGrokHook() = %+v, %t, %v", event, emit, err)
+	}
+	if event.Source != protocol.SourceGrokBuild || event.State != protocol.StateWaitingForUser || event.WaitingReason != protocol.WaitingReasonOther {
+		t.Fatalf("event = %+v", event)
+	}
+	encoded, _ := json.Marshal(event)
+	if strings.Contains(string(encoded), "private answer") {
+		t.Fatalf("normalized Grok event leaked provider text: %s", encoded)
+	}
+}
+
+func TestMapPiLifecycleUsesOnlyExtensionSuppliedIdentity(t *testing.T) {
+	event, err := MapPiLifecycle("pi-session-1", "agent_settled", protocol.StateWaitingForUser, protocol.WaitingReasonOther, AdapterConfig{MachineID: "studio-m2", TaskTitle: "Punaro / tests"}, time.Now())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if event.Source != protocol.SourcePi || event.SessionID != "pi-session-1" || event.AgentInstanceID != "pi-session-1" || event.State != protocol.StateWaitingForUser || event.Metadata["hook"] != "agent_settled" {
+		t.Fatalf("event = %+v", event)
+	}
+}

--- a/internal/canopiadapter/providers.go
+++ b/internal/canopiadapter/providers.go
@@ -1,0 +1,166 @@
+package canopiadapter
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/rock3r/punaro/canopi/protocol"
+)
+
+// MapCodexHook maps the installed Codex CLI's Claude-compatible command-hook
+// payload. It deliberately reads only lifecycle identity fields, never prompts,
+// transcripts, tool input, tool output, or approval text.
+func MapCodexHook(raw []byte, config AdapterConfig, now time.Time) (protocol.Event, bool, error) {
+	return mapSnakeCaseHook(raw, config, now, protocol.SourceCodex, "Codex")
+}
+
+// MapGrokHook maps Grok Build's camelCase lifecycle hook payload without
+// retaining provider messages, tool data, or hook output.
+func MapGrokHook(raw []byte, config AdapterConfig, now time.Time) (protocol.Event, bool, error) {
+	if err := protocol.ValidateJSONEncoding(raw); err != nil {
+		return protocol.Event{}, false, fmt.Errorf("decode Grok hook: %w", err)
+	}
+	var hook struct {
+		SessionID        string `json:"sessionId"`
+		CWD              string `json:"cwd"`
+		HookEventName    string `json:"hookEventName"`
+		NotificationType string `json:"notificationType"`
+		AgentID          string `json:"agentId"`
+		AgentType        string `json:"agentType"`
+	}
+	if err := json.Unmarshal(raw, &hook); err != nil {
+		return protocol.Event{}, false, fmt.Errorf("decode Grok hook: %w", err)
+	}
+	return mapProviderLifecycle(protocol.SourceGrokBuild, "Grok Build", hook.SessionID, hook.CWD, hook.HookEventName, hook.NotificationType, hook.AgentID, hook.AgentType, config, now)
+}
+
+// MapPiLifecycle constructs a normalized Pi event from the deliberately tiny
+// extension boundary. Pi's extension must not forward the prompt, system prompt,
+// context, tool arguments, tool results, or assistant messages to this package.
+func MapPiLifecycle(sessionID, lifecycle string, state protocol.State, reason protocol.WaitingReason, config AdapterConfig, now time.Time) (protocol.Event, error) {
+	if lifecycle == "" {
+		return protocol.Event{}, errors.New("pi lifecycle is required")
+	}
+	return newProviderEvent(protocol.SourcePi, "Pi", sessionID, "", lifecycle, state, reason, "", "", config, now)
+}
+
+func mapSnakeCaseHook(raw []byte, config AdapterConfig, now time.Time, source protocol.Source, providerName string) (protocol.Event, bool, error) {
+	if err := protocol.ValidateJSONEncoding(raw); err != nil {
+		return protocol.Event{}, false, fmt.Errorf("decode %s hook: %w", providerName, err)
+	}
+	var hook claudeHook
+	if err := json.Unmarshal(raw, &hook); err != nil {
+		return protocol.Event{}, false, fmt.Errorf("decode %s hook: %w", providerName, err)
+	}
+	return mapProviderLifecycle(source, providerName, hook.SessionID, hook.CWD, hook.HookEventName, hook.NotificationType, hook.AgentID, hook.AgentType, config, now)
+}
+
+func mapProviderLifecycle(source protocol.Source, providerName, sessionID, cwd, lifecycle, notificationType, agentID, agentType string, config AdapterConfig, now time.Time) (protocol.Event, bool, error) {
+	if sessionID == "" || lifecycle == "" {
+		return protocol.Event{}, false, errors.New("provider hook requires session identity and lifecycle name")
+	}
+	state, reason, emit := classifyProviderLifecycle(lifecycle, notificationType)
+	if !emit {
+		return protocol.Event{}, false, nil
+	}
+	event, err := newProviderEvent(source, providerName, sessionID, cwd, lifecycle, state, reason, agentID, agentType, config, now)
+	return event, true, err
+}
+
+func newProviderEvent(source protocol.Source, providerName, sessionID, cwd, lifecycle string, state protocol.State, reason protocol.WaitingReason, agentID, agentType string, config AdapterConfig, now time.Time) (protocol.Event, error) {
+	if config.MachineID == "" {
+		return protocol.Event{}, errors.New("machine ID is required")
+	}
+	if sessionID == "" {
+		return protocol.Event{}, errors.New("provider session identity is required")
+	}
+	machineLabel := config.MachineLabel
+	if machineLabel == "" {
+		machineLabel = truncateRunes(config.MachineID, 40)
+	}
+	taskTitle := config.TaskTitle
+	if taskTitle == "" {
+		name := filepath.Base(cwd)
+		if name == "." || name == string(filepath.Separator) || name == "" {
+			name = providerName
+		}
+		suffix := " / " + providerName
+		taskTitle = truncateRunes(name, 80-len([]rune(suffix))) + suffix
+	}
+	if agentID == "" {
+		agentID = sessionID
+	}
+	parentID := ""
+	if agentID != sessionID {
+		parentID = sessionID
+	}
+	eventID, err := newProviderEventID(source)
+	if err != nil {
+		return protocol.Event{}, err
+	}
+	event := protocol.Event{
+		SpecVersion:           protocol.SpecVersion,
+		EventID:               eventID,
+		Source:                source,
+		Machine:               protocol.Machine{ID: config.MachineID, Label: machineLabel},
+		SessionID:             sessionID,
+		AgentInstanceID:       agentID,
+		ParentAgentInstanceID: parentID,
+		State:                 state,
+		WaitingReason:         reason,
+		ActivityAt:            now.UTC(),
+		EmittedAt:             now.UTC(),
+		Task:                  protocol.Task{Title: taskTitle, Repository: config.Repository},
+		Metadata:              map[string]any{"hook": lifecycle},
+	}
+	if agentType != "" {
+		event.Metadata["agent_type"] = agentType
+	}
+	if err := event.Validate(); err != nil {
+		return protocol.Event{}, err
+	}
+	return event, nil
+}
+
+func classifyProviderLifecycle(lifecycle, notificationType string) (protocol.State, protocol.WaitingReason, bool) {
+	switch compactLifecycleName(lifecycle) {
+	case "permissionrequest":
+		return protocol.StateWaitingForUser, protocol.WaitingReasonPermission, true
+	case "elicitation":
+		return protocol.StateWaitingForUser, protocol.WaitingReasonElicitation, true
+	case "elicitationresult":
+		return protocol.StateWorking, "", true
+	case "notification":
+		switch compactLifecycleName(notificationType) {
+		case "permissionprompt":
+			return protocol.StateWaitingForUser, protocol.WaitingReasonPermission, true
+		case "agentneedsinput", "idleprompt", "elicitationdialog":
+			return protocol.StateWaitingForUser, protocol.WaitingReasonOther, true
+		default:
+			return "", "", false
+		}
+	case "stop", "subagentstop", "sessionend", "sessionshutdown":
+		return protocol.StateDone, "", true
+	case "taskcompleted":
+		return "", "", false
+	case "sessionstart", "userpromptsubmit", "pretooluse", "posttooluse", "posttoolusefailure", "posttoolbatch", "subagentstart", "taskcreated", "turnstart", "toolcall", "toolresult":
+		return protocol.StateWorking, "", true
+	default:
+		return "", "", false
+	}
+}
+
+func compactLifecycleName(value string) string {
+	var compact strings.Builder
+	compact.Grow(len(value))
+	for _, runeValue := range strings.ToLower(value) {
+		if runeValue >= 'a' && runeValue <= 'z' || runeValue >= '0' && runeValue <= '9' {
+			compact.WriteRune(runeValue)
+		}
+	}
+	return compact.String()
+}

--- a/scripts/test-canopi-binaries.sh
+++ b/scripts/test-canopi-binaries.sh
@@ -8,9 +8,11 @@ trap 'rm -rf "$fixture"' EXIT HUP INT TERM
 make -C "$root" --no-print-directory canopi-binaries \
   CANOPI_OUTPUT="$fixture/collector/canopi" \
   CANOPI_CLAUDE_HOOK_OUTPUT="$fixture/adapter/canopi-claude-hook" \
+  CANOPI_PROVIDER_HOOK_OUTPUT="$fixture/adapter/canopi-provider-hook" \
   CANOPI_SIM_OUTPUT="$fixture/simulator/canopi-sim"
 
 test -x "$fixture/collector/canopi"
 test -x "$fixture/adapter/canopi-claude-hook"
+test -x "$fixture/adapter/canopi-provider-hook"
 test -x "$fixture/simulator/canopi-sim"
 printf '%s\n' canopi_binary_output_tests_passed


### PR DESCRIPTION
## Summary
- add privacy-safe Codex, Pi, and Grok Build adapter runners alongside Claude Code
- add actual installed-provider contract tests plus normalized-event to collector to 800x480 render coverage
- document provider setup, Codex relay behaviour, and Pi extension decision

## Validation
- make test
- make test-race
- make lint
- make security