### PR TITLE
Add immutable fleet-global configuration release contract

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -626,6 +626,32 @@ The opportunistic reconnect is rate-limited (for example, once per 30 seconds),
 single-flight per adapter, and allowed to bypass backoff only once while work
 remains. This prevents a large backlog from creating a reconnect storm.
 
+## Fleet-global agent configuration
+
+Punaro can distribute a user-published coding-agent configuration as a
+**data-only** v1 release. The contract lives in `internal/fleetconfig` and is
+documented in
+[`docs/fleet-global-agent-config.md`](docs/fleet-global-agent-config.md).
+
+The source of truth is an explicitly published immutable Git commit from a
+configured repository. Mutable branches, tags, `HEAD`, and abbreviated object
+names are never desired state. Publication validates and materializes a
+content-addressed archive **before** changing fleet desired revision; a failed
+publish leaves the prior desired revision unchanged.
+
+v1 source layout is `AGENTS.md`, optional `skills/<name>/` trees rooted by
+`SKILL.md`, and optional `projects/<name>/` trees with the same shape. Skill
+`name` frontmatter must match the directory. Machine-local `AGENTS.md` trailer
+markers are illegal in fleet source and are never archived. `scripts/` files
+may be present as regular files; Punaro never executes them and records no
+destinations or post-install commands.
+
+Validation rejects absolute paths, traversal, links, special files, duplicate
+or case-colliding paths, oversized files, excessive skill counts, and malformed
+skill metadata. Identical input yields identical archive bytes and digest.
+Product binary releases remain `internal/release`; this pipeline is a separate
+trust domain.
+
 ## Canonical memory model
 
 Canonical memory is project-scoped PostgreSQL authority. Each item has an

--- a/docs/fleet-global-agent-config.md
+++ b/docs/fleet-global-agent-config.md
@@ -113,6 +113,7 @@ keys are ignored and not executed.
 | Condition | Reason |
 | --- | --- |
 | Absolute path, `\`, NUL, `.`, `..`, empty component | Path escape |
+| Path not USTAR-representable (over 255 bytes, or no `/` split with prefix ≤155 and suffix ≤100) | Archive format |
 | Duplicate path or case-colliding path | Windows/macOS case folding |
 | Symlink, extra hard link (`Nlink > 1` on Unix), device, socket, FIFO, non-regular file | Unsafe file type |
 | File larger than 256 KiB | Bound |
@@ -143,7 +144,9 @@ keys are ignored and not executed.
 
 4. Archive as gzip+tar of those files (and their parent directories):
    sorted paths, mode `0644` files / `0755` dirs, uid/gid 0, empty uname/gname,
-   mtime unix 0, gzip Name empty, ModTime unix 0, OS = 3 (Unix).
+   mtime unix 0, gzip Name empty, ModTime unix 0, OS = 3 (Unix). Directory
+   headers omit a trailing slash so a 100-byte final directory component stays
+   inside the USTAR name field.
 5. Identical input bytes yield identical archive bytes and digest.
 
 The archive does not include trailer text. Manifest `digest` is the release

--- a/docs/fleet-global-agent-config.md
+++ b/docs/fleet-global-agent-config.md
@@ -1,0 +1,497 @@
+# Fleet-global agent configuration
+
+Status: accepted for implementation of GitHub issues
+[#210](https://github.com/rock3r/punaro/issues/210)–[#217](https://github.com/rock3r/punaro/issues/217)
+plus the three v1 operator additions (machine-global vs project-only trees,
+machine-local `AGENTS.md` trailers, and opt-in Claude aliases).
+
+This document is the contract. `DESIGN.md` records the protocol and security
+invariants as they land. Binary product releases remain `internal/release`;
+this feature is a separate data-only synchronizer.
+
+## Overview
+
+An operator explicitly publishes one immutable Git commit from a configured
+source repository. Punaro validates and materializes a content-addressed v1
+release **before** changing desired fleet state. Enrolled clients receive a
+payload-free WebSocket wake hint, HTTP-fetch the exact release under
+server-side authorization, and atomically apply a managed tree on macOS,
+Linux, and Windows. Clients never publish. Failed apply keeps last known-good.
+Configuration contents never appear in logs, inventory, audit, wake hints,
+status, or doctor output.
+
+## Background & Motivation
+
+Punaro already has enrolled machine identity, signed HTTP, payload-free wake
+hints (`internal/relay.Notifier`), cross-platform adapters, and content-free
+doctor reports. Operators still copy `AGENTS.md` and Agent Skills by hand.
+Existing `scripts/install-agent-guidance.sh` is a local installer, not a fleet
+synchronizer, and must not become the v1 apply path.
+
+## Goals & Non-Goals
+
+Goals: issues #211–#217 plus:
+
+1. Machine-global `AGENTS.md`/`skills/` **and** project-only trees matched by
+   top-level directory names under a configured base path (default `~/src`) or
+   an explicit machine-local path override that is never published back.
+2. A durable machine-local trailer at the bottom of every applied `AGENTS.md`.
+3. Opt-in Claude aliases (`CLAUDE.md` → `AGENTS.md`, and Claude skill dirs onto
+   Agents-flavoured trees): POSIX symlink; Windows supported surviving
+   equivalent or fail closed without copying.
+
+Non-goals: general dotfile sync, arbitrary destinations, executable/plugin
+deployment, recursive workspace discovery, bidirectional editing,
+client-originated publication, following branches/tags/repo changes, guaranteed
+hot reload, provisioning a new relay, checking official `docs/release-evidence/`
+boxes from a LAN run.
+
+## Key Decisions
+
+1. **Full commit identity only.** `ParseCommitID` accepts lowercase hex of
+   length 40 (SHA-1) or 64 (SHA-256). Branches, tags, `HEAD`, short hashes,
+   mixed case, and any `/` are rejected before Git is invoked.
+2. **Source repository is operator configuration**, stored in the host-local
+   installation, never taken from a client or from the commit contents.
+3. **Validate and materialize before desired-state mutation.** Store the
+   immutable release bytes, then atomically set the singleton desired row. A
+   failed publish leaves the prior desired revision unchanged. Identical retry
+   is idempotent. Rollback is `publish` of a previously stored digest's source
+   commit (same command).
+4. **Layout uses an explicit `projects/` prefix** so project names cannot
+   collide with `skills/` or `AGENTS.md`. Matching on the machine is still
+   top-level directory names under the base path.
+5. **v1 is data only.** `scripts/` files may exist as regular files. Punaro
+   never executes them, never records destinations or post-install commands,
+   and never treats mode bits as activation.
+6. **Trailer markers are illegal in fleet source** and reserved on disk.
+   Punaro creates the trailer if missing and preserves it across
+   publish/rollback/reconverge. Fleet-prefix edits are drift, not a merge.
+7. **Operator CLI talks to PostgreSQL via the owner DSN** (same pattern as
+   `punaro client add` in `cmd/punaro`). Clients talk to signed HTTP on
+   `punarod`. Clients have no publish route.
+8. **Wake hints reuse `Notifier` with a reserved topic id `fleet-config`**
+   and `sequence` equal to the desired generation. No digest, commit, path, or
+   contents. HTTP remains authoritative. Broadcast to every currently
+   registered enrolled-machine subscription.
+9. **Release bytes live in PostgreSQL `bytea`** under a hard size bound. v1
+   volume is small; a separate blob store would add a deployable surface.
+10. **Package name `internal/fleetconfig`** so it cannot be confused with
+    `internal/release` (signed product artifacts).
+11. **Harness projection is a built-in adapter table**, not a plugin runtime.
+    Unknown installed harnesses report `unsupported`.
+12. **Claude aliases are opt-in per machine** in local adapter config. Never
+    overwrite a colliding real Claude file that is not already a Punaro-managed
+    alias.
+
+## Source tree layout
+
+A published commit must contain:
+
+```text
+AGENTS.md                         # required, machine-global
+skills/<skill>/SKILL.md           # optional bounded global skills
+skills/<skill>/**                 # optional data files (never executed)
+projects/<project>/AGENTS.md      # optional project-only
+projects/<project>/skills/...     # optional project skills
+```
+
+No other top-level names. No extra files next to `AGENTS.md`. Empty
+directories are ignored (not archived).
+
+Project and skill directory names match
+`^[a-z0-9]([a-z0-9._-]{0,62}[a-z0-9])?$` (same shape as `auth.client_installations.machine_id`).
+
+`SKILL.md` must begin with YAML frontmatter containing `name` and
+`description`. `name` must equal the parent directory. Additional frontmatter
+keys are ignored and not executed.
+
+## Validation
+
+`InspectRoot` uses `Lstat` and never follows links. Reject:
+
+| Condition | Reason |
+| --- | --- |
+| Absolute path, `\`, NUL, `.`, `..`, empty component | Path escape |
+| Duplicate path or case-colliding path | Windows/macOS case folding |
+| Symlink, extra hard link (`Nlink > 1` on Unix), device, socket, FIFO, non-regular file | Unsafe file type |
+| File larger than 256 KiB | Bound |
+| More than 64 skills (global + all projects) | Bound |
+| More than 512 files or 4 MiB total | Bound |
+| Missing global `AGENTS.md` | Required |
+| Global `AGENTS.md` contains trailer start/end markers | Trailer is machine-local |
+| Project `AGENTS.md` contains trailer markers | Same |
+| Malformed `SKILL.md` frontmatter | Contract |
+| UTF-8 invalid or NUL in text files (`AGENTS.md`, `SKILL.md`) | Text contract |
+| Executable activation fields, destination lists, or post-install commands in any Punaro-owned metadata | Data only |
+
+`ParseCommitID` is independent of the tree.
+
+## Deterministic materialization
+
+1. Walk validated files, hash each SHA-256.
+2. Build a versioned manifest binding source commit, every relative path
+   (slash-separated), byte length, content digest, skill count, total bytes.
+3. Compute release digest as SHA-256 of the canonical digest plaintext:
+
+   ```text
+   fleet-config-v1\n
+   <source-commit>\n
+   <path>\0<size>\0<file-sha256>\n
+   …sorted by path…
+   ```
+
+4. Archive as gzip+tar of those files (and their parent directories):
+   sorted paths, mode `0644` files / `0755` dirs, uid/gid 0, empty uname/gname,
+   mtime unix 0, gzip Name empty, ModTime unix 0, OS = 3 (Unix).
+5. Identical input bytes yield identical archive bytes and digest.
+
+The archive does not include trailer text. Manifest `digest` is the release
+identity used as the desired-state key.
+
+## Trust boundary
+
+```text
+configured repo  --explicit publish COMMIT-->  git object
+       |                                         |
+       | InspectRoot + Validate + Materialize    |
+       v                                         v
+ immutable (manifest, archive, digest) stored first
+       |
+       | atomic desired-state row (generation++)
+       v
+ enrolled clients: wake hint -> GET desired -> GET archive by digest
+       |
+       v
+ local apply (atomic rename) + last-known-good
+```
+
+Changing the repository without `fleet-config publish` causes no fleet change.
+A digest not produced by this pipeline is never desired state.
+
+## Operator CLI
+
+Host-local `punaro` commands, owner DSN, installation directory:
+
+```text
+punaro fleet-config configure --directory DIR --repository ABSOLUTE_GIT_DIR --yes
+punaro fleet-config publish COMMIT --directory DIR
+punaro fleet-config publish COMMIT --directory DIR --yes --preview-hash HASH
+punaro fleet-config status --directory DIR
+```
+
+`publish` without `--yes` prints a content-free preview (source commit, release
+digest, skill count, total bytes, current desired revision/digest/generation)
+and a preview hash. `--yes` requires that exact hash, matching `punaro client add`.
+
+Rollback is `publish` of a previously published commit that still exists as a
+stored release (or can be rematerialized identically from the configured repo).
+
+Failed materialize or store does not update desired. Retry of the same commit
+after success returns the same digest and does not bump generation.
+
+## Data model (PostgreSQL schema `fleet`, migration 058)
+
+```sql
+fleet.releases (
+  digest text PRIMARY KEY CHECK (digest ~ '^[0-9a-f]{64}$'),
+  source_commit text NOT NULL CHECK (source_commit ~ '^[0-9a-f]{40}$' OR source_commit ~ '^[0-9a-f]{64}$'),
+  archive bytea NOT NULL,
+  skill_count integer NOT NULL CHECK (skill_count BETWEEN 0 AND 64),
+  file_count integer NOT NULL CHECK (file_count BETWEEN 1 AND 512),
+  total_bytes bigint NOT NULL CHECK (total_bytes BETWEEN 1 AND 4194304),
+  created_at timestamptz NOT NULL DEFAULT statement_timestamp()
+);
+
+fleet.desired (
+  id boolean PRIMARY KEY DEFAULT true CHECK (id),
+  release_digest text NOT NULL REFERENCES fleet.releases(digest),
+  generation bigint NOT NULL CHECK (generation >= 1),
+  published_at timestamptz NOT NULL,
+  preview_hash text NOT NULL
+);
+
+fleet.client_status (
+  client_id uuid PRIMARY KEY REFERENCES auth.client_installations(id),
+  generation bigint NOT NULL CHECK (generation >= 1),
+  applied_digest text CHECK (applied_digest ~ '^[0-9a-f]{64}$'),
+  state text NOT NULL CHECK (state IN (
+    'current','pending','applying','failed','offline','drifted','unsupported','restart_required'
+  )),
+  activation text CHECK (activation IN (
+    'immediate','next_turn','next_session','restart_required'
+  )),
+  trailer_state text,
+  alias_state text,
+  project_match_state text,
+  reported_at timestamptz NOT NULL,
+  report_generation bigint NOT NULL CHECK (report_generation >= 1)
+);
+```
+
+No file contents, host paths, or raw errors in `client_status`. Revoked
+clients cannot insert or update. Application role uses security-definer
+routines with enrolled-client predicates in the same transaction.
+
+Desired mutation is one transaction: insert release if absent (conflict on
+digest is success), then update `fleet.desired` only when the digest changes,
+incrementing `generation`. Same digest: no generation bump.
+
+## HTTP (enrolled client only)
+
+| Method | Route | Purpose |
+| --- | --- | --- |
+| `GET` | `/v1/fleet-config/desired` | Metadata: generation, digest, source commit, skill count, total bytes. Empty body. |
+| `GET` | `/v1/fleet-config/releases/{digest}` | Exact archive bytes. Digest in the path must match stored digest. |
+| `PUT` | `/v1/fleet-config/status` | Bounded status write for the authenticated client's row only. |
+
+Authorization is the existing signed-request / device-credential enrolled
+identity (`internal/relay` `authenticate`). Stale credential generation,
+revoked clients, and replayed nonces fail closed. There is no client publish,
+delete, or select route. Status writes require `Idempotency-Key`, bind
+`(client_id, key, request hash)`, reject stale `report_generation`, and never
+echo contents.
+
+Wake: after a generation bump, `Notifier.Publish(machineID, "fleet-config", generation)`
+for each currently registered subscriber. Payload is the existing `WakeEvent`
+shape. Clients that miss the hint recover on the adapter poll interval.
+
+## Client reconciler
+
+Lives in `internal/fleetconfig` (pure apply/trailer/match) +
+`internal/adapter` / `cmd/punaro-adapter` (HTTP, lock, I/O).
+
+On startup, poll, and `topic_id=fleet-config` wake:
+
+1. Fetch desired metadata.
+2. If applied digest matches and no local drift, report `current` and stop.
+3. Fetch exact archive; verify digest and re-validate.
+4. Take a single-flight file lock under the adapter data directory.
+5. Stage into a new directory; fsync; atomic publish (`rename` on POSIX,
+   `MoveFileEx` replace on Windows).
+6. On failure, retain last-known-good and report `failed` without contents.
+7. After success, project into harnesses and optional aliases.
+
+Protected live files: regular files/directories only. Reject symlinks,
+junctions, reparse points, unexpected hard links, world-writable ancestors,
+and ownership that is not the adapter user. `//go:build` platform files follow
+`cmd/punaro-adapter/private_file_*`.
+
+### Project matching
+
+Default base path `~/src`, overridable in machine-local config.
+
+- Published `projects/punaro/` applies to `$BASE/punaro` if that path is an
+  existing directory (not a symlink).
+- `$BASE/nested/punaro` does **not** match.
+- `project_path_overrides` in local config maps a project name to an absolute
+  existing directory. Never uploaded.
+
+### Trailer
+
+Markers (exact lines):
+
+```text
+<!-- punaro-local-trailer:start -->
+<!-- punaro-local-trailer:end -->
+```
+
+Apply writes `fleet-prefix + "\n" + start + preserved-or-empty-body + end + "\n"`.
+If the live file is missing, create prefix + empty trailer. If the live file
+exists without markers, report collision (`drifted`) and do not overwrite.
+If markers are present, replace only the prefix. Interrupted apply must not
+delete the trailer: stage a complete file then atomic rename.
+
+### Machine-local config
+
+Stored next to the adapter profile (already a protected file). Schema v1 JSON:
+
+```json
+{
+  "schema": 1,
+  "project_base_path": "",
+  "project_path_overrides": {},
+  "claude_aliases": false
+}
+```
+
+Empty `project_base_path` means `~/src`. This file is never fleet source.
+
+## Harness projection
+
+Built-in adapters, detection + destinations + activation:
+
+| Harness | Detect | Managed destinations | Activation |
+| --- | --- | --- | --- |
+| Portable Agents | project dir exists | `$project/AGENTS.md`, `$project/.agents/skills` | next_turn |
+| Codex plugin | Codex plugin/registration present | same Agents-flavoured paths | next_turn |
+| Claude Code | Claude plugin/registration or `~/.claude` | Agents paths; optional aliases | next_session |
+| Gemini CLI | `GEMINI.md` already present or `~/.gemini` | Agents paths; do not create `GEMINI.md` unless it is already a Punaro alias | next_session |
+| Unknown installed agent dir | other known vendor dirs | none | `unsupported` |
+
+Install **only** Punaro-managed `AGENTS.md` and skill trees. Never overwrite
+credentials, settings, sessions, caches, or unmanaged local skills. Collision
+or local modification of a managed file is `drifted`.
+
+### Claude aliases
+
+When `claude_aliases` is true:
+
+- `$project/CLAUDE.md` → `$project/AGENTS.md`
+- `$project/.claude/skills` → `$project/.agents/skills` if the Claude skills
+  directory is absent or already a Punaro-managed alias
+- Same idea for machine-global files under the Punaro-managed global tree
+
+POSIX: `os.Symlink`. Windows: `os.Symlink` (survives reboot, does not weaken
+ACLs). If symlink creation is unsupported, report `unsupported` and do not
+copy. A colliding regular Claude file that is not a Punaro-managed alias is
+never overwritten.
+
+## Status, doctor, Canopi
+
+`punaro fleet-config status` aggregates desired + each enrolled client's
+latest status row. States: `current`, `pending`, `applying`, `failed`,
+`offline`, `drifted`, `unsupported`, `restart_required`. Also print source
+commit, release digest, generation, trailer/alias/project-match **states**,
+and activation enum. Omit contents, host paths, raw errors.
+
+Doctor adds content-free checks with stable codes, for example
+`fleet_config_desired`, `fleet_config_client_stale`, `fleet_config_drifted`,
+`fleet_config_failed`, `fleet_config_unsupported`, wired through
+`internal/diagnostic` the same way as existing adapter checks.
+
+Canopi/dashboard hooks receive the same bounded fields as lifecycle events
+(generation changed, client state changed). No bodies.
+
+Offline: last report older than twice the adapter poll interval (recorded as
+`offline` by status aggregation, not by guessing).
+
+## Security & Privacy
+
+- Treat published Git contents as untrusted data, never control-plane input.
+- Server-side enrolled identity is the only authority. Client-provided paths,
+  project names, and alias choices cannot change desired fleet state.
+- Revoked clients cannot fetch or report.
+- At-least-once with durable digest identity; never claim exactly-once.
+- No credentials, JWTs, Access headers, `AGENTS.md`, or skill bytes in logs.
+- Independent deployability: `punarod` serves HTTP; adapters apply locally;
+  Telegram gateway is untouched.
+- Public origin stays closed; Access is admission, not authorization.
+
+## Observability
+
+Log only digest, generation, client id, state enum, and skill/file counts.
+Metrics: publish success/fail, fetch status codes (not bodies), apply
+success/fail, drift count. Audit events are content-free.
+
+## Rollout
+
+1. Schema 058 via the existing operator update transaction.
+2. Adapter binary with reconciler; old adapters ignore the new wake topic.
+3. LAN qualification on `mac-studio`, `coso`, `mattone` per
+   `docs/durable-role-lan-e2e.md` safety rules.
+4. Add the workflow as **unchecked** boxes in `docs/security-release-gates.md`.
+   `./scripts/verify-release-gates.sh` must still refuse checked boxes without
+   official `docs/release-evidence/`.
+5. README split only after LAN evidence exists.
+
+Rollback of a bad desired release is `fleet-config publish` of the previous
+commit. Rollback of the feature is: stop publishing, adapters keep
+last-known-good.
+
+## LAN qualification
+
+Owner-managed hosts named in `docs/durable-role-lan-e2e.md`. Real platform
+execution for filesystem/ACL/symlink/junction behavior. Record a redacted
+personal record under `docs/deployment-validation/`. If a host is unreachable,
+record `lan-unreachable` and stop; do not substitute path simulation.
+
+Minimum scenarios: the parent plan
+`.plans/210-fleet-global-agent-config.md` list (publish with two project trees,
+wake+fetch+apply on three clients, top-level match + override, trailer
+survival, Claude alias or unsupported on Windows, offline reconverge, revoked
+denial, invalid/corrupt/interrupted/drift/unsupported/rollback, repo change
+without publish is a no-op, content-free status/doctor).
+
+## Tracker updates
+
+GitHub #210–#217 predate the three operator additions. Proposed additions
+(apply to issue bodies; do not silently ship undocumented behavior):
+
+- **#210 / #211:** source layout includes `projects/<name>/`; trailer markers
+  are illegal in source; v1 data-only includes `scripts/` as inert files.
+- **#214:** top-level project match, per-machine overrides, trailer create/preserve.
+- **#215:** opt-in Claude aliases, POSIX symlink / Windows fail-closed.
+- **#216:** expose trailer/alias/project-match states without contents.
+- **#217:** LAN hosts `mac-studio`, `coso`, `mattone`; include those scenarios.
+
+## Alternatives Considered
+
+1. **Watch a branch / tag.** Rejected: mutable desired state, no operator
+   confirmation, contradicts #210.
+2. **Client-side Git pull.** Rejected: clients would need repo credentials and
+   could diverge; Punaro would not have a single content-addressed release.
+3. **Reuse `internal/release` product artifacts.** Rejected: different trust
+   domain (signed binaries vs operator Git data).
+4. **Copy Claude files instead of symlinks.** Rejected: duplicates drift and
+   weakens the “one fleet prefix” invariant; Windows copy would also bypass
+   the fail-closed ACL requirement.
+5. **Filesystem blob store for archives.** Deferred: v1 size bound fits
+   `bytea`; a blob root would be a new deployable path.
+
+## Open Questions
+
+None. The parent execution plan already chose commit-only publish, trailer
+markers, top-level match, and fail-closed Windows aliases.
+
+## References
+
+- GitHub #210–#217
+- `.plans/210-fleet-global-agent-config.md`
+- `DESIGN.md` (wake hints, signed requests, enrollment)
+- `docs/platform-contracts.md`
+- `docs/durable-role-lan-e2e.md`
+- `docs/security-release-gates.md`
+- Agent Skills v1 (`SKILL.md` YAML `name` + `description`)
+
+## PR Plan
+
+### PR 1: Define the immutable fleet-global configuration release contract
+- **Description:** Add `internal/fleetconfig` with source layout, strict validation, deterministic materialization, data-only classification, commit-id parsing, and trailer-not-in-source rules. Document the contract. No HTTP, no CLI publish yet.
+- **Files/components affected:** `internal/fleetconfig/`, `docs/fleet-global-agent-config.md`, `DESIGN.md`
+- **Dependencies:** None
+
+### PR 2: Add explicit fleet-config publish and rollback
+- **Description:** `punaro fleet-config configure|publish` requiring a full commit identity, preview+`--yes` preview-hash, materialize-before-desired, idempotent retry, rollback as republish. Schema 058 releases+desired. Failed publish leaves prior desired unchanged.
+- **Files/components affected:** `cmd/punaro/`, `internal/postgres/migrations/058_fleet_config.sql`, `internal/postgres/` store, `internal/operator/`, `docs/operator-guide.md`
+- **Dependencies:** PR 1
+
+### PR 3: Add authenticated desired-state and configuration release distribution
+- **Description:** Client HTTP desired/fetch/status, enrolled-identity auth, revocation, stale generation, replay, size bounds, concurrent publication tests, payload-free wake broadcast, no client publish routes, `fleet.client_status`.
+- **Files/components affected:** `internal/relay/http.go`, `internal/relay/notifier.go`, `internal/postgres/`, `internal/relay/http_test.go`
+- **Dependencies:** PR 2
+
+### PR 4: Add the cross-platform fleet configuration reconciler
+- **Description:** Adapter reconcile on start/poll/wake: fetch, verify, stage, atomic apply, last-known-good, serialized lock, protected files, top-level project match, per-machine overrides, trailer create/preserve, drift on fleet-prefix edits.
+- **Files/components affected:** `internal/fleetconfig/` apply/trailer/match, `internal/adapter/`, `cmd/punaro-adapter/`, `//go:build` platform files
+- **Dependencies:** PR 3
+
+### PR 5: Project fleet-global instructions and skills into coding-agent harnesses
+- **Description:** Built-in harness adapters, drift vs merge, activation enums, opt-in Claude aliases (POSIX symlink, Windows equivalent or fail closed, never overwrite unmanaged Claude files).
+- **Files/components affected:** `internal/fleetconfig/harness.go`, `internal/fleetconfig/alias_*.go`, `cmd/punaro-adapter/`
+- **Dependencies:** PR 4
+
+### PR 6: Expose fleet configuration convergence in status, doctor, and Canopi
+- **Description:** `punaro fleet-config status` and doctor checks; content-free Canopi/dashboard hooks; trailer/alias/project-match states; no contents/paths/raw errors.
+- **Files/components affected:** `cmd/punaro/`, `internal/diagnostic/`, `internal/canopi/`, `docs/user-guide.md`, `docs/operator-guide.md`
+- **Dependencies:** PR 5
+
+### PR 7: Qualify fleet configuration publish, convergence, and rollback end to end
+- **Description:** LAN runbook, redacted `docs/deployment-validation/` record, unchecked security-release-gate entries, compatibility/CI wiring that still refuses checked boxes without official release-evidence.
+- **Files/components affected:** `docs/durable-role-lan-e2e.md` (pointer), `docs/security-release-gates.md`, `docs/deployment-validation/`, `scripts/verify-release-gates.sh`, `.github/workflows/quality.yml` if needed
+- **Dependencies:** PR 6
+
+### PR 8: Reorganize README after LAN qualification
+- **Description:** README contains only what Punaro is, status, architecture sketch, shortest safe quick start, security pointer, and links. Relocate setup/config/runbooks/Telegram/attachments/fleet-config usage into user-guide docs without deleting information.
+- **Files/components affected:** `README.md`, `docs/user-guide.md`, `docs/operator-guide.md`, `docs/installation.md`
+- **Dependencies:** PR 7

--- a/internal/fleetconfig/commit.go
+++ b/internal/fleetconfig/commit.go
@@ -1,0 +1,16 @@
+package fleetconfig
+
+import (
+	"errors"
+	"regexp"
+)
+
+var commitIDPattern = regexp.MustCompile(`^[0-9a-f]{40}$|^[0-9a-f]{64}$`)
+
+// ParseCommitID accepts a full immutable Git commit identity only.
+func ParseCommitID(id string) (string, error) {
+	if !commitIDPattern.MatchString(id) {
+		return "", errors.New("commit identity must be a full lowercase Git object name")
+	}
+	return id, nil
+}

--- a/internal/fleetconfig/commit_test.go
+++ b/internal/fleetconfig/commit_test.go
@@ -1,0 +1,39 @@
+package fleetconfig
+
+import "testing"
+
+func TestParseCommitIDAcceptsFullImmutableIdentities(t *testing.T) {
+	t.Parallel()
+	sha1 := "0123456789abcdef0123456789abcdef01234567"
+	sha256 := "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+	for _, id := range []string{sha1, sha256} {
+		got, err := ParseCommitID(id)
+		if err != nil || got != id {
+			t.Fatalf("id=%q got=%q err=%v", id, got, err)
+		}
+	}
+}
+
+func TestParseCommitIDRejectsMutableAndPartialIdentities(t *testing.T) {
+	t.Parallel()
+	for _, id := range []string{
+		"",
+		"HEAD",
+		"main",
+		"origin/main",
+		"refs/heads/main",
+		"v1.0.0",
+		"abc1234",
+		"0123456789ABCDEF0123456789ABCDEF01234567",
+		"0123456789abcdef0123456789abcdef0123456",
+		"0123456789abcdef0123456789abcdef012345678",
+		"0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcde",
+		"0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdeg",
+		"0123456789abcdef0123456789abcdef01234567\n",
+		" 0123456789abcdef0123456789abcdef01234567",
+	} {
+		if _, err := ParseCommitID(id); err == nil {
+			t.Fatalf("accepted %q", id)
+		}
+	}
+}

--- a/internal/fleetconfig/hardlink_other.go
+++ b/internal/fleetconfig/hardlink_other.go
@@ -1,7 +1,12 @@
-//go:build !unix
+//go:build !unix && !windows
 
 package fleetconfig
 
-import "io/fs"
+import (
+	"io/fs"
+	"os"
+)
 
 func extraHardLink(fs.FileInfo) bool { return false }
+
+func extraHardLinkFile(*os.File) bool { return false }

--- a/internal/fleetconfig/hardlink_other.go
+++ b/internal/fleetconfig/hardlink_other.go
@@ -1,0 +1,7 @@
+//go:build !unix
+
+package fleetconfig
+
+import "io/fs"
+
+func extraHardLink(fs.FileInfo) bool { return false }

--- a/internal/fleetconfig/hardlink_unix.go
+++ b/internal/fleetconfig/hardlink_unix.go
@@ -1,0 +1,13 @@
+//go:build unix
+
+package fleetconfig
+
+import (
+	"io/fs"
+	"syscall"
+)
+
+func extraHardLink(info fs.FileInfo) bool {
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	return ok && stat.Nlink > 1
+}

--- a/internal/fleetconfig/hardlink_unix.go
+++ b/internal/fleetconfig/hardlink_unix.go
@@ -4,10 +4,16 @@ package fleetconfig
 
 import (
 	"io/fs"
+	"os"
 	"syscall"
 )
 
 func extraHardLink(info fs.FileInfo) bool {
 	stat, ok := info.Sys().(*syscall.Stat_t)
 	return ok && stat.Nlink > 1
+}
+
+func extraHardLinkFile(file *os.File) bool {
+	info, err := file.Stat()
+	return err != nil || extraHardLink(info)
 }

--- a/internal/fleetconfig/hardlink_windows.go
+++ b/internal/fleetconfig/hardlink_windows.go
@@ -1,0 +1,20 @@
+//go:build windows
+
+package fleetconfig
+
+import (
+	"io/fs"
+	"os"
+
+	"golang.org/x/sys/windows"
+)
+
+func extraHardLink(fs.FileInfo) bool { return false }
+
+func extraHardLinkFile(file *os.File) bool {
+	var info windows.ByHandleFileInformation
+	if err := windows.GetFileInformationByHandle(windows.Handle(file.Fd()), &info); err != nil {
+		return true
+	}
+	return info.NumberOfLinks > 1
+}

--- a/internal/fleetconfig/inspect.go
+++ b/internal/fleetconfig/inspect.go
@@ -102,17 +102,7 @@ func canonicalPath(path string) (string, error) {
 	if path == "" || strings.Contains(path, "\\") || strings.ContainsRune(path, 0) || strings.HasPrefix(path, "/") {
 		return "", errors.New("fleet-config path is invalid")
 	}
-	if len(path) > 255 {
-		return "", errors.New("fleet-config path is invalid")
-	}
-	slash := strings.LastIndex(path, "/")
-	name := path
-	prefix := ""
-	if slash >= 0 {
-		name = path[slash+1:]
-		prefix = path[:slash]
-	}
-	if len(name) > 100 || len(prefix) > 155 {
+	if !ustarRepresentable(path) {
 		return "", errors.New("fleet-config path is invalid")
 	}
 	for i := 0; i < len(path); i++ {
@@ -127,6 +117,27 @@ func canonicalPath(path string) (string, error) {
 		}
 	}
 	return path, nil
+}
+
+// ustarRepresentable matches archive/tar FormatUSTAR: last '/' within the first
+// 156 bytes must leave a 1..155 byte prefix and 1..100 byte suffix.
+func ustarRepresentable(path string) bool {
+	if path == "" || len(path) > 255 || path[len(path)-1] == '/' {
+		return false
+	}
+	if len(path) <= 100 {
+		return true
+	}
+	n := len(path)
+	if n > 156 {
+		n = 156
+	}
+	i := strings.LastIndex(path[:n], "/")
+	if i <= 0 {
+		return false
+	}
+	nameLen := len(path) - i - 1
+	return nameLen > 0 && nameLen <= 100 && i <= 155
 }
 
 func windowsSafeName(part string) bool {

--- a/internal/fleetconfig/inspect.go
+++ b/internal/fleetconfig/inspect.go
@@ -2,6 +2,7 @@ package fleetconfig
 
 import (
 	"errors"
+	"io"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -20,14 +21,15 @@ func InspectRoot(root string) (Tree, error) {
 	if !info.IsDir() || info.Mode()&os.ModeSymlink != 0 {
 		return Tree{}, errors.New("fleet-config source root must be a directory")
 	}
+	scoped, err := os.OpenRoot(root)
+	if err != nil {
+		return Tree{}, errors.New("fleet-config source root is unavailable")
+	}
+	defer func() { _ = scoped.Close() }()
 	var files []File
-	err = filepath.WalkDir(root, func(path string, entry fs.DirEntry, walkErr error) error {
+	err = fs.WalkDir(scoped.FS(), ".", func(rel string, entry fs.DirEntry, walkErr error) error {
 		if walkErr != nil {
 			return errors.New("fleet-config source walk failed")
-		}
-		rel, relErr := filepath.Rel(root, path)
-		if relErr != nil {
-			return errors.New("fleet-config source path is invalid")
 		}
 		if rel == "." {
 			return nil
@@ -35,6 +37,9 @@ func InspectRoot(root string) (Tree, error) {
 		slash, pathErr := canonicalPath(filepath.ToSlash(rel))
 		if pathErr != nil {
 			return pathErr
+		}
+		if entry.Type()&os.ModeSymlink != 0 {
+			return errors.New("fleet-config source must not contain links")
 		}
 		info, err := entry.Info()
 		if err != nil {
@@ -55,11 +60,21 @@ func InspectRoot(root string) (Tree, error) {
 		if info.Size() > MaxFileBytes {
 			return errors.New("fleet-config file is too large")
 		}
-		data, err := os.ReadFile(path) // #nosec G304 -- bounded walk of a caller-selected source tree.
+		file, err := scoped.OpenFile(rel, os.O_RDONLY, 0)
 		if err != nil {
 			return errors.New("fleet-config source walk failed")
 		}
-		if int64(len(data)) != info.Size() {
+		opened, statErr := file.Stat()
+		if statErr != nil || !opened.Mode().IsRegular() || opened.Mode()&os.ModeSymlink != 0 {
+			_ = file.Close()
+			return errors.New("fleet-config source contains a special file")
+		}
+		data, readErr := io.ReadAll(io.LimitReader(file, MaxFileBytes+1))
+		_ = file.Close()
+		if readErr != nil {
+			return errors.New("fleet-config source walk failed")
+		}
+		if int64(len(data)) != info.Size() || int64(len(data)) != opened.Size() {
 			return errors.New("fleet-config source file changed during read")
 		}
 		files = append(files, File{Path: slash, Data: data})

--- a/internal/fleetconfig/inspect.go
+++ b/internal/fleetconfig/inspect.go
@@ -74,7 +74,7 @@ func InspectRoot(root string) (Tree, error) {
 			return errors.New("fleet-config source walk failed")
 		}
 		opened, statErr := file.Stat()
-		if statErr != nil || !opened.Mode().IsRegular() || opened.Mode()&os.ModeSymlink != 0 || !os.SameFile(info, opened) {
+		if statErr != nil || !opened.Mode().IsRegular() || opened.Mode()&os.ModeSymlink != 0 || !os.SameFile(info, opened) || extraHardLink(opened) || extraHardLinkFile(file) {
 			_ = file.Close()
 			return errors.New("fleet-config source contains a special file")
 		}
@@ -102,7 +102,7 @@ func canonicalPath(path string) (string, error) {
 	if path == "" || strings.Contains(path, "\\") || strings.ContainsRune(path, 0) || strings.HasPrefix(path, "/") {
 		return "", errors.New("fleet-config path is invalid")
 	}
-	if len(path) > 100 {
+	if len(path) > 255 {
 		return "", errors.New("fleet-config path is invalid")
 	}
 	for i := 0; i < len(path); i++ {

--- a/internal/fleetconfig/inspect.go
+++ b/internal/fleetconfig/inspect.go
@@ -26,6 +26,15 @@ func InspectRoot(root string) (Tree, error) {
 		return Tree{}, errors.New("fleet-config source root is unavailable")
 	}
 	defer func() { _ = scoped.Close() }()
+	dot, err := scoped.Open(".")
+	if err != nil {
+		return Tree{}, errors.New("fleet-config source root is unavailable")
+	}
+	openedRoot, statErr := dot.Stat()
+	_ = dot.Close()
+	if statErr != nil || !os.SameFile(info, openedRoot) {
+		return Tree{}, errors.New("fleet-config source root is unavailable")
+	}
 	var files []File
 	err = fs.WalkDir(scoped.FS(), ".", func(rel string, entry fs.DirEntry, walkErr error) error {
 		if walkErr != nil {
@@ -93,11 +102,39 @@ func canonicalPath(path string) (string, error) {
 	if path == "" || strings.Contains(path, "\\") || strings.ContainsRune(path, 0) || strings.HasPrefix(path, "/") {
 		return "", errors.New("fleet-config path is invalid")
 	}
+	if len(path) > 100 {
+		return "", errors.New("fleet-config path is invalid")
+	}
+	for i := 0; i < len(path); i++ {
+		if path[i] > 127 {
+			return "", errors.New("fleet-config path is invalid")
+		}
+	}
 	parts := strings.Split(path, "/")
 	for _, part := range parts {
-		if part == "" || part == "." || part == ".." {
+		if part == "" || part == "." || part == ".." || !windowsSafeName(part) {
 			return "", errors.New("fleet-config path is invalid")
 		}
 	}
 	return path, nil
+}
+
+func windowsSafeName(part string) bool {
+	if strings.HasSuffix(part, " ") || strings.HasSuffix(part, ".") {
+		return false
+	}
+	if strings.ContainsAny(part, `<>:"|?*`) {
+		return false
+	}
+	base := strings.ToUpper(part)
+	if i := strings.IndexByte(base, '.'); i >= 0 {
+		base = base[:i]
+	}
+	switch base {
+	case "CON", "PRN", "AUX", "NUL",
+		"COM1", "COM2", "COM3", "COM4", "COM5", "COM6", "COM7", "COM8", "COM9",
+		"LPT1", "LPT2", "LPT3", "LPT4", "LPT5", "LPT6", "LPT7", "LPT8", "LPT9":
+		return false
+	}
+	return true
 }

--- a/internal/fleetconfig/inspect.go
+++ b/internal/fleetconfig/inspect.go
@@ -105,6 +105,16 @@ func canonicalPath(path string) (string, error) {
 	if len(path) > 255 {
 		return "", errors.New("fleet-config path is invalid")
 	}
+	slash := strings.LastIndex(path, "/")
+	name := path
+	prefix := ""
+	if slash >= 0 {
+		name = path[slash+1:]
+		prefix = path[:slash]
+	}
+	if len(name) > 100 || len(prefix) > 155 {
+		return "", errors.New("fleet-config path is invalid")
+	}
 	for i := 0; i < len(path); i++ {
 		if path[i] > 127 {
 			return "", errors.New("fleet-config path is invalid")
@@ -122,6 +132,11 @@ func canonicalPath(path string) (string, error) {
 func windowsSafeName(part string) bool {
 	if strings.HasSuffix(part, " ") || strings.HasSuffix(part, ".") {
 		return false
+	}
+	for i := 0; i < len(part); i++ {
+		if part[i] < 32 {
+			return false
+		}
 	}
 	if strings.ContainsAny(part, `<>:"|?*`) {
 		return false

--- a/internal/fleetconfig/inspect.go
+++ b/internal/fleetconfig/inspect.go
@@ -1,0 +1,88 @@
+package fleetconfig
+
+import (
+	"errors"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// InspectRoot reads a source checkout using Lstat and never follows links.
+func InspectRoot(root string) (Tree, error) {
+	if root == "" {
+		return Tree{}, errors.New("fleet-config source root is required")
+	}
+	info, err := os.Lstat(root)
+	if err != nil {
+		return Tree{}, errors.New("fleet-config source root is unavailable")
+	}
+	if !info.IsDir() || info.Mode()&os.ModeSymlink != 0 {
+		return Tree{}, errors.New("fleet-config source root must be a directory")
+	}
+	var files []File
+	err = filepath.WalkDir(root, func(path string, entry fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return errors.New("fleet-config source walk failed")
+		}
+		rel, relErr := filepath.Rel(root, path)
+		if relErr != nil {
+			return errors.New("fleet-config source path is invalid")
+		}
+		if rel == "." {
+			return nil
+		}
+		slash, pathErr := canonicalPath(filepath.ToSlash(rel))
+		if pathErr != nil {
+			return pathErr
+		}
+		info, err := entry.Info()
+		if err != nil {
+			return errors.New("fleet-config source walk failed")
+		}
+		if info.Mode()&os.ModeSymlink != 0 {
+			return errors.New("fleet-config source must not contain links")
+		}
+		if entry.IsDir() {
+			return nil
+		}
+		if !info.Mode().IsRegular() {
+			return errors.New("fleet-config source contains a special file")
+		}
+		if extraHardLink(info) {
+			return errors.New("fleet-config source contains a special file")
+		}
+		if info.Size() > MaxFileBytes {
+			return errors.New("fleet-config file is too large")
+		}
+		data, err := os.ReadFile(path) // #nosec G304 -- bounded walk of a caller-selected source tree.
+		if err != nil {
+			return errors.New("fleet-config source walk failed")
+		}
+		if int64(len(data)) != info.Size() {
+			return errors.New("fleet-config source file changed during read")
+		}
+		files = append(files, File{Path: slash, Data: data})
+		if len(files) > MaxFiles {
+			return errors.New("fleet-config source has too many files")
+		}
+		return nil
+	})
+	if err != nil {
+		return Tree{}, err
+	}
+	return Tree{Files: files}, nil
+}
+
+func canonicalPath(path string) (string, error) {
+	if path == "" || strings.Contains(path, "\\") || strings.ContainsRune(path, 0) || strings.HasPrefix(path, "/") {
+		return "", errors.New("fleet-config path is invalid")
+	}
+	parts := strings.Split(path, "/")
+	for _, part := range parts {
+		if part == "" || part == "." || part == ".." {
+			return "", errors.New("fleet-config path is invalid")
+		}
+	}
+	return path, nil
+}

--- a/internal/fleetconfig/inspect.go
+++ b/internal/fleetconfig/inspect.go
@@ -74,7 +74,7 @@ func InspectRoot(root string) (Tree, error) {
 			return errors.New("fleet-config source walk failed")
 		}
 		opened, statErr := file.Stat()
-		if statErr != nil || !opened.Mode().IsRegular() || opened.Mode()&os.ModeSymlink != 0 {
+		if statErr != nil || !opened.Mode().IsRegular() || opened.Mode()&os.ModeSymlink != 0 || !os.SameFile(info, opened) {
 			_ = file.Close()
 			return errors.New("fleet-config source contains a special file")
 		}

--- a/internal/fleetconfig/materialize.go
+++ b/internal/fleetconfig/materialize.go
@@ -119,7 +119,7 @@ func archiveDirectories(files []File) []string {
 				break
 			}
 			dir = dir[:slash]
-			seen[dir+"/"] = struct{}{}
+			seen[dir] = struct{}{}
 		}
 	}
 	dirs := make([]string, 0, len(seen))

--- a/internal/fleetconfig/materialize.go
+++ b/internal/fleetconfig/materialize.go
@@ -1,0 +1,131 @@
+package fleetconfig
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// Materialize builds a deterministic, data-only v1 release from a source tree.
+func Materialize(tree Tree, sourceCommit string) (Release, error) {
+	commit, err := ParseCommitID(sourceCommit)
+	if err != nil {
+		return Release{}, err
+	}
+	if err := Validate(tree); err != nil {
+		return Release{}, err
+	}
+	files := append([]File(nil), tree.Files...)
+	sort.Slice(files, func(i, j int) bool { return files[i].Path < files[j].Path })
+	manifest := make([]ManifestFile, 0, len(files))
+	var total int64
+	var digestPlain bytes.Buffer
+	_, _ = digestPlain.WriteString("fleet-config-v1\n")
+	_, _ = digestPlain.WriteString(commit)
+	_, _ = digestPlain.WriteString("\n")
+	for _, file := range files {
+		sum := sha256.Sum256(file.Data)
+		hexSum := hex.EncodeToString(sum[:])
+		size := int64(len(file.Data))
+		total += size
+		manifest = append(manifest, ManifestFile{Path: file.Path, Size: size, SHA256: hexSum})
+		_, _ = digestPlain.WriteString(file.Path)
+		_ = digestPlain.WriteByte(0)
+		_, _ = digestPlain.WriteString(strconv.FormatInt(size, 10))
+		_ = digestPlain.WriteByte(0)
+		_, _ = digestPlain.WriteString(hexSum)
+		_, _ = digestPlain.WriteString("\n")
+	}
+	digestSum := sha256.Sum256(digestPlain.Bytes())
+	digest := hex.EncodeToString(digestSum[:])
+	archive, err := writeArchive(files)
+	if err != nil {
+		return Release{}, err
+	}
+	return Release{
+		Schema:             SchemaV1,
+		SourceCommit:       commit,
+		Digest:             digest,
+		Archive:            archive,
+		Files:              manifest,
+		SkillCount:         tree.SkillCount(),
+		TotalBytes:         total,
+		DataOnly:           true,
+		ActivationCommands: 0,
+		Destinations:       nil,
+	}, nil
+}
+
+func writeArchive(files []File) ([]byte, error) {
+	var raw bytes.Buffer
+	gzipWriter := gzip.NewWriter(&raw)
+	gzipWriter.Name = ""
+	gzipWriter.ModTime = time.Unix(0, 0).UTC()
+	gzipWriter.OS = 3
+	tarWriter := tar.NewWriter(gzipWriter)
+	dirs := archiveDirectories(files)
+	for _, dir := range dirs {
+		if err := tarWriter.WriteHeader(&tar.Header{
+			Typeflag: tar.TypeDir,
+			Name:     dir,
+			Mode:     0o755,
+			ModTime:  time.Unix(0, 0).UTC(),
+			Format:   tar.FormatUSTAR,
+		}); err != nil {
+			return nil, errors.New("fleet-config archive failed")
+		}
+	}
+	for _, file := range files {
+		if err := tarWriter.WriteHeader(&tar.Header{
+			Typeflag: tar.TypeReg,
+			Name:     file.Path,
+			Size:     int64(len(file.Data)),
+			Mode:     0o644,
+			ModTime:  time.Unix(0, 0).UTC(),
+			Format:   tar.FormatUSTAR,
+		}); err != nil {
+			return nil, errors.New("fleet-config archive failed")
+		}
+		if _, err := tarWriter.Write(file.Data); err != nil {
+			return nil, errors.New("fleet-config archive failed")
+		}
+	}
+	if err := tarWriter.Close(); err != nil {
+		return nil, errors.New("fleet-config archive failed")
+	}
+	if err := gzipWriter.Close(); err != nil {
+		return nil, errors.New("fleet-config archive failed")
+	}
+	if raw.Len() == 0 {
+		return nil, errors.New("fleet-config archive failed")
+	}
+	return raw.Bytes(), nil
+}
+
+func archiveDirectories(files []File) []string {
+	seen := map[string]struct{}{}
+	for _, file := range files {
+		dir := file.Path
+		for {
+			slash := strings.LastIndex(dir, "/")
+			if slash <= 0 {
+				break
+			}
+			dir = dir[:slash]
+			seen[dir+"/"] = struct{}{}
+		}
+	}
+	dirs := make([]string, 0, len(seen))
+	for dir := range seen {
+		dirs = append(dirs, dir)
+	}
+	sort.Strings(dirs)
+	return dirs
+}

--- a/internal/fleetconfig/materialize_test.go
+++ b/internal/fleetconfig/materialize_test.go
@@ -11,10 +11,10 @@ const testCommit = "0123456789abcdef0123456789abcdef01234567"
 func TestMaterializeIsDeterministicAndOmitsTrailer(t *testing.T) {
 	t.Parallel()
 	root := writeTree(t, map[string]string{
-		"AGENTS.md":                  "# fleet\n",
-		"skills/demo/SKILL.md":       skillMarkdown("demo", "A bounded demo skill."),
+		"AGENTS.md":                    "# fleet\n",
+		"skills/demo/SKILL.md":         skillMarkdown("demo", "A bounded demo skill."),
 		"skills/demo/scripts/hint.txt": "data only\n",
-		"projects/punaro/AGENTS.md":  "# punaro\n",
+		"projects/punaro/AGENTS.md":    "# punaro\n",
 	})
 	tree, err := InspectRoot(root)
 	if err != nil {

--- a/internal/fleetconfig/materialize_test.go
+++ b/internal/fleetconfig/materialize_test.go
@@ -92,3 +92,16 @@ func TestMaterializeRejectsInvalidCommit(t *testing.T) {
 		t.Fatal("materialized a branch name")
 	}
 }
+
+func TestMaterializeArchivesHundredByteDirectory(t *testing.T) {
+	t.Parallel()
+	dir := strings.Repeat("c", 100)
+	tree := Tree{Files: []File{
+		{Path: "AGENTS.md", Data: []byte("# fleet\n")},
+		{Path: "skills/demo/SKILL.md", Data: []byte(skillMarkdown("demo", "Demo skill."))},
+		{Path: "skills/demo/" + dir + "/x", Data: []byte("data\n")},
+	}}
+	if _, err := Materialize(tree, testCommit); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/fleetconfig/materialize_test.go
+++ b/internal/fleetconfig/materialize_test.go
@@ -1,0 +1,88 @@
+package fleetconfig
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+const testCommit = "0123456789abcdef0123456789abcdef01234567"
+
+func TestMaterializeIsDeterministicAndOmitsTrailer(t *testing.T) {
+	t.Parallel()
+	root := writeTree(t, map[string]string{
+		"AGENTS.md":                  "# fleet\n",
+		"skills/demo/SKILL.md":       skillMarkdown("demo", "A bounded demo skill."),
+		"skills/demo/scripts/hint.txt": "data only\n",
+		"projects/punaro/AGENTS.md":  "# punaro\n",
+	})
+	tree, err := InspectRoot(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	first, err := Materialize(tree, testCommit)
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := Materialize(tree, testCommit)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first.Digest != second.Digest || !bytes.Equal(first.Archive, second.Archive) {
+		t.Fatal("identical input produced different release bytes")
+	}
+	if first.SourceCommit != testCommit || first.SkillCount != 1 || first.TotalBytes == 0 {
+		t.Fatalf("manifest=%#v", first)
+	}
+	if !strings.HasPrefix(first.Digest, "") || len(first.Digest) != 64 {
+		t.Fatalf("digest=%q", first.Digest)
+	}
+	if bytes.Contains(first.Archive, []byte(TrailerStart)) || bytes.Contains(first.Archive, []byte(TrailerEnd)) {
+		t.Fatal("trailer text present in published archive")
+	}
+	if bytes.Contains(first.Archive, []byte("/bin/sh")) && bytes.Contains(first.Archive, []byte("post-install")) {
+		t.Fatal("activation metadata leaked into archive")
+	}
+	seenAgents := false
+	for _, file := range first.Files {
+		if file.Path == "AGENTS.md" {
+			seenAgents = true
+		}
+		if strings.Contains(file.Path, "\\") || strings.HasPrefix(file.Path, "/") || strings.Contains(file.Path, "..") {
+			t.Fatalf("unsafe path %q", file.Path)
+		}
+		if file.Size <= 0 || len(file.SHA256) != 64 {
+			t.Fatalf("file=%#v", file)
+		}
+	}
+	if !seenAgents {
+		t.Fatal("AGENTS.md missing from manifest")
+	}
+}
+
+func TestMaterializeClassifiesReleaseAsDataOnly(t *testing.T) {
+	t.Parallel()
+	tree := Tree{Files: []File{
+		{Path: "AGENTS.md", Data: []byte("# fleet\n")},
+		{Path: "skills/demo/SKILL.md", Data: []byte(skillMarkdown("demo", "Demo skill."))},
+		{Path: "skills/demo/scripts/run.sh", Data: []byte("#!/bin/sh\necho hi\n")},
+	}}
+	release, err := Materialize(tree, testCommit)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !release.DataOnly {
+		t.Fatal("scripts/ caused the release to leave data-only classification")
+	}
+	if release.ActivationCommands != 0 || len(release.Destinations) != 0 {
+		t.Fatalf("activation leaked: %#v", release)
+	}
+}
+
+func TestMaterializeRejectsInvalidCommit(t *testing.T) {
+	t.Parallel()
+	tree := Tree{Files: []File{{Path: "AGENTS.md", Data: []byte("# fleet\n")}}}
+	if _, err := Materialize(tree, "main"); err == nil {
+		t.Fatal("materialized a branch name")
+	}
+}

--- a/internal/fleetconfig/materialize_test.go
+++ b/internal/fleetconfig/materialize_test.go
@@ -34,8 +34,14 @@ func TestMaterializeIsDeterministicAndOmitsTrailer(t *testing.T) {
 	if first.SourceCommit != testCommit || first.SkillCount != 1 || first.TotalBytes == 0 {
 		t.Fatalf("manifest=%#v", first)
 	}
-	if !strings.HasPrefix(first.Digest, "") || len(first.Digest) != 64 {
+	if len(first.Digest) != 64 {
 		t.Fatalf("digest=%q", first.Digest)
+	}
+	for i := 0; i < len(first.Digest); i++ {
+		c := first.Digest[i]
+		if (c < '0' || c > '9') && (c < 'a' || c > 'f') {
+			t.Fatalf("digest=%q", first.Digest)
+		}
 	}
 	if bytes.Contains(first.Archive, []byte(TrailerStart)) || bytes.Contains(first.Archive, []byte(TrailerEnd)) {
 		t.Fatal("trailer text present in published archive")

--- a/internal/fleetconfig/tree.go
+++ b/internal/fleetconfig/tree.go
@@ -1,0 +1,117 @@
+package fleetconfig
+
+import "sort"
+
+const (
+	// SchemaV1 is the fleet-config source/release schema.
+	SchemaV1 = 1
+	// TrailerStart marks the machine-local AGENTS.md trailer. It is illegal in fleet source.
+	TrailerStart = "<!-- punaro-local-trailer:start -->"
+	// TrailerEnd closes the machine-local trailer.
+	TrailerEnd = "<!-- punaro-local-trailer:end -->"
+	// MaxFileBytes is the per-file bound for v1 source files.
+	MaxFileBytes = 256 << 10
+	// MaxSkills bounds global plus project skills.
+	MaxSkills = 64
+	// MaxFiles bounds archived regular files.
+	MaxFiles = 512
+	// MaxTotalBytes bounds the sum of file contents.
+	MaxTotalBytes = 4 << 20
+)
+
+// File is one regular source file with a slash-separated relative path.
+type File struct {
+	Path string
+	Data []byte
+}
+
+// Tree is a validated or candidate source snapshot.
+type Tree struct {
+	Files []File
+}
+
+// ManifestFile is one path recorded in a materialized release.
+type ManifestFile struct {
+	Path   string
+	Size   int64
+	SHA256 string
+}
+
+// Release is a content-addressed, data-only fleet-config archive plus manifest.
+type Release struct {
+	Schema              int
+	SourceCommit        string
+	Digest              string
+	Archive             []byte
+	Files               []ManifestFile
+	SkillCount          int
+	TotalBytes          int64
+	DataOnly            bool
+	ActivationCommands  int
+	Destinations        []string
+}
+
+// SkillCount counts SKILL.md files in the tree.
+func (tree Tree) SkillCount() int {
+	count := 0
+	for _, file := range tree.Files {
+		if isSkillMarkdown(file.Path) {
+			count++
+		}
+	}
+	return count
+}
+
+// Projects returns sorted unique project names.
+func (tree Tree) Projects() []string {
+	seen := map[string]struct{}{}
+	for _, file := range tree.Files {
+		if name, ok := projectName(file.Path); ok {
+			seen[name] = struct{}{}
+		}
+	}
+	names := make([]string, 0, len(seen))
+	for name := range seen {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+// HasProject reports whether a project tree is present.
+func (tree Tree) HasProject(name string) bool {
+	_, ok := indexOf(tree.Projects(), name)
+	return ok
+}
+
+func indexOf(values []string, want string) (int, bool) {
+	for i, value := range values {
+		if value == want {
+			return i, true
+		}
+	}
+	return 0, false
+}
+
+func isSkillMarkdown(path string) bool {
+	return len(path) >= 9 && path[len(path)-8:] == "SKILL.md" && (path == "SKILL.md" || path[len(path)-9] == '/')
+}
+
+func projectName(path string) (string, bool) {
+	const prefix = "projects/"
+	if len(path) < len(prefix)+1 || path[:len(prefix)] != prefix {
+		return "", false
+	}
+	rest := path[len(prefix):]
+	name, _, ok := splitFirst(rest)
+	return name, ok && name != ""
+}
+
+func splitFirst(path string) (string, string, bool) {
+	for i := 0; i < len(path); i++ {
+		if path[i] == '/' {
+			return path[:i], path[i+1:], true
+		}
+	}
+	return path, "", path != ""
+}

--- a/internal/fleetconfig/tree.go
+++ b/internal/fleetconfig/tree.go
@@ -1,3 +1,4 @@
+// Package fleetconfig validates and materializes data-only fleet agent configuration.
 package fleetconfig
 
 import "sort"
@@ -39,23 +40,24 @@ type ManifestFile struct {
 
 // Release is a content-addressed, data-only fleet-config archive plus manifest.
 type Release struct {
-	Schema              int
-	SourceCommit        string
-	Digest              string
-	Archive             []byte
-	Files               []ManifestFile
-	SkillCount          int
-	TotalBytes          int64
-	DataOnly            bool
-	ActivationCommands  int
-	Destinations        []string
+	Schema             int
+	SourceCommit       string
+	Digest             string
+	Archive            []byte
+	Files              []ManifestFile
+	SkillCount         int
+	TotalBytes         int64
+	DataOnly           bool
+	ActivationCommands int
+	Destinations       []string
 }
 
-// SkillCount counts SKILL.md files in the tree.
+// SkillCount counts validated skill roots (SKILL.md at the skill directory).
 func (tree Tree) SkillCount() int {
 	count := 0
 	for _, file := range tree.Files {
-		if isSkillMarkdown(file.Path) {
+		kind, err := classifyPath(file.Path)
+		if err == nil && kind.class == pathSkillMarkdown {
 			count++
 		}
 	}
@@ -91,10 +93,6 @@ func indexOf(values []string, want string) (int, bool) {
 		}
 	}
 	return 0, false
-}
-
-func isSkillMarkdown(path string) bool {
-	return len(path) >= 9 && path[len(path)-8:] == "SKILL.md" && (path == "SKILL.md" || path[len(path)-9] == '/')
 }
 
 func projectName(path string) (string, bool) {

--- a/internal/fleetconfig/validate.go
+++ b/internal/fleetconfig/validate.go
@@ -1,0 +1,200 @@
+package fleetconfig
+
+import (
+	"bytes"
+	"errors"
+	"regexp"
+	"strings"
+	"unicode/utf8"
+)
+
+var (
+	entryNamePattern = regexp.MustCompile(`^[a-z0-9]([a-z0-9._-]{0,62}[a-z0-9])?$`)
+	agentsSuffix     = "AGENTS.md"
+)
+
+// Validate enforces the v1 source-tree contract.
+func Validate(tree Tree) error {
+	if len(tree.Files) == 0 || len(tree.Files) > MaxFiles {
+		return errors.New("fleet-config source layout is invalid")
+	}
+	var total int64
+	seen := map[string]struct{}{}
+	folded := map[string]struct{}{}
+	hasGlobalAgents := false
+	skills := map[string]struct{}{}
+	for _, file := range tree.Files {
+		path, err := canonicalPath(file.Path)
+		if err != nil {
+			return err
+		}
+		if _, exists := seen[path]; exists {
+			return errors.New("fleet-config source contains a duplicate path")
+		}
+		lower := strings.ToLower(path)
+		if _, exists := folded[lower]; exists {
+			return errors.New("fleet-config source contains a case-colliding path")
+		}
+		seen[path] = struct{}{}
+		folded[lower] = struct{}{}
+		if int64(len(file.Data)) > MaxFileBytes {
+			return errors.New("fleet-config file is too large")
+		}
+		total += int64(len(file.Data))
+		if total > MaxTotalBytes {
+			return errors.New("fleet-config source is too large")
+		}
+		kind, err := classifyPath(path)
+		if err != nil {
+			return err
+		}
+		switch kind.class {
+		case pathGlobalAgents, pathProjectAgents:
+			if err := validateAgents(file.Data); err != nil {
+				return err
+			}
+			if kind.class == pathGlobalAgents {
+				hasGlobalAgents = true
+			}
+		case pathSkillMarkdown:
+			if err := validateSkillMarkdown(kind.skill, file.Data); err != nil {
+				return err
+			}
+			skills[kind.skillKey] = struct{}{}
+		case pathSkillData:
+			if bytes.Contains(file.Data, []byte{0}) && isTextPath(path) {
+				return errors.New("fleet-config text file is invalid")
+			}
+		}
+	}
+	if !hasGlobalAgents {
+		return errors.New("fleet-config source requires AGENTS.md")
+	}
+	if len(skills) > MaxSkills {
+		return errors.New("fleet-config source has too many skills")
+	}
+	return nil
+}
+
+type pathClass int
+
+const (
+	pathGlobalAgents pathClass = iota
+	pathProjectAgents
+	pathSkillMarkdown
+	pathSkillData
+)
+
+type classifiedPath struct {
+	class    pathClass
+	skill    string
+	skillKey string
+}
+
+func classifyPath(path string) (classifiedPath, error) {
+	if path == agentsSuffix {
+		return classifiedPath{class: pathGlobalAgents}, nil
+	}
+	switch {
+	case strings.HasPrefix(path, "skills/"):
+		skill, rest, ok := splitFirst(strings.TrimPrefix(path, "skills/"))
+		if !ok || !entryNamePattern.MatchString(skill) || rest == "" {
+			return classifiedPath{}, errors.New("fleet-config skill path is invalid")
+		}
+		if rest == "SKILL.md" {
+			return classifiedPath{class: pathSkillMarkdown, skill: skill, skillKey: "global/" + skill}, nil
+		}
+		if _, err := canonicalPath(rest); err != nil {
+			return classifiedPath{}, err
+		}
+		return classifiedPath{class: pathSkillData, skill: skill, skillKey: "global/" + skill}, nil
+	case strings.HasPrefix(path, "projects/"):
+		project, rest, ok := splitFirst(strings.TrimPrefix(path, "projects/"))
+		if !ok || !entryNamePattern.MatchString(project) || rest == "" {
+			return classifiedPath{}, errors.New("fleet-config project path is invalid")
+		}
+		if rest == agentsSuffix {
+			return classifiedPath{class: pathProjectAgents}, nil
+		}
+		if strings.HasPrefix(rest, "skills/") {
+			skill, skillRest, skillOK := splitFirst(strings.TrimPrefix(rest, "skills/"))
+			if !skillOK || !entryNamePattern.MatchString(skill) || skillRest == "" {
+				return classifiedPath{}, errors.New("fleet-config skill path is invalid")
+			}
+			if skillRest == "SKILL.md" {
+				return classifiedPath{class: pathSkillMarkdown, skill: skill, skillKey: project + "/" + skill}, nil
+			}
+			if _, err := canonicalPath(skillRest); err != nil {
+				return classifiedPath{}, err
+			}
+			return classifiedPath{class: pathSkillData, skill: skill, skillKey: project + "/" + skill}, nil
+		}
+		return classifiedPath{}, errors.New("fleet-config source layout is invalid")
+	default:
+		return classifiedPath{}, errors.New("fleet-config source layout is invalid")
+	}
+}
+
+func validateAgents(data []byte) error {
+	if !utf8.Valid(data) || bytes.Contains(data, []byte{0}) {
+		return errors.New("fleet-config text file is invalid")
+	}
+	if bytes.Contains(data, []byte(TrailerStart)) || bytes.Contains(data, []byte(TrailerEnd)) {
+		return errors.New("fleet-config source must not contain a machine-local trailer")
+	}
+	return nil
+}
+
+func validateSkillMarkdown(directory string, data []byte) error {
+	if !utf8.Valid(data) || bytes.Contains(data, []byte{0}) {
+		return errors.New("fleet-config text file is invalid")
+	}
+	name, description, err := parseSkillFrontmatter(data)
+	if err != nil || name != directory || description == "" {
+		return errors.New("fleet-config skill metadata is invalid")
+	}
+	return nil
+}
+
+func parseSkillFrontmatter(data []byte) (string, string, error) {
+	text := string(data)
+	if !strings.HasPrefix(text, "---\n") && !strings.HasPrefix(text, "---\r\n") {
+		return "", "", errors.New("missing frontmatter")
+	}
+	rest := text[3:]
+	if strings.HasPrefix(rest, "\r\n") {
+		rest = rest[2:]
+	} else if strings.HasPrefix(rest, "\n") {
+		rest = rest[1:]
+	}
+	end := strings.Index(rest, "\n---")
+	if end < 0 {
+		return "", "", errors.New("missing frontmatter")
+	}
+	body := rest[:end]
+	name := ""
+	description := ""
+	for _, line := range strings.Split(body, "\n") {
+		line = strings.TrimRight(line, "\r")
+		key, value, ok := strings.Cut(line, ":")
+		if !ok {
+			continue
+		}
+		key = strings.TrimSpace(key)
+		value = strings.TrimSpace(value)
+		switch key {
+		case "name":
+			name = value
+		case "description":
+			description = value
+		}
+	}
+	if name == "" || description == "" {
+		return "", "", errors.New("missing frontmatter fields")
+	}
+	return name, description, nil
+}
+
+func isTextPath(path string) bool {
+	return strings.HasSuffix(path, ".md") || strings.HasSuffix(path, ".txt")
+}

--- a/internal/fleetconfig/validate.go
+++ b/internal/fleetconfig/validate.go
@@ -69,8 +69,11 @@ func Validate(tree Tree) error {
 			dataSkills[kind.skillKey] = struct{}{}
 		}
 	}
-	if !hasGlobalAgents {
-		return errors.New("fleet-config source requires AGENTS.md")
+	if !hasGlobalAgents || total < 1 {
+		if !hasGlobalAgents {
+			return errors.New("fleet-config source requires AGENTS.md")
+		}
+		return errors.New("fleet-config source layout is invalid")
 	}
 	for key := range dataSkills {
 		if _, ok := skills[key]; !ok {
@@ -109,12 +112,12 @@ func classifyPath(path string) (classifiedPath, error) {
 			return classifiedPath{}, errors.New("fleet-config skill path is invalid")
 		}
 		if rest == "SKILL.md" {
-			return classifiedPath{class: pathSkillMarkdown, skill: skill, skillKey: "global/" + skill}, nil
+			return classifiedPath{class: pathSkillMarkdown, skill: skill, skillKey: "./skills/" + skill}, nil
 		}
 		if _, err := canonicalPath(rest); err != nil {
 			return classifiedPath{}, err
 		}
-		return classifiedPath{class: pathSkillData, skill: skill, skillKey: "global/" + skill}, nil
+		return classifiedPath{class: pathSkillData, skill: skill, skillKey: "./skills/" + skill}, nil
 	case strings.HasPrefix(path, "projects/"):
 		project, rest, ok := splitFirst(strings.TrimPrefix(path, "projects/"))
 		if !ok || !entryNamePattern.MatchString(project) || rest == "" {

--- a/internal/fleetconfig/validate.go
+++ b/internal/fleetconfig/validate.go
@@ -196,7 +196,7 @@ func parseSkillFrontmatter(data []byte) (string, string, error) {
 		if key == "" || strings.ContainsAny(key, " \t") {
 			return "", "", errors.New("missing frontmatter")
 		}
-		if unclosedFlow(value) {
+		if unclosedScalar(value) {
 			return "", "", errors.New("missing frontmatter")
 		}
 		switch key {
@@ -212,11 +212,17 @@ func parseSkillFrontmatter(data []byte) (string, string, error) {
 	return name, description, nil
 }
 
-func unclosedFlow(value string) bool {
+func unclosedScalar(value string) bool {
 	if strings.HasPrefix(value, "[") && !strings.HasSuffix(value, "]") {
 		return true
 	}
 	if strings.HasPrefix(value, "{") && !strings.HasSuffix(value, "}") {
+		return true
+	}
+	if strings.HasPrefix(value, "\"") && !strings.HasSuffix(value, "\"") {
+		return true
+	}
+	if strings.HasPrefix(value, "'") && !strings.HasSuffix(value, "'") {
 		return true
 	}
 	return false

--- a/internal/fleetconfig/validate.go
+++ b/internal/fleetconfig/validate.go
@@ -23,6 +23,7 @@ func Validate(tree Tree) error {
 	folded := map[string]struct{}{}
 	hasGlobalAgents := false
 	skills := map[string]struct{}{}
+	dataSkills := map[string]struct{}{}
 	for _, file := range tree.Files {
 		path, err := canonicalPath(file.Path)
 		if err != nil {
@@ -65,10 +66,16 @@ func Validate(tree Tree) error {
 			if bytes.Contains(file.Data, []byte{0}) && isTextPath(path) {
 				return errors.New("fleet-config text file is invalid")
 			}
+			dataSkills[kind.skillKey] = struct{}{}
 		}
 	}
 	if !hasGlobalAgents {
 		return errors.New("fleet-config source requires AGENTS.md")
+	}
+	for key := range dataSkills {
+		if _, ok := skills[key]; !ok {
+			return errors.New("fleet-config skill path is invalid")
+		}
 	}
 	if len(skills) > MaxSkills {
 		return errors.New("fleet-config source has too many skills")
@@ -176,12 +183,22 @@ func parseSkillFrontmatter(data []byte) (string, string, error) {
 	description := ""
 	for _, line := range strings.Split(body, "\n") {
 		line = strings.TrimRight(line, "\r")
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" || strings.HasPrefix(trimmed, "#") {
+			continue
+		}
 		key, value, ok := strings.Cut(line, ":")
 		if !ok {
-			continue
+			return "", "", errors.New("missing frontmatter")
 		}
 		key = strings.TrimSpace(key)
 		value = strings.TrimSpace(value)
+		if key == "" || strings.ContainsAny(key, " \t") {
+			return "", "", errors.New("missing frontmatter")
+		}
+		if unclosedFlow(value) {
+			return "", "", errors.New("missing frontmatter")
+		}
 		switch key {
 		case "name":
 			name = value
@@ -193,6 +210,16 @@ func parseSkillFrontmatter(data []byte) (string, string, error) {
 		return "", "", errors.New("missing frontmatter fields")
 	}
 	return name, description, nil
+}
+
+func unclosedFlow(value string) bool {
+	if strings.HasPrefix(value, "[") && !strings.HasSuffix(value, "]") {
+		return true
+	}
+	if strings.HasPrefix(value, "{") && !strings.HasSuffix(value, "}") {
+		return true
+	}
+	return false
 }
 
 func isTextPath(path string) bool {

--- a/internal/fleetconfig/validate_test.go
+++ b/internal/fleetconfig/validate_test.go
@@ -188,7 +188,7 @@ func TestValidateRejectsOversizedAndDuplicateCasePaths(t *testing.T) {
 	}}
 	if err := Validate(Tree{Files: []File{
 		{Path: "AGENTS.md", Data: []byte("# fleet\n")},
-		{Path: "skills/demo/" + strings.Repeat("a", 250), Data: []byte("too long\n")},
+		{Path: "skills/demo/" + strings.Repeat("a", 101), Data: []byte("too long\n")},
 	}}); err == nil {
 		t.Fatal("accepted USTAR-oversized path")
 	}

--- a/internal/fleetconfig/validate_test.go
+++ b/internal/fleetconfig/validate_test.go
@@ -1,0 +1,207 @@
+package fleetconfig
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+func TestInspectRootAcceptsGlobalAgentsAndProjectSkills(t *testing.T) {
+	t.Parallel()
+	root := writeTree(t, map[string]string{
+		"AGENTS.md":                      "# fleet\n",
+		"skills/demo/SKILL.md":           skillMarkdown("demo", "A bounded demo skill."),
+		"skills/demo/scripts/run.sh":     "#!/bin/sh\necho unused\n",
+		"projects/punaro/AGENTS.md":      "# punaro\n",
+		"projects/canopi/AGENTS.md":      "# canopi\n",
+		"projects/canopi/skills/x/SKILL.md": skillMarkdown("x", "Project skill."),
+	})
+	tree, err := InspectRoot(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := Validate(tree); err != nil {
+		t.Fatal(err)
+	}
+	if tree.SkillCount() != 2 {
+		t.Fatalf("skill count=%d", tree.SkillCount())
+	}
+	if !tree.HasProject("punaro") || !tree.HasProject("canopi") {
+		t.Fatalf("projects=%v", tree.Projects())
+	}
+	for _, file := range tree.Files {
+		if strings.Contains(string(file.Data), TrailerStart) || strings.Contains(string(file.Data), TrailerEnd) {
+			t.Fatal("trailer text entered the inspected source tree")
+		}
+	}
+}
+
+func TestInspectRootRejectsTrailerMarkersInSourceAgents(t *testing.T) {
+	t.Parallel()
+	root := writeTree(t, map[string]string{
+		"AGENTS.md": "# fleet\n" + TrailerStart + "\nlocal\n" + TrailerEnd + "\n",
+	})
+	tree, err := InspectRoot(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := Validate(tree); err == nil {
+		t.Fatal("accepted trailer markers in fleet source")
+	}
+}
+
+func TestInspectRootRejectsUnsafeLayout(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name  string
+		files map[string]string
+	}{
+		{"missing agents", map[string]string{"skills/demo/SKILL.md": skillMarkdown("demo", "Demo.")}},
+		{"unknown top-level", map[string]string{"AGENTS.md": "# fleet\n", "README.md": "nope\n"}},
+		{"malformed skill name", map[string]string{
+			"AGENTS.md":            "# fleet\n",
+			"skills/demo/SKILL.md": skillMarkdown("other", "Name mismatch."),
+		}},
+		{"missing skill description", map[string]string{
+			"AGENTS.md":            "# fleet\n",
+			"skills/demo/SKILL.md": "---\nname: demo\n---\n# Demo\n",
+		}},
+		{"nested project outside projects", map[string]string{
+			"AGENTS.md":             "# fleet\n",
+			"nested/punaro/AGENTS.md": "# nested\n",
+		}},
+		{"uppercase project", map[string]string{
+			"AGENTS.md":                 "# fleet\n",
+			"projects/Punaro/AGENTS.md": "# p\n",
+		}},
+		{"nul in agents", map[string]string{"AGENTS.md": "ok\x00nope"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			root := writeTree(t, tc.files)
+			tree, err := InspectRoot(root)
+			if err == nil {
+				err = Validate(tree)
+			}
+			if err == nil {
+				t.Fatal("accepted invalid tree")
+			}
+		})
+	}
+}
+
+func TestInspectRootRejectsSymlinkAndTraversalNames(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "AGENTS.md"), []byte("# fleet\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(root, "skills", "demo"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "skills", "demo", "SKILL.md"), []byte(skillMarkdown("demo", "Demo.")), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink("SKILL.md", filepath.Join(root, "skills", "demo", "link.md")); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := InspectRoot(root); err == nil {
+		t.Fatal("accepted symlink")
+	}
+
+	escape := t.TempDir()
+	if err := os.WriteFile(filepath.Join(escape, "AGENTS.md"), []byte("# fleet\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(escape, "skills", "..", "outside"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	tree, err := InspectRoot(escape)
+	if err == nil {
+		for _, file := range tree.Files {
+			if strings.Contains(file.Path, "..") || strings.HasPrefix(file.Path, "/") {
+				t.Fatalf("escaped path %q", file.Path)
+			}
+		}
+	}
+}
+
+func TestValidateRejectsOversizedAndDuplicateCasePaths(t *testing.T) {
+	t.Parallel()
+	huge := strings.Repeat("a", MaxFileBytes+1)
+	root := writeTree(t, map[string]string{
+		"AGENTS.md": huge,
+	})
+	tree, err := InspectRoot(root)
+	if err == nil {
+		err = Validate(tree)
+	}
+	if err == nil {
+		t.Fatal("accepted oversized file")
+	}
+
+	colliding := Tree{Files: []File{
+		{Path: "AGENTS.md", Data: []byte("# fleet\n")},
+		{Path: "skills/demo/SKILL.md", Data: []byte(skillMarkdown("demo", "Demo."))},
+		{Path: "skills/Demo/SKILL.md", Data: []byte(skillMarkdown("Demo", "Collision."))},
+	}}
+	if err := Validate(colliding); err == nil {
+		t.Fatal("accepted case-colliding paths")
+	}
+}
+
+func TestValidateRejectsAbsoluteTraversalAndDuplicatePaths(t *testing.T) {
+	t.Parallel()
+	agents := File{Path: "AGENTS.md", Data: []byte("# fleet\n")}
+	for _, tree := range []Tree{
+		{Files: []File{{Path: "/AGENTS.md", Data: []byte("# fleet\n")}}},
+		{Files: []File{agents, {Path: "skills/../secret/SKILL.md", Data: []byte(skillMarkdown("secret", "Escape."))}}},
+		{Files: []File{agents, {Path: "skills/demo/SKILL.md", Data: []byte(skillMarkdown("demo", "Demo."))}, {Path: "skills/demo/SKILL.md", Data: []byte(skillMarkdown("demo", "Dup."))}}},
+		{Files: []File{agents, {Path: "skills/demo/SKILL.md", Data: []byte("---\nname: demo\n---\n")}}},
+	} {
+		if err := Validate(tree); err == nil {
+			t.Fatalf("accepted %#v", tree.Files)
+		}
+	}
+}
+
+func TestValidateRejectsExcessiveSkillCount(t *testing.T) {
+	t.Parallel()
+	files := []File{{Path: "AGENTS.md", Data: []byte("# fleet\n")}}
+	for i := 0; i < MaxSkills+1; i++ {
+		name := skillName(i)
+		files = append(files, File{
+			Path: "skills/" + name + "/SKILL.md",
+			Data: []byte(skillMarkdown(name, "Skill "+name+".")),
+		})
+	}
+	if err := Validate(Tree{Files: files}); err == nil {
+		t.Fatal("accepted too many skills")
+	}
+}
+
+func skillName(i int) string {
+	return "skill-" + strconv.Itoa(i)
+}
+
+func skillMarkdown(name, description string) string {
+	return "---\nname: " + name + "\ndescription: " + description + "\n---\n# " + name + "\n"
+}
+
+func writeTree(t *testing.T, files map[string]string) string {
+	t.Helper()
+	root := t.TempDir()
+	for path, body := range files {
+		full := filepath.Join(append([]string{root}, strings.Split(path, "/")...)...)
+		if err := os.MkdirAll(filepath.Dir(full), 0o700); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(full, []byte(body), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return root
+}

--- a/internal/fleetconfig/validate_test.go
+++ b/internal/fleetconfig/validate_test.go
@@ -204,6 +204,21 @@ func TestValidateRejectsOversizedAndDuplicateCasePaths(t *testing.T) {
 	}
 }
 
+func TestValidateAcceptsUSTARSplitBeforeLastComponent(t *testing.T) {
+	t.Parallel()
+	project := strings.Repeat("a", 64)
+	skill := strings.Repeat("b", 64)
+	nested := "projects/" + project + "/skills/" + skill + "/abcdefghijk/x"
+	tree := Tree{Files: []File{
+		{Path: "AGENTS.md", Data: []byte("# fleet\n")},
+		{Path: "projects/" + project + "/skills/" + skill + "/SKILL.md", Data: []byte(skillMarkdown(skill, "Nested USTAR split."))},
+		{Path: nested, Data: []byte("data\n")},
+	}}
+	if err := Validate(tree); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestValidateRejectsAbsoluteTraversalAndDuplicatePaths(t *testing.T) {
 	t.Parallel()
 	agents := File{Path: "AGENTS.md", Data: []byte("# fleet\n")}

--- a/internal/fleetconfig/validate_test.go
+++ b/internal/fleetconfig/validate_test.go
@@ -99,6 +99,7 @@ func TestInspectRootRejectsUnsafeLayout(t *testing.T) {
 			"projects/Punaro/AGENTS.md": "# p\n",
 		}},
 		{"nul in agents", map[string]string{"AGENTS.md": "ok\x00nope"}},
+		{"empty agents", map[string]string{"AGENTS.md": ""}},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/fleetconfig/validate_test.go
+++ b/internal/fleetconfig/validate_test.go
@@ -76,6 +76,20 @@ func TestInspectRootRejectsUnsafeLayout(t *testing.T) {
 			"AGENTS.md":            "# fleet\n",
 			"skills/demo/SKILL.md": "---\nname: demo\ndescription: Demo.\nextra: [\n---\n# Demo\n",
 		}},
+		{"unterminated frontmatter quote", map[string]string{
+			"AGENTS.md":            "# fleet\n",
+			"skills/demo/SKILL.md": "---\nname: demo\ndescription: \"unterminated\n---\n# Demo\n",
+		}},
+		{"windows reserved name", map[string]string{
+			"AGENTS.md":            "# fleet\n",
+			"skills/demo/CON.txt":  "nope\n",
+			"skills/demo/SKILL.md": skillMarkdown("demo", "Demo."),
+		}},
+		{"windows colon name", map[string]string{
+			"AGENTS.md":            "# fleet\n",
+			"skills/demo/a:b.txt":  "nope\n",
+			"skills/demo/SKILL.md": skillMarkdown("demo", "Demo."),
+		}},
 		{"nested project outside projects", map[string]string{
 			"AGENTS.md":               "# fleet\n",
 			"nested/punaro/AGENTS.md": "# nested\n",
@@ -171,6 +185,19 @@ func TestValidateRejectsOversizedAndDuplicateCasePaths(t *testing.T) {
 		{Path: "skills/demo/SKILL.md", Data: []byte(skillMarkdown("demo", "Demo."))},
 		{Path: "skills/Demo/SKILL.md", Data: []byte(skillMarkdown("Demo", "Collision."))},
 	}}
+	if err := Validate(Tree{Files: []File{
+		{Path: "AGENTS.md", Data: []byte("# fleet\n")},
+		{Path: "skills/demo/" + strings.Repeat("a", 120), Data: []byte("too long\n")},
+	}}); err == nil {
+		t.Fatal("accepted USTAR-oversized path")
+	}
+	if err := Validate(Tree{Files: []File{
+		{Path: "AGENTS.md", Data: []byte("# fleet\n")},
+		{Path: "skills/demo/café.txt", Data: []byte("non-ascii\n")},
+	}}); err == nil {
+		t.Fatal("accepted non-ASCII path")
+	}
+
 	if err := Validate(colliding); err == nil {
 		t.Fatal("accepted case-colliding paths")
 	}

--- a/internal/fleetconfig/validate_test.go
+++ b/internal/fleetconfig/validate_test.go
@@ -188,7 +188,7 @@ func TestValidateRejectsOversizedAndDuplicateCasePaths(t *testing.T) {
 	}}
 	if err := Validate(Tree{Files: []File{
 		{Path: "AGENTS.md", Data: []byte("# fleet\n")},
-		{Path: "skills/demo/" + strings.Repeat("a", 120), Data: []byte("too long\n")},
+		{Path: "skills/demo/" + strings.Repeat("a", 250), Data: []byte("too long\n")},
 	}}); err == nil {
 		t.Fatal("accepted USTAR-oversized path")
 	}

--- a/internal/fleetconfig/validate_test.go
+++ b/internal/fleetconfig/validate_test.go
@@ -11,11 +11,11 @@ import (
 func TestInspectRootAcceptsGlobalAgentsAndProjectSkills(t *testing.T) {
 	t.Parallel()
 	root := writeTree(t, map[string]string{
-		"AGENTS.md":                      "# fleet\n",
-		"skills/demo/SKILL.md":           skillMarkdown("demo", "A bounded demo skill."),
-		"skills/demo/scripts/run.sh":     "#!/bin/sh\necho unused\n",
-		"projects/punaro/AGENTS.md":      "# punaro\n",
-		"projects/canopi/AGENTS.md":      "# canopi\n",
+		"AGENTS.md":                         "# fleet\n",
+		"skills/demo/SKILL.md":              skillMarkdown("demo", "A bounded demo skill."),
+		"skills/demo/scripts/run.sh":        "#!/bin/sh\necho unused\n",
+		"projects/punaro/AGENTS.md":         "# punaro\n",
+		"projects/canopi/AGENTS.md":         "# canopi\n",
 		"projects/canopi/skills/x/SKILL.md": skillMarkdown("x", "Project skill."),
 	})
 	tree, err := InspectRoot(root)
@@ -68,8 +68,16 @@ func TestInspectRootRejectsUnsafeLayout(t *testing.T) {
 			"AGENTS.md":            "# fleet\n",
 			"skills/demo/SKILL.md": "---\nname: demo\n---\n# Demo\n",
 		}},
+		{"skill data without skill markdown", map[string]string{
+			"AGENTS.md":                  "# fleet\n",
+			"skills/demo/scripts/run.sh": "#!/bin/sh\necho unused\n",
+		}},
+		{"unterminated frontmatter flow", map[string]string{
+			"AGENTS.md":            "# fleet\n",
+			"skills/demo/SKILL.md": "---\nname: demo\ndescription: Demo.\nextra: [\n---\n# Demo\n",
+		}},
 		{"nested project outside projects", map[string]string{
-			"AGENTS.md":             "# fleet\n",
+			"AGENTS.md":               "# fleet\n",
 			"nested/punaro/AGENTS.md": "# nested\n",
 		}},
 		{"uppercase project", map[string]string{
@@ -126,6 +134,21 @@ func TestInspectRootRejectsSymlinkAndTraversalNames(t *testing.T) {
 				t.Fatalf("escaped path %q", file.Path)
 			}
 		}
+	}
+}
+
+func TestSkillCountCountsOnlyValidatedSkillRoots(t *testing.T) {
+	t.Parallel()
+	tree := Tree{Files: []File{
+		{Path: "AGENTS.md", Data: []byte("# fleet\n")},
+		{Path: "skills/demo/SKILL.md", Data: []byte(skillMarkdown("demo", "Demo skill."))},
+		{Path: "skills/demo/examples/SKILL.md", Data: []byte("# example\n")},
+	}}
+	if err := Validate(tree); err != nil {
+		t.Fatal(err)
+	}
+	if tree.SkillCount() != 1 {
+		t.Fatalf("nested SKILL.md counted as a skill: %d", tree.SkillCount())
 	}
 }
 


### PR DESCRIPTION
Closes #211.

Defines the v1 data-only fleet-config source contract in `internal/fleetconfig`: full Git commit identities only, global `AGENTS.md` plus `skills/` and `projects/<name>/` trees, strict validation, deterministic materialization, and trailer-not-in-source.

Contract: `docs/fleet-global-agent-config.md`.