### PR TITLE
fix(update): retry transient release downloads

### DIFF
--- a/docs/github-releases.md
+++ b/docs/github-releases.md
@@ -94,8 +94,11 @@ embedded in that bootstrap.
 
 The offline publisher re-hashes every native artifact named by the verified
 manifest in the operator's signing directory and in the GitHub draft before it
-publishes anything. It repeats remote artifact verification after publication;
-a mismatch prevents catalog advancement or restores/hides the previous catalog
+publishes anything. Once the immutable prerelease is visible, it also downloads
+the manifest, detached signature, and every manifest-listed platform artifact
+through the unauthenticated public `github.com/.../releases/download` origin and
+verifies those exact bytes before advancing the catalog. An API or public-origin
+mismatch prevents catalog advancement or restores/hides the previous catalog
 state. Replacing an existing catalog first makes that GitHub Release a draft,
 uploads the document/signature pair while it is unavailable to bootstrap
 clients, downloads and verifies the remote bytes, and only then exposes the
@@ -312,6 +315,16 @@ A healthy child that exits while the supervisor is still running is a
 supervisor failure so the platform service restarts it. The one-shot decision
 is durable across supervisor restarts. It does not enroll or open PostgreSQL. HTTPS is required
 except for loopback test origins.
+
+Each resource fetch retries at most twice after its first attempt, using bounded
+backoff, only for transport/read failures, timeouts, HTTP 408/425/429, and HTTP
+5xx gateway/service failures. All resource attempts share one four-minute
+update deadline. Redirect-policy, bounds, signature, catalog-freshness,
+compatibility, length, and digest failures are single-shot. A failed download
+names only `catalog`, `signature`, `manifest`, or `artifact` plus a content-free
+category such as `transport`, `timeout`, `http_status`, `length`, or `policy`.
+Published slots remain unchanged and any staging journal remains atomically
+parseable for recovery.
 
 ```sh
 punaro-bootstrap update \

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -139,7 +139,13 @@ punaro-adapter doctor --plugin-root /absolute/installed/punaro-plugin
 ```
 
 The update verifies the signed catalog and manifest plus every exact artifact
-length/digest before changing slots. Do not download a binary named `latest`,
+length/digest before changing slots. Each catalog, signature, manifest, and
+artifact fetch gets up to three attempts for bounded transient transport,
+timeout, rate-limit, or server failures under one four-minute update deadline.
+Policy, signature, freshness, compatibility, length, and digest failures are
+never retried. Download errors report only a content-free `phase` and
+`category`; they never include an origin, path, token, or response body. Do not
+download a binary named `latest`,
 replace current-slot files manually, or run a versioned adapter directly from
 the service. See [GitHub Releases](github-releases.md) and
 [doctor](doctor.md).

--- a/internal/bootstrap/fetch.go
+++ b/internal/bootstrap/fetch.go
@@ -17,8 +17,79 @@ type fetcher interface {
 }
 
 type httpFetcher struct {
-	origin *url.URL
-	client *http.Client
+	origin         *url.URL
+	client         *http.Client
+	attempts       int
+	attemptTimeout time.Duration
+	retryDelays    []time.Duration
+}
+
+type downloadCategory string
+
+const (
+	downloadCategoryCanceled  downloadCategory = "canceled"
+	downloadCategoryHTTP      downloadCategory = "http_status"
+	downloadCategoryLength    downloadCategory = "length"
+	downloadCategoryPolicy    downloadCategory = "policy"
+	downloadCategoryTimeout   downloadCategory = "timeout"
+	downloadCategoryTransport downloadCategory = "transport"
+
+	defaultDownloadAttempts       = 3
+	defaultDownloadAttemptTimeout = 60 * time.Second
+)
+
+var (
+	defaultDownloadRetryDelays = []time.Duration{250 * time.Millisecond, time.Second}
+	errReleaseDownloadPolicy   = errors.New("release download policy rejected")
+)
+
+type downloadFailure struct {
+	phase     string
+	category  downloadCategory
+	cause     error
+	retryable bool
+}
+
+func (failure *downloadFailure) Error() string {
+	if failure.phase != "" {
+		return "release download failed: phase=" + failure.phase + " category=" + string(failure.category)
+	}
+	return "release download failed: category=" + string(failure.category)
+}
+
+func (failure *downloadFailure) Unwrap() error {
+	if errors.Is(failure.cause, context.DeadlineExceeded) {
+		return context.DeadlineExceeded
+	}
+	if errors.Is(failure.cause, context.Canceled) {
+		return context.Canceled
+	}
+	return nil
+}
+
+func downloadFailureCategory(err error) downloadCategory {
+	var failure *downloadFailure
+	if errors.As(err, &failure) {
+		return failure.category
+	}
+	if errors.Is(err, context.DeadlineExceeded) {
+		return downloadCategoryTimeout
+	}
+	if errors.Is(err, context.Canceled) {
+		return downloadCategoryCanceled
+	}
+	return downloadCategoryTransport
+}
+
+func withDownloadPhase(err error, phase string) error {
+	if err == nil {
+		return nil
+	}
+	var failure *downloadFailure
+	if errors.As(err, &failure) {
+		return &downloadFailure{phase: phase, category: failure.category, cause: failure.cause, retryable: failure.retryable}
+	}
+	return &downloadFailure{phase: phase, category: downloadFailureCategory(err), cause: err}
 }
 
 func newFetcher(origin string) (*httpFetcher, error) {
@@ -41,57 +112,147 @@ func newFetcher(origin string) (*httpFetcher, error) {
 	return &httpFetcher{
 		origin: parsed,
 		client: &http.Client{
-			Timeout:       60 * time.Second,
 			CheckRedirect: boundedHTTPSRedirects,
 		},
+		attempts:       defaultDownloadAttempts,
+		attemptTimeout: defaultDownloadAttemptTimeout,
+		retryDelays:    append([]time.Duration(nil), defaultDownloadRetryDelays...),
 	}, nil
 }
 
 func (transport *httpFetcher) Get(ctx context.Context, relative string, limit int64) ([]byte, error) {
 	if err := punarorelease.ValidateRelativePath(relative); err != nil {
-		return nil, err
+		return nil, &downloadFailure{category: downloadCategoryPolicy, cause: err}
 	}
 	if limit < 1 {
-		return nil, errors.New("release download is invalid")
+		return nil, &downloadFailure{category: downloadCategoryPolicy, cause: errors.New("release download is invalid")}
 	}
 	target := strings.TrimRight(transport.origin.String(), "/") + "/" + relative
 	if ctx == nil {
 		ctx = context.Background()
 	}
-	parent := ctx
-	ctx, cancel := context.WithTimeout(parent, 60*time.Second)
+	attempts := transport.attempts
+	if attempts < 1 {
+		attempts = defaultDownloadAttempts
+	}
+	for attempt := 0; attempt < attempts; attempt++ {
+		body, err := transport.getOnce(ctx, target, limit)
+		if err == nil {
+			return body, nil
+		}
+		var failure *downloadFailure
+		if !errors.As(err, &failure) || !failure.retryable || attempt+1 == attempts {
+			return nil, err
+		}
+		if err := waitForRetry(ctx, transport.retryDelay(attempt)); err != nil {
+			return nil, &downloadFailure{category: downloadFailureCategory(err), cause: err}
+		}
+	}
+	return nil, &downloadFailure{category: downloadCategoryTransport, cause: errors.New("release download attempts exhausted")}
+}
+
+func (transport *httpFetcher) getOnce(parent context.Context, target string, limit int64) ([]byte, error) {
+	attemptTimeout := transport.attemptTimeout
+	if attemptTimeout <= 0 {
+		attemptTimeout = defaultDownloadAttemptTimeout
+	}
+	ctx, cancel := context.WithTimeout(parent, attemptTimeout)
 	defer cancel()
 	request, err := http.NewRequestWithContext(ctx, http.MethodGet, target, nil)
 	if err != nil {
-		return nil, errors.New("release download failed")
+		return nil, &downloadFailure{category: downloadCategoryPolicy, cause: err}
 	}
 	response, err := transport.client.Do(request) // #nosec G107 -- target is origin plus a validated relative path.
 	if err != nil {
-		if parent.Err() != nil {
-			return nil, parent.Err()
+		if response != nil && response.Body != nil {
+			_ = response.Body.Close()
 		}
-		return nil, errors.New("release download failed")
+		if parent.Err() != nil {
+			return nil, &downloadFailure{category: downloadFailureCategory(parent.Err()), cause: parent.Err()}
+		}
+		if errors.Is(err, errReleaseDownloadPolicy) {
+			return nil, &downloadFailure{category: downloadCategoryPolicy, cause: err}
+		}
+		category := downloadCategoryTransport
+		if errors.Is(err, context.DeadlineExceeded) {
+			category = downloadCategoryTimeout
+		}
+		return nil, &downloadFailure{category: category, cause: err, retryable: true}
 	}
-	defer func() { _ = response.Body.Close() }()
 	if response.StatusCode != http.StatusOK {
-		return nil, errors.New("release download failed")
+		retryable := transientHTTPStatus(response.StatusCode)
+		if retryable {
+			_, _ = io.Copy(io.Discard, io.LimitReader(response.Body, 4096))
+		}
+		_ = response.Body.Close()
+		return nil, &downloadFailure{category: downloadCategoryHTTP, cause: errors.New("release download returned an invalid status"), retryable: retryable}
 	}
 	if response.ContentLength > limit {
-		return nil, errors.New("release download exceeds bound")
+		_ = response.Body.Close()
+		return nil, &downloadFailure{category: downloadCategoryLength, cause: errors.New("release download exceeds bound")}
 	}
-	body, err := io.ReadAll(io.LimitReader(response.Body, limit+1))
-	if err != nil {
-		return nil, errors.New("release download failed")
+	body, readErr := io.ReadAll(io.LimitReader(response.Body, limit+1))
+	closeErr := response.Body.Close()
+	if readErr != nil {
+		category := downloadFailureCategory(readErr)
+		cause := readErr
+		retryable := true
+		if parent.Err() != nil {
+			category = downloadFailureCategory(parent.Err())
+			cause = parent.Err()
+			retryable = false
+		} else if ctx.Err() != nil {
+			category = downloadFailureCategory(ctx.Err())
+			cause = ctx.Err()
+		}
+		return nil, &downloadFailure{category: category, cause: cause, retryable: retryable}
+	}
+	if closeErr != nil {
+		return nil, &downloadFailure{category: downloadCategoryTransport, cause: closeErr, retryable: true}
 	}
 	if int64(len(body)) > limit {
-		return nil, errors.New("release download exceeds bound")
+		return nil, &downloadFailure{category: downloadCategoryLength, cause: errors.New("release download exceeds bound")}
 	}
 	return body, nil
 }
 
+func (transport *httpFetcher) retryDelay(attempt int) time.Duration {
+	if attempt < len(transport.retryDelays) {
+		return transport.retryDelays[attempt]
+	}
+	if len(transport.retryDelays) > 0 {
+		return transport.retryDelays[len(transport.retryDelays)-1]
+	}
+	return 0
+}
+
+func waitForRetry(ctx context.Context, delay time.Duration) error {
+	if delay <= 0 {
+		return nil
+	}
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
+}
+
+func transientHTTPStatus(status int) bool {
+	switch status {
+	case http.StatusRequestTimeout, http.StatusTooEarly, http.StatusTooManyRequests,
+		http.StatusInternalServerError, http.StatusBadGateway, http.StatusServiceUnavailable, http.StatusGatewayTimeout:
+		return true
+	default:
+		return false
+	}
+}
+
 func boundedHTTPSRedirects(req *http.Request, via []*http.Request) error {
 	if len(via) >= 5 {
-		return errors.New("release download failed")
+		return errReleaseDownloadPolicy
 	}
 	if req.URL.Scheme == "https" {
 		return nil
@@ -99,7 +260,7 @@ func boundedHTTPSRedirects(req *http.Request, via []*http.Request) error {
 	if req.URL.Scheme == "http" && localhostHost(req.URL.Hostname()) {
 		return nil
 	}
-	return errors.New("release download failed")
+	return errReleaseDownloadPolicy
 }
 
 func localhostHost(host string) bool {

--- a/internal/bootstrap/fetch_test.go
+++ b/internal/bootstrap/fetch_test.go
@@ -3,13 +3,61 @@ package bootstrap
 import (
 	"context"
 	"errors"
+	"io"
+	"net"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strings"
+	"sync"
+	"syscall"
 	"testing"
+	"time"
 
 	punarorelease "github.com/rock3r/punaro/internal/release"
 )
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (fn roundTripFunc) RoundTrip(request *http.Request) (*http.Response, error) {
+	return fn(request)
+}
+
+type unexpectedEOFReader struct {
+	read bool
+}
+
+func (reader *unexpectedEOFReader) Read(body []byte) (int, error) {
+	if reader.read {
+		return 0, io.ErrUnexpectedEOF
+	}
+	reader.read = true
+	return copy(body, "partial"), nil
+}
+
+type contextDeadlineReader struct {
+	ctx context.Context
+}
+
+func (reader *contextDeadlineReader) Read([]byte) (int, error) {
+	<-reader.ctx.Done()
+	return 0, reader.ctx.Err()
+}
+
+func testHTTPFetcher(t *testing.T, transport http.RoundTripper) *httpFetcher {
+	t.Helper()
+	origin, err := url.Parse("https://release.example")
+	if err != nil {
+		t.Fatal(err)
+	}
+	return &httpFetcher{
+		origin:         origin,
+		client:         &http.Client{Transport: transport},
+		attempts:       3,
+		attemptTimeout: 20 * time.Millisecond,
+		retryDelays:    []time.Duration{0, 0},
+	}
+}
 
 func TestNewFetcherRejectsNonLocalHTTP(t *testing.T) {
 	if _, err := newFetcher("http://example.com/releases"); err == nil {
@@ -120,5 +168,195 @@ func TestFetcherPreservesContextCancel(t *testing.T) {
 	cancel()
 	if err := <-errCh; !errors.Is(err, context.Canceled) {
 		t.Fatalf("canceled fetch err=%v", err)
+	}
+}
+
+func TestHTTPFetcherRetriesConnectionResetAndReusesClient(t *testing.T) {
+	attempts := 0
+	client := testHTTPFetcher(t, roundTripFunc(func(*http.Request) (*http.Response, error) {
+		attempts++
+		if attempts == 1 {
+			return nil, &net.OpError{Op: "read", Net: "tcp", Err: syscall.ECONNRESET}
+		}
+		return &http.Response{
+			StatusCode:    http.StatusOK,
+			Body:          io.NopCloser(strings.NewReader("catalog")),
+			ContentLength: int64(len("catalog")),
+		}, nil
+	}))
+	body, err := client.Get(context.Background(), punarorelease.CatalogReleaseName+"/"+punarorelease.CatalogFile, 64)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if attempts != 2 || string(body) != "catalog" {
+		t.Fatalf("attempts=%d body=%q", attempts, body)
+	}
+}
+
+func TestHTTPFetcherRetriesMidstreamTruncation(t *testing.T) {
+	attempts := 0
+	client := testHTTPFetcher(t, roundTripFunc(func(*http.Request) (*http.Response, error) {
+		attempts++
+		if attempts == 1 {
+			return &http.Response{
+				StatusCode:    http.StatusOK,
+				Body:          io.NopCloser(&unexpectedEOFReader{}),
+				ContentLength: int64(len("complete")),
+			}, nil
+		}
+		return &http.Response{
+			StatusCode:    http.StatusOK,
+			Body:          io.NopCloser(strings.NewReader("complete")),
+			ContentLength: int64(len("complete")),
+		}, nil
+	}))
+	body, err := client.Get(context.Background(), "v0.1.0/punaro-adapter-linux-amd64", 64)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if attempts != 2 || string(body) != "complete" {
+		t.Fatalf("attempts=%d body=%q", attempts, body)
+	}
+}
+
+func TestHTTPFetcherRetriesTransientStatus(t *testing.T) {
+	attempts := 0
+	client := testHTTPFetcher(t, roundTripFunc(func(*http.Request) (*http.Response, error) {
+		attempts++
+		status := http.StatusServiceUnavailable
+		body := "retry"
+		if attempts == 2 {
+			status = http.StatusOK
+			body = "catalog"
+		}
+		return &http.Response{
+			StatusCode:    status,
+			Body:          io.NopCloser(strings.NewReader(body)),
+			ContentLength: int64(len(body)),
+		}, nil
+	}))
+	body, err := client.Get(context.Background(), punarorelease.CatalogReleaseName+"/"+punarorelease.CatalogFile, 64)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if attempts != 2 || string(body) != "catalog" {
+		t.Fatalf("attempts=%d body=%q", attempts, body)
+	}
+}
+
+func TestHTTPFetcherReusesConnectionAfterTransientStatus(t *testing.T) {
+	var lock sync.Mutex
+	var remotes []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
+		lock.Lock()
+		remotes = append(remotes, request.RemoteAddr)
+		attempt := len(remotes)
+		lock.Unlock()
+		if attempt == 1 {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			_, _ = w.Write([]byte("retry"))
+			return
+		}
+		_, _ = w.Write([]byte("catalog"))
+	}))
+	t.Cleanup(server.Close)
+	client, err := newFetcher(server.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	client.retryDelays = []time.Duration{0, 0}
+	body, err := client.Get(context.Background(), punarorelease.CatalogReleaseName+"/"+punarorelease.CatalogFile, 64)
+	if err != nil {
+		t.Fatal(err)
+	}
+	lock.Lock()
+	defer lock.Unlock()
+	if len(remotes) != 2 || remotes[0] != remotes[1] || string(body) != "catalog" {
+		t.Fatalf("remotes=%v body=%q", remotes, body)
+	}
+}
+
+func TestHTTPFetcherRetriesTimeoutThenExhausts(t *testing.T) {
+	attempts := 0
+	client := testHTTPFetcher(t, roundTripFunc(func(request *http.Request) (*http.Response, error) {
+		attempts++
+		<-request.Context().Done()
+		return nil, request.Context().Err()
+	}))
+	_, err := client.Get(context.Background(), punarorelease.CatalogReleaseName+"/"+punarorelease.CatalogFile, 64)
+	if err == nil || downloadFailureCategory(err) != downloadCategoryTimeout {
+		t.Fatalf("err=%v category=%q", err, downloadFailureCategory(err))
+	}
+	if attempts != 3 {
+		t.Fatalf("attempts=%d want=3", attempts)
+	}
+}
+
+func TestHTTPFetcherClassifiesStalledResponseBodyAsTimeout(t *testing.T) {
+	attempts := 0
+	client := testHTTPFetcher(t, roundTripFunc(func(request *http.Request) (*http.Response, error) {
+		attempts++
+		return &http.Response{
+			StatusCode:    http.StatusOK,
+			Body:          io.NopCloser(&contextDeadlineReader{ctx: request.Context()}),
+			ContentLength: -1,
+		}, nil
+	}))
+	_, err := client.Get(context.Background(), punarorelease.CatalogReleaseName+"/"+punarorelease.CatalogFile, 64)
+	if err == nil || downloadFailureCategory(err) != downloadCategoryTimeout {
+		t.Fatalf("err=%v category=%q", err, downloadFailureCategory(err))
+	}
+	if attempts != 3 {
+		t.Fatalf("attempts=%d want=3", attempts)
+	}
+}
+
+func TestHTTPFetcherDoesNotRetryPermanentStatusOrBoundFailure(t *testing.T) {
+	for _, test := range []struct {
+		name   string
+		status int
+		body   string
+		limit  int64
+	}{
+		{name: "permanent status", status: http.StatusNotFound, body: "not found", limit: 64},
+		{name: "length bound", status: http.StatusOK, body: "too large", limit: 4},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			attempts := 0
+			client := testHTTPFetcher(t, roundTripFunc(func(*http.Request) (*http.Response, error) {
+				attempts++
+				return &http.Response{
+					StatusCode:    test.status,
+					Body:          io.NopCloser(strings.NewReader(test.body)),
+					ContentLength: int64(len(test.body)),
+				}, nil
+			}))
+			if _, err := client.Get(context.Background(), punarorelease.CatalogReleaseName+"/"+punarorelease.CatalogFile, test.limit); err == nil {
+				t.Fatal("permanent failure accepted")
+			}
+			if attempts != 1 {
+				t.Fatalf("attempts=%d want=1", attempts)
+			}
+		})
+	}
+}
+
+func TestHTTPFetcherExhaustionIsContentFree(t *testing.T) {
+	attempts := 0
+	client := testHTTPFetcher(t, roundTripFunc(func(*http.Request) (*http.Response, error) {
+		attempts++
+		return nil, &net.OpError{Op: "read", Net: "tcp", Err: syscall.ECONNRESET}
+	}))
+	_, err := client.Get(context.Background(), "v0.1.0/private-artifact", 64)
+	if err == nil || downloadFailureCategory(err) != downloadCategoryTransport {
+		t.Fatalf("err=%v category=%q", err, downloadFailureCategory(err))
+	}
+	if attempts != 3 {
+		t.Fatalf("attempts=%d want=3", attempts)
+	}
+	for _, forbidden := range []string{"release.example", "private-artifact", "connection reset"} {
+		if strings.Contains(err.Error(), forbidden) {
+			t.Fatalf("error leaks %q: %v", forbidden, err)
+		}
 	}
 }

--- a/internal/bootstrap/update.go
+++ b/internal/bootstrap/update.go
@@ -34,6 +34,7 @@ const (
 	autoRollbackFile        = "auto-rollback.json"
 	healthyGenerationFile   = "healthy-generation.json"
 	generationHighWaterFile = "generation.json"
+	defaultDownloadDeadline = 4 * time.Minute
 )
 
 // Request is one host-local update from a fixed origin.
@@ -46,6 +47,9 @@ type Request struct {
 	GOARCH    string
 	Now       time.Time
 	HTTP      fetcher
+	// DownloadTimeout bounds catalog, signature, manifest, and artifact fetches
+	// as one operation. Zero selects the production default.
+	DownloadTimeout time.Duration
 }
 
 // Result is the published slot after a successful update.
@@ -105,7 +109,9 @@ func Update(request Request) (Result, error) {
 			}
 		}
 	}
-	catalog, err := fetchVerifiedCatalog(context.Background(), request)
+	downloadCtx, cancelDownloads := context.WithTimeout(context.Background(), request.DownloadTimeout)
+	defer cancelDownloads()
+	catalog, err := fetchVerifiedCatalog(downloadCtx, request)
 	if err != nil {
 		return Result{}, err
 	}
@@ -142,7 +148,7 @@ func Update(request Request) (Result, error) {
 	if err := writeJournal(request.Directory, journal{Schema: 1, Phase: "staging", Release: listed.Release, Sequence: listed.Sequence, ManifestSHA256: listed.ManifestSHA256}); err != nil {
 		return Result{}, err
 	}
-	manifestBody, err := client.Get(context.Background(), listed.ManifestPath, listed.ManifestLength)
+	manifestBody, err := fetchDownload(downloadCtx, client, "manifest", listed.ManifestPath, listed.ManifestLength)
 	if err != nil {
 		return Result{}, err
 	}
@@ -153,7 +159,7 @@ func Update(request Request) (Result, error) {
 	if hex.EncodeToString(sum[:]) != listed.ManifestSHA256 {
 		return Result{}, errors.New("release manifest digest mismatch")
 	}
-	manifestSig, err := client.Get(context.Background(), listed.Release+"/"+punarorelease.ReleaseSignatureFile, punarorelease.MaximumEnvelopeBytes)
+	manifestSig, err := fetchDownload(downloadCtx, client, "signature", listed.Release+"/"+punarorelease.ReleaseSignatureFile, punarorelease.MaximumEnvelopeBytes)
 	if err != nil {
 		return Result{}, err
 	}
@@ -210,7 +216,7 @@ func Update(request Request) (Result, error) {
 	}
 	var installed []string
 	for _, artifact := range artifacts {
-		body, err := client.Get(context.Background(), artifact.Path, artifact.Length)
+		body, err := fetchDownload(downloadCtx, client, "artifact", artifact.Path, artifact.Length)
 		if err != nil {
 			return Result{}, err
 		}
@@ -282,6 +288,12 @@ func (request *Request) normalize() error {
 	if request.Now.IsZero() {
 		request.Now = time.Now().UTC()
 	}
+	if request.DownloadTimeout < 0 {
+		return errors.New("bootstrap download timeout is invalid")
+	}
+	if request.DownloadTimeout == 0 {
+		request.DownloadTimeout = defaultDownloadDeadline
+	}
 	return nil
 }
 
@@ -297,11 +309,11 @@ func fetchVerifiedCatalog(ctx context.Context, request Request) (punarorelease.C
 		}
 		client = transport
 	}
-	catalogBody, err := client.Get(ctx, punarorelease.CatalogReleaseName+"/"+punarorelease.CatalogFile, punarorelease.MaximumManifestBytes)
+	catalogBody, err := fetchDownload(ctx, client, "catalog", punarorelease.CatalogReleaseName+"/"+punarorelease.CatalogFile, punarorelease.MaximumManifestBytes)
 	if err != nil {
 		return punarorelease.Catalog{}, err
 	}
-	catalogSig, err := client.Get(ctx, punarorelease.CatalogReleaseName+"/"+punarorelease.CatalogSignatureFile, punarorelease.MaximumEnvelopeBytes)
+	catalogSig, err := fetchDownload(ctx, client, "signature", punarorelease.CatalogReleaseName+"/"+punarorelease.CatalogSignatureFile, punarorelease.MaximumEnvelopeBytes)
 	if err != nil {
 		return punarorelease.Catalog{}, err
 	}
@@ -316,6 +328,14 @@ func fetchVerifiedCatalog(ctx context.Context, request Request) (punarorelease.C
 		return punarorelease.Catalog{}, errors.New("release catalog is stale")
 	}
 	return catalog, nil
+}
+
+func fetchDownload(ctx context.Context, client fetcher, phase, relative string, limit int64) ([]byte, error) {
+	body, err := client.Get(ctx, relative, limit)
+	if err != nil {
+		return nil, withDownloadPhase(err, phase)
+	}
+	return body, nil
 }
 
 func verifyDocument(document, signature []byte, keys map[string]ed25519.PublicKey) error {

--- a/internal/bootstrap/update_test.go
+++ b/internal/bootstrap/update_test.go
@@ -1,6 +1,7 @@
 package bootstrap
 
 import (
+	"bytes"
 	"context"
 	"crypto/ed25519"
 	"crypto/rand"
@@ -66,6 +67,128 @@ func TestUpdateInstallsSignedPlatformArtifacts(t *testing.T) {
 	}
 	if status.Current != "v0.1.0" || status.CurrentSequence != 1 || status.Previous != "" {
 		t.Fatalf("status=%#v", status)
+	}
+}
+
+func TestUpdateReportsContentFreeDownloadPhase(t *testing.T) {
+	name := artifactName("punaro-adapter", runtime.GOOS, runtime.GOARCH)
+	for _, test := range []struct {
+		name     string
+		failPath string
+		phase    string
+	}{
+		{name: "catalog", failPath: punarorelease.CatalogReleaseName + "/" + punarorelease.CatalogFile, phase: "catalog"},
+		{name: "catalog signature", failPath: punarorelease.CatalogReleaseName + "/" + punarorelease.CatalogSignatureFile, phase: "signature"},
+		{name: "manifest", failPath: "v0.1.0/" + punarorelease.ReleaseManifestFile, phase: "manifest"},
+		{name: "artifact", failPath: "v0.1.0/" + name, phase: "artifact"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			origin := newSignedOrigin(t, originSpec{payload: testArtifact, goos: runtime.GOOS, goarch: runtime.GOARCH})
+			fetcher := &recordingFetcher{files: origin.Files, failPath: test.failPath}
+			_, err := Update(Request{
+				Directory: privateDir(t),
+				Origin:    origin.URL,
+				Keys:      origin.Keys,
+				GOOS:      runtime.GOOS,
+				GOARCH:    runtime.GOARCH,
+				Now:       time.Date(2026, 8, 20, 0, 0, 0, 0, time.UTC),
+				HTTP:      fetcher,
+			})
+			want := "release download failed: phase=" + test.phase + " category=transport"
+			if err == nil || err.Error() != want {
+				t.Fatalf("err=%v want=%q", err, want)
+			}
+			if strings.Contains(err.Error(), test.failPath) || fetcher.calls[test.failPath] != 1 {
+				t.Fatalf("err=%v calls=%d", err, fetcher.calls[test.failPath])
+			}
+		})
+	}
+}
+
+func TestUpdateAppliesOneOverallDownloadDeadline(t *testing.T) {
+	origin := newSignedOrigin(t, originSpec{payload: testArtifact, goos: runtime.GOOS, goarch: runtime.GOARCH})
+	fetcher := &recordingFetcher{files: origin.Files, waitForCancel: true}
+	started := time.Now()
+	_, err := Update(Request{
+		Directory:       privateDir(t),
+		Origin:          origin.URL,
+		Keys:            origin.Keys,
+		GOOS:            runtime.GOOS,
+		GOARCH:          runtime.GOARCH,
+		Now:             time.Date(2026, 8, 20, 0, 0, 0, 0, time.UTC),
+		HTTP:            fetcher,
+		DownloadTimeout: 20 * time.Millisecond,
+	})
+	if err == nil || err.Error() != "release download failed: phase=catalog category=timeout" {
+		t.Fatalf("err=%v", err)
+	}
+	if elapsed := time.Since(started); elapsed > time.Second {
+		t.Fatalf("overall deadline took %s", elapsed)
+	}
+}
+
+func TestUpdateDoesNotRetryVerificationFailure(t *testing.T) {
+	origin := newSignedOrigin(t, originSpec{payload: testArtifact, goos: runtime.GOOS, goarch: runtime.GOARCH})
+	name := artifactName("punaro-adapter", runtime.GOOS, runtime.GOARCH)
+	path := "v0.1.0/" + name
+	files := cloneFiles(origin.Files)
+	files[path] = []byte(strings.Repeat("x", len(testArtifact)))
+	fetcher := &recordingFetcher{files: files}
+	_, err := Update(Request{
+		Directory: privateDir(t),
+		Origin:    origin.URL,
+		Keys:      origin.Keys,
+		GOOS:      runtime.GOOS,
+		GOARCH:    runtime.GOARCH,
+		Now:       time.Date(2026, 8, 20, 0, 0, 0, 0, time.UTC),
+		HTTP:      fetcher,
+	})
+	if err == nil || err.Error() != "release artifact digest mismatch" {
+		t.Fatalf("err=%v", err)
+	}
+	if fetcher.calls[path] != 1 {
+		t.Fatalf("verification failure fetched artifact %d times", fetcher.calls[path])
+	}
+}
+
+func TestFailedArtifactDownloadPreservesPublishedSlotsAndValidJournal(t *testing.T) {
+	origin := newSignedOrigin(t, originSpec{payload: "first", goos: runtime.GOOS, goarch: runtime.GOARCH})
+	dir := privateDir(t)
+	req := Request{Directory: dir, Origin: origin.URL, Keys: origin.Keys, GOOS: runtime.GOOS, GOARCH: runtime.GOARCH, Now: time.Date(2026, 8, 20, 0, 0, 0, 0, time.UTC)}
+	if _, err := Update(req); err != nil {
+		t.Fatal(err)
+	}
+	currentBefore, err := os.ReadFile(filepath.Join(dir, currentSlot, slotRecord)) // #nosec G304 -- fixed fixture path under t.TempDir.
+	if err != nil {
+		t.Fatal(err)
+	}
+	acceptedBefore, err := os.ReadFile(filepath.Join(dir, acceptedFile)) // #nosec G304 -- fixed fixture path under t.TempDir.
+	if err != nil {
+		t.Fatal(err)
+	}
+	origin.republish(t, originSpec{payload: "second", goos: runtime.GOOS, goarch: runtime.GOARCH, release: "v0.2.0", sequence: 2, catalogSequence: 2})
+	artifactPath := "v0.2.0/" + artifactName("punaro-adapter", runtime.GOOS, runtime.GOARCH)
+	req.HTTP = &recordingFetcher{files: origin.Files, failPath: artifactPath}
+	if _, err := Update(req); err == nil {
+		t.Fatal("failed artifact download succeeded")
+	}
+	currentAfter, err := os.ReadFile(filepath.Join(dir, currentSlot, slotRecord)) // #nosec G304 -- fixed fixture path under t.TempDir.
+	if err != nil {
+		t.Fatal(err)
+	}
+	acceptedAfter, err := os.ReadFile(filepath.Join(dir, acceptedFile)) // #nosec G304 -- fixed fixture path under t.TempDir.
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(currentBefore, currentAfter) || !bytes.Equal(acceptedBefore, acceptedAfter) {
+		t.Fatal("failed download changed published current or accepted state")
+	}
+	if _, err := os.Lstat(filepath.Join(dir, previousSlot)); !os.IsNotExist(err) {
+		t.Fatal("failed download published a previous slot")
+	}
+	record, err := readJournal(dir)
+	if err != nil || record.Phase != "staging" || record.Release != "v0.2.0" {
+		t.Fatalf("journal=%#v err=%v", record, err)
 	}
 }
 
@@ -504,6 +627,43 @@ type signedOrigin struct {
 	Keys  map[string]ed25519.PublicKey
 	Files map[string][]byte
 	priv  ed25519.PrivateKey
+}
+
+type recordingFetcher struct {
+	files         map[string][]byte
+	failPath      string
+	waitForCancel bool
+	calls         map[string]int
+}
+
+func (fetcher *recordingFetcher) Get(ctx context.Context, relative string, limit int64) ([]byte, error) {
+	if fetcher.calls == nil {
+		fetcher.calls = map[string]int{}
+	}
+	fetcher.calls[relative]++
+	if fetcher.waitForCancel {
+		<-ctx.Done()
+		return nil, ctx.Err()
+	}
+	if relative == fetcher.failPath {
+		return nil, &downloadFailure{category: downloadCategoryTransport, cause: errors.New("private transport detail")}
+	}
+	body, ok := fetcher.files[relative]
+	if !ok {
+		return nil, &downloadFailure{category: downloadCategoryHTTP, cause: errors.New("missing fixture")}
+	}
+	if int64(len(body)) > limit {
+		return nil, &downloadFailure{category: downloadCategoryLength, cause: errors.New("fixture exceeds bound")}
+	}
+	return append([]byte(nil), body...), nil
+}
+
+func cloneFiles(source map[string][]byte) map[string][]byte {
+	cloned := make(map[string][]byte, len(source))
+	for name, body := range source {
+		cloned[name] = append([]byte(nil), body...)
+	}
+	return cloned
 }
 
 func newSignedOrigin(t *testing.T, spec originSpec) *signedOrigin {

--- a/scripts/publish-signed-release.sh
+++ b/scripts/publish-signed-release.sh
@@ -68,6 +68,7 @@ done
 
 command -v gh >/dev/null 2>&1 || fail 'gh is required'
 command -v jq >/dev/null 2>&1 || fail 'jq is required'
+command -v curl >/dev/null 2>&1 || fail 'curl is required'
 draft_state=$(gh release view "$release" --repo "$repository" --json tagName,isDraft,isPrerelease)
 [ "$(printf '%s\n' "$draft_state" | jq -er .tagName)" = "$release" ] || fail 'draft release identity is invalid'
 release_is_draft=$(printf '%s\n' "$draft_state" | jq -er 'if .isDraft == true then "true" elif .isDraft == false then "false" else error("invalid draft state") end')
@@ -93,6 +94,20 @@ download_release_candidate() {
 	while IFS= read -r asset; do
 		[ -n "$asset" ] || return 1
 		gh release download "$tag" --repo "$repository" --pattern "$asset" --dir "$destination"
+	done <"$artifact_names"
+}
+download_public_release_candidate() {
+	destination=$1
+	mkdir "$destination"
+	base="https://github.com/$repository/releases/download/$release"
+	for asset in punaro-release.json punaro-release.sig; do
+		curl --proto '=https' --tlsv1.2 --fail --silent --show-error --location \
+			--connect-timeout 15 --max-time 120 --output "$destination/$asset" "$base/$asset"
+	done
+	while IFS= read -r asset; do
+		[ -n "$asset" ] || return 1
+		curl --proto '=https' --tlsv1.2 --fail --silent --show-error --location \
+			--connect-timeout 15 --max-time 120 --output "$destination/$asset" "$base/$asset"
 	done <"$artifact_names"
 }
 restore_previous_catalog() {
@@ -204,6 +219,20 @@ gh release upload "$release" "$manifest_signature" "$catalog_signature" --repo "
 if [ "$release_is_draft" = true ]; then
 	gh release edit "$release" --repo "$repository" --draft=false --prerelease
 fi
+
+# Exercise the same public GitHub Releases origin used by bootstrap, rather
+# than treating an authenticated API download as proof of public egress. Fetch
+# every platform artifact bound by the signed manifest before exposing the new
+# catalog, then compare and cryptographically verify those exact bytes.
+public_origin_dir="$download_dir/public-origin"
+download_public_release_candidate "$public_origin_dir" || fail 'public release origin smoke failed'
+cmp -s "$manifest" "$public_origin_dir/punaro-release.json" || fail 'public origin manifest differs from signed bytes'
+cmp -s "$manifest_signature" "$public_origin_dir/punaro-release.sig" || fail 'public origin manifest signature differs from signed bytes'
+(
+	cd "$repo_dir"
+	go run ./cmd/punaro-release verify --keys-file "$keys_file" --document "$public_origin_dir/punaro-release.json" --signature "$public_origin_dir/punaro-release.sig"
+	go run ./cmd/punaro-release verify-artifacts --manifest "$public_origin_dir/punaro-release.json" --dir "$public_origin_dir"
+) || fail 'public release origin bytes failed signed verification'
 
 if [ "$catalog_exists" = true ] && [ "$catalog_draft" = false ]; then
 	# A clobber is delete-then-upload per asset. Hide the release before changing

--- a/scripts/test-publish-signed-release.sh
+++ b/scripts/test-publish-signed-release.sh
@@ -14,16 +14,19 @@ prepare_case() {
 	mkdir -p "$case_root/bin" "$case_root/documents" "$case_root/state/remote/v0.1.0-alpha.1"
 	cp "$repo_dir/scripts/testdata/fake-publish-go.sh" "$case_root/bin/go"
 	cp "$repo_dir/scripts/testdata/fake-publish-gh.sh" "$case_root/bin/gh"
-	chmod +x "$case_root/bin/go" "$case_root/bin/gh"
-	printf '%s\n' '{"artifacts":[{"path":"v0.1.0-alpha.1/punaro-adapter-linux-amd64"}]}' >"$case_root/documents/punaro-release.json"
+	cp "$repo_dir/scripts/testdata/fake-publish-curl.sh" "$case_root/bin/curl"
+	chmod +x "$case_root/bin/go" "$case_root/bin/gh" "$case_root/bin/curl"
+	printf '%s\n' '{"artifacts":[{"path":"v0.1.0-alpha.1/punaro-adapter-linux-amd64"},{"path":"v0.1.0-alpha.1/punaro-adapter-windows-amd64.exe"}]}' >"$case_root/documents/punaro-release.json"
 	printf '%s\n' manifest-signature >"$case_root/documents/punaro-release.sig"
 	printf '%s\n' catalog >"$case_root/documents/punaro-catalog.json"
 	printf '%s\n' catalog-signature >"$case_root/documents/punaro-catalog.sig"
 	printf '%s\n' artifact >"$case_root/documents/punaro-adapter-linux-amd64"
+	printf '%s\n' windows-artifact >"$case_root/documents/punaro-adapter-windows-amd64.exe"
 	printf '%s\n' public-key >"$case_root/release.pub"
 	cp "$case_root/documents/punaro-release.json" "$case_root/state/remote/v0.1.0-alpha.1/"
 	cp "$case_root/documents/punaro-catalog.json" "$case_root/state/remote/v0.1.0-alpha.1/"
 	cp "$case_root/documents/punaro-adapter-linux-amd64" "$case_root/state/remote/v0.1.0-alpha.1/"
+	cp "$case_root/documents/punaro-adapter-windows-amd64.exe" "$case_root/state/remote/v0.1.0-alpha.1/"
 	printf '%s\n' true >"$case_root/state/release-draft"
 	printf '%s\n' false >"$case_root/state/release-prerelease"
 }
@@ -136,6 +139,39 @@ if [ "$(cat "$retry/state/catalog-draft")" != false ]; then
 fi
 if [ "$(grep -Fc 'release edit v0.1.0-alpha.1 --repo rock3r/punaro --draft=false --prerelease' "$retry/gh.log")" -ne 1 ]; then
 	printf '%s\n' 'publication retry attempted to republish the already exact prerelease' >&2
+	exit 1
+fi
+
+public_origin="$temporary/public-origin"
+prepare_case "$public_origin"
+touch "$public_origin/state/fail-public-origin-once"
+if PATH="$public_origin/bin:$PATH" \
+	PUNARO_FAKE_GH_STATE="$public_origin/state" \
+	PUNARO_FAKE_GH_LOG="$public_origin/gh.log" \
+	PUNARO_FAKE_GO_LOG="$public_origin/go.log" \
+	PUNARO_FAKE_CURL_LOG="$public_origin/curl.log" \
+	"$repo_dir/scripts/publish-signed-release.sh" --release v0.1.0-alpha.1 --dir "$public_origin/documents" --keys-file "$public_origin/release.pub" >/dev/null 2>&1; then
+	printf '%s\n' 'failed public-origin smoke unexpectedly published the catalog' >&2
+	exit 1
+fi
+if [ "$(cat "$public_origin/state/release-draft")" != false ] || [ "$(cat "$public_origin/state/release-prerelease")" != true ] || [ -d "$public_origin/state/remote/catalog" ]; then
+	printf '%s\n' 'public-origin smoke failure did not preserve a retryable prerelease and prior catalog' >&2
+	exit 1
+fi
+PATH="$public_origin/bin:$PATH" \
+	PUNARO_FAKE_GH_STATE="$public_origin/state" \
+	PUNARO_FAKE_GH_LOG="$public_origin/gh.log" \
+	PUNARO_FAKE_GO_LOG="$public_origin/go.log" \
+	PUNARO_FAKE_CURL_LOG="$public_origin/curl.log" \
+	"$repo_dir/scripts/publish-signed-release.sh" --release v0.1.0-alpha.1 --dir "$public_origin/documents" --keys-file "$public_origin/release.pub" >/dev/null
+for asset in punaro-release.json punaro-release.sig punaro-adapter-linux-amd64 punaro-adapter-windows-amd64.exe; do
+	if ! grep -Fq "https://github.com/rock3r/punaro/releases/download/v0.1.0-alpha.1/$asset" "$public_origin/curl.log"; then
+		printf '%s\n' "public-origin smoke omitted $asset" >&2
+		exit 1
+	fi
+done
+if [ "$(cat "$public_origin/state/catalog-draft")" != false ]; then
+	printf '%s\n' 'successful public-origin smoke did not expose the verified catalog' >&2
 	exit 1
 fi
 

--- a/scripts/testdata/fake-publish-curl.sh
+++ b/scripts/testdata/fake-publish-curl.sh
@@ -1,0 +1,42 @@
+#!/bin/sh
+set -eu
+
+state=$PUNARO_FAKE_GH_STATE
+log=${PUNARO_FAKE_CURL_LOG:-/dev/null}
+printf '%s\n' "$*" >>"$log"
+
+output=
+url=
+while [ "$#" -gt 0 ]; do
+	case "$1" in
+		--output|--connect-timeout|--max-time|--proto)
+			[ "$#" -ge 2 ] || exit 2
+			[ "$1" = --output ] && output=$2
+			shift 2
+			;;
+		--fail|--silent|--show-error|--location|--tlsv1.2)
+			shift
+			;;
+		*)
+			url=$1
+			shift
+			;;
+	esac
+done
+
+[ -n "$output" ] && [ -n "$url" ] || exit 2
+prefix=https://github.com/rock3r/punaro/releases/download/
+case "$url" in "$prefix"*) ;; *) exit 2 ;; esac
+relative=${url#"$prefix"}
+tag=${relative%%/*}
+asset=${relative#*/}
+[ -n "$tag" ] && [ -n "$asset" ] && [ "$asset" != "$relative" ] || exit 2
+case "$asset" in */*) exit 2 ;; esac
+
+if [ -f "$state/fail-public-origin-once" ]; then
+	rm "$state/fail-public-origin-once"
+	exit 1
+fi
+source=$state/remote/$tag/$asset
+[ -f "$source" ] || exit 1
+cp "$source" "$output"


### PR DESCRIPTION
Closes #206.

## Summary
- retry transient catalog, signature, manifest, and artifact download failures with bounded per-attempt and overall deadlines
- keep verification and permanent/policy failures non-retryable while returning content-free phase/category errors
- preserve slot and journal integrity across exhausted artifact downloads
- smoke every published release asset through its unauthenticated public GitHub Release URL before advancing the signed catalog
- document retry and publication behavior

## Verification
- deterministic reset, EOF, timeout, HTTP status, deadline, verification, and slot-integrity tests
- Linux and Windows publication smoke tests, including failure/retry
- make test test-race staticcheck security lint
- git diff --check