### PR TITLE
Fix Windows client installation and plugin byte stability

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,9 @@
+# Release-bound plugin text must retain the exact Git blob bytes on Windows.
+/plugin.json text eol=lf
+/mcp.json text eol=lf
+/.mcp.json text eol=lf
+/.codex-plugin/*.json text eol=lf
+/.claude-plugin/*.json text eol=lf
+/scripts/punaro-plugin-mcp text eol=lf
+/scripts/punaro-plugin-mcp.cmd text eol=lf
+/skills/** text eol=lf

--- a/scripts/install-client.ps1
+++ b/scripts/install-client.ps1
@@ -257,6 +257,28 @@ function Invoke-Program([string]$Program, [string[]]$Arguments, [string]$Descrip
     return (($result.Output | ForEach-Object { [string]$_ }) -join "`n").Trim()
 }
 
+function Get-PunaroGroupAddresses($Parsed) {
+    if ($null -eq $Parsed) { return @() }
+    $entries = @()
+    $itemsProperty = $Parsed.PSObject.Properties['items']
+    if ($null -ne $itemsProperty) {
+        $entries = @($itemsProperty.Value)
+    } else {
+        # Windows PowerShell may unwrap a one-element top-level JSON array;
+        # @() preserves scalars while continuing to enumerate larger arrays.
+        $entries = @($Parsed)
+    }
+    $addresses = @()
+    foreach ($entry in $entries) {
+        if ($null -eq $entry) { continue }
+        $addressProperty = $entry.PSObject.Properties['address']
+        if ($null -ne $addressProperty -and $null -ne $addressProperty.Value) {
+            $addresses += [string]$addressProperty.Value
+        }
+    }
+    return $addresses
+}
+
 if ($env:OS -ne 'Windows_NT') { Stop-Install 'Windows client installation must run on Windows' }
 if ($MachineId -notmatch '^[A-Za-z0-9][A-Za-z0-9._-]*$') { Stop-Install 'machine ID must start with a letter or digit and contain only letters, digits, dot, underscore, or hyphen' }
 if ($AttachedGroup -notmatch '^group/[A-Za-z0-9._/-]+$') { Stop-Install 'attached group must be a group/ address' }
@@ -487,7 +509,7 @@ if (Test-Path -LiteralPath $configFile) {
 $groupCreate = Invoke-NativeProgramRaw -Program $mailbox -Arguments @('--state-dir', $MailboxStateDir, 'group', 'create', '--group', $AttachedGroup)
 if ($groupCreate.ExitCode -ne 0) {
     $groups = Invoke-Program -Program $mailbox -Arguments @('--state-dir', $MailboxStateDir, 'group', 'list', '--json') -Description 'attachment group lookup' | ConvertFrom-Json
-    $groupAddresses = @($groups | ForEach-Object { $_.address })
+    $groupAddresses = @(Get-PunaroGroupAddresses -Parsed $groups)
     if ($groupAddresses -notcontains $AttachedGroup) { Stop-Install 'could not create the local Punaro attachment group' }
 }
 
@@ -517,7 +539,9 @@ if ($Enable -or $adapterTaskWasRunning -or $hadRepeatTrigger) { $triggers += $re
 $principal = New-ScheduledTaskPrincipal -UserId $user -LogonType Interactive -RunLevel Limited
 $settings = New-ScheduledTaskSettingsSet -AllowStartIfOnBatteries -DontStopIfGoingOnBatteries -Hidden -ExecutionTimeLimit ([TimeSpan]::Zero)
 $settings.RestartCount = 255
-$settings.RestartInterval = [TimeSpan]::FromMinutes(1)
+# The ScheduledTasks CIM property is an XML-duration string. Assigning a
+# TimeSpan produces 00:01:00, which Register-ScheduledTask rejects.
+$settings.RestartInterval = 'PT1M'
 Register-ScheduledTask -TaskName $adapterTaskName -Action $action -Trigger $triggers -Principal $principal -Settings $settings -Description 'Punaro local mailbox adapter' -Force | Out-Null
 if ($Enable -or $adapterTaskWasRunning) {
     Start-ScheduledTask -TaskName $adapterTaskName

--- a/scripts/test-agent-plugin.py
+++ b/scripts/test-agent-plugin.py
@@ -48,10 +48,34 @@ SHARED_METADATA = {
 }
 PUNARO_ICON = "./assets/punaro.png"
 PUNARO_ICON_SHA256 = "5cf8313cbe88e41887db89b0ecd7a668c622416ea83369fc0ec7da4f72b5a353"
+PLUGIN_LF_ATTRIBUTES = {
+    "/plugin.json text eol=lf",
+    "/mcp.json text eol=lf",
+    "/.mcp.json text eol=lf",
+    "/.codex-plugin/*.json text eol=lf",
+    "/.claude-plugin/*.json text eol=lf",
+    "/scripts/punaro-plugin-mcp text eol=lf",
+    "/scripts/punaro-plugin-mcp.cmd text eol=lf",
+    "/skills/** text eol=lf",
+}
 
 
 class ValidationError(RuntimeError):
     pass
+
+
+def validate_git_eol_contract() -> None:
+    attributes_path = ROOT / ".gitattributes"
+    if not attributes_path.is_file() or attributes_path.is_symlink():
+        raise ValidationError("missing regular .gitattributes")
+    lines = {
+        line.strip()
+        for line in attributes_path.read_text(encoding="utf-8").splitlines()
+        if line.strip() and not line.lstrip().startswith("#")
+    }
+    missing = PLUGIN_LF_ATTRIBUTES - lines
+    if missing:
+        raise ValidationError(f"plugin LF attributes are incomplete: {sorted(missing)}")
 
 
 def reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
@@ -253,6 +277,7 @@ def validate_codex_adapter(portable: dict[str, Any]) -> None:
 
 
 def main() -> None:
+    validate_git_eol_contract()
     portable = validate_portable_manifest()
     validate_skills()
     portable_mcp = validate_mcp()

--- a/scripts/test-install-client-windows.ps1
+++ b/scripts/test-install-client-windows.ps1
@@ -16,7 +16,7 @@ foreach ($path in $paths) {
 }
 
 $installer = [System.IO.File]::ReadAllText((Join-Path $repoDir 'scripts\install-client.ps1'))
-foreach ($expected in @('LogonType Interactive', 'ExecutionTimeLimit ([TimeSpan]::Zero)', 'RestartCount', 'RepetitionInterval', 'RepetitionDuration', '-WindowStyle Hidden', '-Hidden', 'SetAccessRuleProtection($true, $false)', '-ExecutionPolicy Bypass', 'ForEach-Object { $_.address }', 'punaro-trusted-attachment.exe', 'punaro-memory.exe', 'punaro-enroll.exe', 'agent-mailbox', '[string]$AgentMailboxBin', '$mailboxIsWaypost', 'AgentGuidanceDir', 'AllowLanHttp', 'PUNARO_ADAPTER_TRUSTED_LAN_CIDR')) {
+foreach ($expected in @('LogonType Interactive', 'ExecutionTimeLimit ([TimeSpan]::Zero)', 'RestartCount', "RestartInterval = 'PT1M'", 'RepetitionInterval', 'RepetitionDuration', '-WindowStyle Hidden', '-Hidden', 'SetAccessRuleProtection($true, $false)', '-ExecutionPolicy Bypass', 'Get-PunaroGroupAddresses', "PSObject.Properties['items']", "PSObject.Properties['address']", 'punaro-trusted-attachment.exe', 'punaro-memory.exe', 'punaro-enroll.exe', 'agent-mailbox', '[string]$AgentMailboxBin', '$mailboxIsWaypost', 'AgentGuidanceDir', 'AllowLanHttp', 'PUNARO_ADAPTER_TRUSTED_LAN_CIDR')) {
     if (-not $installer.Contains($expected)) { throw "Windows installer is missing required behavior: $expected" }
 }
 $dispatcherWait = 'Wait-PunaroReplaceableBinary -Path $destination'
@@ -166,6 +166,7 @@ try {
         if (Test-Path -LiteralPath $path) { throw "Windows client installer must not create retired attachment artifact $path" }
     }
     if ($global:punaroRegisteredTask -ne 'Punaro Adapter') { throw 'Windows client installer did not register the expected per-user task' }
+    if ($global:punaroRegisteredSettings.RestartInterval -ne 'PT1M') { throw 'Windows client adapter task restart interval must use an ISO 8601 duration' }
     if (@($global:punaroRegisteredTriggers | Where-Object { $_.Once }).Count -ne 0 -or $global:punaroStartTaskCalled) {
         throw 'Windows client installer armed or started a fresh adapter without -Enable'
     }
@@ -303,14 +304,41 @@ if not errorlevel 1 (
 )
 echo %* | findstr /C:"group list --json" >nul
 if not errorlevel 1 (
-  echo [{"group_id":"grp_test","address":"group/punaro-attached","created_at":"2026-01-01T00:00:00Z"}]
+  echo {"items":[{"group_id":"grp_test","address":"group/punaro-attached","created_at":"2026-01-01T00:00:00Z"}]}
   exit /b 0
 )
 exit /b 0
 '@
     [System.IO.File]::WriteAllText($mailbox, $existingGroupMailbox, [System.Text.Encoding]::ASCII)
     & (Join-Path $repoDir 'scripts\install-client.ps1') -RelayUrl 'https://relay.example.test' -MachineId 'windows-test' -AgentMailboxBin $mailbox -AgentGuidanceDir $project
-    if ($LASTEXITCODE -ne 0) { throw 'Windows client installer was not idempotent' }
+    if ($LASTEXITCODE -ne 0) { throw 'Windows client installer was not idempotent with wrapped group JSON' }
+    $legacyArrayGroupMailbox = $existingGroupMailbox.Replace(
+        'echo {"items":[{"group_id":"grp_test","address":"group/punaro-attached","created_at":"2026-01-01T00:00:00Z"}]}',
+        'echo [{"group_id":"grp_test","address":"group/punaro-attached","created_at":"2026-01-01T00:00:00Z"}]'
+    )
+    [System.IO.File]::WriteAllText($mailbox, $legacyArrayGroupMailbox, [System.Text.Encoding]::ASCII)
+    & (Join-Path $repoDir 'scripts\install-client.ps1') -RelayUrl 'https://relay.example.test' -MachineId 'windows-test' -AgentMailboxBin $mailbox -AgentGuidanceDir $project
+    if ($LASTEXITCODE -ne 0) { throw 'Windows client installer was not idempotent with legacy array group JSON' }
+    $legacyMultiGroupMailbox = $existingGroupMailbox.Replace(
+        'echo {"items":[{"group_id":"grp_test","address":"group/punaro-attached","created_at":"2026-01-01T00:00:00Z"}]}',
+        'echo [{"group_id":"grp_other","address":"group/other","created_at":"2026-01-01T00:00:00Z"},{"group_id":"grp_test","address":"group/punaro-attached","created_at":"2026-01-01T00:00:00Z"}]'
+    )
+    [System.IO.File]::WriteAllText($mailbox, $legacyMultiGroupMailbox, [System.Text.Encoding]::ASCII)
+    & (Join-Path $repoDir 'scripts\install-client.ps1') -RelayUrl 'https://relay.example.test' -MachineId 'windows-test' -AgentMailboxBin $mailbox -AgentGuidanceDir $project
+    if ($LASTEXITCODE -ne 0) { throw 'Windows client installer was not idempotent with multi-element legacy array group JSON' }
+    $emptyWrappedGroupMailbox = $existingGroupMailbox.Replace(
+        'echo {"items":[{"group_id":"grp_test","address":"group/punaro-attached","created_at":"2026-01-01T00:00:00Z"}]}',
+        'echo {"items":[]}'
+    )
+    [System.IO.File]::WriteAllText($mailbox, $emptyWrappedGroupMailbox, [System.Text.Encoding]::ASCII)
+    $emptyWrappedBlocked = $false
+    try {
+        & (Join-Path $repoDir 'scripts\install-client.ps1') -RelayUrl 'https://relay.example.test' -MachineId 'windows-test' -AgentMailboxBin $mailbox -AgentGuidanceDir $project
+    } catch {
+        if ($_.Exception.Message.Contains('could not create the local Punaro attachment group')) { $emptyWrappedBlocked = $true } else { throw }
+    }
+    if (-not $emptyWrappedBlocked) { throw 'Windows client installer accepted empty wrapped group JSON' }
+    [System.IO.File]::WriteAllText($mailbox, $existingGroupMailbox, [System.Text.Encoding]::ASCII)
     $adapterEnvironment = Join-Path $root 'config\adapter.env'
     $prePolicyProfile = @([System.IO.File]::ReadAllLines($adapterEnvironment) | Where-Object { $_ -notmatch '^PUNARO_ADAPTER_(ALLOW_LAN_HTTP|TRUSTED_LAN_CIDR)=' })
     [System.IO.File]::WriteAllLines($adapterEnvironment, $prePolicyProfile, [System.Text.Encoding]::UTF8)


### PR DESCRIPTION
Fixes three release-blocking Windows deployment issues found during the alpha.9 fleet rollout:

- accept Waypost group-list responses wrapped in `items` while preserving legacy array support and fail-closed behavior
- serialize the Scheduled Task restart interval as ISO 8601 `PT1M`
- pin signed plugin manifests, launchers, and skills to LF bytes across Windows checkouts

Validation:
- `make test test-race staticcheck security lint`
- native Windows PowerShell installer suite on Mattone
- two independent Pioneer reviews; final review reported no blocking findings
- `git diff --check`