### PR TITLE
Wire adapter HTTP fleet-config fetch/apply and record LAN gating

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -29,3 +29,5 @@
 !deploy/systemd/
 !deploy/systemd/user/
 !deploy/systemd/user/punaro-adapter.service
+!deploy/compose/
+!deploy/compose/postgres-bootstrap.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM golang:1.26-alpine@sha256:1a9c10cf505a9e6b1e96ea77ebdbfe79a0f10380181faf88bc3b51d7e4315fae AS build
-RUN apk add --no-cache postgresql18-client=18.6-r0
+RUN apk add --no-cache postgresql18-client=18.6-r0 git=2.54.0-r0
 WORKDIR /src
 ARG PUNARO_RELEASE
 ARG PUNARO_SEQUENCE
@@ -23,6 +23,7 @@ COPY Dockerfile .dockerignore docker-compose.memory-onboarding-e2e.yml ./
 COPY scripts/install-client.sh scripts/install-adapter.sh ./scripts/
 COPY scripts/verify-deployment-files.sh ./scripts/
 COPY deploy/systemd/user/punaro-adapter.service ./deploy/systemd/user/
+COPY deploy/compose/postgres-bootstrap.sh ./deploy/compose/
 RUN mkdir -p /home/punaro/tmp \
  && chown 65532:65532 /home/punaro /home/punaro/tmp \
  && chmod 700 /home/punaro /home/punaro/tmp

--- a/README.md
+++ b/README.md
@@ -6,30 +6,23 @@ Punaro is a self-hosted relay for durable conversations between coding agents
 across multiple computers, with an optional Telegram gateway for a human
 operator.
 
-Punaro now also contains the first end-to-end MVP of **Canopi** (provisional
-name), its “what are my agents doing?” surface: normalized lifecycle events,
-multi-machine current state, an 800x480 monochrome renderer, Claude Code,
-Codex/ChatGPT, Pi, and Grok Build adapters, a simulator, and XIAO e-paper
-firmware path. Canopi is independently deployable and its event protocol does
-not depend on Punaro transport. See the [Canopi guide](docs/canopi.md).
+It also contains **Canopi**, an independently deployable “what are my agents
+doing?” surface (lifecycle events, multi-machine state, 800x480 monochrome
+render, coding-agent adapters, simulator, and e-paper firmware). Canopi’s
+event protocol does not depend on Punaro transport. See the
+[Canopi guide](docs/canopi.md).
 
 ![Canopi MVP e-paper dashboard](artifacts/canopi-implementation.png)
 
 The current alpha is not a remote MCP server and never shares a local agent
-mailbox database over the network. A local adapter on each machine communicates
-with its own mailbox implementation and with the central Punaro relay. The
-accepted target later adds an independently optional OAuth-scoped remote MCP
-adapter over Punaro's own API.
+mailbox database over the network. A local adapter on each machine talks to
+its own mailbox and to the central relay.
 
-> Status: signed prerelease `v0.1.0-alpha.11` is deployed across the personal
-> four-machine fleet under the accepted PostgreSQL/trusted-relay/Big Brain
-> migration plan. Enrolled adapters can exchange durable
-> text through the loopback relay, with signed requests, payload-free wake
-> hints, local Waypost handoff (with rolling legacy `agent-mailbox`
-> compatibility), and a separately enrolled Telegram
-> gateway process. Authenticated attachments use the separately gated trusted
-> relay and native client. Attachment v2/v3 production settings, routes, and
-> binaries are retired; their code, tests, RFCs, and vectors remain evidence.
+> Status: signed prerelease `v0.1.0-alpha.11` is deployed on the personal
+> four-machine fleet. Enrolled adapters exchange durable text through the
+> loopback relay (signed requests, payload-free wake hints, local Waypost
+> handoff). Attachments use the separately gated trusted relay. Attachment
+> v2/v3 production settings, routes, and binaries are retired.
 
 ## Architecture
 
@@ -39,168 +32,47 @@ local agent mailbox <-> adapter -- HTTPS + WebSocket hints --> Punaro relay
                                               optional Telegram gateway
 ```
 
-HTTPS fetch/lease/ack is authoritative. WebSocket frames are lossy, payload-free
-wake-up hints containing an opaque conversation ID and sequence only.
-
-Read the [accepted platform and Big Brain plan](docs/big-brain-plan.md),
-[architecture and security design](DESIGN.md),
-[Canopi coding-agent dashboard guide](docs/canopi.md),
-[platform compatibility contracts](docs/platform-contracts.md),
-[proposed client lifecycle, compatibility, and recovery RFC](docs/client-lifecycle-compatibility-recovery-rfc.md),
-[GitHub Releases origin](docs/github-releases.md),
-[user guide](docs/user-guide.md), [operator guide](docs/operator-guide.md),
-[installation guide](docs/installation.md),
-[doctor and fleet-readiness guide](docs/doctor.md),
-[agent plugin guide](docs/agent-plugin.md),
-[trusted-LAN deployment guide](docs/trusted-lan-deployment.md),
-[alpha text-relay onboarding](docs/alpha-text-relay.md),
-[Telegram gateway guide](docs/telegram-gateway.md),
-[historical attachment RFC](docs/attachments-v2-rfc.md),
-[historical v3 attachment RFC](docs/attachments-v3-rfc.md), and the
-[explicit attachment agent workflow](skills/punaro-attachment/SKILL.md),
-[security release gates](docs/security-release-gates.md), and
-[review record](REVIEWS.md).
+HTTPS fetch/lease/ack is authoritative. WebSocket frames are lossy,
+payload-free wake hints (opaque conversation ID and sequence only).
 
 ## Quick start
 
-Requires Go 1.26 or later.
-
-Build the host-side operator wrapper explicitly; it must run on the non-root
-Unix host where Docker Compose is available:
-
-```sh
-make operator-binary
-./bin/punaro
-```
-
-The host wrapper also provides exported-snapshot `backup`, strict `backup
-verify`, clean-stack `restore --into-new-stack`, the durable backup-gated
-`update` path, and the explicit one-shot `mail cutover` path. Mail cutover is
-always dry-run first, imports in bounded resumable pages, and requires the
-printed source fingerprint plus an explicit epoch and `--yes`. See the operator
-guide for the pre-seal abort and irreversible recovery boundaries.
+Requires Go 1.26 or later. For a real install, follow
+[installation](docs/installation.md) and the
+[operator guide](docs/operator-guide.md). Local smoke test:
 
 ```sh
 cp .env.example .env
 go run ./cmd/punarod --env-file .env
-curl http://127.0.0.1:8081/healthz
+curl --fail http://127.0.0.1:8081/healthz
 ```
 
-The development container is a hardened build/run baseline:
+`punarod` does not auto-load `.env`. Do not treat `docker compose up` as a
+public deployment.
 
-```sh
-docker compose up --build
-```
+## Security
 
-It deliberately publishes no port and does not load `.env`.  It is not a
-public deployment. See the operator guide before using containers or systemd.
+Cloudflare Access is optional admission, not application authorization. The
+relay still requires enrolled per-machine cryptographic identity.
+Conversation membership is server-enforced and deny-by-default. All message
+content is inert untrusted data.
 
-For the reviewed single-node production bundle, use
-[the reference production Compose guide](docs/production-compose.md). It starts
-only PostgreSQL and its one-shot role bootstrap by default, pins both image
-inputs, keeps PostgreSQL private, and accepts credentials only through
-read-only secret files. `punarod` is a non-default reference profile; the
-supported daemon lifecycle is the host-local `punaro` workflow.
+See [DESIGN.md](DESIGN.md) and
+[security release gates](docs/security-release-gates.md) before any remote
+exposure.
 
-The separate PostgreSQL Compose file is integration-test infrastructure only;
-it does not change any running relay or deployed environment:
+## Guides
 
-```sh
-make test-postgres
-```
-
-That target starts a fresh private, digest-pinned pgvector service, runs the
-PostgreSQL substrate and dark control-plane contract tests inside the isolated
-network, and removes the database volume afterward. The tests cover migration
-compatibility, explicit project scopes, operation-bound idempotency, closed
-audit records, queue ceilings, and fenced job leases. It requires Docker
-Compose v2 and does not switch any running relay.
-
-## Configuration and secrets
-
-Punaro reads ordinary environment variables. For local development, pass an
-explicit dotenv file with `--env-file PATH` or set `PUNARO_ENV_FILE=PATH`.
-It deliberately does not auto-load `.env`; this avoids accidental secret
-selection in services and test processes. Existing environment variables take
-precedence over dotenv values.
-
-| Variable | Default | Description |
-| --- | --- | --- |
-| `PUNARO_LISTEN_ADDR` | `127.0.0.1:8080` | Concrete HTTP listener. It remains loopback-only unless validated device ingress explicitly selects trusted-LAN mode. |
-| `PUNARO_HEALTH_LISTEN_ADDR` | `127.0.0.1:8081` | Distinct concrete loopback-only listener for `/healthz` and `/readyz`; health routes are never mounted on the device/legacy listener. |
-| `PUNARO_DATA_DIR` | `./data` | Relay SQLite state location when `PUNARO_RELAY_ENABLED=true`. |
-| `PUNARO_LOG_LEVEL` | `info` | Validated reserved setting; current standard logging does not filter by it. |
-| `PUNARO_ENV_FILE` | unset | Optional dotenv file when no CLI flag is used. |
-| `PUNARO_POSTGRES_ENABLED` | `false` | Opts into the PostgreSQL platform substrate. Ordinary startup only checks compatibility and never migrates. |
-| `PUNARO_POSTGRES_DSN_FILE` | unset | Required with PostgreSQL enabled: absolute path to a private application-role DSN file. The application role has no DDL authority. |
-| `PUNARO_DEVICE_AUTH_ENABLED` | `false` | Mounts bounded enrollment redemption and device-session authentication; requires PostgreSQL and a complete ingress policy. |
-| `PUNARO_MEMORY_API_ENABLED` | `false` | Separately mounts the dark authenticated native memory read API; requires PostgreSQL device authentication. It does not enable mutations, semantic retrieval, remote MCP, or Compose Pi integration. The separately installed local `punaro-memory` client/MCP mode still requires protected device credentials. |
-| `PUNARO_REMOTE_MCP_METADATA_ENABLED` | `false` | Mounts the remote MCP OAuth protected-resource metadata document and an unauthenticated `/mcp` discovery challenge. Requires authenticated proxy/Internet ingress, `PUNARO_REMOTE_MCP_RESOURCE_URL` exactly equal to `PUNARO_PUBLIC_URL/mcp`, and one or more HTTPS authorization-server origins. The challenge advertises only `memory.search`, `memory.read`, and `memory.propose`; it accepts no token and exposes no MCP transport or tools. It remains reachable for the OAuth discovery flow even when optional Access admission is configured. |
-| `PUNARO_REMOTE_MCP_TOKEN_VALIDATION_ENABLED` | `false` | Enables strict JWT validation for remote MCP bearer tokens. Requires the enabled metadata gate, an issuer listed in `PUNARO_REMOTE_MCP_AUTHORIZATION_SERVERS`, `PUNARO_REMOTE_MCP_JWKS_URL` over HTTPS, and subject bindings. Tokens must be signed, unexpired, audience-bound to the canonical MCP resource, and carry at least one advertised default scope (`memory.search`, `memory.read`, or `memory.propose`). A verified, bound, scoped token still reaches no MCP transport or tools in this slice. |
-| `PUNARO_REMOTE_MCP_SUBJECT_BINDINGS_JSON` | unset | Required when remote MCP token validation is enabled: a bounded JSON array of unique `{"subject":"...","principal_id":"existing-enabled-principal-uuid"}` entries. It binds an OAuth subject to an existing enabled Punaro principal; it does not accept a client-supplied project claim or grant any project capability. A later transport must enforce both the token scope and the authoritative server-side project grant for that bound principal. |
-| `PUNARO_CREDENTIAL_TRANSITION_ENABLED` | `false` | Dormant M-9 relay bridge. Proof-bound exchange uses device auth and registered PostgreSQL legacy inventory before cutover; bearer relay use additionally requires the PostgreSQL relay. Legacy Ed25519 requests must pass the durable global gate, and a migrated bearer resolves to the exact static machine enrollment with no additional endpoint authority. |
-| `PUNARO_INGRESS_MODE` | unset | Required with device auth: `lan`, `proxy`, or `internet`. Proxy and Internet origins bind loopback and require `PUNARO_PUBLIC_URL=https://...`. |
-| `PUNARO_PUBLIC_URL` | unset | Canonical HTTPS public URL for proxy/Internet mode. It does not make forwarded headers trustworthy. |
-| `PUNARO_TRUSTED_LAN_CIDR` | unset | Private/link-local CIDR containing the concrete LAN bind. Valid only in LAN mode. |
-| `PUNARO_TRUSTED_LAN_HTTP` | `false` | Explicit plaintext credential exception for observed peers inside the validated trusted LAN. Public peers never qualify. |
-| `PUNARO_RELAY_ENABLED` | `false` | Enables the loopback text relay; requires public machine enrollment records. |
-| `PUNARO_RELAY_STORE` | `sqlite` | Explicit relay backend selector. Before cutover, `postgres` is limited to empty-destination parity/qualification. The supported one-shot executor publishes `postgres` marker-last only after verified import, SQLite retirement, legacy-gate closure, and PostgreSQL activation. It never dual-writes. |
-| `PUNARO_RELAY_MACHINES_JSON` | unset | Explicit public-key machine enrollment records. `endpoint_prefixes` claims disjoint machine namespaces; `endpoints` can grant a named exact endpoint without creating a prefix. |
-| `PUNARO_TRUSTED_ATTACHMENTS_ENABLED` | `false` | Separately gates the authenticated trusted-relay attachment surface; requires PostgreSQL device authentication, a valid ingress policy, schema v13, and successful startup reconciliation. |
-| `PUNARO_TRUSTED_ATTACHMENT_BLOB_DIR` | unset | Required with trusted attachments: absolute private (`0700`) daemon-owned blob root. |
-
-Every legacy `PUNARO_ATTACHMENTS_*`, `PUNARO_ATTACHMENT_*`,
-`PUNARO_DIRECTORY_*`, and `PUNARO_PERMIT_*` production setting is retired.
-`punarod` rejects its presence—even empty or `false`—so stale deployment
-configuration cannot silently reactivate the v2/v3 runtime.
-
-The optional `punaro-telegram` process takes its bot token from exactly one of
-`PUNARO_TELEGRAM_BOT_TOKEN` or `PUNARO_TELEGRAM_BOT_TOKEN_FILE`. Prefer a
-private credential file supplied by the OS service manager; the checked-in
-systemd unit uses `LoadCredential`. Never place a token in source control, a
-CLI argument, an agent prompt, logs, or a message body. See the
-[Telegram gateway guide](docs/telegram-gateway.md).
-
-The v2/v3 packages, vectors, RFCs, and tests remain source-level experimental
-evidence only. They are not shipped in the production container and have no
-`punarod` routes or supported deployment workflow.
-
-## Security model
-
-Cloudflare Access is optional admission, not complete application authorization.
-When configured, the relay validates its JWT and also requires a separate
-enrolled per-machine cryptographic identity. Conversation membership is
-server-enforced and deny-by-default. All message content remains inert
-untrusted data, not an instruction to alter routing, run a command, or fetch a
-URL.
-
-Administrators reconfigure a live conversation with the separate typed control
-plane: `punaro-adapter member set` and `punaro-adapter member remove` require
-an attached admin endpoint and a stable retry key. They create content-free,
-server-authorized audit events; they do not send control text through the
-message-delivery path.
-
-See `DESIGN.md` for required origin isolation, delivery semantics, and
-adversarial test gates before remote exposure. Preserved v2/v3 evidence cannot
-authorize production use after that direction was superseded.
-
-## Development
-
-Punaro follows a strict test-first discipline. See [AGENTS.md](AGENTS.md) for
-the required red-green-refactor workflow, security invariants, and handoff
-rules.
-
-```sh
-make ci
-```
-
-The Makefile also exposes individual `test`, `test-race`, `test-postgres`, `staticcheck`,
-`security`, `dockerfile-lint`, and `workflow-lint` targets.
-
-Release and deployment readiness is checked with the strict, read-only doctor
-commands for the server, adapter, bootstrap, Telegram gateway, and collected
-fleet. See [the doctor guide](docs/doctor.md) for the JSON/exit contract and
-complete stable check-code registry.
+- [User guide](docs/user-guide.md)
+- [Operator guide](docs/operator-guide.md)
+- [Installation](docs/installation.md)
+- [Configuration](docs/configuration.md)
+- [Fleet-global agent configuration](docs/fleet-global-agent-config.md)
+- [Doctor](docs/doctor.md)
+- [Telegram gateway](docs/telegram-gateway.md)
+- [Trusted-LAN deployment](docs/trusted-lan-deployment.md)
+- [Canopi](docs/canopi.md)
+- [AGENTS.md](AGENTS.md) — test-first workflow and invariants
 
 ## License
 

--- a/canopi/protocol/event.go
+++ b/canopi/protocol/event.go
@@ -108,9 +108,12 @@ func (e *Event) UnmarshalJSON(payload []byte) error {
 var machineIDPattern = regexp.MustCompile(`^[A-Za-z0-9._-]+$`)
 
 var allowedMetadataKeys = map[string]struct{}{
-	"agent_type": {},
-	"hook":       {},
-	"simulated":  {},
+	"agent_type":       {},
+	"hook":             {},
+	"simulated":        {},
+	"fleet_digest":     {},
+	"fleet_state":      {},
+	"fleet_generation": {},
 }
 
 // Key returns the stable identity used to track an agent across events.

--- a/cmd/punaro-adapter/main.go
+++ b/cmd/punaro-adapter/main.go
@@ -25,6 +25,7 @@ import (
 	"github.com/rock3r/punaro/internal/bootstrap"
 	"github.com/rock3r/punaro/internal/clientidentity"
 	"github.com/rock3r/punaro/internal/clienttransport"
+	"github.com/rock3r/punaro/internal/fleetconfig"
 	"github.com/rock3r/punaro/internal/memoryclient"
 	"github.com/rock3r/punaro/internal/relay"
 )
@@ -1057,6 +1058,9 @@ func run() error {
 				reportedReady = true
 			}
 		}
+		if err := reconcileFleet(ctx, config, relayClient); err != nil && !errors.Is(err, context.Canceled) {
+			log.Printf("fleet-config reconcile failed: %v", err)
+		}
 		timer := time.NewTimer(config.pollInterval)
 		select {
 		case <-ctx.Done():
@@ -1097,6 +1101,31 @@ func runNotifications(ctx context.Context, client *adapter.HTTPRelayClient, wake
 			backoff *= 2
 		}
 	}
+}
+
+func reconcileFleet(ctx context.Context, config adapterConfig, client *adapter.HTTPRelayClient) error {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return err
+	}
+	local, err := fleetconfig.LoadLocalConfig(fleetLocalConfigPath(config))
+	if err != nil {
+		return err
+	}
+	_, err = adapter.ReconcileFleetOnce(ctx, adapter.FleetReconcileRequest{
+		Client: client,
+		Root:   filepath.Join(config.dataDir, "fleet"),
+		Home:   home,
+		Local:  local,
+	})
+	return err
+}
+
+func fleetLocalConfigPath(config adapterConfig) string {
+	if config.profileFile != "" {
+		return filepath.Join(filepath.Dir(config.profileFile), "fleet-config.local.json")
+	}
+	return filepath.Join(config.dataDir, "fleet-config.local.json")
 }
 
 func loadConfig() (adapterConfig, error) {

--- a/cmd/punaro/main.go
+++ b/cmd/punaro/main.go
@@ -785,6 +785,7 @@ func unavailableServerDoctorChecks(gatewayColocated bool) []punarodiagnostic.Che
 	for _, code := range codes {
 		checks = append(checks, punarodiagnostic.Unavailable(code, "repair_installation_configuration"))
 	}
+	checks = append(checks, punarodiagnostic.FleetConfigChecks("", nil)...)
 	checks = appendServerGatewayChecks(checks, serverDoctorState{}, gatewayColocated)
 	return checks
 }
@@ -936,6 +937,22 @@ func diagnoseServer(ctx context.Context, installation operator.Installation, mac
 		checks = append(checks, punarodiagnostic.Fail("readiness_endpoint", "repair_server_readiness"))
 	} else {
 		checks = append(checks, punarodiagnostic.Pass("readiness_endpoint"))
+	}
+
+	if state.Version >= 58 {
+		desiredDigest := ""
+		if desired, err := loadFleetDesired(ctx, installation.OwnerDSNFile); err == nil {
+			desiredDigest = desired.Digest
+		}
+		var clientStates []string
+		if clients, err := loadFleetClients(ctx, installation.OwnerDSNFile); err == nil {
+			for _, client := range clients {
+				clientStates = append(clientStates, client.State)
+			}
+		}
+		checks = append(checks, punarodiagnostic.FleetConfigChecks(desiredDigest, clientStates)...)
+	} else {
+		checks = append(checks, punarodiagnostic.FleetConfigChecks("schema-below-fleet-config", nil)...)
 	}
 
 	return punarodiagnostic.NewComponentReport(punarodiagnostic.ComponentServer, identity, checks)

--- a/cmd/punarod/main.go
+++ b/cmd/punarod/main.go
@@ -224,6 +224,9 @@ func run(args []string, stderr io.Writer) int {
 		if stopMaintain := startDeliveryMaintenance(relayStore, postgresRelay); stopMaintain != nil {
 			defer stopMaintain()
 		}
+		if stopWake := startFleetWake(relayHandler); stopWake != nil {
+			defer stopWake()
+		}
 	}
 	relayMetricsSnapshot := func() relay.MetricsSnapshot { return relay.MetricsSnapshot{} }
 	if provider, ok := relayHandler.(interface{ MetricsSnapshot() relay.MetricsSnapshot }); ok {
@@ -832,12 +835,14 @@ func buildRelayHandler(cfg config.Config, fleet relay.FleetConfigStore, postgres
 		}
 		handler = verifier.Middleware(handler)
 	}
-	return relayMetricsHandler{Handler: handler, metrics: metrics}, store, nil
+	return relayMetricsHandler{Handler: handler, metrics: metrics, notifier: notifier, fleet: fleet}, store, nil
 }
 
 type relayMetricsHandler struct {
 	http.Handler
-	metrics *relay.Metrics
+	metrics  *relay.Metrics
+	notifier *relay.Notifier
+	fleet    relay.FleetConfigStore
 }
 
 func (h relayMetricsHandler) MetricsSnapshot() relay.MetricsSnapshot {
@@ -846,6 +851,24 @@ func (h relayMetricsHandler) MetricsSnapshot() relay.MetricsSnapshot {
 
 type deliveryMaintainer interface {
 	MaintainDeliveries(time.Time) (relay.MaintenanceResult, error)
+}
+
+func startFleetWake(handler http.Handler) func() {
+	metricsHandler, ok := handler.(relayMetricsHandler)
+	if !ok || metricsHandler.fleet == nil || metricsHandler.notifier == nil {
+		return nil
+	}
+	// #nosec G118 -- the returned stop function owns and invokes cancel.
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		relay.WatchFleetDesired(ctx, metricsHandler.fleet, metricsHandler.notifier, 2*time.Second)
+	}()
+	return func() {
+		cancel()
+		<-done
+	}
 }
 
 func startDeliveryMaintenance(store *relay.Store, postgresRelay relay.Backend) func() {

--- a/cmd/punarod/main.go
+++ b/cmd/punarod/main.go
@@ -822,9 +822,6 @@ func buildRelayHandler(cfg config.Config, fleet relay.FleetConfigStore, postgres
 	notifier := relay.NewNotifier()
 	handlerOptions := relay.HandlerOptions{Metrics: metrics, FleetConfig: fleet, Notifier: notifier}
 	handler := relay.NewHandler(backend, authenticator, handlerOptions)
-	if fleet != nil {
-		go relay.WatchFleetDesired(context.Background(), fleet, notifier, 2*time.Second)
-	}
 	if cfg.AccessIssuer != "" {
 		verifier, err := newAccessVerifier(cfg)
 		if err != nil {

--- a/cmd/punarod/relay_test.go
+++ b/cmd/punarod/relay_test.go
@@ -11,6 +11,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -131,6 +132,17 @@ func TestBuildRelayCanSelectPostgresBackendWithoutOpeningSQLite(t *testing.T) {
 	}, nil, backend)
 	if err != nil || handler == nil || sqliteStore != nil {
 		t.Fatalf("handler=%v sqlite=%v err=%v", handler, sqliteStore, err)
+	}
+}
+
+func TestPunaroDHasOneFleetWatcher(t *testing.T) {
+	t.Parallel()
+	body, err := os.ReadFile("main.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Count(string(body), "WatchFleetDesired") != 1 {
+		t.Fatal("punarod starts more than one fleet desired watcher")
 	}
 }
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,52 @@
+# Configuration and secrets
+
+Punaro reads ordinary environment variables. For local development, pass an
+explicit dotenv file with `--env-file PATH` or set `PUNARO_ENV_FILE=PATH`.
+It deliberately does not auto-load `.env`; this avoids accidental secret
+selection in services and test processes. Existing environment variables take
+precedence over dotenv values.
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `PUNARO_LISTEN_ADDR` | `127.0.0.1:8080` | Concrete HTTP listener. It remains loopback-only unless validated device ingress explicitly selects trusted-LAN mode. |
+| `PUNARO_HEALTH_LISTEN_ADDR` | `127.0.0.1:8081` | Distinct concrete loopback-only listener for `/healthz` and `/readyz`; health routes are never mounted on the device/legacy listener. |
+| `PUNARO_DATA_DIR` | `./data` | Relay SQLite state location when `PUNARO_RELAY_ENABLED=true`. |
+| `PUNARO_LOG_LEVEL` | `info` | Validated reserved setting; current standard logging does not filter by it. |
+| `PUNARO_ENV_FILE` | unset | Optional dotenv file when no CLI flag is used. |
+| `PUNARO_POSTGRES_ENABLED` | `false` | Opts into the PostgreSQL platform substrate. Ordinary startup only checks compatibility and never migrates. |
+| `PUNARO_POSTGRES_DSN_FILE` | unset | Required with PostgreSQL enabled: absolute path to a private application-role DSN file. The application role has no DDL authority. |
+| `PUNARO_DEVICE_AUTH_ENABLED` | `false` | Mounts bounded enrollment redemption and device-session authentication; requires PostgreSQL and a complete ingress policy. |
+| `PUNARO_MEMORY_API_ENABLED` | `false` | Separately mounts the dark authenticated native memory read API; requires PostgreSQL device authentication. It does not enable mutations, semantic retrieval, remote MCP, or Compose Pi integration. The separately installed local `punaro-memory` client/MCP mode still requires protected device credentials. |
+| `PUNARO_REMOTE_MCP_METADATA_ENABLED` | `false` | Mounts the remote MCP OAuth protected-resource metadata document and an unauthenticated `/mcp` discovery challenge. Requires authenticated proxy/Internet ingress, `PUNARO_REMOTE_MCP_RESOURCE_URL` exactly equal to `PUNARO_PUBLIC_URL/mcp`, and one or more HTTPS authorization-server origins. The challenge advertises only `memory.search`, `memory.read`, and `memory.propose`; it accepts no token and exposes no MCP transport or tools. It remains reachable for the OAuth discovery flow even when optional Access admission is configured. |
+| `PUNARO_REMOTE_MCP_TOKEN_VALIDATION_ENABLED` | `false` | Enables strict JWT validation for remote MCP bearer tokens. Requires the enabled metadata gate, an issuer listed in `PUNARO_REMOTE_MCP_AUTHORIZATION_SERVERS`, `PUNARO_REMOTE_MCP_JWKS_URL` over HTTPS, and subject bindings. Tokens must be signed, unexpired, audience-bound to the canonical MCP resource, and carry at least one advertised default scope (`memory.search`, `memory.read`, or `memory.propose`). A verified, bound, scoped token still reaches no MCP transport or tools in this slice. |
+| `PUNARO_REMOTE_MCP_SUBJECT_BINDINGS_JSON` | unset | Required when remote MCP token validation is enabled: a bounded JSON array of unique `{"subject":"...","principal_id":"existing-enabled-principal-uuid"}` entries. It binds an OAuth subject to an existing enabled Punaro principal; it does not accept a client-supplied project claim or grant any project capability. A later transport must enforce both the token scope and the authoritative server-side project grant for that bound principal. |
+| `PUNARO_CREDENTIAL_TRANSITION_ENABLED` | `false` | Dormant M-9 relay bridge. Proof-bound exchange uses device auth and registered PostgreSQL legacy inventory before cutover; bearer relay use additionally requires the PostgreSQL relay. Legacy Ed25519 requests must pass the durable global gate, and a migrated bearer resolves to the exact static machine enrollment with no additional endpoint authority. |
+| `PUNARO_INGRESS_MODE` | unset | Required with device auth: `lan`, `proxy`, or `internet`. Proxy and Internet origins bind loopback and require `PUNARO_PUBLIC_URL=https://...`. |
+| `PUNARO_PUBLIC_URL` | unset | Canonical HTTPS public URL for proxy/Internet mode. It does not make forwarded headers trustworthy. |
+| `PUNARO_TRUSTED_LAN_CIDR` | unset | Private/link-local CIDR containing the concrete LAN bind. Valid only in LAN mode. |
+| `PUNARO_TRUSTED_LAN_HTTP` | `false` | Explicit plaintext credential exception for observed peers inside the validated trusted LAN. Public peers never qualify. |
+| `PUNARO_RELAY_ENABLED` | `false` | Enables the loopback text relay; requires public machine enrollment records. |
+| `PUNARO_RELAY_STORE` | `sqlite` | Explicit relay backend selector. Before cutover, `postgres` is limited to empty-destination parity/qualification. The supported one-shot executor publishes `postgres` marker-last only after verified import, SQLite retirement, legacy-gate closure, and PostgreSQL activation. It never dual-writes. |
+| `PUNARO_RELAY_MACHINES_JSON` | unset | Explicit public-key machine enrollment records. `endpoint_prefixes` claims disjoint machine namespaces; `endpoints` can grant a named exact endpoint without creating a prefix. |
+| `PUNARO_TRUSTED_ATTACHMENTS_ENABLED` | `false` | Separately gates the authenticated trusted-relay attachment surface; requires PostgreSQL device authentication, a valid ingress policy, schema v13, and successful startup reconciliation. |
+| `PUNARO_TRUSTED_ATTACHMENT_BLOB_DIR` | unset | Required with trusted attachments: absolute private (`0700`) daemon-owned blob root. |
+
+Every legacy `PUNARO_ATTACHMENTS_*`, `PUNARO_ATTACHMENT_*`,
+`PUNARO_DIRECTORY_*`, and `PUNARO_PERMIT_*` production setting is retired.
+`punarod` rejects its presence—even empty or `false`—so stale deployment
+configuration cannot silently reactivate the v2/v3 runtime.
+
+The optional `punaro-telegram` process takes its bot token from exactly one of
+`PUNARO_TELEGRAM_BOT_TOKEN` or `PUNARO_TELEGRAM_BOT_TOKEN_FILE`. Prefer a
+private credential file supplied by the OS service manager; the checked-in
+systemd unit uses `LoadCredential`. Never place a token in source control, a
+CLI argument, an agent prompt, logs, or a message body. See the
+[Telegram gateway guide](telegram-gateway.md).
+
+The v2/v3 packages, vectors, RFCs, and tests remain source-level experimental
+evidence only. They are not shipped in the production container and have no
+`punarod` routes or supported deployment workflow.
+
+Operator lifecycle, Compose, Cloudflare Access, doctor, and incident response
+live in the [operator guide](operator-guide.md). Server and client installers
+live in the [installation guide](installation.md).

--- a/docs/deployment-validation/2026-08-29-fleet-config-lan.md
+++ b/docs/deployment-validation/2026-08-29-fleet-config-lan.md
@@ -220,3 +220,16 @@ the mac-studio sandbox home did not block apply.
 README split remains the earlier `722c3ac` relocation; this retry did not
 re-duplicate operator/runbook detail into `README.md`. Security-release-gate
 boxes stay unchecked. Same Darwin HTTP and JSON-only PUT residuals as above.
+
+## Apply/status/LKG retry (2026-08-30)
+
+Candidate: `agent/fleet-config-adapter-http` `23e64b2`. Adapters on the three
+named hosts were rebuilt from that commit. Exact-commit publish
+`4b36b696…` became desired generation 12, digest `82d51a0d…`. Wake:
+`{"type":"wake","topic_id":"fleet-config","sequence":12}` with three JSON
+keys and `extra_keys=0`. mac-studio, coso, and mattone applied that digest
+with surviving trailer tokens and no unmatched `other` tree. mac-studio
+operator status was `unsupported` while a leftover `.cursor` dir existed in
+the sandbox home, then `current` generation 12 after that dir was removed.
+`report_generation` incremented across current-path polls instead of reusing
+one status key. Coso/mattone still PUT 403 without installation rows.

--- a/docs/deployment-validation/2026-08-29-fleet-config-lan.md
+++ b/docs/deployment-validation/2026-08-29-fleet-config-lan.md
@@ -177,3 +177,46 @@ are code-signed for Local Network. Status PUT requires
 `auth.client_installations`; JSON-only machines apply but cannot report.
 Official security-release-gate boxes stay unchecked. Production was not
 migrated.
+
+## Contract-fix retry (2026-08-30)
+
+Candidate: `agent/fleet-config-adapter-http` `66e269c` (last-known-good only
+after live is displaced; harness/alias apply; doctor/Canopi fleet checks;
+stale client reports expire to `offline`). lan-test `punarod` and the three
+named-host adapters were rebuilt from that commit. Production listeners on
+`127.0.0.1:8080` / `127.0.0.1:5432` stayed untouched; lan-test remained on
+`192.168.1.254:8080`, health `127.0.0.1:18081`, Postgres `127.0.0.1:15432`,
+schema 59.
+
+| Host | Live apply after `66e269c` |
+| --- | --- |
+| `mac-studio` | PASS via SSH `-L` loopback; operator status `current` |
+| `coso` | PASS via threaded loopback forwarder + path override; PUT 403 |
+| `mattone` | PASS direct LAN HTTP; `CLAUDE.md` reparse point; PUT 403 |
+
+Post-contract publish of exact source `0870c8b2…` became desired generation
+10, digest `688048f6…`. Signed WebSocket capture:
+`{"type":"wake","topic_id":"fleet-config","sequence":10}` with three JSON
+keys and `extra_keys=0`. All three named hosts applied that digest; machine-local
+trailer token survived; unmatched `other` was not written; `coso` wrote
+`canopi` only at the override path.
+
+A later exact-commit publish (`114f4677…`, generation 11, digest `db856b83…`)
+was used for last-known-good. With a keepalive-aware truncating proxy in
+front of the mac-studio loopback, the adapter logged
+`fleet-config archive is invalid` and kept last-good `688048f6…`. Restoring
+the uncorrupted path applied `db856b83…`; trailer token remained. `coso` and
+`mattone` applied generation 11 directly.
+
+Unpublished working-tree edit left desired generation 10 unchanged. Extra
+top-level `README.md` refused materialize (`preview_rc=1`); desired
+unchanged. After the new `punarod`, operator status showed
+`fleet-lan-lxc` as `offline` (stale report expired) and
+`fleet-lan-mac-studio` `current` at generation 11. `punaro doctor` emitted
+content-free `fleet_config_desired` pass and `fleet_config_client_stale` fail
+for that offline row; no configuration contents. A `.cursor` directory in
+the mac-studio sandbox home did not block apply.
+
+README split remains the earlier `722c3ac` relocation; this retry did not
+re-duplicate operator/runbook detail into `README.md`. Security-release-gate
+boxes stay unchecked. Same Darwin HTTP and JSON-only PUT residuals as above.

--- a/docs/deployment-validation/2026-08-29-fleet-config-lan.md
+++ b/docs/deployment-validation/2026-08-29-fleet-config-lan.md
@@ -5,10 +5,11 @@
 - Capability: fleet-global agent configuration from issues #210–#217 plus the
   three operator additions (project-only trees, machine-local trailers, opt-in
   Claude aliases).
-- Personal deployment result: **partial**. Real platform execution of the
-  shipped `internal/fleetconfig` test binary passed on the named LAN hosts.
-  End-to-end publish, payload-free wake, HTTP fetch, and adapter apply against
-  the live enrolled adapters were **not** run.
+- Personal deployment result: **partial**. Filesystem/symlink/apply binaries
+  passed on the named LAN hosts. Live publish, HTTP fetch, atomic apply,
+  trailer survival, and Claude aliases were proven on a Linux adapter against
+  the recovered **lan-test** relay. Darwin and Windows live HTTP apply were
+  not completed.
 - Official Internet-facing release decision: **withheld**. This record does
   not check any box in
   [`security-release-gates.md`](../security-release-gates.md).
@@ -17,67 +18,87 @@
 
 ## Exact candidate
 
-- Source commit: `43aa48a64577304dac55d83d33bef7badf6cc44e`
-  (`agent/fleet-config-217`).
-- Review reference: stacked PRs #222–#227.
+- Source commit: stacked tip `agent/fleet-config-adapter-http` (based on
+  `agent/fleet-config-217` `5ed2309`).
+- Review reference: stacked PRs #222–#227 plus this adapter HTTP follow-up.
 - Signed/tagged release reference: none.
 
 ## Hosts
 
-| Host role | OS observed | Reachability | Platform test binary |
-| --- | --- | --- | --- |
-| `mac-studio` (adapter, this workstation) | Darwin arm64 | local | PASS |
-| `coso` (adapter) | Darwin arm64 | SSH | PASS |
-| `mattone` (adapter) | Windows NT 10.0.26200 | SSH + native PowerShell | PASS |
-| relay LXC (server only; not a named client) | Linux x86_64 | SSH | PASS (extra Linux FS run) |
+| Host role | OS observed | Reachability | Platform test binary | Live HTTP apply |
+| --- | --- | --- | --- | --- |
+| `mac-studio` (adapter, this workstation) | Darwin arm64 | local | PASS | not verified (Go HTTP to LAN listen EOF; curl/Python 401) |
+| `coso` (adapter) | Darwin arm64 | SSH | PASS | not verified (same Go HTTP EOF) |
+| `mattone` (adapter) | Windows NT 10.0.26200 | SSH + native PowerShell | PASS | not verified (sandbox adapter profile ACL) |
+| relay LXC (lan-test punarod + extra Linux adapter) | Linux x86_64 | SSH | PASS | PASS |
 
-`coso` is Darwin, not Linux. The named three-host fleet therefore exercised
-two macOS clients and one Windows client. Linux filesystem behavior was
-exercised on the relay LXC in a disposable temp directory only.
+`coso` is Darwin, not Linux.
 
 ## What ran
 
-On each host, the compiled `internal/fleetconfig` test binary from the
-candidate was executed (`go test -c`, then the binary). That binary contains
-the shipped validation, materialize, trailer, project-match, atomic publish,
-last-known-good, and Claude-alias functions. Results:
+### lan-test Postgres recovery (not production)
 
-- Atomic apply and last-known-good restore: pass on Darwin, Linux, and Windows.
-- Live-tree symlink rejection: pass on Darwin and Linux (Windows covered by
-  the same compiled suite PASS).
-- Claude alias: POSIX symlink pass on Darwin/Linux. Windows suite PASS
-  (symlink success or fail-closed `unsupported` without copying unmanaged
-  files).
-- Trailer create/preserve/drift/collision: pass on all four.
+Production Postgres remained on `127.0.0.1:5432`. lan-test was recovered onto
+`127.0.0.1:15432` using the existing lan-test volume. Owner/app DSN files under
+the lan-test installation were rewritten to that port only. A custom-format
+dump was taken first. Schema 43 was upgraded to 59 with the shipped migrator
+(`migrateConnExpectedAppRole(..., allowExistingUpgrade=true)`), refuse-closed
+on any DSN port other than 15432. The `fleet` namespace exists after the
+upgrade. Production schema was not migrated.
+
+### Live lan-test publish / fetch / apply (Linux)
+
+A candidate `punarod` listened on the LAN address with health on a
+non-colliding loopback port. `punaro fleet-config configure` and
+`publish` of an exact fixture commit succeeded (preview then
+`--yes --confirm-preview-hash`). A Linux adapter on the relay LXC fetched
+desired metadata and the digest-addressed archive over signed HTTP, applied
+the managed tree, projected matched project files, created POSIX Claude
+aliases, and reported `current` without configuration contents.
+
+A second exact-commit publish (generation 2) reconverged the same Linux
+adapter. A machine-local trailer body survived. Status showed desired
+generation 2, applied digest matching the new release, `trailer_state=present`,
+`alias_state=linked`.
+
+### Filesystem suite (named hosts, earlier the same day)
+
+On each named host, the compiled `internal/fleetconfig` test binary from
+`agent/fleet-config-217` passed atomic apply, last-known-good, trailer, and
+Claude-alias behavior.
 
 SSH used an on-disk identity because the 1Password SSH agent would not sign
-for this agent process. Adapter services were observed running on all three
-named hosts and were not restarted, re-profiled, or re-enrolled.
+for this agent process. Production adapter profiles were not edited.
 
 ## What did not run
 
-- `punaro fleet-config publish` against the owner-managed relay. Production
-  PostgreSQL has no `fleet` schema (pre-migration-58). The separate lan-test
-  Postgres container crash-looped on start and was stopped again.
-- Payload-free wake + HTTP fetch + adapter apply on enrolled clients. Deployed
-  adapters are bootstrap-selected binaries from before this feature.
-- Offline reconverge, revocation, corrupted-release, and live rollback of a
-  desired revision.
-- Changing the source repository without publish (no desired-state row exists
-  in production).
-
-No production schema migration, adapter profile edit, or new relay was
-performed.
+- Live HTTP fetch/apply on `mac-studio` and `coso`. Unsigned Darwin binaries
+  from this session get EOF against the LAN listen address; curl and Python
+  from the same hosts receive the expected unauthenticated 401. This is
+  recorded as unverified, not simulated.
+- Live HTTP fetch/apply on `mattone`. The sandbox adapter profile failed
+  closed as unsafe under Windows ACL rules.
+- Payload-free WebSocket wake was not separately captured; Linux converge
+  used the adapter poll interval after publish.
+- Offline reconverge, revocation, corrupted-release, interrupted apply, and
+  rollback of a bad desired release on the named three hosts.
+- Changing the source repository without `fleet-config publish` on the named
+  three hosts (Linux publish path did require an explicit publish to change
+  desired state).
+- Production schema migration, production adapter profile edit, or a new
+  Internet-facing relay.
 
 ## Cleanup
 
-- Remote test binaries were deleted after the run.
-- lan-test Postgres left stopped (exited), matching its prior state.
+- Sandbox adapters on mac-studio, coso, and the LXC were stopped.
+- lan-test Postgres on 15432 and the candidate lan-test `punarod` were left
+  running for further operator use; production listeners were unchanged.
+- Fixture source, keys, and enrollment material remain host-local and are not
+  in git.
 
 ## Residual risk
 
-Live fleet-config publish/converge still requires a schema-59 operator update
-and adapter rollout. Until that happens, LAN evidence covers real
-filesystem/symlink/apply behavior of the shipped package only. README
-reorganization remains blocked until publish/wake/apply can run on the
-enrolled clients.
+Named-host live HTTP apply is still unverified on Darwin and Windows.
+README reorganization stays blocked until those hosts can fetch and apply, or
+the operator accepts Linux-only live evidence plus the earlier filesystem
+suite. Official security-release-gate boxes stay unchecked.

--- a/docs/deployment-validation/2026-08-29-fleet-config-lan.md
+++ b/docs/deployment-validation/2026-08-29-fleet-config-lan.md
@@ -5,9 +5,9 @@
 - Capability: fleet-global agent configuration from issues #210–#217 plus the
   three operator additions (project-only trees, machine-local trailers, opt-in
   Claude aliases).
-- Personal deployment result: **pass for live apply on the named three
-  hosts plus Linux**, with Darwin HTTP reaching the LAN origin through a
-  loopback forwarder (see Darwin HTTP).
+- Personal deployment result: **pass for live apply and remaining gating on
+  the named three hosts plus Linux**, with Darwin HTTP reaching the LAN origin
+  through a loopback forwarder (see Darwin HTTP).
 - Official Internet-facing release decision: **withheld**. This record does
   not check any box in
   [`security-release-gates.md`](../security-release-gates.md).
@@ -26,7 +26,7 @@
 | Host role | OS observed | Reachability | Platform test binary | Live HTTP apply |
 | --- | --- | --- | --- | --- |
 | `mac-studio` (adapter, this workstation) | Darwin arm64 | local | PASS | PASS (loopback forwarder; see Darwin HTTP) |
-| `coso` (adapter) | Darwin arm64 | SSH | PASS | PASS (loopback forwarder + path override) |
+| `coso` (adapter) | Darwin arm64 | SSH | PASS | PASS (threaded loopback forwarder + path override) |
 | `mattone` (adapter) | Windows NT 10.0.26200 | SSH + native PowerShell | PASS | PASS (direct LAN HTTP; Windows symlink alias) |
 | relay LXC (lan-test punarod + extra Linux adapter) | Linux x86_64 | SSH | PASS | PASS (direct LAN HTTP) |
 
@@ -49,32 +49,36 @@ upgrade. Production schema was not migrated.
 A candidate `punarod` listened on the LAN address with health on a
 non-colliding loopback port. `punaro fleet-config configure` and
 `publish` of an exact fixture commit succeeded (preview then
-`--yes --confirm-preview-hash`). Generation 2 republish reconverged Linux
-with a surviving machine-local trailer body.
+`--yes --confirm-preview-hash`). Preview listed source commit, release digest,
+skill count, total bytes, and current desired revision. Generation 2
+republish reconverged Linux with a surviving machine-local trailer body.
 
 Shipped `punaro-adapter` then fetched desired metadata and the
 digest-addressed archive and applied it:
 
 - Linux LXC: direct LAN HTTP; POSIX `CLAUDE.md` symlink; status `current`.
 - `mac-studio` and `coso`: same shipped Darwin adapter. Direct Go HTTP to
-  `192.168.1.254:8080` completes TCP but never sends request payload
+  the LAN listen address completes TCP but never sends request payload
   (tcpdump: handshake only; server `ReadHeaderTimeout` FIN). `curl` and
   Apple-signed Python GET the same URL and receive `401`. A loopback
-  forwarder (Apple-signed Python on Darwin) lets the adapter speak HTTP
-  on `127.0.0.1` while still applying on the host filesystem. `coso` used
-  an explicit project path override; an unmatched top-level name was not
-  written.
+  forwarder (SSH `-L` on mac-studio; Apple-signed threaded Python on `coso`)
+  lets the adapter speak HTTP on `127.0.0.1` while still applying on the host
+  filesystem. `coso` used an explicit project path override; an unmatched
+  top-level name was not written.
 - `mattone`: direct LAN HTTP after an exclusive current-user DACL on the
-  sandbox profile. Native `CLAUDE.md` symlink to `AGENTS.md`. Status PUT
-  returned 403 because that sandbox machine had no
-  `auth.client_installations` row; apply still occurred.
+  sandbox profile. Native `CLAUDE.md` symlink to `AGENTS.md` (reparse point).
+  Status PUT returned 403 because that sandbox machine had no
+  `auth.client_installations` row; apply still occurred. `coso` has the same
+  PUT 403 for the same reason.
 
 ### Darwin HTTP
 
 Root cause is macOS 26 Local Network filtering of ad-hoc-signed Go
 binaries: SYN/ACK succeeds, `Write` returns success, no PSH appears on
 the LAN interface. Not a Punaro request-signing bug. Loopback to the
-same `punarod` (SSH `-L` or Python forwarder) returns normally.
+same `punarod` (SSH `-L` or Python forwarder) returns normally. A
+single-connection Python forwarder stalls HTTP while a WebSocket is
+held; multiplexing (SSH `-L` or a threaded forwarder) is required.
 
 ### Filesystem suite (named hosts, earlier the same day)
 
@@ -85,29 +89,91 @@ Claude-alias behavior.
 SSH used an on-disk identity because the 1Password SSH agent would not sign
 for this agent process. Production adapter profiles were not edited.
 
+### Remaining gating (named hosts)
+
+Scenarios below used the same lan-test origin and sandbox apply roots. Fixture
+source commits and release digests are recorded; configuration contents are
+not.
+
+1. **Publish preview + confirm.** Exact-commit publish printed content-free
+   preview (source commit, release digest, skill count, total bytes, current
+   desired generation/digest) then required `--yes --confirm-preview-hash`.
+2. **Payload-free wake + HTTP apply.** A signed WebSocket subscriber captured
+   `{"type":"wake","topic_id":"fleet-config","sequence":3}` with three JSON
+   keys and no extra fields (no digest, commit, path, or contents). mac-studio
+   then applied generation 3 (`94d8a17b…`). `coso` and `mattone` applied the
+   same digest on disk after the multiplexed forwarder / live adapter were
+   running.
+3. **Project-only match.** `coso` has a top-level `punaro` match and an
+   unmatched `other` directory; project `AGENTS.md` was written only for the
+   match. `canopi` was written on mac-studio and mattone where that top-level
+   directory existed.
+4. **Trailer survival.** A machine-local trailer token seeded before later
+   publishes survived v3 apply, offline reconverge, corrupt/interrupt
+   recovery, and rollback to the previously published v2 digest
+   (`de205931…`, generation 7).
+5. **Claude aliases.** POSIX `CLAUDE.md` symlink on mac-studio and coso;
+   Windows reparse-point symlink on mattone. No content copy.
+6. **Offline reconverge.** mac-studio sandbox adapter stopped; generation 4
+   published (`7d84126e…`); on-disk digest stayed at generation 3; operator
+   status kept the stale client generation; adapter restart applied generation
+   4 and reported `current`.
+7. **Revoke.** Extra Linux machine `fleet-lan-lxc` fetched desired (HTTP 200)
+   while enrolled. After removing it from lan-test `RELAY_MACHINES_JSON` and
+   restarting only the lan-test `punarod`, the same key received HTTP 401 on
+   desired fetch. mac-studio still fetched HTTP 200. Named-host machines were
+   not revoked.
+8. **Invalid publication.** An extra top-level `README.md` commit refused
+   materialize (`preview_rc=1`); desired generation/digest unchanged; source
+   HEAD restored to the previously published commit.
+9. **Corrupt release.** A keepalive-aware loopback proxy truncated
+   `GET /v1/fleet-config/releases/…` bodies. Adapter log:
+   `fleet-config archive is invalid`. Applied digest stayed on last-known-good
+   (`4b5b28cc…`). Restoring the uncorrupted path applied generation 6
+   (`2327bd0b…`).
+10. **Interrupted apply.** `chflags uchg` on the live tree produced
+    `fleet-config last-known-good failed`; applied.json was not advanced.
+    Clearing the flag reconverged. Trailer token remained.
+11. **Fleet-prefix drift.** A local prefix edit in the managed `AGENTS.md`
+    was replaced (not merged) on the next desired-generation apply; trailer
+    token remained.
+12. **Unsupported harness marker.** A `.cursor` directory was created in the
+    sandbox home. Live apply does not fail closed on that vendor dir;
+    `DetectHarnesses` unit tests cover the `unsupported` report.
+13. **Rollback.** `fleet-config publish` of previously stored source commit
+    `f9415d9d…` set desired generation 7 / digest `de205931…`. mac-studio
+    applied it and reported `current`. Trailer token remained.
+14. **Unpublished source change.** Dirty working-tree edit of the configured
+    source `AGENTS.md` left desired generation 2 / digest `de205931…`
+    unchanged; the edit was reverted without publish.
+15. **Status/doctor.** `punaro fleet-config status` returned bounded fields
+    only (source commit, digest, generation, skill/byte counts, client
+    machine id + state enum + trailer/alias states). No configuration
+    contents, host paths, or raw errors.
+
 ## What did not run
 
 - Direct (unproxied) Darwin Go HTTP to the LAN listen address. Documented
   above; apply used a loopback forwarder.
-- `mattone` content-free status row (PUT 403 without an enrollment
-  installation). Apply and alias were still observed on disk.
-- Payload-free WebSocket wake was not separately captured; converge used
-  the adapter poll interval after publish.
-- Offline reconverge, revocation, corrupted-release, and interrupted apply
-  on the named three hosts.
+- `mattone` and `coso` content-free status rows (PUT 403 without an
+  enrollment installation). Apply and alias were still observed on disk.
 - Production schema migration, production adapter profile edit, or a new
   Internet-facing relay.
 
 ## Cleanup
 
-- Sandbox adapters on mac-studio, coso, and the LXC were stopped.
+- Sandbox adapters on mac-studio, coso, and mattone were left for operator
+  follow-up or stopped after the run; production adapters were not edited.
 - lan-test Postgres on 15432 and the candidate lan-test `punarod` were left
   running for further operator use; production listeners were unchanged.
 - Fixture source, keys, and enrollment material remain host-local and are not
-  in git.
+  in git. A lan-test extra machine was removed from the sandbox machines JSON
+  as the revoke scenario; named-host entries remain.
 
 ## Residual risk
 
-Darwin live fetch depends on a loopback forwarder until adapters are
-code-signed for Local Network. Official security-release-gate boxes stay
-unchecked. Production was not migrated.
+Darwin live fetch depends on a multiplexed loopback forwarder until adapters
+are code-signed for Local Network. Status PUT requires
+`auth.client_installations`; JSON-only machines apply but cannot report.
+Official security-release-gate boxes stay unchecked. Production was not
+migrated.

--- a/docs/deployment-validation/2026-08-29-fleet-config-lan.md
+++ b/docs/deployment-validation/2026-08-29-fleet-config-lan.md
@@ -5,11 +5,9 @@
 - Capability: fleet-global agent configuration from issues #210–#217 plus the
   three operator additions (project-only trees, machine-local trailers, opt-in
   Claude aliases).
-- Personal deployment result: **partial**. Filesystem/symlink/apply binaries
-  passed on the named LAN hosts. Live publish, HTTP fetch, atomic apply,
-  trailer survival, and Claude aliases were proven on a Linux adapter against
-  the recovered **lan-test** relay. Darwin and Windows live HTTP apply were
-  not completed.
+- Personal deployment result: **pass for live apply on the named three
+  hosts plus Linux**, with Darwin HTTP reaching the LAN origin through a
+  loopback forwarder (see Darwin HTTP).
 - Official Internet-facing release decision: **withheld**. This record does
   not check any box in
   [`security-release-gates.md`](../security-release-gates.md).
@@ -27,10 +25,10 @@
 
 | Host role | OS observed | Reachability | Platform test binary | Live HTTP apply |
 | --- | --- | --- | --- | --- |
-| `mac-studio` (adapter, this workstation) | Darwin arm64 | local | PASS | not verified (Go HTTP to LAN listen EOF; curl/Python 401) |
-| `coso` (adapter) | Darwin arm64 | SSH | PASS | not verified (same Go HTTP EOF) |
-| `mattone` (adapter) | Windows NT 10.0.26200 | SSH + native PowerShell | PASS | not verified (sandbox adapter profile ACL) |
-| relay LXC (lan-test punarod + extra Linux adapter) | Linux x86_64 | SSH | PASS | PASS |
+| `mac-studio` (adapter, this workstation) | Darwin arm64 | local | PASS | PASS (loopback forwarder; see Darwin HTTP) |
+| `coso` (adapter) | Darwin arm64 | SSH | PASS | PASS (loopback forwarder + path override) |
+| `mattone` (adapter) | Windows NT 10.0.26200 | SSH + native PowerShell | PASS | PASS (direct LAN HTTP; Windows symlink alias) |
+| relay LXC (lan-test punarod + extra Linux adapter) | Linux x86_64 | SSH | PASS | PASS (direct LAN HTTP) |
 
 `coso` is Darwin, not Linux.
 
@@ -46,20 +44,37 @@ dump was taken first. Schema 43 was upgraded to 59 with the shipped migrator
 on any DSN port other than 15432. The `fleet` namespace exists after the
 upgrade. Production schema was not migrated.
 
-### Live lan-test publish / fetch / apply (Linux)
+### Live lan-test publish / fetch / apply
 
 A candidate `punarod` listened on the LAN address with health on a
 non-colliding loopback port. `punaro fleet-config configure` and
 `publish` of an exact fixture commit succeeded (preview then
-`--yes --confirm-preview-hash`). A Linux adapter on the relay LXC fetched
-desired metadata and the digest-addressed archive over signed HTTP, applied
-the managed tree, projected matched project files, created POSIX Claude
-aliases, and reported `current` without configuration contents.
+`--yes --confirm-preview-hash`). Generation 2 republish reconverged Linux
+with a surviving machine-local trailer body.
 
-A second exact-commit publish (generation 2) reconverged the same Linux
-adapter. A machine-local trailer body survived. Status showed desired
-generation 2, applied digest matching the new release, `trailer_state=present`,
-`alias_state=linked`.
+Shipped `punaro-adapter` then fetched desired metadata and the
+digest-addressed archive and applied it:
+
+- Linux LXC: direct LAN HTTP; POSIX `CLAUDE.md` symlink; status `current`.
+- `mac-studio` and `coso`: same shipped Darwin adapter. Direct Go HTTP to
+  `192.168.1.254:8080` completes TCP but never sends request payload
+  (tcpdump: handshake only; server `ReadHeaderTimeout` FIN). `curl` and
+  Apple-signed Python GET the same URL and receive `401`. A loopback
+  forwarder (Apple-signed Python on Darwin) lets the adapter speak HTTP
+  on `127.0.0.1` while still applying on the host filesystem. `coso` used
+  an explicit project path override; an unmatched top-level name was not
+  written.
+- `mattone`: direct LAN HTTP after an exclusive current-user DACL on the
+  sandbox profile. Native `CLAUDE.md` symlink to `AGENTS.md`. Status PUT
+  returned 403 because that sandbox machine had no
+  `auth.client_installations` row; apply still occurred.
+
+### Darwin HTTP
+
+Root cause is macOS 26 Local Network filtering of ad-hoc-signed Go
+binaries: SYN/ACK succeeds, `Write` returns success, no PSH appears on
+the LAN interface. Not a Punaro request-signing bug. Loopback to the
+same `punarod` (SSH `-L` or Python forwarder) returns normally.
 
 ### Filesystem suite (named hosts, earlier the same day)
 
@@ -72,19 +87,14 @@ for this agent process. Production adapter profiles were not edited.
 
 ## What did not run
 
-- Live HTTP fetch/apply on `mac-studio` and `coso`. Unsigned Darwin binaries
-  from this session get EOF against the LAN listen address; curl and Python
-  from the same hosts receive the expected unauthenticated 401. This is
-  recorded as unverified, not simulated.
-- Live HTTP fetch/apply on `mattone`. The sandbox adapter profile failed
-  closed as unsafe under Windows ACL rules.
-- Payload-free WebSocket wake was not separately captured; Linux converge
-  used the adapter poll interval after publish.
-- Offline reconverge, revocation, corrupted-release, interrupted apply, and
-  rollback of a bad desired release on the named three hosts.
-- Changing the source repository without `fleet-config publish` on the named
-  three hosts (Linux publish path did require an explicit publish to change
-  desired state).
+- Direct (unproxied) Darwin Go HTTP to the LAN listen address. Documented
+  above; apply used a loopback forwarder.
+- `mattone` content-free status row (PUT 403 without an enrollment
+  installation). Apply and alias were still observed on disk.
+- Payload-free WebSocket wake was not separately captured; converge used
+  the adapter poll interval after publish.
+- Offline reconverge, revocation, corrupted-release, and interrupted apply
+  on the named three hosts.
 - Production schema migration, production adapter profile edit, or a new
   Internet-facing relay.
 
@@ -98,7 +108,6 @@ for this agent process. Production adapter profiles were not edited.
 
 ## Residual risk
 
-Named-host live HTTP apply is still unverified on Darwin and Windows.
-README reorganization stays blocked until those hosts can fetch and apply, or
-the operator accepts Linux-only live evidence plus the earlier filesystem
-suite. Official security-release-gate boxes stay unchecked.
+Darwin live fetch depends on a loopback forwarder until adapters are
+code-signed for Local Network. Official security-release-gate boxes stay
+unchecked. Production was not migrated.

--- a/docs/fleet-config-lan-e2e.md
+++ b/docs/fleet-config-lan-e2e.md
@@ -15,6 +15,12 @@ If any host is unreachable, or a real symlink/ACL/junction check cannot run,
 stop and record the host as unverified. Do not substitute unit-test path
 simulation.
 
+On current macOS, an ad-hoc-signed `punaro-adapter` may handshake to the LAN
+listen address without sending HTTP payload bytes. Confirm with `curl` first.
+If Go clients time out while `curl` returns `401` for the same unsigned GET,
+use a loopback forwarder (SSH `-L` or Apple-signed Python) so the shipped
+adapter still performs HTTP fetch and local apply on that host.
+
 ## Preconditions
 
 From the candidate checkout:

--- a/docs/operator-guide.md
+++ b/docs/operator-guide.md
@@ -29,6 +29,29 @@ platform service restarts it. Recovery-only keeps the supervisor parked
 until a later signed update or seed clears that marker, then the platform
 service restarts onto the repaired slot.
 
+## Fleet-global agent configuration
+
+Publish an exact Git commit (never a branch) after configuring the source
+repository on the installation:
+
+```sh
+punaro fleet-config configure --directory INSTALL_DIR --repository ABSOLUTE_GIT_DIR --yes
+punaro fleet-config publish COMMIT --directory INSTALL_DIR
+punaro fleet-config publish COMMIT --directory INSTALL_DIR --yes --confirm-preview-hash HASH
+punaro fleet-config status --directory INSTALL_DIR
+```
+
+The contract, layout, trailer markers, and project matching are in
+[fleet-global agent configuration](fleet-global-agent-config.md). The LAN
+qualification runbook is [fleet-config-lan-e2e.md](fleet-config-lan-e2e.md).
+Daemon settings remain in [configuration.md](configuration.md).
+
+On macOS 15+, ad-hoc-signed adapter binaries can complete a TCP handshake to
+a private LAN origin and still never put HTTP request bytes on the wire
+(Local Network filtering). Apple-signed `curl`/`python3` are unaffected.
+Until the adapter is signed for Local Network, Darwin hosts can reach the
+relay through loopback (SSH tunnel or a signed local forwarder).
+
 ## Run locally
 
 Use Go for the current local smoke test:

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -46,6 +46,11 @@ as a local stdio MCP server with `punaro-memory mcp --profile ...`; MCP tool
 calls cannot provide credentials, origin, profile, or credential-file
 arguments. See the [operator guide](operator-guide.md#native-memory-client).
 
+Operators can publish a fleet `AGENTS.md` and skill tree from an immutable
+Git commit. Enrolled adapters fetch it over signed HTTP and apply it locally
+(with machine-local trailers and optional Claude aliases). See
+[fleet-global agent configuration](fleet-global-agent-config.md).
+
 ## What you can do today
 
 Developers can run the local health check and alpha relay described in the

--- a/internal/adapter/client.go
+++ b/internal/adapter/client.go
@@ -1039,6 +1039,118 @@ func (c *HTTPRelayClient) addAccessCookies(headers http.Header) {
 	}
 }
 
+const maxFleetReleaseBytes = 8 << 20
+
+// FleetDesired fetches content-free desired-revision metadata.
+func (c *HTTPRelayClient) FleetDesired(ctx context.Context) (relay.FleetDesiredMetadata, error) {
+	var payload struct {
+		Generation   int64  `json:"generation"`
+		Digest       string `json:"digest"`
+		SourceCommit string `json:"source_commit"`
+		SkillCount   int    `json:"skill_count"`
+		TotalBytes   int64  `json:"total_bytes"`
+	}
+	if _, err := c.doSignedEmpty(ctx, http.MethodGet, "/v1/fleet-config/desired", "application/json", 32<<10, &payload); err != nil {
+		return relay.FleetDesiredMetadata{}, err
+	}
+	return relay.FleetDesiredMetadata{
+		Generation:   payload.Generation,
+		Digest:       payload.Digest,
+		SourceCommit: payload.SourceCommit,
+		SkillCount:   payload.SkillCount,
+		TotalBytes:   payload.TotalBytes,
+	}, nil
+}
+
+// FleetRelease fetches exact archive bytes for one digest.
+func (c *HTTPRelayClient) FleetRelease(ctx context.Context, digest string) ([]byte, error) {
+	if !validFleetDigest(digest) {
+		return nil, errors.New("fleet-config digest is invalid")
+	}
+	path := "/v1/fleet-config/releases/" + digest
+	raw, err := c.doSignedEmpty(ctx, http.MethodGet, path, "application/octet-stream", maxFleetReleaseBytes, nil)
+	if err != nil {
+		return nil, err
+	}
+	if len(raw) == 0 {
+		return nil, errors.New("fleet-config release is unavailable")
+	}
+	return raw, nil
+}
+
+// PutFleetStatus writes one bounded client status row.
+func (c *HTTPRelayClient) PutFleetStatus(ctx context.Context, report relay.FleetStatusReport) error {
+	if report.IdempotencyKey == "" {
+		return errors.New("fleet-config status idempotency key is required")
+	}
+	payload := map[string]any{
+		"generation":          report.Generation,
+		"applied_digest":      report.AppliedDigest,
+		"state":               report.State,
+		"activation":          report.Activation,
+		"trailer_state":       report.TrailerState,
+		"alias_state":         report.AliasState,
+		"project_match_state": report.ProjectMatchState,
+		"report_generation":   report.ReportGeneration,
+	}
+	_, err := c.doJSONWithIdempotency(ctx, http.MethodPut, "/v1/fleet-config/status", payload, report.IdempotencyKey, nil)
+	return err
+}
+
+func validFleetDigest(digest string) bool {
+	if len(digest) != 64 {
+		return false
+	}
+	for _, c := range digest {
+		if (c < '0' || c > '9') && (c < 'a' || c > 'f') {
+			return false
+		}
+	}
+	return true
+}
+
+func (c *HTTPRelayClient) doSignedEmpty(ctx context.Context, method, path, accept string, maximum int, responseValue any) ([]byte, error) {
+	if c == nil || c.httpClient == nil || c.baseURL == nil || path == "" || maximum <= 0 {
+		return nil, errors.New("relay client is unavailable")
+	}
+	target := c.baseURL.ResolveReference(&url.URL{Path: path})
+	request, err := http.NewRequestWithContext(ctx, method, target.String(), nil)
+	if err != nil {
+		return nil, fmt.Errorf("build relay request: %w", err)
+	}
+	if accept != "" {
+		request.Header.Set("Accept", accept)
+	}
+	if _, err := c.authenticateRequest(request, method, path, nil); err != nil {
+		return nil, err
+	}
+	if c.accessToken.ClientID != "" {
+		request.Header.Set("CF-Access-Client-Id", c.accessToken.ClientID)
+		request.Header.Set("CF-Access-Client-Secret", c.accessToken.ClientSecret)
+	}
+	client := *c.httpClient
+	client.CheckRedirect = func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse }
+	response, err := client.Do(request)
+	if err != nil {
+		return nil, fmt.Errorf("relay request failed: %w", err)
+	}
+	defer func() { _ = response.Body.Close() }()
+	if response.StatusCode != http.StatusOK {
+		return nil, &relayRejectionError{status: response.StatusCode}
+	}
+	raw, err := io.ReadAll(io.LimitReader(response.Body, int64(maximum)+1))
+	if err != nil || len(raw) > maximum {
+		return nil, errors.New("invalid relay response")
+	}
+	if responseValue == nil {
+		return raw, nil
+	}
+	if err := json.Unmarshal(raw, responseValue); err != nil {
+		return nil, fmt.Errorf("decode relay response: %w", err)
+	}
+	return raw, nil
+}
+
 func (c *HTTPRelayClient) doJSON(ctx context.Context, method, path string, requestValue, responseValue any) (int, error) {
 	return c.doJSONAllowing(ctx, method, path, requestValue, responseValue)
 }

--- a/internal/adapter/fleet.go
+++ b/internal/adapter/fleet.go
@@ -1,6 +1,35 @@
 package adapter
 
-import "github.com/rock3r/punaro/internal/fleetconfig"
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/rock3r/punaro/internal/fleetconfig"
+	"github.com/rock3r/punaro/internal/relay"
+)
+
+// FleetReconcileRequest is one adapter-side fetch/apply/status cycle.
+type FleetReconcileRequest struct {
+	Client *HTTPRelayClient
+	Root   string
+	Home   string
+	Local  fleetconfig.LocalConfig
+}
+
+// FleetReconcileResult is the content-free outcome of one cycle.
+type FleetReconcileResult struct {
+	State             string
+	AppliedDigest     string
+	Generation        int64
+	TrailerState      string
+	AliasState        string
+	ProjectMatchState string
+}
 
 // ReconcileFleet atomically applies a validated tree under root, preserving trailers.
 func ReconcileFleet(root string, tree fleetconfig.Tree, existing map[string][]byte, lastPrefixDigests map[string]string, digest string) (map[string]fleetconfig.TrailerResult, error) {
@@ -15,4 +44,375 @@ func ReconcileFleet(root string, tree fleetconfig.Tree, existing map[string][]by
 		return trailers, err
 	}
 	return trailers, nil
+}
+
+// ReconcileFleetOnce fetches desired state, applies a matching archive, and reports.
+func ReconcileFleetOnce(ctx context.Context, request FleetReconcileRequest) (FleetReconcileResult, error) {
+	if request.Client == nil || request.Root == "" {
+		return FleetReconcileResult{}, errors.New("fleet-config reconcile input is invalid")
+	}
+	desired, err := request.Client.FleetDesired(ctx)
+	if err != nil {
+		return FleetReconcileResult{}, err
+	}
+	if desired.Digest == "" || desired.Generation < 1 {
+		return FleetReconcileResult{State: "pending"}, nil
+	}
+	state := loadFleetApplyState(request.Root)
+	reportGeneration := state.ReportGeneration + 1
+	if reportGeneration < 1 {
+		reportGeneration = 1
+	}
+	if state.Digest == desired.Digest {
+		result := FleetReconcileResult{
+			State:         "current",
+			AppliedDigest: desired.Digest,
+			Generation:    desired.Generation,
+			TrailerState:  "present",
+			AliasState:    aliasState(request.Local.ClaudeAliases, nil),
+		}
+		if err := projectLiveTree(request, readManagedTree(request.Root), state.PrefixDigests); err != nil {
+			result.State = "failed"
+		}
+		_ = request.Client.PutFleetStatus(ctx, statusReport(desired, result, reportGeneration, "fleet-status-"+strconv.FormatInt(reportGeneration, 10)))
+		return result, nil
+	}
+	archive, err := request.Client.FleetRelease(ctx, desired.Digest)
+	if err != nil {
+		result := FleetReconcileResult{State: "failed", Generation: desired.Generation}
+		_ = request.Client.PutFleetStatus(ctx, statusReport(desired, result, reportGeneration, "fleet-status-"+strconv.FormatInt(reportGeneration, 10)))
+		return result, err
+	}
+	tree, err := fleetconfig.ReadArchive(archive)
+	if err != nil {
+		_ = fleetconfig.RestoreLastGood(request.Root)
+		result := FleetReconcileResult{State: "failed", Generation: desired.Generation}
+		_ = request.Client.PutFleetStatus(ctx, statusReport(desired, result, reportGeneration, "fleet-status-"+strconv.FormatInt(reportGeneration, 10)))
+		return result, err
+	}
+	release, err := fleetconfig.Materialize(tree, desired.SourceCommit)
+	if err != nil || release.Digest != desired.Digest {
+		_ = fleetconfig.RestoreLastGood(request.Root)
+		result := FleetReconcileResult{State: "failed", Generation: desired.Generation}
+		_ = request.Client.PutFleetStatus(ctx, statusReport(desired, result, reportGeneration, "fleet-status-"+strconv.FormatInt(reportGeneration, 10)))
+		return result, errors.New("fleet-config release digest mismatch")
+	}
+	existing := readManagedAgents(request.Root)
+	trailers, err := ReconcileFleet(request.Root, tree, existing, state.PrefixDigests, desired.Digest)
+	if err != nil {
+		result := FleetReconcileResult{State: "failed", Generation: desired.Generation, TrailerState: trailerState(trailers)}
+		_ = request.Client.PutFleetStatus(ctx, statusReport(desired, result, reportGeneration, "fleet-status-"+strconv.FormatInt(reportGeneration, 10)))
+		return result, err
+	}
+	prefixes := prefixDigests(tree)
+	if err := writeFleetApplyState(request.Root, fleetconfig.ApplyState{Digest: desired.Digest, LastGoodDigest: desired.Digest, PrefixDigests: prefixes, ReportGeneration: reportGeneration}); err != nil {
+		result := FleetReconcileResult{State: "failed", Generation: desired.Generation, AppliedDigest: desired.Digest, TrailerState: trailerState(trailers)}
+		_ = request.Client.PutFleetStatus(ctx, statusReport(desired, result, reportGeneration, "fleet-status-"+strconv.FormatInt(reportGeneration, 10)))
+		return result, err
+	}
+	matches := fleetconfig.MatchProjects(request.Local.ProjectBasePath, request.Local.ProjectPathOverrides, tree.Projects(), nil)
+	aliases := map[string]fleetconfig.AliasResult{}
+	if err := projectLiveTree(request, tree, prefixes); err != nil {
+		result := FleetReconcileResult{State: "failed", AppliedDigest: desired.Digest, Generation: desired.Generation, TrailerState: trailerState(trailers), ProjectMatchState: projectMatchState(matches)}
+		_ = request.Client.PutFleetStatus(ctx, statusReport(desired, result, reportGeneration, "fleet-status-"+strconv.FormatInt(reportGeneration, 10)))
+		return result, err
+	}
+	if request.Local.ClaudeAliases {
+		aliases = applyClaudeAliases(request, tree, matches)
+	}
+	result := FleetReconcileResult{
+		State:             reconcileState(trailers),
+		AppliedDigest:     desired.Digest,
+		Generation:        desired.Generation,
+		TrailerState:      trailerState(trailers),
+		AliasState:        aliasState(request.Local.ClaudeAliases, aliases),
+		ProjectMatchState: projectMatchState(matches),
+	}
+	if err := request.Client.PutFleetStatus(ctx, statusReport(desired, result, reportGeneration, "fleet-status-"+strconv.FormatInt(reportGeneration, 10))); err != nil {
+		return result, err
+	}
+	return result, nil
+}
+
+func statusReport(desired relay.FleetDesiredMetadata, result FleetReconcileResult, reportGeneration int64, key string) relay.FleetStatusReport {
+	return relay.FleetStatusReport{
+		Generation:        desired.Generation,
+		AppliedDigest:     result.AppliedDigest,
+		State:             result.State,
+		Activation:        "next_turn",
+		TrailerState:      result.TrailerState,
+		AliasState:        result.AliasState,
+		ProjectMatchState: result.ProjectMatchState,
+		ReportGeneration:  reportGeneration,
+		IdempotencyKey:    key,
+	}
+}
+
+func loadFleetApplyState(root string) fleetconfig.ApplyState {
+	// #nosec G304 -- adapter-owned fleet state under the configured data directory.
+	body, err := os.ReadFile(filepath.Join(root, "applied.json"))
+	if err != nil {
+		return fleetconfig.ApplyState{}
+	}
+	var state fleetconfig.ApplyState
+	if json.Unmarshal(body, &state) != nil {
+		return fleetconfig.ApplyState{}
+	}
+	return state
+}
+
+func writeFleetApplyState(root string, state fleetconfig.ApplyState) error {
+	body, err := json.Marshal(state)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(filepath.Join(root, "applied.json"), append(body, '\n'), 0o600)
+}
+
+func readManagedTree(root string) fleetconfig.Tree {
+	current := filepath.Join(root, "current")
+	var files []fleetconfig.File
+	_ = filepath.WalkDir(current, func(path string, entry os.DirEntry, err error) error {
+		if err != nil || entry.IsDir() {
+			return err
+		}
+		rel, relErr := filepath.Rel(current, path)
+		if relErr != nil {
+			return relErr
+		}
+		// #nosec G304,G122 -- adapter-owned managed tree under the configured data directory.
+		body, readErr := os.ReadFile(path)
+		if readErr != nil {
+			return readErr
+		}
+		slash := filepath.ToSlash(rel)
+		if slash == "AGENTS.md" || strings.HasSuffix(slash, "/AGENTS.md") {
+			if prefix, _, ok := fleetconfig.SplitAgents(body); ok {
+				body = prefix
+			}
+		}
+		files = append(files, fleetconfig.File{Path: slash, Data: body})
+		return nil
+	})
+	return fleetconfig.Tree{Files: files}
+}
+
+func readManagedAgents(root string) map[string][]byte {
+	existing := map[string][]byte{}
+	current := filepath.Join(root, "current")
+	_ = filepath.WalkDir(current, func(path string, entry os.DirEntry, err error) error {
+		if err != nil || entry.IsDir() {
+			return err
+		}
+		rel, relErr := filepath.Rel(current, path)
+		if relErr != nil {
+			return relErr
+		}
+		slash := filepath.ToSlash(rel)
+		if slash != "AGENTS.md" && !strings.HasSuffix(slash, "/AGENTS.md") {
+			return nil
+		}
+		// #nosec G304,G122 -- adapter-owned managed tree under the configured data directory.
+		body, readErr := os.ReadFile(path)
+		if readErr != nil {
+			return readErr
+		}
+		existing[slash] = body
+		return nil
+	})
+	return existing
+}
+
+func prefixDigests(tree fleetconfig.Tree) map[string]string {
+	digests := map[string]string{}
+	for _, file := range tree.Files {
+		if file.Path == "AGENTS.md" || strings.HasSuffix(file.Path, "/AGENTS.md") {
+			digests[file.Path] = fleetconfig.DigestBytes(file.Data)
+		}
+	}
+	return digests
+}
+
+func projectLiveTree(request FleetReconcileRequest, tree fleetconfig.Tree, lastPrefixDigests map[string]string) error {
+	home := request.Home
+	if home == "" {
+		var err error
+		home, err = os.UserHomeDir()
+		if err != nil || home == "" {
+			return errors.New("fleet-config home is unavailable")
+		}
+	}
+	matches := fleetconfig.MatchProjects(request.Local.ProjectBasePath, request.Local.ProjectPathOverrides, tree.Projects(), nil)
+	matched := map[string]string{}
+	for _, match := range matches {
+		if match.Path != "" {
+			matched[match.Name] = match.Path
+		}
+	}
+	for _, file := range tree.Files {
+		dest, agents := liveDestination(home, matched, file.Path)
+		if dest == "" {
+			continue
+		}
+		body := file.Data
+		if agents {
+			existing, existed := readExisting(dest)
+			next, result, err := fleetconfig.ApplyAgents(file.Data, existing, existed, lastPrefixDigests[file.Path])
+			if err != nil {
+				return err
+			}
+			if result.Collision {
+				continue
+			}
+			body = next
+		}
+		if err := writeLiveFile(dest, body); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func liveDestination(home string, matched map[string]string, path string) (string, bool) {
+	switch {
+	case path == "AGENTS.md":
+		return filepath.Join(home, "AGENTS.md"), true
+	case strings.HasPrefix(path, "skills/"):
+		return filepath.Join(append([]string{home, ".agents"}, strings.Split(path, "/")...)...), false
+	case strings.HasPrefix(path, "projects/"):
+		name, rest, ok := strings.Cut(strings.TrimPrefix(path, "projects/"), "/")
+		if !ok {
+			return "", false
+		}
+		root, found := matched[name]
+		if !found {
+			return "", false
+		}
+		if rest == "AGENTS.md" {
+			return filepath.Join(root, "AGENTS.md"), true
+		}
+		if skillRest, ok := strings.CutPrefix(rest, "skills/"); ok {
+			return filepath.Join(append([]string{root, ".agents", "skills"}, strings.Split(skillRest, "/")...)...), false
+		}
+	}
+	return "", false
+}
+
+func applyClaudeAliases(request FleetReconcileRequest, tree fleetconfig.Tree, matches []fleetconfig.ProjectMatch) map[string]fleetconfig.AliasResult {
+	results := map[string]fleetconfig.AliasResult{}
+	home := request.Home
+	if home != "" {
+		if result, err := fleetconfig.CreateAlias(filepath.Join(home, "AGENTS.md"), filepath.Join(home, "CLAUDE.md"), true); err == nil || result.State != "" {
+			results["global"] = result
+		}
+		if result, _ := fleetconfig.CreateAlias(filepath.Join(home, ".agents", "skills"), filepath.Join(home, ".claude", "skills"), true); result.State != "" {
+			results["global-skills"] = result
+		}
+	}
+	for _, match := range matches {
+		if match.Path == "" {
+			continue
+		}
+		result, _ := fleetconfig.CreateAlias(filepath.Join(match.Path, "AGENTS.md"), filepath.Join(match.Path, "CLAUDE.md"), true)
+		results[match.Name] = result
+		skillResult, _ := fleetconfig.CreateAlias(filepath.Join(match.Path, ".agents", "skills"), filepath.Join(match.Path, ".claude", "skills"), true)
+		results[match.Name+"-skills"] = skillResult
+	}
+	_ = tree
+	return results
+}
+
+func writeLiveFile(path string, body []byte) error {
+	info, statErr := os.Lstat(path)
+	if statErr == nil && info.Mode()&os.ModeSymlink != 0 {
+		return errors.New("fleet-config live tree is unsafe")
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return errors.New("fleet-config apply failed")
+	}
+	tmp := path + ".punaro-tmp"
+	if err := os.WriteFile(tmp, body, 0o600); err != nil {
+		return errors.New("fleet-config apply failed")
+	}
+	if statErr == nil && info.Mode().IsRegular() {
+		_ = os.Remove(path)
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		_ = os.Remove(tmp)
+		return errors.New("fleet-config apply failed")
+	}
+	return nil
+}
+
+func readExisting(path string) ([]byte, bool) {
+	info, err := os.Lstat(path)
+	if err != nil || !info.Mode().IsRegular() {
+		return nil, false
+	}
+	// #nosec G304 -- live destination fenced by Lstat as a regular file.
+	body, err := os.ReadFile(path)
+	if err != nil {
+		return nil, false
+	}
+	return body, true
+}
+
+func trailerState(trailers map[string]fleetconfig.TrailerResult) string {
+	if len(trailers) == 0 {
+		return "missing"
+	}
+	for _, trailer := range trailers {
+		if trailer.Collision {
+			return "collision"
+		}
+	}
+	return "present"
+}
+
+func reconcileState(trailers map[string]fleetconfig.TrailerResult) string {
+	for _, trailer := range trailers {
+		if trailer.Collision || trailer.Drift {
+			return "drifted"
+		}
+	}
+	return "current"
+}
+
+func aliasState(enabled bool, results map[string]fleetconfig.AliasResult) string {
+	if !enabled {
+		return "disabled"
+	}
+	state := "linked"
+	for _, result := range results {
+		if result.State == "unsupported" {
+			return "unsupported"
+		}
+		if result.State == "collision" {
+			state = "collision"
+		}
+	}
+	return state
+}
+
+func projectMatchState(matches []fleetconfig.ProjectMatch) string {
+	if len(matches) == 0 {
+		return "none"
+	}
+	sawOverride, sawMatched := false, false
+	for _, match := range matches {
+		switch match.Kind {
+		case "override":
+			sawOverride = true
+		case "matched":
+			sawMatched = true
+		}
+	}
+	switch {
+	case sawOverride:
+		return "override"
+	case sawMatched:
+		return "matched"
+	default:
+		return "unmatched"
+	}
 }

--- a/internal/adapter/fleet.go
+++ b/internal/adapter/fleet.go
@@ -382,7 +382,18 @@ func writeLiveFile(path string, body []byte) error {
 		return errors.New("fleet-config apply failed")
 	}
 	tmp := path + ".punaro-tmp"
-	if err := os.WriteFile(tmp, body, 0o600); err != nil {
+	_ = os.Remove(tmp)
+	file, err := os.OpenFile(tmp, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600) // #nosec G304 -- tmp is a sibling of a validated destination.
+	if err != nil {
+		return errors.New("fleet-config apply failed")
+	}
+	if _, err := file.Write(body); err != nil {
+		_ = file.Close()
+		_ = os.Remove(tmp)
+		return errors.New("fleet-config apply failed")
+	}
+	if err := file.Close(); err != nil {
+		_ = os.Remove(tmp)
 		return errors.New("fleet-config apply failed")
 	}
 	if statErr == nil && info.Mode().IsRegular() {

--- a/internal/adapter/fleet.go
+++ b/internal/adapter/fleet.go
@@ -446,7 +446,7 @@ func aliasState(enabled bool, results map[string]fleetconfig.AliasResult) string
 }
 
 func unsupportedHarness(home string) bool {
-	for _, harness := range fleetconfig.DetectHarnesses(home, nil) {
+	for _, harness := range fleetconfig.DetectHarnesses(home, "", nil) {
 		if harness.State == "unsupported" {
 			return true
 		}

--- a/internal/adapter/fleet.go
+++ b/internal/adapter/fleet.go
@@ -85,14 +85,12 @@ func ReconcileFleetOnce(ctx context.Context, request FleetReconcileRequest) (Fle
 	}
 	tree, err := fleetconfig.ReadArchive(archive)
 	if err != nil {
-		_ = fleetconfig.RestoreLastGood(request.Root)
 		result := FleetReconcileResult{State: "failed", Generation: desired.Generation}
 		_ = request.Client.PutFleetStatus(ctx, statusReport(desired, result, reportGeneration, "fleet-status-"+strconv.FormatInt(reportGeneration, 10)))
 		return result, err
 	}
 	release, err := fleetconfig.Materialize(tree, desired.SourceCommit)
 	if err != nil || release.Digest != desired.Digest {
-		_ = fleetconfig.RestoreLastGood(request.Root)
 		result := FleetReconcileResult{State: "failed", Generation: desired.Generation}
 		_ = request.Client.PutFleetStatus(ctx, statusReport(desired, result, reportGeneration, "fleet-status-"+strconv.FormatInt(reportGeneration, 10)))
 		return result, errors.New("fleet-config release digest mismatch")
@@ -127,6 +125,9 @@ func ReconcileFleetOnce(ctx context.Context, request FleetReconcileRequest) (Fle
 		TrailerState:      trailerState(trailers),
 		AliasState:        aliasState(request.Local.ClaudeAliases, aliases),
 		ProjectMatchState: projectMatchState(matches),
+	}
+	if result.State == "current" && unsupportedHarness(request.Home) {
+		result.State = "unsupported"
 	}
 	if err := request.Client.PutFleetStatus(ctx, statusReport(desired, result, reportGeneration, "fleet-status-"+strconv.FormatInt(reportGeneration, 10))); err != nil {
 		return result, err
@@ -392,6 +393,15 @@ func aliasState(enabled bool, results map[string]fleetconfig.AliasResult) string
 		}
 	}
 	return state
+}
+
+func unsupportedHarness(home string) bool {
+	for _, harness := range fleetconfig.DetectHarnesses(home, nil) {
+		if harness.State == "unsupported" {
+			return true
+		}
+	}
+	return false
 }
 
 func projectMatchState(matches []fleetconfig.ProjectMatch) string {

--- a/internal/adapter/fleet.go
+++ b/internal/adapter/fleet.go
@@ -64,55 +64,74 @@ func ReconcileFleetOnce(ctx context.Context, request FleetReconcileRequest) (Fle
 		reportGeneration = 1
 	}
 	if state.Digest == desired.Digest {
+		tree := readManagedTree(request.Root)
 		result := FleetReconcileResult{
-			State:         "current",
 			AppliedDigest: desired.Digest,
 			Generation:    desired.Generation,
-			TrailerState:  "present",
 			AliasState:    aliasState(request.Local.ClaudeAliases, nil),
 		}
-		if err := projectLiveTree(request, readManagedTree(request.Root), state.PrefixDigests); err != nil {
+		matches := fleetconfig.MatchProjects(request.Local.ProjectBasePath, request.Local.ProjectPathOverrides, tree.Projects(), nil)
+		result.ProjectMatchState = projectMatchState(matches)
+		liveTrailers, projectErr := projectLiveTree(request, tree, state.PrefixDigests)
+		result.TrailerState = trailerState(liveTrailers)
+		if projectErr != nil {
 			result.State = "failed"
+		} else {
+			result.State = reconcileState(liveTrailers)
+			if request.Local.ClaudeAliases {
+				result.AliasState = aliasState(request.Local.ClaudeAliases, applyClaudeAliases(request, tree, matches))
+			}
+			if result.State == "current" && unsupportedHarness(request.Home) {
+				result.State = "unsupported"
+			}
 		}
-		_ = request.Client.PutFleetStatus(ctx, statusReport(desired, result, reportGeneration, "fleet-status-"+strconv.FormatInt(reportGeneration, 10)))
+		putErr := putFleetStatus(ctx, request, desired, result, reportGeneration)
+		if putErr != nil {
+			return result, putErr
+		}
+		if projectErr != nil {
+			return result, projectErr
+		}
 		return result, nil
 	}
 	archive, err := request.Client.FleetRelease(ctx, desired.Digest)
 	if err != nil {
 		result := FleetReconcileResult{State: "failed", Generation: desired.Generation}
-		_ = request.Client.PutFleetStatus(ctx, statusReport(desired, result, reportGeneration, "fleet-status-"+strconv.FormatInt(reportGeneration, 10)))
+		_ = putFleetStatus(ctx, request, desired, result, reportGeneration)
 		return result, err
 	}
 	tree, err := fleetconfig.ReadArchive(archive)
 	if err != nil {
 		result := FleetReconcileResult{State: "failed", Generation: desired.Generation}
-		_ = request.Client.PutFleetStatus(ctx, statusReport(desired, result, reportGeneration, "fleet-status-"+strconv.FormatInt(reportGeneration, 10)))
+		_ = putFleetStatus(ctx, request, desired, result, reportGeneration)
 		return result, err
 	}
 	release, err := fleetconfig.Materialize(tree, desired.SourceCommit)
 	if err != nil || release.Digest != desired.Digest {
 		result := FleetReconcileResult{State: "failed", Generation: desired.Generation}
-		_ = request.Client.PutFleetStatus(ctx, statusReport(desired, result, reportGeneration, "fleet-status-"+strconv.FormatInt(reportGeneration, 10)))
+		_ = putFleetStatus(ctx, request, desired, result, reportGeneration)
 		return result, errors.New("fleet-config release digest mismatch")
 	}
 	existing := readManagedAgents(request.Root)
 	trailers, err := ReconcileFleet(request.Root, tree, existing, state.PrefixDigests, desired.Digest)
 	if err != nil {
 		result := FleetReconcileResult{State: "failed", Generation: desired.Generation, TrailerState: trailerState(trailers)}
-		_ = request.Client.PutFleetStatus(ctx, statusReport(desired, result, reportGeneration, "fleet-status-"+strconv.FormatInt(reportGeneration, 10)))
+		_ = putFleetStatus(ctx, request, desired, result, reportGeneration)
 		return result, err
 	}
 	prefixes := prefixDigests(tree)
 	if err := writeFleetApplyState(request.Root, fleetconfig.ApplyState{Digest: desired.Digest, LastGoodDigest: desired.Digest, PrefixDigests: prefixes, ReportGeneration: reportGeneration}); err != nil {
 		result := FleetReconcileResult{State: "failed", Generation: desired.Generation, AppliedDigest: desired.Digest, TrailerState: trailerState(trailers)}
-		_ = request.Client.PutFleetStatus(ctx, statusReport(desired, result, reportGeneration, "fleet-status-"+strconv.FormatInt(reportGeneration, 10)))
+		_ = putFleetStatus(ctx, request, desired, result, reportGeneration)
 		return result, err
 	}
 	matches := fleetconfig.MatchProjects(request.Local.ProjectBasePath, request.Local.ProjectPathOverrides, tree.Projects(), nil)
 	aliases := map[string]fleetconfig.AliasResult{}
-	if err := projectLiveTree(request, tree, prefixes); err != nil {
+	liveTrailers, err := projectLiveTree(request, tree, prefixes)
+	trailers = mergeTrailerResults(trailers, liveTrailers)
+	if err != nil {
 		result := FleetReconcileResult{State: "failed", AppliedDigest: desired.Digest, Generation: desired.Generation, TrailerState: trailerState(trailers), ProjectMatchState: projectMatchState(matches)}
-		_ = request.Client.PutFleetStatus(ctx, statusReport(desired, result, reportGeneration, "fleet-status-"+strconv.FormatInt(reportGeneration, 10)))
+		_ = putFleetStatus(ctx, request, desired, result, reportGeneration)
 		return result, err
 	}
 	if request.Local.ClaudeAliases {
@@ -129,10 +148,39 @@ func ReconcileFleetOnce(ctx context.Context, request FleetReconcileRequest) (Fle
 	if result.State == "current" && unsupportedHarness(request.Home) {
 		result.State = "unsupported"
 	}
-	if err := request.Client.PutFleetStatus(ctx, statusReport(desired, result, reportGeneration, "fleet-status-"+strconv.FormatInt(reportGeneration, 10))); err != nil {
+	if err := putFleetStatus(ctx, request, desired, result, reportGeneration); err != nil {
 		return result, err
 	}
 	return result, nil
+}
+
+func putFleetStatus(ctx context.Context, request FleetReconcileRequest, desired relay.FleetDesiredMetadata, result FleetReconcileResult, reportGeneration int64) error {
+	putErr := request.Client.PutFleetStatus(ctx, statusReport(desired, result, reportGeneration, "fleet-status-"+strconv.FormatInt(reportGeneration, 10)))
+	state := loadFleetApplyState(request.Root)
+	state.ReportGeneration = reportGeneration
+	_ = writeFleetApplyState(request.Root, state)
+	return putErr
+}
+
+func mergeTrailerResults(parts ...map[string]fleetconfig.TrailerResult) map[string]fleetconfig.TrailerResult {
+	out := map[string]fleetconfig.TrailerResult{}
+	for _, part := range parts {
+		for path, trailer := range part {
+			existing := out[path]
+			if trailer.Collision {
+				existing.Collision = true
+				existing.State = "collision"
+			}
+			if trailer.Drift {
+				existing.Drift = true
+			}
+			if existing.State == "" {
+				existing.State = trailer.State
+			}
+			out[path] = existing
+		}
+	}
+	return out
 }
 
 func statusReport(desired relay.FleetDesiredMetadata, result FleetReconcileResult, reportGeneration int64, key string) relay.FleetStatusReport {
@@ -234,13 +282,14 @@ func prefixDigests(tree fleetconfig.Tree) map[string]string {
 	return digests
 }
 
-func projectLiveTree(request FleetReconcileRequest, tree fleetconfig.Tree, lastPrefixDigests map[string]string) error {
+func projectLiveTree(request FleetReconcileRequest, tree fleetconfig.Tree, lastPrefixDigests map[string]string) (map[string]fleetconfig.TrailerResult, error) {
+	trailers := map[string]fleetconfig.TrailerResult{}
 	home := request.Home
 	if home == "" {
 		var err error
 		home, err = os.UserHomeDir()
 		if err != nil || home == "" {
-			return errors.New("fleet-config home is unavailable")
+			return trailers, errors.New("fleet-config home is unavailable")
 		}
 	}
 	matches := fleetconfig.MatchProjects(request.Local.ProjectBasePath, request.Local.ProjectPathOverrides, tree.Projects(), nil)
@@ -260,18 +309,19 @@ func projectLiveTree(request FleetReconcileRequest, tree fleetconfig.Tree, lastP
 			existing, existed := readExisting(dest)
 			next, result, err := fleetconfig.ApplyAgents(file.Data, existing, existed, lastPrefixDigests[file.Path])
 			if err != nil {
-				return err
+				return trailers, err
 			}
+			trailers[file.Path] = result
 			if result.Collision {
 				continue
 			}
 			body = next
 		}
 		if err := writeLiveFile(dest, body); err != nil {
-			return err
+			return trailers, err
 		}
 	}
-	return nil
+	return trailers, nil
 }
 
 func liveDestination(home string, matched map[string]string, path string) (string, bool) {

--- a/internal/adapter/fleet_client_test.go
+++ b/internal/adapter/fleet_client_test.go
@@ -193,6 +193,74 @@ func TestReconcileFleetOnceFetchesAppliesAndReports(t *testing.T) {
 	}
 }
 
+func TestReconcileFleetOnceProjectsClaudeAliasesAndUnsupportedHarness(t *testing.T) {
+	_, private, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tree := fleetconfig.Tree{Files: []fleetconfig.File{
+		{Path: "AGENTS.md", Data: []byte("# fleet\n")},
+		{Path: "skills/demo/SKILL.md", Data: []byte("---\nname: demo\ndescription: Demo skill.\n---\n# demo\n")},
+		{Path: "projects/punaro/AGENTS.md", Data: []byte("# punaro\n")},
+	}}
+	release, err := fleetconfig.Materialize(tree, "0123456789abcdef0123456789abcdef01234567")
+	if err != nil {
+		t.Fatal(err)
+	}
+	home := t.TempDir()
+	base := filepath.Join(home, "src")
+	if err := os.MkdirAll(filepath.Join(base, "punaro"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(home, ".cursor"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/v1/fleet-config/desired":
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"generation": 2, "digest": release.Digest, "source_commit": release.SourceCommit,
+				"skill_count": release.SkillCount, "total_bytes": release.TotalBytes,
+			})
+		case r.Method == http.MethodGet && strings.HasPrefix(r.URL.Path, "/v1/fleet-config/releases/"):
+			w.Header().Set("Content-Type", "application/octet-stream")
+			_, _ = w.Write(release.Archive)
+		case r.Method == http.MethodPut && r.URL.Path == "/v1/fleet-config/status":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"status":"recorded"}`))
+		default:
+			t.Fatalf("unexpected %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer server.Close()
+	client, err := NewHTTPRelayClient(server.URL, "machine-a", private, server.Client(), AccessServiceToken{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	result, err := ReconcileFleetOnce(context.Background(), FleetReconcileRequest{
+		Client: client,
+		Root:   t.TempDir(),
+		Home:   home,
+		Local:  fleetconfig.LocalConfig{Schema: 1, ProjectBasePath: base, ClaudeAliases: true},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.State != "unsupported" || result.AliasState != "linked" {
+		t.Fatalf("result=%#v", result)
+	}
+	if _, err := os.Lstat(filepath.Join(home, "CLAUDE.md")); err != nil {
+		t.Fatalf("global alias missing: %v", err)
+	}
+	if _, err := os.Lstat(filepath.Join(home, ".claude", "skills")); err != nil {
+		t.Fatalf("global skills alias missing: %v", err)
+	}
+	if _, err := os.Lstat(filepath.Join(base, "punaro", "CLAUDE.md")); err != nil {
+		t.Fatalf("project alias missing: %v", err)
+	}
+}
+
 func bytesRepeat(b byte, n int) []byte {
 	out := make([]byte, n)
 	for i := range out {

--- a/internal/adapter/fleet_client_test.go
+++ b/internal/adapter/fleet_client_test.go
@@ -1,0 +1,202 @@
+package adapter
+
+import (
+	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/rock3r/punaro/internal/fleetconfig"
+	"github.com/rock3r/punaro/internal/relay"
+)
+
+func TestHTTPRelayClientFetchesFleetDesiredAndRelease(t *testing.T) {
+	public, private, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	digest := "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+	archive := bytesRepeat('A', 200)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		timestamp, parseErr := time.Parse(time.RFC3339Nano, r.Header.Get("X-Punaro-Timestamp"))
+		signature, signatureErr := base64.RawURLEncoding.DecodeString(r.Header.Get("X-Punaro-Signature"))
+		signed := relay.SignedRequest{MachineID: r.Header.Get("X-Punaro-Machine"), Method: r.Method, Path: r.URL.Path, Body: body, Timestamp: timestamp, Nonce: r.Header.Get("X-Punaro-Nonce")}
+		if parseErr != nil || signatureErr != nil || !ed25519.Verify(public, relay.CanonicalRequest(signed), signature) {
+			t.Fatal("fleet-config request was not machine-signed")
+		}
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/v1/fleet-config/desired":
+			if len(body) != 0 {
+				t.Fatalf("desired GET had body %q", body)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"generation": 4, "digest": digest, "source_commit": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+				"skill_count": 1, "total_bytes": 12,
+			})
+		case r.Method == http.MethodGet && r.URL.Path == "/v1/fleet-config/releases/"+digest:
+			w.Header().Set("Content-Type", "application/octet-stream")
+			_, _ = w.Write(archive)
+		default:
+			t.Fatalf("unexpected %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer server.Close()
+	client, err := NewHTTPRelayClient(server.URL, "machine-a", private, server.Client(), AccessServiceToken{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	desired, err := client.FleetDesired(context.Background())
+	if err != nil || desired.Generation != 4 || desired.Digest != digest || desired.SkillCount != 1 {
+		t.Fatalf("desired=%#v err=%v", desired, err)
+	}
+	got, err := client.FleetRelease(context.Background(), digest)
+	if err != nil || string(got) != string(archive) {
+		t.Fatalf("archive=%q err=%v", got, err)
+	}
+}
+
+func TestHTTPRelayClientPutsFleetStatusIdempotently(t *testing.T) {
+	_, private, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var keys []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPut || r.URL.Path != "/v1/fleet-config/status" {
+			t.Fatalf("unexpected %s %s", r.Method, r.URL.Path)
+		}
+		keys = append(keys, r.Header.Get("Idempotency-Key"))
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"status":"recorded"}`))
+	}))
+	defer server.Close()
+	client, err := NewHTTPRelayClient(server.URL, "machine-a", private, server.Client(), AccessServiceToken{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	report := relay.FleetStatusReport{Generation: 1, AppliedDigest: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef", State: "current", ReportGeneration: 1, IdempotencyKey: "status-1"}
+	if err := client.PutFleetStatus(context.Background(), report); err != nil {
+		t.Fatal(err)
+	}
+	if err := client.PutFleetStatus(context.Background(), report); err != nil {
+		t.Fatal(err)
+	}
+	if len(keys) != 2 || keys[0] != "status-1" || keys[1] != "status-1" {
+		t.Fatalf("keys=%v", keys)
+	}
+}
+
+func TestHTTPRelayClientFleetReleaseRejectsUnauthorized(t *testing.T) {
+	_, private, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	digest := "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "forbidden", http.StatusForbidden)
+	}))
+	defer server.Close()
+	client, err := NewHTTPRelayClient(server.URL, "machine-revoked", private, server.Client(), AccessServiceToken{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := client.FleetDesired(context.Background()); err == nil {
+		t.Fatal("revoked client fetched desired")
+	}
+	if _, err := client.FleetRelease(context.Background(), digest); err == nil {
+		t.Fatal("revoked client fetched release")
+	}
+}
+
+func TestReconcileFleetOnceFetchesAppliesAndReports(t *testing.T) {
+	_, private, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tree := fleetconfig.Tree{Files: []fleetconfig.File{
+		{Path: "AGENTS.md", Data: []byte("# fleet\n")},
+		{Path: "projects/punaro/AGENTS.md", Data: []byte("# punaro\n")},
+		{Path: "projects/other/AGENTS.md", Data: []byte("# other\n")},
+	}}
+	release, err := fleetconfig.Materialize(tree, "0123456789abcdef0123456789abcdef01234567")
+	if err != nil {
+		t.Fatal(err)
+	}
+	home := t.TempDir()
+	base := filepath.Join(home, "src")
+	if err := os.MkdirAll(filepath.Join(base, "punaro"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	var reported []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/v1/fleet-config/desired":
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"generation": 2, "digest": release.Digest, "source_commit": release.SourceCommit,
+				"skill_count": release.SkillCount, "total_bytes": release.TotalBytes,
+			})
+		case r.Method == http.MethodGet && strings.HasPrefix(r.URL.Path, "/v1/fleet-config/releases/"):
+			w.Header().Set("Content-Type", "application/octet-stream")
+			_, _ = w.Write(release.Archive)
+		case r.Method == http.MethodPut && r.URL.Path == "/v1/fleet-config/status":
+			body, _ := io.ReadAll(r.Body)
+			reported = append(reported, string(body))
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"status":"recorded"}`))
+		default:
+			t.Fatalf("unexpected %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer server.Close()
+	client, err := NewHTTPRelayClient(server.URL, "machine-a", private, server.Client(), AccessServiceToken{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	root := t.TempDir()
+	result, err := ReconcileFleetOnce(context.Background(), FleetReconcileRequest{
+		Client: client,
+		Root:   root,
+		Home:   home,
+		Local:  fleetconfig.LocalConfig{Schema: 1, ProjectBasePath: base},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.State != "current" || result.AppliedDigest != release.Digest {
+		t.Fatalf("result=%#v", result)
+	}
+	live, err := os.ReadFile(filepath.Join(root, "current", "AGENTS.md")) //nolint:gosec // G304: test fixture under t.TempDir.
+	if err != nil || !strings.Contains(string(live), "# fleet") {
+		t.Fatalf("managed tree=%q err=%v", live, err)
+	}
+	project, err := os.ReadFile(filepath.Join(base, "punaro", "AGENTS.md")) //nolint:gosec // G304: test fixture under t.TempDir.
+	if err != nil || !strings.Contains(string(project), "# punaro") {
+		t.Fatalf("project apply=%q err=%v", project, err)
+	}
+	if _, err := os.Stat(filepath.Join(base, "other", "AGENTS.md")); !os.IsNotExist(err) {
+		t.Fatal("applied unmatched project tree")
+	}
+	if len(reported) == 0 || !strings.Contains(strings.Join(reported, ""), `"current"`) {
+		t.Fatalf("status writes=%v", reported)
+	}
+}
+
+func bytesRepeat(b byte, n int) []byte {
+	out := make([]byte, n)
+	for i := range out {
+		out[i] = b
+	}
+	return out
+}

--- a/internal/adapter/fleet_client_test.go
+++ b/internal/adapter/fleet_client_test.go
@@ -191,6 +191,25 @@ func TestReconcileFleetOnceFetchesAppliesAndReports(t *testing.T) {
 	if len(reported) == 0 || !strings.Contains(strings.Join(reported, ""), `"current"`) {
 		t.Fatalf("status writes=%v", reported)
 	}
+	if err := os.WriteFile(filepath.Join(home, "AGENTS.md"), []byte("# unmanaged\n"), 0o600); err != nil { //nolint:gosec // G306: test fixture under t.TempDir.
+		t.Fatal(err)
+	}
+	result, err = ReconcileFleetOnce(context.Background(), FleetReconcileRequest{
+		Client: client,
+		Root:   root,
+		Home:   home,
+		Local:  fleetconfig.LocalConfig{Schema: 1, ProjectBasePath: base},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.State == "current" || result.TrailerState != "collision" {
+		t.Fatalf("unmanaged AGENTS.md reported as current: %#v", result)
+	}
+	unmanaged, err := os.ReadFile(filepath.Join(home, "AGENTS.md")) //nolint:gosec // G304: test fixture under t.TempDir.
+	if err != nil || !strings.Contains(string(unmanaged), "unmanaged") {
+		t.Fatalf("overwrote unmanaged AGENTS.md: %q err=%v", unmanaged, err)
+	}
 }
 
 func TestReconcileFleetOnceProjectsClaudeAliasesAndUnsupportedHarness(t *testing.T) {
@@ -258,6 +277,149 @@ func TestReconcileFleetOnceProjectsClaudeAliasesAndUnsupportedHarness(t *testing
 	}
 	if _, err := os.Lstat(filepath.Join(base, "punaro", "CLAUDE.md")); err != nil {
 		t.Fatalf("project alias missing: %v", err)
+	}
+}
+
+func TestReconcileFleetOncePersistsReportGenerationAcrossCurrentAndNextDigest(t *testing.T) {
+	_, private, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	first, err := fleetconfig.Materialize(fleetconfig.Tree{Files: []fleetconfig.File{{Path: "AGENTS.md", Data: []byte("# a\n")}}}, "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := fleetconfig.Materialize(fleetconfig.Tree{Files: []fleetconfig.File{{Path: "AGENTS.md", Data: []byte("# b\n")}}}, "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var keys []string
+	var bodies []string
+	seen := map[string]string{}
+	desired := first
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/v1/fleet-config/desired":
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"generation": 2, "digest": desired.Digest, "source_commit": desired.SourceCommit,
+				"skill_count": desired.SkillCount, "total_bytes": desired.TotalBytes,
+			})
+		case r.Method == http.MethodGet && strings.HasPrefix(r.URL.Path, "/v1/fleet-config/releases/"):
+			w.Header().Set("Content-Type", "application/octet-stream")
+			if strings.HasSuffix(r.URL.Path, second.Digest) {
+				_, _ = w.Write(second.Archive)
+				return
+			}
+			_, _ = w.Write(first.Archive)
+		case r.Method == http.MethodPut && r.URL.Path == "/v1/fleet-config/status":
+			body, _ := io.ReadAll(r.Body)
+			key := r.Header.Get("Idempotency-Key")
+			if previous, ok := seen[key]; ok && previous != string(body) {
+				http.Error(w, "conflict", http.StatusConflict)
+				return
+			}
+			seen[key] = string(body)
+			keys = append(keys, key)
+			bodies = append(bodies, string(body))
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"status":"recorded"}`))
+		default:
+			t.Fatalf("unexpected %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer server.Close()
+	client, err := NewHTTPRelayClient(server.URL, "machine-a", private, server.Client(), AccessServiceToken{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	home := t.TempDir()
+	root := t.TempDir()
+	req := FleetReconcileRequest{Client: client, Root: root, Home: home, Local: fleetconfig.LocalConfig{Schema: 1, ProjectBasePath: filepath.Join(home, "src")}}
+	if _, err := ReconcileFleetOnce(context.Background(), req); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ReconcileFleetOnce(context.Background(), req); err != nil {
+		t.Fatal(err)
+	}
+	desired = second
+	if _, err := ReconcileFleetOnce(context.Background(), req); err != nil {
+		t.Fatal(err)
+	}
+	if len(keys) != 3 || keys[0] == keys[1] || keys[1] == keys[2] {
+		t.Fatalf("reused status idempotency keys: %v bodies=%v", keys, bodies)
+	}
+	state := loadFleetApplyState(root)
+	if state.ReportGeneration != 3 {
+		t.Fatalf("report_generation=%d", state.ReportGeneration)
+	}
+}
+
+func TestReconcileFleetOnceCurrentPathLiveFailureReportsFailed(t *testing.T) {
+	_, private, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	release, err := fleetconfig.Materialize(fleetconfig.Tree{Files: []fleetconfig.File{{Path: "AGENTS.md", Data: []byte("# fleet\n")}}}, "0123456789abcdef0123456789abcdef01234567")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var keys []string
+	var states []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/v1/fleet-config/desired":
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"generation": 2, "digest": release.Digest, "source_commit": release.SourceCommit,
+				"skill_count": release.SkillCount, "total_bytes": release.TotalBytes,
+			})
+		case r.Method == http.MethodGet && strings.HasPrefix(r.URL.Path, "/v1/fleet-config/releases/"):
+			w.Header().Set("Content-Type", "application/octet-stream")
+			_, _ = w.Write(release.Archive)
+		case r.Method == http.MethodPut && r.URL.Path == "/v1/fleet-config/status":
+			body, _ := io.ReadAll(r.Body)
+			keys = append(keys, r.Header.Get("Idempotency-Key"))
+			var payload map[string]any
+			_ = json.Unmarshal(body, &payload)
+			if state, _ := payload["state"].(string); state != "" {
+				states = append(states, state)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"status":"recorded"}`))
+		default:
+			t.Fatalf("unexpected %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer server.Close()
+	client, err := NewHTTPRelayClient(server.URL, "machine-a", private, server.Client(), AccessServiceToken{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	home := t.TempDir()
+	root := t.TempDir()
+	req := FleetReconcileRequest{Client: client, Root: root, Home: home, Local: fleetconfig.LocalConfig{Schema: 1, ProjectBasePath: filepath.Join(home, "src")}}
+	if _, err := ReconcileFleetOnce(context.Background(), req); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Remove(filepath.Join(home, "AGENTS.md")); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(filepath.Join(home, "missing"), filepath.Join(home, "AGENTS.md")); err != nil {
+		t.Fatal(err)
+	}
+	result, err := ReconcileFleetOnce(context.Background(), req)
+	if err == nil {
+		t.Fatal("live apply failure was not reported")
+	}
+	if result.State != "failed" {
+		t.Fatalf("result=%#v", result)
+	}
+	if len(states) < 2 || states[len(states)-1] != "failed" {
+		t.Fatalf("status states=%v", states)
+	}
+	if len(keys) < 2 || keys[0] == keys[1] {
+		t.Fatalf("reused status key after live failure: %v", keys)
 	}
 }
 

--- a/internal/adapter/fleet_unix_test.go
+++ b/internal/adapter/fleet_unix_test.go
@@ -11,6 +11,31 @@ import (
 	"github.com/rock3r/punaro/internal/fleetconfig"
 )
 
+func TestWriteLiveFileDoesNotFollowTmpSymlink(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	target := filepath.Join(dir, "secret")
+	if err := os.WriteFile(target, []byte("keep\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	dest := filepath.Join(dir, "AGENTS.md")
+	tmp := dest + ".punaro-tmp"
+	if err := os.Symlink(target, tmp); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeLiveFile(dest, []byte("# fleet\n")); err != nil {
+		t.Fatal(err)
+	}
+	got, err := os.ReadFile(target) //nolint:gosec // G304: test fixture under t.TempDir.
+	if err != nil || string(got) != "keep\n" {
+		t.Fatalf("followed tmp symlink: %q err=%v", got, err)
+	}
+	live, err := os.ReadFile(dest) //nolint:gosec // G304: test fixture under t.TempDir.
+	if err != nil || string(live) != "# fleet\n" {
+		t.Fatalf("live=%q err=%v", live, err)
+	}
+}
+
 func TestReconcileFleetStagingFailureKeepsLiveTree(t *testing.T) {
 	t.Parallel()
 	if os.Geteuid() == 0 {

--- a/internal/canopi/fleet.go
+++ b/internal/canopi/fleet.go
@@ -24,7 +24,7 @@ func FleetConvergenceEvent(generation int64, digest, state string, now time.Time
 	}
 	event := protocol.Event{
 		SpecVersion:     protocol.SpecVersion,
-		EventID:         "fleet-config-" + strconv.FormatInt(generation, 10),
+		EventID:         "fleet-config-" + strconv.FormatInt(generation, 10) + "-" + state,
 		Source:          protocol.SourceOther,
 		Machine:         protocol.Machine{ID: "fleet-config", Label: "fleet-config"},
 		SessionID:       "fleet-config",

--- a/internal/canopi/fleet.go
+++ b/internal/canopi/fleet.go
@@ -1,16 +1,55 @@
 package canopi
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"strconv"
+	"time"
 
-// FleetConvergenceEvent is a content-free dashboard hook for fleet-config.
-type FleetConvergenceEvent struct {
-	Kind       string `json:"kind"`
-	Generation int64  `json:"generation"`
-	Digest     string `json:"digest"`
-	State      string `json:"state"`
+	"github.com/rock3r/punaro/canopi/protocol"
+)
+
+// EncodeFleetConvergence encodes one bounded convergence event as a Canopi lifecycle event.
+func EncodeFleetConvergence(generation int64, digest, state string) ([]byte, error) {
+	event, err := FleetConvergenceEvent(generation, digest, state, time.Unix(1, 0).UTC())
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(event)
 }
 
-// EncodeFleetConvergence encodes one bounded convergence event.
-func EncodeFleetConvergence(generation int64, digest, state string) ([]byte, error) {
-	return json.Marshal(FleetConvergenceEvent{Kind: "fleet_config", Generation: generation, Digest: digest, State: state})
+// FleetConvergenceEvent builds a content-free lifecycle event Store.Apply accepts.
+func FleetConvergenceEvent(generation int64, digest, state string, now time.Time) (protocol.Event, error) {
+	if now.IsZero() {
+		now = time.Unix(1, 0).UTC()
+	}
+	event := protocol.Event{
+		SpecVersion:     protocol.SpecVersion,
+		EventID:         "fleet-config-" + strconv.FormatInt(generation, 10),
+		Source:          protocol.SourceOther,
+		Machine:         protocol.Machine{ID: "fleet-config", Label: "fleet-config"},
+		SessionID:       "fleet-config",
+		AgentInstanceID: "fleet-config",
+		State:           protocol.StateDone,
+		ActivityAt:      now,
+		EmittedAt:       now,
+		Task:            protocol.Task{Title: "fleet-config"},
+		Metadata: map[string]any{
+			"fleet_digest":     digest,
+			"fleet_state":      state,
+			"fleet_generation": generation,
+		},
+	}
+	if err := event.Validate(); err != nil {
+		return protocol.Event{}, err
+	}
+	return event, nil
+}
+
+// ApplyFleetConvergence records one fleet-config convergence event in the dashboard store.
+func (s *Store) ApplyFleetConvergence(generation int64, digest, state string, now time.Time) (ApplyResult, error) {
+	event, err := FleetConvergenceEvent(generation, digest, state, now)
+	if err != nil {
+		return ApplyResult{}, err
+	}
+	return s.Apply(event)
 }

--- a/internal/canopi/fleet_test.go
+++ b/internal/canopi/fleet_test.go
@@ -41,4 +41,8 @@ func TestStoreAppliesFleetConvergenceEvent(t *testing.T) {
 	if err != nil || !result.Applied {
 		t.Fatalf("apply=%#v err=%v", result, err)
 	}
+	again, err := store.ApplyFleetConvergence(4, strings.Repeat("ab", 32), "failed", now)
+	if err != nil || !again.Applied {
+		t.Fatalf("state change=%#v err=%v", again, err)
+	}
 }

--- a/internal/canopi/fleet_test.go
+++ b/internal/canopi/fleet_test.go
@@ -1,21 +1,44 @@
 package canopi
 
 import (
+	"bytes"
 	"strings"
 	"testing"
+	"time"
+
+	"github.com/rock3r/punaro/canopi/protocol"
 )
 
 func TestEncodeFleetConvergenceOmitsConfigurationContents(t *testing.T) {
 	t.Parallel()
-	body, err := EncodeFleetConvergence(4, strings.Repeat("ab", 32), "current")
+	digest := strings.Repeat("ab", 32)
+	body, err := EncodeFleetConvergence(4, digest, "current")
 	if err != nil {
 		t.Fatal(err)
 	}
 	text := string(body)
-	if !strings.Contains(text, `"kind":"fleet_config"`) || !strings.Contains(text, `"generation":4`) {
+	if !strings.Contains(text, `"fleet_state":"current"`) || !strings.Contains(text, `"fleet_generation":4`) {
 		t.Fatalf("body=%s", text)
 	}
 	if strings.Contains(text, "AGENTS.md") || strings.Contains(text, "# fleet") || strings.Contains(text, "/Users/") {
 		t.Fatalf("leaked contents: %s", text)
+	}
+	event, err := protocol.DecodeEvent(bytes.NewReader(body), 32<<10)
+	if err != nil {
+		t.Fatalf("decode=%v body=%s", err, text)
+	}
+	if event.Metadata["fleet_digest"] != digest || event.Metadata["fleet_state"] != "current" {
+		t.Fatalf("event=%#v", event)
+	}
+}
+
+func TestStoreAppliesFleetConvergenceEvent(t *testing.T) {
+	t.Parallel()
+	store := NewStore(Config{WorkingTTL: time.Hour, DoneRetention: 2 * time.Hour})
+	now := time.Date(2026, 8, 30, 12, 0, 0, 0, time.UTC)
+	store.now = func() time.Time { return now }
+	result, err := store.ApplyFleetConvergence(4, strings.Repeat("ab", 32), "current", now)
+	if err != nil || !result.Applied {
+		t.Fatalf("apply=%#v err=%v", result, err)
 	}
 }

--- a/internal/diagnostic/fleet.go
+++ b/internal/diagnostic/fleet.go
@@ -41,6 +41,7 @@ var requiredComponentCheckCodes = map[Component][]string{
 		"installation_paths", "maintenance_fence", "migration_manifest_binding", "owner_credential_file", "postgres_major", "readiness_endpoint", "recovery_receipt", "relay_enrollment",
 		"relay_protocol", "running_image", "storage_capacity", "storage_credential_isolation", "storage_directory_separation", "tunnel_origin", "tunnel_route",
 		"update_recovery", "update_transaction", "verified_backup",
+		"fleet_config_desired", "fleet_config_client_stale", "fleet_config_failed", "fleet_config_drifted", "fleet_config_unsupported",
 	},
 	ComponentAdapter: {
 		"adapter_configuration", "adapter_data_directory", "adapter_profile_file", "adapter_service_enabled", "adapter_service_executable", "adapter_service_installed",

--- a/internal/diagnostic/fleet_config.go
+++ b/internal/diagnostic/fleet_config.go
@@ -14,7 +14,7 @@ func FleetConfigChecks(desiredDigest string, clientStates []string) []Check {
 			drifted = true
 		case "unsupported":
 			unsupported = true
-		case "offline", "pending":
+		case "offline":
 			stale = true
 		}
 	}

--- a/internal/diagnostic/fleet_config_test.go
+++ b/internal/diagnostic/fleet_config_test.go
@@ -19,3 +19,41 @@ func TestFleetConfigChecksAreContentFree(t *testing.T) {
 		t.Fatalf("byCode=%#v", byCode)
 	}
 }
+
+func TestFleetConfigChecksTreatOfflineNotPendingAsStale(t *testing.T) {
+	t.Parallel()
+	pending := FleetConfigChecks("digest", []string{"pending", "applying", "current"})
+	offline := FleetConfigChecks("digest", []string{"offline"})
+	byPending, byOffline := map[string]Check{}, map[string]Check{}
+	for _, check := range pending {
+		byPending[check.Code] = check
+	}
+	for _, check := range offline {
+		byOffline[check.Code] = check
+	}
+	if byPending["fleet_config_client_stale"].Status != StatusPass {
+		t.Fatalf("pending marked stale: %#v", pending)
+	}
+	if byOffline["fleet_config_client_stale"].Status != StatusFail {
+		t.Fatalf("offline not stale: %#v", offline)
+	}
+}
+
+func TestRequiredServerChecksIncludeFleetConfig(t *testing.T) {
+	t.Parallel()
+	codes := RequiredComponentCheckCodes(ComponentServer)
+	want := map[string]bool{
+		"fleet_config_desired": false, "fleet_config_client_stale": false, "fleet_config_failed": false,
+		"fleet_config_drifted": false, "fleet_config_unsupported": false,
+	}
+	for _, code := range codes {
+		if _, ok := want[code]; ok {
+			want[code] = true
+		}
+	}
+	for code, found := range want {
+		if !found {
+			t.Fatalf("missing required server check %s", code)
+		}
+	}
+}

--- a/internal/fleetconfig/alias.go
+++ b/internal/fleetconfig/alias.go
@@ -46,6 +46,9 @@ func CreateAlias(targetPath, linkPath string, enabled bool) (AliasResult, error)
 	} else if !errors.Is(err, os.ErrNotExist) {
 		return AliasResult{State: "unsupported"}, err
 	}
+	if err := os.MkdirAll(filepath.Dir(linkPath), 0o700); err != nil {
+		return AliasResult{State: "unsupported"}, err
+	}
 	if err := createAliasLink(targetPath, linkPath); err != nil {
 		return AliasResult{State: "unsupported"}, err
 	}

--- a/internal/fleetconfig/apply.go
+++ b/internal/fleetconfig/apply.go
@@ -11,9 +11,10 @@ import (
 
 // ApplyState is persisted next to the live tree without configuration contents.
 type ApplyState struct {
-	Digest         string            `json:"digest"`
-	PrefixDigests  map[string]string `json:"prefix_digests,omitempty"`
-	LastGoodDigest string            `json:"last_good_digest,omitempty"`
+	Digest           string            `json:"digest"`
+	PrefixDigests    map[string]string `json:"prefix_digests,omitempty"`
+	LastGoodDigest   string            `json:"last_good_digest,omitempty"`
+	ReportGeneration int64             `json:"report_generation,omitempty"`
 }
 
 var reconcileMu sync.Mutex

--- a/internal/fleetconfig/local.go
+++ b/internal/fleetconfig/local.go
@@ -1,0 +1,57 @@
+package fleetconfig
+
+import (
+	"encoding/json"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+)
+
+const maxLocalConfigBytes = 8 << 10
+
+// LocalConfig is machine-local fleet-config choice. It is never fleet source.
+type LocalConfig struct {
+	Schema               int               `json:"schema"`
+	ProjectBasePath      string            `json:"project_base_path"`
+	ProjectPathOverrides map[string]string `json:"project_path_overrides"`
+	ClaudeAliases        bool              `json:"claude_aliases"`
+}
+
+// LoadLocalConfig reads a bounded v1 machine-local config, or returns defaults.
+func LoadLocalConfig(path string) (LocalConfig, error) {
+	defaults := LocalConfig{Schema: SchemaV1}
+	if path == "" {
+		return defaults, nil
+	}
+	info, err := os.Lstat(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return defaults, nil
+	}
+	if err != nil || info.Mode()&os.ModeSymlink != 0 || !info.Mode().IsRegular() {
+		return LocalConfig{}, errors.New("fleet-config local config is unsafe")
+	}
+	// #nosec G304 -- operator-supplied local adapter path, Lstat-fenced.
+	file, err := os.Open(path)
+	if err != nil {
+		return LocalConfig{}, errors.New("fleet-config local config is unavailable")
+	}
+	defer func() { _ = file.Close() }()
+	data, err := io.ReadAll(io.LimitReader(file, maxLocalConfigBytes+1))
+	if err != nil || len(data) > maxLocalConfigBytes {
+		return LocalConfig{}, errors.New("fleet-config local config is invalid")
+	}
+	var config LocalConfig
+	if err := json.Unmarshal(data, &config); err != nil || config.Schema != SchemaV1 {
+		return LocalConfig{}, errors.New("fleet-config local config is invalid")
+	}
+	if config.ProjectBasePath != "" && !filepath.IsAbs(config.ProjectBasePath) {
+		return LocalConfig{}, errors.New("fleet-config local config is invalid")
+	}
+	for name, override := range config.ProjectPathOverrides {
+		if name == "" || !filepath.IsAbs(override) {
+			return LocalConfig{}, errors.New("fleet-config local config is invalid")
+		}
+	}
+	return config, nil
+}

--- a/internal/fleetconfig/materialize.go
+++ b/internal/fleetconfig/materialize.go
@@ -7,6 +7,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"errors"
+	"io"
 	"sort"
 	"strconv"
 	"strings"
@@ -107,6 +108,60 @@ func writeArchive(files []File) ([]byte, error) {
 		return nil, errors.New("fleet-config archive failed")
 	}
 	return raw.Bytes(), nil
+}
+
+const maxArchiveBytes = 8 << 20
+
+// ReadArchive unpacks a deterministic gzip+tar release into a validated tree.
+func ReadArchive(archive []byte) (Tree, error) {
+	if len(archive) == 0 || len(archive) > maxArchiveBytes {
+		return Tree{}, errors.New("fleet-config archive is invalid")
+	}
+	gzipReader, err := gzip.NewReader(bytes.NewReader(archive))
+	if err != nil {
+		return Tree{}, errors.New("fleet-config archive is invalid")
+	}
+	defer func() { _ = gzipReader.Close() }()
+	tarReader := tar.NewReader(gzipReader)
+	var files []File
+	var total int64
+	for {
+		header, err := tarReader.Next()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			return Tree{}, errors.New("fleet-config archive is invalid")
+		}
+		switch header.Typeflag {
+		case tar.TypeDir:
+			continue
+		case tar.TypeReg:
+		default:
+			return Tree{}, errors.New("fleet-config archive contains a special file")
+		}
+		path, err := canonicalPath(header.Name)
+		if err != nil {
+			return Tree{}, errors.New("fleet-config archive path is invalid")
+		}
+		if header.Size < 0 || header.Size > MaxFileBytes {
+			return Tree{}, errors.New("fleet-config file is too large")
+		}
+		data, err := io.ReadAll(io.LimitReader(tarReader, header.Size+1))
+		if err != nil || int64(len(data)) != header.Size {
+			return Tree{}, errors.New("fleet-config archive is invalid")
+		}
+		total += int64(len(data))
+		if total > MaxTotalBytes || len(files) >= MaxFiles {
+			return Tree{}, errors.New("fleet-config source is too large")
+		}
+		files = append(files, File{Path: path, Data: data})
+	}
+	tree := Tree{Files: files}
+	if err := Validate(tree); err != nil {
+		return Tree{}, err
+	}
+	return tree, nil
 }
 
 func archiveDirectories(files []File) []string {

--- a/internal/fleetconfig/materialize_test.go
+++ b/internal/fleetconfig/materialize_test.go
@@ -1,9 +1,12 @@
 package fleetconfig
 
 import (
+	"archive/tar"
 	"bytes"
+	"compress/gzip"
 	"strings"
 	"testing"
+	"time"
 )
 
 const testCommit = "0123456789abcdef0123456789abcdef01234567"
@@ -103,5 +106,48 @@ func TestMaterializeArchivesHundredByteDirectory(t *testing.T) {
 	}}
 	if _, err := Materialize(tree, testCommit); err != nil {
 		t.Fatal(err)
+	}
+}
+
+func TestReadArchiveRoundTripsMaterialize(t *testing.T) {
+	t.Parallel()
+	tree := Tree{Files: []File{
+		{Path: "AGENTS.md", Data: []byte("# fleet\n")},
+		{Path: "skills/demo/SKILL.md", Data: []byte(skillMarkdown("demo", "Demo skill."))},
+		{Path: "projects/punaro/AGENTS.md", Data: []byte("# punaro\n")},
+	}}
+	release, err := Materialize(tree, testCommit)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := ReadArchive(release.Archive)
+	if err != nil {
+		t.Fatal(err)
+	}
+	again, err := Materialize(got, testCommit)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if again.Digest != release.Digest {
+		t.Fatalf("unpacked digest=%s want %s", again.Digest, release.Digest)
+	}
+}
+
+func TestReadArchiveRejectsSymlink(t *testing.T) {
+	t.Parallel()
+	var raw bytes.Buffer
+	gzipWriter := gzip.NewWriter(&raw)
+	tarWriter := tar.NewWriter(gzipWriter)
+	if err := tarWriter.WriteHeader(&tar.Header{Typeflag: tar.TypeSymlink, Name: "AGENTS.md", Linkname: "/etc/passwd", Mode: 0o644, ModTime: time.Unix(0, 0).UTC(), Format: tar.FormatUSTAR}); err != nil {
+		t.Fatal(err)
+	}
+	if err := tarWriter.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := gzipWriter.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ReadArchive(raw.Bytes()); err == nil {
+		t.Fatal("accepted a symlink archive entry")
 	}
 }

--- a/internal/postgres/state_test.go
+++ b/internal/postgres/state_test.go
@@ -109,13 +109,6 @@ func TestPostgresIntegrationImageIncludesFleetBootstrapAndGit(t *testing.T) {
 	if !strings.Contains(string(ignored), "!deploy/compose/postgres-bootstrap.sh") {
 		t.Fatal("build context excludes postgres-bootstrap.sh")
 	}
-	compose, err := os.ReadFile(filepath.Join("..", "..", "docker-compose.postgres-test.yml")) // #nosec G304 -- test reads the checked-out postgres-test Compose manifest.
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !strings.Contains(string(compose), "target: build") {
-		t.Fatal("postgres-tests does not run the image stage that holds source, git, and bootstrap")
-	}
 }
 
 func TestManifestValidationRejectsMutableOrNonContiguousHistory(t *testing.T) {

--- a/internal/postgres/state_test.go
+++ b/internal/postgres/state_test.go
@@ -1,6 +1,8 @@
 package postgres
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -49,6 +51,70 @@ func TestClassifySchemaState(t *testing.T) {
 				t.Fatalf("Classify() = %s, want %s", got.Classification, tt.want)
 			}
 		})
+	}
+}
+
+func TestOwnedSchemaNamesIncludeFleet(t *testing.T) {
+	found := false
+	for _, name := range ownedSchemaNames {
+		if name == "fleet" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatal("inspect owned-schema list omits fleet")
+	}
+	if len(ownedSchemaNames) < 7 {
+		t.Fatalf("owned schema count=%d, want at least the original six plus fleet", len(ownedSchemaNames))
+	}
+}
+
+func TestProductionBootstrapAllowlistIncludesFleet(t *testing.T) {
+	body, err := os.ReadFile(filepath.Join("..", "..", "deploy", "compose", "postgres-bootstrap.sh"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	text := string(body)
+	for _, needle := range []string{
+		"'auth', 'relay', 'attachment', 'brain', 'audit', 'jobs', 'public'",
+		"'auth', 'relay', 'attachment', 'brain', 'audit', 'jobs', 'public', 'information_schema'",
+	} {
+		if strings.Contains(text, needle) {
+			t.Fatalf("bootstrap still treats Punaro schemas without fleet: %s", needle)
+		}
+	}
+	if !strings.Contains(text, "'fleet'") {
+		t.Fatal("bootstrap allowlist omits fleet")
+	}
+}
+
+func TestPostgresIntegrationImageIncludesFleetBootstrapAndGit(t *testing.T) {
+	dockerfile, err := os.ReadFile(filepath.Join("..", "..", "Dockerfile")) // #nosec G304 -- test reads the checked-out postgres-test Dockerfile.
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, expected := range []string{
+		"COPY deploy/compose/postgres-bootstrap.sh ./deploy/compose/",
+		"git=2.54.0-r0",
+	} {
+		if !strings.Contains(string(dockerfile), expected) {
+			t.Fatalf("postgres-test image omits %s", expected)
+		}
+	}
+	ignored, err := os.ReadFile(filepath.Join("..", "..", ".dockerignore")) // #nosec G304 -- test reads the checked-out build-context policy.
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(ignored), "!deploy/compose/postgres-bootstrap.sh") {
+		t.Fatal("build context excludes postgres-bootstrap.sh")
+	}
+	compose, err := os.ReadFile(filepath.Join("..", "..", "docker-compose.postgres-test.yml")) // #nosec G304 -- test reads the checked-out postgres-test Compose manifest.
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(compose), "target: build") {
+		t.Fatal("postgres-tests does not run the image stage that holds source, git, and bootstrap")
 	}
 }
 

--- a/internal/postgres/state_test.go
+++ b/internal/postgres/state_test.go
@@ -54,22 +54,6 @@ func TestClassifySchemaState(t *testing.T) {
 	}
 }
 
-func TestOwnedSchemaNamesIncludeFleet(t *testing.T) {
-	found := false
-	for _, name := range ownedSchemaNames {
-		if name == "fleet" {
-			found = true
-			break
-		}
-	}
-	if !found {
-		t.Fatal("inspect owned-schema list omits fleet")
-	}
-	if len(ownedSchemaNames) < 7 {
-		t.Fatalf("owned schema count=%d, want at least the original six plus fleet", len(ownedSchemaNames))
-	}
-}
-
 func TestProductionBootstrapAllowlistIncludesFleet(t *testing.T) {
 	body, err := os.ReadFile(filepath.Join("..", "..", "deploy", "compose", "postgres-bootstrap.sh"))
 	if err != nil {

--- a/internal/relay/fleet_config_http_test.go
+++ b/internal/relay/fleet_config_http_test.go
@@ -298,6 +298,36 @@ func TestBroadcastFleetWakeUsesReservedTopic(t *testing.T) {
 	}
 }
 
+func TestWatchFleetDesiredBroadcastsGenerationBump(t *testing.T) {
+	t.Parallel()
+	store := &memoryFleetStore{desired: FleetDesiredMetadata{Generation: 1, Digest: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"}}
+	notifier := NewNotifier()
+	client := notifier.Register("machine-a")
+	t.Cleanup(client.Close)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go WatchFleetDesired(ctx, store, notifier, 20*time.Millisecond)
+	select {
+	case event := <-client.Events():
+		if event.TopicID != FleetConfigTopic || event.Sequence != 1 || event.Type != "wake" {
+			t.Fatalf("event=%#v", event)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("missed initial fleet-config wake")
+	}
+	store.mu.Lock()
+	store.desired.Generation = 3
+	store.mu.Unlock()
+	select {
+	case event := <-client.Events():
+		if event.TopicID != FleetConfigTopic || event.Sequence != 3 {
+			t.Fatalf("bump=%#v", event)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("missed fleet-config generation bump")
+	}
+}
+
 func serveUnsigned(t *testing.T, handler http.Handler, method, path, body string) *httptest.ResponseRecorder {
 	t.Helper()
 	request := httptest.NewRequestWithContext(context.Background(), method, path, bytes.NewBufferString(body))


### PR DESCRIPTION
## Summary
- Adapter HTTP fetch of desired metadata and digest-addressed archives, atomic apply, and bounded status PUT.
- README split into user-guide docs after LAN apply existed.
- Personal LAN gating on mac-studio, coso, and mattone: payload-free wake, offline reconverge, revoke, corrupt/interrupt/rollback, unpublished source, trailer/alias/project-match. Mattone/coso status PUT 403 recorded (no client_installations). Darwin live HTTP uses a multiplexed loopback forwarder.

Stacked on #227 (`agent/fleet-config-217`). Does not check security-release-gate boxes.

## Test plan
- [x] `make test` `make test-race` `make staticcheck` `make security` `make lint`
- [x] LAN scenarios in `docs/fleet-config-lan-e2e.md` on named hosts (redacted record under `docs/deployment-validation/`)