### PR TITLE
Add the cross-platform fleet-config reconciler

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -663,6 +663,11 @@ and may write only their own bounded status row (schema 59). There is no client
 publish route. Desired-generation advances emit a payload-free WebSocket wake
 with `topic_id=fleet-config` and `sequence` equal to the generation.
 
+The client reconciler stages a complete tree, applies `AGENTS.md` trailers
+without merging fleet-prefix edits, matches project names only as top-level
+directories under a configured base path (or an explicit override), and keeps
+last-known-good on failed activation. Concurrent reconcile is serialized.
+
 ## Canonical memory model
 
 Canonical memory is project-scoped PostgreSQL authority. Each item has an

--- a/internal/adapter/fleet.go
+++ b/internal/adapter/fleet.go
@@ -1,0 +1,19 @@
+package adapter
+
+import "github.com/rock3r/punaro/internal/fleetconfig"
+
+// ReconcileFleet atomically applies a validated tree under root, preserving trailers.
+func ReconcileFleet(root string, tree fleetconfig.Tree, existing map[string][]byte, lastPrefixDigests map[string]string, digest string) (map[string]fleetconfig.TrailerResult, error) {
+	files, trailers, err := fleetconfig.PrepareApply(tree, existing, lastPrefixDigests)
+	if err != nil {
+		return nil, err
+	}
+	if len(files) == 0 {
+		return trailers, nil
+	}
+	if err := fleetconfig.PublishTree(root, files, digest); err != nil {
+		_ = fleetconfig.RestoreLastGood(root)
+		return trailers, err
+	}
+	return trailers, nil
+}

--- a/internal/adapter/fleet.go
+++ b/internal/adapter/fleet.go
@@ -12,7 +12,6 @@ func ReconcileFleet(root string, tree fleetconfig.Tree, existing map[string][]by
 		return trailers, nil
 	}
 	if err := fleetconfig.PublishTree(root, files, digest); err != nil {
-		_ = fleetconfig.RestoreLastGood(root)
 		return trailers, err
 	}
 	return trailers, nil

--- a/internal/adapter/fleet_test.go
+++ b/internal/adapter/fleet_test.go
@@ -1,0 +1,33 @@
+package adapter
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/rock3r/punaro/internal/fleetconfig"
+)
+
+func TestReconcileFleetAppliesAtomicallyAndPreservesTrailer(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	tree := fleetconfig.Tree{Files: []fleetconfig.File{
+		{Path: "AGENTS.md", Data: []byte("# fleet\n")},
+		{Path: "skills/demo/SKILL.md", Data: []byte("---\nname: demo\ndescription: Demo skill.\n---\n# demo\n")},
+	}}
+	existing := map[string][]byte{
+		"AGENTS.md": fleetconfig.ComposeAgents([]byte("# old\n"), []byte("\nstay\n")),
+	}
+	trailers, err := ReconcileFleet(root, tree, existing, map[string]string{"AGENTS.md": fleetconfig.DigestBytes([]byte("# old"))}, "digest-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if trailers["AGENTS.md"].Collision {
+		t.Fatal("false collision")
+	}
+	got, err := os.ReadFile(filepath.Join(root, "current", "AGENTS.md"))
+	if err != nil || !strings.Contains(string(got), "# fleet") || !strings.Contains(string(got), "stay") {
+		t.Fatalf("applied=%q err=%v", got, err)
+	}
+}

--- a/internal/adapter/fleet_test.go
+++ b/internal/adapter/fleet_test.go
@@ -26,7 +26,7 @@ func TestReconcileFleetAppliesAtomicallyAndPreservesTrailer(t *testing.T) {
 	if trailers["AGENTS.md"].Collision {
 		t.Fatal("false collision")
 	}
-	got, err := os.ReadFile(filepath.Join(root, "current", "AGENTS.md"))
+	got, err := os.ReadFile(filepath.Join(root, "current", "AGENTS.md")) //nolint:gosec // G304: test fixture under t.TempDir.
 	if err != nil || !strings.Contains(string(got), "# fleet") || !strings.Contains(string(got), "stay") {
 		t.Fatalf("applied=%q err=%v", got, err)
 	}

--- a/internal/adapter/fleet_unix_test.go
+++ b/internal/adapter/fleet_unix_test.go
@@ -1,0 +1,40 @@
+//go:build unix
+
+package adapter
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/rock3r/punaro/internal/fleetconfig"
+)
+
+func TestReconcileFleetStagingFailureKeepsLiveTree(t *testing.T) {
+	t.Parallel()
+	if os.Geteuid() == 0 {
+		t.Skip("root can write into a 0500 directory")
+	}
+	root := t.TempDir()
+	first := fleetconfig.Tree{Files: []fleetconfig.File{{Path: "AGENTS.md", Data: []byte("# v1\n")}}}
+	second := fleetconfig.Tree{Files: []fleetconfig.File{{Path: "AGENTS.md", Data: []byte("# v2\n")}}}
+	if _, err := ReconcileFleet(root, first, nil, nil, "d1"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ReconcileFleet(root, second, nil, nil, "d2"); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(root, 0o500); err != nil { //nolint:gosec // G302: directory must be unwritable to fail staging.
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(root, 0o700) }) //nolint:gosec // G302: restore directory perms after staging failure.
+	third := fleetconfig.Tree{Files: []fleetconfig.File{{Path: "AGENTS.md", Data: []byte("# v3\n")}}}
+	if _, err := ReconcileFleet(root, third, nil, nil, "d3"); err == nil {
+		t.Fatal("staging failure was not reported")
+	}
+	got, err := os.ReadFile(filepath.Join(root, "current", "AGENTS.md")) //nolint:gosec // G304: test fixture under t.TempDir.
+	if err != nil || !strings.Contains(string(got), "# v2") || strings.Contains(string(got), "# v3") {
+		t.Fatalf("live tree was rolled back: %q err=%v", got, err)
+	}
+}

--- a/internal/fleetconfig/apply.go
+++ b/internal/fleetconfig/apply.go
@@ -74,7 +74,18 @@ func PublishTree(root string, files map[string][]byte, digest string) error {
 		_ = os.RemoveAll(lastGood)
 		_ = os.Rename(nextGood, lastGood)
 	}
-	state := ApplyState{Digest: digest, LastGoodDigest: digest}
+	prefixDigests := map[string]string{}
+	for path, content := range files {
+		if !stringsHasSuffixAgents(path) {
+			continue
+		}
+		prefix, _, ok := SplitAgents(content)
+		if !ok {
+			continue
+		}
+		prefixDigests[path] = DigestBytes(prefix)
+	}
+	state := ApplyState{Digest: digest, LastGoodDigest: digest, PrefixDigests: prefixDigests}
 	body, err := json.Marshal(state)
 	if err != nil {
 		return errors.New("fleet-config apply state failed")

--- a/internal/fleetconfig/apply.go
+++ b/internal/fleetconfig/apply.go
@@ -29,6 +29,11 @@ func PublishTree(root string, files map[string][]byte, digest string) error {
 	if root == "" || digest == "" || len(files) == 0 {
 		return errors.New("fleet-config apply input is invalid")
 	}
+	unlockFile, err := lockReconcile(filepath.Join(root, "reconcile.lock"))
+	if err != nil {
+		return errors.New("fleet-config reconcile lock failed")
+	}
+	defer unlockFile()
 	unlock := ReconcileLock()
 	defer unlock()
 	live := filepath.Join(root, "current")
@@ -47,20 +52,27 @@ func PublishTree(root string, files map[string][]byte, digest string) error {
 			return errors.New("fleet-config staging failed")
 		}
 	}
+	nextGood := lastGood + ".next"
+	if err := recoverPublishSwap(live, lastGood, nextGood); err != nil {
+		return err
+	}
 	if info, err := os.Lstat(live); err == nil {
 		if !info.IsDir() || info.Mode()&os.ModeSymlink != 0 {
 			return errors.New("fleet-config live tree is unsafe")
 		}
-		_ = os.RemoveAll(lastGood)
-		if err := os.Rename(live, lastGood); err != nil {
+		if err := os.Rename(live, nextGood); err != nil {
 			return errors.New("fleet-config last-known-good failed")
 		}
 	}
 	if err := os.Rename(stage, live); err != nil {
-		if _, lastErr := os.Lstat(lastGood); lastErr == nil {
-			_ = os.Rename(lastGood, live)
+		if _, nextErr := os.Lstat(nextGood); nextErr == nil {
+			_ = os.Rename(nextGood, live)
 		}
 		return errors.New("fleet-config apply failed")
+	}
+	if _, err := os.Lstat(nextGood); err == nil {
+		_ = os.RemoveAll(lastGood)
+		_ = os.Rename(nextGood, lastGood)
 	}
 	state := ApplyState{Digest: digest, LastGoodDigest: digest}
 	body, err := json.Marshal(state)
@@ -73,8 +85,39 @@ func PublishTree(root string, files map[string][]byte, digest string) error {
 	return nil
 }
 
+func recoverPublishSwap(live, lastGood, nextGood string) error {
+	liveInfo, liveErr := os.Lstat(live)
+	nextInfo, nextErr := os.Lstat(nextGood)
+	liveOK := liveErr == nil && liveInfo.IsDir() && liveInfo.Mode()&os.ModeSymlink == 0
+	nextOK := nextErr == nil && nextInfo.IsDir() && nextInfo.Mode()&os.ModeSymlink == 0
+	if liveErr == nil && !liveOK {
+		return errors.New("fleet-config live tree is unsafe")
+	}
+	if nextErr == nil && !nextOK {
+		return errors.New("fleet-config last-known-good failed")
+	}
+	if liveErr != nil && nextOK {
+		if err := os.Rename(nextGood, live); err != nil {
+			return errors.New("fleet-config last-known-good failed")
+		}
+		return nil
+	}
+	if liveOK && nextOK {
+		_ = os.RemoveAll(lastGood)
+		if err := os.Rename(nextGood, lastGood); err != nil {
+			return errors.New("fleet-config last-known-good failed")
+		}
+	}
+	return nil
+}
+
 // RestoreLastGood puts the retained tree back after a failed activation.
 func RestoreLastGood(root string) error {
+	unlockFile, err := lockReconcile(filepath.Join(root, "reconcile.lock"))
+	if err != nil {
+		return errors.New("fleet-config reconcile lock failed")
+	}
+	defer unlockFile()
 	unlock := ReconcileLock()
 	defer unlock()
 	live := filepath.Join(root, "current")

--- a/internal/fleetconfig/apply.go
+++ b/internal/fleetconfig/apply.go
@@ -1,0 +1,90 @@
+package fleetconfig
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+)
+
+// ApplyState is persisted next to the live tree without configuration contents.
+type ApplyState struct {
+	Digest         string            `json:"digest"`
+	PrefixDigests  map[string]string `json:"prefix_digests,omitempty"`
+	LastGoodDigest string            `json:"last_good_digest,omitempty"`
+}
+
+var reconcileMu sync.Mutex
+
+// ReconcileLock serializes local apply attempts in-process.
+func ReconcileLock() func() {
+	reconcileMu.Lock()
+	return reconcileMu.Unlock
+}
+
+// PublishTree writes files into staging and atomically replaces live.
+func PublishTree(root string, files map[string][]byte, digest string) error {
+	if root == "" || digest == "" || len(files) == 0 {
+		return errors.New("fleet-config apply input is invalid")
+	}
+	unlock := ReconcileLock()
+	defer unlock()
+	live := filepath.Join(root, "current")
+	stage := filepath.Join(root, "staging")
+	lastGood := filepath.Join(root, "last-good")
+	_ = os.RemoveAll(stage)
+	if err := os.MkdirAll(stage, 0o700); err != nil {
+		return errors.New("fleet-config staging failed")
+	}
+	for path, body := range files {
+		full := filepath.Join(append([]string{stage}, strings.Split(path, "/")...)...)
+		if err := os.MkdirAll(filepath.Dir(full), 0o700); err != nil {
+			return errors.New("fleet-config staging failed")
+		}
+		if err := os.WriteFile(full, body, 0o600); err != nil {
+			return errors.New("fleet-config staging failed")
+		}
+	}
+	if info, err := os.Lstat(live); err == nil {
+		if !info.IsDir() || info.Mode()&os.ModeSymlink != 0 {
+			return errors.New("fleet-config live tree is unsafe")
+		}
+		_ = os.RemoveAll(lastGood)
+		if err := os.Rename(live, lastGood); err != nil {
+			return errors.New("fleet-config last-known-good failed")
+		}
+	}
+	if err := os.Rename(stage, live); err != nil {
+		if _, lastErr := os.Lstat(lastGood); lastErr == nil {
+			_ = os.Rename(lastGood, live)
+		}
+		return errors.New("fleet-config apply failed")
+	}
+	state := ApplyState{Digest: digest, LastGoodDigest: digest}
+	body, err := json.Marshal(state)
+	if err != nil {
+		return errors.New("fleet-config apply state failed")
+	}
+	if err := os.WriteFile(filepath.Join(root, "applied.json"), append(body, '\n'), 0o600); err != nil {
+		return errors.New("fleet-config apply state failed")
+	}
+	return nil
+}
+
+// RestoreLastGood puts the retained tree back after a failed activation.
+func RestoreLastGood(root string) error {
+	unlock := ReconcileLock()
+	defer unlock()
+	live := filepath.Join(root, "current")
+	lastGood := filepath.Join(root, "last-good")
+	if _, err := os.Lstat(lastGood); err != nil {
+		return errors.New("fleet-config last-known-good is unavailable")
+	}
+	_ = os.RemoveAll(live)
+	if err := os.Rename(lastGood, live); err != nil {
+		return errors.New("fleet-config last-known-good restore failed")
+	}
+	return nil
+}

--- a/internal/fleetconfig/apply_lock_unix.go
+++ b/internal/fleetconfig/apply_lock_unix.go
@@ -1,0 +1,23 @@
+//go:build !windows
+
+package fleetconfig
+
+import (
+	"os"
+	"syscall"
+)
+
+func lockReconcile(path string) (func(), error) {
+	file, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE, 0o600) // #nosec G304 -- lock lives in the caller-provided apply root.
+	if err != nil {
+		return nil, err
+	}
+	if err := syscall.Flock(int(file.Fd()), syscall.LOCK_EX); err != nil { // #nosec G115 -- os.File descriptors are platform ints.
+		_ = file.Close()
+		return nil, err
+	}
+	return func() {
+		_ = syscall.Flock(int(file.Fd()), syscall.LOCK_UN) // #nosec G115 -- os.File descriptors are platform ints.
+		_ = file.Close()
+	}, nil
+}

--- a/internal/fleetconfig/apply_lock_windows.go
+++ b/internal/fleetconfig/apply_lock_windows.go
@@ -1,0 +1,25 @@
+//go:build windows
+
+package fleetconfig
+
+import (
+	"os"
+
+	"golang.org/x/sys/windows"
+)
+
+func lockReconcile(path string) (func(), error) {
+	file, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE, 0o600) // #nosec G304 -- lock lives in the caller-provided apply root.
+	if err != nil {
+		return nil, err
+	}
+	overlapped := new(windows.Overlapped)
+	if err := windows.LockFileEx(windows.Handle(file.Fd()), windows.LOCKFILE_EXCLUSIVE_LOCK, 0, 1, 0, overlapped); err != nil {
+		_ = file.Close()
+		return nil, err
+	}
+	return func() {
+		_ = windows.UnlockFileEx(windows.Handle(file.Fd()), 0, 1, 0, overlapped)
+		_ = file.Close()
+	}, nil
+}

--- a/internal/fleetconfig/apply_test.go
+++ b/internal/fleetconfig/apply_test.go
@@ -13,22 +13,22 @@ func TestPublishTreeIsAtomicAndKeepsLastKnownGood(t *testing.T) {
 	if err := PublishTree(root, map[string][]byte{"AGENTS.md": []byte("# v1\n")}, "d1"); err != nil {
 		t.Fatal(err)
 	}
-	if got, err := os.ReadFile(filepath.Join(root, "current", "AGENTS.md")); err != nil || string(got) != "# v1\n" {
+	if got, err := os.ReadFile(filepath.Join(root, "current", "AGENTS.md")); err != nil || string(got) != "# v1\n" { //nolint:gosec // G304: test fixture under t.TempDir.
 		t.Fatalf("live=%q err=%v", got, err)
 	}
 	if err := PublishTree(root, map[string][]byte{"AGENTS.md": []byte("# v2\n")}, "d2"); err != nil {
 		t.Fatal(err)
 	}
-	if got, err := os.ReadFile(filepath.Join(root, "current", "AGENTS.md")); err != nil || string(got) != "# v2\n" {
+	if got, err := os.ReadFile(filepath.Join(root, "current", "AGENTS.md")); err != nil || string(got) != "# v2\n" { //nolint:gosec // G304: test fixture under t.TempDir.
 		t.Fatalf("updated=%q err=%v", got, err)
 	}
-	if got, err := os.ReadFile(filepath.Join(root, "last-good", "AGENTS.md")); err != nil || string(got) != "# v1\n" {
+	if got, err := os.ReadFile(filepath.Join(root, "last-good", "AGENTS.md")); err != nil || string(got) != "# v1\n" { //nolint:gosec // G304: test fixture under t.TempDir.
 		t.Fatalf("last-good=%q err=%v", got, err)
 	}
 	if err := RestoreLastGood(root); err != nil {
 		t.Fatal(err)
 	}
-	if got, err := os.ReadFile(filepath.Join(root, "current", "AGENTS.md")); err != nil || string(got) != "# v1\n" {
+	if got, err := os.ReadFile(filepath.Join(root, "current", "AGENTS.md")); err != nil || string(got) != "# v1\n" { //nolint:gosec // G304: test fixture under t.TempDir.
 		t.Fatalf("restored=%q err=%v", got, err)
 	}
 }
@@ -42,7 +42,8 @@ func TestPublishTreeSerializesConcurrentReconcile(t *testing.T) {
 		wg.Add(1)
 		go func(n int) {
 			defer wg.Done()
-			body := []byte{byte('A' + n), '\n'}
+			body := []byte("ABCDEFGH")[n : n+1]
+			body = append(body, '\n')
 			errCh <- PublishTree(root, map[string][]byte{"AGENTS.md": body}, "d")
 		}(i)
 	}
@@ -53,8 +54,42 @@ func TestPublishTreeSerializesConcurrentReconcile(t *testing.T) {
 			t.Fatal(err)
 		}
 	}
-	if _, err := os.ReadFile(filepath.Join(root, "current", "AGENTS.md")); err != nil {
+	if _, err := os.ReadFile(filepath.Join(root, "current", "AGENTS.md")); err != nil { //nolint:gosec // G304: test fixture under t.TempDir.
 		t.Fatal(err)
+	}
+}
+
+func TestPublishTreeRecoversDisplacedLiveFromNext(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	if err := PublishTree(root, map[string][]byte{"AGENTS.md": []byte("# v1\n")}, "d1"); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Rename(filepath.Join(root, "current"), filepath.Join(root, "last-good.next")); err != nil {
+		t.Fatal(err)
+	}
+	if err := PublishTree(root, map[string][]byte{"AGENTS.md": []byte("# v2\n")}, "d2"); err != nil {
+		t.Fatal(err)
+	}
+	if got, err := os.ReadFile(filepath.Join(root, "current", "AGENTS.md")); err != nil || string(got) != "# v2\n" { //nolint:gosec // G304: test fixture under t.TempDir.
+		t.Fatalf("live=%q err=%v", got, err)
+	}
+	if got, err := os.ReadFile(filepath.Join(root, "last-good", "AGENTS.md")); err != nil || string(got) != "# v1\n" { //nolint:gosec // G304: test fixture under t.TempDir.
+		t.Fatalf("last-good=%q err=%v", got, err)
+	}
+	if _, err := os.Lstat(filepath.Join(root, "last-good.next")); !os.IsNotExist(err) {
+		t.Fatal("left leftover last-good.next")
+	}
+}
+
+func TestPublishTreeCreatesExclusiveLockFile(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	if err := PublishTree(root, map[string][]byte{"AGENTS.md": []byte("# v1\n")}, "d1"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Lstat(filepath.Join(root, "reconcile.lock")); err != nil {
+		t.Fatalf("missing reconcile.lock: %v", err)
 	}
 }
 

--- a/internal/fleetconfig/apply_test.go
+++ b/internal/fleetconfig/apply_test.go
@@ -1,6 +1,7 @@
 package fleetconfig
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"sync"
@@ -79,6 +80,26 @@ func TestPublishTreeRecoversDisplacedLiveFromNext(t *testing.T) {
 	}
 	if _, err := os.Lstat(filepath.Join(root, "last-good.next")); !os.IsNotExist(err) {
 		t.Fatal("left leftover last-good.next")
+	}
+}
+
+func TestPublishTreePersistsPrefixDigests(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	body := ComposeAgents([]byte("# fleet v1\n"), []byte("\nkeep\n"))
+	if err := PublishTree(root, map[string][]byte{"AGENTS.md": body}, "d1"); err != nil {
+		t.Fatal(err)
+	}
+	raw, err := os.ReadFile(filepath.Join(root, "applied.json")) //nolint:gosec // G304: test fixture under t.TempDir.
+	if err != nil {
+		t.Fatal(err)
+	}
+	var state ApplyState
+	if err := json.Unmarshal(raw, &state); err != nil {
+		t.Fatal(err)
+	}
+	if state.PrefixDigests["AGENTS.md"] != DigestBytes([]byte("# fleet v1")) {
+		t.Fatalf("prefix digests=%#v", state.PrefixDigests)
 	}
 }
 

--- a/internal/fleetconfig/apply_test.go
+++ b/internal/fleetconfig/apply_test.go
@@ -1,0 +1,73 @@
+package fleetconfig
+
+import (
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+)
+
+func TestPublishTreeIsAtomicAndKeepsLastKnownGood(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	if err := PublishTree(root, map[string][]byte{"AGENTS.md": []byte("# v1\n")}, "d1"); err != nil {
+		t.Fatal(err)
+	}
+	if got, err := os.ReadFile(filepath.Join(root, "current", "AGENTS.md")); err != nil || string(got) != "# v1\n" {
+		t.Fatalf("live=%q err=%v", got, err)
+	}
+	if err := PublishTree(root, map[string][]byte{"AGENTS.md": []byte("# v2\n")}, "d2"); err != nil {
+		t.Fatal(err)
+	}
+	if got, err := os.ReadFile(filepath.Join(root, "current", "AGENTS.md")); err != nil || string(got) != "# v2\n" {
+		t.Fatalf("updated=%q err=%v", got, err)
+	}
+	if got, err := os.ReadFile(filepath.Join(root, "last-good", "AGENTS.md")); err != nil || string(got) != "# v1\n" {
+		t.Fatalf("last-good=%q err=%v", got, err)
+	}
+	if err := RestoreLastGood(root); err != nil {
+		t.Fatal(err)
+	}
+	if got, err := os.ReadFile(filepath.Join(root, "current", "AGENTS.md")); err != nil || string(got) != "# v1\n" {
+		t.Fatalf("restored=%q err=%v", got, err)
+	}
+}
+
+func TestPublishTreeSerializesConcurrentReconcile(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	var wg sync.WaitGroup
+	errCh := make(chan error, 8)
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func(n int) {
+			defer wg.Done()
+			body := []byte{byte('A' + n), '\n'}
+			errCh <- PublishTree(root, map[string][]byte{"AGENTS.md": body}, "d")
+		}(i)
+	}
+	wg.Wait()
+	close(errCh)
+	for err := range errCh {
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	if _, err := os.ReadFile(filepath.Join(root, "current", "AGENTS.md")); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestPublishTreeRejectsLiveSymlink(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	if err := os.Mkdir(filepath.Join(root, "other"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(filepath.Join(root, "other"), filepath.Join(root, "current")); err != nil {
+		t.Fatal(err)
+	}
+	if err := PublishTree(root, map[string][]byte{"AGENTS.md": []byte("# v1\n")}, "d1"); err == nil {
+		t.Fatal("replaced a symlink live tree")
+	}
+}

--- a/internal/fleetconfig/match.go
+++ b/internal/fleetconfig/match.go
@@ -1,0 +1,50 @@
+package fleetconfig
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// ProjectMatch is a content-free project-path decision.
+type ProjectMatch struct {
+	Name string
+	Path string
+	Kind string
+}
+
+// MatchProjects maps published project names onto top-level directories.
+func MatchProjects(base string, overrides map[string]string, names []string, lookup func(string) bool) []ProjectMatch {
+	if lookup == nil {
+		lookup = dirExists
+	}
+	if base == "" {
+		home, err := os.UserHomeDir()
+		if err == nil {
+			base = filepath.Join(home, "src")
+		}
+	}
+	matches := make([]ProjectMatch, 0, len(names))
+	for _, name := range names {
+		if override := strings.TrimSpace(overrides[name]); override != "" {
+			if filepath.IsAbs(override) && lookup(override) {
+				matches = append(matches, ProjectMatch{Name: name, Path: override, Kind: "override"})
+			} else {
+				matches = append(matches, ProjectMatch{Name: name, Kind: "unmatched"})
+			}
+			continue
+		}
+		path := filepath.Join(base, name)
+		if lookup(path) {
+			matches = append(matches, ProjectMatch{Name: name, Path: path, Kind: "matched"})
+			continue
+		}
+		matches = append(matches, ProjectMatch{Name: name, Kind: "unmatched"})
+	}
+	return matches
+}
+
+func dirExists(path string) bool {
+	info, err := os.Lstat(path)
+	return err == nil && info.IsDir() && info.Mode()&os.ModeSymlink == 0
+}

--- a/internal/fleetconfig/match_test.go
+++ b/internal/fleetconfig/match_test.go
@@ -1,0 +1,38 @@
+package fleetconfig
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestMatchProjectsIsTopLevelOnlyAndHonorsOverride(t *testing.T) {
+	t.Parallel()
+	base := t.TempDir()
+	if err := os.Mkdir(filepath.Join(base, "punaro"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(base, "nested", "canopi"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	override := t.TempDir()
+	matches := MatchProjects(base, map[string]string{"canopi": override}, []string{"punaro", "canopi", "missing"}, dirExists)
+	if len(matches) != 3 {
+		t.Fatalf("matches=%#v", matches)
+	}
+	if matches[0].Kind != "matched" || matches[0].Path != filepath.Join(base, "punaro") {
+		t.Fatalf("punaro=%#v", matches[0])
+	}
+	if matches[1].Kind != "override" || matches[1].Path != override {
+		t.Fatalf("canopi=%#v", matches[1])
+	}
+	if matches[2].Kind != "unmatched" || matches[2].Path != "" {
+		t.Fatalf("missing=%#v", matches[2])
+	}
+	nested := filepath.Join(base, "nested", "canopi")
+	for _, match := range matches {
+		if match.Path == nested {
+			t.Fatal("nested project matched")
+		}
+	}
+}

--- a/internal/fleetconfig/reconcile.go
+++ b/internal/fleetconfig/reconcile.go
@@ -1,0 +1,33 @@
+package fleetconfig
+
+import "strings"
+
+// PrepareApply builds the live file set from a validated tree, applying trailers.
+func PrepareApply(tree Tree, existing map[string][]byte, lastPrefixDigests map[string]string) (map[string][]byte, map[string]TrailerResult, error) {
+	if err := Validate(tree); err != nil {
+		return nil, nil, err
+	}
+	files := make(map[string][]byte, len(tree.Files))
+	trailers := map[string]TrailerResult{}
+	for _, file := range tree.Files {
+		if stringsHasSuffixAgents(file.Path) {
+			live, ok := existing[file.Path]
+			next, result, err := ApplyAgents(file.Data, live, ok, lastPrefixDigests[file.Path])
+			if err != nil {
+				return nil, nil, err
+			}
+			trailers[file.Path] = result
+			if result.Collision {
+				continue
+			}
+			files[file.Path] = next
+			continue
+		}
+		files[file.Path] = file.Data
+	}
+	return files, trailers, nil
+}
+
+func stringsHasSuffixAgents(path string) bool {
+	return path == "AGENTS.md" || strings.HasSuffix(path, "/AGENTS.md")
+}

--- a/internal/fleetconfig/reconcile_test.go
+++ b/internal/fleetconfig/reconcile_test.go
@@ -1,0 +1,35 @@
+package fleetconfig
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestPrepareApplyPreservesTrailerAndSkipsCollisions(t *testing.T) {
+	t.Parallel()
+	tree := Tree{Files: []File{
+		{Path: "AGENTS.md", Data: []byte("# global\n")},
+		{Path: "projects/punaro/AGENTS.md", Data: []byte("# punaro\n")},
+		{Path: "skills/demo/SKILL.md", Data: []byte(skillMarkdown("demo", "Demo skill."))},
+	}}
+	existing := map[string][]byte{
+		"AGENTS.md":                 ComposeAgents([]byte("# global\n"), []byte("\nlocal trailer\n")),
+		"projects/punaro/AGENTS.md": []byte("unmanaged"),
+	}
+	files, trailers, err := PrepareApply(tree, existing, map[string]string{"AGENTS.md": DigestBytes([]byte("# global"))})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(files["AGENTS.md"]), "local trailer") {
+		t.Fatalf("global trailer lost: %s", files["AGENTS.md"])
+	}
+	if _, ok := files["projects/punaro/AGENTS.md"]; ok {
+		t.Fatal("overwrote unmanaged project AGENTS.md")
+	}
+	if !trailers["projects/punaro/AGENTS.md"].Collision {
+		t.Fatalf("collision=%#v", trailers)
+	}
+	if _, ok := files["skills/demo/SKILL.md"]; !ok {
+		t.Fatal("skill data dropped")
+	}
+}

--- a/internal/fleetconfig/trailer.go
+++ b/internal/fleetconfig/trailer.go
@@ -1,0 +1,71 @@
+package fleetconfig
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"strings"
+)
+
+// TrailerResult is the content-free trailer outcome of one apply.
+type TrailerResult struct {
+	State     string
+	Drift     bool
+	Collision bool
+}
+
+// SplitAgents separates a fleet-managed prefix from a machine-local trailer.
+func SplitAgents(content []byte) (prefix, trailer []byte, ok bool) {
+	text := string(content)
+	start := strings.Index(text, TrailerStart)
+	end := strings.LastIndex(text, TrailerEnd)
+	if start < 0 || end < 0 || end < start {
+		return nil, nil, false
+	}
+	prefix = []byte(strings.TrimRight(text[:start], "\n"))
+	bodyStart := start + len(TrailerStart)
+	trailer = []byte(text[bodyStart:end])
+	return prefix, trailer, true
+}
+
+// ComposeAgents writes fleet prefix plus reserved trailer markers.
+func ComposeAgents(prefix, trailer []byte) []byte {
+	var buf bytes.Buffer
+	if len(prefix) > 0 {
+		buf.Write(bytes.TrimRight(prefix, "\n"))
+		buf.WriteByte('\n')
+	}
+	buf.WriteString(TrailerStart)
+	if len(trailer) > 0 && trailer[0] != '\n' {
+		buf.WriteByte('\n')
+	}
+	buf.Write(trailer)
+	if len(trailer) > 0 && trailer[len(trailer)-1] != '\n' {
+		buf.WriteByte('\n')
+	}
+	buf.WriteString(TrailerEnd)
+	buf.WriteByte('\n')
+	return buf.Bytes()
+}
+
+// ApplyAgents replaces the fleet prefix while preserving or creating the trailer.
+func ApplyAgents(fleetPrefix, existing []byte, existed bool, lastPrefixDigest string) ([]byte, TrailerResult, error) {
+	if !existed || len(existing) == 0 {
+		return ComposeAgents(fleetPrefix, nil), TrailerResult{State: "present"}, nil
+	}
+	prefix, trailer, ok := SplitAgents(existing)
+	if !ok {
+		return nil, TrailerResult{State: "collision", Collision: true}, nil
+	}
+	result := TrailerResult{State: "present"}
+	if lastPrefixDigest != "" && DigestBytes(prefix) != lastPrefixDigest && DigestBytes(prefix) != DigestBytes(fleetPrefix) {
+		result.Drift = true
+	}
+	return ComposeAgents(fleetPrefix, trailer), result, nil
+}
+
+// DigestBytes returns the hex SHA-256 of one blob.
+func DigestBytes(data []byte) string {
+	sum := sha256.Sum256(data)
+	return hex.EncodeToString(sum[:])
+}

--- a/internal/fleetconfig/trailer.go
+++ b/internal/fleetconfig/trailer.go
@@ -22,6 +22,10 @@ func SplitAgents(content []byte) (prefix, trailer []byte, ok bool) {
 	if start < 0 || end < 0 || end < start {
 		return nil, nil, false
 	}
+	suffix := strings.Trim(text[end+len(TrailerEnd):], "\n")
+	if suffix != "" {
+		return nil, nil, false
+	}
 	prefix = []byte(strings.TrimRight(text[:start], "\n"))
 	bodyStart := start + len(TrailerStart)
 	trailer = []byte(text[bodyStart:end])
@@ -50,7 +54,7 @@ func ComposeAgents(prefix, trailer []byte) []byte {
 
 // ApplyAgents replaces the fleet prefix while preserving or creating the trailer.
 func ApplyAgents(fleetPrefix, existing []byte, existed bool, lastPrefixDigest string) ([]byte, TrailerResult, error) {
-	if !existed || len(existing) == 0 {
+	if !existed {
 		return ComposeAgents(fleetPrefix, nil), TrailerResult{State: "present"}, nil
 	}
 	prefix, trailer, ok := SplitAgents(existing)

--- a/internal/fleetconfig/trailer_test.go
+++ b/internal/fleetconfig/trailer_test.go
@@ -47,6 +47,18 @@ func TestApplyAgentsReportsDriftAndCollision(t *testing.T) {
 	if err != nil || !result.Collision || result.State != "collision" || collision != nil {
 		t.Fatalf("collision result=%#v next=%s err=%v", result, collision, err)
 	}
+	empty, result, err := ApplyAgents([]byte("# fleet\n"), []byte{}, true, "")
+	if err != nil || !result.Collision || result.State != "collision" || empty != nil {
+		t.Fatalf("empty existing result=%#v next=%s err=%v", result, empty, err)
+	}
+	suffix := append(ComposeAgents([]byte("# fleet v1\n"), []byte("\nkeep\n")), []byte("after\n")...)
+	if _, _, ok := SplitAgents(suffix); ok {
+		t.Fatal("accepted content after trailer end")
+	}
+	lost, result, err := ApplyAgents([]byte("# fleet v2\n"), suffix, true, "")
+	if err != nil || !result.Collision || lost != nil {
+		t.Fatalf("suffix result=%#v next=%s err=%v", result, lost, err)
+	}
 }
 
 func TestApplyAgentsOmitsTrailerFromFleetPrefix(t *testing.T) {

--- a/internal/fleetconfig/trailer_test.go
+++ b/internal/fleetconfig/trailer_test.go
@@ -15,8 +15,7 @@ func TestApplyAgentsCreatesAndPreservesTrailer(t *testing.T) {
 	if !bytes.Contains(created, []byte(TrailerStart)) || !bytes.Contains(created, []byte(TrailerEnd)) {
 		t.Fatalf("missing trailer markers: %s", created)
 	}
-	_, trailer, ok := SplitAgents(created)
-	if !ok {
+	if _, _, ok := SplitAgents(created); !ok {
 		t.Fatal("created file missing trailer")
 	}
 	withLocal := ComposeAgents([]byte("# fleet v1\n"), []byte("\nmachine note\n"))
@@ -24,7 +23,7 @@ func TestApplyAgentsCreatesAndPreservesTrailer(t *testing.T) {
 	if err != nil || result.Collision || result.Drift {
 		t.Fatalf("update result=%#v err=%v", result, err)
 	}
-	_, trailer, ok = SplitAgents(updated)
+	_, trailer, ok := SplitAgents(updated)
 	if !ok || !strings.Contains(string(trailer), "machine note") || !strings.Contains(string(updated), "# fleet v2") {
 		t.Fatalf("trailer lost: %s", updated)
 	}

--- a/internal/fleetconfig/trailer_test.go
+++ b/internal/fleetconfig/trailer_test.go
@@ -1,0 +1,63 @@
+package fleetconfig
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestApplyAgentsCreatesAndPreservesTrailer(t *testing.T) {
+	t.Parallel()
+	created, result, err := ApplyAgents([]byte("# fleet v1\n"), nil, false, "")
+	if err != nil || result.Collision || result.State != "present" {
+		t.Fatalf("create result=%#v err=%v", result, err)
+	}
+	if !bytes.Contains(created, []byte(TrailerStart)) || !bytes.Contains(created, []byte(TrailerEnd)) {
+		t.Fatalf("missing trailer markers: %s", created)
+	}
+	_, trailer, ok := SplitAgents(created)
+	if !ok {
+		t.Fatal("created file missing trailer")
+	}
+	withLocal := ComposeAgents([]byte("# fleet v1\n"), []byte("\nmachine note\n"))
+	updated, result, err := ApplyAgents([]byte("# fleet v2\n"), withLocal, true, DigestBytes([]byte("# fleet v1")))
+	if err != nil || result.Collision || result.Drift {
+		t.Fatalf("update result=%#v err=%v", result, err)
+	}
+	_, trailer, ok = SplitAgents(updated)
+	if !ok || !strings.Contains(string(trailer), "machine note") || !strings.Contains(string(updated), "# fleet v2") {
+		t.Fatalf("trailer lost: %s", updated)
+	}
+	if bytes.Contains(updated, []byte("# fleet v1\n# fleet v2")) {
+		t.Fatal("merged prefixes")
+	}
+}
+
+func TestApplyAgentsReportsDriftAndCollision(t *testing.T) {
+	t.Parallel()
+	existing := ComposeAgents([]byte("# edited prefix\n"), []byte("\nkeep me\n"))
+	next, result, err := ApplyAgents([]byte("# fleet v2\n"), existing, true, DigestBytes([]byte("# fleet v1")))
+	if err != nil || !result.Drift || result.Collision {
+		t.Fatalf("drift result=%#v err=%v", result, err)
+	}
+	_, trailer, ok := SplitAgents(next)
+	if !ok || !strings.Contains(string(trailer), "keep me") {
+		t.Fatal("drift apply dropped trailer")
+	}
+	collision, result, err := ApplyAgents([]byte("# fleet\n"), []byte("# unmanaged\n"), true, "")
+	if err != nil || !result.Collision || result.State != "collision" || collision != nil {
+		t.Fatalf("collision result=%#v next=%s err=%v", result, collision, err)
+	}
+}
+
+func TestApplyAgentsOmitsTrailerFromFleetPrefix(t *testing.T) {
+	t.Parallel()
+	next, _, err := ApplyAgents([]byte("# fleet\n"), nil, false, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	prefix, _, ok := SplitAgents(next)
+	if !ok || bytes.Contains(prefix, []byte(TrailerStart)) {
+		t.Fatalf("trailer leaked into prefix %q", prefix)
+	}
+}


### PR DESCRIPTION
Closes #214.

Stages and atomically publishes the managed tree, preserves machine-local `AGENTS.md` trailers, matches project names only as top-level directories under a configured base path or an explicit override, serializes concurrent reconcile, and retains last-known-good after a failed apply.