### PR TITLE
Document alpha.11 fleet readiness

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1091,9 +1091,11 @@ sender.
 Adopt of the two live routes is fence-legal only in this order: rename the
 keeper while the non-keeper is still unnamed; run `punaro-relay-adopt-prepare
 --drop-role role/telegram-codex --yes` on the non-keeper; then
-`punaro-telegram adopt` on `dae86ecc-05ff-4431-967a-584e2cd82916` (thread
-795446) and `e5c269b6-7e4c-450d-82bb-c25209096c10` (thread 795625). Adopt
-never calls `createForumTopic`.
+`punaro-telegram adopt` on `<KEEPER_CONVERSATION_ID>` (thread
+`<KEEPER_THREAD_ID>`) and `<NON_KEEPER_CONVERSATION_ID>` (thread
+`<NON_KEEPER_THREAD_ID>`). Resolve those operator-protected values from the
+live gateway state; never record them in source. Adopt never calls
+`createForumTopic`.
 
 ## Local adapter boundary
 

--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -1,7 +1,7 @@
 # Product: Punaro
 
 > What Punaro is and where it is going. Architectural authority lives in `DESIGN.md` and
-> `docs/big-brain-plan.md`; this document is the product-level view. Last updated 2026-08-23.
+> `docs/big-brain-plan.md`; this document is the product-level view. Last updated 2026-08-28.
 
 ## 1. What this is
 
@@ -46,7 +46,9 @@ Hard boundaries that define the product:
   broadcasting — preventing unattended agent-answers-agent loops. The relay bounds
   message rate and pending capacity, and retains terminal deliveries in an
   operator-inspectable dead-letter — always without parsing bodies. Opt-in role
-  discovery and direct addressing (#143) is the remaining open tracker.
+  discovery and direct addressing are shipped: machines register canonical roles,
+  bind them to live sessions, list only opted-in contacts, and fail ambiguous short
+  names closed unless the caller supplies a qualified handle.
 
 ### Attachments
 
@@ -58,12 +60,10 @@ still closed.
 
 ### The Telegram operator surface
 
-Each relay conversation surfaces as one forum topic in the operator's private chat, via a
-separately enrolled gateway (`punaro-telegram`) that long-polls the Bot API and never
-touches an agent-mailbox database. The claim-gated model below is the accepted direction,
-landing via PR #138; until that merges, `DESIGN.md` and `docs/telegram-gateway.md`
-describe the deployed route-based binding and remain the implementation authority. The
-contract:
+Each claimed relay conversation surfaces as one forum topic in the operator's private
+chat, via a separately enrolled gateway (`punaro-telegram`) that long-polls the Bot API
+and never touches an agent-mailbox database. The claim-gated model from PR #138 is now
+the shipped contract described by `DESIGN.md` and `docs/telegram-gateway.md`:
 
 - **A conversation IS its topic.** One topic ↔ one conversation, held in durable,
   content-free gateway state. No main-chat fallback, no picker, no routing by inference;
@@ -83,7 +83,9 @@ contract:
   (the Telegram `update_id` is the relay idempotency key, marked processed only after the
   append succeeds), so retries and crashes neither duplicate nor lose mail. Outbound to
   Telegram is deliberately at-least-once (no Bot API send idempotency key; ack only after
-  send).
+  send). Message-less updates advance durably, permanent inbound/outbound failures are
+  isolated without wedging other topics, and transient failures retain the exact retry
+  identity and remain visible to doctor.
 - **Agent content stays inert:** rendered as escaped HTML, entity detection off, 32 KiB
   bound with splitting. Agents never call the Bot API and never see tokens, chat IDs, or
   thread IDs. Operator replies-to arrive as inert envelope metadata. Credentials are
@@ -146,25 +148,25 @@ Mail carries the conversation; Big Brain carries the knowledge.
 
 ## 5. Where it stands and where it goes
 
-Alpha, unpublished, single live deployment. The mail pillar is furthest along: relay,
-adapter, durable roles, targeted routing, rate/capacity/dead-letter bounds, and the
-enrolled Telegram gateway are live; the claim/`user-telegram` model (PR #138) is landing
-now, and once it merges fresh topics will be created through the claim flow — no legacy
-routes are carried forward. Big Brain has the full canonical store, proposal machinery, lexical retrieval,
-and native client built, but runs dark pending its enablement slices.
+The signed `v0.1.0-alpha.11` prerelease is published and runs on the personal four-machine
+fleet: the Punaro LXC, Mac Studio, MacBook/Coso, and Mattone. The mail pillar includes the
+PostgreSQL relay, signed adapters, durable roles and discovery, targeted routing,
+rate/capacity/dead-letter bounds, claim-gated `user-telegram` topics, and the enrolled
+Telegram gateway. Big Brain has the full canonical store, proposal machinery, lexical
+retrieval, and native client built, but runs dark pending its enablement slices.
 
-The alpha release candidate now has a shared read-only doctor contract for the
-Linux server and Telegram gateway plus macOS/Linux/Windows clients. It verifies
-release/update provenance, service and relay readiness, mailbox/plugin/skill
-parity, recovery state, and fleet compatibility without reading content or
-granting repair authority. The four-machine signed-release drill remains the
-deployment evidence gate.
+The shared read-only doctor contract covers the Linux server and Telegram gateway,
+macOS/Linux/Windows adapters, bootstrap slots and recovery, plugins and skills, and
+offline fleet compatibility. The alpha.11 release record captures a green four-machine
+matrix plus signed update, rollback, interrupted-recovery, durable-role, and Telegram
+multi-topic drills without reading content or granting repair authority.
 
 Runway, roughly in order:
 
-- **Mail:** tighten outbound sends to require a completed claim (post-#138 follow-up);
-  decide whether the gateway gets the relay's park-and-continue semantic instead of
-  head-of-line blocking on a permanently failing delivery; role discovery (#143).
+- **Mail:** finish the fleet-wide Waypost migration after the rolling legacy mailbox
+  compatibility window; keep attachment production authority closed until its separate
+  release gates and live drills pass; continue hardening provider-edge observability
+  without adding content to diagnostics.
 - **Big Brain:** end-to-end testing, integration into the agent skills, and proving it
   in real day-to-day use; configuring a production embedding provider so the built
   semantic slices light up; then the remaining remote MCP transport slices (the OAuth

--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -166,7 +166,8 @@ Runway, roughly in order:
 - **Mail:** finish the fleet-wide Waypost migration after the rolling legacy mailbox
   compatibility window; keep attachment production authority closed until its separate
   release gates and live drills pass; continue hardening provider-edge observability
-  without adding content to diagnostics.
+  without adding content to diagnostics; and tighten Telegram outbound sends to require
+  a completed claim after the post-adopt soak.
 - **Big Brain:** end-to-end testing, integration into the agent skills, and proving it
   in real day-to-day use; configuring a production embedding provider so the built
   semantic slices light up; then the remaining remote MCP transport slices (the OAuth

--- a/README.md
+++ b/README.md
@@ -21,8 +21,9 @@ with its own mailbox implementation and with the central Punaro relay. The
 accepted target later adds an independently optional OAuth-scoped remote MCP
 adapter over Punaro's own API.
 
-> Status: alpha implementation under an accepted PostgreSQL/trusted-relay/Big
-> Brain migration plan. Enrolled adapters can exchange durable
+> Status: signed prerelease `v0.1.0-alpha.11` is deployed across the personal
+> four-machine fleet under the accepted PostgreSQL/trusted-relay/Big Brain
+> migration plan. Enrolled adapters can exchange durable
 > text through the loopback relay, with signed requests, payload-free wake
 > hints, local Waypost handoff (with rolling legacy `agent-mailbox`
 > compatibility), and a separately enrolled Telegram

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ read-only secret files. `punarod` is a non-default reference profile; the
 supported daemon lifecycle is the host-local `punaro` workflow.
 
 The separate PostgreSQL Compose file is integration-test infrastructure only;
-it does not change the SQLite relay or the alpha deployment:
+it does not change any running relay or deployed environment:
 
 ```sh
 make test-postgres
@@ -114,7 +114,7 @@ PostgreSQL substrate and dark control-plane contract tests inside the isolated
 network, and removes the database volume afterward. The tests cover migration
 compatibility, explicit project scopes, operation-bound idempotency, closed
 audit records, queue ceilings, and fenced job leases. It requires Docker
-Compose v2 and does not switch the active SQLite relay.
+Compose v2 and does not switch any running relay.
 
 ## Configuration and secrets
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -130,7 +130,7 @@ and keep the fixed bootstrap-owned service lifecycle:
 punaro-bootstrap update \
   --directory "$HOME/.local/state/punaro-bootstrap" \
   --keys-file /absolute/private/punaro-release.pub \
-  --release v0.1.0-alpha.4
+  --release v0.1.0-alpha.11
 punaro-bootstrap doctor \
   --directory "$HOME/.local/state/punaro-bootstrap" \
   --keys-file /absolute/private/punaro-release.pub \

--- a/docs/release-evidence/2026-08-28-v0.1.0-alpha.11.md
+++ b/docs/release-evidence/2026-08-28-v0.1.0-alpha.11.md
@@ -131,6 +131,189 @@ The cutover summary is SHA-256
 `db0cf9786a2a4eba7a18fabcd076c16d3a4bb648d4f7c7f34023218e91fcbaaa`.
 It contains no message content, credentials, raw identifiers, or private paths.
 
+### Sanitized reproduction transcript
+
+The following are the exact supported command shapes used for the
+approval-critical drills. Angle-bracket values replace protected paths,
+identities, fingerprints, idempotency keys, and content; they are not shell
+variables and must be supplied from each machine's owner-only configuration.
+Every JSON output below was written directly into the protected evidence
+directory rather than printed into a shared log.
+
+Server update, retained-source rollback, return to alpha.11, and the exact
+retry after an interrupted post-migration update used:
+
+```sh
+punaro update \
+  --directory <INSTALLATION_DIR> \
+  --release-metadata <ALPHA11_RELEASE_METADATA>
+punaro update \
+  --directory <INSTALLATION_DIR> \
+  --release-metadata <ALPHA10_RELEASE_METADATA>
+punaro update \
+  --directory <INSTALLATION_DIR> \
+  --release-metadata <ALPHA11_RELEASE_METADATA>
+punaro update \
+  --directory <INSTALLATION_DIR> \
+  --release-metadata <ALPHA11_RELEASE_METADATA> \
+  --recover compatible
+```
+
+The commands returned only content-free transaction JSON. A committed update
+reported `status`, an opaque `update_id`, the selected `target_release`, and
+its digest-pinned `target_image`; recovery reported the same shape with status
+`recovered`. No DSN, backup content, or credential entered stdout.
+
+Each client used the same signed bootstrap interface (the Windows executable
+has the same arguments). The interrupted-client drill reran the identical
+`update` command after the durable state reported recovery-only:
+
+```sh
+punaro-bootstrap update \
+  --directory <BOOTSTRAP_DIR> \
+  --keys-file <RELEASE_PUBLIC_KEYS> \
+  --release v0.1.0-alpha.11
+```
+
+The bootstrap output was limited to `installed <RELEASE> sequence <N>`. Its
+subsequent doctor report binds the current/previous slots, artifact hashes,
+journal, and recovery state in the component hashes below.
+
+Mail cutover first proved the read-only plan, then executed only with the exact
+dry-run epoch and source fingerprint. The enrollment file contained public
+records but remained protected because it identifies the private fleet:
+
+```sh
+punaro mail cutover \
+  --directory <INSTALLATION_DIR> \
+  --dry-run
+punaro mail cutover \
+  --directory <INSTALLATION_DIR> \
+  --epoch-id <DRY_RUN_EPOCH_UUID> \
+  --expected-source-fingerprint <DRY_RUN_SOURCE_FINGERPRINT> \
+  --relay-machines-file <PROTECTED_RELAY_ENROLLMENT_JSON> \
+  --yes
+```
+
+The content-free cutover result is the `db0cf978...` artifact above. It records
+the exact backup verification, empty-target check, committed epoch, source
+retirement, and published target authority without preserving message rows.
+Its complete reviewable payload was:
+
+```json
+{"cutover_active":true,"legacy_source_retired":true,"old_doctor_key_preserved":true,"post_cutover_doctor_checks":54,"post_cutover_doctor_healthy":true,"schema":1,"target_backup_verified":true,"target_rows_after":0,"target_rows_before":32}
+```
+
+Durable-role discovery and cross-restart delivery used the adapter's supported
+role surface and one private body file. The Mattone destination service was
+restarted after relay acceptance and before the local claim through its fixed
+Windows Scheduled Task:
+
+```sh
+punaro-adapter register-role \
+  --role role/<SOURCE_MACHINE>/<SOURCE_ROLE> \
+  --display-name <PORTABLE_DISPLAY_NAME> \
+  --direct-addressable \
+  --idempotency-key <STABLE_ROLE_KEY>
+punaro-adapter bind-role \
+  --role role/<SOURCE_MACHINE>/<SOURCE_ROLE> \
+  --session <SOURCE_ATTACHED_ENDPOINT>
+punaro-adapter contacts list --limit 100
+punaro-adapter contacts resolve <PORTABLE_DISPLAY_NAME>
+punaro-adapter send \
+  --to role/<DESTINATION_MACHINE>/<DESTINATION_ROLE> \
+  --from-role role/<SOURCE_MACHINE>/<SOURCE_ROLE> \
+  --body-file <PRIVATE_BODY_FILE> \
+  --idempotency-key <STABLE_MESSAGE_KEY>
+schtasks.exe /End /TN "Punaro Adapter"
+schtasks.exe /Run /TN "Punaro Adapter"
+```
+
+After restart the destination used the installed Waypost MCP calls
+`waypost_status()`, `waypost_recv()`, and
+`waypost_ack(delivery_id=<DELIVERY_ID>, lease_token=<LEASE_TOKEN>)`. Retrying
+the same send key returned the same relay result and did not create another
+delivery. The content-free role proof is SHA-256
+`0f9e0ed1d0f02c1a94ebfa497eb7ed7c25ccec3fba4aac577372d2e56123eeec`;
+its complete reviewable payload was:
+
+```json
+{"acknowledged":true,"adapter_restarted":true,"baseline_queued":0,"leased":true,"post_send_queued":1,"schema":1,"typed_envelope":true}
+```
+
+Telegram used two separately claimed sessions. Each outbound send used its own
+private body file and stable key; the gateway was restarted between accepted
+sends and confirmation, then one operator reply in each existing topic was
+claimed and acknowledged through the same Waypost MCP calls:
+
+```sh
+punaro-adapter send \
+  --to user-telegram \
+  --from <TOPIC_A_ATTACHED_ENDPOINT> \
+  --body-file <PRIVATE_TOPIC_A_BODY_FILE> \
+  --idempotency-key <STABLE_TOPIC_A_KEY>
+punaro-adapter send \
+  --to user-telegram \
+  --from <TOPIC_B_ATTACHED_ENDPOINT> \
+  --body-file <PRIVATE_TOPIC_B_BODY_FILE> \
+  --idempotency-key <STABLE_TOPIC_B_KEY>
+sudo systemctl restart punaro-telegram.service
+punaro-telegram doctor --timeout 15s
+```
+
+The gateway preserved both routes across restart. Permanent-failure isolation
+and transient retry behavior were also rerun with the focused test command in
+the gates section below. The content-free Telegram proof is SHA-256
+`11d32fadbd89ffb45e9f8c16ce11ec5575a19ca322c8a7a5ca3e55f92eff0edc`.
+The operator action was one text reply in each already claimed topic; no topic
+or chat identifier was supplied to an agent command. The complete reviewable
+proof was:
+
+```json
+{"agent_memberships":2,"claims_complete":2,"distinct_threads":2,"gateway_memberships":2,"gateway_restarted":true,"inbound_conversations":2,"inbound_messages":2,"inbound_threads":2,"mattone_fresh_typed_deliveries":1,"mattone_queue_after_reply":1,"mattone_queue_baseline":0,"message_content_observed":false,"outbound_conversations":2,"post_restart_doctors_healthy":true,"post_restart_server_doctor_checks":54,"post_restart_telegram_doctor_checks":42,"relay_outbound_messages":2,"routes":2,"schema":1,"studio_fresh_typed_deliveries":1,"studio_queue_after_reply":8,"studio_queue_baseline":7,"telegram_outbound_messages":2,"topics":2}
+```
+
+Finally, each component report and the aggregate were reproduced with the
+documented bounded read-only commands:
+
+```sh
+punaro doctor \
+  --directory <INSTALLATION_DIR> \
+  --machine-id <SERVER_MACHINE> \
+  --relay-profile <PROTECTED_SERVER_DOCTOR_PROFILE> \
+  --timeout 20s > <EVIDENCE_DIR>/server.json
+punaro-telegram doctor --timeout 15s > <EVIDENCE_DIR>/telegram.json
+
+punaro-adapter doctor \
+  --bootstrap-directory <BOOTSTRAP_DIR> \
+  --plugin-root <INSTALLED_PLUGIN_ROOT> \
+  --timeout 20s > <EVIDENCE_DIR>/<MACHINE>-adapter.json
+punaro-bootstrap doctor \
+  --directory <BOOTSTRAP_DIR> \
+  --keys-file <RELEASE_PUBLIC_KEYS> \
+  --machine-id <MACHINE> \
+  --timeout 20s > <EVIDENCE_DIR>/<MACHINE>-bootstrap.json
+
+punaro-bootstrap fleet-doctor \
+  --report <EVIDENCE_DIR>/server.json --expect <SERVER_MACHINE>/server \
+  --report <EVIDENCE_DIR>/telegram.json --expect <SERVER_MACHINE>/telegram \
+  --report <EVIDENCE_DIR>/<MAC_STUDIO>-adapter.json --expect <MAC_STUDIO>/adapter \
+  --report <EVIDENCE_DIR>/<MAC_STUDIO>-bootstrap.json --expect <MAC_STUDIO>/bootstrap \
+  --report <EVIDENCE_DIR>/<MACBOOK>-adapter.json --expect <MACBOOK>/adapter \
+  --report <EVIDENCE_DIR>/<MACBOOK>-bootstrap.json --expect <MACBOOK>/bootstrap \
+  --report <EVIDENCE_DIR>/<WINDOWS>-adapter.json --expect <WINDOWS>/adapter \
+  --report <EVIDENCE_DIR>/<WINDOWS>-bootstrap.json --expect <WINDOWS>/bootstrap \
+  --catalog <VERIFIED_RELEASE_DIR>/punaro-catalog.json \
+  --catalog-signature <VERIFIED_RELEASE_DIR>/punaro-catalog.sig \
+  --release-root <VERIFIED_RELEASE_ROOT> \
+  --keys-file <RELEASE_PUBLIC_KEYS> > <EVIDENCE_DIR>/fleet.json
+```
+
+The per-component and fleet SHA-256 values in the next table bind these exact
+content-free JSON results. They are reviewable against the stable schema and
+check-code registry in [`doctor.md`](../doctor.md) without exposing protected
+configuration or operational content.
+
 ## Four-machine doctor matrix
 
 Every report used schema version 1 and had zero non-passing required checks.

--- a/docs/release-evidence/2026-08-28-v0.1.0-alpha.11.md
+++ b/docs/release-evidence/2026-08-28-v0.1.0-alpha.11.md
@@ -27,6 +27,12 @@ This is a personal self-hosted alpha under the allowance in
 [`security-release-gates.md`](../security-release-gates.md). It is not an
 official Internet-facing production release.
 
+Sequences alpha.5 through alpha.10 were incremental engineering prereleases
+used to reach this fleet cutover; none received a separate normal-use capability
+approval. This alpha.11 record is the first post-alpha.4 fleet-readiness
+decision and consolidates the capabilities introduced across those sequences.
+Their signed catalogs and manifests remain the immutable release artifacts.
+
 ## Immutable release and review evidence
 
 - [PR #208](https://github.com/rock3r/punaro/pull/208) is the release source.
@@ -159,7 +165,7 @@ protocol, schema, upgrade-edge, identity, and skill compatibility.
 | Client/adapter | `punaro-adapter doctor` is supported on macOS, Linux, and Windows and covers protected state, service manager and process identity, bootstrap-selected artifact, relay/Access and notifications, endpoint/role state, mailbox MCP, plugin launchers, manifests, and exact skill set. Three fresh platform reports passed all required checks. |
 | Bootstrap/update | `punaro-bootstrap doctor` verifies signed catalog/manifests, release policy, slots and artifact hashes, journal/stage/recovery, process/service handoff, rollback, disk/path safety, and recovery protocol. Three fresh reports passed 32 checks each and the signed update/rollback/interruption drills passed. |
 | Telegram | `punaro-telegram doctor` covers protected configuration/state, service and release identity, Access/relay authorization, endpoint attachment, Bot API reachability, polling progress, backlog/retry/terminal state, routes, topics, and failure classes from #165-#167. The fresh report passed 42 checks. |
-| Fleet aggregation | Offline `fleet-doctor` consumes independently collected reports plus the signed catalog/manifests. It rejected neither the exact expected component set nor release, schema, protocol, upgrade-edge, identity, plugin, or skill parity; all 12 checks passed. The server holds no SSH or client-management credentials. |
+| Fleet aggregation | Offline `fleet-doctor` consumes independently collected reports plus the signed catalog/manifests. It accepted the exact expected component set and found no release, schema, protocol, upgrade-edge, identity, plugin, or skill skew; all 12 checks passed. The server holds no SSH or client-management credentials. |
 | Failure and adversarial tests | RED-to-GREEN unit, contract, integration, platform-service, redaction, timeout, cancellation, partial-result, immutable-snapshot, broken-state, and release-policy tests are in the repository suite. PR #172 supplied the complete diagnostic contract; PRs #189, #190, #192, #193, #195, #196, #198, and #208 hardened the live Windows, Waypost, cutover, selected-client, and device-credential cases. |
 | Documentation and skills | README, product, installation, operator, GitHub Releases, doctor, Telegram, platform, plugin, and release evidence describe the shipped behavior. Installers/manifests and `punaro-mailbox`, `punaro-reply`, and `punaro-attachment` require read-only doctor readiness without granting repair authority. Installed skill trees on all three clients match alpha.11. |
 

--- a/docs/release-evidence/2026-08-28-v0.1.0-alpha.11.md
+++ b/docs/release-evidence/2026-08-28-v0.1.0-alpha.11.md
@@ -225,10 +225,12 @@ complete reviewable payload was:
 {"cutover_active":true,"destination_verified_rows":414,"legacy_source_retired":true,"materialized_counts_match":true,"old_doctor_key_preserved":true,"post_cutover_doctor_checks":54,"post_cutover_doctor_healthy":true,"schema":2,"source_manifest_rows":414,"source_tables_total":25,"source_tables_with_rows":18,"target_backup_verified":true,"verified_checkpoint_tables":25}
 ```
 
-Durable-role discovery and cross-restart delivery used the adapter's supported
-role surface and one private body file. The Mattone destination service was
-restarted after relay acceptance and before the local claim through its fixed
-Windows Scheduled Task:
+Durable-role discovery and queued-delivery restart durability used the
+adapter's supported role surface and one private body file. The Mattone
+adapter was running for relay-to-local synchronization. After both same-key
+sends returned the same relay result, exactly one typed local delivery was
+queued but not claimed or leased. The destination service was then restarted
+through its fixed Windows Scheduled Task before the local claim:
 
 ```sh
 punaro-adapter register-role \
@@ -259,14 +261,16 @@ After restart the destination used the installed Waypost MCP calls
 `waypost_status()`, `waypost_recv()`, and
 `waypost_ack(delivery_id=<DELIVERY_ID>, lease_token=<LEASE_TOKEN>)`. Retrying
 the same send key returned the same relay result and did not create another
-delivery. The operator-assembled role proof consolidates the protected
+delivery. This proves durable local-mailbox state across the adapter restart;
+it does not claim that the adapter was stopped before relay acceptance. The
+operator-assembled role proof consolidates the exact protected ordering,
 baseline/post-send queue counts, typed-envelope lease and acknowledgement
 observations, and adapter-restart check. It is SHA-256
-`0ff56a73cc2dee0f82cb635029ab1b9607f17aa989795f3af6e4b82d92aceb91`;
+`95c77a3ee6c2ae4f6cdd4dc42f119a47db855bb77146b24624fdf210b4bccb2f`;
 its complete reviewable payload was:
 
 ```json
-{"acknowledged":true,"adapter_restarted":true,"baseline_queued":0,"delivery_count_after_replay":1,"leased":true,"post_send_queued":1,"replay_same_relay_result":true,"schema":2,"typed_envelope":true}
+{"ack_after_restart":true,"adapter_restarted_after_local_queue":true,"baseline_queued":0,"delivery_count_after_replay":1,"lease_after_restart":true,"local_claim_before_restart":false,"local_delivery_queued_before_restart":true,"post_send_queued":1,"relay_acceptance_before_restart":true,"replay_same_relay_result":true,"schema":3,"typed_envelope":true}
 ```
 
 Telegram used two separately claimed sessions. Each outbound send used its own
@@ -387,10 +391,11 @@ protocol, schema, upgrade-edge, identity, and skill compatibility.
 
 - One canonical opt-in role was registered and bound per client. Qualified
   direct resolution passed; an ambiguous short name failed closed.
-- A cross-machine direct-role delivery survived the recipient adapter restart,
-  was received as a typed Punaro envelope, leased, and acknowledged. Its
+- A cross-machine direct-role delivery reached the destination's durable local
+  queue exactly once, remained unclaimed across the recipient adapter restart,
+  and was then leased and acknowledged as a typed Punaro envelope. Its
   content-free proof is SHA-256
-  `0ff56a73cc2dee0f82cb635029ab1b9607f17aa989795f3af6e4b82d92aceb91`.
+  `95c77a3ee6c2ae4f6cdd4dc42f119a47db855bb77146b24624fdf210b4bccb2f`.
 - Two fresh claimed conversations mapped to two distinct Telegram topics and
   two current client sessions. Each completed relay-to-Telegram outbound and
   Telegram-to-relay inbound delivery across a gateway restart; exactly one

--- a/docs/release-evidence/2026-08-28-v0.1.0-alpha.11.md
+++ b/docs/release-evidence/2026-08-28-v0.1.0-alpha.11.md
@@ -30,15 +30,32 @@ official Internet-facing production release.
   Its five quality jobs passed, and it merged as the exact source commit above.
   Bugbot was unavailable because its team quota was exhausted; the operator
   explicitly waived only that unavailable quota gate for this personal alpha.
+- The exact source commit passed
+  [quality run 33169001687](https://github.com/rock3r/punaro/actions/runs/33169001687).
+  [Go tests and analysis](https://github.com/rock3r/punaro/actions/runs/33169001687/job/98841242732)
+  includes race tests, vet, lint, `govulncheck`, gosec, gitleaks, fuzzing, and
+  release gates; [configuration and container validation](https://github.com/rock3r/punaro/actions/runs/33169001687/job/98841242739)
+  includes the CRITICAL/HIGH Trivy scan. All five jobs passed.
 - [Release workflow run 33169048126](https://github.com/rock3r/punaro/actions/runs/33169048126)
-  passed validation, SBOM/provenance publication, native builds for
-  Linux/amd64, Linux/arm64, Darwin/arm64, and Windows/amd64, and final
-  assembly/publication.
+  passed release-policy validation,
+  [SBOM/provenance image publication](https://github.com/rock3r/punaro/actions/runs/33169048126/job/98841507631),
+  native builds for Linux/amd64, Linux/arm64, Darwin/arm64, and Windows/amd64,
+  and final assembly/publication.
 - The published release has 26 manifest-bound native artifacts plus the signed
   manifest and catalog. Fresh downloads verified both detached signatures and
   every artifact digest before fleet use.
 - Digest-pinned server image:
   `ghcr.io/rock3r/punaro@sha256:f00f95b272cd26ad1f0217e7717c2352a884df52c0664a8f109e91b9186356a1`.
+
+### Image, SBOM, and provenance
+
+- Image manifest: `sha256:a7117ad16764e9580e52b714258d369a70e6caa1022a226fbde599b01b82fe4d`.
+- [OCI attestation manifest](https://ghcr.io/v2/rock3r/punaro/manifests/sha256:4644cec22d5b7f3438e36247190435a85e11825e13ce35895c3634ef1dc2a25a):
+  `sha256:4644cec22d5b7f3438e36247190435a85e11825e13ce35895c3634ef1dc2a25a`.
+- [SPDX SBOM in-toto layer](https://ghcr.io/v2/rock3r/punaro/blobs/sha256:2e39015a249d7ee317d3e1045d3ba896ff063b6b4c708cc704594a7b1cfa39fe):
+  `sha256:2e39015a249d7ee317d3e1045d3ba896ff063b6b4c708cc704594a7b1cfa39fe`.
+- [SLSA provenance v1 in-toto layer](https://ghcr.io/v2/rock3r/punaro/blobs/sha256:2e1a0c2f95041cb1b5e3bc4d4ebf272d1ae781e62408f57d11a5571dc4a42fc9):
+  `sha256:2e1a0c2f95041cb1b5e3bc4d4ebf272d1ae781e62408f57d11a5571dc4a42fc9`.
 
 ### Signed documents
 
@@ -160,11 +177,13 @@ go test ./internal/telegram ./cmd/punaro-telegram \
 python3 scripts/test-agent-plugin.py
 ```
 
-The release workflow is the authoritative cross-platform build, security scan,
-SBOM/provenance, and publication result. The local gates verified that this
-evidence-only change does not drift code, deployment, plugin, skill, or release
-contracts. `govulncheck` found no called vulnerabilities, gosec reported zero
-issues across 329 files, and gitleaks found no leaks.
+The exact-source quality workflow is the authoritative test, security-scan,
+and reviewed-container result. The release workflow is authoritative for the
+cross-platform artifacts, published image, SBOM/provenance, and release. The
+local gates verified that this evidence-only change does not drift code,
+deployment, plugin, skill, or release contracts. `govulncheck` found no called
+vulnerabilities, gosec reported zero issues across 329 files, and gitleaks
+found no leaks.
 
 ## Approvers and residual risk
 

--- a/docs/release-evidence/2026-08-28-v0.1.0-alpha.11.md
+++ b/docs/release-evidence/2026-08-28-v0.1.0-alpha.11.md
@@ -14,9 +14,12 @@
 - **Release reference:**
   [`v0.1.0-alpha.11`](https://github.com/rock3r/punaro/releases/tag/v0.1.0-alpha.11),
   published as a non-draft prerelease from that exact source.
-- **Release sequence:** `11`; **catalog sequence:** `11`; **minimum bootstrap
+- **Release sequence:** `11`; **catalog sequence:** `11`; **minimum safe
+  sequence:** `1`; **critical block:** `2`; **minimum bootstrap
   release:** `v0.1.0-alpha.8`; **supported direct source:**
   `v0.1.0-alpha.10`.
+- **Retained rollback:** sequence `1`, release `v0.1.0-alpha.1`, manifest
+  SHA-256 `3f1f92f4a6a4834eb01125946984593730ed5a054e105cdd9e242fecd172ab32`.
 - **Database schema:** supported `10..57`, target `57`, rollback floor `10`.
 - **Catalog expiry:** `2026-09-04T11:59:32Z`.
 
@@ -30,6 +33,10 @@ official Internet-facing production release.
   Its five quality jobs passed, and it merged as the exact source commit above.
   Bugbot was unavailable because its team quota was exhausted; the operator
   explicitly waived only that unavailable quota gate for this personal alpha.
+- Independent Pioneer review did not complete on source PR #208 because source
+  egress authorization had not yet been recorded. No Pi configuration or
+  credentials were inspected or bypassed. Independent review is required on
+  this release-evidence PR before it merges.
 - The exact source commit passed
   [quality run 33169001687](https://github.com/rock3r/punaro/actions/runs/33169001687).
   [Go tests and analysis](https://github.com/rock3r/punaro/actions/runs/33169001687/job/98841242732)
@@ -78,6 +85,24 @@ official Internet-facing production release.
 | `punaro-bootstrap-windows-amd64.exe` | Windows/amd64 | `54f7c9e2acdc6dc0257d868f70be2ad33de0066e82a08d47f6ecb429c64603d7` |
 
 The signed manifest is authoritative for every other shipped artifact.
+
+Fresh release downloads passed these exact verification commands:
+
+```sh
+go run ./cmd/punaro-release verify-artifacts \
+  --manifest "$RELEASE_DIR/punaro-release.json" \
+  --dir "$RELEASE_DIR"
+go run ./cmd/punaro-release verify \
+  --keys-file "$RELEASE_DIR/../punaro-release.pub" \
+  --document "$RELEASE_DIR/punaro-release.json" \
+  --signature "$RELEASE_DIR/punaro-release.sig"
+go run ./cmd/punaro-release verify \
+  --keys-file "$RELEASE_DIR/../punaro-release.pub" \
+  --document "$RELEASE_DIR/punaro-catalog.json" \
+  --signature "$RELEASE_DIR/punaro-catalog.sig"
+docker manifest inspect --verbose \
+  ghcr.io/rock3r/punaro@sha256:f00f95b272cd26ad1f0217e7717c2352a884df52c0664a8f109e91b9186356a1
+```
 
 ## Update, rollback, cutover, and recovery drills
 
@@ -200,6 +225,9 @@ found no leaks.
   Durable progress, retry identity, terminal isolation, and doctor visibility
   bound the risk, but the Bot API provides no idempotency key for exact-once
   sends.
+- Telegram outbound sends do not yet require a completed claim. That is a
+  post-adopt soak hardening follow-up retained in `PRODUCT.md` and `DESIGN.md`;
+  inbound polling remains claim-gated.
 - The catalog expires on `2026-09-04T11:59:32Z`; updates fail closed after
   expiry unless a reviewed signed catalog succeeds it.
 - Trust is rooted in digest-bound artifacts and the offline-signed manifest and

--- a/docs/release-evidence/2026-08-28-v0.1.0-alpha.11.md
+++ b/docs/release-evidence/2026-08-28-v0.1.0-alpha.11.md
@@ -129,7 +129,8 @@ content-free outcomes and hashes are recorded here.
 
 The cutover summary is SHA-256
 `db0cf9786a2a4eba7a18fabcd076c16d3a4bb648d4f7c7f34023218e91fcbaaa`.
-It contains no message content, credentials, raw identifiers, or private paths.
+It contains no message content, credentials, raw identifier values, or private
+paths.
 
 ### Sanitized reproduction transcript
 
@@ -137,8 +138,12 @@ The following are the exact supported command shapes used for the
 approval-critical drills. Angle-bracket values replace protected paths,
 identities, fingerprints, idempotency keys, and content; they are not shell
 variables and must be supplied from each machine's owner-only configuration.
-Every JSON output below was written directly into the protected evidence
-directory rather than printed into a shared log.
+Every JSON proof below is an operator-assembled, content-free consolidation of
+the named protected inputs and was written directly into the protected evidence
+directory rather than printed into a shared log. Each proof digest is SHA-256
+of the exact JSON payload line as shown, including its single terminating LF;
+for example, `printf '%s\n' '<PAYLOAD>' | sha256sum`. The digest attests that
+serialized consolidation, not the individual protected input artifacts.
 
 Server update, retained-source rollback, return to alpha.11, and the exact
 retry after an interrupted post-migration update used:
@@ -195,10 +200,11 @@ punaro mail cutover \
   --yes
 ```
 
-The content-free cutover result is the `db0cf978...` artifact above. It records
-the exact backup verification, empty-target check, committed epoch, source
-retirement, and published target authority without preserving message rows.
-Its complete reviewable payload was:
+The operator-assembled cutover summary is the `db0cf978...` artifact above. It
+consolidates the protected `punaro mail cutover` result, preflight row counts,
+backup verification, post-cutover doctor report, source-retirement check, and
+published target-authority check without preserving message rows. Its complete
+reviewable payload was:
 
 ```json
 {"cutover_active":true,"legacy_source_retired":true,"old_doctor_key_preserved":true,"post_cutover_doctor_checks":54,"post_cutover_doctor_healthy":true,"schema":1,"target_backup_verified":true,"target_rows_after":0,"target_rows_before":32}
@@ -233,7 +239,9 @@ After restart the destination used the installed Waypost MCP calls
 `waypost_status()`, `waypost_recv()`, and
 `waypost_ack(delivery_id=<DELIVERY_ID>, lease_token=<LEASE_TOKEN>)`. Retrying
 the same send key returned the same relay result and did not create another
-delivery. The content-free role proof is SHA-256
+delivery. The operator-assembled role proof consolidates the protected
+baseline/post-send queue counts, typed-envelope lease and acknowledgement
+observations, and adapter-restart check. It is SHA-256
 `0f9e0ed1d0f02c1a94ebfa497eb7ed7c25ccec3fba4aac577372d2e56123eeec`;
 its complete reviewable payload was:
 
@@ -263,7 +271,10 @@ punaro-telegram doctor --timeout 15s
 
 The gateway preserved both routes across restart. Permanent-failure isolation
 and transient retry behavior were also rerun with the focused test command in
-the gates section below. The content-free Telegram proof is SHA-256
+the gates section below. The operator-assembled Telegram proof consolidates
+the protected claim/route audits, gateway and agent membership counts,
+outbound/inbound observations, queue deltas, restart state, and doctor reports.
+It is SHA-256
 `11d32fadbd89ffb45e9f8c16ce11ec5575a19ca322c8a7a5ca3e55f92eff0edc`.
 The operator action was one text reply in each already claimed topic; no topic
 or chat identifier was supplied to an agent command. The complete reviewable
@@ -421,3 +432,6 @@ found no leaks.
   expiry unless a reviewed signed catalog succeeds it.
 - Trust is rooted in digest-bound artifacts and the offline-signed manifest and
   catalog, not in a production signed Git tag. This remains a personal alpha.
+- The three proof digests attest operator-assembled content-free
+  consolidations. Their named protected command results, doctor reports, and
+  audit inputs remain the authority for the underlying observations.

--- a/docs/release-evidence/2026-08-28-v0.1.0-alpha.11.md
+++ b/docs/release-evidence/2026-08-28-v0.1.0-alpha.11.md
@@ -185,9 +185,10 @@ The bootstrap output was limited to `installed <RELEASE> sequence <N>`. Its
 subsequent doctor report binds the current/previous slots, artifact hashes,
 journal, and recovery state in the component hashes below.
 
-Mail cutover first proved the read-only plan, then executed only with the exact
-dry-run epoch and source fingerprint. The enrollment file contained public
-records but remained protected because it identifies the private fleet:
+Mail cutover first proved the read-only plan, then executed only with an
+operator-chosen epoch UUID and the exact dry-run-printed source fingerprint.
+The enrollment file contained public records but remained protected because it
+identifies the private fleet:
 
 ```sh
 punaro mail cutover \
@@ -195,7 +196,7 @@ punaro mail cutover \
   --dry-run
 punaro mail cutover \
   --directory <INSTALLATION_DIR> \
-  --epoch-id <DRY_RUN_EPOCH_UUID> \
+  --epoch-id <OPERATOR_CHOSEN_EPOCH_UUID> \
   --expected-source-fingerprint <DRY_RUN_SOURCE_FINGERPRINT> \
   --relay-machines-file <PROTECTED_RELAY_ENROLLMENT_JSON> \
   --yes

--- a/docs/release-evidence/2026-08-28-v0.1.0-alpha.11.md
+++ b/docs/release-evidence/2026-08-28-v0.1.0-alpha.11.md
@@ -57,7 +57,8 @@ Their signed catalogs and manifests remain the immutable release artifacts.
 - The published release has 26 manifest-bound native artifacts plus the signed
   manifest and catalog. Fresh downloads verified both detached signatures and
   every artifact digest before fleet use.
-- Digest-pinned multi-architecture server image index:
+- Digest-pinned single-platform Linux/amd64 OCI image index (including its
+  attestations):
   `ghcr.io/rock3r/punaro@sha256:f00f95b272cd26ad1f0217e7717c2352a884df52c0664a8f109e91b9186356a1`.
 
 ### Image, SBOM, and provenance
@@ -128,8 +129,8 @@ content-free outcomes and hashes are recorded here.
 | Legacy relay mail cutover | Exact scoped backup verified, target cleared, cutover committed, source retired, and old doctor key preserved |
 | Post-transition restart | Server, Telegram gateway, and all three client services returned healthy |
 
-The cutover summary is SHA-256
-`db0cf9786a2a4eba7a18fabcd076c16d3a4bb648d4f7c7f34023218e91fcbaaa`.
+The cutover materialization proof is SHA-256
+`753e8c214aff5caf92356a70fdab511bdbe45577f9af5c0c2c266fcbb2f75558`.
 It contains no message content, credentials, raw identifier values, or private
 paths.
 
@@ -185,6 +186,15 @@ The bootstrap output was limited to `installed <RELEASE> sequence <N>`. Its
 subsequent doctor report binds the current/previous slots, artifact hashes,
 journal, and recovery state in the component hashes below.
 
+The owner-only `lifecycle-proof.json` binds the four command results above. It
+is SHA-256
+`a9c93fb5301e934d8433ad5b3b5a540ef0dca6e1b430655f876c3d1ed21cc02f`;
+its complete reviewable payload was:
+
+```json
+{"interrupted_recovery":{"command_exit":0,"current_release":"v0.1.0-alpha.11","recovery_cleared":true,"recovery_only_observed":true},"return_to_alpha11":{"command_exit":0,"current_release":"v0.1.0-alpha.11","previous_release":"v0.1.0-alpha.10"},"rollback_to_alpha10":{"command_exit":0,"current_release":"v0.1.0-alpha.10","previous_release":"v0.1.0-alpha.11"},"schema":1,"update_to_alpha11":{"command_exit":0,"current_release":"v0.1.0-alpha.11","previous_release":"v0.1.0-alpha.10","status":"committed"}}
+```
+
 Mail cutover first proved the read-only plan, then executed only with an
 operator-chosen epoch UUID and the exact dry-run-printed source fingerprint.
 The enrollment file contained public records but remained protected because it
@@ -202,14 +212,17 @@ punaro mail cutover \
   --yes
 ```
 
-The operator-assembled cutover summary is the `db0cf978...` artifact above. It
-consolidates the protected `punaro mail cutover` result, preflight row counts,
-backup verification, post-cutover doctor report, source-retirement check, and
-published target-authority check without preserving message rows. Its complete
-reviewable payload was:
+The owner-only `lxc-cutover-materialization-proof.json` is SHA-256
+`753e8c214aff5caf92356a70fdab511bdbe45577f9af5c0c2c266fcbb2f75558`.
+It consolidates the protected `punaro mail cutover` result, source-manifest
+aggregate, all 25 verified destination checkpoints, backup verification,
+post-cutover doctor report, source-retirement check, and published
+target-authority check without preserving message rows. The 414 source rows
+equal the 414 materialized destination checkpoint rows before activation. Its
+complete reviewable payload was:
 
 ```json
-{"cutover_active":true,"legacy_source_retired":true,"old_doctor_key_preserved":true,"post_cutover_doctor_checks":54,"post_cutover_doctor_healthy":true,"schema":1,"target_backup_verified":true,"target_rows_after":0,"target_rows_before":32}
+{"cutover_active":true,"destination_verified_rows":414,"legacy_source_retired":true,"materialized_counts_match":true,"old_doctor_key_preserved":true,"post_cutover_doctor_checks":54,"post_cutover_doctor_healthy":true,"schema":2,"source_manifest_rows":414,"source_tables_total":25,"source_tables_with_rows":18,"target_backup_verified":true,"verified_checkpoint_tables":25}
 ```
 
 Durable-role discovery and cross-restart delivery used the adapter's supported
@@ -233,6 +246,11 @@ punaro-adapter send \
   --from-role role/<SOURCE_MACHINE>/<SOURCE_ROLE> \
   --body-file <PRIVATE_BODY_FILE> \
   --idempotency-key <STABLE_MESSAGE_KEY>
+punaro-adapter send \
+  --to role/<DESTINATION_MACHINE>/<DESTINATION_ROLE> \
+  --from-role role/<SOURCE_MACHINE>/<SOURCE_ROLE> \
+  --body-file <PRIVATE_BODY_FILE> \
+  --idempotency-key <STABLE_MESSAGE_KEY>
 schtasks.exe /End /TN "Punaro Adapter"
 schtasks.exe /Run /TN "Punaro Adapter"
 ```
@@ -244,11 +262,11 @@ the same send key returned the same relay result and did not create another
 delivery. The operator-assembled role proof consolidates the protected
 baseline/post-send queue counts, typed-envelope lease and acknowledgement
 observations, and adapter-restart check. It is SHA-256
-`0f9e0ed1d0f02c1a94ebfa497eb7ed7c25ccec3fba4aac577372d2e56123eeec`;
+`0ff56a73cc2dee0f82cb635029ab1b9607f17aa989795f3af6e4b82d92aceb91`;
 its complete reviewable payload was:
 
 ```json
-{"schema":1,"baseline_queued":0,"post_send_queued":1,"typed_envelope":true,"leased":true,"acknowledged":true,"adapter_restarted":true}
+{"acknowledged":true,"adapter_restarted":true,"baseline_queued":0,"delivery_count_after_replay":1,"leased":true,"post_send_queued":1,"replay_same_relay_result":true,"schema":2,"typed_envelope":true}
 ```
 
 Telegram used two separately claimed sessions. Each outbound send used its own
@@ -372,7 +390,7 @@ protocol, schema, upgrade-edge, identity, and skill compatibility.
 - A cross-machine direct-role delivery survived the recipient adapter restart,
   was received as a typed Punaro envelope, leased, and acknowledged. Its
   content-free proof is SHA-256
-  `0f9e0ed1d0f02c1a94ebfa497eb7ed7c25ccec3fba4aac577372d2e56123eeec`.
+  `0ff56a73cc2dee0f82cb635029ab1b9607f17aa989795f3af6e4b82d92aceb91`.
 - Two fresh claimed conversations mapped to two distinct Telegram topics and
   two current client sessions. Each completed relay-to-Telegram outbound and
   Telegram-to-relay inbound delivery across a gateway restart; exactly one
@@ -434,6 +452,6 @@ found no leaks.
   expiry unless a reviewed signed catalog succeeds it.
 - Trust is rooted in digest-bound artifacts and the offline-signed manifest and
   catalog, not in a production signed Git tag. This remains a personal alpha.
-- The three proof digests attest operator-assembled content-free
+- The four proof digests attest operator-assembled content-free
   consolidations. Their named protected command results, doctor reports, and
   audit inputs remain the authority for the underlying observations.

--- a/docs/release-evidence/2026-08-28-v0.1.0-alpha.11.md
+++ b/docs/release-evidence/2026-08-28-v0.1.0-alpha.11.md
@@ -1,0 +1,187 @@
+# v0.1.0-alpha.11 fleet-readiness release evidence
+
+## Decision and scope
+
+- **Decision:** approved for normal use on the named personal self-hosted fleet:
+  Punaro LXC, Mac Studio, MacBook/Coso, and Mattone.
+- **Release capability:** signed, catalog-controlled core relay, adapter,
+  bootstrap, enrollment, memory, Telegram, and local trusted-attachment client
+  artifacts. This record authorizes text mail, durable roles, and the private
+  Telegram operator surface. It does not authorize sensitive attachment use,
+  an Internet-facing public relay, or multi-tenant operation.
+- **Source commit:**
+  [`7f2698202bb09e634a17f253719ae9b7e63a87e0`](https://github.com/rock3r/punaro/commit/7f2698202bb09e634a17f253719ae9b7e63a87e0).
+- **Release reference:**
+  [`v0.1.0-alpha.11`](https://github.com/rock3r/punaro/releases/tag/v0.1.0-alpha.11),
+  published as a non-draft prerelease from that exact source.
+- **Release sequence:** `11`; **catalog sequence:** `11`; **minimum bootstrap
+  release:** `v0.1.0-alpha.8`; **supported direct source:**
+  `v0.1.0-alpha.10`.
+- **Database schema:** supported `10..57`, target `57`, rollback floor `10`.
+- **Catalog expiry:** `2026-09-04T11:59:32Z`.
+
+This is a personal self-hosted alpha under the allowance in
+[`security-release-gates.md`](../security-release-gates.md). It is not an
+official Internet-facing production release.
+
+## Immutable release and review evidence
+
+- [PR #208](https://github.com/rock3r/punaro/pull/208) is the release source.
+  Its five quality jobs passed, and it merged as the exact source commit above.
+  Bugbot was unavailable because its team quota was exhausted; the operator
+  explicitly waived only that unavailable quota gate for this personal alpha.
+- [Release workflow run 33169048126](https://github.com/rock3r/punaro/actions/runs/33169048126)
+  passed validation, SBOM/provenance publication, native builds for
+  Linux/amd64, Linux/arm64, Darwin/arm64, and Windows/amd64, and final
+  assembly/publication.
+- The published release has 26 manifest-bound native artifacts plus the signed
+  manifest and catalog. Fresh downloads verified both detached signatures and
+  every artifact digest before fleet use.
+- Digest-pinned server image:
+  `ghcr.io/rock3r/punaro@sha256:f00f95b272cd26ad1f0217e7717c2352a884df52c0664a8f109e91b9186356a1`.
+
+### Signed documents
+
+| File | SHA-256 |
+| --- | --- |
+| `punaro-release.json` | `e519d51359a23dd0f6d4326ad2be540b68a2a36fdb32d57cfcd4469b44e04f5c` |
+| `punaro-release.sig` | `d8862c6938e5e0c727712577302a08e4f8f0ef0df8f1c782ea6be532a190e25b` |
+| `punaro-catalog.json` | `9d599f1c3b9a48919850c66742ee2a1d97b25f76d999403221e018e98bf5e0f3` |
+| `punaro-catalog.sig` | `1503505ed212158105d2b2d57abea8794c5954d65b2e6e85b974b573decf572b` |
+
+### Fleet-critical native artifacts
+
+| Artifact | OS/architecture | SHA-256 |
+| --- | --- | --- |
+| `punaro-linux-amd64` | Linux/amd64 | `589532b80a22940347185740daa9d3b8d2a578711b90e59bc9c53a31c8827c87` |
+| `punaro-telegram-linux-amd64` | Linux/amd64 | `6a49cb880c6f7f70b7c4c556e78f0c8fa73a5132c636f31fcc460a5e4f93c452` |
+| `punaro-adapter-darwin-arm64` | Darwin/arm64 | `30746a15469f2aa99ee80a12c59f43db04b9361b1f875ee139dc98c5b7d701b4` |
+| `punaro-bootstrap-darwin-arm64` | Darwin/arm64 | `8e7c512795db7dfce32fa39c0773b587edf406754389295dd654c08f25bc6351` |
+| `punaro-adapter-windows-amd64.exe` | Windows/amd64 | `4dffb2460c0c3b3bb4e03a406cba135d41051b5d12531d136107cd4eb0a19c18` |
+| `punaro-bootstrap-windows-amd64.exe` | Windows/amd64 | `54f7c9e2acdc6dc0257d868f70be2ad33de0066e82a08d47f6ecb429c64603d7` |
+
+The signed manifest is authoritative for every other shipped artifact.
+
+## Update, rollback, cutover, and recovery drills
+
+The built-in lifecycle, rather than manual binary replacement, performed each
+transition. Protected local evidence was retained outside the repository; only
+content-free outcomes and hashes are recorded here.
+
+| Drill | Result |
+| --- | --- |
+| LXC signed update from alpha.10 to alpha.11 | Passed; exact target image and operator release selected |
+| LXC rollback from alpha.11 to alpha.10 | Passed; retained signed source restored |
+| LXC return from alpha.10 to alpha.11 | Passed; catalog edge and signatures reverified |
+| Interrupted bootstrap/update recovery | Passed; recovery-only state cleared by the exact verified retry |
+| Mac Studio and MacBook/Coso client update | Passed through the installed bootstrap lifecycle |
+| Mattone client update | Passed through the Windows bootstrap and Scheduled Task lifecycle |
+| Legacy relay mail cutover | Exact scoped backup verified, target cleared, cutover committed, source retired, and old doctor key preserved |
+| Post-transition restart | Server, Telegram gateway, and all three client services returned healthy |
+
+The cutover summary is SHA-256
+`db0cf9786a2a4eba7a18fabcd076c16d3a4bb648d4f7c7f34023218e91fcbaaa`.
+It contains no message content, credentials, raw identifiers, or private paths.
+
+## Four-machine doctor matrix
+
+Every report used schema version 1 and had zero non-passing required checks.
+Optional absent checks remained explicit rather than being synthesized as
+healthy. The aggregate fleet report accepted exactly eight component reports
+and all twelve fleet checks.
+
+| Fleet member | Component | Checks | Result | Protected report SHA-256 |
+| --- | --- | ---: | --- | --- |
+| Punaro LXC | server | 54 | healthy | `1ddfc7f555df980f2f9ae4e9a77b6a3145c62493c1980694dcdcf8190e354f71` |
+| Punaro LXC | Telegram | 42 | healthy | `44f15fc2e2ba17a036dde08bcd257af1a71a28e7f02297ac3568abf2a6f24002` |
+| Mac Studio | adapter | 39 | healthy | `ccb4b1f383c909f2485693a821410fa3c350eaf4055dc24d9d3c085597bab292` |
+| Mac Studio | bootstrap | 32 | healthy | `2a286b40fea3c342c0b226bd83df6fd6d1b529ecd9e8efe349a6eb836b15e19c` |
+| MacBook/Coso | adapter | 39 | healthy | `264596cb347ae86a2c8f0832eee4cbc773133ec6a34df4bac7c0866961625ff2` |
+| MacBook/Coso | bootstrap | 32 | healthy | `0343e541956a353cfe69fbb568ba82b5c2cd960db049cfe5f7fe793d1740db2b` |
+| Mattone | adapter | 39 | healthy | `8f78212d2308b09b0c878ef78be4560c51b13e37803485df9fe0f717568e24ad` |
+| Mattone | bootstrap | 32 | healthy | `f861578b966cbed9fe7277909c9d3c779e82e7cffbf8857131c954ca2c32bb60` |
+| Collected fleet | fleet | 12 | healthy | `968316081740cda0b129dfac339eece7607b0c0269e5594e838dcd0c574789ed` |
+
+The matrix proves installed release and service identity, signed catalog and
+slot integrity, relay and notification admission, endpoint/role state,
+mailbox MCP launchability, plugin/skill parity, Telegram polling and terminal
+failure state, server storage/update/cutover state, and fleet release,
+protocol, schema, upgrade-edge, identity, and skill compatibility.
+
+## Doctor issue #169 acceptance matrix
+
+| Requirement family | Shipped evidence |
+| --- | --- |
+| Shared contract | [`doctor.md`](../doctor.md) defines the strict bounded JSON schema, deterministic stable codes, exit `0/1/2`, required-unavailable semantics, content exclusions, deadlines, and read-only boundary. Contract, redaction, cancellation, bounds, and mutation tests run in the normal suite. |
+| Server/operator | `punaro doctor` covers protected installation paths, database pair/schema/listeners, immutable release/image and Compose/migration binding, storage/backups, update fence/journal/recovery receipt, cutover, edge/Tunnel/Access, relay protocol, and optional co-located gateway state. The fresh LXC report passed all 54 checks. |
+| Client/adapter | `punaro-adapter doctor` is supported on macOS, Linux, and Windows and covers protected state, service manager and process identity, bootstrap-selected artifact, relay/Access and notifications, endpoint/role state, mailbox MCP, plugin launchers, manifests, and exact skill set. Three fresh platform reports passed all required checks. |
+| Bootstrap/update | `punaro-bootstrap doctor` verifies signed catalog/manifests, release policy, slots and artifact hashes, journal/stage/recovery, process/service handoff, rollback, disk/path safety, and recovery protocol. Three fresh reports passed 32 checks each and the signed update/rollback/interruption drills passed. |
+| Telegram | `punaro-telegram doctor` covers protected configuration/state, service and release identity, Access/relay authorization, endpoint attachment, Bot API reachability, polling progress, backlog/retry/terminal state, routes, topics, and failure classes from #165-#167. The fresh report passed 42 checks. |
+| Fleet aggregation | Offline `fleet-doctor` consumes independently collected reports plus the signed catalog/manifests. It rejected neither the exact expected component set nor release, schema, protocol, upgrade-edge, identity, plugin, or skill parity; all 12 checks passed. The server holds no SSH or client-management credentials. |
+| Failure and adversarial tests | RED-to-GREEN unit, contract, integration, platform-service, redaction, timeout, cancellation, partial-result, immutable-snapshot, broken-state, and release-policy tests are in the repository suite. PR #172 supplied the complete diagnostic contract; PRs #189, #190, #192, #193, #195, #196, #198, and #208 hardened the live Windows, Waypost, cutover, selected-client, and device-credential cases. |
+| Documentation and skills | README, product, installation, operator, GitHub Releases, doctor, Telegram, platform, plugin, and release evidence describe the shipped behavior. Installers/manifests and `punaro-mailbox`, `punaro-reply`, and `punaro-attachment` require read-only doctor readiness without granting repair authority. Installed skill trees on all three clients match alpha.11. |
+
+## End-to-end mail and Telegram evidence
+
+- One canonical opt-in role was registered and bound per client. Qualified
+  direct resolution passed; an ambiguous short name failed closed.
+- A cross-machine direct-role delivery survived the recipient adapter restart,
+  was received as a typed Punaro envelope, leased, and acknowledged. Its
+  content-free proof is SHA-256
+  `0f9e0ed1d0f02c1a94ebfa497eb7ed7c25ccec3fba4aac577372d2e56123eeec`.
+- Two fresh claimed conversations mapped to two distinct Telegram topics and
+  two current client sessions. Each completed relay-to-Telegram outbound and
+  Telegram-to-relay inbound delivery across a gateway restart; exactly one
+  fresh typed local delivery appeared on each destination. The audit observed
+  counts and identities only, never message content. Its proof is SHA-256
+  `11d32fadbd89ffb45e9f8c16ce11ec5575a19ca322c8a7a5ca3e55f92eff0edc`.
+- Focused regressions passed for message-less update offset progress, permanent
+  inbound/outbound rejection isolation, transient retry, terminal-class health,
+  stuck-progress detection, and non-fatal terminal-drop accounting. Issues
+  [#165](https://github.com/rock3r/punaro/issues/165),
+  [#166](https://github.com/rock3r/punaro/issues/166), and
+  [#167](https://github.com/rock3r/punaro/issues/167) remain closed through the
+  implementation merged in [PR #172](https://github.com/rock3r/punaro/pull/172).
+
+## Verification commands
+
+The final evidence change passed:
+
+```sh
+make plugin-validate deployment-lint release-gates
+make test
+make test-race
+make staticcheck
+make security
+make lint
+go test ./internal/telegram ./cmd/punaro-telegram \
+  -run 'Test(ClientPreservesMessageLessUpdateIDsForOffsetProgress|GatewayDropsPermanentRelayRejectionAndContinuesPage|BridgeDropsPermanentTelegramRejectionThenContinues|BridgeRetriesTransientTelegramRejection|GatewayHealthSeparatesTerminalFailureClassesAndStuckProgress|FailedGatewayCycleRecordPreservesNonFatalTerminalDropCounts)$' \
+  -count=1
+python3 scripts/test-agent-plugin.py
+```
+
+The release workflow is the authoritative cross-platform build, security scan,
+SBOM/provenance, and publication result. The local gates verified that this
+evidence-only change does not drift code, deployment, plugin, skill, or release
+contracts. `govulncheck` found no called vulnerabilities, gosec reported zero
+issues across 329 files, and gitleaks found no leaks.
+
+## Approvers and residual risk
+
+- **Security, release-signature, and operations approver:** Sebastiano Poggi,
+  limited to this controlled personal self-hosted alpha and named fleet.
+- No checkbox in [`security-release-gates.md`](../security-release-gates.md) is
+  changed by this record. Trusted-relay attachments, superseded attachment
+  protocols, and public relay/operations remain closed.
+- The installed mailbox MCP still exposes the complete legacy `mailbox_*`
+  surface on Mac Studio during the documented rolling Waypost compatibility
+  window. Fleet-wide Waypost migration remains follow-up work; doctor fails
+  ambiguous dual-database state and requires one complete supported surface.
+- Telegram outbound delivery across the external Bot API remains at-least-once.
+  Durable progress, retry identity, terminal isolation, and doctor visibility
+  bound the risk, but the Bot API provides no idempotency key for exact-once
+  sends.
+- The catalog expires on `2026-09-04T11:59:32Z`; updates fail closed after
+  expiry unless a reviewed signed catalog succeeds it.
+- Trust is rooted in digest-bound artifacts and the offline-signed manifest and
+  catalog, not in a production signed Git tag. This remains a personal alpha.

--- a/docs/release-evidence/2026-08-28-v0.1.0-alpha.11.md
+++ b/docs/release-evidence/2026-08-28-v0.1.0-alpha.11.md
@@ -57,12 +57,13 @@ Their signed catalogs and manifests remain the immutable release artifacts.
 - The published release has 26 manifest-bound native artifacts plus the signed
   manifest and catalog. Fresh downloads verified both detached signatures and
   every artifact digest before fleet use.
-- Digest-pinned server image:
+- Digest-pinned multi-architecture server image index:
   `ghcr.io/rock3r/punaro@sha256:f00f95b272cd26ad1f0217e7717c2352a884df52c0664a8f109e91b9186356a1`.
 
 ### Image, SBOM, and provenance
 
-- Image manifest: `sha256:a7117ad16764e9580e52b714258d369a70e6caa1022a226fbde599b01b82fe4d`.
+- Linux/amd64 image manifest:
+  `sha256:a7117ad16764e9580e52b714258d369a70e6caa1022a226fbde599b01b82fe4d`.
 - [OCI attestation manifest](https://ghcr.io/v2/rock3r/punaro/manifests/sha256:4644cec22d5b7f3438e36247190435a85e11825e13ce35895c3634ef1dc2a25a):
   `sha256:4644cec22d5b7f3438e36247190435a85e11825e13ce35895c3634ef1dc2a25a`.
 - [SPDX SBOM in-toto layer](https://ghcr.io/v2/rock3r/punaro/blobs/sha256:2e39015a249d7ee317d3e1045d3ba896ff063b6b4c708cc704594a7b1cfa39fe):

--- a/docs/release-evidence/2026-08-28-v0.1.0-alpha.11.md
+++ b/docs/release-evidence/2026-08-28-v0.1.0-alpha.11.md
@@ -238,7 +238,7 @@ delivery. The content-free role proof is SHA-256
 its complete reviewable payload was:
 
 ```json
-{"acknowledged":true,"adapter_restarted":true,"baseline_queued":0,"leased":true,"post_send_queued":1,"schema":1,"typed_envelope":true}
+{"schema":1,"baseline_queued":0,"post_send_queued":1,"typed_envelope":true,"leased":true,"acknowledged":true,"adapter_restarted":true}
 ```
 
 Telegram used two separately claimed sessions. Each outbound send used its own
@@ -270,7 +270,7 @@ or chat identifier was supplied to an agent command. The complete reviewable
 proof was:
 
 ```json
-{"agent_memberships":2,"claims_complete":2,"distinct_threads":2,"gateway_memberships":2,"gateway_restarted":true,"inbound_conversations":2,"inbound_messages":2,"inbound_threads":2,"mattone_fresh_typed_deliveries":1,"mattone_queue_after_reply":1,"mattone_queue_baseline":0,"message_content_observed":false,"outbound_conversations":2,"post_restart_doctors_healthy":true,"post_restart_server_doctor_checks":54,"post_restart_telegram_doctor_checks":42,"relay_outbound_messages":2,"routes":2,"schema":1,"studio_fresh_typed_deliveries":1,"studio_queue_after_reply":8,"studio_queue_baseline":7,"telegram_outbound_messages":2,"topics":2}
+{"schema":1,"topics":2,"claims_complete":2,"agent_memberships":2,"gateway_memberships":2,"routes":2,"distinct_threads":2,"relay_outbound_messages":2,"telegram_outbound_messages":2,"outbound_conversations":2,"inbound_messages":2,"inbound_conversations":2,"inbound_threads":2,"gateway_restarted":true,"post_restart_server_doctor_checks":54,"post_restart_telegram_doctor_checks":42,"post_restart_doctors_healthy":true,"studio_queue_baseline":7,"studio_queue_after_reply":8,"studio_fresh_typed_deliveries":1,"mattone_queue_baseline":0,"mattone_queue_after_reply":1,"mattone_fresh_typed_deliveries":1,"message_content_observed":false}
 ```
 
 Finally, each component report and the aggregate were reproduced with the

--- a/docs/telegram-gateway.md
+++ b/docs/telegram-gateway.md
@@ -244,8 +244,8 @@ Fence-legal order (operator chooses which topic **keeps**
 3. **Adopt both live conversations** without creating topics:
 
    ```sh
-   punaro-telegram adopt --conversation <KEEPER_CONVERSATION_ID>
-   punaro-telegram adopt --conversation <NON_KEEPER_CONVERSATION_ID>
+   punaro-telegram adopt --conversation KEEPER_CONVERSATION_ID
+   punaro-telegram adopt --conversation NON_KEEPER_CONVERSATION_ID
    ```
 
    Resolve the corresponding `<KEEPER_THREAD_ID>` and

--- a/docs/telegram-gateway.md
+++ b/docs/telegram-gateway.md
@@ -244,19 +244,22 @@ Fence-legal order (operator chooses which topic **keeps**
 3. **Adopt both live conversations** without creating topics:
 
    ```sh
-   punaro-telegram adopt --conversation dae86ecc-05ff-4431-967a-584e2cd82916
-   punaro-telegram adopt --conversation e5c269b6-7e4c-450d-82bb-c25209096c10
+   punaro-telegram adopt --conversation <KEEPER_CONVERSATION_ID>
+   punaro-telegram adopt --conversation <NON_KEEPER_CONVERSATION_ID>
    ```
 
-   These are thread `795446` and thread `795625`. Adopt requires a display
-   name and an existing `topic_routes` row. It reserves as `telegram/primary`
-   with `adopt-<conversation-id>`, records the local execution at
-   `route_persisted`, and completes. A reserve that already returns
-   `status=complete` is success. It never calls `createForumTopic`.
+   Resolve the corresponding `<KEEPER_THREAD_ID>` and
+   `<NON_KEEPER_THREAD_ID>` from the operator-protected live gateway state;
+   never record those values in source. Adopt requires a display name and an
+   existing `topic_routes` row. It reserves as `telegram/primary` with
+   `adopt-<conversation-id>`, records the local execution at `route_persisted`,
+   and completes. A reserve that already returns `status=complete` is success.
+   It never calls `createForumTopic`.
 
-4. Confirm `sendRichMessage` still hits threads `795446` and `795625`. Renew
-   `role/telegram-codex` onto `agent/punaro-studio/validation` and send
-   `--to user-telegram` from that session into the **keeper** topic only.
+4. Confirm `sendRichMessage` still hits `<KEEPER_THREAD_ID>` and
+   `<NON_KEEPER_THREAD_ID>`. Renew `role/telegram-codex` onto
+   `agent/punaro-studio/validation` and send `--to user-telegram` from that
+   session into the **keeper** topic only.
 
 If adopt is skipped, those two threads keep working as today (route +
 broadcast to a conversation that already includes `telegram/primary`). They

--- a/internal/adapter/mailbox_test.go
+++ b/internal/adapter/mailbox_test.go
@@ -124,7 +124,7 @@ func TestCLIMailboxSendsTelegramInboundMetadata(t *testing.T) {
 		FromParticipant:          relay.TelegramUserParticipant,
 		InReplyToEndpoint:        "agent/sender",
 		InReplyToPunaroMessageID: "message-0",
-		TelegramThreadID:         795446,
+		TelegramThreadID:         700001,
 		Body:                     "untrusted body",
 		CreatedAt:                createdAt,
 	}); err != nil {
@@ -137,7 +137,7 @@ func TestCLIMailboxSendsTelegramInboundMetadata(t *testing.T) {
 	if got.FromEndpoint != relay.TelegramUserParticipant || got.FromParticipant != relay.TelegramUserParticipant {
 		t.Fatalf("from = %#v", got)
 	}
-	if got.InReplyToEndpoint != "agent/sender" || got.InReplyToPunaroMessageID != "message-0" || got.TelegramThreadID != 795446 {
+	if got.InReplyToEndpoint != "agent/sender" || got.InReplyToPunaroMessageID != "message-0" || got.TelegramThreadID != 700001 {
 		t.Fatalf("reply metadata = %#v body=%s", got, stdin)
 	}
 }

--- a/internal/adapter/sync_test.go
+++ b/internal/adapter/sync_test.go
@@ -95,7 +95,7 @@ func TestSyncOnceCopiesTelegramInboundMetadataAndRewritesFromEndpoint(t *testing
 			FromParticipant:          relay.TelegramUserParticipant,
 			InReplyToPunaroMessageID: "message-0",
 			InReplyToEndpoint:        "agent/sender",
-			TelegramThreadID:         795446,
+			TelegramThreadID:         700001,
 			Body:                     "ship it",
 			CreatedAt:                createdAt,
 		},
@@ -116,7 +116,7 @@ func TestSyncOnceCopiesTelegramInboundMetadataAndRewritesFromEndpoint(t *testing
 	if got.FromEndpoint != relay.TelegramUserParticipant || got.FromParticipant != relay.TelegramUserParticipant {
 		t.Fatalf("from = %#v", got)
 	}
-	if got.InReplyToPunaroMessageID != "message-0" || got.InReplyToEndpoint != "agent/sender" || got.TelegramThreadID != 795446 {
+	if got.InReplyToPunaroMessageID != "message-0" || got.InReplyToEndpoint != "agent/sender" || got.TelegramThreadID != 700001 {
 		t.Fatalf("reply metadata = %#v", got)
 	}
 	if got.Body != "ship it" || !got.CreatedAt.Equal(createdAt) {

--- a/internal/relay/http_test.go
+++ b/internal/relay/http_test.go
@@ -587,9 +587,9 @@ func TestHTTPTelegramClaimAPIsAndUserTelegramSend(t *testing.T) {
 	if lease.Code != http.StatusOK || json.NewDecoder(lease.Body).Decode(&page) != nil || len(page.Deliveries) != 1 || page.Deliveries[0].RecipientEndpoint != TelegramGatewayEndpoint {
 		t.Fatalf("gateway lease=%d %#v %s", lease.Code, page, lease.Body.String())
 	}
-	inbound := serveSigned(t, handler, privateTG, "machine-telegram", http.MethodPost, "/v1/conversations/"+conversation.ID+"/telegram-inbound", `{"from_endpoint":"telegram/primary","from_participant":"user-telegram","body":"ship it","in_reply_to_punaro_message_id":"`+sent.ID+`","in_reply_to_endpoint":"agent/a/session","telegram_thread_id":795446}`, "inbound", "telegram-update:7")
+	inbound := serveSigned(t, handler, privateTG, "machine-telegram", http.MethodPost, "/v1/conversations/"+conversation.ID+"/telegram-inbound", `{"from_endpoint":"telegram/primary","from_participant":"user-telegram","body":"ship it","in_reply_to_punaro_message_id":"`+sent.ID+`","in_reply_to_endpoint":"agent/a/session","telegram_thread_id":700001}`, "inbound", "telegram-update:7")
 	var inboundMessage Message
-	if inbound.Code != http.StatusCreated || json.NewDecoder(inbound.Body).Decode(&inboundMessage) != nil || inboundMessage.FromParticipant != TelegramUserParticipant || inboundMessage.InReplyToPunaroMessageID != sent.ID || inboundMessage.InReplyToEndpoint != "agent/a/session" || inboundMessage.TelegramThreadID != 795446 {
+	if inbound.Code != http.StatusCreated || json.NewDecoder(inbound.Body).Decode(&inboundMessage) != nil || inboundMessage.FromParticipant != TelegramUserParticipant || inboundMessage.InReplyToPunaroMessageID != sent.ID || inboundMessage.InReplyToEndpoint != "agent/a/session" || inboundMessage.TelegramThreadID != 700001 {
 		t.Fatalf("inbound=%d %s", inbound.Code, inbound.Body.String())
 	}
 	inboundRetry := serveSigned(t, handler, privateTG, "machine-telegram", http.MethodPost, "/v1/conversations/"+conversation.ID+"/telegram-inbound", `{"from_endpoint":"telegram/primary","from_participant":"user-telegram","body":"ship it"}`, "inbound-retry", "telegram-update:7")
@@ -606,7 +606,7 @@ func TestHTTPTelegramClaimAPIsAndUserTelegramSend(t *testing.T) {
 		{"from_participant", `{"from_endpoint":"agent/a/session","body":"nope","from_participant":"user-telegram"}`},
 		{"in_reply_to_punaro_message_id", `{"from_endpoint":"agent/a/session","body":"nope","in_reply_to_punaro_message_id":"` + sent.ID + `"}`},
 		{"in_reply_to_endpoint", `{"from_endpoint":"agent/a/session","body":"nope","in_reply_to_endpoint":"agent/a/session"}`},
-		{"telegram_thread_id", `{"from_endpoint":"agent/a/session","body":"nope","telegram_thread_id":795446}`},
+		{"telegram_thread_id", `{"from_endpoint":"agent/a/session","body":"nope","telegram_thread_id":700001}`},
 	} {
 		if extra := serveSigned(t, handler, privateA, "machine-a", http.MethodPost, "/v1/conversations/"+conversation.ID+"/messages", field.body, "send-meta-"+field.name, "send-meta-"+field.name); extra.Code != http.StatusBadRequest {
 			t.Fatalf("agent %s send=%d %s", field.name, extra.Code, extra.Body.String())
@@ -618,7 +618,7 @@ func TestHTTPTelegramClaimAPIsAndUserTelegramSend(t *testing.T) {
 		t.Fatalf("inbound lease=%d %s", leased.Code, leased.Body.String())
 	}
 	got := inboundPage.Deliveries[0].Message
-	if got.ID != inboundMessage.ID || got.FromEndpoint != TelegramGatewayEndpoint || got.FromParticipant != TelegramUserParticipant || got.InReplyToPunaroMessageID != sent.ID || got.InReplyToEndpoint != "agent/a/session" || got.TelegramThreadID != 795446 {
+	if got.ID != inboundMessage.ID || got.FromEndpoint != TelegramGatewayEndpoint || got.FromParticipant != TelegramUserParticipant || got.InReplyToPunaroMessageID != sent.ID || got.InReplyToEndpoint != "agent/a/session" || got.TelegramThreadID != 700001 {
 		t.Fatalf("leased inbound=%#v", got)
 	}
 }

--- a/internal/relay/migration_source_test.go
+++ b/internal/relay/migration_source_test.go
@@ -1514,7 +1514,7 @@ func TestInspectMigrationSourceV7HashesIncludeDisplayNameAndInboundMetadata(t *t
 	inbound, duplicate, err := store.AppendTelegramInbound(TelegramInboundInput{
 		ConversationID: conversation.ID, SenderMachineID: "machine-telegram", FromEndpoint: TelegramGatewayEndpoint,
 		FromParticipant: TelegramUserParticipant, Body: "v7 inbound", InReplyToMessageID: "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee",
-		InReplyToEndpoint: "agent/a", TelegramThreadID: 795446, IdempotencyKey: "telegram-update:v7", Now: now,
+		InReplyToEndpoint: "agent/a", TelegramThreadID: 700001, IdempotencyKey: "telegram-update:v7", Now: now,
 	})
 	if err != nil || duplicate || inbound.FromParticipant != TelegramUserParticipant {
 		_ = store.Close()
@@ -1585,9 +1585,9 @@ func TestInspectMigrationSourceExportsTelegramClaimsAndInboundMetadata(t *testin
 	inbound, duplicate, err := store.AppendTelegramInbound(TelegramInboundInput{
 		ConversationID: conversation.ID, SenderMachineID: "machine-telegram", FromEndpoint: TelegramGatewayEndpoint,
 		FromParticipant: TelegramUserParticipant, Body: "ship it", InReplyToMessageID: "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee",
-		InReplyToEndpoint: "agent/a", TelegramThreadID: 795446, IdempotencyKey: "telegram-update:7", Now: now,
+		InReplyToEndpoint: "agent/a", TelegramThreadID: 700001, IdempotencyKey: "telegram-update:7", Now: now,
 	})
-	if err != nil || duplicate || inbound.FromParticipant != TelegramUserParticipant || inbound.TelegramThreadID != 795446 {
+	if err != nil || duplicate || inbound.FromParticipant != TelegramUserParticipant || inbound.TelegramThreadID != 700001 {
 		t.Fatalf("inbound=%#v duplicate=%t err=%v", inbound, duplicate, err)
 	}
 	inspected, err := InspectMigrationSource(ctx, path)
@@ -1642,7 +1642,7 @@ func TestInspectMigrationSourceExportsTelegramClaimsAndInboundMetadata(t *testin
 	if err := json.Unmarshal(messages.Rows[0].Payload, &message); err != nil {
 		t.Fatal(err)
 	}
-	if message["from_participant"] != TelegramUserParticipant || message["in_reply_to_message_id"] != "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee" || message["in_reply_to_endpoint"] != "agent/a" || message["telegram_thread_id"] != float64(795446) {
+	if message["from_participant"] != TelegramUserParticipant || message["in_reply_to_message_id"] != "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee" || message["in_reply_to_endpoint"] != "agent/a" || message["telegram_thread_id"] != float64(700001) {
 		t.Fatalf("message metadata=%#v", message)
 	}
 }

--- a/internal/relay/store_test.go
+++ b/internal/relay/store_test.go
@@ -2333,7 +2333,7 @@ func TestStoreTelegramInboundExcludesMetadataFromHash(t *testing.T) {
 	retry, duplicate, err := store.AppendTelegramInbound(TelegramInboundInput{
 		ConversationID: conversation.ID, SenderMachineID: "machine-telegram", FromEndpoint: TelegramGatewayEndpoint,
 		FromParticipant: TelegramUserParticipant, Body: "ship it", InReplyToMessageID: first.ID,
-		InReplyToEndpoint: "agent/a", TelegramThreadID: 795446, IdempotencyKey: "telegram-update:42", Now: now.Add(time.Second),
+		InReplyToEndpoint: "agent/a", TelegramThreadID: 700001, IdempotencyKey: "telegram-update:42", Now: now.Add(time.Second),
 	})
 	if err != nil || !duplicate || retry.ID != first.ID || retry.InReplyToPunaroMessageID != "" || retry.TelegramThreadID != 0 {
 		t.Fatalf("metadata retry=%#v duplicate=%t err=%v", retry, duplicate, err)
@@ -2341,9 +2341,9 @@ func TestStoreTelegramInboundExcludesMetadataFromHash(t *testing.T) {
 	second, duplicate, err := store.AppendTelegramInbound(TelegramInboundInput{
 		ConversationID: conversation.ID, SenderMachineID: "machine-telegram", FromEndpoint: TelegramGatewayEndpoint,
 		FromParticipant: TelegramUserParticipant, Body: "follow up", InReplyToMessageID: first.ID,
-		InReplyToEndpoint: "agent/a", TelegramThreadID: 795446, IdempotencyKey: "telegram-update:43", Now: now.Add(2 * time.Second),
+		InReplyToEndpoint: "agent/a", TelegramThreadID: 700001, IdempotencyKey: "telegram-update:43", Now: now.Add(2 * time.Second),
 	})
-	if err != nil || duplicate || second.InReplyToPunaroMessageID != first.ID || second.InReplyToEndpoint != "agent/a" || second.TelegramThreadID != 795446 {
+	if err != nil || duplicate || second.InReplyToPunaroMessageID != first.ID || second.InReplyToEndpoint != "agent/a" || second.TelegramThreadID != 700001 {
 		t.Fatalf("second inbound=%#v duplicate=%t err=%v", second, duplicate, err)
 	}
 	if err := store.AdvertiseEndpoints("machine-a", []string{"agent/a"}, now.Add(3*time.Second), time.Hour); err != nil {
@@ -2359,7 +2359,7 @@ func TestStoreTelegramInboundExcludesMetadataFromHash(t *testing.T) {
 			leased = delivery.Message
 		}
 	}
-	if leased.ID != second.ID || leased.FromEndpoint != TelegramGatewayEndpoint || leased.FromParticipant != TelegramUserParticipant || leased.InReplyToPunaroMessageID != first.ID || leased.InReplyToEndpoint != "agent/a" || leased.TelegramThreadID != 795446 {
+	if leased.ID != second.ID || leased.FromEndpoint != TelegramGatewayEndpoint || leased.FromParticipant != TelegramUserParticipant || leased.InReplyToPunaroMessageID != first.ID || leased.InReplyToEndpoint != "agent/a" || leased.TelegramThreadID != 700001 {
 		t.Fatalf("leased inbound=%#v deliveries=%#v", leased, page.Deliveries)
 	}
 }

--- a/internal/telegram/claim_test.go
+++ b/internal/telegram/claim_test.go
@@ -140,7 +140,7 @@ func TestExecuteClaimCreatesTopicPersistsThreadThenCompletes(t *testing.T) {
 		t.Fatal(err)
 	}
 	var logs []string
-	topics := &recordingTopicCreator{threadID: 795446}
+	topics := &recordingTopicCreator{threadID: 700001}
 	claims := &recordingClaimRelay{claim: relay.TelegramClaim{ConversationID: "conversation-1", Status: "pending", DisplayName: "How is it going"}}
 	executor := ClaimExecutor{State: state, Relay: claims, Topics: topics, AllowedUserID: 55, Log: func(format string, args ...any) { logs = append(logs, fmt.Sprintf(format, args...)) }}
 	if err := executor.Execute(context.Background(), "conversation-1"); err != nil {
@@ -156,10 +156,10 @@ func TestExecuteClaimCreatesTopicPersistsThreadThenCompletes(t *testing.T) {
 		t.Fatalf("completes=%#v", claims.completes)
 	}
 	execution, found, err := state.ClaimExecution("conversation-1")
-	if err != nil || !found || execution.Phase != ClaimPhaseComplete || execution.ThreadID != 795446 {
+	if err != nil || !found || execution.Phase != ClaimPhaseComplete || execution.ThreadID != 700001 {
 		t.Fatalf("execution=%#v found=%v err=%v", execution, found, err)
 	}
-	conversation, found, err := state.Route(55, 795446)
+	conversation, found, err := state.Route(55, 700001)
 	if err != nil || !found || conversation != "conversation-1" {
 		t.Fatalf("route conversation=%q found=%v err=%v", conversation, found, err)
 	}
@@ -245,7 +245,7 @@ func TestExecuteClaimPersistsCreatingFenceBeforeCreateForumTopic(t *testing.T) {
 	if _, _, err := state.ReserveClaimAndConsumeTokenMust(t, "conversation-1"); err != nil {
 		t.Fatal(err)
 	}
-	topics := &recordingTopicCreator{threadID: 795446, onCreate: func() {
+	topics := &recordingTopicCreator{threadID: 700001, onCreate: func() {
 		execution, found, err := state.ClaimExecution("conversation-1")
 		if err != nil || !found || execution.Phase != ClaimPhaseCreating || execution.ThreadID != 0 {
 			t.Fatalf("createForumTopic without creating fence execution=%#v found=%v err=%v", execution, found, err)
@@ -310,7 +310,7 @@ func TestExecuteClaimRetriesAfterDefinitiveTopicCreateRejection(t *testing.T) {
 		t.Fatalf("retryable after HTTP 429 execution=%#v found=%v err=%v", execution, found, err)
 	}
 	topics.err = nil
-	topics.threadID = 795446
+	topics.threadID = 700001
 	if err := executor.Execute(context.Background(), "conversation-1"); err != nil {
 		t.Fatal(err)
 	}
@@ -318,7 +318,7 @@ func TestExecuteClaimRetriesAfterDefinitiveTopicCreateRejection(t *testing.T) {
 		t.Fatalf("createForumTopic after HTTP 429 names=%#v", topics.names)
 	}
 	execution, found, err = state.ClaimExecution("conversation-1")
-	if err != nil || !found || execution.Phase != ClaimPhaseComplete || execution.ThreadID != 795446 {
+	if err != nil || !found || execution.Phase != ClaimPhaseComplete || execution.ThreadID != 700001 {
 		t.Fatalf("completed after HTTP 429 retry execution=%#v found=%v err=%v", execution, found, err)
 	}
 }
@@ -394,7 +394,7 @@ func TestExecuteClaimRecoversUnthreadedCreatingViaEmergencyRoute(t *testing.T) {
 		t.Fatal(err)
 	}
 	t.Cleanup(func() { _ = restarted.Close() })
-	if err := restarted.SetRoute(55, 795446, "conversation-1"); err != nil {
+	if err := restarted.SetRoute(55, 700001, "conversation-1"); err != nil {
 		t.Fatalf("emergency route during unthreaded creating: %v", err)
 	}
 	topics := &recordingTopicCreator{threadID: 1}
@@ -407,10 +407,10 @@ func TestExecuteClaimRecoversUnthreadedCreatingViaEmergencyRoute(t *testing.T) {
 		t.Fatalf("createForumTopic after emergency route recovery: %#v", topics.names)
 	}
 	execution, found, err := restarted.ClaimExecution("conversation-1")
-	if err != nil || !found || execution.Phase != ClaimPhaseComplete || execution.ThreadID != 795446 || execution.ChatID != 55 {
+	if err != nil || !found || execution.Phase != ClaimPhaseComplete || execution.ThreadID != 700001 || execution.ChatID != 55 {
 		t.Fatalf("recovered execution=%#v found=%v err=%v", execution, found, err)
 	}
-	conversation, found, err := restarted.Route(55, 795446)
+	conversation, found, err := restarted.Route(55, 700001)
 	if err != nil || !found || conversation != "conversation-1" {
 		t.Fatalf("route conversation=%q found=%v err=%v", conversation, found, err)
 	}
@@ -457,7 +457,7 @@ func TestExecuteClaimTopicCreatedDoesNotRebindThreadToNewChat(t *testing.T) {
 	if _, _, err := state.ReserveClaimAndConsumeTokenMust(t, "conversation-1"); err != nil {
 		t.Fatal(err)
 	}
-	if err := state.PersistClaimThread("conversation-1", 55, 795446); err != nil {
+	if err := state.PersistClaimThread("conversation-1", 55, 700001); err != nil {
 		t.Fatal(err)
 	}
 	topics := &recordingTopicCreator{threadID: 1}
@@ -466,14 +466,14 @@ func TestExecuteClaimTopicCreatedDoesNotRebindThreadToNewChat(t *testing.T) {
 	if err := executor.Execute(context.Background(), "conversation-1"); err == nil || err.Error() != "telegram_route_persist_failed" {
 		t.Fatalf("topic_created thread was bound to a new allowed chat: err=%v", err)
 	}
-	if _, found, err := state.Route(99, 795446); err != nil || found {
+	if _, found, err := state.Route(99, 700001); err != nil || found {
 		t.Fatalf("new chat route found=%v err=%v", found, err)
 	}
-	if _, found, err := state.Route(55, 795446); err != nil || found {
+	if _, found, err := state.Route(55, 700001); err != nil || found {
 		t.Fatalf("mismatched resume inserted original chat route found=%v err=%v", found, err)
 	}
 	execution, found, err := state.ClaimExecution("conversation-1")
-	if err != nil || !found || execution.Phase != ClaimPhaseTopicCreated || execution.ThreadID != 795446 || execution.ChatID != 55 {
+	if err != nil || !found || execution.Phase != ClaimPhaseTopicCreated || execution.ThreadID != 700001 || execution.ChatID != 55 {
 		t.Fatalf("execution=%#v found=%v err=%v", execution, found, err)
 	}
 	if len(claims.completes) != 0 {
@@ -494,7 +494,7 @@ func TestExecuteClaimReusesStoredThreadAndNeverCreatesTwice(t *testing.T) {
 	if _, _, err := state.ReserveClaimAndConsumeTokenMust(t, "conversation-1"); err != nil {
 		t.Fatal(err)
 	}
-	if err := state.PersistClaimThread("conversation-1", 55, 795446); err != nil {
+	if err := state.PersistClaimThread("conversation-1", 55, 700001); err != nil {
 		t.Fatal(err)
 	}
 	topics := &recordingTopicCreator{threadID: 1}
@@ -507,7 +507,7 @@ func TestExecuteClaimReusesStoredThreadAndNeverCreatesTwice(t *testing.T) {
 		t.Fatalf("createForumTopic called again: %#v", topics.names)
 	}
 	execution, found, err := state.ClaimExecution("conversation-1")
-	if err != nil || !found || execution.Phase != ClaimPhaseComplete || execution.ThreadID != 795446 {
+	if err != nil || !found || execution.Phase != ClaimPhaseComplete || execution.ThreadID != 700001 {
 		t.Fatalf("execution=%#v found=%v err=%v", execution, found, err)
 	}
 }
@@ -574,7 +574,7 @@ func TestAdoptUsesExistingRouteWithoutCreateForumTopic(t *testing.T) {
 		t.Fatal(err)
 	}
 	t.Cleanup(func() { _ = state.Close() })
-	if err := state.SetRoute(55, 795446, "conversation-1"); err != nil {
+	if err := state.SetRoute(55, 700001, "conversation-1"); err != nil {
 		t.Fatal(err)
 	}
 	claims := &recordingClaimRelay{claim: relay.TelegramClaim{ConversationID: "conversation-1", Status: "pending", DisplayName: "How is it going"}}
@@ -588,7 +588,7 @@ func TestAdoptUsesExistingRouteWithoutCreateForumTopic(t *testing.T) {
 		t.Fatalf("completes=%#v", claims.completes)
 	}
 	execution, found, err := state.ClaimExecution("conversation-1")
-	if err != nil || !found || execution.Phase != ClaimPhaseComplete || execution.ThreadID != 795446 {
+	if err != nil || !found || execution.Phase != ClaimPhaseComplete || execution.ThreadID != 700001 {
 		t.Fatalf("execution=%#v found=%v err=%v", execution, found, err)
 	}
 }
@@ -600,7 +600,7 @@ func TestAdoptAlreadyCompleteIsNoopSuccess(t *testing.T) {
 		t.Fatal(err)
 	}
 	t.Cleanup(func() { _ = state.Close() })
-	if err := state.SetRoute(55, 795625, "conversation-2"); err != nil {
+	if err := state.SetRoute(55, 700002, "conversation-2"); err != nil {
 		t.Fatal(err)
 	}
 	claims := &recordingClaimRelay{claim: relay.TelegramClaim{ConversationID: "conversation-2", Status: "complete", DisplayName: "Other"}}
@@ -611,7 +611,7 @@ func TestAdoptAlreadyCompleteIsNoopSuccess(t *testing.T) {
 		t.Fatalf("complete-status adopt was not a no-op: completes=%#v", claims.completes)
 	}
 	execution, found, err := state.ClaimExecution("conversation-2")
-	if err != nil || !found || execution.Phase != ClaimPhaseComplete || execution.ThreadID != 795625 {
+	if err != nil || !found || execution.Phase != ClaimPhaseComplete || execution.ThreadID != 700002 {
 		t.Fatalf("execution=%#v found=%v err=%v", execution, found, err)
 	}
 }
@@ -623,7 +623,7 @@ func TestExecuteClaimReusesExistingTopicRouteWithoutCreateForumTopic(t *testing.
 		t.Fatal(err)
 	}
 	t.Cleanup(func() { _ = state.Close() })
-	if err := state.SetRoute(55, 795446, "conversation-1"); err != nil {
+	if err := state.SetRoute(55, 700001, "conversation-1"); err != nil {
 		t.Fatal(err)
 	}
 	if _, _, err := state.ReserveClaimAndConsumeTokenMust(t, "conversation-1"); err != nil {
@@ -639,10 +639,10 @@ func TestExecuteClaimReusesExistingTopicRouteWithoutCreateForumTopic(t *testing.
 		t.Fatalf("createForumTopic on already-routed conversation: %#v", topics.names)
 	}
 	execution, found, err := state.ClaimExecution("conversation-1")
-	if err != nil || !found || execution.Phase != ClaimPhaseComplete || execution.ThreadID != 795446 {
+	if err != nil || !found || execution.Phase != ClaimPhaseComplete || execution.ThreadID != 700001 {
 		t.Fatalf("execution=%#v found=%v err=%v", execution, found, err)
 	}
-	conversation, found, err := state.Route(55, 795446)
+	conversation, found, err := state.Route(55, 700001)
 	if err != nil || !found || conversation != "conversation-1" {
 		t.Fatalf("route conversation=%q found=%v err=%v", conversation, found, err)
 	}
@@ -680,7 +680,7 @@ func TestExecuteClaimReusesRouteWhenRelayClaimAlreadyComplete(t *testing.T) {
 		t.Fatal(err)
 	}
 	t.Cleanup(func() { _ = state.Close() })
-	if err := state.SetRoute(55, 795625, "conversation-1"); err != nil {
+	if err := state.SetRoute(55, 700002, "conversation-1"); err != nil {
 		t.Fatal(err)
 	}
 	if _, _, err := state.ReserveClaimAndConsumeTokenMust(t, "conversation-1"); err != nil {
@@ -696,7 +696,7 @@ func TestExecuteClaimReusesRouteWhenRelayClaimAlreadyComplete(t *testing.T) {
 		t.Fatalf("createForumTopic after complete+route: %#v", topics.names)
 	}
 	execution, found, err := state.ClaimExecution("conversation-1")
-	if err != nil || !found || execution.Phase != ClaimPhaseComplete || execution.ThreadID != 795625 {
+	if err != nil || !found || execution.Phase != ClaimPhaseComplete || execution.ThreadID != 700002 {
 		t.Fatalf("execution=%#v found=%v err=%v", execution, found, err)
 	}
 }
@@ -708,10 +708,10 @@ func TestAdoptDoesNotDowngradeCompleteExecution(t *testing.T) {
 		t.Fatal(err)
 	}
 	t.Cleanup(func() { _ = state.Close() })
-	if err := state.SetRoute(55, 795446, "conversation-1"); err != nil {
+	if err := state.SetRoute(55, 700001, "conversation-1"); err != nil {
 		t.Fatal(err)
 	}
-	if err := state.AdoptExecution("conversation-1", 795446); err != nil {
+	if err := state.AdoptExecution("conversation-1", 700001); err != nil {
 		t.Fatal(err)
 	}
 	if err := state.MarkClaimComplete("conversation-1"); err != nil {
@@ -721,7 +721,7 @@ func TestAdoptDoesNotDowngradeCompleteExecution(t *testing.T) {
 		t.Fatal(err)
 	}
 	execution, found, err := state.ClaimExecution("conversation-1")
-	if err != nil || !found || execution.Phase != ClaimPhaseComplete || execution.ThreadID != 795446 {
+	if err != nil || !found || execution.Phase != ClaimPhaseComplete || execution.ThreadID != 700001 {
 		t.Fatalf("AdoptExecution downgraded complete: %#v found=%v err=%v", execution, found, err)
 	}
 	claims := &recordingClaimRelay{claim: relay.TelegramClaim{ConversationID: "conversation-1", Status: "complete", DisplayName: "How is it going"}}
@@ -732,7 +732,7 @@ func TestAdoptDoesNotDowngradeCompleteExecution(t *testing.T) {
 		t.Fatalf("complete adopt retried complete: %#v", claims.completes)
 	}
 	execution, found, err = state.ClaimExecution("conversation-1")
-	if err != nil || !found || execution.Phase != ClaimPhaseComplete || execution.ThreadID != 795446 {
+	if err != nil || !found || execution.Phase != ClaimPhaseComplete || execution.ThreadID != 700001 {
 		t.Fatalf("downgraded execution=%#v found=%v err=%v", execution, found, err)
 	}
 }
@@ -836,10 +836,10 @@ func TestExecuteCompleteRejectsRouteForDifferentTelegramChat(t *testing.T) {
 		t.Fatal(err)
 	}
 	t.Cleanup(func() { _ = state.Close() })
-	if err := state.SetRoute(99, 795446, "conversation-1"); err != nil {
+	if err := state.SetRoute(99, 700001, "conversation-1"); err != nil {
 		t.Fatal(err)
 	}
-	if err := state.AdoptExecution("conversation-1", 795446); err != nil {
+	if err := state.AdoptExecution("conversation-1", 700001); err != nil {
 		t.Fatal(err)
 	}
 	if err := state.MarkClaimComplete("conversation-1"); err != nil {
@@ -896,7 +896,7 @@ func TestAdoptFencesLocalRouteBeforeRemoteReserve(t *testing.T) {
 		t.Fatal(err)
 	}
 	t.Cleanup(func() { _ = state.Close() })
-	if err := state.SetRoute(55, 795446, "conversation-1"); err != nil {
+	if err := state.SetRoute(55, 700001, "conversation-1"); err != nil {
 		t.Fatal(err)
 	}
 	claims := &adoptFenceRelay{state: state, claim: relay.TelegramClaim{ConversationID: "conversation-1", Status: "pending", DisplayName: "How is it going"}}
@@ -1014,7 +1014,7 @@ func TestResumeAllReservesAdoptingExecutionInsteadOfCompleting(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := state.SetRoute(55, 795446, "conversation-1"); err != nil {
+	if err := state.SetRoute(55, 700001, "conversation-1"); err != nil {
 		_ = state.Close()
 		t.Fatal(err)
 	}
@@ -1023,7 +1023,7 @@ func TestResumeAllReservesAdoptingExecutionInsteadOfCompleting(t *testing.T) {
 		t.Fatal(err)
 	}
 	execution, found, err := state.ClaimExecution("conversation-1")
-	if err != nil || !found || execution.Phase != ClaimPhaseAdopting || execution.ThreadID != 795446 {
+	if err != nil || !found || execution.Phase != ClaimPhaseAdopting || execution.ThreadID != 700001 {
 		_ = state.Close()
 		t.Fatalf("pre-reserve adopt fence execution=%#v found=%v err=%v", execution, found, err)
 	}
@@ -1047,7 +1047,7 @@ func TestResumeAllReservesAdoptingExecutionInsteadOfCompleting(t *testing.T) {
 		t.Fatalf("adopting resume completes=%#v", claims.completes)
 	}
 	execution, found, err = restarted.ClaimExecution("conversation-1")
-	if err != nil || !found || execution.Phase != ClaimPhaseComplete || execution.ThreadID != 795446 {
+	if err != nil || !found || execution.Phase != ClaimPhaseComplete || execution.ThreadID != 700001 {
 		t.Fatalf("resumed adopting execution=%#v found=%v err=%v", execution, found, err)
 	}
 }
@@ -1059,7 +1059,7 @@ func TestAdoptRejectsRouteForDifferentTelegramChat(t *testing.T) {
 		t.Fatal(err)
 	}
 	t.Cleanup(func() { _ = state.Close() })
-	if err := state.SetRoute(99, 795446, "conversation-1"); err != nil {
+	if err := state.SetRoute(99, 700001, "conversation-1"); err != nil {
 		t.Fatal(err)
 	}
 	claims := &recordingClaimRelay{claim: relay.TelegramClaim{ConversationID: "conversation-1", Status: "pending", DisplayName: "How is it going"}}

--- a/internal/telegram/client_test.go
+++ b/internal/telegram/client_test.go
@@ -306,7 +306,7 @@ func TestClientCreateForumTopicReturnsThreadIDWithoutGetForumTopic(t *testing.T)
 		if request.ChatID != 55 || request.Name != "How is it going" {
 			t.Fatalf("createForumTopic=%#v", request)
 		}
-		_, _ = w.Write([]byte(`{"ok":true,"result":{"message_thread_id":795446,"name":"How is it going"}}`))
+		_, _ = w.Write([]byte(`{"ok":true,"result":{"message_thread_id":700001,"name":"How is it going"}}`))
 	}))
 	defer server.Close()
 	client, err := NewClient(server.URL, "secret", server.Client())
@@ -314,7 +314,7 @@ func TestClientCreateForumTopicReturnsThreadIDWithoutGetForumTopic(t *testing.T)
 		t.Fatal(err)
 	}
 	threadID, err := client.CreateForumTopic(context.Background(), 55, "How is it going")
-	if err != nil || threadID != 795446 {
+	if err != nil || threadID != 700001 {
 		t.Fatalf("thread_id=%d err=%v", threadID, err)
 	}
 	if seen["/botsecret/getForumTopic"] != 0 || seen["/botsecret/createForumTopic"] != 1 {

--- a/internal/telegram/gateway_test.go
+++ b/internal/telegram/gateway_test.go
@@ -317,7 +317,7 @@ func TestGatewayCallbackReservesExecutionThenConsumesToken(t *testing.T) {
 	t.Cleanup(func() { _ = state.Close() })
 	notify := &recordingNotify{}
 	var logs []string
-	topics := &recordingTopicCreator{threadID: 795446}
+	topics := &recordingTopicCreator{threadID: 700001}
 	claims := &recordingClaimRelay{claim: relay.TelegramClaim{ConversationID: "conversation-1", Status: "pending", DisplayName: "Ops"}}
 	executor := &ClaimExecutor{State: state, Relay: claims, Topics: topics, AllowedUserID: 55, Log: func(format string, args ...any) { logs = append(logs, fmt.Sprintf(format, args...)) }}
 	gateway := Gateway{
@@ -352,7 +352,7 @@ func TestGatewayCallbackReservesExecutionThenConsumesToken(t *testing.T) {
 		t.Fatalf("createForumTopic=%#v chats=%#v", topics.names, topics.chatIDs)
 	}
 	execution, found, err := state.ClaimExecution("conversation-1")
-	if err != nil || !found || execution.Phase != ClaimPhaseComplete || execution.ThreadID != 795446 {
+	if err != nil || !found || execution.Phase != ClaimPhaseComplete || execution.ThreadID != 700001 {
 		t.Fatalf("execution=%#v found=%v err=%v", execution, found, err)
 	}
 	if !hasLogClass(logs, "telegram_claim_reserved") || !hasLogClass(logs, "telegram_claim_completed") {

--- a/internal/telegram/state_test.go
+++ b/internal/telegram/state_test.go
@@ -759,11 +759,11 @@ func TestOpenAddsClaimExecutionChatIDOnExistingDatabase(t *testing.T) {
 		t.Fatal(err)
 	}
 	t.Cleanup(func() { _ = state.Close() })
-	if err := state.PersistClaimThread("conversation-1", 55, 795446); err != nil {
+	if err := state.PersistClaimThread("conversation-1", 55, 700001); err != nil {
 		t.Fatal(err)
 	}
 	execution, found, err := state.ClaimExecution("conversation-1")
-	if err != nil || !found || execution.Phase != ClaimPhaseTopicCreated || execution.ThreadID != 795446 || execution.ChatID != 55 {
+	if err != nil || !found || execution.Phase != ClaimPhaseTopicCreated || execution.ThreadID != 700001 || execution.ChatID != 55 {
 		t.Fatalf("upgraded execution=%#v found=%v err=%v", execution, found, err)
 	}
 }
@@ -778,14 +778,14 @@ func TestStatePersistsClaimThreadAndOutboundMap(t *testing.T) {
 	if _, err := state.InsertPendingExecution("conversation-1", "How is it going"); err != nil {
 		t.Fatal(err)
 	}
-	if err := state.PersistClaimThread("conversation-1", 55, 795446); err != nil {
+	if err := state.PersistClaimThread("conversation-1", 55, 700001); err != nil {
 		t.Fatal(err)
 	}
 	execution, found, err := state.ClaimExecution("conversation-1")
-	if err != nil || !found || execution.Phase != ClaimPhaseTopicCreated || execution.ThreadID != 795446 || execution.ChatID != 55 || !execution.SkipReserve || execution.DisplayName != "How is it going" {
+	if err != nil || !found || execution.Phase != ClaimPhaseTopicCreated || execution.ThreadID != 700001 || execution.ChatID != 55 || !execution.SkipReserve || execution.DisplayName != "How is it going" {
 		t.Fatalf("after thread persist %#v found=%v err=%v", execution, found, err)
 	}
-	if err := state.PersistClaimRoute(55, 795446, "conversation-1"); err != nil {
+	if err := state.PersistClaimRoute(55, 700001, "conversation-1"); err != nil {
 		t.Fatal(err)
 	}
 	if err := state.MarkClaimComplete("conversation-1"); err != nil {
@@ -1152,7 +1152,7 @@ func TestStatePersistClaimRouteReusesExistingConversationThread(t *testing.T) {
 		t.Fatal(err)
 	}
 	t.Cleanup(func() { _ = state.Close() })
-	if err := state.SetRoute(55, 795446, "conversation-1"); err != nil {
+	if err := state.SetRoute(55, 700001, "conversation-1"); err != nil {
 		t.Fatal(err)
 	}
 	if _, _, err := state.ReserveClaimAndConsumeTokenMust(t, "conversation-1"); err != nil {
@@ -1165,10 +1165,10 @@ func TestStatePersistClaimRouteReusesExistingConversationThread(t *testing.T) {
 		t.Fatal(err)
 	}
 	execution, found, err := state.ClaimExecution("conversation-1")
-	if err != nil || !found || execution.Phase != ClaimPhaseRoutePersisted || execution.ThreadID != 795446 {
+	if err != nil || !found || execution.Phase != ClaimPhaseRoutePersisted || execution.ThreadID != 700001 {
 		t.Fatalf("reuse execution=%#v found=%v err=%v", execution, found, err)
 	}
-	conversation, found, err := state.Route(55, 795446)
+	conversation, found, err := state.Route(55, 700001)
 	if err != nil || !found || conversation != "conversation-1" {
 		t.Fatalf("kept route conversation=%q found=%v err=%v", conversation, found, err)
 	}
@@ -1184,18 +1184,18 @@ func TestAdoptExistingRoutePersistsAdoptingFence(t *testing.T) {
 		t.Fatal(err)
 	}
 	t.Cleanup(func() { _ = state.Close() })
-	if err := state.SetRoute(55, 795446, "conversation-1"); err != nil {
+	if err := state.SetRoute(55, 700001, "conversation-1"); err != nil {
 		t.Fatal(err)
 	}
 	threadID, err := state.AdoptExistingRoute("conversation-1", 55)
-	if err != nil || threadID != 795446 {
+	if err != nil || threadID != 700001 {
 		t.Fatalf("adopt fence thread=%d err=%v", threadID, err)
 	}
 	execution, found, err := state.ClaimExecution("conversation-1")
-	if err != nil || !found || execution.Phase != ClaimPhaseAdopting || execution.ThreadID != 795446 || execution.ChatID != 55 || !execution.SkipReserve {
+	if err != nil || !found || execution.Phase != ClaimPhaseAdopting || execution.ThreadID != 700001 || execution.ChatID != 55 || !execution.SkipReserve {
 		t.Fatalf("adopting fence execution=%#v found=%v err=%v", execution, found, err)
 	}
-	if err := state.SetRoute(55, 795446, "conversation-other"); err == nil {
+	if err := state.SetRoute(55, 700001, "conversation-other"); err == nil {
 		t.Fatal("adopting fence allowed a remapped route")
 	}
 	if err := state.PersistClaimAdoptReserved("conversation-1"); err != nil {


### PR DESCRIPTION
## Summary

- document the signed `v0.1.0-alpha.11` release and immutable artifact identities
- record the four-machine server, Telegram, adapter, bootstrap, and fleet doctor matrix
- map every doctor issue #169 acceptance family to shipped code, tests, docs, and live evidence
- record signed update, rollback, interrupted recovery, mail cutover, durable-role delivery, and Telegram multi-topic restart/failure proof
- refresh README, PRODUCT, and installation guidance to the deployed alpha.11 state

The protected reports remain outside Git. The record contains only content-free outcomes and SHA-256 identities; it includes no credentials, raw machine/client identifiers, message bodies, Telegram content, or private paths.

## Validation

- `make plugin-validate deployment-lint release-gates`
- `make test`
- `make test-race`
- `make staticcheck`
- `make security`
- `make lint`
- focused Telegram #165-#167 recovery regressions
- `python3 scripts/test-agent-plugin.py`

All passed. `govulncheck` found no called vulnerabilities, gosec reported zero issues across 329 files, and gitleaks found no leaks.

## Review note

The earlier release-source PR #208 merged with all five required quality jobs green. Bugbot was unavailable only because its team quota was exhausted; the operator explicitly waived that unavailable quota gate for this personal alpha. This PR should still complete ordinary CI and review before merge.

Closes the evidence gap in #169.
