### PR TITLE
fix: retire assumed-present Bugbot babysit gate

### DIFF
--- a/.agents/skills/babysit-pr/SKILL.md
+++ b/.agents/skills/babysit-pr/SKILL.md
@@ -74,13 +74,13 @@ python3 .agents/skills/babysit-pr/scripts/gh_pr_watch.py --pr 42 --once
 | `stop_ready_to_merge` | CI green, no blocking reviews, no conflicts — the only positive readiness verdict. Before acting on it, run the full Punaro gate locally on the PR head (a PR can go green without any babysitter push, and the gate must still pass before merge) |
 | `stop_exhausted_retries` | Flaky reruns hit the retry limit — user must investigate |
 | `stop_non_retryable_failure` | Terminal failure is not in retry-eligible workflows — diagnose/fix before continuing |
-| `stop_bugbot_not_green` | Cursor Bugbot is not clean — do not merge |
+| `stop_bugbot_not_green` | A *present* Bugbot check is not clean — do not merge (Bugbot is retired as an assumed-present gate; absence does not emit this) |
 | `stop_session_timeout` | `--max-session-minutes` elapsed (default 90 min) — stop and report |
 | `diagnose_hung_check` | A pending check exceeded its hung threshold — stop and report |
 | `diagnose_merge_conflict` | PR is merge-conflicted (`CONFLICTING` / `DIRTY`) — resolve before waiting on checks |
 | `diagnose_branch_behind` | PR branch is behind its base — rebase onto the PR's base ref (batch with any pending fixes) |
 | `diagnose_skipping_checks` | One or more checks completed with `neutral`/`skipping` — investigate why |
-| `wait_bugbot` | Bugbot still running — do not push or merge |
+| `wait_bugbot` | A *present* Bugbot check is still running — do not push or merge |
 | `wait_codex` | Codex is still reviewing (👀 reaction present) — do not push or merge |
 | `wait_coderabbit` | CodeRabbit is still reviewing — do not push or merge |
 
@@ -142,14 +142,20 @@ push is immediately followed by a second bot-fix push.
 
 **Never merge until every present review bot reports clean.**
 
-### Bugbot (CI check)
+### Bugbot (retired as assumed-present; presence-conditional)
+
+Cursor Bugbot is **not** required on every PR. A missing Bugbot check does not
+block merge, and Bugbot enablement/upsell / account-mismatch notices from
+`cursor[bot]` are inert (do not treat them as review feedback).
+
+If a Bugbot CI check *does* appear on a PR:
 
 - Still in progress → keep polling, do not push.
 - `NEUTRAL` → it found potential issues. Read the inline comments from `cursor[bot]`, fix
   every reported issue locally, run the full Punaro gate, then push once.
-- `SKIPPING` → treat as **not green**; Bugbot may have posted comments before skipping —
-  check `gh api repos/{owner}/{repo}/pulls/{pr}/comments` for `cursor[bot]` comments and
-  fix them; if none exist, re-request review or ask the user.
+- `SKIPPING` → treat as **not green** while the check is present; Bugbot may have posted
+  comments before skipping — check `gh api repos/{owner}/{repo}/pulls/{pr}/comments` for
+  `cursor[bot]` comments and fix them; if none exist, re-request review or ask the user.
 - `SUCCESS` (or a SHA-matched clean manual Bugbot review — the watcher accepts both) →
   gate is clear.
 
@@ -163,9 +169,9 @@ comments → satisfied. Reaction removed with comments → fix them under push d
 ### CodeRabbit (presence-conditional)
 
 CodeRabbit gates a PR only when it shows signs of life (a CodeRabbit check, reaction, or
-authored comment); when dormant the watcher degrades to a Bugbot+Codex-only gate. While
-`coderabbit_gate.reviewing` is `true` (`wait_coderabbit`), do not push or merge; treat its
-comments like any other bot comments.
+authored comment); when dormant the watcher degrades to a Codex-only gate (plus any
+presence-conditional Bugbot check). While `coderabbit_gate.reviewing` is `true`
+(`wait_coderabbit`), do not push or merge; treat its comments like any other bot comments.
 
 ## Decision rules
 
@@ -186,7 +192,7 @@ See `references/heuristics.md` for the full classification checklist:
 
 The watcher surfaces feedback from:
 
-- **cursor[bot]** — Cursor Bugbot (CI check-based code review)
+- **cursor[bot]** — Cursor Bugbot when present (CI check-based); enablement/upsell notices are inert
 - **chatgpt-codex-connector[bot]** — OpenAI Codex (emoji reaction-based code review)
 - **coderabbitai** — CodeRabbit (presence-conditional review)
 - Trusted humans: authors with `OWNER`, `MEMBER`, or `COLLABORATOR` association
@@ -233,7 +239,7 @@ Example snapshot payload shape:
   "pr": { "number": 42, "head_sha": "abc123", "mergeable": "MERGEABLE" },
   "checks": { "pending_count": 0, "failed_count": 1, "passed_count": 8, "skipping_count": 0, "all_terminal": true },
   "failed_runs": [{ "run_id": 123, "workflow_name": "CI", "conclusion": "failure", "retry_eligible": false }],
-  "bugbot_gate": { "status": "completed", "conclusion": "success", "is_success": true },
+  "bugbot_gate": { "required": false, "present": false, "status": "missing", "is_success": false },
   "codex_gate": { "reviewing": false, "status": "idle" },
   "coderabbit_gate": { "reviewing": false },
   "hung_checks": [],

--- a/.agents/skills/babysit-pr/scripts/gh_pr_watch.py
+++ b/.agents/skills/babysit-pr/scripts/gh_pr_watch.py
@@ -115,6 +115,18 @@ HUNG_CHECK_THRESHOLDS_SECONDS = {
 RETRY_ELIGIBLE_WORKFLOW_KEYWORDS = {
     "e2e",
 }
+
+# Expected jobs from .github/workflows/quality.yml. Readiness requires every
+# named quality job to be present and passed so a lone third-party check (e.g.
+# Bugbot) cannot satisfy merge after Bugbot stopped being assumed-present.
+QUALITY_WORKFLOW_NAME = "quality"
+QUALITY_JOB_NAMES = frozenset({
+    "Go tests and analysis",
+    "PostgreSQL integration",
+    "Complete product E2E",
+    "Configuration lint",
+    "Windows client build",
+})
 # Login keyword fragments for Codex bot, used for emoji reaction gate detection.
 # Codex signals it is reviewing a PR by adding a 👀 reaction; it either posts a
 # review with comments (issues found) or removes the reaction silently (clean).
@@ -436,11 +448,43 @@ def is_pending_check(check):
     return bucket == "pending" or state in PENDING_CHECK_STATES
 
 
+def is_quality_job_check(check):
+    """Return whether a check is one of the expected quality.yml jobs."""
+    if not isinstance(check, dict):
+        return False
+    name = str(check.get("name") or "")
+    if name not in QUALITY_JOB_NAMES:
+        return False
+    workflow = str(check.get("workflow") or "").lower()
+    # Prefer an explicit quality workflow label when present; still accept the
+    # known job name if workflow is blank (some payloads omit it).
+    return (not workflow) or workflow == QUALITY_WORKFLOW_NAME
+
+
+def quality_jobs_passed(checks):
+    """True only when every expected quality.yml job is present and passed."""
+    by_name = {}
+    for check in checks:
+        if not is_quality_job_check(check):
+            continue
+        name = str(check.get("name") or "")
+        by_name[name] = check
+    if set(by_name) != QUALITY_JOB_NAMES:
+        return False
+    for check in by_name.values():
+        bucket = str(check.get("bucket") or "").lower()
+        state = str(check.get("state") or "").upper()
+        if bucket != "pass" and state != "SUCCESS":
+            return False
+    return True
+
+
 def summarize_checks(checks):
     pending_count = 0
     failed_count = 0
     passed_count = 0
     skipping_count = 0
+    quality_passed_count = 0
     for check in checks:
         bucket = str(check.get("bucket") or "").lower()
         if is_pending_check(check):
@@ -449,6 +493,8 @@ def summarize_checks(checks):
             failed_count += 1
         elif bucket == "pass":
             passed_count += 1
+            if is_quality_job_check(check):
+                quality_passed_count += 1
         elif bucket in ("neutral", "skipping"):
             skipping_count += 1
     return {
@@ -456,6 +502,8 @@ def summarize_checks(checks):
         "failed_count": failed_count,
         "passed_count": passed_count,
         "skipping_count": skipping_count,
+        "quality_passed_count": quality_passed_count,
+        "quality_jobs_passed": quality_jobs_passed(checks),
         "all_terminal": pending_count == 0,
     }
 
@@ -1411,10 +1459,10 @@ def is_pr_ready_to_merge(
         return False
     if not checks_summary["all_terminal"]:
         return False
-    # An empty check set is all_terminal with passed_count==0 (e.g. right after a
-    # push, before quality.yml jobs register). Bugbot is no longer assumed-present,
-    # so require at least one passing check before declaring readiness.
-    if int(checks_summary.get("passed_count") or 0) < 1:
+    # Bugbot is no longer assumed-present, so an empty/pre-registration check set
+    # (or a lone third-party pass) must not declare readiness. Require every
+    # expected quality.yml job to be present and passed.
+    if not bool(checks_summary.get("quality_jobs_passed")):
         return False
     if (
         checks_summary["failed_count"] > 0
@@ -1878,7 +1926,7 @@ def is_ci_green(snapshot):
     coderabbit_reviewing = bool(coderabbit_gate.get("reviewing"))
     return (
         bool(checks.get("all_terminal"))
-        and int(checks.get("passed_count") or 0) >= 1
+        and bool(checks.get("quality_jobs_passed"))
         and int(checks.get("failed_count") or 0) == 0
         and int(checks.get("pending_count") or 0) == 0
         and not blocking_review_items

--- a/.agents/skills/babysit-pr/scripts/gh_pr_watch.py
+++ b/.agents/skills/babysit-pr/scripts/gh_pr_watch.py
@@ -40,8 +40,9 @@ REVIEW_BOT_LOGIN_KEYWORDS = {
 # Login / check-name keyword fragments for CodeRabbit. CodeRabbit is treated as
 # a *presence-conditional* gate, not an assumed-present one: it only gates a PR
 # when it shows signs of life (a CodeRabbit CI check, a reaction, or an authored
-# comment). When dormant, the watcher behaves as a bugbot+codex-only gate, so
-# the gate degrades gracefully if CodeRabbit is later removed from the repo.
+# comment). When dormant, the watcher behaves as a Codex-only gate (plus any
+# presence-conditional Bugbot check), so the gate degrades gracefully if
+# CodeRabbit is later removed from the repo.
 CODERABBIT_LOGIN_KEYWORDS = {
     "coderabbit",
 }
@@ -49,10 +50,10 @@ CODERABBIT_CHECK_KEYWORDS = {
     "coderabbit",
 }
 # Workflow name keyword fragments used to identify Cursor Bugbot CI runs.
-# The merge gate is hard-blocked unless the latest Bugbot run for the current
-# head SHA is `completed` with conclusion `success`. Cursor currently reports
-# a clean manual Bugbot review as a neutral/skipped check, though, so the
-# accompanying SHA-matched clean review is also accepted (see below).
+# Bugbot is retired as an assumed-present gate: absence does not block merge.
+# If a Bugbot check still appears on a PR, it is presence-conditional (required
+# only while present). A clean manual Bugbot review reported as neutral/skipped
+# is still reconciled via the SHA-matched clean review path below.
 BUGBOT_WORKFLOW_KEYWORDS = {
     "cursor",
     "bugbot",
@@ -575,7 +576,7 @@ def summarize_bugbot_gate_from_checks(checks):
 
     if not bugbot_checks:
         return {
-            "required": True,
+            "required": False,
             "present": False,
             "status": "missing",
             "conclusion": "",
@@ -648,7 +649,7 @@ def summarize_bugbot_gate_from_runs(runs, head_sha):
 
     if not bugbot_runs:
         return {
-            "required": True,
+            "required": False,
             "present": False,
             "status": "missing",
             "conclusion": "",
@@ -779,8 +780,9 @@ def summarize_coderabbit_gate(checks, reactions):
     when it shows signs of life: a CodeRabbit CI check, or a reaction from the
     CodeRabbit bot. (Authored review comments are surfaced and block merge
     independently via the normal review-item path.) When CodeRabbit is dormant
-    the gate is inert and the watcher behaves as a bugbot+codex-only gate, so
-    the watcher stays correct if CodeRabbit is later removed.
+    the gate is inert and the watcher behaves as a Codex-only gate (plus any
+    presence-conditional Bugbot check), so the watcher stays correct if
+    CodeRabbit is later removed.
 
     `reviewing` is True only while CodeRabbit appears to still be working: its
     CI check is pending, or it has an active 👀 (eyes) reaction on the PR. A
@@ -1154,6 +1156,24 @@ def is_actionable_review_bot_login(login):
     return any(keyword in lower_login for keyword in REVIEW_BOT_LOGIN_KEYWORDS)
 
 
+def is_inert_bugbot_notice(item):
+    """Return True for retired Bugbot enablement/upsell notices that must not block merge."""
+    if not isinstance(item, dict):
+        return False
+    if str(item.get("kind") or "") != "issue_comment":
+        return False
+    if str(item.get("author") or "").lower() != CURSOR_BUGBOT_LOGIN:
+        return False
+    body = str(item.get("body") or "")
+    lower = body.lower()
+    return (
+        "BUGBOT_FREE_TIER_DISABLED_UPSELL" in body
+        or "bugbot is not enabled for your account" in lower
+        or "bugbot couldn't run" in lower
+        or "github account mismatch" in lower
+    )
+
+
 def is_trusted_human_review_author(item, authenticated_login):
     _ = authenticated_login
     author = str(item.get("author") or "")
@@ -1293,6 +1313,11 @@ def fetch_new_review_items(pr, state, fresh_state, authenticated_login=None):
         if is_clean_bugbot_review_item(item, head_sha):
             seen_review.add(item_id)
             seen_review_updated_at[item_id] = item_updated_at
+            continue
+        if is_inert_bugbot_notice(item):
+            if kind == "issue_comment":
+                seen_issue.add(item_id)
+                seen_issue_updated_at[item_id] = item_updated_at
             continue
         if kind == "review" and str(item.get("review_state") or "") == "APPROVED":
             seen_review.add(item_id)

--- a/.agents/skills/babysit-pr/scripts/gh_pr_watch.py
+++ b/.agents/skills/babysit-pr/scripts/gh_pr_watch.py
@@ -1411,6 +1411,11 @@ def is_pr_ready_to_merge(
         return False
     if not checks_summary["all_terminal"]:
         return False
+    # An empty check set is all_terminal with passed_count==0 (e.g. right after a
+    # push, before quality.yml jobs register). Bugbot is no longer assumed-present,
+    # so require at least one passing check before declaring readiness.
+    if int(checks_summary.get("passed_count") or 0) < 1:
+        return False
     if (
         checks_summary["failed_count"] > 0
         or checks_summary["pending_count"] > 0
@@ -1873,6 +1878,7 @@ def is_ci_green(snapshot):
     coderabbit_reviewing = bool(coderabbit_gate.get("reviewing"))
     return (
         bool(checks.get("all_terminal"))
+        and int(checks.get("passed_count") or 0) >= 1
         and int(checks.get("failed_count") or 0) == 0
         and int(checks.get("pending_count") or 0) == 0
         and not blocking_review_items

--- a/.agents/skills/babysit-pr/scripts/test_gh_pr_watch.py
+++ b/.agents/skills/babysit-pr/scripts/test_gh_pr_watch.py
@@ -48,7 +48,22 @@ class RetryEligibilityTests(unittest.TestCase):
             "failed_count": 1,
             "pending_count": 0,
             "passed_count": 0,
+            "quality_passed_count": 0,
+            "quality_jobs_passed": False,
         }
+
+    def _green_checks_summary(self, **overrides):
+        summary = {
+            "all_terminal": True,
+            "failed_count": 0,
+            "pending_count": 0,
+            "passed_count": 5,
+            "skipping_count": 0,
+            "quality_passed_count": 5,
+            "quality_jobs_passed": True,
+        }
+        summary.update(overrides)
+        return summary
 
     def test_recommend_actions_does_not_retry_non_flaky_ci_failures(self):
         actions = watch.recommend_actions(
@@ -134,6 +149,8 @@ class RetryEligibilityTests(unittest.TestCase):
                 "failed_count": 0,
                 "pending_count": 0,
                 "passed_count": 2,
+                "quality_passed_count": 2,
+                "quality_jobs_passed": True,
             },
             new_review_items=[],
             checks_terminal_elapsed=120,
@@ -177,6 +194,8 @@ class RetryEligibilityTests(unittest.TestCase):
                 "failed_count": 0,
                 "pending_count": 0,
                 "passed_count": 0,
+                "quality_passed_count": 0,
+                "quality_jobs_passed": False,
             },
             failed_runs=[],
             new_review_items=[],
@@ -235,13 +254,11 @@ class RetryEligibilityTests(unittest.TestCase):
         """Empty CI (pre-registration) must stay non-ready even if Bugbot is optional."""
         actions = watch.recommend_actions(
             pr=self._base_pr(),
-            checks_summary={
-                "all_terminal": True,
-                "failed_count": 0,
-                "pending_count": 0,
-                "passed_count": 0,
-                "skipping_count": 0,
-            },
+            checks_summary=self._green_checks_summary(
+                passed_count=0,
+                quality_passed_count=0,
+                quality_jobs_passed=False,
+            ),
             failed_runs=[],
             new_review_items=[],
             hung_checks=[],
@@ -261,16 +278,14 @@ class RetryEligibilityTests(unittest.TestCase):
         self.assertNotIn("stop_ready_to_merge", actions)
         self.assertIn("idle", actions)
 
-    def test_is_pr_ready_to_merge_requires_passed_check(self):
+    def test_is_pr_ready_to_merge_requires_quality_jobs(self):
         ready = watch.is_pr_ready_to_merge(
             pr=self._base_pr(),
-            checks_summary={
-                "all_terminal": True,
-                "failed_count": 0,
-                "pending_count": 0,
-                "passed_count": 0,
-                "skipping_count": 0,
-            },
+            checks_summary=self._green_checks_summary(
+                passed_count=1,
+                quality_passed_count=0,
+                quality_jobs_passed=False,
+            ),
             new_review_items=[],
             checks_terminal_elapsed=120,
             blocking_review_items=[],
@@ -283,16 +298,27 @@ class RetryEligibilityTests(unittest.TestCase):
         )
         self.assertFalse(ready)
 
+    def test_summarize_checks_quality_jobs_passed_requires_all_jobs(self):
+        checks = [
+            {"name": name, "workflow": "quality", "bucket": "pass", "state": "SUCCESS"}
+            for name in sorted(watch.QUALITY_JOB_NAMES)
+        ]
+        summary = watch.summarize_checks(checks)
+        self.assertTrue(summary["quality_jobs_passed"])
+        self.assertEqual(summary["quality_passed_count"], len(watch.QUALITY_JOB_NAMES))
+
+        # A lone third-party pass must not satisfy the quality gate.
+        third_party = watch.summarize_checks(
+            [{"name": "Cursor Bugbot", "workflow": "Cursor Bugbot", "bucket": "pass", "state": "SUCCESS"}]
+        )
+        self.assertFalse(third_party["quality_jobs_passed"])
+        self.assertEqual(third_party["quality_passed_count"], 0)
+        self.assertEqual(third_party["passed_count"], 1)
+
     def test_recommend_actions_ready_when_bugbot_missing_not_required(self):
         actions = watch.recommend_actions(
             pr=self._base_pr(),
-            checks_summary={
-                "all_terminal": True,
-                "failed_count": 0,
-                "pending_count": 0,
-                "passed_count": 2,
-                "skipping_count": 0,
-            },
+            checks_summary=self._green_checks_summary(),
             failed_runs=[],
             new_review_items=[],
             hung_checks=[],
@@ -321,6 +347,8 @@ class RetryEligibilityTests(unittest.TestCase):
                 "failed_count": 0,
                 "pending_count": 0,
                 "passed_count": 2,
+                "quality_passed_count": 2,
+                "quality_jobs_passed": True,
             },
             failed_runs=[],
             new_review_items=[],
@@ -348,6 +376,8 @@ class RetryEligibilityTests(unittest.TestCase):
                 "failed_count": 0,
                 "pending_count": 0,
                 "passed_count": 2,
+                "quality_passed_count": 2,
+                "quality_jobs_passed": True,
             },
             failed_runs=[],
             new_review_items=[],
@@ -1064,6 +1094,8 @@ class RetryEligibilityTests(unittest.TestCase):
                 "failed_count": 0,
                 "pending_count": 1,
                 "passed_count": 0,
+                "quality_passed_count": 0,
+                "quality_jobs_passed": False,
             },
             failed_runs=[],
             new_review_items=[],
@@ -1092,6 +1124,8 @@ class RetryEligibilityTests(unittest.TestCase):
                 "failed_count": 0,
                 "pending_count": 0,
                 "passed_count": 2,
+                "quality_passed_count": 2,
+                "quality_jobs_passed": True,
                 "skipping_count": 0,
             },
             failed_runs=[],
@@ -1178,12 +1212,7 @@ class RetryEligibilityTests(unittest.TestCase):
     def test_is_ci_green_allows_non_required_bugbot(self):
         snapshot = {
             "pr": {"review_decision": "APPROVED"},
-            "checks": {
-                "all_terminal": True,
-                "failed_count": 0,
-                "pending_count": 0,
-                "passed_count": 2,
-            },
+            "checks": self._green_checks_summary(),
             "bugbot_gate": {"required": False, "is_success": False},
             "blocking_review_items": [],
             "checks_terminal_elapsed_seconds": 120,
@@ -1194,12 +1223,26 @@ class RetryEligibilityTests(unittest.TestCase):
     def test_is_ci_green_false_when_check_set_empty(self):
         snapshot = {
             "pr": {"review_decision": "APPROVED"},
-            "checks": {
-                "all_terminal": True,
-                "failed_count": 0,
-                "pending_count": 0,
-                "passed_count": 0,
-            },
+            "checks": self._green_checks_summary(
+                passed_count=0,
+                quality_passed_count=0,
+                quality_jobs_passed=False,
+            ),
+            "bugbot_gate": {"required": False, "is_success": False},
+            "blocking_review_items": [],
+            "checks_terminal_elapsed_seconds": 120,
+        }
+
+        self.assertFalse(watch.is_ci_green(snapshot))
+
+    def test_is_ci_green_false_when_only_third_party_pass(self):
+        snapshot = {
+            "pr": {"review_decision": "APPROVED"},
+            "checks": self._green_checks_summary(
+                passed_count=1,
+                quality_passed_count=0,
+                quality_jobs_passed=False,
+            ),
             "bugbot_gate": {"required": False, "is_success": False},
             "blocking_review_items": [],
             "checks_terminal_elapsed_seconds": 120,
@@ -1225,6 +1268,8 @@ class RetryEligibilityTests(unittest.TestCase):
                 "failed_count": 0,
                 "pending_count": 0,
                 "passed_count": 3,
+                "quality_passed_count": 3,
+                "quality_jobs_passed": True,
             },
             "bugbot_gate": {
                 "required": True,
@@ -1270,6 +1315,8 @@ class RetryEligibilityTests(unittest.TestCase):
                 "all_terminal": True,
                 "pending_count": 0,
                 "passed_count": 0,
+                "quality_passed_count": 0,
+                "quality_jobs_passed": False,
             },
             "failed_runs": [
                 {
@@ -1471,6 +1518,8 @@ class CodexGateTests(unittest.TestCase):
             "failed_count": 0,
             "pending_count": 0,
             "passed_count": 2,
+            "quality_passed_count": 2,
+            "quality_jobs_passed": True,
             "skipping_count": 0,
         }
         ready = watch.is_pr_ready_to_merge(
@@ -1494,6 +1543,8 @@ class CodexGateTests(unittest.TestCase):
             "failed_count": 0,
             "pending_count": 0,
             "passed_count": 2,
+            "quality_passed_count": 2,
+            "quality_jobs_passed": True,
             "skipping_count": 0,
         }
         ready = watch.is_pr_ready_to_merge(
@@ -1517,6 +1568,8 @@ class CodexGateTests(unittest.TestCase):
             "failed_count": 0,
             "pending_count": 0,
             "passed_count": 2,
+            "quality_passed_count": 2,
+            "quality_jobs_passed": True,
             "skipping_count": 0,
         }
         ready = watch.is_pr_ready_to_merge(
@@ -1566,6 +1619,8 @@ class SkippingChecksTests(unittest.TestCase):
             "failed_count": 0,
             "pending_count": 0,
             "passed_count": 2,
+            "quality_passed_count": 2,
+            "quality_jobs_passed": True,
             "skipping_count": 1,
         }
         ready = watch.is_pr_ready_to_merge(
@@ -1788,6 +1843,8 @@ class CodeRabbitGateTests(unittest.TestCase):
             "failed_count": 0,
             "pending_count": 0,
             "passed_count": 2,
+            "quality_passed_count": 2,
+            "quality_jobs_passed": True,
             "skipping_count": 0,
         }
 

--- a/.agents/skills/babysit-pr/scripts/test_gh_pr_watch.py
+++ b/.agents/skills/babysit-pr/scripts/test_gh_pr_watch.py
@@ -231,6 +231,58 @@ class RetryEligibilityTests(unittest.TestCase):
         self.assertTrue(gate["required"])
         self.assertTrue(gate["is_success"])
 
+    def test_recommend_actions_not_ready_when_check_set_empty(self):
+        """Empty CI (pre-registration) must stay non-ready even if Bugbot is optional."""
+        actions = watch.recommend_actions(
+            pr=self._base_pr(),
+            checks_summary={
+                "all_terminal": True,
+                "failed_count": 0,
+                "pending_count": 0,
+                "passed_count": 0,
+                "skipping_count": 0,
+            },
+            failed_runs=[],
+            new_review_items=[],
+            hung_checks=[],
+            retries_used=0,
+            max_retries=3,
+            checks_terminal_elapsed=120,
+            blocking_review_items=[],
+            bugbot_gate={
+                "required": False,
+                "present": False,
+                "status": "missing",
+                "conclusion": "",
+                "is_success": False,
+            },
+        )
+
+        self.assertNotIn("stop_ready_to_merge", actions)
+        self.assertIn("idle", actions)
+
+    def test_is_pr_ready_to_merge_requires_passed_check(self):
+        ready = watch.is_pr_ready_to_merge(
+            pr=self._base_pr(),
+            checks_summary={
+                "all_terminal": True,
+                "failed_count": 0,
+                "pending_count": 0,
+                "passed_count": 0,
+                "skipping_count": 0,
+            },
+            new_review_items=[],
+            checks_terminal_elapsed=120,
+            blocking_review_items=[],
+            bugbot_gate={
+                "required": False,
+                "present": False,
+                "status": "missing",
+                "is_success": False,
+            },
+        )
+        self.assertFalse(ready)
+
     def test_recommend_actions_ready_when_bugbot_missing_not_required(self):
         actions = watch.recommend_actions(
             pr=self._base_pr(),
@@ -1130,6 +1182,7 @@ class RetryEligibilityTests(unittest.TestCase):
                 "all_terminal": True,
                 "failed_count": 0,
                 "pending_count": 0,
+                "passed_count": 2,
             },
             "bugbot_gate": {"required": False, "is_success": False},
             "blocking_review_items": [],
@@ -1137,6 +1190,22 @@ class RetryEligibilityTests(unittest.TestCase):
         }
 
         self.assertTrue(watch.is_ci_green(snapshot))
+
+    def test_is_ci_green_false_when_check_set_empty(self):
+        snapshot = {
+            "pr": {"review_decision": "APPROVED"},
+            "checks": {
+                "all_terminal": True,
+                "failed_count": 0,
+                "pending_count": 0,
+                "passed_count": 0,
+            },
+            "bugbot_gate": {"required": False, "is_success": False},
+            "blocking_review_items": [],
+            "checks_terminal_elapsed_seconds": 120,
+        }
+
+        self.assertFalse(watch.is_ci_green(snapshot))
 
     def test_run_watch_backs_off_on_unchanged_green_state(self):
         sleeps = []

--- a/.agents/skills/babysit-pr/scripts/test_gh_pr_watch.py
+++ b/.agents/skills/babysit-pr/scripts/test_gh_pr_watch.py
@@ -202,6 +202,65 @@ class RetryEligibilityTests(unittest.TestCase):
         self.assertIn("diagnose_branch_behind", actions)
         self.assertNotIn("diagnose_merge_conflict", actions)
 
+    def test_summarize_bugbot_gate_missing_is_not_required(self):
+        """Bugbot is retired: absence must not hard-block the merge gate."""
+        gate = watch.summarize_bugbot_gate_from_checks([])
+        self.assertFalse(gate["present"])
+        self.assertFalse(gate["required"])
+        self.assertEqual(gate["status"], "missing")
+
+        gate_runs = watch.summarize_bugbot_gate_from_runs([], "abc123")
+        self.assertFalse(gate_runs["present"])
+        self.assertFalse(gate_runs["required"])
+
+    def test_summarize_bugbot_gate_present_remains_required(self):
+        """If Bugbot still posts a check, keep a presence-conditional gate."""
+        gate = watch.summarize_bugbot_gate(
+            [
+                {
+                    "name": "Cursor Bugbot",
+                    "state": "SUCCESS",
+                    "bucket": "pass",
+                    "link": "https://example.invalid/bugbot-check",
+                }
+            ],
+            [],
+            "abc123",
+        )
+        self.assertTrue(gate["present"])
+        self.assertTrue(gate["required"])
+        self.assertTrue(gate["is_success"])
+
+    def test_recommend_actions_ready_when_bugbot_missing_not_required(self):
+        actions = watch.recommend_actions(
+            pr=self._base_pr(),
+            checks_summary={
+                "all_terminal": True,
+                "failed_count": 0,
+                "pending_count": 0,
+                "passed_count": 2,
+                "skipping_count": 0,
+            },
+            failed_runs=[],
+            new_review_items=[],
+            hung_checks=[],
+            retries_used=0,
+            max_retries=3,
+            checks_terminal_elapsed=120,
+            blocking_review_items=[],
+            bugbot_gate={
+                "required": False,
+                "present": False,
+                "status": "missing",
+                "conclusion": "",
+                "is_success": False,
+            },
+        )
+
+        self.assertIn("stop_ready_to_merge", actions)
+        self.assertNotIn("stop_bugbot_not_green", actions)
+        self.assertNotIn("wait_bugbot", actions)
+
     def test_recommend_actions_hard_blocks_bugbot_non_success(self):
         actions = watch.recommend_actions(
             pr=self._base_pr(),
@@ -255,6 +314,26 @@ class RetryEligibilityTests(unittest.TestCase):
 
         self.assertIn("wait_bugbot", actions)
         self.assertNotIn("stop_bugbot_not_green", actions)
+
+    def test_inert_bugbot_notice_is_not_actionable_review(self):
+        self.assertTrue(
+            watch.is_inert_bugbot_notice(
+                {
+                    "kind": "issue_comment",
+                    "author": "cursor[bot]",
+                    "body": "<!-- BUGBOT_FREE_TIER_DISABLED_UPSELL -->\nBugbot is not enabled for your account, so this pull request was not reviewed.",
+                }
+            )
+        )
+        self.assertFalse(
+            watch.is_inert_bugbot_notice(
+                {
+                    "kind": "review_comment",
+                    "author": "cursor[bot]",
+                    "body": "This looks like a real Bugbot finding on line 12.",
+                }
+            )
+        )
 
     def test_summarize_bugbot_gate_prefers_pr_checks_over_actions_runs(self):
         checks = [
@@ -925,7 +1004,7 @@ class RetryEligibilityTests(unittest.TestCase):
         self.assertEqual(len(hung), 1)
         self.assertEqual(hung[0]["name"], "CI")
 
-    def test_recommend_actions_waits_for_missing_bugbot_while_checks_pending(self):
+    def test_recommend_actions_ignores_missing_bugbot_while_checks_pending(self):
         actions = watch.recommend_actions(
             pr=self._base_pr(),
             checks_summary={
@@ -942,17 +1021,18 @@ class RetryEligibilityTests(unittest.TestCase):
             checks_terminal_elapsed=None,
             blocking_review_items=[],
             bugbot_gate={
-                "required": True,
+                "required": False,
+                "present": False,
                 "status": "missing",
                 "conclusion": "",
                 "is_success": False,
             },
         )
 
-        self.assertIn("wait_bugbot", actions)
+        self.assertNotIn("wait_bugbot", actions)
         self.assertNotIn("stop_bugbot_not_green", actions)
 
-    def test_recommend_actions_waits_for_missing_bugbot_during_grace(self):
+    def test_recommend_actions_ignores_missing_bugbot_during_grace(self):
         actions = watch.recommend_actions(
             pr=self._base_pr(),
             checks_summary={
@@ -960,6 +1040,7 @@ class RetryEligibilityTests(unittest.TestCase):
                 "failed_count": 0,
                 "pending_count": 0,
                 "passed_count": 2,
+                "skipping_count": 0,
             },
             failed_runs=[],
             new_review_items=[],
@@ -969,15 +1050,18 @@ class RetryEligibilityTests(unittest.TestCase):
             checks_terminal_elapsed=10,
             blocking_review_items=[],
             bugbot_gate={
-                "required": True,
+                "required": False,
+                "present": False,
                 "status": "missing",
                 "conclusion": "",
                 "is_success": False,
             },
         )
 
-        self.assertIn("wait_bugbot", actions)
+        self.assertNotIn("wait_bugbot", actions)
         self.assertNotIn("stop_bugbot_not_green", actions)
+        # Grace period still applies for review-bot comment race.
+        self.assertNotIn("stop_ready_to_merge", actions)
 
     def test_reset_state_for_new_head_sha_clears_pending_map(self):
         state = {


### PR DESCRIPTION
## Summary
- Cursor Bugbot is retired as an assumed-present merge gate: a missing Bugbot check no longer blocks `stop_ready_to_merge`.
- If a Bugbot check still appears, it remains presence-conditional; enablement/upsell / account-mismatch notices from `cursor[bot]` are inert.
- Updates `babysit-pr` skill docs to match.

## Test plan
- [x] `python3 -m unittest test_gh_pr_watch` (101 tests)
- [ ] Merge #152 and #218 after this lands (were blocked only on retired Bugbot)


Made with [Cursor](https://cursor.com)