### PR TITLE
Expose fleet-config convergence in status, doctor, and Canopi

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -674,6 +674,10 @@ closed without copying. Unmanaged Claude files are never overwritten.
 Activation is reported as immediate, next turn, next session, or restart
 required. Unknown installed harnesses are `unsupported`.
 
+`punaro fleet-config status` and content-free Canopi/doctor hooks expose
+desired/applied generation, digest, and trailer/alias/project-match states
+without file contents, host paths, or raw errors.
+
 ## Canonical memory model
 
 Canonical memory is project-scoped PostgreSQL authority. Each item has an

--- a/cmd/punaro/fleet_config_command.go
+++ b/cmd/punaro/fleet_config_command.go
@@ -40,6 +40,7 @@ var (
 	loadFleetDesired       = loadFleetDesiredDefault
 	loadStoredFleetRelease = loadStoredFleetReleaseDefault
 	afterFleetPublish      = func(_, _ int64) {}
+	loadFleetClients       = loadFleetClientsDefault
 )
 
 func runFleetConfigConfigure(args []string, stdout, stderr io.Writer) int {
@@ -189,6 +190,11 @@ func runFleetConfigStatus(args []string, stdout, stderr io.Writer) int {
 		_, _ = fmt.Fprintln(stderr, "fleet-config status refused: desired revision is unavailable")
 		return 1
 	}
+	clients, err := loadFleetClients(context.Background(), installation.OwnerDSNFile)
+	if err != nil {
+		_, _ = fmt.Fprintln(stderr, "fleet-config status refused: client status is unavailable")
+		return 1
+	}
 	state := "pending"
 	if desired.Digest != "" {
 		state = "current"
@@ -200,6 +206,7 @@ func runFleetConfigStatus(args []string, stdout, stderr io.Writer) int {
 		"skill_count":        desired.SkillCount,
 		"total_bytes":        desired.TotalBytes,
 		"state":              state,
+		"clients":            clients,
 	})
 }
 
@@ -369,6 +376,15 @@ func loadStoredFleetReleaseDefault(ctx context.Context, ownerDSNFile, commit str
 	}
 	defer func() { _ = admin.Close() }()
 	return admin.LoadFleetReleaseByCommit(ctx, commit)
+}
+
+func loadFleetClientsDefault(ctx context.Context, ownerDSNFile string) ([]punaropostgres.FleetClientStatus, error) {
+	admin, err := punaropostgres.OpenAdministration(ctx, punaropostgres.Config{DSNFile: ownerDSNFile})
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = admin.Close() }()
+	return admin.ListFleetClientStatus(ctx)
 }
 
 func loadFleetDesiredDefault(ctx context.Context, ownerDSNFile string) (punaropostgres.FleetDesired, error) {

--- a/cmd/punaro/fleet_config_command_test.go
+++ b/cmd/punaro/fleet_config_command_test.go
@@ -311,6 +311,33 @@ func TestFleetConfigPublishFromRealGitCommit(t *testing.T) {
 	}
 }
 
+func TestFleetConfigStatusOmitsContentsAndIncludesClientStates(t *testing.T) {
+	preserveFleetConfig(t)
+	directory := testInstallation(t)
+	loadFleetDesired = func(context.Context, string) (punaropostgres.FleetDesired, error) {
+		return punaropostgres.FleetDesired{Digest: strings.Repeat("ab", 32), SourceCommit: testPublishCommit, Generation: 3}, nil
+	}
+	loadFleetClients = func(context.Context, string) ([]punaropostgres.FleetClientStatus, error) {
+		return []punaropostgres.FleetClientStatus{{
+			MachineID: "mac-studio", AppliedDigest: strings.Repeat("ab", 32), State: "current",
+			Activation: "next_turn", TrailerState: "present", AliasState: "linked", ProjectMatchState: "matched",
+		}}, nil
+	}
+	var stdout bytes.Buffer
+	if code := run([]string{"fleet-config", "status", "--directory", directory}, &stdout, bytes.NewBuffer(nil)); code != 0 {
+		t.Fatalf("code=%d body=%s", code, stdout.String())
+	}
+	body := stdout.String()
+	for _, want := range []string{`"state": "current"`, `"trailer_state": "present"`, `"alias_state": "linked"`, `"project_match_state": "matched"`, `"activation": "next_turn"`, strings.Repeat("ab", 32)} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("missing %s in %s", want, body)
+		}
+	}
+	if strings.Contains(body, "# fleet") || strings.Contains(body, "/Users/") || strings.Contains(body, "pq:") {
+		t.Fatalf("status leaked contents or paths: %s", body)
+	}
+}
+
 func TrailerLeak() string { return fleetconfig.TrailerStart }
 
 func testRelease() fleetconfig.Release {
@@ -409,12 +436,15 @@ func gitHead(t *testing.T, repo string) string {
 func preserveFleetConfig(t *testing.T) {
 	t.Helper()
 	preserveDependencies(t)
-	originalMaterialize, originalPersist, originalDesired, originalStored, originalWake := materializeFleetCommit, persistFleetRelease, loadFleetDesired, loadStoredFleetRelease, afterFleetPublish
+	originalMaterialize, originalPersist, originalDesired, originalStored, originalWake, originalClients := materializeFleetCommit, persistFleetRelease, loadFleetDesired, loadStoredFleetRelease, afterFleetPublish, loadFleetClients
 	t.Cleanup(func() {
-		materializeFleetCommit, persistFleetRelease, loadFleetDesired, loadStoredFleetRelease, afterFleetPublish = originalMaterialize, originalPersist, originalDesired, originalStored, originalWake
+		materializeFleetCommit, persistFleetRelease, loadFleetDesired, loadStoredFleetRelease, afterFleetPublish, loadFleetClients = originalMaterialize, originalPersist, originalDesired, originalStored, originalWake, originalClients
 	})
 	loadStoredFleetRelease = func(context.Context, string, string) (fleetconfig.Release, error) {
 		return fleetconfig.Release{}, errors.New("no stored release")
+	}
+	loadFleetClients = func(context.Context, string) ([]punaropostgres.FleetClientStatus, error) {
+		return nil, nil
 	}
 	inspectSchema = func(context.Context, string) (punaropostgres.SchemaState, error) {
 		return punaropostgres.SchemaState{Classification: punaropostgres.Compatible, Version: 58}, nil

--- a/internal/canopi/fleet.go
+++ b/internal/canopi/fleet.go
@@ -1,0 +1,16 @@
+package canopi
+
+import "encoding/json"
+
+// FleetConvergenceEvent is a content-free dashboard hook for fleet-config.
+type FleetConvergenceEvent struct {
+	Kind       string `json:"kind"`
+	Generation int64  `json:"generation"`
+	Digest     string `json:"digest"`
+	State      string `json:"state"`
+}
+
+// EncodeFleetConvergence encodes one bounded convergence event.
+func EncodeFleetConvergence(generation int64, digest, state string) ([]byte, error) {
+	return json.Marshal(FleetConvergenceEvent{Kind: "fleet_config", Generation: generation, Digest: digest, State: state})
+}

--- a/internal/canopi/fleet_test.go
+++ b/internal/canopi/fleet_test.go
@@ -1,0 +1,21 @@
+package canopi
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestEncodeFleetConvergenceOmitsConfigurationContents(t *testing.T) {
+	t.Parallel()
+	body, err := EncodeFleetConvergence(4, strings.Repeat("ab", 32), "current")
+	if err != nil {
+		t.Fatal(err)
+	}
+	text := string(body)
+	if !strings.Contains(text, `"kind":"fleet_config"`) || !strings.Contains(text, `"generation":4`) {
+		t.Fatalf("body=%s", text)
+	}
+	if strings.Contains(text, "AGENTS.md") || strings.Contains(text, "# fleet") || strings.Contains(text, "/Users/") {
+		t.Fatalf("leaked contents: %s", text)
+	}
+}

--- a/internal/diagnostic/fleet_config.go
+++ b/internal/diagnostic/fleet_config.go
@@ -1,0 +1,35 @@
+package diagnostic
+
+// FleetConfigChecks builds content-free doctor checks for fleet-config convergence.
+func FleetConfigChecks(desiredDigest string, clientStates []string) []Check {
+	checks := []Check{
+		boolCheck("fleet_config_desired", desiredDigest != "", "publish_fleet_config"),
+	}
+	stale, failed, drifted, unsupported := false, false, false, false
+	for _, state := range clientStates {
+		switch state {
+		case "failed":
+			failed = true
+		case "drifted":
+			drifted = true
+		case "unsupported":
+			unsupported = true
+		case "offline", "pending":
+			stale = true
+		}
+	}
+	checks = append(checks,
+		boolCheck("fleet_config_client_stale", !stale, "reconnect_fleet_client"),
+		boolCheck("fleet_config_failed", !failed, "retry_fleet_apply"),
+		boolCheck("fleet_config_drifted", !drifted, "replace_fleet_prefix"),
+		boolCheck("fleet_config_unsupported", !unsupported, "disable_unsupported_harness"),
+	)
+	return checks
+}
+
+func boolCheck(code string, ok bool, remediation string) Check {
+	if ok {
+		return Check{Code: code, Status: StatusPass, Required: true}
+	}
+	return Check{Code: code, Status: StatusFail, Required: true, Remediation: remediation}
+}

--- a/internal/diagnostic/fleet_config_test.go
+++ b/internal/diagnostic/fleet_config_test.go
@@ -1,0 +1,21 @@
+package diagnostic
+
+import "testing"
+
+func TestFleetConfigChecksAreContentFree(t *testing.T) {
+	t.Parallel()
+	checks := FleetConfigChecks("abc", []string{"current", "drifted", "unsupported"})
+	if len(checks) != 5 {
+		t.Fatalf("checks=%#v", checks)
+	}
+	byCode := map[string]Check{}
+	for _, check := range checks {
+		byCode[check.Code] = check
+		if check.Code == "" || (check.Status != StatusPass && check.Remediation == "") {
+			t.Fatalf("invalid %#v", check)
+		}
+	}
+	if byCode["fleet_config_desired"].Status != StatusPass || byCode["fleet_config_drifted"].Status != StatusFail || byCode["fleet_config_unsupported"].Status != StatusFail {
+		t.Fatalf("byCode=%#v", byCode)
+	}
+}

--- a/internal/postgres/fleet_config.go
+++ b/internal/postgres/fleet_config.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"errors"
 	"strings"
+	"time"
 
 	"github.com/rock3r/punaro/internal/fleetconfig"
 	"github.com/rock3r/punaro/internal/relay"
@@ -29,6 +30,16 @@ type FleetClientStatus struct {
 	AliasState        string `json:"alias_state"`
 	ProjectMatchState string `json:"project_match_state"`
 	Generation        int64  `json:"generation"`
+}
+
+const fleetClientOfflineAfter = 10 * time.Minute
+
+// ExpireFleetClientState records offline when a report is missing or older than twice the maximum adapter poll.
+func ExpireFleetClientState(state string, reportedAt, now time.Time) string {
+	if state == "" || reportedAt.IsZero() || now.Sub(reportedAt) > fleetClientOfflineAfter {
+		return "offline"
+	}
+	return state
 }
 
 // LoadFleetDesired returns the current desired revision, or a zero value when none exists.
@@ -200,24 +211,25 @@ func (a *Administration) ListFleetClientStatus(ctx context.Context) ([]FleetClie
 		return nil, errors.New("fleet-config store is unavailable")
 	}
 	rows, err := a.db.QueryContext(ctx, `
-SELECT client.machine_id, COALESCE(status.applied_digest, ''), COALESCE(status.state, 'offline'),
-       COALESCE(status.activation, ''), COALESCE(status.trailer_state, ''), COALESCE(status.alias_state, ''),
-       COALESCE(status.project_match_state, ''), COALESCE(status.generation, 0)
-FROM auth.client_installations AS client
-LEFT JOIN fleet.client_status AS status ON status.client_id = client.id
-WHERE client.lifecycle_state = 'active'
-ORDER BY client.machine_id
+SELECT machine_id, COALESCE(applied_digest, ''), COALESCE(state, ''),
+       COALESCE(activation, ''), COALESCE(trailer_state, ''), COALESCE(alias_state, ''),
+       COALESCE(project_match_state, ''), generation, reported_at
+FROM fleet.client_status
+ORDER BY machine_id
 LIMIT 256`)
 	if err != nil {
 		return nil, errors.New("fleet-config status is unavailable")
 	}
 	defer func() { _ = rows.Close() }()
-	var result []FleetClientStatus
+	result := []FleetClientStatus{}
+	now := time.Now().UTC()
 	for rows.Next() {
 		var row FleetClientStatus
-		if err := rows.Scan(&row.MachineID, &row.AppliedDigest, &row.State, &row.Activation, &row.TrailerState, &row.AliasState, &row.ProjectMatchState, &row.Generation); err != nil {
+		var reportedAt time.Time
+		if err := rows.Scan(&row.MachineID, &row.AppliedDigest, &row.State, &row.Activation, &row.TrailerState, &row.AliasState, &row.ProjectMatchState, &row.Generation, &reportedAt); err != nil {
 			return nil, errors.New("fleet-config status is unavailable")
 		}
+		row.State = ExpireFleetClientState(row.State, reportedAt, now)
 		result = append(result, row)
 	}
 	if err := rows.Err(); err != nil {

--- a/internal/postgres/fleet_config.go
+++ b/internal/postgres/fleet_config.go
@@ -19,6 +19,18 @@ type FleetDesired struct {
 	TotalBytes   int64
 }
 
+// FleetClientStatus is one enrolled client's content-free convergence row.
+type FleetClientStatus struct {
+	MachineID         string `json:"machine_id"`
+	AppliedDigest     string `json:"applied_digest"`
+	State             string `json:"state"`
+	Activation        string `json:"activation"`
+	TrailerState      string `json:"trailer_state"`
+	AliasState        string `json:"alias_state"`
+	ProjectMatchState string `json:"project_match_state"`
+	Generation        int64  `json:"generation"`
+}
+
 // LoadFleetDesired returns the current desired revision, or a zero value when none exists.
 func (a *Administration) LoadFleetDesired(ctx context.Context) (FleetDesired, error) {
 	if a == nil {
@@ -180,6 +192,38 @@ func nullIfEmpty(value string) any {
 		return nil
 	}
 	return value
+}
+
+// ListFleetClientStatus returns bounded client rows without configuration contents.
+func (a *Administration) ListFleetClientStatus(ctx context.Context) ([]FleetClientStatus, error) {
+	if a == nil {
+		return nil, errors.New("fleet-config store is unavailable")
+	}
+	rows, err := a.db.QueryContext(ctx, `
+SELECT client.machine_id, COALESCE(status.applied_digest, ''), COALESCE(status.state, 'offline'),
+       COALESCE(status.activation, ''), COALESCE(status.trailer_state, ''), COALESCE(status.alias_state, ''),
+       COALESCE(status.project_match_state, ''), COALESCE(status.generation, 0)
+FROM auth.client_installations AS client
+LEFT JOIN fleet.client_status AS status ON status.client_id = client.id
+WHERE client.lifecycle_state = 'active'
+ORDER BY client.machine_id
+LIMIT 256`)
+	if err != nil {
+		return nil, errors.New("fleet-config status is unavailable")
+	}
+	defer func() { _ = rows.Close() }()
+	var result []FleetClientStatus
+	for rows.Next() {
+		var row FleetClientStatus
+		if err := rows.Scan(&row.MachineID, &row.AppliedDigest, &row.State, &row.Activation, &row.TrailerState, &row.AliasState, &row.ProjectMatchState, &row.Generation); err != nil {
+			return nil, errors.New("fleet-config status is unavailable")
+		}
+		result = append(result, row)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, errors.New("fleet-config status is unavailable")
+	}
+	return result, nil
 }
 
 func postgresFleetStatusError(err error) string {

--- a/internal/postgres/fleet_status_test.go
+++ b/internal/postgres/fleet_status_test.go
@@ -1,0 +1,40 @@
+package postgres
+
+import (
+	"os"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestExpireFleetClientStateMarksStaleReportsOffline(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 8, 30, 12, 0, 0, 0, time.UTC)
+	if got := ExpireFleetClientState("current", now.Add(-time.Minute), now); got != "current" {
+		t.Fatalf("fresh=%s", got)
+	}
+	if got := ExpireFleetClientState("current", now.Add(-11*time.Minute), now); got != "offline" {
+		t.Fatalf("stale=%s", got)
+	}
+	if got := ExpireFleetClientState("", now, now); got != "offline" {
+		t.Fatalf("missing=%s", got)
+	}
+	if got := ExpireFleetClientState("current", time.Time{}, now); got != "offline" {
+		t.Fatalf("zero=%s", got)
+	}
+}
+
+func TestListFleetClientStatusReadsMachineReports(t *testing.T) {
+	t.Parallel()
+	body, err := os.ReadFile("fleet_config.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	source := string(body)
+	if strings.Contains(source, "status.client_id") {
+		t.Fatal("client status list still joins client_installations by client_id")
+	}
+	if !strings.Contains(source, "FROM fleet.client_status") || !strings.Contains(source, "reported_at") || !strings.Contains(source, "ExpireFleetClientState") {
+		t.Fatal("client status list does not expire stale machine reports")
+	}
+}


### PR DESCRIPTION
Closes #216.

`punaro fleet-config status` lists desired revision and per-client states including trailer/alias/project-match without configuration contents, host paths, or raw errors. Doctor and Canopi hooks stay content-free.