### PR TITLE
Fix Canopi private collector deployment

### DIFF
--- a/canopi/providers/pi/canopi.ts
+++ b/canopi/providers/pi/canopi.ts
@@ -3,6 +3,9 @@
 // is the normalized lifecycle event below.
 import { randomUUID } from "node:crypto";
 import { spawn } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
 
 type CanopiState = "working" | "waiting_for_user" | "done";
 
@@ -21,7 +24,47 @@ type CanopiEvent = {
   metadata: { hook: string };
 };
 
+const configurationKeys = new Set([
+  "CANOPI_ENDPOINT",
+  "CANOPI_TOKEN_FILE",
+  "CANOPI_MACHINE_ID",
+  "CANOPI_MACHINE_LABEL",
+  "CANOPI_TASK_TITLE",
+  "CANOPI_REPOSITORY",
+  "CANOPI_SPOOL_DIR",
+  "CANOPI_PROVIDER_HOOK",
+  "CANOPI_TLS_CA_FILE",
+]);
+let configurationLoaded = false;
+
+// A global Pi extension does not inherit a shell profile. Read only the small,
+// non-secret adapter configuration file that the operator installed locally.
+// Existing explicit environment values always win, and this deliberately does
+// not interpret shell substitutions, commands, or arbitrary variables.
+function loadConfiguration(): void {
+  if (configurationLoaded) return;
+  configurationLoaded = true;
+  const path = process.env.CANOPI_CONFIG_FILE || join(process.env.HOME || homedir(), ".config", "canopi", "env");
+  try {
+    for (const line of readFileSync(path, "utf8").split(/\r?\n/)) {
+      const match = line.match(/^\s*(CANOPI_[A-Z_]+)=(.*)$/);
+      if (!match || !configurationKeys.has(match[1]) || process.env[match[1]]) continue;
+      let value = match[2].trim();
+      if (
+        value.length >= 2 &&
+        ((value.startsWith("'") && value.endsWith("'")) || (value.startsWith('"') && value.endsWith('"')))
+      ) {
+        value = value.slice(1, -1);
+      }
+      if (value) process.env[match[1]] = value;
+    }
+  } catch {
+    // Canopi is optional; an unreadable local configuration must not affect Pi.
+  }
+}
+
 function configured(): boolean {
+  loadConfiguration();
   return Boolean(
     process.env.CANOPI_ENDPOINT &&
       process.env.CANOPI_TOKEN_FILE &&

--- a/cmd/canopi-claude-hook/main.go
+++ b/cmd/canopi-claude-hook/main.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"errors"
 	"io"
-	"net/http"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -122,7 +121,10 @@ func runDelivery(getenv func(string) string) error {
 	if err != nil {
 		return err
 	}
-	client := &http.Client{Timeout: 750 * time.Millisecond}
+	client, err := canopiadapter.NewDeliveryClient(getenv("CANOPI_TLS_CA_FILE"))
+	if err != nil {
+		return err
+	}
 	token := strings.TrimSpace(string(tokenBytes))
 	return spool.Drain(context.Background(), func(ctx context.Context, event protocol.Event) error {
 		return canopiadapter.Deliver(ctx, client, getenv("CANOPI_ENDPOINT"), token, event)
@@ -138,7 +140,10 @@ func runSupervisor(getenv func(string) string) error {
 	if err != nil {
 		return err
 	}
-	client := &http.Client{Timeout: 750 * time.Millisecond}
+	client, err := canopiadapter.NewDeliveryClient(getenv("CANOPI_TLS_CA_FILE"))
+	if err != nil {
+		return err
+	}
 	token := strings.TrimSpace(string(tokenBytes))
 	return spool.Serve(context.Background(), func(ctx context.Context, event protocol.Event) error {
 		return canopiadapter.Deliver(ctx, client, getenv("CANOPI_ENDPOINT"), token, event)

--- a/cmd/canopi-provider-hook/main.go
+++ b/cmd/canopi-provider-hook/main.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"errors"
 	"io"
-	"net/http"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -207,7 +206,10 @@ func runDelivery(selected provider, getenv func(string) string) error {
 	if err != nil {
 		return err
 	}
-	client := &http.Client{Timeout: 750 * time.Millisecond}
+	client, err := canopiadapter.NewDeliveryClient(getenv("CANOPI_TLS_CA_FILE"))
+	if err != nil {
+		return err
+	}
 	return spool.Drain(context.Background(), func(ctx context.Context, event protocol.Event) error {
 		return canopiadapter.Deliver(ctx, client, getenv("CANOPI_ENDPOINT"), token, event)
 	})
@@ -222,7 +224,10 @@ func runSupervisor(selected provider, getenv func(string) string) error {
 	if err != nil {
 		return err
 	}
-	client := &http.Client{Timeout: 750 * time.Millisecond}
+	client, err := canopiadapter.NewDeliveryClient(getenv("CANOPI_TLS_CA_FILE"))
+	if err != nil {
+		return err
+	}
 	return spool.Serve(context.Background(), func(ctx context.Context, event protocol.Event) error {
 		return canopiadapter.Deliver(ctx, client, getenv("CANOPI_ENDPOINT"), token, event)
 	})

--- a/cmd/canopi-provider-hook/main_test.go
+++ b/cmd/canopi-provider-hook/main_test.go
@@ -257,16 +257,28 @@ func TestPiExtensionEmitsSessionStartToCollector(t *testing.T) {
 	if err := os.WriteFile(tokenPath, []byte("test-token-123456\n"), 0o600); err != nil {
 		t.Fatal(err)
 	}
-	environment := append(os.Environ(),
+	spoolPath := filepath.Join(t.TempDir(), "spool")
+	runnerEnvironment := append(os.Environ(),
 		"CANOPI_ENDPOINT="+collector.URL,
 		"CANOPI_TOKEN_FILE="+tokenPath,
 		"CANOPI_MACHINE_ID=pi-contract-test",
-		"CANOPI_SPOOL_DIR="+filepath.Join(t.TempDir(), "spool"),
+		"CANOPI_SPOOL_DIR="+spoolPath,
 		"CANOPI_PROVIDER_HOOK="+outputPath,
 		"PI_CODING_AGENT_DIR="+t.TempDir(),
 	)
+	configPath := filepath.Join(t.TempDir(), "canopi.env")
+	config := strings.Join([]string{
+		"CANOPI_ENDPOINT=" + collector.URL,
+		"CANOPI_TOKEN_FILE=" + tokenPath,
+		"CANOPI_MACHINE_ID=pi-contract-test",
+		"CANOPI_SPOOL_DIR=" + spoolPath,
+		"CANOPI_PROVIDER_HOOK=" + outputPath,
+	}, "\n") + "\n"
+	if err := os.WriteFile(configPath, []byte(config), 0o600); err != nil {
+		t.Fatal(err)
+	}
 	prepare := exec.CommandContext(t.Context(), outputPath, "pi", "prepare") // #nosec G204 -- fixed provider runner built above.
-	prepare.Env = environment
+	prepare.Env = runnerEnvironment
 	if output, err := prepare.CombinedOutput(); err != nil {
 		t.Fatalf("prepare Pi spool: %v: %s", err, output)
 	}
@@ -275,7 +287,7 @@ func TestPiExtensionEmitsSessionStartToCollector(t *testing.T) {
 	defer cancelPi()
 	pi := exec.CommandContext(piContext, piPath, "--offline", "--no-session", "--mode", "rpc", "--extension", extensionPath) // #nosec G204 -- fixed installed Pi path and repository extension path in a host contract test.
 	pi.Dir = root
-	pi.Env = environment
+	pi.Env = append(os.Environ(), "CANOPI_CONFIG_FILE="+configPath, "PI_CODING_AGENT_DIR="+t.TempDir())
 	var stdout, stderr bytes.Buffer
 	pi.Stdout = &stdout
 	pi.Stderr = &stderr

--- a/docs/canopi.md
+++ b/docs/canopi.md
@@ -250,6 +250,7 @@ that launches Claude Code:
 go build -trimpath -o /absolute/bin/canopi-claude-hook ./cmd/canopi-claude-hook
 export CANOPI_ENDPOINT=https://canopi.example.internal:8443
 export CANOPI_TOKEN_FILE=/absolute/private/canopi.token
+export CANOPI_TLS_CA_FILE=/absolute/private/collector-ca.pem
 export CANOPI_SPOOL_DIR=/absolute/private/canopi-claude-spool
 export CANOPI_MACHINE_ID=studio-m2
 export CANOPI_MACHINE_LABEL=studio-m2
@@ -257,6 +258,12 @@ export CANOPI_TASK_TITLE='Punaro / current task'
 export CANOPI_REPOSITORY='rock3r/punaro'
 /absolute/bin/canopi-claude-hook prepare
 ```
+
+`CANOPI_TLS_CA_FILE` is optional. Set it to an absolute PEM root bundle when
+the collector uses a private CA, including on macOS and Windows where a
+per-process bundle is more reliable than changing a system trust store. It
+adds that root without disabling hostname or certificate verification; it must
+contain a certificate, never a private key.
 
 Copy the `hooks` object from
 `canopi/providers/claude-code-hooks.example.json` into project-local
@@ -355,6 +362,7 @@ service that starts the coding agent:
 go build -trimpath -o /absolute/bin/canopi-provider-hook ./cmd/canopi-provider-hook
 export CANOPI_ENDPOINT=https://canopi.example.internal:8443
 export CANOPI_TOKEN_FILE=/absolute/private/canopi.token
+export CANOPI_TLS_CA_FILE=/absolute/private/collector-ca.pem
 export CANOPI_MACHINE_ID=studio-m2
 export CANOPI_MACHINE_LABEL=studio-m2
 export CANOPI_TASK_TITLE='Punaro / current task'
@@ -414,11 +422,22 @@ native extension lifecycle exposes `session_start`, `agent_start`,
 automatic retry, compaction, or queued continuation left. Copy
 `canopi/providers/pi/canopi.ts` to Pi's trusted global extension directory
 (`~/.pi/agent/extensions/canopi.ts`) or load that file explicitly with
-`pi --extension /absolute/path/to/canopi.ts`. Also set:
+`pi --extension /absolute/path/to/canopi.ts`. A global extension normally does
+not inherit an interactive shell profile, so it reads the non-secret Canopi
+configuration file at `~/.config/canopi/env` by default (or the absolute path
+in `CANOPI_CONFIG_FILE`). Use simple `KEY=value` lines, for example:
 
 ```sh
-export CANOPI_PROVIDER_HOOK=/absolute/bin/canopi-provider-hook
+CANOPI_ENDPOINT=https://canopi.example.internal:8443
+CANOPI_TOKEN_FILE=/absolute/private/canopi.token
+CANOPI_TLS_CA_FILE=/absolute/private/collector-ca.pem
+CANOPI_MACHINE_ID=studio-m2
+CANOPI_MACHINE_LABEL=studio-m2
+CANOPI_PROVIDER_HOOK=/absolute/bin/canopi-provider-hook
 ```
+
+The extension accepts only the documented `CANOPI_*` keys from that file;
+explicit environment values win and no shell expressions are evaluated.
 
 The extension sends only an already-normalized Pi event to
 `canopi-provider-hook pi emit` through a detached local child. Pi awaits

--- a/internal/canopiadapter/http_client.go
+++ b/internal/canopiadapter/http_client.go
@@ -21,11 +21,6 @@ func NewDeliveryClient(caFile string) (*http.Client, error) {
 	// route that bearer-authenticated private-LAN traffic through a shell or
 	// desktop proxy inherited by the coding-agent process.
 	transport.Proxy = nil
-	// The collector's small private deployment serves HTTP/1.1 reliably across
-	// the supported desktops. Avoid inheriting a platform-specific HTTP/2
-	// transport from the Go default and keep the worker's request path simple.
-	transport.ForceAttemptHTTP2 = false
-	transport.TLSNextProto = map[string]func(string, *tls.Conn) http.RoundTripper{}
 	caFile = strings.TrimSpace(caFile)
 	if caFile == "" {
 		return &http.Client{Timeout: 3 * time.Second, Transport: transport}, nil
@@ -43,7 +38,6 @@ func NewDeliveryClient(caFile string) (*http.Client, error) {
 	}
 	transport.TLSClientConfig = &tls.Config{
 		MinVersion: tls.VersionTLS12,
-		NextProtos: []string{"http/1.1"},
 		RootCAs:    pool,
 	}
 	return &http.Client{Timeout: 3 * time.Second, Transport: transport}, nil

--- a/internal/canopiadapter/http_client.go
+++ b/internal/canopiadapter/http_client.go
@@ -1,0 +1,40 @@
+package canopiadapter
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"errors"
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// NewDeliveryClient creates the bounded HTTPS client used by durable adapter
+// workers. caFile, when set, is an operator-selected PEM root bundle for a
+// private collector CA; certificate validation is always retained.
+func NewDeliveryClient(caFile string) (*http.Client, error) {
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	caFile = strings.TrimSpace(caFile)
+	if caFile == "" {
+		return &http.Client{Timeout: 750 * time.Millisecond, Transport: transport}, nil
+	}
+	if !filepath.IsAbs(caFile) {
+		return nil, errors.New("Canopi TLS CA file must be an absolute path")
+	}
+	pemBytes, err := os.ReadFile(caFile)
+	if err != nil {
+		return nil, fmt.Errorf("read Canopi TLS CA file: %w", err)
+	}
+	pool := x509.NewCertPool()
+	if !pool.AppendCertsFromPEM(pemBytes) {
+		return nil, errors.New("Canopi TLS CA file contains no PEM certificates")
+	}
+	transport.TLSClientConfig = &tls.Config{
+		MinVersion: tls.VersionTLS12,
+		RootCAs:    pool,
+	}
+	return &http.Client{Timeout: 750 * time.Millisecond, Transport: transport}, nil
+}

--- a/internal/canopiadapter/http_client.go
+++ b/internal/canopiadapter/http_client.go
@@ -17,9 +17,18 @@ import (
 // private collector CA; certificate validation is always retained.
 func NewDeliveryClient(caFile string) (*http.Client, error) {
 	transport := http.DefaultTransport.(*http.Transport).Clone()
+	// Adapter events authenticate directly to the operator's collector. Never
+	// route that bearer-authenticated private-LAN traffic through a shell or
+	// desktop proxy inherited by the coding-agent process.
+	transport.Proxy = nil
+	// The collector's small private deployment serves HTTP/1.1 reliably across
+	// the supported desktops. Avoid inheriting a platform-specific HTTP/2
+	// transport from the Go default and keep the worker's request path simple.
+	transport.ForceAttemptHTTP2 = false
+	transport.TLSNextProto = map[string]func(string, *tls.Conn) http.RoundTripper{}
 	caFile = strings.TrimSpace(caFile)
 	if caFile == "" {
-		return &http.Client{Timeout: 750 * time.Millisecond, Transport: transport}, nil
+		return &http.Client{Timeout: 3 * time.Second, Transport: transport}, nil
 	}
 	if !filepath.IsAbs(caFile) {
 		return nil, errors.New("Canopi TLS CA file must be an absolute path")
@@ -34,7 +43,8 @@ func NewDeliveryClient(caFile string) (*http.Client, error) {
 	}
 	transport.TLSClientConfig = &tls.Config{
 		MinVersion: tls.VersionTLS12,
+		NextProtos: []string{"http/1.1"},
 		RootCAs:    pool,
 	}
-	return &http.Client{Timeout: 750 * time.Millisecond, Transport: transport}, nil
+	return &http.Client{Timeout: 3 * time.Second, Transport: transport}, nil
 }

--- a/internal/canopiadapter/http_client.go
+++ b/internal/canopiadapter/http_client.go
@@ -26,15 +26,15 @@ func NewDeliveryClient(caFile string) (*http.Client, error) {
 		return &http.Client{Timeout: 3 * time.Second, Transport: transport}, nil
 	}
 	if !filepath.IsAbs(caFile) {
-		return nil, errors.New("Canopi TLS CA file must be an absolute path")
+		return nil, errors.New("canopi TLS CA file must be an absolute path")
 	}
-	pemBytes, err := os.ReadFile(caFile)
+	pemBytes, err := os.ReadFile(caFile) // #nosec G304 -- an absolute operator-selected PEM bundle is validated before use.
 	if err != nil {
 		return nil, fmt.Errorf("read Canopi TLS CA file: %w", err)
 	}
 	pool := x509.NewCertPool()
 	if !pool.AppendCertsFromPEM(pemBytes) {
-		return nil, errors.New("Canopi TLS CA file contains no PEM certificates")
+		return nil, errors.New("canopi TLS CA file contains no PEM certificates")
 	}
 	transport.TLSClientConfig = &tls.Config{
 		MinVersion: tls.VersionTLS12,

--- a/internal/canopiadapter/http_client_test.go
+++ b/internal/canopiadapter/http_client_test.go
@@ -1,0 +1,53 @@
+package canopiadapter
+
+import (
+	"encoding/pem"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestNewDeliveryClientTrustsConfiguredPEMRoot(t *testing.T) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+		writer.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+
+	certificate := server.Certificate()
+	pemBytes := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certificate.Raw})
+	caPath := filepath.Join(t.TempDir(), "collector-ca.pem")
+	if err := os.WriteFile(caPath, pemBytes, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	client, err := NewDeliveryClient(caPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	response, err := client.Get(server.URL)
+	if err != nil {
+		t.Fatalf("request with configured CA: %v", err)
+	}
+	defer response.Body.Close()
+	if response.StatusCode != http.StatusNoContent {
+		t.Fatalf("status = %d, want %d", response.StatusCode, http.StatusNoContent)
+	}
+}
+
+func TestNewDeliveryClientRejectsInvalidPEM(t *testing.T) {
+	caPath := filepath.Join(t.TempDir(), "collector-ca.pem")
+	if err := os.WriteFile(caPath, []byte("not a certificate"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := NewDeliveryClient(caPath); err == nil {
+		t.Fatal("NewDeliveryClient accepted invalid PEM")
+	}
+}
+
+func TestNewDeliveryClientRejectsRelativeCAPath(t *testing.T) {
+	if _, err := NewDeliveryClient("collector-ca.pem"); err == nil {
+		t.Fatal("NewDeliveryClient accepted a relative CA path")
+	}
+}

--- a/internal/canopiadapter/http_client_test.go
+++ b/internal/canopiadapter/http_client_test.go
@@ -26,11 +26,15 @@ func TestNewDeliveryClientTrustsConfiguredPEMRoot(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	response, err := client.Get(server.URL)
+	request, err := http.NewRequestWithContext(t.Context(), http.MethodGet, server.URL, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	response, err := client.Do(request)
 	if err != nil {
 		t.Fatalf("request with configured CA: %v", err)
 	}
-	defer response.Body.Close()
+	defer func() { _ = response.Body.Close() }()
 	if response.StatusCode != http.StatusNoContent {
 		t.Fatalf("status = %d, want %d", response.StatusCode, http.StatusNoContent)
 	}

--- a/internal/canopiadapter/spool_file_lock_windows.go
+++ b/internal/canopiadapter/spool_file_lock_windows.go
@@ -144,7 +144,7 @@ func openWindowsSpoolLockFile(path string, disposition uint32) (*os.File, error)
 		if sid == nil {
 			return nil, errors.New("cannot identify the current user for a Canopi spool lock")
 		}
-		descriptor, descriptorErr := windows.SecurityDescriptorFromString("D:P(A;;FA;;;" + sid.String() + ")")
+		descriptor, descriptorErr := windows.SecurityDescriptorFromString("O:" + sid.String() + "D:P(A;;FA;;;" + sid.String() + ")")
 		if descriptorErr != nil {
 			return nil, descriptorErr
 		}

--- a/internal/canopiadapter/spool_privacy_windows.go
+++ b/internal/canopiadapter/spool_privacy_windows.go
@@ -141,7 +141,7 @@ func protectSpoolFile(path string, file *os.File) error {
 	if err != nil || dacl == nil {
 		return errors.New("cannot construct a private queued-event ACL")
 	}
-	if err := windows.SetNamedSecurityInfo(path, windows.SE_FILE_OBJECT, windows.DACL_SECURITY_INFORMATION|windows.PROTECTED_DACL_SECURITY_INFORMATION, nil, nil, dacl, nil); err != nil {
+	if err := windows.SetNamedSecurityInfo(path, windows.SE_FILE_OBJECT, windows.OWNER_SECURITY_INFORMATION|windows.DACL_SECURITY_INFORMATION|windows.PROTECTED_DACL_SECURITY_INFORMATION, sid, nil, dacl, nil); err != nil {
 		return err
 	}
 	info, err := file.Stat()


### PR DESCRIPTION
Adds explicit private-CA support for adapter workers and Pi's globally loaded extension, documents the configuration, keeps bearer-authenticated private collector traffic direct, and fixes Windows current-user ownership for durable spool files.\n\nValidation:\n- make test\n- focused adapter tests\n- Windows cross-compiled adapter test binary\n- live authenticated collector delivery after Little Snitch approval: Claude, Codex, Grok Build, and Pi runner paths on Studio and Coso; Claude on Mattone\n\nMattone intentionally installs Claude only because its other provider CLIs are not present. Codex hook definitions remain subject to Codex's one-time /hooks trust confirmation on each Mac.