### PR TITLE
Teach bootstrap doctor about rollback high-water state

### DIFF
--- a/docs/doctor.md
+++ b/docs/doctor.md
@@ -366,8 +366,8 @@ matching string.
 ### Bootstrap
 
 `bootstrap_directory`, `bootstrap_lock`, `run_lock`, `disk_space`,
-`release_keys`, `accepted_state`, `current_slot`, `previous_slot`,
-`journal_state`, `recovery_state`, `candidate_state`, `swap_state`,
+`release_keys`, `accepted_state`, `auto_rollback_state`, `current_slot`,
+`previous_slot`, `journal_state`, `recovery_state`, `candidate_state`, `swap_state`,
 `catalog_reachability`, `catalog_signature`, `catalog_freshness`,
 `catalog_sequence`, `current_catalog_allowed`, `current_critical_block`,
 `current_manifest_signature`, `current_platform_compatibility`,
@@ -377,6 +377,13 @@ matching string.
 `previous_platform_compatibility`, `previous_artifact_integrity`,
 `rollback_available`, `running_artifact`, `supervisor_process`,
 `candidate_health`.
+
+`accepted_state` validates the monotonic signed-release high-water mark. It
+normally matches the current slot. After an intentional or automatic rollback
+it instead matches the rolled-away previous slot, corroborated by the exact
+`auto_rollback_state` identity; rollback deliberately does not lower this
+high-water mark. A malformed auto-rollback record or an accepted/current
+mismatch without that exact rollback evidence fails closed.
 
 Compose-manifest hashing and bootstrap slot inspection reject non-regular or
 linked paths before opening files and use bounded incremental reads. Both the

--- a/internal/bootstrap/doctor.go
+++ b/internal/bootstrap/doctor.go
@@ -112,6 +112,7 @@ func Doctor(ctx context.Context, request DoctorRequest) (punarodiagnostic.Report
 	accepted, acceptedErr := doctorLoadAccepted(ctx, request.Directory)
 	current, currentErr := doctorReadOptionalSlot(ctx, filepath.Join(request.Directory, currentSlot))
 	previous, previousErr := doctorReadOptionalSlot(ctx, filepath.Join(request.Directory, previousSlot))
+	autoRollback, autoRollbackExists, autoRollbackErr := doctorLoadAutoRollback(ctx, request.Directory)
 	if currentErr != nil || current.Release == "" {
 		checks = append(checks, punarodiagnostic.Fail("current_slot", "reinstall_signed_release"))
 	} else {
@@ -127,7 +128,14 @@ func Doctor(ctx context.Context, request DoctorRequest) (punarodiagnostic.Report
 	default:
 		checks = append(checks, punarodiagnostic.Pass("previous_slot"))
 	}
-	if acceptedErr != nil || currentErr != nil || current.Release == "" || accepted.Release != current.Release || accepted.ReleaseSequence != current.Sequence || accepted.ManifestSHA256 != current.ManifestSHA256 {
+	if autoRollbackErr != nil {
+		checks = append(checks, punarodiagnostic.Fail("auto_rollback_state", "repair_bootstrap_state"))
+	} else {
+		checks = append(checks, punarodiagnostic.Pass("auto_rollback_state"))
+	}
+	acceptedMatchesCurrent := acceptedErr == nil && currentErr == nil && acceptedMatchesSlot(accepted, current)
+	acceptedMatchesRollback := acceptedErr == nil && currentErr == nil && current.Release != "" && previousErr == nil && autoRollbackErr == nil && autoRollbackExists && accepted.ReleaseSequence > current.Sequence && acceptedMatchesSlot(accepted, previous) && autoRollbackMatchesSlot(autoRollback, previous)
+	if !acceptedMatchesCurrent && !acceptedMatchesRollback {
 		checks = append(checks, punarodiagnostic.Fail("accepted_state", "repair_bootstrap_state"))
 	} else {
 		checks = append(checks, punarodiagnostic.Pass("accepted_state"))
@@ -230,6 +238,23 @@ func doctorLoadAccepted(ctx context.Context, directory string) (acceptedState, e
 	return parseAccepted(body)
 }
 
+func doctorLoadAutoRollback(ctx context.Context, directory string) (autoRollbackState, bool, error) {
+	body, exists, err := doctorReadOptionalState(ctx, filepath.Join(directory, autoRollbackFile), maximumDoctorStateBytes)
+	if err != nil || !exists {
+		return autoRollbackState{}, exists, err
+	}
+	record, err := parseAutoRollback(body)
+	return record, true, err
+}
+
+func acceptedMatchesSlot(accepted acceptedState, slot slotState) bool {
+	return slot.Release != "" && accepted.Release == slot.Release && accepted.ReleaseSequence == slot.Sequence && accepted.ManifestSHA256 == slot.ManifestSHA256
+}
+
+func autoRollbackMatchesSlot(record autoRollbackState, slot slotState) bool {
+	return record.Release == slot.Release && record.Sequence == slot.Sequence && record.ManifestSHA256 == slot.ManifestSHA256 && record.Generation == slot.Generation
+}
+
 func doctorReadOptionalSlot(ctx context.Context, directory string) (slotState, error) {
 	if err := ctx.Err(); err != nil {
 		return slotState{}, err
@@ -281,7 +306,7 @@ func doctorLoadRecovery(ctx context.Context, directory string) (recoveryState, e
 }
 
 func unavailableBootstrapStateChecks() []punarodiagnostic.Check {
-	codes := []string{"bootstrap_lock", "run_lock", "disk_space", "release_keys", "accepted_state", "current_slot", "previous_slot", "journal_state", "recovery_state", "candidate_state", "swap_state", "catalog_reachability", "catalog_signature", "catalog_freshness", "catalog_sequence", "current_catalog_allowed", "current_critical_block", "current_manifest_signature", "current_platform_compatibility", "minimum_bootstrap_release", "minimum_recovery_protocol", "current_artifact_integrity", "previous_catalog_allowed", "previous_critical_block", "previous_manifest_signature", "previous_platform_compatibility", "previous_artifact_integrity", "rollback_available", "running_artifact", "supervisor_process", "candidate_health"}
+	codes := []string{"bootstrap_lock", "run_lock", "disk_space", "release_keys", "accepted_state", "auto_rollback_state", "current_slot", "previous_slot", "journal_state", "recovery_state", "candidate_state", "swap_state", "catalog_reachability", "catalog_signature", "catalog_freshness", "catalog_sequence", "current_catalog_allowed", "current_critical_block", "current_manifest_signature", "current_platform_compatibility", "minimum_bootstrap_release", "minimum_recovery_protocol", "current_artifact_integrity", "previous_catalog_allowed", "previous_critical_block", "previous_manifest_signature", "previous_platform_compatibility", "previous_artifact_integrity", "rollback_available", "running_artifact", "supervisor_process", "candidate_health"}
 	checks := make([]punarodiagnostic.Check, 0, len(codes))
 	for _, code := range codes {
 		checks = append(checks, punarodiagnostic.Unavailable(code, "repair_bootstrap_directory"))

--- a/internal/bootstrap/doctor_test.go
+++ b/internal/bootstrap/doctor_test.go
@@ -3,6 +3,7 @@ package bootstrap
 import (
 	"context"
 	"crypto/sha256"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
@@ -38,6 +39,229 @@ func TestDoctorVerifiesSignedSlotWithoutMutatingBootstrapState(t *testing.T) {
 	}
 	if after := bootstrapTreeDigest(t, directory); after != before {
 		t.Fatalf("doctor mutated bootstrap state\nbefore=%s\nafter=%s", before, after)
+	}
+}
+
+func TestDoctorAcceptsExplicitRollbackHighWaterStateWithoutMutation(t *testing.T) {
+	origin, directory, now, _ := doctorRollbackFixture(t)
+	if _, err := Rollback(directory); err != nil {
+		t.Fatal(err)
+	}
+	assertDoctorAcceptsRollbackHighWater(t, origin, directory, now)
+}
+
+func TestDoctorAcceptsAutomaticRollbackHighWaterStateWithoutMutation(t *testing.T) {
+	origin, directory, now, current := doctorRollbackFixture(t)
+	unlocked, rolled, err := rollbackIfAllowed(t.Context(), RunRequest{
+		Directory: directory,
+		Origin:    origin.URL,
+		Keys:      origin.Keys,
+		GOOS:      runtime.GOOS,
+		GOARCH:    runtime.GOARCH,
+		Now:       now,
+	}, current)
+	if err != nil || !unlocked || rolled.Release != "v0.1.0" {
+		t.Fatalf("automatic rollback unlocked=%t rolled=%#v err=%v", unlocked, rolled, err)
+	}
+	assertDoctorAcceptsRollbackHighWater(t, origin, directory, now)
+}
+
+func TestDoctorRejectsInvalidRollbackEvidenceWithoutMutation(t *testing.T) {
+	tests := []struct {
+		name               string
+		body               func(*testing.T, slotState) []byte
+		remove             bool
+		autoRollbackStatus punarodiagnostic.Status
+	}{
+		{
+			name: "missing",
+			body: func(*testing.T, slotState) []byte {
+				return nil
+			},
+			remove:             true,
+			autoRollbackStatus: punarodiagnostic.StatusPass,
+		},
+		{
+			name: "malformed",
+			body: func(*testing.T, slotState) []byte {
+				return []byte(`{"schema":1`)
+			},
+			autoRollbackStatus: punarodiagnostic.StatusFail,
+		},
+		{
+			name: "oversized",
+			body: func(*testing.T, slotState) []byte {
+				return []byte(strings.Repeat("x", maximumDoctorStateBytes+1))
+			},
+			autoRollbackStatus: punarodiagnostic.StatusFail,
+		},
+		{
+			name: "identity mismatch",
+			body: func(t *testing.T, rolledAway slotState) []byte {
+				t.Helper()
+				body, err := json.Marshal(autoRollbackState{
+					Schema:         1,
+					Release:        rolledAway.Release,
+					Sequence:       rolledAway.Sequence,
+					ManifestSHA256: rolledAway.ManifestSHA256,
+					Generation:     rolledAway.Generation + 1,
+				})
+				if err != nil {
+					t.Fatal(err)
+				}
+				return body
+			},
+			autoRollbackStatus: punarodiagnostic.StatusPass,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			origin, directory, now, rolledAway := doctorRollbackFixture(t)
+			if _, err := Rollback(directory); err != nil {
+				t.Fatal(err)
+			}
+			path := filepath.Join(directory, autoRollbackFile)
+			if test.remove {
+				if err := os.Remove(path); err != nil {
+					t.Fatal(err)
+				}
+			} else {
+				if err := os.WriteFile(path, test.body(t, rolledAway), 0o600); err != nil {
+					t.Fatal(err)
+				}
+			}
+			before := bootstrapTreeDigest(t, directory)
+			report, err := Doctor(t.Context(), DoctorRequest{Directory: directory, Origin: origin.URL, Keys: origin.Keys, GOOS: runtime.GOOS, GOARCH: runtime.GOARCH, Now: now, BootstrapRelease: "v0.1.0", FreeBytes: func(string) (uint64, error) { return 1 << 40, nil }})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if doctorCheckStatus(report, "auto_rollback_state") != test.autoRollbackStatus || doctorCheckStatus(report, "accepted_state") != punarodiagnostic.StatusFail {
+				t.Fatalf("invalid rollback evidence passed: report=%#v", report)
+			}
+			if after := bootstrapTreeDigest(t, directory); after != before {
+				t.Fatalf("doctor mutated invalid rollback evidence\nbefore=%s\nafter=%s", before, after)
+			}
+		})
+	}
+}
+
+func TestDoctorRejectsRollbackEvidenceWithoutCurrentSlot(t *testing.T) {
+	origin, directory, now, _ := doctorRollbackFixture(t)
+	if _, err := Rollback(directory); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.RemoveAll(filepath.Join(directory, currentSlot)); err != nil {
+		t.Fatal(err)
+	}
+	before := bootstrapTreeDigest(t, directory)
+	report, err := Doctor(t.Context(), DoctorRequest{Directory: directory, Origin: origin.URL, Keys: origin.Keys, GOOS: runtime.GOOS, GOARCH: runtime.GOARCH, Now: now, BootstrapRelease: "v0.1.0", FreeBytes: func(string) (uint64, error) { return 1 << 40, nil }})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if doctorCheckStatus(report, "current_slot") != punarodiagnostic.StatusFail || doctorCheckStatus(report, "accepted_state") != punarodiagnostic.StatusFail {
+		t.Fatalf("rollback evidence without current slot passed: report=%#v", report)
+	}
+	if after := bootstrapTreeDigest(t, directory); after != before {
+		t.Fatalf("doctor mutated missing-current evidence\nbefore=%s\nafter=%s", before, after)
+	}
+}
+
+func TestDoctorRejectsRollbackHighWaterOlderThanCurrent(t *testing.T) {
+	origin, directory, now, _ := doctorRollbackFixture(t)
+	if _, err := Rollback(directory); err != nil {
+		t.Fatal(err)
+	}
+	current, err := readSlot(filepath.Join(directory, currentSlot))
+	if err != nil {
+		t.Fatal(err)
+	}
+	current.Release = "v0.3.0"
+	current.Sequence = 3
+	current.ManifestSHA256 = strings.Repeat("d", 64)
+	body, err := json.Marshal(current)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(directory, currentSlot, slotRecord), body, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	before := bootstrapTreeDigest(t, directory)
+	report, err := Doctor(t.Context(), DoctorRequest{Directory: directory, Origin: origin.URL, Keys: origin.Keys, GOOS: runtime.GOOS, GOARCH: runtime.GOARCH, Now: now, BootstrapRelease: "v0.1.0", FreeBytes: func(string) (uint64, error) { return 1 << 40, nil }})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if doctorCheckStatus(report, "accepted_state") != punarodiagnostic.StatusFail {
+		t.Fatalf("accepted state older than current passed: report=%#v", report)
+	}
+	if after := bootstrapTreeDigest(t, directory); after != before {
+		t.Fatalf("doctor mutated sequence-conflict evidence\nbefore=%s\nafter=%s", before, after)
+	}
+}
+
+func doctorRollbackFixture(t *testing.T) (*signedOrigin, string, time.Time, slotState) {
+	t.Helper()
+	now := time.Date(2026, 8, 20, 0, 0, 0, 0, time.UTC)
+	origin := newSignedOrigin(t, originSpec{payload: "previous-adapter", goos: runtime.GOOS, goarch: runtime.GOARCH, release: "v0.1.0", sequence: 1, catalogSequence: 1})
+	directory := privateDir(t)
+	request := Request{Directory: directory, Origin: origin.URL, Keys: origin.Keys, GOOS: runtime.GOOS, GOARCH: runtime.GOARCH, Now: now}
+	if _, err := Update(request); err != nil {
+		t.Fatal(err)
+	}
+	previous, err := readSlot(filepath.Join(directory, currentSlot))
+	if err != nil {
+		t.Fatal(err)
+	}
+	previousFiles := make(map[string][]byte)
+	for name, body := range origin.Files {
+		if strings.HasPrefix(name, previous.Release+"/") {
+			previousFiles[name] = body
+		}
+	}
+	origin.republish(t, originSpec{payload: "current-adapter", goos: runtime.GOOS, goarch: runtime.GOARCH, release: "v0.2.0", sequence: 2, catalogSequence: 2})
+	for name, body := range previousFiles {
+		origin.Files[name] = body
+	}
+	allowPreviousInCatalog(t, origin, previous.Release, previous.Sequence, previous.ManifestSHA256)
+	if _, err := Update(request); err != nil {
+		t.Fatal(err)
+	}
+	current, err := readSlot(filepath.Join(directory, currentSlot))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return origin, directory, now, current
+}
+
+func assertDoctorAcceptsRollbackHighWater(t *testing.T, origin *signedOrigin, directory string, now time.Time) {
+	t.Helper()
+	accepted, err := loadAccepted(directory)
+	if err != nil {
+		t.Fatal(err)
+	}
+	before := bootstrapTreeDigest(t, directory)
+	report, err := Doctor(t.Context(), DoctorRequest{Directory: directory, Origin: origin.URL, Keys: origin.Keys, GOOS: runtime.GOOS, GOARCH: runtime.GOARCH, Now: now, BootstrapRelease: "v0.1.0", FreeBytes: func(string) (uint64, error) { return 1 << 40, nil }})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if report.Identity.Release != "v0.1.0" || report.Identity.ReleaseSequence != 1 {
+		t.Fatalf("identity=%#v", report.Identity)
+	}
+	if doctorCheckStatus(report, "accepted_state") != punarodiagnostic.StatusPass {
+		t.Fatalf("accepted state did not recognize rollback high-water: report=%#v", report)
+	}
+	if doctorCheckStatus(report, "auto_rollback_state") != punarodiagnostic.StatusPass {
+		t.Fatalf("auto-rollback state was not valid: report=%#v", report)
+	}
+	for _, code := range []string{"current_catalog_allowed", "current_manifest_signature", "current_platform_compatibility", "current_artifact_integrity", "previous_catalog_allowed", "previous_manifest_signature", "previous_platform_compatibility", "previous_artifact_integrity"} {
+		if doctorCheckStatus(report, code) != punarodiagnostic.StatusPass {
+			t.Fatalf("signed slot check %s did not pass: report=%#v", code, report)
+		}
+	}
+	if report.Identity.CatalogSequence != accepted.CatalogSequence {
+		t.Fatalf("catalog sequence=%d want=%d", report.Identity.CatalogSequence, accepted.CatalogSequence)
+	}
+	if after := bootstrapTreeDigest(t, directory); after != before {
+		t.Fatalf("doctor mutated rollback state\nbefore=%s\nafter=%s", before, after)
 	}
 }
 

--- a/internal/bootstrap/run_test.go
+++ b/internal/bootstrap/run_test.go
@@ -2330,11 +2330,15 @@ func allowPreviousInCatalog(t *testing.T, origin *signedOrigin, release string, 
 		t.Fatal(err)
 	}
 	current.MinimumSafeSequence = 1
+	manifestLength := int64(32)
+	if manifest, ok := origin.Files[release+"/"+punarorelease.ReleaseManifestFile]; ok {
+		manifestLength = int64(len(manifest))
+	}
 	current.Releases = append(current.Releases, punarorelease.CatalogRelease{
 		Release:        release,
 		Sequence:       sequence,
 		ManifestPath:   release + "/" + punarorelease.ReleaseManifestFile,
-		ManifestLength: 32,
+		ManifestLength: manifestLength,
 		ManifestSHA256: digest,
 	})
 	body, err := json.Marshal(current)

--- a/internal/bootstrap/slots.go
+++ b/internal/bootstrap/slots.go
@@ -457,21 +457,29 @@ func loadAutoRollback(directory string) (autoRollbackState, error) {
 	if err != nil {
 		return autoRollbackState{}, err
 	}
-	if err := rejectDuplicateJSONFields(body); err != nil {
+	record, err := parseAutoRollback(body)
+	if err != nil {
 		return quarantineInvalidAutoRollback(directory)
+	}
+	return record, nil
+}
+
+func parseAutoRollback(body []byte) (autoRollbackState, error) {
+	if err := rejectDuplicateJSONFields(body); err != nil {
+		return autoRollbackState{}, errors.New("bootstrap auto-rollback state is invalid")
 	}
 	decoder := json.NewDecoder(strings.NewReader(string(body)))
 	decoder.DisallowUnknownFields()
 	var record autoRollbackState
 	if err := decoder.Decode(&record); err != nil {
-		return quarantineInvalidAutoRollback(directory)
+		return autoRollbackState{}, errors.New("bootstrap auto-rollback state is invalid")
 	}
 	var trailing any
 	if err := decoder.Decode(&trailing); !errors.Is(err, io.EOF) {
-		return quarantineInvalidAutoRollback(directory)
+		return autoRollbackState{}, errors.New("bootstrap auto-rollback state is invalid")
 	}
 	if record.Schema != 1 || record.Release == "" || record.Sequence < 1 || record.Generation < 0 || !validManifestDigest(record.ManifestSHA256) {
-		return quarantineInvalidAutoRollback(directory)
+		return autoRollbackState{}, errors.New("bootstrap auto-rollback state is invalid")
 	}
 	return record, nil
 }

--- a/internal/diagnostic/fleet.go
+++ b/internal/diagnostic/fleet.go
@@ -51,7 +51,7 @@ var requiredComponentCheckCodes = map[Component][]string{
 		"relay_access", "relay_enrollment", "relay_origin", "relay_protocol", "relay_transport", "skill_set_parity",
 	},
 	ComponentBootstrap: {
-		"accepted_state", "bootstrap_directory", "bootstrap_lock", "candidate_health", "candidate_state", "catalog_freshness", "catalog_reachability", "catalog_sequence",
+		"accepted_state", "auto_rollback_state", "bootstrap_directory", "bootstrap_lock", "candidate_health", "candidate_state", "catalog_freshness", "catalog_reachability", "catalog_sequence",
 		"catalog_signature", "current_artifact_integrity", "current_catalog_allowed", "current_critical_block", "current_manifest_signature", "current_platform_compatibility",
 		"current_slot", "disk_space", "journal_state", "minimum_bootstrap_release", "minimum_recovery_protocol", "previous_artifact_integrity", "previous_catalog_allowed",
 		"previous_critical_block", "previous_manifest_signature", "previous_platform_compatibility", "previous_slot", "recovery_state", "release_keys", "rollback_available",

--- a/internal/diagnostic/fleet_test.go
+++ b/internal/diagnostic/fleet_test.go
@@ -57,6 +57,28 @@ func TestFleetRejectsAdapterReportMissingClientComponentLaunchers(t *testing.T) 
 	}
 }
 
+func TestFleetRejectsBootstrapReportMissingAutoRollbackState(t *testing.T) {
+	report := mustFleetInput(t, ComponentBootstrap, Identity{MachineID: "mac-studio", Release: "v0.1.0-alpha.2", ReleaseSequence: 2, Protocol: 1, Platform: "darwin-arm64"})
+	checks := make([]Check, 0, len(report.Checks)-1)
+	for _, check := range report.Checks {
+		if check.Code != "auto_rollback_state" {
+			checks = append(checks, check)
+		}
+	}
+	incomplete, err := New(ComponentBootstrap, report.Identity, checks)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = AggregateFleet([]Report{incomplete}, FleetPolicy{
+		Expected:        []FleetTarget{{MachineID: "mac-studio", Component: ComponentBootstrap}},
+		CatalogSequence: 2,
+		Catalog:         map[string]int64{"v0.1.0-alpha.2": 2},
+	})
+	if err == nil {
+		t.Fatal("bootstrap report without auto_rollback_state was accepted")
+	}
+}
+
 func TestFleetDetectsMissingDuplicateCatalogAndCompatibilitySkew(t *testing.T) {
 	reports := []Report{
 		mustFleetInput(t, ComponentServer, Identity{MachineID: "punaro-lxc", Release: "v0.1.0-alpha.2", ReleaseSequence: 2, Protocol: 2, StorageSchema: 44, Platform: "linux-arm64"}),


### PR DESCRIPTION
Closes #231

- Preserve accepted release sequence as a monotonic high-water mark after rollback.
- Validate the exact auto-rollback record before accepting a current/accepted mismatch.
- Add auto_rollback_state to standalone and fleet doctor contracts.
- Cover automatic and explicit rollback plus malformed and conflicting evidence.

Validation before commit:
- focused doctor and rollback tests
- full make ci
- two independent Pioneer reviews with no blocking findings

The full Punaro gate will be rerun on this PR head before merge.