### PR TITLE
Fix loopback device enrollment persistence

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1589,6 +1589,9 @@ The supported onboarding client is `punaro-enroll`. `prepare` creates a
 private current-user state directory and records only the canonical origin,
 an explicit containing CIDR for trusted-LAN plaintext when selected, and a
 fresh opaque binding in the versioned non-secret sidecar. It
+accepts literal loopback HTTP under the same zero-policy version-one identity
+shape as HTTPS; non-loopback HTTP still requires the version-two explicit LAN
+acknowledgement and containing CIDR. It
 prints that public binding for the server owner to use in the exact
 least-privilege `trusted-agent` grant preview. `redeem` reads the server's
 short-lived enrollment JSON only from a protected local file, requires its

--- a/cmd/punaro-enroll/main.go
+++ b/cmd/punaro-enroll/main.go
@@ -148,7 +148,7 @@ func runProtectMaterial(args []string, stdout, stderr io.Writer) int {
 func runPrepare(args []string, stdout, stderr io.Writer) int {
 	flags := flag.NewFlagSet("prepare", flag.ContinueOnError)
 	flags.SetOutput(io.Discard)
-	origin := flags.String("origin", "", "fixed Punaro HTTPS origin")
+	origin := flags.String("origin", "", "fixed Punaro origin")
 	stateDir := flags.String("state-dir", "", "absolute private enrollment state directory")
 	allowLANHTTP := flags.Bool("allow-lan-http", false, "explicitly allow plaintext credentials on the pinned trusted LAN")
 	trustedLANCIDR := flags.String("trusted-lan-cidr", "", "private or link-local CIDR containing the literal HTTP origin")

--- a/cmd/punaro-enroll/main_test.go
+++ b/cmd/punaro-enroll/main_test.go
@@ -282,6 +282,24 @@ func TestPreparePersistsExplicitTrustedLANPolicy(t *testing.T) {
 	}
 }
 
+func TestPreparePersistsLoopbackHTTPWithoutTrustedLANPolicy(t *testing.T) {
+	stateDir := filepath.Join(t.TempDir(), "state")
+	args := []string{"prepare", "--origin", "http://127.0.0.1:18080/", "--state-dir", stateDir}
+	for attempt := 1; attempt <= 2; attempt++ {
+		var stdout, stderr bytes.Buffer
+		if code := run(args, &stdout, &stderr); code != 0 || stderr.Len() != 0 {
+			t.Fatalf("attempt=%d code=%d stdout=%q stderr=%q", attempt, code, stdout.String(), stderr.String())
+		}
+	}
+	state, err := loadIdentity(filepath.Join(stateDir, identityFileName))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if state.Version != clientidentity.Version || state.Origin != "http://127.0.0.1:18080" || state.AllowLANHTTP || state.TrustedLANCIDR != "" {
+		t.Fatalf("identity=%#v", state)
+	}
+}
+
 func TestUnverifiedBadRequestRetainsRecoveryJournal(t *testing.T) {
 	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusBadRequest)

--- a/cmd/punaro-enroll/main_test.go
+++ b/cmd/punaro-enroll/main_test.go
@@ -87,7 +87,9 @@ func TestPrepareThenRedeemOverLoopbackHTTP(t *testing.T) {
 	var prepared publicEnrollment
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost || r.URL.Path != "/v1/enrollments/redeem" {
-			t.Fatalf("request=%s %s", r.Method, r.URL.Path)
+			t.Errorf("request=%s %s", r.Method, r.URL.Path)
+			w.WriteHeader(http.StatusBadRequest)
+			return
 		}
 		w.Header().Set("Cache-Control", "no-store")
 		w.WriteHeader(http.StatusCreated)

--- a/cmd/punaro-enroll/main_test.go
+++ b/cmd/punaro-enroll/main_test.go
@@ -81,6 +81,38 @@ func TestPrepareThenRedeemKeepsSecretsOutOfOutputAndRecoversIdempotently(t *test
 	}
 }
 
+func TestPrepareThenRedeemOverLoopbackHTTP(t *testing.T) {
+	stateDir := filepath.Join(t.TempDir(), "state")
+	credential := "22222222-2222-4222-8222-222222222222." + strings.Repeat("A", 43)
+	var prepared publicEnrollment
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/v1/enrollments/redeem" {
+			t.Fatalf("request=%s %s", r.Method, r.URL.Path)
+		}
+		w.Header().Set("Cache-Control", "no-store")
+		w.WriteHeader(http.StatusCreated)
+		_, _ = io.WriteString(w, `{"principal_id":"11111111-1111-4111-8111-111111111111","lookup_id":"22222222-2222-4222-8222-222222222222","credential":"`+credential+`","generation":1}`)
+	}))
+	defer server.Close()
+
+	var prepareOut, prepareErr bytes.Buffer
+	if code := run([]string{"prepare", "--origin", server.URL, "--state-dir", stateDir}, &prepareOut, &prepareErr); code != 0 || prepareErr.Len() != 0 {
+		t.Fatalf("prepare code=%d stdout=%q stderr=%q", code, prepareOut.String(), prepareErr.String())
+	}
+	if err := json.Unmarshal(prepareOut.Bytes(), &prepared); err != nil {
+		t.Fatalf("parse prepare output: %v", err)
+	}
+	material := writeTestMaterial(t, `{"enrollment_id":"33333333-3333-4333-8333-333333333333","client_binding":"`+prepared.ClientBinding+`","code":"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"}`)
+	credentialFile := filepath.Join(stateDir, "device.credential")
+	var redeemOut, redeemErr bytes.Buffer
+	if code := run([]string{"redeem", "--state-dir", stateDir, "--enrollment-file", material, "--credential-file", credentialFile}, &redeemOut, &redeemErr); code != 0 || redeemErr.Len() != 0 {
+		t.Fatalf("redeem code=%d stdout=%q stderr=%q", code, redeemOut.String(), redeemErr.String())
+	}
+	if raw, err := os.ReadFile(credentialFile); err != nil || string(raw) != credential+"\n" { // #nosec G304 -- test reads its own protected credential fixture.
+		t.Fatalf("credential persistence err=%v", err)
+	}
+}
+
 func TestLegacyPrepareAndRedeemUsesProofBoundExchangeRoute(t *testing.T) {
 	stateDir := filepath.Join(t.TempDir(), "legacy-state")
 	public, private, err := ed25519.GenerateKey(rand.Reader)
@@ -297,6 +329,9 @@ func TestPreparePersistsLoopbackHTTPWithoutTrustedLANPolicy(t *testing.T) {
 	}
 	if state.Version != clientidentity.Version || state.Origin != "http://127.0.0.1:18080" || state.AllowLANHTTP || state.TrustedLANCIDR != "" {
 		t.Fatalf("identity=%#v", state)
+	}
+	if code := run([]string{"prepare", "--origin", "http://127.0.0.1:18080", "--state-dir", filepath.Join(t.TempDir(), "policy"), "--allow-lan-http", "--trusted-lan-cidr", "127.0.0.0/8"}, io.Discard, io.Discard); code != 2 {
+		t.Fatalf("loopback with trusted-LAN policy code=%d", code)
 	}
 }
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -533,7 +533,8 @@ punaro-enroll prepare \
 This exception is limited to literal loopback addresses. DNS names and private
 or link-local addresses still fail unless they use HTTPS or the explicit
 trusted-LAN policy described below. An explicit port is part of the stored
-identity, including `:80`, so use the same port spelling in the adapter profile.
+identity for loopback HTTP, including `:80`, so use the same port spelling in
+the adapter profile. HTTPS remains canonicalized: an explicit `:443` is omitted.
 
 For a registered legacy adapter or gateway, bind preparation to its exact
 existing machine ID:

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -532,7 +532,8 @@ punaro-enroll prepare \
 
 This exception is limited to literal loopback addresses. DNS names and private
 or link-local addresses still fail unless they use HTTPS or the explicit
-trusted-LAN policy described below.
+trusted-LAN policy described below. An explicit port is part of the stored
+identity, including `:80`, so use the same port spelling in the adapter profile.
 
 For a registered legacy adapter or gateway, bind preparation to its exact
 existing machine ID:

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -485,10 +485,12 @@ PUNARO_CLIENT_IDENTITY_FILE=/absolute/private/client-identity.json
 PUNARO_CLIENT_BINDING=the-enrollment-client-binding
 ```
 
-The sidecar contains only version `1`, the fixed canonical HTTPS origin, the
-opaque client binding, and (during a legacy transition) the exact legacy
-machine ID. It never contains an enrollment code, bearer credential, private
-key, Access token, project grant, or mailbox address. The adapter refuses a
+The sidecar contains only version `1`, the fixed canonical HTTPS or literal
+loopback HTTP origin, the opaque client binding, and (during a legacy
+transition) the exact legacy machine ID. Non-loopback trusted-LAN HTTP uses
+version `2` with its explicit acknowledgement and containing CIDR. It never
+contains an enrollment code, bearer credential, private key, Access token,
+project grant, or mailbox address. The adapter refuses a
 missing pair, unsafe sidecar, unknown version, or origin/binding/machine
 mismatch before it opens a transport client. Existing legacy profiles without
 both entries continue their existing path; adding the sidecar alone neither
@@ -518,6 +520,19 @@ punaro-enroll prepare \
   --origin https://punaro.example \
   --state-dir "$HOME/.config/punaro/device-enrollment"
 ```
+
+For a same-host listener, literal loopback HTTP uses the same zero-policy
+version-one state and needs no trusted-LAN flags:
+
+```sh
+punaro-enroll prepare \
+  --origin http://127.0.0.1:8080 \
+  --state-dir "$HOME/.config/punaro/device-enrollment"
+```
+
+This exception is limited to literal loopback addresses. DNS names and private
+or link-local addresses still fail unless they use HTTPS or the explicit
+trusted-LAN policy described below.
 
 For a registered legacy adapter or gateway, bind preparation to its exact
 existing machine ID:
@@ -620,9 +635,9 @@ or diagnostics. Continue to keep the token in the owner-only adapter profile
 for the installed relay adapter; do not reuse it on another device.
 
 `punaro-enroll` checks the exact binding before any network request, contacts
-only the canonical HTTPS origin selected during `prepare`, and writes a private
-recovery journal before redemption. If a network interruption occurs, rerun
-the same `redeem` command; if the transfer file is gone, use `punaro-enroll
+only the canonical validated origin selected during `prepare`, and writes a
+private recovery journal before redemption. If a network interruption occurs,
+rerun the same `redeem` command; if the transfer file is gone, use `punaro-enroll
 recover` with the state and credential paths, and include the same
 `--access-file` when the origin is Access-protected. The retry has the same
 idempotency key, so it cannot mint a second device credential. A legacy journal

--- a/internal/clientidentity/state.go
+++ b/internal/clientidentity/state.go
@@ -18,12 +18,12 @@ import (
 	"golang.org/x/net/idna"
 )
 
-// Version is the current compatible client identity state schema.
+// Version is the current HTTPS or literal-loopback client identity state schema.
 const Version = 1
 
 // LANVersion adds the explicit client-side plaintext acknowledgement and
 // pinned CIDR required for a trusted-LAN origin. Version one remains the
-// canonical HTTPS identity shape.
+// canonical zero-policy identity shape for HTTPS and literal loopback HTTP.
 const LANVersion = 2
 
 var (
@@ -44,7 +44,7 @@ type State struct {
 	TrustedLANCIDR  string
 }
 
-// Parse accepts only the defined HTTPS and trusted-LAN schema versions and
+// Parse accepts only the defined zero-policy and trusted-LAN schema versions and
 // rejects ambiguous JSON before any client uses its local routing or migration
 // relationship.
 func Parse(raw []byte) (State, error) {
@@ -149,7 +149,8 @@ func (s State) validate() error {
 	}
 	switch s.Version {
 	case Version:
-		if s.AllowLANHTTP || s.TrustedLANCIDR != "" || !validOrigin(s.Origin) {
+		canonical, ok := canonicalOriginForPolicy(s.Origin, clienttransport.Policy{})
+		if s.AllowLANHTTP || s.TrustedLANCIDR != "" || !ok || canonical != s.Origin {
 			return ErrInvalidState
 		}
 	case LANVersion:
@@ -167,14 +168,10 @@ func (s State) validate() error {
 }
 
 // TransportPolicy returns the non-secret LAN transport boundary bound into
-// this identity. HTTPS version-one identities return the zero policy.
+// this identity. HTTPS and literal-loopback version-one identities return the
+// zero policy.
 func (s State) TransportPolicy() clienttransport.Policy {
 	return clienttransport.Policy{AllowLANHTTP: s.AllowLANHTTP, TrustedLANCIDR: s.TrustedLANCIDR}
-}
-
-func validOrigin(raw string) bool {
-	canonical, ok := canonicalOrigin(raw)
-	return ok && canonical == raw
 }
 
 func canonicalOrigin(raw string) (string, bool) {
@@ -212,15 +209,32 @@ func canonicalOrigin(raw string) (string, bool) {
 // before accepting credentials or network input.
 func CanonicalOrigin(raw string) (string, bool) { return canonicalOrigin(raw) }
 
-// CanonicalOriginWithPolicy validates the explicit trusted-LAN HTTP exception
-// used only by version-two identity records.
+// CanonicalOriginWithPolicy validates HTTPS and literal loopback HTTP under the
+// zero policy, or the explicit trusted-LAN HTTP exception used by version-two
+// identity records.
 func CanonicalOriginWithPolicy(raw string, policy clienttransport.Policy) (string, bool) {
 	return canonicalOriginForPolicy(raw, policy)
 }
 
 func canonicalOriginForPolicy(raw string, policy clienttransport.Policy) (string, bool) {
 	if !policy.AllowLANHTTP && policy.TrustedLANCIDR == "" {
-		return canonicalOrigin(raw)
+		if canonical, ok := canonicalOrigin(raw); ok {
+			return canonical, true
+		}
+		parsed, err := clienttransport.ValidateOrigin(raw, policy)
+		if err != nil || parsed.Scheme != "http" {
+			return "", false
+		}
+		hostname, ok := canonicalHostname(parsed.Hostname())
+		if !ok {
+			return "", false
+		}
+		if port := parsed.Port(); port != "" {
+			parsed.Host = net.JoinHostPort(hostname, port)
+		} else {
+			parsed.Host = canonicalHost(hostname)
+		}
+		return parsed.String(), true
 	}
 	parsed, err := clienttransport.ValidateOrigin(raw, policy)
 	if err != nil {

--- a/internal/clientidentity/state.go
+++ b/internal/clientidentity/state.go
@@ -222,14 +222,14 @@ func canonicalOriginForPolicy(raw string, policy clienttransport.Policy) (string
 			return canonical, true
 		}
 		parsed, err := clienttransport.ValidateOrigin(raw, policy)
-		if err != nil || parsed.Scheme != "http" {
+		if err != nil || parsed.Scheme != "http" || strings.HasSuffix(parsed.Host, ":") {
 			return "", false
 		}
 		hostname, ok := canonicalHostname(parsed.Hostname())
 		if !ok {
 			return "", false
 		}
-		if port := parsed.Port(); port != "" {
+		if port := parsed.Port(); port != "" && port != "80" {
 			parsed.Host = net.JoinHostPort(hostname, port)
 		} else {
 			parsed.Host = canonicalHost(hostname)

--- a/internal/clientidentity/state.go
+++ b/internal/clientidentity/state.go
@@ -222,14 +222,14 @@ func canonicalOriginForPolicy(raw string, policy clienttransport.Policy) (string
 			return canonical, true
 		}
 		parsed, err := clienttransport.ValidateOrigin(raw, policy)
-		if err != nil || parsed.Scheme != "http" || strings.HasSuffix(parsed.Host, ":") {
+		if err != nil || parsed.Scheme != "http" {
 			return "", false
 		}
 		hostname, ok := canonicalHostname(parsed.Hostname())
 		if !ok {
 			return "", false
 		}
-		if port := parsed.Port(); port != "" && port != "80" {
+		if port := parsed.Port(); port != "" {
 			parsed.Host = net.JoinHostPort(hostname, port)
 		} else {
 			parsed.Host = canonicalHost(hostname)

--- a/internal/clientidentity/state_test.go
+++ b/internal/clientidentity/state_test.go
@@ -53,8 +53,9 @@ func TestCanonicalLoopbackOriginEdges(t *testing.T) {
 		want string
 		ok   bool
 	}{
-		"default port":      {raw: "http://127.0.0.1:80", want: "http://127.0.0.1", ok: true},
+		"default port":      {raw: "http://127.0.0.1:80", want: "http://127.0.0.1:80", ok: true},
 		"canonical IPv6":    {raw: "http://[0:0:0:0:0:0:0:1]:18080/", want: "http://[::1]:18080", ok: true},
+		"IPv6 default port": {raw: "http://[0:0:0:0:0:0:0:1]:80", want: "http://[::1]:80", ok: true},
 		"zoned IPv6":        {raw: "http://[::1%25lo0]:18080", want: "http://[::1%25lo0]:18080", ok: true},
 		"trailing colon":    {raw: "http://127.0.0.1:", ok: false},
 		"leading-zero port": {raw: "http://127.0.0.1:018080", ok: false},
@@ -84,6 +85,7 @@ func TestParseAcceptsOnlyExplicitVersionTwoLANState(t *testing.T) {
 		"missing cidr":           `{"version":2,"origin":"http://192.168.1.4:8080","client_binding":"11111111-1111-4111-8111-111111111111","allow_lan_http":true}`,
 		"dns plaintext":          `{"version":2,"origin":"http://punaro.lan:8080","client_binding":"11111111-1111-4111-8111-111111111111","allow_lan_http":true,"trusted_lan_cidr":"192.168.1.0/24"}`,
 		"https downgrade fields": `{"version":2,"origin":"https://punaro.example","client_binding":"11111111-1111-4111-8111-111111111111","allow_lan_http":true,"trusted_lan_cidr":"192.168.1.0/24"}`,
+		"loopback LAN policy":    `{"version":2,"origin":"http://127.0.0.1:8080","client_binding":"11111111-1111-4111-8111-111111111111","allow_lan_http":true,"trusted_lan_cidr":"127.0.0.0/8"}`,
 	} {
 		t.Run(name, func(t *testing.T) {
 			if _, err := Parse([]byte(raw)); err == nil {

--- a/internal/clientidentity/state_test.go
+++ b/internal/clientidentity/state_test.go
@@ -3,6 +3,8 @@ package clientidentity
 import (
 	"strings"
 	"testing"
+
+	"github.com/rock3r/punaro/internal/clienttransport"
 )
 
 func TestParseAcceptsVersionOneFreshAndMigratingStates(t *testing.T) {
@@ -23,6 +25,22 @@ func TestParseAcceptsVersionOneFreshAndMigratingStates(t *testing.T) {
 	legacyRelayID, err := Parse([]byte(`{"version":1,"origin":"https://punaro.example","client_binding":"11111111-1111-4111-8111-111111111111","legacy_machine_id":"machine:west"}`))
 	if err != nil || legacyRelayID.LegacyMachineID != "machine:west" {
 		t.Fatalf("relay-compatible legacy state=%+v err=%v", legacyRelayID, err)
+	}
+}
+
+func TestParseAcceptsVersionOneLoopbackHTTPWithoutLANPolicy(t *testing.T) {
+	state, err := Parse([]byte(`{"version":1,"origin":"http://127.0.0.1:18080","client_binding":"11111111-1111-4111-8111-111111111111"}`))
+	if err != nil {
+		t.Fatalf("parse loopback state: %v", err)
+	}
+	if state.Origin != "http://127.0.0.1:18080" || state.TransportPolicy() != (clienttransport.Policy{}) {
+		t.Fatalf("state=%#v policy=%#v", state, state.TransportPolicy())
+	}
+	if canonical, ok := CanonicalOriginWithPolicy("http://127.0.0.1:18080/", clienttransport.Policy{}); !ok || canonical != state.Origin {
+		t.Fatalf("canonical loopback origin=%q ok=%t", canonical, ok)
+	}
+	if _, ok := CanonicalOriginWithPolicy("http://192.168.1.4:18080", clienttransport.Policy{}); ok {
+		t.Fatal("private LAN HTTP was accepted without explicit policy")
 	}
 }
 

--- a/internal/clientidentity/state_test.go
+++ b/internal/clientidentity/state_test.go
@@ -42,6 +42,30 @@ func TestParseAcceptsVersionOneLoopbackHTTPWithoutLANPolicy(t *testing.T) {
 	if _, ok := CanonicalOriginWithPolicy("http://192.168.1.4:18080", clienttransport.Policy{}); ok {
 		t.Fatal("private LAN HTTP was accepted without explicit policy")
 	}
+	if err := state.Match("http://127.0.0.1:18080/", state.ClientBinding, ""); err != nil {
+		t.Fatalf("match canonical loopback origin: %v", err)
+	}
+}
+
+func TestCanonicalLoopbackOriginEdges(t *testing.T) {
+	for name, test := range map[string]struct {
+		raw  string
+		want string
+		ok   bool
+	}{
+		"default port":      {raw: "http://127.0.0.1:80", want: "http://127.0.0.1", ok: true},
+		"canonical IPv6":    {raw: "http://[0:0:0:0:0:0:0:1]:18080/", want: "http://[::1]:18080", ok: true},
+		"zoned IPv6":        {raw: "http://[::1%25lo0]:18080", want: "http://[::1%25lo0]:18080", ok: true},
+		"trailing colon":    {raw: "http://127.0.0.1:", ok: false},
+		"leading-zero port": {raw: "http://127.0.0.1:018080", ok: false},
+	} {
+		t.Run(name, func(t *testing.T) {
+			got, ok := CanonicalOriginWithPolicy(test.raw, clienttransport.Policy{})
+			if ok != test.ok || got != test.want {
+				t.Fatalf("canonical=%q ok=%t, want=%q ok=%t", got, ok, test.want, test.ok)
+			}
+		})
+	}
 }
 
 func TestParseAcceptsOnlyExplicitVersionTwoLANState(t *testing.T) {

--- a/internal/clientidentity/state_test.go
+++ b/internal/clientidentity/state_test.go
@@ -47,18 +47,29 @@ func TestParseAcceptsVersionOneLoopbackHTTPWithoutLANPolicy(t *testing.T) {
 	}
 }
 
+func TestParsePreservesExplicitLoopbackHTTPDefaultPort(t *testing.T) {
+	state, err := Parse([]byte(`{"version":1,"origin":"http://127.0.0.1:80","client_binding":"11111111-1111-4111-8111-111111111111"}`))
+	if err != nil {
+		t.Fatalf("parse loopback default-port state: %v", err)
+	}
+	if state.Origin != "http://127.0.0.1:80" {
+		t.Fatalf("origin=%q, want explicit default port", state.Origin)
+	}
+}
+
 func TestCanonicalLoopbackOriginEdges(t *testing.T) {
 	for name, test := range map[string]struct {
 		raw  string
 		want string
 		ok   bool
 	}{
-		"default port":      {raw: "http://127.0.0.1:80", want: "http://127.0.0.1:80", ok: true},
-		"canonical IPv6":    {raw: "http://[0:0:0:0:0:0:0:1]:18080/", want: "http://[::1]:18080", ok: true},
-		"IPv6 default port": {raw: "http://[0:0:0:0:0:0:0:1]:80", want: "http://[::1]:80", ok: true},
-		"zoned IPv6":        {raw: "http://[::1%25lo0]:18080", want: "http://[::1%25lo0]:18080", ok: true},
-		"trailing colon":    {raw: "http://127.0.0.1:", ok: false},
-		"leading-zero port": {raw: "http://127.0.0.1:018080", ok: false},
+		"default port":        {raw: "http://127.0.0.1:80", want: "http://127.0.0.1:80", ok: true},
+		"canonical IPv6":      {raw: "http://[0:0:0:0:0:0:0:1]:18080/", want: "http://[::1]:18080", ok: true},
+		"IPv6 default port":   {raw: "http://[0:0:0:0:0:0:0:1]:80", want: "http://[::1]:80", ok: true},
+		"zoned IPv6":          {raw: "http://[::1%25lo0]:18080", want: "http://[::1%25lo0]:18080", ok: true},
+		"trailing colon":      {raw: "http://127.0.0.1:", ok: false},
+		"IPv6 trailing colon": {raw: "http://[::1]:", ok: false},
+		"leading-zero port":   {raw: "http://127.0.0.1:018080", ok: false},
 	} {
 		t.Run(name, func(t *testing.T) {
 			got, ok := CanonicalOriginWithPolicy(test.raw, clienttransport.Policy{})

--- a/internal/clienttransport/policy.go
+++ b/internal/clienttransport/policy.go
@@ -106,6 +106,9 @@ func HardenClient(provided *http.Client, raw string, policy Policy) (*http.Clien
 }
 
 func validatePort(parsed *url.URL) error {
+	if strings.HasSuffix(parsed.Host, ":") {
+		return errors.New("invalid port")
+	}
 	port := parsed.Port()
 	if port == "" {
 		return nil

--- a/internal/clienttransport/policy_test.go
+++ b/internal/clienttransport/policy_test.go
@@ -14,6 +14,7 @@ func TestPolicyValidatesExplicitTrustedLANHTTP(t *testing.T) {
 	}{
 		{name: "https", origin: "https://punaro.example", ok: true},
 		{name: "loopback development", origin: "http://127.0.0.1:8080", ok: true},
+		{name: "loopback rejects LAN policy", origin: "http://127.0.0.1:8080", policy: Policy{AllowLANHTTP: true, TrustedLANCIDR: "127.0.0.0/8"}, ok: false},
 		{name: "explicit private ipv4", origin: "http://192.168.1.4:8080", policy: Policy{AllowLANHTTP: true, TrustedLANCIDR: "192.168.1.0/24"}, ok: true},
 		{name: "explicit private ipv6", origin: "http://[fd12:3456::4]:8080", policy: Policy{AllowLANHTTP: true, TrustedLANCIDR: "fd12:3456::/64"}, ok: true},
 		{name: "explicit zoned link-local ipv6", origin: "http://[fe80::4%25en0]:8080", policy: Policy{AllowLANHTTP: true, TrustedLANCIDR: "fe80::/64"}, ok: true},

--- a/internal/clienttransport/policy_test.go
+++ b/internal/clienttransport/policy_test.go
@@ -26,6 +26,9 @@ func TestPolicyValidatesExplicitTrustedLANHTTP(t *testing.T) {
 		{name: "public cidr", origin: "http://203.0.113.4:8080", policy: Policy{AllowLANHTTP: true, TrustedLANCIDR: "203.0.113.0/24"}, ok: false},
 		{name: "credentials", origin: "http://user@192.168.1.4:8080", policy: Policy{AllowLANHTTP: true, TrustedLANCIDR: "192.168.1.0/24"}, ok: false},
 		{name: "path", origin: "http://192.168.1.4:8080/v1", policy: Policy{AllowLANHTTP: true, TrustedLANCIDR: "192.168.1.0/24"}, ok: false},
+		{name: "HTTPS trailing colon", origin: "https://punaro.example:", ok: false},
+		{name: "loopback trailing colon", origin: "http://127.0.0.1:", ok: false},
+		{name: "LAN trailing colon", origin: "http://192.168.1.4:", policy: Policy{AllowLANHTTP: true, TrustedLANCIDR: "192.168.1.0/24"}, ok: false},
 		{name: "stale lan policy on https", origin: "https://punaro.example", policy: Policy{AllowLANHTTP: true, TrustedLANCIDR: "192.168.1.0/24"}, ok: false},
 	}
 	for _, test := range tests {


### PR DESCRIPTION
## Summary
- allow literal loopback HTTP origins in version-one device identity state, matching the existing zero-policy transport contract
- keep non-loopback HTTP behind explicit trusted-LAN acknowledgement and pinned CIDR
- add RED-to-GREEN identity and CLI retry coverage
- update the design, installation guide, and CLI help text

## Validation
- make test
- make test-race
- make staticcheck
- make security
- make lint
- make release-gates

## Review status
Independent Pioneer review is pending because the configured provider actor is currently returning an immediate assistant error; the immutable resume token is preserved.