### PR TITLE
Require accepted state for catalog sequence diagnosis

### DIFF
--- a/docs/doctor.md
+++ b/docs/doctor.md
@@ -385,6 +385,10 @@ it instead matches the rolled-away previous slot, corroborated by the exact
 high-water mark. A malformed auto-rollback record or an accepted/current
 mismatch without that exact rollback evidence fails closed.
 
+`catalog_sequence` is unavailable, rather than passing, when the accepted
+bootstrap state is missing or unreadable because there is no trustworthy local
+high-water mark to compare with the signed catalog.
+
 Compose-manifest hashing and bootstrap slot inspection reject non-regular or
 linked paths before opening files and use bounded incremental reads. Both the
 standalone bootstrap doctor and the adapter's embedded bootstrap checks run the

--- a/internal/bootstrap/doctor.go
+++ b/internal/bootstrap/doctor.go
@@ -157,7 +157,8 @@ func Doctor(ctx context.Context, request DoctorRequest) (punarodiagnostic.Report
 	checks = append(checks, absentBootstrapNodeCheck(request.Directory, candidateSlot, "candidate_state", "resume_or_recover_bootstrap"))
 	checks = append(checks, absentBootstrapNodeCheck(request.Directory, swapSlot, "swap_state", "resume_or_recover_bootstrap"))
 
-	catalog, catalogChecks, catalogOK := doctorCatalog(ctx, request, keys, accepted)
+	acceptedAvailable := acceptedErr == nil && accepted.CatalogSequence > 0
+	catalog, catalogChecks, catalogOK := doctorCatalog(ctx, request, keys, accepted, acceptedAvailable)
 	checks = append(checks, catalogChecks...)
 	var currentAdapterDigest string
 	if currentErr == nil && current.Release != "" {
@@ -346,7 +347,7 @@ func absentBootstrapNodeCheck(directory, name, code, remediation string) punarod
 	return punarodiagnostic.Fail(code, remediation)
 }
 
-func doctorCatalog(ctx context.Context, request DoctorRequest, keys map[string]ed25519.PublicKey, accepted acceptedState) (punarorelease.Catalog, []punarodiagnostic.Check, bool) {
+func doctorCatalog(ctx context.Context, request DoctorRequest, keys map[string]ed25519.PublicKey, accepted acceptedState, acceptedAvailable bool) (punarorelease.Catalog, []punarodiagnostic.Check, bool) {
 	checks := make([]punarodiagnostic.Check, 0, 5)
 	client := request.HTTP
 	if client == nil {
@@ -393,9 +394,12 @@ func doctorCatalog(ctx context.Context, request DoctorRequest, keys map[string]e
 	} else {
 		checks = append(checks, punarodiagnostic.Fail("catalog_freshness", "refresh_release_catalog"))
 	}
-	if accepted.CatalogSequence == 0 || catalog.Sequence >= accepted.CatalogSequence {
+	switch {
+	case !acceptedAvailable:
+		checks = append(checks, punarodiagnostic.Unavailable("catalog_sequence", "repair_bootstrap_state"))
+	case catalog.Sequence >= accepted.CatalogSequence:
 		checks = append(checks, punarodiagnostic.Pass("catalog_sequence"))
-	} else {
+	default:
 		checks = append(checks, punarodiagnostic.Fail("catalog_sequence", "repair_release_catalog"))
 	}
 	return catalog, checks, true

--- a/internal/bootstrap/doctor_test.go
+++ b/internal/bootstrap/doctor_test.go
@@ -32,7 +32,7 @@ func TestDoctorVerifiesSignedSlotWithoutMutatingBootstrapState(t *testing.T) {
 	if report.Component != punarodiagnostic.ComponentBootstrap || report.Identity.Release != "v0.1.0" || report.Identity.ReleaseSequence != 1 || report.Identity.CatalogSequence != 1 || report.Identity.Protocol != BootstrapProtocolVersion || report.Identity.ArtifactDigest == "" {
 		t.Fatalf("report=%#v", report)
 	}
-	for _, code := range []string{"bootstrap_directory", "bootstrap_lock", "run_lock", "disk_space", "release_keys", "catalog_signature", "catalog_freshness", "accepted_state", "current_slot", "current_catalog_allowed", "current_critical_block", "current_manifest_signature", "current_platform_compatibility", "current_artifact_integrity", "minimum_bootstrap_release", "minimum_recovery_protocol", "journal_state", "recovery_state"} {
+	for _, code := range []string{"bootstrap_directory", "bootstrap_lock", "run_lock", "disk_space", "release_keys", "catalog_signature", "catalog_freshness", "catalog_sequence", "accepted_state", "current_slot", "current_catalog_allowed", "current_critical_block", "current_manifest_signature", "current_platform_compatibility", "current_artifact_integrity", "minimum_bootstrap_release", "minimum_recovery_protocol", "journal_state", "recovery_state"} {
 		if doctorCheckStatus(report, code) != punarodiagnostic.StatusPass {
 			t.Fatalf("check %s report=%#v", code, report)
 		}
@@ -422,7 +422,101 @@ func TestDoctorRejectsOversizedAcceptedStateWithoutReadingIt(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if report.Healthy || doctorCheckStatus(report, "accepted_state") != punarodiagnostic.StatusFail {
+	if report.Healthy || doctorCheckStatus(report, "accepted_state") != punarodiagnostic.StatusFail || doctorCheckStatus(report, "catalog_sequence") != punarodiagnostic.StatusUnavailable {
+		t.Fatalf("report=%#v", report)
+	}
+}
+
+func TestDoctorDoesNotPassCatalogSequenceWithoutAcceptedState(t *testing.T) {
+	origin := newSignedOrigin(t, originSpec{payload: testArtifact, goos: runtime.GOOS, goarch: runtime.GOARCH})
+	now := time.Date(2026, 8, 20, 0, 0, 0, 0, time.UTC)
+	for _, test := range []struct {
+		name   string
+		mutate func(*testing.T, string)
+	}{
+		{
+			name: "missing",
+			mutate: func(t *testing.T, directory string) {
+				t.Helper()
+				if err := os.Remove(filepath.Join(directory, acceptedFile)); err != nil {
+					t.Fatal(err)
+				}
+			},
+		},
+		{
+			name: "malformed",
+			mutate: func(t *testing.T, directory string) {
+				t.Helper()
+				if err := os.WriteFile(filepath.Join(directory, acceptedFile), []byte(`{"schema":1`), 0o600); err != nil {
+					t.Fatal(err)
+				}
+			},
+		},
+		{
+			name: "duplicate field",
+			mutate: func(t *testing.T, directory string) {
+				t.Helper()
+				accepted, err := loadAccepted(directory)
+				if err != nil {
+					t.Fatal(err)
+				}
+				body := fmt.Sprintf(`{"schema":1,"schema":1,"release":%q,"release_sequence":%d,"catalog_sequence":%d,"manifest_sha256":%q}`, accepted.Release, accepted.ReleaseSequence, accepted.CatalogSequence, accepted.ManifestSHA256)
+				if err := os.WriteFile(filepath.Join(directory, acceptedFile), []byte(body), 0o600); err != nil {
+					t.Fatal(err)
+				}
+			},
+		},
+		{
+			name: "unsafe node",
+			mutate: func(t *testing.T, directory string) {
+				t.Helper()
+				path := filepath.Join(directory, acceptedFile)
+				if err := os.Remove(path); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.Mkdir(path, 0o700); err != nil {
+					t.Fatal(err)
+				}
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			directory := privateDir(t)
+			if _, err := Update(Request{Directory: directory, Origin: origin.URL, Keys: origin.Keys, GOOS: runtime.GOOS, GOARCH: runtime.GOARCH, Now: now}); err != nil {
+				t.Fatal(err)
+			}
+			test.mutate(t, directory)
+			report, err := Doctor(t.Context(), DoctorRequest{Directory: directory, Origin: origin.URL, Keys: origin.Keys, GOOS: runtime.GOOS, GOARCH: runtime.GOARCH, Now: now, FreeBytes: func(string) (uint64, error) { return 1 << 40, nil }})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if doctorCheckStatus(report, "catalog_signature") != punarodiagnostic.StatusPass || doctorCheckStatus(report, "accepted_state") != punarodiagnostic.StatusFail || doctorCheckStatus(report, "catalog_sequence") != punarodiagnostic.StatusUnavailable {
+				t.Fatalf("report=%#v", report)
+			}
+		})
+	}
+}
+
+func TestDoctorFailsCatalogSequenceBelowAcceptedHighWater(t *testing.T) {
+	origin := newSignedOrigin(t, originSpec{payload: testArtifact, goos: runtime.GOOS, goarch: runtime.GOARCH})
+	directory := privateDir(t)
+	now := time.Date(2026, 8, 20, 0, 0, 0, 0, time.UTC)
+	if _, err := Update(Request{Directory: directory, Origin: origin.URL, Keys: origin.Keys, GOOS: runtime.GOOS, GOARCH: runtime.GOARCH, Now: now}); err != nil {
+		t.Fatal(err)
+	}
+	accepted, err := loadAccepted(directory)
+	if err != nil {
+		t.Fatal(err)
+	}
+	accepted.CatalogSequence++
+	if err := saveAccepted(directory, accepted); err != nil {
+		t.Fatal(err)
+	}
+	report, err := Doctor(t.Context(), DoctorRequest{Directory: directory, Origin: origin.URL, Keys: origin.Keys, GOOS: runtime.GOOS, GOARCH: runtime.GOARCH, Now: now, FreeBytes: func(string) (uint64, error) { return 1 << 40, nil }})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if doctorCheckStatus(report, "accepted_state") != punarodiagnostic.StatusPass || doctorCheckStatus(report, "catalog_sequence") != punarodiagnostic.StatusFail {
 		t.Fatalf("report=%#v", report)
 	}
 }


### PR DESCRIPTION
Closes #232

- Report catalog_sequence unavailable when accepted state is missing or unreadable.
- Preserve pass and downgrade-failure behavior when the high-water mark is trustworthy.
- Add missing, malformed, duplicate-field, oversized, and unsafe-node coverage.
- Document the standalone and embedded doctor semantics.

Validation before commit:
- focused doctor tests
- full make ci
- two independent Pioneer reviews with no blocking findings

The full Punaro gate will be rerun on this PR head before merge.