### PR TITLE
Enable zero-grant server doctor migration

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "punaro",
   "displayName": "Punaro",
-  "version": "0.1.0-alpha.10",
+  "version": "0.1.0-alpha.11",
   "description": "Safely receive and reply to durable Punaro messages and handle explicitly authorized trusted attachments.",
   "author": {
     "name": "Punaro contributors",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "punaro",
-  "version": "0.1.0-alpha.10",
+  "version": "0.1.0-alpha.11",
   "description": "Safely receive and reply to durable Punaro messages and handle explicitly authorized trusted attachments.",
   "author": {
     "name": "Punaro contributors",

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -293,7 +293,9 @@ grant set and creates a revocable device principal that can authenticate only
 routes requiring no capability grant, such as server doctor probes. Template,
 scope, and grants are bound into the owner-confirmed preview hash and pending
 enrollment; `service` cannot be combined with project scope, all-project scope,
-or legacy exchange.
+or any capability grant. It may carry one exact owner-selected legacy principal
+only for a proof-bound exchange, allowing an existing server doctor to replace
+its Ed25519 key with a zero-grant device credential without widening authority.
 
 An endpoint belongs to exactly one currently connected machine lease. A machine
 can only advertise endpoints in its configured namespace (for example,

--- a/cmd/punaro-adapter/main_test.go
+++ b/cmd/punaro-adapter/main_test.go
@@ -971,12 +971,12 @@ func TestPluginDoctorValidatesAllAdaptersLauncherAndExactSkillTree(t *testing.T)
 		t.Fatal(err)
 	}
 	oldRelease, oldDigest, oldRuntimeDigest := adapterBuildRelease, adapterExpectedSkillSetDigest, adapterExpectedPluginRuntimeDigest
-	adapterBuildRelease, adapterExpectedSkillSetDigest, adapterExpectedPluginRuntimeDigest = "v0.1.0-alpha.10", digest, runtimeDigest
+	adapterBuildRelease, adapterExpectedSkillSetDigest, adapterExpectedPluginRuntimeDigest = "v0.1.0-alpha.11", digest, runtimeDigest
 	t.Cleanup(func() {
 		adapterBuildRelease, adapterExpectedSkillSetDigest, adapterExpectedPluginRuntimeDigest = oldRelease, oldDigest, oldRuntimeDigest
 	})
 	result := inspectAdapterPlugin(t.Context(), root)
-	if !result.Portable || !result.Codex || !result.Claude || !result.Launcher || result.Version != "v0.1.0-alpha.10" || result.SkillDigest != "sha256:"+digest {
+	if !result.Portable || !result.Codex || !result.Claude || !result.Launcher || result.Version != "v0.1.0-alpha.11" || result.SkillDigest != "sha256:"+digest {
 		t.Fatalf("plugin=%#v", result)
 	}
 	var helperOutput bytes.Buffer

--- a/cmd/punaro-admin/main.go
+++ b/cmd/punaro-admin/main.go
@@ -137,22 +137,31 @@ func runClientAdd(args []string, stdout, stderr io.Writer) int {
 	var err error
 	template := "trusted-agent"
 	if *serviceOnly {
-		if len(projects) != 0 || *allProjects || *legacyPrincipal != "" {
+		if len(projects) != 0 || *allProjects {
 			return adminError(stderr, errors.New("service enrollment scope is ambiguous"))
 		}
 		template = "service"
-		grants, previewHash, err = punaropostgres.PreviewServiceEnrollment()
+		if *legacyPrincipal != "" {
+			grants, previewHash, err = punaropostgres.PreviewServiceEnrollmentForLegacy(*legacyPrincipal)
+		} else {
+			grants, previewHash, err = punaropostgres.PreviewServiceEnrollment()
+		}
 	} else {
-		grants, previewHash, err = punaropostgres.PreviewTrustedAgentEnrollment(projects, *allProjects)
+		if *legacyPrincipal != "" {
+			grants, previewHash, err = punaropostgres.PreviewTrustedAgentEnrollmentForLegacy(projects, *allProjects, *legacyPrincipal)
+		} else {
+			grants, previewHash, err = punaropostgres.PreviewTrustedAgentEnrollment(projects, *allProjects)
+		}
 	}
 	if err != nil {
 		return adminError(stderr, err)
 	}
 	preview := struct {
-		Template    string                     `json:"template"`
-		PreviewHash string                     `json:"preview_hash"`
-		Grants      []punaropostgres.GrantSpec `json:"grants"`
-	}{Template: template, PreviewHash: previewHash, Grants: grants}
+		Template          string                     `json:"template"`
+		LegacyPrincipalID string                     `json:"legacy_principal_id,omitempty"`
+		PreviewHash       string                     `json:"preview_hash"`
+		Grants            []punaropostgres.GrantSpec `json:"grants"`
+	}{Template: template, LegacyPrincipalID: *legacyPrincipal, PreviewHash: previewHash, Grants: grants}
 	if code := writeJSON(stdout, stderr, preview); code != 0 {
 		return code
 	}

--- a/cmd/punaro-admin/main_test.go
+++ b/cmd/punaro-admin/main_test.go
@@ -60,6 +60,32 @@ func TestClientInvitePrintsServiceOnlyPreviewBeforeOpeningAdministration(t *test
 	}
 }
 
+func TestClientInvitePrintsLegacyLinkedServicePreviewBeforeOpeningAdministration(t *testing.T) {
+	original := openAdminDatabase
+	t.Cleanup(func() { openAdminDatabase = original })
+	openAdminDatabase = func(_ context.Context, _ postgres.Config) (adminDatabase, error) {
+		t.Fatal("administration opened before confirmation")
+		return nil, nil
+	}
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"client", "invite", "--actor-principal-id", "11111111-1111-4111-8111-111111111111", "--name", "server doctor", "--machine-id", "server-doctor", "--client-binding", "22222222-2222-4222-8222-222222222222", "--service", "--legacy-principal-id", "33333333-3333-4333-8333-333333333333"}, &stdout, &stderr)
+	if code != 3 || !strings.Contains(stdout.String(), `"template": "service"`) || !strings.Contains(stdout.String(), `"legacy_principal_id": "33333333-3333-4333-8333-333333333333"`) || !strings.Contains(stdout.String(), `"grants": []`) || !strings.Contains(stdout.String(), `"preview_hash"`) || !strings.Contains(stderr.String(), "rerun with --yes") {
+		t.Fatalf("code=%d stdout=%q stderr=%q", code, stdout.String(), stderr.String())
+	}
+}
+
+func TestClientInviteRejectsServiceProjectScope(t *testing.T) {
+	for _, args := range [][]string{
+		{"client", "invite", "--actor-principal-id", "11111111-1111-4111-8111-111111111111", "--name", "server doctor", "--machine-id", "server-doctor", "--client-binding", "22222222-2222-4222-8222-222222222222", "--service", "--project", "33333333-3333-4333-8333-333333333333"},
+		{"client", "invite", "--actor-principal-id", "11111111-1111-4111-8111-111111111111", "--name", "server doctor", "--machine-id", "server-doctor", "--client-binding", "22222222-2222-4222-8222-222222222222", "--service", "--all-projects"},
+	} {
+		var stdout, stderr bytes.Buffer
+		if code := run(args, &stdout, &stderr); code == 0 || stdout.Len() != 0 || !strings.Contains(stderr.String(), "host-local administration failed") {
+			t.Fatalf("args=%v code=%d stdout=%q stderr=%q", args, code, stdout.String(), stderr.String())
+		}
+	}
+}
+
 func TestClientInviteAliasAndLifecycleCommands(t *testing.T) {
 	original := openAdminDatabase
 	t.Cleanup(func() { openAdminDatabase = original })

--- a/cmd/punaro-enroll/main.go
+++ b/cmd/punaro-enroll/main.go
@@ -64,14 +64,15 @@ type enrollmentEnvelope struct {
 }
 
 type enrollmentPreview struct {
-	Template    string            `json:"template"`
-	PreviewHash string            `json:"preview_hash"`
-	Grants      []json.RawMessage `json:"grants"`
+	Template          string            `json:"template"`
+	LegacyPrincipalID string            `json:"legacy_principal_id,omitempty"`
+	PreviewHash       string            `json:"preview_hash"`
+	Grants            []json.RawMessage `json:"grants"`
 }
 
 type enrollmentGrantPreview struct {
 	Scope      string `json:"scope"`
-	ProjectID  string `json:"project_id"`
+	ProjectID  string `json:"project_id,omitempty"`
 	Capability string `json:"capability"`
 }
 
@@ -396,7 +397,7 @@ func loadMaterial(path string) (enrollmentMaterial, error) {
 		return enrollmentMaterial{}, errors.New("invalid enrollment material")
 	}
 	var preview enrollmentPreview
-	if err := decodeExact(records[0], &preview, "template", "preview_hash", "grants"); err != nil || !validEnrollmentPreview(preview) {
+	if err := decodeFields(records[0], &preview, []string{"template", "preview_hash", "grants"}, []string{"legacy_principal_id"}); err != nil || !validEnrollmentPreview(preview) {
 		return enrollmentMaterial{}, errors.New("invalid enrollment material")
 	}
 	envelope, err := decodeEnrollmentEnvelope(records[1])
@@ -445,17 +446,46 @@ func validPreviewHash(value string) bool {
 }
 
 func validEnrollmentPreview(preview enrollmentPreview) bool {
-	if !validPreviewHash(preview.PreviewHash) {
+	if !validPreviewHash(preview.PreviewHash) || (preview.LegacyPrincipalID != "" && !validUUID(preview.LegacyPrincipalID)) {
 		return false
 	}
+	validGrants := false
 	switch preview.Template {
 	case "trusted-agent":
-		return validGrantPreview(preview.Grants, false)
+		validGrants = validGrantPreview(preview.Grants, false)
 	case "service":
-		return len(preview.Grants) == 0
+		validGrants = len(preview.Grants) == 0
 	default:
 		return false
 	}
+	return validGrants && previewHashMatches(preview)
+}
+
+func previewHashMatches(preview enrollmentPreview) bool {
+	grants := make([]enrollmentGrantPreview, len(preview.Grants))
+	for index, raw := range preview.Grants {
+		if err := decodeFields(raw, &grants[index], []string{"scope", "capability"}, []string{"project_id"}); err != nil {
+			return false
+		}
+	}
+	var value any = grants
+	if preview.LegacyPrincipalID != "" {
+		value = struct {
+			Grants            []enrollmentGrantPreview `json:"grants"`
+			LegacyPrincipalID string                   `json:"legacy_principal_id"`
+		}{Grants: grants, LegacyPrincipalID: preview.LegacyPrincipalID}
+	}
+	body, err := json.Marshal(value)
+	if err != nil {
+		return false
+	}
+	digest := sha256.Sum256(body)
+	return matchesHexDigest(preview.PreviewHash, digest[:])
+}
+
+func matchesHexDigest(encoded string, expected []byte) bool {
+	decoded, err := hex.DecodeString(encoded)
+	return err == nil && len(decoded) == len(expected) && bytes.Equal(decoded, expected)
 }
 
 func validGrantPreview(rawGrants []json.RawMessage, allowEmpty bool) bool {

--- a/cmd/punaro-enroll/main_test.go
+++ b/cmd/punaro-enroll/main_test.go
@@ -680,6 +680,77 @@ func TestEnrollmentMaterialAcceptsExactServiceAdminOutput(t *testing.T) {
 	}
 }
 
+func TestEnrollmentMaterialAcceptsExactLegacyServiceAdminOutput(t *testing.T) {
+	legacyPrincipalID := "55555555-5555-4555-8555-555555555555"
+	grants, previewHash, err := punaropostgres.PreviewServiceEnrollmentForLegacy(legacyPrincipalID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	preview := struct {
+		Template          string                     `json:"template"`
+		LegacyPrincipalID string                     `json:"legacy_principal_id"`
+		PreviewHash       string                     `json:"preview_hash"`
+		Grants            []punaropostgres.GrantSpec `json:"grants"`
+	}{Template: "service", LegacyPrincipalID: legacyPrincipalID, PreviewHash: previewHash, Grants: grants}
+	pending := punaropostgres.PendingEnrollment{ID: "33333333-3333-4333-8333-333333333333", ClientBinding: "44444444-4444-4444-8444-444444444444", Code: strings.Repeat("A", 43), ExpiresAt: time.Date(2030, 1, 2, 3, 4, 5, 0, time.UTC), PreviewHash: previewHash, Grants: grants}
+	previewRaw, err := json.MarshalIndent(preview, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	pendingRaw, err := json.MarshalIndent(pending, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	material, err := loadMaterial(writeTestMaterial(t, string(append(append(previewRaw, '\n'), append(pendingRaw, '\n')...))))
+	if err != nil || material.EnrollmentID != pending.ID {
+		t.Fatalf("legacy service admin output material=%#v err=%v", material, err)
+	}
+	preview.LegacyPrincipalID = "not-a-principal"
+	previewRaw, err = json.MarshalIndent(preview, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := loadMaterial(writeTestMaterial(t, string(append(append(previewRaw, '\n'), append(pendingRaw, '\n')...)))); err == nil {
+		t.Fatal("legacy service admin output accepted an invalid legacy principal")
+	}
+	preview.LegacyPrincipalID = "66666666-6666-4666-8666-666666666666"
+	previewRaw, err = json.MarshalIndent(preview, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := loadMaterial(writeTestMaterial(t, string(append(append(previewRaw, '\n'), append(pendingRaw, '\n')...)))); err == nil {
+		t.Fatal("legacy service admin output accepted a legacy principal not bound by preview_hash")
+	}
+}
+
+func TestEnrollmentMaterialAcceptsExactLegacyTrustedAgentAdminOutput(t *testing.T) {
+	legacyPrincipalID := "55555555-5555-4555-8555-555555555555"
+	projectID := "77777777-7777-4777-8777-777777777777"
+	grants, previewHash, err := punaropostgres.PreviewTrustedAgentEnrollmentForLegacy([]string{projectID}, false, legacyPrincipalID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	preview := struct {
+		Template          string                     `json:"template"`
+		LegacyPrincipalID string                     `json:"legacy_principal_id"`
+		PreviewHash       string                     `json:"preview_hash"`
+		Grants            []punaropostgres.GrantSpec `json:"grants"`
+	}{Template: "trusted-agent", LegacyPrincipalID: legacyPrincipalID, PreviewHash: previewHash, Grants: grants}
+	pending := punaropostgres.PendingEnrollment{ID: "33333333-3333-4333-8333-333333333333", ClientBinding: "44444444-4444-4444-8444-444444444444", Code: strings.Repeat("A", 43), ExpiresAt: time.Date(2030, 1, 2, 3, 4, 5, 0, time.UTC), PreviewHash: previewHash, Grants: grants}
+	previewRaw, err := json.MarshalIndent(preview, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	pendingRaw, err := json.MarshalIndent(pending, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	material, err := loadMaterial(writeTestMaterial(t, string(append(append(previewRaw, '\n'), append(pendingRaw, '\n')...))))
+	if err != nil || material.EnrollmentID != pending.ID {
+		t.Fatalf("legacy trusted-agent admin output material=%#v err=%v", material, err)
+	}
+}
+
 func TestProtectMaterialTightensTransferredFileWithoutReadingIt(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "enrollment-material.json")
 	want := []byte("private enrollment material")

--- a/cmd/punaro-release/main_test.go
+++ b/cmd/punaro-release/main_test.go
@@ -171,8 +171,8 @@ func TestBuildFactsBindsPluginSkillsGeneratedComposeAndMigrations(t *testing.T) 
 	if err != nil {
 		t.Fatal(err)
 	}
-	facts, err := buildFacts([]string{"--release", "v0.1.0-alpha.10", "--plugin-root", root})
-	if err != nil || facts.Release != "v0.1.0-alpha.10" || facts.ComposeSHA256 != operator.ComposeManifestSHA256() || len(facts.MigrationManifestSHA256) != 64 || len(facts.SkillSetSHA256) != 64 || len(facts.PluginRuntimeSHA256) != 64 {
+	facts, err := buildFacts([]string{"--release", "v0.1.0-alpha.11", "--plugin-root", root})
+	if err != nil || facts.Release != "v0.1.0-alpha.11" || facts.ComposeSHA256 != operator.ComposeManifestSHA256() || len(facts.MigrationManifestSHA256) != 64 || len(facts.SkillSetSHA256) != 64 || len(facts.PluginRuntimeSHA256) != 64 {
 		t.Fatalf("facts=%#v err=%v", facts, err)
 	}
 	if _, err := buildFacts([]string{"--release", "v0.1.0", "--plugin-root", root}); err == nil {

--- a/docs/doctor.md
+++ b/docs/doctor.md
@@ -82,7 +82,10 @@ punaro doctor \
 
 The profile contains exactly one relay credential reference. Before mail
 cutover, use the enrolled diagnostic machine's private key as above and migrate
-that same identity through the proof-bound legacy enrollment workflow. Keep the
+that same identity through the proof-bound legacy enrollment workflow. The
+owner invitation uses `--service --legacy-principal-id LEGACY_UUID`: its
+confirmed preview must contain an empty `grants` array, and redemption must use
+the existing doctor private key. Keep the
 key-backed profile active until the server has published cutover and restarted
 with the PostgreSQL credential-transition runtime. Then create a new protected
 profile path (the writer never overwrites an existing file) using the staged

--- a/docs/github-releases.md
+++ b/docs/github-releases.md
@@ -161,6 +161,13 @@ Only the offline-signature publisher can make those stable assets visible.
    `minimum_bootstrap_release=v0.1.0-alpha.8` and
    `supported_from=v0.1.0-alpha.9`; alpha.9 clients can exercise the built-in
    signed update before the fleet enrollment cutover.
+
+   Alpha.11 adds proof-bound, zero-grant migration for the existing server
+   doctor identity without changing the signed-slot or fixed-bootstrap
+   protocol. Dispatch `v0.1.0-alpha.11` with
+   `minimum_bootstrap_release=v0.1.0-alpha.8` and
+   `supported_from=v0.1.0-alpha.10`; alpha.10 clients can exercise the built-in
+   signed update before the server doctor credential cutover.
 3. Wait for the draft release to appear. The live `catalog` prerelease is not
    touched by the unsigned workflow.
 4. Generate the offline key once, on an air-gapped or owner-only machine, and

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -565,8 +565,13 @@ For a non-agent service probe such as server doctor, the owner uses
 `--service` instead of `--project` or `--all-projects`. Its exact preview has an
 empty `grants` array and grants no project, conversation, memory, attachment,
 or installation capability. `--service` is mutually exclusive with project
-scope and legacy exchange; the resulting device credential authenticates only
-routes that require no capability grant.
+scope, but an existing registered legacy machine (such as the key-backed server
+doctor) may also supply its exact `--legacy-principal-id` for the same
+proof-bound exchange described above. The result remains zero-grant and the
+resulting device credential authenticates
+only routes that require no capability grant. This is the supported migration
+for a key-backed server doctor; do not issue a fresh unrelated service client
+and retire the old doctor first.
 
 Windows file transfer tools commonly leave the destination with an inherited
 ACL. Before redemption, tighten that exact transferred file without displaying

--- a/docs/operator-guide.md
+++ b/docs/operator-guide.md
@@ -317,6 +317,23 @@ punaro-admin client invite -owner-dsn-file /absolute/private/owner.dsn \
   -project PROJECT_UUID
 ```
 
+For a registered server doctor, preserve zero authority while replacing the
+legacy key by confirming the empty service preview and binding the exact
+pending legacy principal:
+
+```sh
+punaro-admin client invite -owner-dsn-file /absolute/private/owner.dsn \
+  -actor-principal-id OWNER_UUID -name "server doctor" \
+  -machine-id server-doctor -client-binding CLIENT_UUID \
+  -service -legacy-principal-id LEGACY_UUID
+```
+
+Do not combine `-service` with project scope. The printed preview includes the
+exact `legacy_principal_id` and binds it into `preview_hash`; the confirmed run
+still requires `-yes`, and the client redeems through the legacy exchange with
+the existing doctor private key. Only one live pending enrollment may bind that
+legacy identity.
+
 The confirmed run returns one enrollment ID and code. M-5 mounts bounded
 redemption and device-session authentication under the transport policy below;
 ownership and issuance remain host-local. Redemption binds the code to the

--- a/docs/platform-contracts.md
+++ b/docs/platform-contracts.md
@@ -633,6 +633,13 @@ conversation send/receive; memory search/read/propose/write; and attachment
 upload/download. It excludes attachment delete, every administer/purge
 capability, merge/membership administration, backup, and restore.
 
+The `service` template contains no grants. It cannot be combined with project
+scope, but the owner may bind it to one exact pending legacy principal. That
+combination changes only the credential form after proof of the registered
+Ed25519 key; it does not grant project, conversation, memory, attachment, or
+installation authority. Server doctor migration uses this path so its bearer
+continues to resolve the same relay identity after cutover.
+
 ## Server invariants
 
 - At-least-once mail delivery, immutable message IDs, operation-bound

--- a/internal/postgres/device_auth.go
+++ b/internal/postgres/device_auth.go
@@ -83,18 +83,44 @@ func PreviewTrustedAgentEnrollment(projectIDs []string, allProjects bool) ([]Gra
 	if err != nil {
 		return nil, "", err
 	}
-	return previewEnrollment(grants)
+	return previewEnrollment(grants, "")
+}
+
+// PreviewTrustedAgentEnrollmentForLegacy binds one exact legacy principal to
+// the owner-confirmed grant preview.
+func PreviewTrustedAgentEnrollmentForLegacy(projectIDs []string, allProjects bool, legacyPrincipalID string) ([]GrantSpec, string, error) {
+	grants, err := TrustedAgentGrantPreview(projectIDs, allProjects)
+	if err != nil {
+		return nil, "", err
+	}
+	return previewEnrollment(grants, legacyPrincipalID)
 }
 
 // PreviewServiceEnrollment returns an explicitly empty capability expansion
 // for service identities that authenticate health checks but need no API
 // authority of their own.
 func PreviewServiceEnrollment() ([]GrantSpec, string, error) {
-	return previewEnrollment([]GrantSpec{})
+	return previewEnrollment([]GrantSpec{}, "")
 }
 
-func previewEnrollment(grants []GrantSpec) ([]GrantSpec, string, error) {
-	body, err := json.Marshal(grants)
+// PreviewServiceEnrollmentForLegacy binds one exact legacy principal to the
+// explicitly empty service grant preview.
+func PreviewServiceEnrollmentForLegacy(legacyPrincipalID string) ([]GrantSpec, string, error) {
+	return previewEnrollment([]GrantSpec{}, legacyPrincipalID)
+}
+
+func previewEnrollment(grants []GrantSpec, legacyPrincipalID string) ([]GrantSpec, string, error) {
+	if legacyPrincipalID != "" && !validOpaqueID(legacyPrincipalID) {
+		return nil, "", errors.New("invalid legacy principal")
+	}
+	var value any = grants
+	if legacyPrincipalID != "" {
+		value = struct {
+			Grants            []GrantSpec `json:"grants"`
+			LegacyPrincipalID string      `json:"legacy_principal_id"`
+		}{Grants: grants, LegacyPrincipalID: legacyPrincipalID}
+	}
+	body, err := json.Marshal(value)
 	if err != nil {
 		return nil, "", errors.New("enrollment preview cannot be encoded")
 	}
@@ -122,7 +148,7 @@ func (r EnrollmentRequest) Validate() error {
 		return errors.New("invalid enrollment request")
 	}
 	if r.ServiceOnly {
-		if len(r.ProjectIDs) != 0 || r.AllProjects || r.LegacyPrincipalID != "" {
+		if len(r.ProjectIDs) != 0 || r.AllProjects {
 			return errors.New("invalid enrollment request")
 		}
 		return nil

--- a/internal/postgres/device_auth_integration_test.go
+++ b/internal/postgres/device_auth_integration_test.go
@@ -9,6 +9,7 @@ import (
 	"database/sql"
 	"encoding/base64"
 	"errors"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -434,7 +435,11 @@ VALUES ($1, gen_random_uuid(), $2, 'bounded prune target',
 		t.Fatal("legacy authentication disabled with a pending intended machine")
 	}
 	legacyRequest := EnrollmentRequest{ClientBinding: uuid.NewString(), MachineID: "legacy-replacement", Label: "legacy replacement", AllProjects: true, LegacyPrincipalID: legacy.PrincipalID, TTL: 10 * time.Minute}
-	legacyPending, err := admin.CreateEnrollment(ctx, owner.ID, legacyRequest, concurrentHash)
+	_, legacyPreviewHash, err := PreviewTrustedAgentEnrollmentForLegacy(nil, true, legacy.PrincipalID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	legacyPending, err := admin.CreateEnrollment(ctx, owner.ID, legacyRequest, legacyPreviewHash)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -503,6 +508,51 @@ WHERE id = $1`, legacyPending.ID, uuid.NewString(), owner.ID, credential.LookupI
 	inventory, err := admin.ListLegacyMachines(ctx, owner.ID)
 	if err != nil || len(inventory) != 1 || inventory[0].State != LegacyMigrated {
 		t.Fatalf("legacy inventory=%#v err=%v", inventory, err)
+	}
+	serviceLegacyPublic, serviceLegacyPrivate, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	serviceLegacy, err := admin.RegisterLegacyMachine(ctx, owner.ID, "legacy server doctor", serviceLegacyPublic)
+	if err != nil {
+		t.Fatal(err)
+	}
+	serviceLegacyRequest := EnrollmentRequest{ClientBinding: uuid.NewString(), MachineID: "legacy-server-doctor", Label: "legacy server doctor", ServiceOnly: true, LegacyPrincipalID: serviceLegacy.PrincipalID, TTL: 10 * time.Minute}
+	serviceLegacyGrants, serviceLegacyHash, err := PreviewServiceEnrollmentForLegacy(serviceLegacy.PrincipalID)
+	if err != nil || len(serviceLegacyGrants) != 0 {
+		t.Fatalf("legacy service preview=%#v hash=%q err=%v", serviceLegacyGrants, serviceLegacyHash, err)
+	}
+	serviceLegacyPending, err := admin.CreateEnrollment(ctx, owner.ID, serviceLegacyRequest, serviceLegacyHash)
+	if err != nil || len(serviceLegacyPending.Grants) != 0 {
+		t.Fatalf("legacy service pending=%#v err=%v", serviceLegacyPending, err)
+	}
+	duplicateServiceLegacyRequest := serviceLegacyRequest
+	duplicateServiceLegacyRequest.ClientBinding = uuid.NewString()
+	duplicateServiceLegacyRequest.MachineID = "legacy-server-doctor-duplicate"
+	if _, err := admin.CreateEnrollment(ctx, owner.ID, duplicateServiceLegacyRequest, serviceLegacyHash); err == nil || !strings.Contains(err.Error(), "legacy machine already has a pending enrollment") {
+		t.Fatalf("duplicate legacy service enrollment err=%v", err)
+	}
+	serviceLegacyRedeem := RedeemEnrollment{EnrollmentID: serviceLegacyPending.ID, ClientBinding: serviceLegacyRequest.ClientBinding, Code: serviceLegacyPending.Code, IdempotencyKey: uuid.NewString()}
+	serviceLegacyCode, err := base64.RawURLEncoding.Strict().DecodeString(serviceLegacyRedeem.Code)
+	if err != nil {
+		t.Fatal(err)
+	}
+	serviceLegacyCodeDigest := sha256.Sum256(serviceLegacyCode)
+	serviceLegacyProof := LegacyExchangeProof{PublicKey: serviceLegacyPublic, Signature: ed25519.Sign(serviceLegacyPrivate, legacyexchange.Transcript(serviceLegacyRedeem.EnrollmentID, serviceLegacyRedeem.ClientBinding, serviceLegacyRedeem.IdempotencyKey, serviceLegacyCodeDigest))}
+	serviceLegacyCredential, err := app.RedeemLegacyEnrollment(ctx, serviceLegacyProof, serviceLegacyRedeem)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var serviceLegacyGrantCount int
+	if err := ownerDB.QueryRowContext(ctx, `SELECT count(*) FROM auth.capability_grants WHERE principal_id = $1`, serviceLegacyCredential.PrincipalID).Scan(&serviceLegacyGrantCount); err != nil || serviceLegacyGrantCount != 0 {
+		t.Fatalf("legacy service grant count=%d err=%v", serviceLegacyGrantCount, err)
+	}
+	serviceLegacyAuthenticated, err := app.AuthenticateDevice(ctx, serviceLegacyCredential.Encoded)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resolved, err := app.ResolveMigratedLegacyPublicKey(ctx, serviceLegacyAuthenticated); err != nil || !bytes.Equal(resolved, serviceLegacyPublic) {
+		t.Fatalf("legacy service relay authority=%x err=%v", resolved, err)
 	}
 	racePublic, _, err := ed25519.GenerateKey(rand.Reader)
 	if err != nil {

--- a/internal/postgres/device_auth_store.go
+++ b/internal/postgres/device_auth_store.go
@@ -311,9 +311,17 @@ func (a *Administration) CreateEnrollment(ctx context.Context, actorPrincipalID 
 	var previewHash string
 	var err error
 	if request.ServiceOnly {
-		grants, previewHash, err = PreviewServiceEnrollment()
+		if request.LegacyPrincipalID != "" {
+			grants, previewHash, err = PreviewServiceEnrollmentForLegacy(request.LegacyPrincipalID)
+		} else {
+			grants, previewHash, err = PreviewServiceEnrollment()
+		}
 	} else {
-		grants, previewHash, err = PreviewTrustedAgentEnrollment(request.ProjectIDs, request.AllProjects)
+		if request.LegacyPrincipalID != "" {
+			grants, previewHash, err = PreviewTrustedAgentEnrollmentForLegacy(request.ProjectIDs, request.AllProjects, request.LegacyPrincipalID)
+		} else {
+			grants, previewHash, err = PreviewTrustedAgentEnrollment(request.ProjectIDs, request.AllProjects)
+		}
 	}
 	if err != nil || subtle.ConstantTimeCompare([]byte(previewHash), []byte(confirmedPreviewHash)) != 1 {
 		return PendingEnrollment{}, errors.New("enrollment preview was not confirmed")
@@ -374,6 +382,10 @@ OR EXISTS (SELECT 1 FROM auth.pending_enrollments WHERE machine_id = $1 AND rede
 	if request.LegacyPrincipalID != "" {
 		if err := lockLegacyMutations(ctx, tx); err != nil {
 			return PendingEnrollment{}, err
+		}
+		var legacyEnrollmentExists bool
+		if err := tx.QueryRowContext(ctx, `SELECT EXISTS (SELECT 1 FROM auth.pending_enrollments WHERE legacy_principal_id = $1 AND redeemed_at IS NULL AND invalidated_at IS NULL AND expires_at > statement_timestamp())`, request.LegacyPrincipalID).Scan(&legacyEnrollmentExists); err != nil || legacyEnrollmentExists {
+			return PendingEnrollment{}, errors.New("legacy machine already has a pending enrollment")
 		}
 		var pendingLegacy bool
 		if err := tx.QueryRowContext(ctx, `SELECT EXISTS (SELECT 1 FROM auth.legacy_machines WHERE principal_id = $1 AND state = 'pending')`, request.LegacyPrincipalID).Scan(&pendingLegacy); err != nil || !pendingLegacy {

--- a/internal/postgres/device_auth_test.go
+++ b/internal/postgres/device_auth_test.go
@@ -69,6 +69,27 @@ func TestServiceEnrollmentGrantPreviewIsEmptyAndStable(t *testing.T) {
 	if err := request.Validate(); err != nil {
 		t.Fatalf("service-only request rejected: %v", err)
 	}
+	request.LegacyPrincipalID = testPrincipalA
+	if err := request.Validate(); err != nil {
+		t.Fatalf("legacy-linked service-only request rejected: %v", err)
+	}
+	legacyGrants, legacyHash, err := PreviewServiceEnrollmentForLegacy(testPrincipalA)
+	if err != nil || len(legacyGrants) != 0 || legacyHash == firstHash {
+		t.Fatalf("legacy preview=%#v hash=%q err=%v", legacyGrants, legacyHash, err)
+	}
+	otherLegacyGrants, otherLegacyHash, err := PreviewServiceEnrollmentForLegacy(testPrincipalB)
+	if err != nil || len(otherLegacyGrants) != 0 || otherLegacyHash == legacyHash {
+		t.Fatalf("other legacy preview=%#v hash=%q err=%v", otherLegacyGrants, otherLegacyHash, err)
+	}
+	request.ProjectIDs = []string{testProjectA}
+	if err := request.Validate(); err == nil {
+		t.Fatal("service-only request with project scope accepted")
+	}
+	request.ProjectIDs = nil
+	request.AllProjects = true
+	if err := request.Validate(); err == nil {
+		t.Fatal("service-only request with all-projects scope accepted")
+	}
 }
 
 func TestDeviceCredentialEncodingHasOpaqueLookupAnd256BitSecret(t *testing.T) {

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "punaro",
-  "version": "0.1.0-alpha.10",
+  "version": "0.1.0-alpha.11",
   "description": "Safely receive and reply to durable Punaro messages and handle explicitly authorized trusted attachments.",
   "author": {
     "name": "Punaro contributors",

--- a/scripts/test-install-adapter.sh
+++ b/scripts/test-install-adapter.sh
@@ -104,8 +104,8 @@ file_mode() {
 
 [ -x "$adapter" ] || { printf '%s\n' 'adapter binary was not installed' >&2; exit 1; }
 [ -x "$bootstrap" ] || { printf '%s\n' 'bootstrap binary was not installed' >&2; exit 1; }
-[ "$(HOME="$home" "$adapter" version)" = 'v0.1.0-alpha.10' ] || { printf '%s\n' 'adapter binary lacks the source release identity' >&2; exit 1; }
-[ "$("$bootstrap" version)" = 'v0.1.0-alpha.10' ] || { printf '%s\n' 'bootstrap binary lacks the source release identity' >&2; exit 1; }
+[ "$(HOME="$home" "$adapter" version)" = 'v0.1.0-alpha.11' ] || { printf '%s\n' 'adapter binary lacks the source release identity' >&2; exit 1; }
+[ "$("$bootstrap" version)" = 'v0.1.0-alpha.11' ] || { printf '%s\n' 'bootstrap binary lacks the source release identity' >&2; exit 1; }
 [ -d "$home/.local/state/punaro-bootstrap/current" ] || { printf '%s\n' 'bootstrap current slot was not seeded' >&2; exit 1; }
 [ -x "$attachment" ] || { printf '%s\n' 'attachment binary was not installed' >&2; exit 1; }
 [ -x "$memory" ] || { printf '%s\n' 'memory binary was not installed' >&2; exit 1; }


### PR DESCRIPTION
## Summary
- allow service-only enrollment to bind one exact pending legacy principal without adding capability grants
- bind and display that exact legacy principal in the owner-confirmed preview, and reject duplicate live legacy enrollments
- add unit, CLI, and real PostgreSQL integration coverage for doctor migration and least-privilege invariants
- update doctor/operator/install/platform/release documentation and bump plugin metadata to v0.1.0-alpha.11

## Validation
- make test
- make test-race
- make lint
- make security
- make release-gates
- pristine native-arm64 PostgreSQL integration: go test -p 1 -count=1 -timeout 8m ./internal/postgres ./cmd/punaro
- Pioneer independent review and focused re-review: no remaining findings

## Release
- minimum bootstrap: v0.1.0-alpha.8
- supported from: v0.1.0-alpha.10