### PR TITLE
fix(canopi): validate explicit origin ports

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1961,8 +1961,11 @@ wildcard, public, and plaintext LAN binds fail closed. The panel accepts only an
 HTTPS render URL, synchronizes a valid wall clock over NTP before its first
 request, and validates the collector certificate against its configured CA.
 Adapter and simulator origins use the same HTTPS-except-literal-loopback
-policy and refuse redirects, so no reusable bearer is sent to an unvalidated
-target or over plaintext LAN traffic.
+policy, require every explicit port to be canonical decimal in the range
+1-65535, and refuse redirects, so no reusable bearer is sent to an unvalidated
+target or over plaintext LAN traffic. Empty, zero, leading-zero, non-numeric,
+and out-of-range explicit ports fail closed rather than falling back to a
+scheme default.
 This shared-token LAN MVP is not yet Punaro device-authenticated and must not be
 mounted on the public Punaro origin. Its bearer token must be a protected,
 current-user-owned regular file (or equivalent current-user-only Windows ACL),

--- a/docs/canopi.md
+++ b/docs/canopi.md
@@ -112,7 +112,9 @@ with owner-only access (or an equivalent protected current-user ACL on Windows);
 symlinks and files replaced during open are rejected. The collector, Claude
 adapter, and simulator all use this same protected loader. Adapter and simulator
 origins likewise require HTTPS except for HTTP to a literal loopback address,
-and bearer-authenticated requests never follow redirects.
+and bearer-authenticated requests never follow redirects. An explicit origin
+port must be canonical decimal in the range 1-65535; empty, zero, leading-zero,
+and out-of-range ports are rejected instead of falling back to a scheme default.
 
 ## Run the vertical slice
 

--- a/internal/canopitransport/origin.go
+++ b/internal/canopitransport/origin.go
@@ -6,6 +6,8 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"strconv"
+	"strings"
 )
 
 // ValidateOrigin permits HTTPS origins and plaintext only to a literal
@@ -15,6 +17,9 @@ func ValidateOrigin(raw string) error {
 	if err != nil || origin.Host == "" || origin.User != nil || origin.RawQuery != "" || origin.Fragment != "" || (origin.Path != "" && origin.Path != "/") {
 		return errors.New("canopi endpoint must be an origin without credentials, path, query, or fragment")
 	}
+	if err := validatePort(origin); err != nil {
+		return errors.New("canopi endpoint must use a canonical port in range 1-65535")
+	}
 	if origin.Scheme == "https" {
 		return nil
 	}
@@ -23,6 +28,21 @@ func ValidateOrigin(raw string) error {
 		return nil
 	}
 	return errors.New("canopi endpoint must use HTTPS except for a literal loopback address")
+}
+
+func validatePort(origin *url.URL) error {
+	if strings.HasSuffix(origin.Host, ":") {
+		return errors.New("invalid port")
+	}
+	port := origin.Port()
+	if port == "" {
+		return nil
+	}
+	value, err := strconv.ParseUint(port, 10, 16)
+	if err != nil || value == 0 || strconv.FormatUint(value, 10) != port {
+		return errors.New("invalid port")
+	}
+	return nil
 }
 
 // DoWithoutRedirects sends one request without allowing credentials to cross

--- a/internal/canopitransport/origin_test.go
+++ b/internal/canopitransport/origin_test.go
@@ -23,3 +23,34 @@ func TestValidateOriginRequiresHTTPSOutsideLiteralLoopback(t *testing.T) {
 		}
 	}
 }
+
+func TestValidateOriginRequiresCanonicalExplicitPort(t *testing.T) {
+	for _, origin := range []string{
+		"https://canopi.example.internal",
+		"https://canopi.example.internal:443",
+		"https://192.0.2.10:8443",
+		"https://[2001:db8::10]:8443",
+		"http://127.0.0.1:80",
+		"http://[::1]:80",
+	} {
+		if err := ValidateOrigin(origin); err != nil {
+			t.Errorf("ValidateOrigin(%q) error = %v", origin, err)
+		}
+	}
+
+	for _, origin := range []string{
+		"https://canopi.example.internal:",
+		"http://127.0.0.1:",
+		"http://[::1]:",
+		"https://canopi.example.internal:0443",
+		"http://127.0.0.1:080",
+		"http://[::1]:080",
+		"https://canopi.example.internal:0",
+		"https://canopi.example.internal:65536",
+		"https://canopi.example.internal:not-a-port",
+	} {
+		if err := ValidateOrigin(origin); err == nil {
+			t.Errorf("ValidateOrigin(%q) unexpectedly succeeded", origin)
+		}
+	}
+}


### PR DESCRIPTION
Closes #204.

## Summary
- reject empty, zero, leading-zero, non-numeric, and out-of-range explicit Canopi origin ports
- preserve valid implicit/default, IPv4, and IPv6 origin behavior
- document the canonical port requirement

## Verification
- make test test-race staticcheck security lint
- git diff --check