### PR TITLE
Project fleet-config into harnesses with opt-in Claude aliases

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -668,6 +668,12 @@ without merging fleet-prefix edits, matches project names only as top-level
 directories under a configured base path (or an explicit override), and keeps
 last-known-good on failed activation. Concurrent reconcile is serialized.
 
+Harness projection installs only Punaro-managed `AGENTS.md` and skills.
+Opt-in Claude aliases are POSIX symlinks; Windows uses `os.Symlink` or fails
+closed without copying. Unmanaged Claude files are never overwritten.
+Activation is reported as immediate, next turn, next session, or restart
+required. Unknown installed harnesses are `unsupported`.
+
 ## Canonical memory model
 
 Canonical memory is project-scoped PostgreSQL authority. Each item has an

--- a/internal/fleetconfig/alias.go
+++ b/internal/fleetconfig/alias.go
@@ -1,0 +1,41 @@
+package fleetconfig
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+)
+
+// AliasResult is the content-free Claude alias outcome.
+type AliasResult struct {
+	State string
+}
+
+// CreateAlias points linkPath at targetPath without copying contents.
+func CreateAlias(targetPath, linkPath string, enabled bool) (AliasResult, error) {
+	if !enabled {
+		return AliasResult{State: "disabled"}, nil
+	}
+	if !filepath.IsAbs(targetPath) || !filepath.IsAbs(linkPath) {
+		return AliasResult{State: "unsupported"}, errors.New("alias paths must be absolute")
+	}
+	info, err := os.Lstat(linkPath)
+	if err == nil {
+		if info.Mode()&os.ModeSymlink != 0 {
+			got, readErr := os.Readlink(linkPath)
+			if readErr == nil && filepath.Clean(got) == filepath.Clean(targetPath) {
+				return AliasResult{State: "linked"}, nil
+			}
+			return AliasResult{State: "collision"}, nil
+		}
+		if info.Mode().IsRegular() || info.IsDir() {
+			return AliasResult{State: "collision"}, nil
+		}
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return AliasResult{State: "unsupported"}, err
+	}
+	if err := createAliasLink(targetPath, linkPath); err != nil {
+		return AliasResult{State: "unsupported"}, err
+	}
+	return AliasResult{State: "linked"}, nil
+}

--- a/internal/fleetconfig/alias.go
+++ b/internal/fleetconfig/alias.go
@@ -14,6 +14,18 @@ type AliasResult struct {
 // CreateAlias points linkPath at targetPath without copying contents.
 func CreateAlias(targetPath, linkPath string, enabled bool) (AliasResult, error) {
 	if !enabled {
+		info, err := os.Lstat(linkPath)
+		if errors.Is(err, os.ErrNotExist) {
+			return AliasResult{State: "disabled"}, nil
+		}
+		if err == nil && info.Mode()&os.ModeSymlink != 0 {
+			got, readErr := os.Readlink(linkPath)
+			if readErr == nil && filepath.Clean(got) == filepath.Clean(targetPath) {
+				if removeErr := os.Remove(linkPath); removeErr != nil {
+					return AliasResult{State: "unsupported"}, removeErr
+				}
+			}
+		}
 		return AliasResult{State: "disabled"}, nil
 	}
 	if !filepath.IsAbs(targetPath) || !filepath.IsAbs(linkPath) {

--- a/internal/fleetconfig/alias_other.go
+++ b/internal/fleetconfig/alias_other.go
@@ -1,0 +1,9 @@
+//go:build !unix && !windows
+
+package fleetconfig
+
+import "errors"
+
+func createAliasLink(string, string) error {
+	return errors.New("aliases are unsupported on this platform")
+}

--- a/internal/fleetconfig/alias_test.go
+++ b/internal/fleetconfig/alias_test.go
@@ -23,14 +23,14 @@ func TestCreateAliasSymlinkDoesNotOverwriteUnmanagedFile(t *testing.T) {
 		t.Fatal("disabled alias created a file")
 	}
 	linked, err := CreateAlias(target, link, true)
+	if runtime.GOOS == "windows" && linked.State == "unsupported" {
+		return
+	}
 	if err != nil || linked.State != "linked" {
 		t.Fatalf("linked=%#v err=%v", linked, err)
 	}
 	info, err := os.Lstat(link)
 	if err != nil || info.Mode()&os.ModeSymlink == 0 {
-		if runtime.GOOS == "windows" && linked.State == "unsupported" {
-			return
-		}
 		t.Fatalf("expected symlink info=%v err=%v", info, err)
 	}
 	got, err := os.Readlink(link)
@@ -45,7 +45,7 @@ func TestCreateAliasSymlinkDoesNotOverwriteUnmanagedFile(t *testing.T) {
 	if err != nil || collision.State != "collision" {
 		t.Fatalf("collision=%#v err=%v", collision, err)
 	}
-	body, err := os.ReadFile(collisionPath)
+	body, err := os.ReadFile(collisionPath) //nolint:gosec // G304: test fixture path under t.TempDir.
 	if err != nil || string(body) != "local claude\n" {
 		t.Fatalf("overwrote unmanaged file %q", body)
 	}

--- a/internal/fleetconfig/alias_test.go
+++ b/internal/fleetconfig/alias_test.go
@@ -50,3 +50,39 @@ func TestCreateAliasSymlinkDoesNotOverwriteUnmanagedFile(t *testing.T) {
 		t.Fatalf("overwrote unmanaged file %q", body)
 	}
 }
+
+func TestCreateAliasRemovesManagedLinkWhenDisabled(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	target := filepath.Join(dir, "AGENTS.md")
+	link := filepath.Join(dir, "CLAUDE.md")
+	if err := os.WriteFile(target, []byte("# fleet\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	linked, err := CreateAlias(target, link, true)
+	if runtime.GOOS == "windows" && linked.State == "unsupported" {
+		return
+	}
+	if err != nil || linked.State != "linked" {
+		t.Fatalf("linked=%#v err=%v", linked, err)
+	}
+	disabled, err := CreateAlias(target, link, false)
+	if err != nil || disabled.State != "disabled" {
+		t.Fatalf("disabled=%#v err=%v", disabled, err)
+	}
+	if _, err := os.Lstat(link); !os.IsNotExist(err) {
+		t.Fatal("disabled alias left a managed symlink")
+	}
+	collisionPath := filepath.Join(dir, "CLAUDE-real.md")
+	if err := os.WriteFile(collisionPath, []byte("local claude\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	collision, err := CreateAlias(target, collisionPath, false)
+	if err != nil || collision.State != "disabled" {
+		t.Fatalf("collision disable=%#v err=%v", collision, err)
+	}
+	body, err := os.ReadFile(collisionPath) //nolint:gosec // G304: test fixture path under t.TempDir.
+	if err != nil || string(body) != "local claude\n" {
+		t.Fatalf("disabled alias removed unmanaged file %q", body)
+	}
+}

--- a/internal/fleetconfig/alias_test.go
+++ b/internal/fleetconfig/alias_test.go
@@ -1,0 +1,52 @@
+package fleetconfig
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+func TestCreateAliasSymlinkDoesNotOverwriteUnmanagedFile(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	target := filepath.Join(dir, "AGENTS.md")
+	link := filepath.Join(dir, "CLAUDE.md")
+	if err := os.WriteFile(target, []byte("# fleet\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	disabled, err := CreateAlias(target, link, false)
+	if err != nil || disabled.State != "disabled" {
+		t.Fatalf("disabled=%#v err=%v", disabled, err)
+	}
+	if _, err := os.Lstat(link); !os.IsNotExist(err) {
+		t.Fatal("disabled alias created a file")
+	}
+	linked, err := CreateAlias(target, link, true)
+	if err != nil || linked.State != "linked" {
+		t.Fatalf("linked=%#v err=%v", linked, err)
+	}
+	info, err := os.Lstat(link)
+	if err != nil || info.Mode()&os.ModeSymlink == 0 {
+		if runtime.GOOS == "windows" && linked.State == "unsupported" {
+			return
+		}
+		t.Fatalf("expected symlink info=%v err=%v", info, err)
+	}
+	got, err := os.Readlink(link)
+	if err != nil || filepath.Clean(got) != filepath.Clean(target) {
+		t.Fatalf("readlink=%q err=%v", got, err)
+	}
+	collisionPath := filepath.Join(dir, "CLAUDE-real.md")
+	if err := os.WriteFile(collisionPath, []byte("local claude\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	collision, err := CreateAlias(target, collisionPath, true)
+	if err != nil || collision.State != "collision" {
+		t.Fatalf("collision=%#v err=%v", collision, err)
+	}
+	body, err := os.ReadFile(collisionPath)
+	if err != nil || string(body) != "local claude\n" {
+		t.Fatalf("overwrote unmanaged file %q", body)
+	}
+}

--- a/internal/fleetconfig/alias_unix.go
+++ b/internal/fleetconfig/alias_unix.go
@@ -1,0 +1,9 @@
+//go:build unix
+
+package fleetconfig
+
+import "os"
+
+func createAliasLink(targetPath, linkPath string) error {
+	return os.Symlink(targetPath, linkPath)
+}

--- a/internal/fleetconfig/alias_windows.go
+++ b/internal/fleetconfig/alias_windows.go
@@ -1,0 +1,12 @@
+//go:build windows
+
+package fleetconfig
+
+import "os"
+
+func createAliasLink(targetPath, linkPath string) error {
+	if err := os.Symlink(targetPath, linkPath); err != nil {
+		return err
+	}
+	return nil
+}

--- a/internal/fleetconfig/harness.go
+++ b/internal/fleetconfig/harness.go
@@ -1,0 +1,41 @@
+package fleetconfig
+
+import "os"
+
+// HarnessProjection is one built-in coding-agent mapping.
+type HarnessProjection struct {
+	Name       string
+	Activation string
+	State      string
+}
+
+// DetectHarnesses reports supported and unsupported installed harnesses.
+func DetectHarnesses(home string, lookup func(string) bool) []HarnessProjection {
+	if lookup == nil {
+		lookup = func(path string) bool {
+			_, err := os.Lstat(path)
+			return err == nil
+		}
+	}
+	projections := []HarnessProjection{
+		{Name: "agents", Activation: "next_turn", State: "current"},
+	}
+	known := []struct {
+		name       string
+		marker     string
+		activation string
+	}{
+		{name: "codex", marker: ".codex", activation: "next_turn"},
+		{name: "claude", marker: ".claude", activation: "next_session"},
+		{name: "gemini", marker: ".gemini", activation: "next_session"},
+	}
+	for _, harness := range known {
+		if lookup(home + "/" + harness.marker) {
+			projections = append(projections, HarnessProjection{Name: harness.name, Activation: harness.activation, State: "current"})
+		}
+	}
+	if lookup(home+"/.cursor") || lookup(home+"/.windsurf") {
+		projections = append(projections, HarnessProjection{Name: "unknown", Activation: "restart_required", State: "unsupported"})
+	}
+	return projections
+}

--- a/internal/fleetconfig/harness.go
+++ b/internal/fleetconfig/harness.go
@@ -1,6 +1,9 @@
 package fleetconfig
 
-import "os"
+import (
+	"os"
+	"path/filepath"
+)
 
 // HarnessProjection is one built-in coding-agent mapping.
 type HarnessProjection struct {
@@ -10,7 +13,7 @@ type HarnessProjection struct {
 }
 
 // DetectHarnesses reports supported and unsupported installed harnesses.
-func DetectHarnesses(home string, lookup func(string) bool) []HarnessProjection {
+func DetectHarnesses(home, project string, lookup func(string) bool) []HarnessProjection {
 	if lookup == nil {
 		lookup = func(path string) bool {
 			_, err := os.Lstat(path)
@@ -27,14 +30,16 @@ func DetectHarnesses(home string, lookup func(string) bool) []HarnessProjection 
 	}{
 		{name: "codex", marker: ".codex", activation: "next_turn"},
 		{name: "claude", marker: ".claude", activation: "next_session"},
-		{name: "gemini", marker: ".gemini", activation: "next_session"},
 	}
 	for _, harness := range known {
-		if lookup(home + "/" + harness.marker) {
+		if lookup(filepath.Join(home, harness.marker)) {
 			projections = append(projections, HarnessProjection{Name: harness.name, Activation: harness.activation, State: "current"})
 		}
 	}
-	if lookup(home+"/.cursor") || lookup(home+"/.windsurf") {
+	if lookup(filepath.Join(home, ".gemini")) || (project != "" && lookup(filepath.Join(project, "GEMINI.md"))) {
+		projections = append(projections, HarnessProjection{Name: "gemini", Activation: "next_session", State: "current"})
+	}
+	if lookup(filepath.Join(home, ".cursor")) || lookup(filepath.Join(home, ".windsurf")) {
 		projections = append(projections, HarnessProjection{Name: "unknown", Activation: "restart_required", State: "unsupported"})
 	}
 	return projections

--- a/internal/fleetconfig/harness_test.go
+++ b/internal/fleetconfig/harness_test.go
@@ -1,0 +1,25 @@
+package fleetconfig
+
+import "testing"
+
+func TestDetectHarnessesMarksUnknownInstalledHarnessUnsupported(t *testing.T) {
+	t.Parallel()
+	lookup := func(path string) bool {
+		return path == "/home/me/.claude" || path == "/home/me/.cursor"
+	}
+	got := DetectHarnesses("/home/me", lookup)
+	var sawClaude, sawUnsupported, sawAgents bool
+	for _, harness := range got {
+		switch harness.Name {
+		case "claude":
+			sawClaude = harness.Activation == "next_session" && harness.State == "current"
+		case "unknown":
+			sawUnsupported = harness.State == "unsupported"
+		case "agents":
+			sawAgents = harness.Activation == "next_turn"
+		}
+	}
+	if !sawClaude || !sawUnsupported || !sawAgents {
+		t.Fatalf("projections=%#v", got)
+	}
+}

--- a/internal/fleetconfig/harness_test.go
+++ b/internal/fleetconfig/harness_test.go
@@ -1,13 +1,17 @@
 package fleetconfig
 
-import "testing"
+import (
+	"path/filepath"
+	"testing"
+)
 
 func TestDetectHarnessesMarksUnknownInstalledHarnessUnsupported(t *testing.T) {
 	t.Parallel()
+	home := filepath.Join("home", "me")
 	lookup := func(path string) bool {
-		return path == "/home/me/.claude" || path == "/home/me/.cursor"
+		return path == filepath.Join(home, ".claude") || path == filepath.Join(home, ".cursor")
 	}
-	got := DetectHarnesses("/home/me", lookup)
+	got := DetectHarnesses(home, "", lookup)
 	var sawClaude, sawUnsupported, sawAgents bool
 	for _, harness := range got {
 		switch harness.Name {
@@ -22,4 +26,20 @@ func TestDetectHarnessesMarksUnknownInstalledHarnessUnsupported(t *testing.T) {
 	if !sawClaude || !sawUnsupported || !sawAgents {
 		t.Fatalf("projections=%#v", got)
 	}
+}
+
+func TestDetectHarnessesIncludesGeminiFromProjectMarker(t *testing.T) {
+	t.Parallel()
+	home := filepath.Join("home", "me")
+	project := filepath.Join("repo", "punaro")
+	lookup := func(path string) bool {
+		return path == filepath.Join(project, "GEMINI.md")
+	}
+	got := DetectHarnesses(home, project, lookup)
+	for _, harness := range got {
+		if harness.Name == "gemini" && harness.Activation == "next_session" && harness.State == "current" {
+			return
+		}
+	}
+	t.Fatalf("missing gemini projection=%#v", got)
 }


### PR DESCRIPTION
Closes #215.

Detects Punaro/Canopi-supported coding-agent harnesses, reports unknown installs as unsupported, and creates opt-in Claude aliases as POSIX symlinks. Windows uses `os.Symlink` or fails closed without copying. Unmanaged Claude files are never overwritten.