### PR TITLE
Add authenticated fleet-config desired-state distribution

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -658,6 +658,11 @@ changing the singleton desired row (schema 58). A failed publish leaves the
 prior desired revision unchanged; an identical digest is idempotent; rollback
 is the same command against a previously published commit.
 
+Enrolled clients read desired metadata and exact archive bytes over signed HTTP
+and may write only their own bounded status row (schema 59). There is no client
+publish route. Desired-generation advances emit a payload-free WebSocket wake
+with `topic_id=fleet-config` and `sequence` equal to the generation.
+
 ## Canonical memory model
 
 Canonical memory is project-scoped PostgreSQL authority. Each item has an

--- a/cmd/punaro/fleet_config_command.go
+++ b/cmd/punaro/fleet_config_command.go
@@ -20,6 +20,7 @@ import (
 	"github.com/rock3r/punaro/internal/fleetconfig"
 	"github.com/rock3r/punaro/internal/operator"
 	punaropostgres "github.com/rock3r/punaro/internal/postgres"
+	"github.com/rock3r/punaro/internal/relay"
 )
 
 const (
@@ -38,6 +39,7 @@ var (
 	persistFleetRelease    = persistFleetReleaseDefault
 	loadFleetDesired       = loadFleetDesiredDefault
 	loadStoredFleetRelease = loadStoredFleetReleaseDefault
+	afterFleetPublish      = func(_, _ int64) {}
 )
 
 func runFleetConfigConfigure(args []string, stdout, stderr io.Writer) int {
@@ -157,6 +159,8 @@ func runFleetConfigPublish(args []string, stdout, stderr io.Writer) int {
 		_, _ = fmt.Fprintln(stderr, "fleet-config publish failed; prior desired revision is unchanged")
 		return 1
 	}
+	relay.BroadcastFleetWake(nil, desired.Generation, published.Generation)
+	afterFleetPublish(desired.Generation, published.Generation)
 	return writeJSON(stdout, stderr, map[string]any{
 		"status":             "fleet_config_published",
 		"source_commit":      published.SourceCommit,

--- a/cmd/punaro/fleet_config_command_test.go
+++ b/cmd/punaro/fleet_config_command_test.go
@@ -10,9 +10,11 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/rock3r/punaro/internal/fleetconfig"
 	punaropostgres "github.com/rock3r/punaro/internal/postgres"
+	"github.com/rock3r/punaro/internal/relay"
 )
 
 const testPublishCommit = "0123456789abcdef0123456789abcdef01234567"
@@ -67,6 +69,35 @@ func TestFleetConfigPublishPreviewIncludesContractFields(t *testing.T) {
 	}
 	if strings.Contains(body, "# fleet") || strings.Contains(body, TrailerLeak()) || strings.Contains(strings.ToLower(body), "skill.md") && strings.Contains(body, "description") {
 		t.Fatalf("preview leaked configuration contents: %s", body)
+	}
+}
+
+func TestFleetConfigPublishBroadcastsWakeOnGenerationAdvance(t *testing.T) {
+	preserveFleetConfig(t)
+	directory := testInstallation(t)
+	writeFleetSource(t, directory)
+	release := testRelease()
+	materializeFleetCommit = func(string, string) (fleetconfig.Release, error) { return release, nil }
+	store := &memoryFleetStore{}
+	loadFleetDesired = store.desired
+	persistFleetRelease = store.publish
+	notifier := relay.NewNotifier()
+	client := notifier.Register("machine-a")
+	t.Cleanup(client.Close)
+	afterFleetPublish = func(previous, current int64) {
+		relay.BroadcastFleetWake(notifier, previous, current)
+	}
+	hash := fleetPublishPreviewHash(release, punaropostgres.FleetDesired{})
+	if code := run([]string{"fleet-config", "publish", "--directory", directory, "--yes", "--confirm-preview-hash", hash, testPublishCommit}, bytes.NewBuffer(nil), bytes.NewBuffer(nil)); code != 0 {
+		t.Fatalf("code=%d", code)
+	}
+	select {
+	case event := <-client.Events():
+		if event.TopicID != relay.FleetConfigTopic || event.Sequence != 1 {
+			t.Fatalf("event=%#v", event)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("publish did not broadcast a fleet-config wake")
 	}
 }
 
@@ -378,9 +409,9 @@ func gitHead(t *testing.T, repo string) string {
 func preserveFleetConfig(t *testing.T) {
 	t.Helper()
 	preserveDependencies(t)
-	originalMaterialize, originalPersist, originalDesired, originalStored := materializeFleetCommit, persistFleetRelease, loadFleetDesired, loadStoredFleetRelease
+	originalMaterialize, originalPersist, originalDesired, originalStored, originalWake := materializeFleetCommit, persistFleetRelease, loadFleetDesired, loadStoredFleetRelease, afterFleetPublish
 	t.Cleanup(func() {
-		materializeFleetCommit, persistFleetRelease, loadFleetDesired, loadStoredFleetRelease = originalMaterialize, originalPersist, originalDesired, originalStored
+		materializeFleetCommit, persistFleetRelease, loadFleetDesired, loadStoredFleetRelease, afterFleetPublish = originalMaterialize, originalPersist, originalDesired, originalStored, originalWake
 	})
 	loadStoredFleetRelease = func(context.Context, string, string) (fleetconfig.Release, error) {
 		return fleetconfig.Release{}, errors.New("no stored release")

--- a/cmd/punarod/main.go
+++ b/cmd/punarod/main.go
@@ -805,7 +805,11 @@ func buildRelayHandler(cfg config.Config, postgresBackends ...relay.Backend) (ht
 		}
 		return nil, nil, err
 	}
-	handler := relay.NewHandler(backend, authenticator, relay.HandlerOptions{Metrics: metrics})
+	handlerOptions := relay.HandlerOptions{Metrics: metrics}
+	if fleet, ok := backend.(relay.FleetConfigStore); ok {
+		handlerOptions.FleetConfig = fleet
+	}
+	handler := relay.NewHandler(backend, authenticator, handlerOptions)
 	if cfg.AccessIssuer != "" {
 		verifier, err := newAccessVerifier(cfg)
 		if err != nil {

--- a/cmd/punarod/main.go
+++ b/cmd/punarod/main.go
@@ -198,6 +198,12 @@ func run(args []string, stderr io.Writer) int {
 		}
 	}
 	var postgresRelay relay.Backend
+	var fleetStore relay.FleetConfigStore
+	if platformDB != nil {
+		if fleet, ok := platformDB.(relay.FleetConfigStore); ok {
+			fleetStore = fleet
+		}
+	}
 	if cfg.RelayStore == "postgres" {
 		var ok bool
 		postgresRelay, ok = platformDB.(relay.Backend)
@@ -206,7 +212,7 @@ func run(args []string, stderr io.Writer) int {
 			return 2
 		}
 	}
-	relayHandler, relayStore, err := buildRelayHandler(cfg, postgresRelay)
+	relayHandler, relayStore, err := buildRelayHandler(cfg, fleetStore, postgresRelay)
 	if err != nil {
 		_, _ = fmt.Fprintf(stderr, "punarod relay configuration error: %v\n", err)
 		return 2
@@ -721,7 +727,7 @@ func shutdownHTTPServers(ctx context.Context, servers ...httpShutdowner) error {
 	return errors.Join(joined...)
 }
 
-func buildRelayHandler(cfg config.Config, postgresBackends ...relay.Backend) (http.Handler, *relay.Store, error) {
+func buildRelayHandler(cfg config.Config, fleet relay.FleetConfigStore, postgresBackends ...relay.Backend) (http.Handler, *relay.Store, error) {
 	if !cfg.RelayEnabled {
 		return nil, nil, nil
 	}
@@ -805,11 +811,17 @@ func buildRelayHandler(cfg config.Config, postgresBackends ...relay.Backend) (ht
 		}
 		return nil, nil, err
 	}
-	handlerOptions := relay.HandlerOptions{Metrics: metrics}
-	if fleet, ok := backend.(relay.FleetConfigStore); ok {
-		handlerOptions.FleetConfig = fleet
+	if fleet == nil {
+		if candidate, ok := backend.(relay.FleetConfigStore); ok {
+			fleet = candidate
+		}
 	}
+	notifier := relay.NewNotifier()
+	handlerOptions := relay.HandlerOptions{Metrics: metrics, FleetConfig: fleet, Notifier: notifier}
 	handler := relay.NewHandler(backend, authenticator, handlerOptions)
+	if fleet != nil {
+		go relay.WatchFleetDesired(context.Background(), fleet, notifier, 2*time.Second)
+	}
 	if cfg.AccessIssuer != "" {
 		verifier, err := newAccessVerifier(cfg)
 		if err != nil {

--- a/cmd/punarod/relay_test.go
+++ b/cmd/punarod/relay_test.go
@@ -64,7 +64,7 @@ func (d *transitionDatabaseDouble) ResolveMigratedLegacyPublicKey(_ context.Cont
 }
 
 func TestBuildRelayHandlerRejectsInvalidEnrollment(t *testing.T) {
-	_, closeRelay, err := buildRelayHandler(config.Config{DataDir: t.TempDir(), RelayEnabled: true, RelayMachinesJSON: `[{"id":"machine-a","public_key":"invalid","endpoint_prefixes":["agent/"]}]`})
+	_, closeRelay, err := buildRelayHandler(config.Config{DataDir: t.TempDir(), RelayEnabled: true, RelayMachinesJSON: `[{"id":"machine-a","public_key":"invalid","endpoint_prefixes":["agent/"]}]`}, nil)
 	if closeRelay != nil {
 		t.Fatal("invalid relay configuration returned a closer")
 	}
@@ -80,7 +80,7 @@ func TestBuildRelayHandlerRevokedEnrollmentFailsClosedAfterRestart(t *testing.T)
 	}
 	machines := `[{"id":"machine-a","public_key":"` + base64.RawURLEncoding.EncodeToString(public) + `","endpoint_prefixes":["agent/a/"]}]`
 	dataDir := t.TempDir()
-	first, firstStore, err := buildRelayHandler(config.Config{DataDir: dataDir, RelayEnabled: true, RelayMachinesJSON: machines})
+	first, firstStore, err := buildRelayHandler(config.Config{DataDir: dataDir, RelayEnabled: true, RelayMachinesJSON: machines}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -94,7 +94,7 @@ func TestBuildRelayHandlerRevokedEnrollmentFailsClosedAfterRestart(t *testing.T)
 		t.Fatal(err)
 	}
 
-	restarted, restartedStore, err := buildRelayHandler(config.Config{DataDir: dataDir, RelayEnabled: true, RelayMachinesJSON: `[]`})
+	restarted, restartedStore, err := buildRelayHandler(config.Config{DataDir: dataDir, RelayEnabled: true, RelayMachinesJSON: `[]`}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -128,9 +128,54 @@ func TestBuildRelayCanSelectPostgresBackendWithoutOpeningSQLite(t *testing.T) {
 	handler, sqliteStore, err := buildRelayHandler(config.Config{
 		DataDir: t.TempDir(), RelayEnabled: true, RelayStore: "postgres",
 		RelayMachinesJSON: `[{"id":"machine-a","public_key":"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA","endpoint_prefixes":["agent/a/"]}]`,
-	}, backend)
+	}, nil, backend)
 	if err != nil || handler == nil || sqliteStore != nil {
 		t.Fatalf("handler=%v sqlite=%v err=%v", handler, sqliteStore, err)
+	}
+}
+
+type fleetConfigDouble struct {
+	desired relay.FleetDesiredMetadata
+}
+
+func (d *fleetConfigDouble) FleetDesired(context.Context) (relay.FleetDesiredMetadata, error) {
+	return d.desired, nil
+}
+
+func (d *fleetConfigDouble) FleetRelease(context.Context, string) ([]byte, error) {
+	return nil, errors.New("missing")
+}
+
+func (d *fleetConfigDouble) PutFleetStatus(context.Context, string, relay.FleetStatusReport) error {
+	return nil
+}
+
+func TestBuildRelayHandlerServesFleetConfigWhenRelayIsSQLite(t *testing.T) {
+	public, private, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	machines := `[{"id":"machine-a","public_key":"` + base64.RawURLEncoding.EncodeToString(public) + `","endpoint_prefixes":["agent/a/"]}]`
+	fleet := &fleetConfigDouble{desired: relay.FleetDesiredMetadata{Generation: 3, Digest: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", SourceCommit: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"}}
+	handler, store, err := buildRelayHandler(config.Config{DataDir: t.TempDir(), RelayEnabled: true, RelayMachinesJSON: machines}, fleet)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	request := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/v1/fleet-config/desired", http.NoBody)
+	signed := relay.SignedRequest{MachineID: "machine-a", Method: request.Method, Path: request.URL.Path, Timestamp: time.Now().UTC(), Nonce: "fleet-desired"}
+	signed.Signature = ed25519.Sign(private, relay.CanonicalRequest(signed))
+	request.Header.Set("X-Punaro-Machine", signed.MachineID)
+	request.Header.Set("X-Punaro-Timestamp", signed.Timestamp.Format(time.RFC3339Nano))
+	request.Header.Set("X-Punaro-Nonce", signed.Nonce)
+	request.Header.Set("X-Punaro-Signature", base64.RawURLEncoding.EncodeToString(signed.Signature))
+	response := httptest.NewRecorder()
+	handler.ServeHTTP(response, request)
+	if response.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", response.Code, response.Body.String())
+	}
+	if !bytes.Contains(response.Body.Bytes(), []byte(`"generation": 3`)) && !bytes.Contains(response.Body.Bytes(), []byte(`"generation":3`)) {
+		t.Fatalf("body=%s", response.Body.String())
 	}
 }
 
@@ -175,7 +220,7 @@ func TestBuildPermitHandlerRequiresEnrolledAttachmentDeviceBinding(t *testing.T)
 	if err := os.WriteFile(keyPath, []byte(base64.RawURLEncoding.EncodeToString(issuerPrivate)), 0o600); err != nil {
 		t.Fatal(err)
 	}
-	_, store, err := buildRelayHandler(config.Config{DataDir: t.TempDir(), RelayEnabled: true, RelayMachinesJSON: `[{"id":"machine-a","public_key":"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA","endpoint_prefixes":["agent/a/"]}]`})
+	_, store, err := buildRelayHandler(config.Config{DataDir: t.TempDir(), RelayEnabled: true, RelayMachinesJSON: `[{"id":"machine-a","public_key":"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA","endpoint_prefixes":["agent/a/"]}]`}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -201,7 +246,7 @@ func TestBuildV3AttachmentHandlersRequireEnrolledAttachmentDeviceBinding(t *test
 	}
 	dataDir := t.TempDir()
 	_, store, err := buildRelayHandler(config.Config{DataDir: dataDir, RelayEnabled: true, RelayMachinesJSON: `[{
-"id":"machine-a","public_key":"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA","endpoint_prefixes":["agent/a/"]}]`})
+"id":"machine-a","public_key":"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA","endpoint_prefixes":["agent/a/"]}]`}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -230,7 +275,7 @@ func TestBuildPermitHandlerRejectsUnavailableDirectoryAtStartup(t *testing.T) {
 	}
 	dataDir := t.TempDir()
 	machines := `[{"id":"machine-a","public_key":"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA","endpoint_prefixes":["agent/a/"],"attachment_device_id":"AQEBAQEBAQEBAQEBAQEBAQ"}]`
-	_, store, err := buildRelayHandler(config.Config{DataDir: dataDir, RelayEnabled: true, RelayMachinesJSON: machines})
+	_, store, err := buildRelayHandler(config.Config{DataDir: dataDir, RelayEnabled: true, RelayMachinesJSON: machines}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -308,7 +353,7 @@ func TestPermitRuntimeMintsPermitOnlyForBoundMachineHolder(t *testing.T) {
 	}
 	dataDir := t.TempDir()
 	machines := `[{"id":"machine-a","public_key":"` + base64.RawURLEncoding.EncodeToString(machinePublic) + `","endpoint_prefixes":["agent/a/"],"attachment_device_id":"` + base64.RawURLEncoding.EncodeToString(senderID[:]) + `"},{"id":"machine-b","public_key":"` + base64.RawURLEncoding.EncodeToString(machineBPublic) + `","endpoint_prefixes":["agent/b/"],"attachment_device_id":"` + base64.RawURLEncoding.EncodeToString(recipientID[:]) + `"}]`
-	_, store, err := buildRelayHandler(config.Config{DataDir: dataDir, RelayEnabled: true, RelayMachinesJSON: machines})
+	_, store, err := buildRelayHandler(config.Config{DataDir: dataDir, RelayEnabled: true, RelayMachinesJSON: machines}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -418,7 +463,7 @@ func TestV3PermitRuntimeMintsOnlyForBoundMachineHolder(t *testing.T) {
 	}
 	dataDir := t.TempDir()
 	machines := `[{"id":"machine-a","public_key":"` + base64.RawURLEncoding.EncodeToString(machinePublic) + `","endpoint_prefixes":["agent/a/"],"attachment_device_id":"` + base64.RawURLEncoding.EncodeToString(senderID[:]) + `"},{"id":"machine-b","public_key":"` + base64.RawURLEncoding.EncodeToString(machineBPublic) + `","endpoint_prefixes":["agent/b/"],"attachment_device_id":"` + base64.RawURLEncoding.EncodeToString(recipientID[:]) + `"}]`
-	_, store, err := buildRelayHandler(config.Config{DataDir: dataDir, RelayEnabled: true, RelayMachinesJSON: machines})
+	_, store, err := buildRelayHandler(config.Config{DataDir: dataDir, RelayEnabled: true, RelayMachinesJSON: machines}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -515,7 +560,7 @@ func permitHandlerConfig(t *testing.T, privateDir, keyPath string) legacyAttachm
 }
 
 func TestBuildDirectoryHandlerRequiresValidPrivateSnapshot(t *testing.T) {
-	_, closeRelay, err := buildRelayHandler(config.Config{DataDir: t.TempDir(), RelayEnabled: true, RelayMachinesJSON: `[{"id":"machine-a","public_key":"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA","endpoint_prefixes":["agent/a/"]}]`})
+	_, closeRelay, err := buildRelayHandler(config.Config{DataDir: t.TempDir(), RelayEnabled: true, RelayMachinesJSON: `[{"id":"machine-a","public_key":"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA","endpoint_prefixes":["agent/a/"]}]`}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/docs/operator-guide.md
+++ b/docs/operator-guide.md
@@ -170,8 +170,8 @@ database and investigate. The digest-pinned `make test-postgres` stack is epheme
 test infrastructure, publishes no database port, and deletes its volume on
 exit.
 
-The current binary requires schema version 58 and supports an intact schema
-from version 10 through 58 as an update boundary. Versions 10 through 57 are
+The current binary requires schema version 59 and supports an intact schema
+from version 10 through 59 as an update boundary. Versions 10 through 58 are
 reported as `upgrade_required`; versions below the compatibility floor, newer
 versions, and damaged objects are `incompatible`. The embedded manifest and
 target release metadata are authoritative; check them instead of assuming a
@@ -210,7 +210,7 @@ consume the mail budget indefinitely.
 
 SQLite remains the default active relay. Maintainers may explicitly select an
 empty PostgreSQL relay with `PUNARO_RELAY_STORE=postgres` only after completing
-the supported update through the exact current schema (currently v58). This selector does not import the SQLite file,
+the supported update through the exact current schema (currently v59). This selector does not import the SQLite file,
 does not dual-write, and is incompatible with the superseded directory and
 attachment routes. Do not point an established installation at an empty
 PostgreSQL relay as a migration shortcut; the verified one-shot mail cutover is
@@ -220,7 +220,7 @@ again while retaining both stores unchanged.
 ### One-shot mail cutover
 
 First complete the supported update through the exact current schema (currently
-v58); the preview and execution both fail closed on any runtime-compatible older schema before
+v59); the preview and execution both fail closed on any runtime-compatible older schema before
 inspecting or preparing SQLite. Then stop ordinary operator changes, confirm every intended legacy machine is
 `migrated` or explicitly `retired`, and run the read-only preview:
 

--- a/docs/operator-guide.md
+++ b/docs/operator-guide.md
@@ -184,8 +184,9 @@ mail rate-limit buckets, migration 47 adds idempotent direct-role
 conversations, migration 48 adds explicit pending-delivery capacity
 counters, migration 49 adds content-free terminal delivery metadata,
 migrations 50 through 57 add conversation display names, Telegram topic-claim
-cutover tables, and their idempotency and machine-key fences, and migration 58
-adds the fleet-global configuration release and desired-revision store.
+cutover tables, and their idempotency and machine-key fences, migration 58
+adds the fleet-global configuration release and desired-revision store, and
+migration 59 adds enrolled-client status writes.
 After migration 48, `punaro relay reconcile-capacity
 --directory DIR --yes` rebuilds those counters from pending deliveries if
 startup readiness reports inconsistency. Ordinary SQLite `Open` and PostgreSQL

--- a/internal/postgres/db.go
+++ b/internal/postgres/db.go
@@ -1352,6 +1352,13 @@ FROM objects, table_ownership, routine_safety, routine_acl, table_acl, schema_ac
 		}
 		snapshot.CurrentObjectsPresent = fleetObjectsPresent
 	}
+	if snapshot.CurrentObjectsPresent && len(snapshot.Records) > 0 && snapshot.Records[len(snapshot.Records)-1].Version >= 59 {
+		statusObjectsPresent, err := fleetClientStatusControlsAvailable(ctx, q)
+		if err != nil {
+			return Snapshot{}, errors.New("PostgreSQL fleet-config client-status schema cannot be inspected")
+		}
+		snapshot.CurrentObjectsPresent = statusObjectsPresent
+	}
 	return snapshot, nil
 }
 

--- a/internal/postgres/fleet_config.go
+++ b/internal/postgres/fleet_config.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"strings"
 
 	"github.com/rock3r/punaro/internal/fleetconfig"
+	"github.com/rock3r/punaro/internal/relay"
 )
 
 // FleetDesired is the singleton published fleet-config revision.
@@ -123,4 +125,71 @@ RETURNING generation`, release.Digest, previewHash).Scan(&currentGeneration); er
 		SkillCount:   release.SkillCount,
 		TotalBytes:   release.TotalBytes,
 	}, nil
+}
+
+// FleetDesired returns content-free desired metadata for an enrolled application connection.
+func (d *Database) FleetDesired(ctx context.Context) (relay.FleetDesiredMetadata, error) {
+	if d == nil {
+		return relay.FleetDesiredMetadata{}, errors.New("fleet-config store is unavailable")
+	}
+	var desired relay.FleetDesiredMetadata
+	err := d.db.QueryRowContext(ctx, `
+SELECT desired.generation, desired.release_digest, release.source_commit, release.skill_count, release.total_bytes
+FROM fleet.desired AS desired
+JOIN fleet.releases AS release ON release.digest = desired.release_digest
+WHERE desired.id`).Scan(&desired.Generation, &desired.Digest, &desired.SourceCommit, &desired.SkillCount, &desired.TotalBytes)
+	if errors.Is(err, sql.ErrNoRows) {
+		return relay.FleetDesiredMetadata{}, nil
+	}
+	if err != nil {
+		return relay.FleetDesiredMetadata{}, errors.New("fleet-config desired revision is unavailable")
+	}
+	return desired, nil
+}
+
+// FleetRelease returns exact stored archive bytes for one digest.
+func (d *Database) FleetRelease(ctx context.Context, digest string) ([]byte, error) {
+	if d == nil || digest == "" {
+		return nil, errors.New("fleet-config release is unavailable")
+	}
+	var archive []byte
+	err := d.db.QueryRowContext(ctx, `SELECT archive FROM fleet.releases WHERE digest = $1`, digest).Scan(&archive)
+	if err != nil {
+		return nil, errors.New("fleet-config release is unavailable")
+	}
+	return archive, nil
+}
+
+// PutFleetStatus records one enrolled client's bounded status row.
+func (d *Database) PutFleetStatus(ctx context.Context, machineID string, report relay.FleetStatusReport) error {
+	if d == nil || machineID == "" {
+		return errors.New("fleet-config access is not authorized")
+	}
+	_, err := d.db.ExecContext(ctx, `SELECT fleet.put_client_status($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11)`,
+		machineID, report.Generation, nullIfEmpty(report.AppliedDigest), report.State, nullIfEmpty(report.Activation),
+		nullIfEmpty(report.TrailerState), nullIfEmpty(report.AliasState), nullIfEmpty(report.ProjectMatchState),
+		report.ReportGeneration, report.IdempotencyKey, report.RequestHash)
+	if err != nil {
+		return errors.New(postgresFleetStatusError(err))
+	}
+	return nil
+}
+
+func nullIfEmpty(value string) any {
+	if value == "" {
+		return nil
+	}
+	return value
+}
+
+func postgresFleetStatusError(err error) string {
+	message := err.Error()
+	switch {
+	case strings.Contains(message, "stale"):
+		return "fleet-config status generation is stale"
+	case strings.Contains(message, "idempotency"):
+		return "fleet-config status idempotency conflict"
+	default:
+		return "fleet-config access is not authorized"
+	}
 }

--- a/internal/postgres/fleet_config_schema.go
+++ b/internal/postgres/fleet_config_schema.go
@@ -48,3 +48,28 @@ SELECT fleet_namespace_oid IS NOT NULL
 FROM objects`).Scan(&available)
 	return available, err
 }
+
+func fleetClientStatusControlsAvailable(ctx context.Context, q queryer) (bool, error) {
+	var available bool
+	err := q.QueryRowContext(ctx, `
+WITH objects AS (
+    SELECT to_regclass('fleet.client_status') AS status_oid,
+           to_regclass('fleet.client_status_idempotency') AS idempotency_oid,
+           to_regprocedure('fleet.put_client_status(text,bigint,text,text,text,text,text,text,bigint,text,text)') AS put_oid,
+           to_regprocedure('jobs.guard_application_mutation()') AS fence_oid
+)
+SELECT status_oid IS NOT NULL AND idempotency_oid IS NOT NULL AND put_oid IS NOT NULL AND fence_oid IS NOT NULL
+   AND (SELECT count(*) = 2 AND bool_and(relkind = 'r' AND pg_get_userbyid(relowner) = 'punaro_owner')
+        FROM pg_class WHERE oid = ANY(ARRAY[status_oid, idempotency_oid]))
+   AND EXISTS (SELECT 1 FROM pg_attribute WHERE attrelid = status_oid AND attname = 'report_generation' AND atttypid = 'bigint'::regtype AND attnotnull AND NOT attisdropped)
+   AND (SELECT count(*) = 2 FROM pg_trigger
+        WHERE tgrelid = ANY(ARRAY[status_oid, idempotency_oid])
+          AND tgname = 'application_mutation_fence' AND NOT tgisinternal AND tgenabled = 'O' AND tgfoid = fence_oid AND tgtype = 62)
+   AND has_table_privilege('punaro_app', 'fleet.client_status', 'SELECT')
+   AND has_function_privilege('punaro_app', put_oid, 'EXECUTE')
+   AND NOT has_table_privilege('punaro_app', 'fleet.client_status', 'INSERT')
+   AND NOT has_table_privilege('punaro_app', 'fleet.client_status', 'UPDATE')
+   AND NOT has_table_privilege('punaro_app', 'fleet.client_status_idempotency', 'INSERT')
+FROM objects`).Scan(&available)
+	return available, err
+}

--- a/internal/postgres/fleet_config_schema.go
+++ b/internal/postgres/fleet_config_schema.go
@@ -69,7 +69,17 @@ SELECT status_oid IS NOT NULL AND idempotency_oid IS NOT NULL AND put_oid IS NOT
    AND has_function_privilege('punaro_app', put_oid, 'EXECUTE')
    AND NOT has_table_privilege('punaro_app', 'fleet.client_status', 'INSERT')
    AND NOT has_table_privilege('punaro_app', 'fleet.client_status', 'UPDATE')
+   AND NOT has_table_privilege('punaro_app', 'fleet.client_status', 'DELETE')
+   AND NOT has_table_privilege('punaro_app', 'fleet.client_status', 'TRUNCATE')
+   AND NOT has_table_privilege('punaro_app', 'fleet.client_status', 'REFERENCES')
+   AND NOT has_table_privilege('punaro_app', 'fleet.client_status', 'TRIGGER')
+   AND NOT has_table_privilege('punaro_app', 'fleet.client_status_idempotency', 'SELECT')
    AND NOT has_table_privilege('punaro_app', 'fleet.client_status_idempotency', 'INSERT')
+   AND NOT has_table_privilege('punaro_app', 'fleet.client_status_idempotency', 'UPDATE')
+   AND NOT has_table_privilege('punaro_app', 'fleet.client_status_idempotency', 'DELETE')
+   AND NOT has_table_privilege('punaro_app', 'fleet.client_status_idempotency', 'TRUNCATE')
+   AND NOT has_table_privilege('punaro_app', 'fleet.client_status_idempotency', 'REFERENCES')
+   AND NOT has_table_privilege('punaro_app', 'fleet.client_status_idempotency', 'TRIGGER')
 FROM objects`).Scan(&available)
 	return available, err
 }

--- a/internal/postgres/fleet_config_schema.go
+++ b/internal/postgres/fleet_config_schema.go
@@ -61,12 +61,15 @@ WITH objects AS (
 SELECT status_oid IS NOT NULL AND idempotency_oid IS NOT NULL AND put_oid IS NOT NULL AND fence_oid IS NOT NULL
    AND (SELECT count(*) = 2 AND bool_and(relkind = 'r' AND pg_get_userbyid(relowner) = 'punaro_owner')
         FROM pg_class WHERE oid = ANY(ARRAY[status_oid, idempotency_oid]))
+   AND EXISTS (SELECT 1 FROM pg_attribute WHERE attrelid = status_oid AND attname = 'machine_id' AND atttypid = 'text'::regtype AND attnotnull AND NOT attisdropped)
    AND EXISTS (SELECT 1 FROM pg_attribute WHERE attrelid = status_oid AND attname = 'report_generation' AND atttypid = 'bigint'::regtype AND attnotnull AND NOT attisdropped)
+   AND (SELECT prosecdef AND proconfig = ARRAY['search_path=pg_catalog']::text[] AND pg_get_userbyid(proowner) = 'punaro_owner' FROM pg_proc WHERE oid = put_oid)
    AND (SELECT count(*) = 2 FROM pg_trigger
         WHERE tgrelid = ANY(ARRAY[status_oid, idempotency_oid])
           AND tgname = 'application_mutation_fence' AND NOT tgisinternal AND tgenabled = 'O' AND tgfoid = fence_oid AND tgtype = 62)
    AND has_table_privilege('punaro_app', 'fleet.client_status', 'SELECT')
    AND has_function_privilege('punaro_app', put_oid, 'EXECUTE')
+   AND NOT has_function_privilege('public', put_oid, 'EXECUTE')
    AND NOT has_table_privilege('punaro_app', 'fleet.client_status', 'INSERT')
    AND NOT has_table_privilege('punaro_app', 'fleet.client_status', 'UPDATE')
    AND NOT has_table_privilege('punaro_app', 'fleet.client_status', 'DELETE')

--- a/internal/postgres/fleet_config_test.go
+++ b/internal/postgres/fleet_config_test.go
@@ -28,11 +28,14 @@ func TestFleetPutClientStatusSerializesIdempotencyLookup(t *testing.T) {
 		t.Fatal(err)
 	}
 	sql := string(body)
-	if strings.Contains(sql, "FOR SHARE") {
-		t.Fatal("concurrent first-status retries are not serialized before the idempotency lookup")
+	if strings.Contains(sql, "client_installations") {
+		t.Fatal("status writes require a client installation")
 	}
-	if !strings.Contains(sql, "FROM auth.client_installations") || !strings.Contains(sql, "AND lifecycle_state = 'active'\n    FOR UPDATE;") {
-		t.Fatal("client status does not exclusive-lock the installation before idempotency lookup")
+	if !strings.Contains(sql, "machine_id text PRIMARY KEY") {
+		t.Fatal("status is not keyed by the authenticated machine id")
+	}
+	if !strings.Contains(sql, "pg_advisory_xact_lock") {
+		t.Fatal("concurrent first-status retries are not serialized before the idempotency lookup")
 	}
 }
 
@@ -55,6 +58,9 @@ func TestFleetClientStatusControlsDenyApplicationMutations(t *testing.T) {
 		"AND NOT has_table_privilege('punaro_app', 'fleet.client_status_idempotency', 'TRUNCATE')",
 		"AND NOT has_table_privilege('punaro_app', 'fleet.client_status_idempotency', 'REFERENCES')",
 		"AND NOT has_table_privilege('punaro_app', 'fleet.client_status_idempotency', 'TRIGGER')",
+		"AND NOT has_function_privilege('public', put_oid, 'EXECUTE')",
+		"prosecdef",
+		"search_path=pg_catalog",
 	}
 	for _, want := range required {
 		if !strings.Contains(source, want) {

--- a/internal/postgres/fleet_config_test.go
+++ b/internal/postgres/fleet_config_test.go
@@ -2,10 +2,24 @@ package postgres
 
 import (
 	"context"
+	"os"
+	"strings"
 	"testing"
 
 	"github.com/rock3r/punaro/internal/fleetconfig"
 )
+
+func TestFleetPutClientStatusLocksReportGeneration(t *testing.T) {
+	t.Parallel()
+	body, err := os.ReadFile("migrations/059_fleet_config_client_status.sql")
+	if err != nil {
+		t.Fatal(err)
+	}
+	sql := string(body)
+	if !strings.Contains(sql, "FOR UPDATE") || !strings.Contains(sql, "report_generation < EXCLUDED.report_generation") {
+		t.Fatal("client status upsert is not fenced by report generation")
+	}
+}
 
 func TestPublishFleetReleaseRefusesInvalidInput(t *testing.T) {
 	t.Parallel()

--- a/internal/postgres/fleet_config_test.go
+++ b/internal/postgres/fleet_config_test.go
@@ -21,6 +21,48 @@ func TestFleetPutClientStatusLocksReportGeneration(t *testing.T) {
 	}
 }
 
+func TestFleetPutClientStatusSerializesIdempotencyLookup(t *testing.T) {
+	t.Parallel()
+	body, err := os.ReadFile("migrations/059_fleet_config_client_status.sql")
+	if err != nil {
+		t.Fatal(err)
+	}
+	sql := string(body)
+	if strings.Contains(sql, "FOR SHARE") {
+		t.Fatal("concurrent first-status retries are not serialized before the idempotency lookup")
+	}
+	if !strings.Contains(sql, "FROM auth.client_installations") || !strings.Contains(sql, "AND lifecycle_state = 'active'\n    FOR UPDATE;") {
+		t.Fatal("client status does not exclusive-lock the installation before idempotency lookup")
+	}
+}
+
+func TestFleetClientStatusControlsDenyApplicationMutations(t *testing.T) {
+	t.Parallel()
+	body, err := os.ReadFile("fleet_config_schema.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	source := string(body)
+	required := []string{
+		"AND NOT has_table_privilege('punaro_app', 'fleet.client_status', 'DELETE')",
+		"AND NOT has_table_privilege('punaro_app', 'fleet.client_status', 'TRUNCATE')",
+		"AND NOT has_table_privilege('punaro_app', 'fleet.client_status', 'REFERENCES')",
+		"AND NOT has_table_privilege('punaro_app', 'fleet.client_status', 'TRIGGER')",
+		"AND NOT has_table_privilege('punaro_app', 'fleet.client_status_idempotency', 'SELECT')",
+		"AND NOT has_table_privilege('punaro_app', 'fleet.client_status_idempotency', 'INSERT')",
+		"AND NOT has_table_privilege('punaro_app', 'fleet.client_status_idempotency', 'UPDATE')",
+		"AND NOT has_table_privilege('punaro_app', 'fleet.client_status_idempotency', 'DELETE')",
+		"AND NOT has_table_privilege('punaro_app', 'fleet.client_status_idempotency', 'TRUNCATE')",
+		"AND NOT has_table_privilege('punaro_app', 'fleet.client_status_idempotency', 'REFERENCES')",
+		"AND NOT has_table_privilege('punaro_app', 'fleet.client_status_idempotency', 'TRIGGER')",
+	}
+	for _, want := range required {
+		if !strings.Contains(source, want) {
+			t.Fatalf("status inspect omitted %s", want)
+		}
+	}
+}
+
 func TestPublishFleetReleaseRefusesInvalidInput(t *testing.T) {
 	t.Parallel()
 	var admin *Administration

--- a/internal/postgres/migrate.go
+++ b/internal/postgres/migrate.go
@@ -91,6 +91,7 @@ var migrationCompatibilityFloors = map[int64]int64{
 	56: 10,
 	57: 10,
 	58: 10,
+	59: 10,
 }
 
 // CurrentManifest returns the immutable migrations embedded in this binary.

--- a/internal/postgres/migrations/059_fleet_config_client_status.sql
+++ b/internal/postgres/migrations/059_fleet_config_client_status.sql
@@ -1,5 +1,7 @@
 CREATE TABLE fleet.client_status (
-    client_id uuid PRIMARY KEY REFERENCES auth.client_installations (id),
+    machine_id text PRIMARY KEY CHECK (
+        machine_id ~ '^[a-z0-9]([a-z0-9._-]{0,62}[a-z0-9])?$'
+    ),
     generation bigint NOT NULL CHECK (generation >= 1),
     applied_digest text CHECK (applied_digest ~ '^[0-9a-f]{64}$'),
     state text NOT NULL CHECK (state IN (
@@ -16,7 +18,7 @@ CREATE TABLE fleet.client_status (
 );
 
 CREATE TABLE fleet.client_status_idempotency (
-    client_id uuid NOT NULL REFERENCES auth.client_installations (id),
+    machine_id text NOT NULL REFERENCES fleet.client_status (machine_id),
     idempotency_key text NOT NULL CHECK (
         char_length(idempotency_key) BETWEEN 1 AND 128
         AND octet_length(idempotency_key) <= 512
@@ -24,7 +26,7 @@ CREATE TABLE fleet.client_status_idempotency (
     ),
     request_hash text NOT NULL CHECK (request_hash ~ '^[0-9a-f]{64}$'),
     created_at timestamptz NOT NULL DEFAULT statement_timestamp(),
-    PRIMARY KEY (client_id, idempotency_key)
+    PRIMARY KEY (machine_id, idempotency_key)
 );
 
 CREATE FUNCTION fleet.put_client_status(
@@ -45,21 +47,16 @@ SECURITY DEFINER
 SET search_path = pg_catalog
 AS $function$
 DECLARE
-    target uuid;
     previous_generation bigint;
     previous_hash text;
 BEGIN
-    SELECT id INTO target
-    FROM auth.client_installations
-    WHERE machine_id = p_machine_id
-      AND lifecycle_state = 'active'
-    FOR UPDATE;
-    IF target IS NULL THEN
+    IF p_machine_id IS NULL OR p_machine_id !~ '^[a-z0-9]([a-z0-9._-]{0,62}[a-z0-9])?$' THEN
         RAISE EXCEPTION 'fleet-config status is not authorized';
     END IF;
+    PERFORM pg_advisory_xact_lock(88059, hashtext(p_machine_id));
     SELECT request_hash INTO previous_hash
     FROM fleet.client_status_idempotency
-    WHERE client_id = target AND idempotency_key = p_idempotency_key;
+    WHERE machine_id = p_machine_id AND idempotency_key = p_idempotency_key;
     IF FOUND THEN
         IF previous_hash <> p_request_hash THEN
             RAISE EXCEPTION 'fleet-config status idempotency conflict';
@@ -68,19 +65,19 @@ BEGIN
     END IF;
     SELECT report_generation INTO previous_generation
     FROM fleet.client_status
-    WHERE client_id = target
+    WHERE machine_id = p_machine_id
     FOR UPDATE;
     IF FOUND AND previous_generation >= p_report_generation THEN
         RAISE EXCEPTION 'fleet-config status generation is stale';
     END IF;
     INSERT INTO fleet.client_status (
-        client_id, generation, applied_digest, state, activation,
+        machine_id, generation, applied_digest, state, activation,
         trailer_state, alias_state, project_match_state, report_generation
     ) VALUES (
-        target, p_generation, p_applied_digest, p_state, p_activation,
+        p_machine_id, p_generation, p_applied_digest, p_state, p_activation,
         p_trailer_state, p_alias_state, p_project_match_state, p_report_generation
     )
-    ON CONFLICT (client_id) DO UPDATE SET
+    ON CONFLICT (machine_id) DO UPDATE SET
         generation = EXCLUDED.generation,
         applied_digest = EXCLUDED.applied_digest,
         state = EXCLUDED.state,
@@ -91,8 +88,8 @@ BEGIN
         reported_at = statement_timestamp(),
         report_generation = EXCLUDED.report_generation
     WHERE fleet.client_status.report_generation < EXCLUDED.report_generation;
-    INSERT INTO fleet.client_status_idempotency (client_id, idempotency_key, request_hash)
-    VALUES (target, p_idempotency_key, p_request_hash);
+    INSERT INTO fleet.client_status_idempotency (machine_id, idempotency_key, request_hash)
+    VALUES (p_machine_id, p_idempotency_key, p_request_hash);
 END;
 $function$;
 

--- a/internal/postgres/migrations/059_fleet_config_client_status.sql
+++ b/internal/postgres/migrations/059_fleet_config_client_status.sql
@@ -1,0 +1,101 @@
+CREATE TABLE fleet.client_status (
+    client_id uuid PRIMARY KEY REFERENCES auth.client_installations (id),
+    generation bigint NOT NULL CHECK (generation >= 1),
+    applied_digest text CHECK (applied_digest ~ '^[0-9a-f]{64}$'),
+    state text NOT NULL CHECK (state IN (
+        'current', 'pending', 'applying', 'failed', 'offline', 'drifted', 'unsupported', 'restart_required'
+    )),
+    activation text CHECK (activation IN (
+        'immediate', 'next_turn', 'next_session', 'restart_required'
+    )),
+    trailer_state text CHECK (trailer_state IS NULL OR trailer_state IN ('missing', 'present', 'collision')),
+    alias_state text CHECK (alias_state IS NULL OR alias_state IN ('disabled', 'linked', 'unsupported', 'collision')),
+    project_match_state text CHECK (project_match_state IS NULL OR project_match_state IN ('none', 'matched', 'override', 'unmatched')),
+    reported_at timestamptz NOT NULL DEFAULT statement_timestamp(),
+    report_generation bigint NOT NULL CHECK (report_generation >= 1)
+);
+
+CREATE TABLE fleet.client_status_idempotency (
+    client_id uuid NOT NULL REFERENCES auth.client_installations (id),
+    idempotency_key text NOT NULL CHECK (
+        char_length(idempotency_key) BETWEEN 1 AND 128
+        AND octet_length(idempotency_key) <= 512
+        AND idempotency_key !~ '[[:cntrl:]]'
+    ),
+    request_hash text NOT NULL CHECK (request_hash ~ '^[0-9a-f]{64}$'),
+    created_at timestamptz NOT NULL DEFAULT statement_timestamp(),
+    PRIMARY KEY (client_id, idempotency_key)
+);
+
+CREATE FUNCTION fleet.put_client_status(
+    p_machine_id text,
+    p_generation bigint,
+    p_applied_digest text,
+    p_state text,
+    p_activation text,
+    p_trailer_state text,
+    p_alias_state text,
+    p_project_match_state text,
+    p_report_generation bigint,
+    p_idempotency_key text,
+    p_request_hash text
+) RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog
+AS $function$
+DECLARE
+    target uuid;
+    previous_generation bigint;
+    previous_hash text;
+BEGIN
+    SELECT id INTO target
+    FROM auth.client_installations
+    WHERE machine_id = p_machine_id
+      AND lifecycle_state = 'active'
+    FOR SHARE;
+    IF target IS NULL THEN
+        RAISE EXCEPTION 'fleet-config status is not authorized';
+    END IF;
+    SELECT request_hash INTO previous_hash
+    FROM fleet.client_status_idempotency
+    WHERE client_id = target AND idempotency_key = p_idempotency_key;
+    IF FOUND THEN
+        IF previous_hash <> p_request_hash THEN
+            RAISE EXCEPTION 'fleet-config status idempotency conflict';
+        END IF;
+        RETURN;
+    END IF;
+    SELECT report_generation INTO previous_generation
+    FROM fleet.client_status
+    WHERE client_id = target;
+    IF FOUND AND previous_generation >= p_report_generation THEN
+        RAISE EXCEPTION 'fleet-config status generation is stale';
+    END IF;
+    INSERT INTO fleet.client_status (
+        client_id, generation, applied_digest, state, activation,
+        trailer_state, alias_state, project_match_state, report_generation
+    ) VALUES (
+        target, p_generation, p_applied_digest, p_state, p_activation,
+        p_trailer_state, p_alias_state, p_project_match_state, p_report_generation
+    )
+    ON CONFLICT (client_id) DO UPDATE SET
+        generation = EXCLUDED.generation,
+        applied_digest = EXCLUDED.applied_digest,
+        state = EXCLUDED.state,
+        activation = EXCLUDED.activation,
+        trailer_state = EXCLUDED.trailer_state,
+        alias_state = EXCLUDED.alias_state,
+        project_match_state = EXCLUDED.project_match_state,
+        reported_at = statement_timestamp(),
+        report_generation = EXCLUDED.report_generation;
+    INSERT INTO fleet.client_status_idempotency (client_id, idempotency_key, request_hash)
+    VALUES (target, p_idempotency_key, p_request_hash);
+END;
+$function$;
+
+REVOKE ALL ON fleet.client_status FROM PUBLIC;
+REVOKE ALL ON fleet.client_status_idempotency FROM PUBLIC;
+REVOKE ALL ON FUNCTION fleet.put_client_status(text, bigint, text, text, text, text, text, text, bigint, text, text) FROM PUBLIC;
+GRANT SELECT ON fleet.client_status TO punaro_app;
+GRANT EXECUTE ON FUNCTION fleet.put_client_status(text, bigint, text, text, text, text, text, text, bigint, text, text) TO punaro_app;

--- a/internal/postgres/migrations/059_fleet_config_client_status.sql
+++ b/internal/postgres/migrations/059_fleet_config_client_status.sql
@@ -53,7 +53,7 @@ BEGIN
     FROM auth.client_installations
     WHERE machine_id = p_machine_id
       AND lifecycle_state = 'active'
-    FOR SHARE;
+    FOR UPDATE;
     IF target IS NULL THEN
         RAISE EXCEPTION 'fleet-config status is not authorized';
     END IF;

--- a/internal/postgres/migrations/059_fleet_config_client_status.sql
+++ b/internal/postgres/migrations/059_fleet_config_client_status.sql
@@ -68,7 +68,8 @@ BEGIN
     END IF;
     SELECT report_generation INTO previous_generation
     FROM fleet.client_status
-    WHERE client_id = target;
+    WHERE client_id = target
+    FOR UPDATE;
     IF FOUND AND previous_generation >= p_report_generation THEN
         RAISE EXCEPTION 'fleet-config status generation is stale';
     END IF;
@@ -88,11 +89,19 @@ BEGIN
         alias_state = EXCLUDED.alias_state,
         project_match_state = EXCLUDED.project_match_state,
         reported_at = statement_timestamp(),
-        report_generation = EXCLUDED.report_generation;
+        report_generation = EXCLUDED.report_generation
+    WHERE fleet.client_status.report_generation < EXCLUDED.report_generation;
     INSERT INTO fleet.client_status_idempotency (client_id, idempotency_key, request_hash)
     VALUES (target, p_idempotency_key, p_request_hash);
 END;
 $function$;
+
+CREATE TRIGGER application_mutation_fence
+    BEFORE INSERT OR UPDATE OR DELETE OR TRUNCATE ON fleet.client_status
+    FOR EACH STATEMENT EXECUTE FUNCTION jobs.guard_application_mutation();
+CREATE TRIGGER application_mutation_fence
+    BEFORE INSERT OR UPDATE OR DELETE OR TRUNCATE ON fleet.client_status_idempotency
+    FOR EACH STATEMENT EXECUTE FUNCTION jobs.guard_application_mutation();
 
 REVOKE ALL ON fleet.client_status FROM PUBLIC;
 REVOKE ALL ON fleet.client_status_idempotency FROM PUBLIC;

--- a/internal/postgres/state_test.go
+++ b/internal/postgres/state_test.go
@@ -69,8 +69,8 @@ func TestManifestValidationRejectsMutableOrNonContiguousHistory(t *testing.T) {
 
 func TestCurrentManifestRequiresControlPlaneSchema(t *testing.T) {
 	manifest := CurrentManifest()
-	if manifest.MinSupported != 10 || manifest.MaxSupported != 58 || len(manifest.Migrations) != 58 {
-		t.Fatalf("manifest=%#v, want exact v58 compatibility window", manifest)
+	if manifest.MinSupported != 10 || manifest.MaxSupported != 59 || len(manifest.Migrations) != 59 {
+		t.Fatalf("manifest=%#v, want exact v59 compatibility window", manifest)
 	}
 	embedding := manifest.Migrations[23]
 	if embedding.Version != 24 || embedding.Name != "024_memory_embedding_worker_control" ||
@@ -88,7 +88,7 @@ func TestCurrentManifestRequiresControlPlaneSchema(t *testing.T) {
 			want = 10
 		case 12, 13:
 			want = 10
-		case 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58:
+		case 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59:
 			want = 10
 		}
 		if migration.CompatibilityFloor != want {
@@ -255,7 +255,10 @@ func TestCompatibleSchemaCanStillHavePendingMigrations(t *testing.T) {
 	if !migrationPending(SchemaState{Classification: Compatible, Version: 57}, manifest) {
 		t.Fatal("compatible v57 schema must still apply the pending v58 migration")
 	}
-	if migrationPending(SchemaState{Classification: Compatible, Version: 58}, manifest) {
-		t.Fatal("current v58 schema reported a pending migration")
+	if !migrationPending(SchemaState{Classification: Compatible, Version: 58}, manifest) {
+		t.Fatal("compatible v58 schema must still apply the pending v59 migration")
+	}
+	if migrationPending(SchemaState{Classification: Compatible, Version: 59}, manifest) {
+		t.Fatal("current v59 schema reported a pending migration")
 	}
 }

--- a/internal/relay/fleet_config.go
+++ b/internal/relay/fleet_config.go
@@ -45,7 +45,7 @@ type FleetConfigStore interface {
 }
 
 func validFleetStatus(report FleetStatusReport) bool {
-	if report.Generation < 1 || report.ReportGeneration < 1 || report.IdempotencyKey == "" || len(report.IdempotencyKey) > 128 {
+	if report.Generation < 1 || report.ReportGeneration < 1 || !ValidRequestToken(report.IdempotencyKey) {
 		return false
 	}
 	if report.AppliedDigest != "" && !fleetDigestPattern.MatchString(report.AppliedDigest) {
@@ -62,6 +62,21 @@ func validFleetStatus(report FleetStatusReport) bool {
 		default:
 			return false
 		}
+	}
+	switch report.TrailerState {
+	case "", "missing", "present", "collision":
+	default:
+		return false
+	}
+	switch report.AliasState {
+	case "", "disabled", "linked", "unsupported", "collision":
+	default:
+		return false
+	}
+	switch report.ProjectMatchState {
+	case "", "none", "matched", "override", "unmatched":
+	default:
+		return false
 	}
 	return true
 }

--- a/internal/relay/fleet_config.go
+++ b/internal/relay/fleet_config.go
@@ -1,0 +1,82 @@
+package relay
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"regexp"
+	"strconv"
+)
+
+const FleetConfigTopic = "fleet-config"
+
+var fleetDigestPattern = regexp.MustCompile(`^[0-9a-f]{64}$`)
+
+// FleetDesiredMetadata is content-free desired-revision metadata.
+type FleetDesiredMetadata struct {
+	Generation   int64
+	Digest       string
+	SourceCommit string
+	SkillCount   int
+	TotalBytes   int64
+}
+
+// FleetStatusReport is a bounded client status write.
+type FleetStatusReport struct {
+	Generation        int64
+	AppliedDigest     string
+	State             string
+	Activation        string
+	TrailerState      string
+	AliasState        string
+	ProjectMatchState string
+	ReportGeneration  int64
+	IdempotencyKey    string
+	RequestHash       string
+}
+
+// FleetConfigStore is the server-side desired/fetch/status boundary.
+type FleetConfigStore interface {
+	FleetDesired(ctx context.Context) (FleetDesiredMetadata, error)
+	FleetRelease(ctx context.Context, digest string) ([]byte, error)
+	PutFleetStatus(ctx context.Context, machineID string, report FleetStatusReport) error
+}
+
+func validFleetStatus(report FleetStatusReport) bool {
+	if report.Generation < 1 || report.ReportGeneration < 1 || report.IdempotencyKey == "" || len(report.IdempotencyKey) > 128 {
+		return false
+	}
+	if report.AppliedDigest != "" && !fleetDigestPattern.MatchString(report.AppliedDigest) {
+		return false
+	}
+	switch report.State {
+	case "current", "pending", "applying", "failed", "offline", "drifted", "unsupported", "restart_required":
+	default:
+		return false
+	}
+	if report.Activation != "" {
+		switch report.Activation {
+		case "immediate", "next_turn", "next_session", "restart_required":
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+func fleetStatusRequestHash(machineID string, report FleetStatusReport) string {
+	sum := sha256.Sum256([]byte(machineID + "\n" + report.AppliedDigest + "\n" + report.State + "\n" + strconv.FormatInt(report.Generation, 10) + "\n" + strconv.FormatInt(report.ReportGeneration, 10)))
+	return hex.EncodeToString(sum[:])
+}
+
+func errFleetUnauthorized() error { return errors.New("fleet-config access is not authorized") }
+
+// BroadcastFleetWake emits a payload-free hint when desired generation advances.
+func BroadcastFleetWake(notifier *Notifier, previous, current int64) int64 {
+	if notifier == nil || current <= previous {
+		return previous
+	}
+	notifier.PublishAll(FleetConfigTopic, current)
+	return current
+}

--- a/internal/relay/fleet_config.go
+++ b/internal/relay/fleet_config.go
@@ -4,11 +4,12 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
-	"errors"
 	"regexp"
 	"strconv"
+	"time"
 )
 
+// FleetConfigTopic is the payload-free wake topic for desired-generation advances.
 const FleetConfigTopic = "fleet-config"
 
 var fleetDigestPattern = regexp.MustCompile(`^[0-9a-f]{64}$`)
@@ -66,11 +67,9 @@ func validFleetStatus(report FleetStatusReport) bool {
 }
 
 func fleetStatusRequestHash(machineID string, report FleetStatusReport) string {
-	sum := sha256.Sum256([]byte(machineID + "\n" + report.AppliedDigest + "\n" + report.State + "\n" + strconv.FormatInt(report.Generation, 10) + "\n" + strconv.FormatInt(report.ReportGeneration, 10)))
+	sum := sha256.Sum256([]byte(machineID + "\n" + report.AppliedDigest + "\n" + report.State + "\n" + report.Activation + "\n" + report.TrailerState + "\n" + report.AliasState + "\n" + report.ProjectMatchState + "\n" + strconv.FormatInt(report.Generation, 10) + "\n" + strconv.FormatInt(report.ReportGeneration, 10)))
 	return hex.EncodeToString(sum[:])
 }
-
-func errFleetUnauthorized() error { return errors.New("fleet-config access is not authorized") }
 
 // BroadcastFleetWake emits a payload-free hint when desired generation advances.
 func BroadcastFleetWake(notifier *Notifier, previous, current int64) int64 {
@@ -79,4 +78,30 @@ func BroadcastFleetWake(notifier *Notifier, previous, current int64) int64 {
 	}
 	notifier.PublishAll(FleetConfigTopic, current)
 	return current
+}
+
+// WatchFleetDesired polls desired generation and emits payload-free wake hints.
+func WatchFleetDesired(ctx context.Context, store FleetConfigStore, notifier *Notifier, interval time.Duration) {
+	if store == nil || notifier == nil || interval <= 0 {
+		return
+	}
+	var previous int64
+	poll := func() {
+		desired, err := store.FleetDesired(ctx)
+		if err != nil {
+			return
+		}
+		previous = BroadcastFleetWake(notifier, previous, desired.Generation)
+	}
+	poll()
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			poll()
+		}
+	}
 }

--- a/internal/relay/fleet_config_http.go
+++ b/internal/relay/fleet_config_http.go
@@ -1,0 +1,96 @@
+package relay
+
+import (
+	"net/http"
+	"strings"
+)
+
+func (h *handler) fleetDesired(w http.ResponseWriter, r *http.Request, machineID string) {
+	if h.fleet == nil {
+		writeError(w, http.StatusNotFound, "route not found")
+		return
+	}
+	desired, err := h.fleet.FleetDesired(r.Context())
+	if err != nil {
+		writeError(w, http.StatusForbidden, "fleet-config access is not authorized")
+		return
+	}
+	_ = machineID
+	writeJSON(w, http.StatusOK, map[string]any{
+		"generation":    desired.Generation,
+		"digest":        desired.Digest,
+		"source_commit": desired.SourceCommit,
+		"skill_count":   desired.SkillCount,
+		"total_bytes":   desired.TotalBytes,
+	})
+}
+
+func (h *handler) fleetRelease(w http.ResponseWriter, r *http.Request, digest, machineID string) {
+	if h.fleet == nil || !fleetDigestPattern.MatchString(digest) {
+		writeError(w, http.StatusNotFound, "route not found")
+		return
+	}
+	archive, err := h.fleet.FleetRelease(r.Context(), digest)
+	if err != nil || len(archive) == 0 {
+		writeError(w, http.StatusForbidden, "fleet-config access is not authorized")
+		return
+	}
+	_ = machineID
+	w.Header().Set("Content-Type", "application/octet-stream")
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write(archive)
+}
+
+func (h *handler) fleetStatus(w http.ResponseWriter, r *http.Request, body []byte, machineID, idempotencyKey string) {
+	if h.fleet == nil {
+		writeError(w, http.StatusNotFound, "route not found")
+		return
+	}
+	if idempotencyKey == "" {
+		writeError(w, http.StatusBadRequest, "idempotency key is required")
+		return
+	}
+	var request struct {
+		Generation        int64  `json:"generation"`
+		AppliedDigest     string `json:"applied_digest"`
+		State             string `json:"state"`
+		Activation        string `json:"activation"`
+		TrailerState      string `json:"trailer_state"`
+		AliasState        string `json:"alias_state"`
+		ProjectMatchState string `json:"project_match_state"`
+		ReportGeneration  int64  `json:"report_generation"`
+	}
+	if err := decodeJSON(body, &request); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid fleet-config status")
+		return
+	}
+	report := FleetStatusReport{
+		Generation:        request.Generation,
+		AppliedDigest:     request.AppliedDigest,
+		State:             request.State,
+		Activation:        request.Activation,
+		TrailerState:      request.TrailerState,
+		AliasState:        request.AliasState,
+		ProjectMatchState: request.ProjectMatchState,
+		ReportGeneration:  request.ReportGeneration,
+		IdempotencyKey:    idempotencyKey,
+	}
+	report.RequestHash = fleetStatusRequestHash(machineID, report)
+	if !validFleetStatus(report) {
+		writeError(w, http.StatusBadRequest, "invalid fleet-config status")
+		return
+	}
+	if err := h.fleet.PutFleetStatus(r.Context(), machineID, report); err != nil {
+		if strings.Contains(err.Error(), "stale") {
+			writeError(w, http.StatusConflict, "fleet-config status generation is stale")
+			return
+		}
+		if strings.Contains(err.Error(), "idempotency") {
+			writeError(w, http.StatusConflict, "idempotency key conflicts with an earlier operation")
+			return
+		}
+		writeError(w, http.StatusForbidden, "fleet-config access is not authorized")
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"status": "recorded"})
+}

--- a/internal/relay/fleet_config_http.go
+++ b/internal/relay/fleet_config_http.go
@@ -38,6 +38,7 @@ func (h *handler) fleetRelease(w http.ResponseWriter, r *http.Request, digest, m
 	_ = machineID
 	w.Header().Set("Content-Type", "application/octet-stream")
 	w.WriteHeader(http.StatusOK)
+	// #nosec G705 -- digest-pinned USTAR archive is emitted as octet-stream, never HTML.
 	_, _ = w.Write(archive)
 }
 

--- a/internal/relay/fleet_config_http.go
+++ b/internal/relay/fleet_config_http.go
@@ -47,7 +47,7 @@ func (h *handler) fleetStatus(w http.ResponseWriter, r *http.Request, body []byt
 		writeError(w, http.StatusNotFound, "route not found")
 		return
 	}
-	if idempotencyKey == "" {
+	if !ValidRequestToken(idempotencyKey) {
 		writeError(w, http.StatusBadRequest, "idempotency key is required")
 		return
 	}

--- a/internal/relay/fleet_config_http_test.go
+++ b/internal/relay/fleet_config_http_test.go
@@ -24,6 +24,8 @@ type memoryFleetStore struct {
 }
 
 func (store *memoryFleetStore) FleetDesired(context.Context) (FleetDesiredMetadata, error) {
+	store.mu.Lock()
+	defer store.mu.Unlock()
 	return store.desired, nil
 }
 
@@ -150,6 +152,23 @@ func TestHTTPFleetConfigStatusIsBoundedIdempotentAndRejectsStaleGeneration(t *te
 	if len(fleet.status) != 2 || fleet.status["machine-a"].State != "current" || fleet.status["machine-b"].State != "pending" {
 		t.Fatalf("rows=%#v", fleet.status)
 	}
+	activation := serveSigned(t, handler, private, "machine-a", http.MethodPut, "/v1/fleet-config/status", `{"generation":1,"applied_digest":"`+strings.Repeat("ab", 32)+`","state":"current","activation":"next_session","trailer_state":"present","alias_state":"disabled","project_match_state":"matched","report_generation":2}`, "status-activation", "key-1")
+	if activation.Code != http.StatusConflict {
+		t.Fatalf("activation reuse status=%d body=%s", activation.Code, activation.Body.String())
+	}
+}
+
+func TestFleetStatusRequestHashIncludesOptionalFields(t *testing.T) {
+	t.Parallel()
+	base := FleetStatusReport{Generation: 1, AppliedDigest: strings.Repeat("ab", 32), State: "current", ReportGeneration: 2}
+	changed := base
+	changed.Activation = "next_turn"
+	changed.TrailerState = "present"
+	changed.AliasState = "linked"
+	changed.ProjectMatchState = "matched"
+	if fleetStatusRequestHash("machine-a", base) == fleetStatusRequestHash("machine-a", changed) {
+		t.Fatal("optional status fields omitted from idempotency hash")
+	}
 }
 
 func TestHTTPFleetConfigRejectsUnknownMachineAndClientPublish(t *testing.T) {
@@ -173,6 +192,41 @@ func TestHTTPFleetConfigRejectsUnknownMachineAndClientPublish(t *testing.T) {
 	revoked := serveSigned(t, handler, private, "machine-revoked", http.MethodGet, "/v1/fleet-config/desired", "", "revoked", "")
 	if revoked.Code != http.StatusUnauthorized {
 		t.Fatalf("revoked status=%d body=%s", revoked.Code, revoked.Body.String())
+	}
+}
+
+func TestWatchFleetDesiredBroadcastsGenerationAdvance(t *testing.T) {
+	t.Parallel()
+	store := &memoryFleetStore{desired: FleetDesiredMetadata{Generation: 2, Digest: strings.Repeat("ab", 32)}}
+	notifier := NewNotifier()
+	client := notifier.Register("machine-a")
+	t.Cleanup(client.Close)
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	go WatchFleetDesired(ctx, store, notifier, 20*time.Millisecond)
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		select {
+		case event := <-client.Events():
+			if event.TopicID == FleetConfigTopic && event.Sequence == 2 {
+				store.mu.Lock()
+				store.desired.Generation = 5
+				store.mu.Unlock()
+				goto advanced
+			}
+		default:
+			time.Sleep(10 * time.Millisecond)
+		}
+	}
+	t.Fatal("initial generation was not broadcast")
+advanced:
+	select {
+	case event := <-client.Events():
+		if event.TopicID != FleetConfigTopic || event.Sequence != 5 {
+			t.Fatalf("event=%#v", event)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("advanced generation was not broadcast")
 	}
 }
 

--- a/internal/relay/fleet_config_http_test.go
+++ b/internal/relay/fleet_config_http_test.go
@@ -1,0 +1,207 @@
+package relay
+
+import (
+	"bytes"
+	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+type memoryFleetStore struct {
+	mu       sync.Mutex
+	desired  FleetDesiredMetadata
+	archives map[string][]byte
+	status   map[string]FleetStatusReport
+	keys     map[string]string
+}
+
+func (store *memoryFleetStore) FleetDesired(context.Context) (FleetDesiredMetadata, error) {
+	return store.desired, nil
+}
+
+func (store *memoryFleetStore) FleetRelease(_ context.Context, digest string) ([]byte, error) {
+	archive, ok := store.archives[digest]
+	if !ok {
+		return nil, errors.New("missing")
+	}
+	return archive, nil
+}
+
+func (store *memoryFleetStore) PutFleetStatus(_ context.Context, machineID string, report FleetStatusReport) error {
+	store.mu.Lock()
+	defer store.mu.Unlock()
+	if store.status == nil {
+		store.status = map[string]FleetStatusReport{}
+		store.keys = map[string]string{}
+	}
+	key := machineID + "\x00" + report.IdempotencyKey
+	if previous, ok := store.keys[key]; ok {
+		if previous != report.RequestHash {
+			return errors.New("idempotency conflict")
+		}
+		return nil
+	}
+	if current, ok := store.status[machineID]; ok && current.ReportGeneration >= report.ReportGeneration {
+		return errors.New("stale generation")
+	}
+	store.status[machineID] = report
+	store.keys[key] = report.RequestHash
+	return nil
+}
+
+func TestHTTPFleetConfigRequiresEnrolledIdentityAndOmitsContents(t *testing.T) {
+	t.Parallel()
+	public, private, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	store, err := Open(filepath.Join(t.TempDir(), "relay.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	auth, err := NewAuthenticator(store, []Machine{{ID: "machine-a", PublicKey: public, EndpointPrefixes: []string{"agent/a/"}}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	digest := "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+	fleet := &memoryFleetStore{
+		desired:  FleetDesiredMetadata{Generation: 3, Digest: digest, SourceCommit: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", SkillCount: 1, TotalBytes: 12},
+		archives: map[string][]byte{digest: []byte("archive-bytes")},
+	}
+	clock := time.Date(2026, time.July, 13, 12, 0, 0, 0, time.UTC)
+	handler := NewHandler(store, auth, HandlerOptions{Now: func() time.Time { return clock }, FleetConfig: fleet})
+	unsigned := serveUnsigned(t, handler, http.MethodGet, "/v1/fleet-config/desired", "")
+	if unsigned.Code != http.StatusUnauthorized {
+		t.Fatalf("unsigned status=%d body=%s", unsigned.Code, unsigned.Body.String())
+	}
+	desired := serveSigned(t, handler, private, "machine-a", http.MethodGet, "/v1/fleet-config/desired", "", "desired", "")
+	if desired.Code != http.StatusOK {
+		t.Fatalf("desired status=%d body=%s", desired.Code, desired.Body.String())
+	}
+	body := desired.Body.String()
+	if !strings.Contains(body, digest) || !strings.Contains(body, `"generation":3`) || strings.Contains(body, "archive-bytes") || strings.Contains(body, "# fleet") {
+		t.Fatalf("desired leaked or missing metadata: %s", body)
+	}
+	fetched := serveSigned(t, handler, private, "machine-a", http.MethodGet, "/v1/fleet-config/releases/"+digest, "", "fetch", "")
+	if fetched.Code != http.StatusOK || fetched.Body.String() != "archive-bytes" {
+		t.Fatalf("fetch status=%d body=%s", fetched.Code, fetched.Body.String())
+	}
+	publish := serveSigned(t, handler, private, "machine-a", http.MethodPost, "/v1/fleet-config/publish", `{}`, "publish", "pub-1")
+	if publish.Code != http.StatusNotFound {
+		t.Fatalf("client publish status=%d body=%s", publish.Code, publish.Body.String())
+	}
+}
+
+func TestHTTPFleetConfigStatusIsBoundedIdempotentAndRejectsStaleGeneration(t *testing.T) {
+	t.Parallel()
+	public, private, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	otherPublic, otherPrivate, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	store, err := Open(filepath.Join(t.TempDir(), "relay.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	auth, err := NewAuthenticator(store, []Machine{
+		{ID: "machine-a", PublicKey: public, EndpointPrefixes: []string{"agent/a/"}},
+		{ID: "machine-b", PublicKey: otherPublic, EndpointPrefixes: []string{"agent/b/"}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	fleet := &memoryFleetStore{desired: FleetDesiredMetadata{Generation: 1, Digest: strings.Repeat("ab", 32)}}
+	clock := time.Date(2026, time.July, 13, 12, 0, 0, 0, time.UTC)
+	handler := NewHandler(store, auth, HandlerOptions{Now: func() time.Time { return clock }, FleetConfig: fleet})
+	payload := `{"generation":1,"applied_digest":"` + strings.Repeat("ab", 32) + `","state":"current","activation":"next_turn","trailer_state":"present","alias_state":"disabled","project_match_state":"matched","report_generation":2}`
+	first := serveSigned(t, handler, private, "machine-a", http.MethodPut, "/v1/fleet-config/status", payload, "status-1", "key-1")
+	if first.Code != http.StatusOK {
+		t.Fatalf("first status=%d body=%s", first.Code, first.Body.String())
+	}
+	retry := serveSigned(t, handler, private, "machine-a", http.MethodPut, "/v1/fleet-config/status", payload, "status-2", "key-1")
+	if retry.Code != http.StatusOK {
+		t.Fatalf("retry status=%d body=%s", retry.Code, retry.Body.String())
+	}
+	conflict := serveSigned(t, handler, private, "machine-a", http.MethodPut, "/v1/fleet-config/status", `{"generation":1,"state":"failed","report_generation":2}`, "status-3", "key-1")
+	if conflict.Code != http.StatusConflict {
+		t.Fatalf("conflict status=%d body=%s", conflict.Code, conflict.Body.String())
+	}
+	stale := serveSigned(t, handler, private, "machine-a", http.MethodPut, "/v1/fleet-config/status", `{"generation":1,"state":"pending","report_generation":1}`, "status-4", "key-2")
+	if stale.Code != http.StatusConflict {
+		t.Fatalf("stale status=%d body=%s", stale.Code, stale.Body.String())
+	}
+	other := serveSigned(t, handler, otherPrivate, "machine-b", http.MethodPut, "/v1/fleet-config/status", `{"generation":1,"state":"pending","report_generation":1}`, "status-b", "key-b")
+	if other.Code != http.StatusOK {
+		t.Fatalf("other machine status=%d body=%s", other.Code, other.Body.String())
+	}
+	if len(fleet.status) != 2 || fleet.status["machine-a"].State != "current" || fleet.status["machine-b"].State != "pending" {
+		t.Fatalf("rows=%#v", fleet.status)
+	}
+}
+
+func TestHTTPFleetConfigRejectsUnknownMachineAndClientPublish(t *testing.T) {
+	t.Parallel()
+	public, private, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	store, err := Open(filepath.Join(t.TempDir(), "relay.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	auth, err := NewAuthenticator(store, []Machine{{ID: "machine-a", PublicKey: public, EndpointPrefixes: []string{"agent/a/"}}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	handler := NewHandler(store, auth, HandlerOptions{Now: func() time.Time {
+		return time.Date(2026, time.July, 13, 12, 0, 0, 0, time.UTC)
+	}, FleetConfig: &memoryFleetStore{}})
+	revoked := serveSigned(t, handler, private, "machine-revoked", http.MethodGet, "/v1/fleet-config/desired", "", "revoked", "")
+	if revoked.Code != http.StatusUnauthorized {
+		t.Fatalf("revoked status=%d body=%s", revoked.Code, revoked.Body.String())
+	}
+}
+
+func TestBroadcastFleetWakeUsesReservedTopic(t *testing.T) {
+	t.Parallel()
+	notifier := NewNotifier()
+	client := notifier.Register("machine-a")
+	t.Cleanup(client.Close)
+	if next := BroadcastFleetWake(notifier, 2, 2); next != 2 {
+		t.Fatalf("unchanged generation=%d", next)
+	}
+	select {
+	case event := <-client.Events():
+		t.Fatalf("unexpected wake %#v", event)
+	default:
+	}
+	if next := BroadcastFleetWake(notifier, 2, 4); next != 4 {
+		t.Fatalf("broadcast generation=%d", next)
+	}
+	event := <-client.Events()
+	if event.TopicID != FleetConfigTopic || event.Sequence != 4 || event.Type != "wake" {
+		t.Fatalf("event=%#v", event)
+	}
+}
+
+func serveUnsigned(t *testing.T, handler http.Handler, method, path, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	request := httptest.NewRequestWithContext(context.Background(), method, path, bytes.NewBufferString(body))
+	response := httptest.NewRecorder()
+	handler.ServeHTTP(response, request)
+	return response
+}

--- a/internal/relay/fleet_config_http_test.go
+++ b/internal/relay/fleet_config_http_test.go
@@ -158,6 +158,52 @@ func TestHTTPFleetConfigStatusIsBoundedIdempotentAndRejectsStaleGeneration(t *te
 	}
 }
 
+func TestValidFleetStatusRejectsUnknownOptionalEnums(t *testing.T) {
+	t.Parallel()
+	base := FleetStatusReport{
+		Generation: 1, AppliedDigest: strings.Repeat("ab", 32), State: "current",
+		ReportGeneration: 2, IdempotencyKey: "key-1",
+	}
+	if !validFleetStatus(base) {
+		t.Fatal("empty optional enums must be valid")
+	}
+	invalid := []FleetStatusReport{
+		{Generation: 1, State: "current", ReportGeneration: 2, IdempotencyKey: "key-1", TrailerState: "weird"},
+		{Generation: 1, State: "current", ReportGeneration: 2, IdempotencyKey: "key-1", AliasState: "weird"},
+		{Generation: 1, State: "current", ReportGeneration: 2, IdempotencyKey: "key-1", ProjectMatchState: "weird"},
+		{Generation: 1, State: "current", ReportGeneration: 2, IdempotencyKey: "key\x00"},
+	}
+	for _, report := range invalid {
+		if validFleetStatus(report) {
+			t.Fatalf("accepted %#v", report)
+		}
+	}
+}
+
+func TestHTTPFleetConfigStatusRejectsUnknownTrailerState(t *testing.T) {
+	t.Parallel()
+	public, private, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	store, err := Open(filepath.Join(t.TempDir(), "relay.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	auth, err := NewAuthenticator(store, []Machine{{ID: "machine-a", PublicKey: public, EndpointPrefixes: []string{"agent/a/"}}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	handler := NewHandler(store, auth, HandlerOptions{Now: func() time.Time {
+		return time.Date(2026, time.July, 13, 12, 0, 0, 0, time.UTC)
+	}, FleetConfig: &memoryFleetStore{}})
+	response := serveSigned(t, handler, private, "machine-a", http.MethodPut, "/v1/fleet-config/status", `{"generation":1,"state":"current","trailer_state":"weird","report_generation":1}`, "bad-trailer", "key-1")
+	if response.Code != http.StatusBadRequest {
+		t.Fatalf("status=%d body=%s", response.Code, response.Body.String())
+	}
+}
+
 func TestFleetStatusRequestHashIncludesOptionalFields(t *testing.T) {
 	t.Parallel()
 	base := FleetStatusReport{Generation: 1, AppliedDigest: strings.Repeat("ab", 32), State: "current", ReportGeneration: 2}

--- a/internal/relay/http.go
+++ b/internal/relay/http.go
@@ -61,6 +61,7 @@ type HandlerOptions struct {
 	Notifier                  *Notifier
 	SessionRevalidateInterval time.Duration
 	Metrics                   *Metrics
+	FleetConfig               FleetConfigStore
 }
 
 // NewHandler returns the authenticated relay API, including the wake-metadata
@@ -84,7 +85,7 @@ func NewHandler(store Backend, auth *Authenticator, options HandlerOptions) http
 	if options.Metrics == nil {
 		options.Metrics = &Metrics{}
 	}
-	h := &handler{store: store, auth: auth, notifier: options.Notifier, now: options.Now, endpointLeaseTTL: options.EndpointLeaseTTL, deliveryLeaseTTL: options.DeliveryLeaseTTL, sessionRevalidateInterval: options.SessionRevalidateInterval, metrics: options.Metrics}
+	h := &handler{store: store, auth: auth, notifier: options.Notifier, now: options.Now, endpointLeaseTTL: options.EndpointLeaseTTL, deliveryLeaseTTL: options.DeliveryLeaseTTL, sessionRevalidateInterval: options.SessionRevalidateInterval, metrics: options.Metrics, fleet: options.FleetConfig}
 	if setter, ok := store.(interface{ SetMetrics(*Metrics) }); ok {
 		setter.SetMetrics(options.Metrics)
 	}
@@ -100,6 +101,7 @@ type handler struct {
 	deliveryLeaseTTL          time.Duration
 	sessionRevalidateInterval time.Duration
 	metrics                   *Metrics
+	fleet                     FleetConfigStore
 }
 
 func (h *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -150,6 +152,17 @@ func (h *handler) serveHTTP(w http.ResponseWriter, r *http.Request) {
 		h.listConversations(w, machineID, now)
 	case r.Method == http.MethodGet && r.URL.Path == "/v1/notifications":
 		h.notifications(w, r, session)
+	case r.Method == http.MethodGet && r.URL.Path == "/v1/fleet-config/desired":
+		h.fleetDesired(w, r, machineID)
+	case r.Method == http.MethodGet && strings.HasPrefix(r.URL.Path, "/v1/fleet-config/releases/"):
+		digest := strings.TrimPrefix(r.URL.Path, "/v1/fleet-config/releases/")
+		if digest == "" || strings.Contains(digest, "/") {
+			writeError(w, http.StatusNotFound, "route not found")
+			return
+		}
+		h.fleetRelease(w, r, digest, machineID)
+	case r.Method == http.MethodPut && r.URL.Path == "/v1/fleet-config/status":
+		h.fleetStatus(w, r, body, machineID, r.Header.Get("Idempotency-Key"))
 	case r.Method == http.MethodPut && r.URL.Path == "/v1/machines/me/endpoints":
 		h.advertiseEndpoints(w, body, machineID, authority, now)
 	case r.Method == http.MethodPost && r.URL.Path == "/v1/roles/bindings":

--- a/internal/relay/notifier.go
+++ b/internal/relay/notifier.go
@@ -38,6 +38,19 @@ func (n *Notifier) Register(machineID string) *NotificationClient {
 func (n *Notifier) Publish(machineID, topicID string, sequence int64) {
 	n.mu.Lock()
 	defer n.mu.Unlock()
+	n.publishLocked(machineID, topicID, sequence)
+}
+
+// PublishAll delivers a content-free wake hint to every current subscriber.
+func (n *Notifier) PublishAll(topicID string, sequence int64) {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	for machineID := range n.clients {
+		n.publishLocked(machineID, topicID, sequence)
+	}
+}
+
+func (n *Notifier) publishLocked(machineID, topicID string, sequence int64) {
 	for client := range n.clients[machineID] {
 		select {
 		case client.events <- WakeEvent{Type: "wake", TopicID: topicID, Sequence: sequence}:

--- a/internal/relay/notifier_test.go
+++ b/internal/relay/notifier_test.go
@@ -1,6 +1,7 @@
 package relay
 
 import (
+	"strings"
 	"testing"
 	"time"
 )
@@ -25,5 +26,28 @@ func TestNotifierTargetsOnlyRegisteredMachineAndDropsOverflow(t *testing.T) {
 	case event := <-b.Events():
 		t.Fatalf("wrong machine received wake %#v", event)
 	default:
+	}
+}
+
+func TestNotifierPublishAllIsPayloadFreeAndFanout(t *testing.T) {
+	t.Parallel()
+	notifier := NewNotifier()
+	a := notifier.Register("machine-a")
+	b := notifier.Register("machine-b")
+	t.Cleanup(a.Close)
+	t.Cleanup(b.Close)
+	notifier.PublishAll("fleet-config", 9)
+	for _, client := range []*NotificationClient{a, b} {
+		select {
+		case event := <-client.Events():
+			if event.Type != "wake" || event.TopicID != "fleet-config" || event.Sequence != 9 {
+				t.Fatalf("event=%#v", event)
+			}
+			if strings.Contains(event.TopicID, "AGENTS") {
+				t.Fatal("wake contained configuration contents")
+			}
+		case <-time.After(time.Second):
+			t.Fatal("subscriber missed fleet-config wake")
+		}
 	}
 }


### PR DESCRIPTION
Closes #213.

Enrolled clients may GET desired metadata and exact release bytes and PUT only their own bounded status row (schema 59). There is no client publish route. Desired-generation advances emit a payload-free `fleet-config` WebSocket wake.