### PR TITLE
fix(update): verify signed server release manifest

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1803,9 +1803,35 @@ The seventh foundation slice adds the single-node supported update transaction.
 Every PostgreSQL business mutation takes the shared side of one transactional
 maintenance gate; the owner-side update fence drains prior writers, rejects
 later writes before acknowledgement, and remains durable through crashes. The
-host wrapper verifies protected release metadata, the exact pulled image digest,
-the generated Compose artifact, PostgreSQL major, installation identity, disk
-capacity, and current health before fencing. It then stops the generated writer,
+host wrapper accepts the exact public release manifest only with its detached
+signature and an independently provisioned operator trust root. All three inputs
+must be bounded owner-controlled regular files beneath trusted ancestors; linked,
+foreign-owned, or group/world-writable trust material fails closed. Signature
+verification covers the exact manifest bytes before the wrapper projects the
+release name, digest-pinned image, schema range, PostgreSQL major, image digest,
+Compose digest, or migration-manifest digest, so no unsigned server-update value
+can enter that boundary. The wrapper also derives the source release from the
+durable transaction or host stage (requiring an explicit source only for an old
+installation without a release lock) and requires that source in the manifest's
+signed `supported_from` allowlist before any preflight or fencing; an empty list
+permits no server update. Before creating a new transaction, it also verifies a
+fresh catalog under that same trust root and requires the exact target release,
+sequence, and manifest digest to remain allowed. Catalog retirement blocks new
+starts but is not re-applied to an exact durable resume, which must remain
+recoverable. Before transaction creation, the wrapper durably advances an
+installation-local accepted catalog high-water under a file lock. Catalogs
+below either the release binary's embedded catalog sequence or that accepted
+sequence are rejected; a synced pending advance is recovered after a crash so
+replaying an older, still-fresh signed catalog cannot undo a retirement. The
+same cross-process lock remains held through preflight until the database
+transaction is durably created, so concurrent starts cannot authorize under
+different catalog generations and publish in the opposite order. The one-time
+schema-5 bridge also reconciles an uncertain commit against the exact durable
+update ID; when none exists, the previous writer must regain readiness before
+the unpublished host stage is removed. It
+then verifies the exact pulled image digest,
+generated Compose artifact, installation identity, disk capacity, and current
+health before fencing. It then stops the generated writer,
 creates an update-bound M-6 backup, and runs the exact target image as a hardened
 one-shot owner migrator. The target starts under the still-active fence and must
 pass readiness and a non-mutating doctor before marker-last configuration

--- a/cmd/punaro/main.go
+++ b/cmd/punaro/main.go
@@ -430,6 +430,8 @@ func run(args []string, stdout, stderr io.Writer) int {
 		return runDoctorGatewayServiceInspect(args[1:], stdout)
 	case "doctor-update-stage-check":
 		return runDoctorUpdateStageCheck(args[1:], stdout)
+	case "doctor-catalog-acceptance-check":
+		return runDoctorCatalogAcceptanceCheck(args[1:], stdout)
 	case "doctor-relay-profile-check":
 		return runDoctorRelayProfileCheck(args[1:], stdout)
 	case "doctor-recovery-receipt-check":
@@ -516,9 +518,18 @@ func runInit(args []string, stdout, stderr io.Writer) int {
 	if flags.Parse(args) != nil || flags.NArg() != 0 || *directory == "" {
 		return 2
 	}
+	catalogSequence, err := serverInstallationCatalogSequence(0)
+	if err != nil {
+		_, _ = fmt.Fprintf(stderr, "punaro init failed: %v\n", err)
+		return 1
+	}
 	if *resume {
 		installation, err := operator.Resume(context.Background(), *directory, recoverInstallationOwner)
 		if err != nil {
+			_, _ = fmt.Fprintf(stderr, "punaro init recovery failed: %v\n", err)
+			return 1
+		}
+		if err := publishServerCatalogAcceptance(installation.Directory, catalogSequence); err != nil {
 			_, _ = fmt.Fprintf(stderr, "punaro init recovery failed: %v\n", err)
 			return 1
 		}
@@ -561,10 +572,41 @@ func runInit(args []string, stdout, stderr io.Writer) int {
 		_, _ = fmt.Fprintf(stderr, "punaro init failed: %v\n", err)
 		return 1
 	}
+	if err := publishServerCatalogAcceptance(installation.Directory, catalogSequence); err != nil {
+		_, _ = fmt.Fprintf(stderr, "punaro init failed: %v\n", err)
+		return 1
+	}
 	if installation.Ingress.Mode == ingress.LAN {
 		_, _ = fmt.Fprintln(stderr, "WARNING: trusted-LAN HTTP sends enrollment and device credentials without TLS; use only on the validated private/link-local network")
 	}
 	return writeJSON(stdout, stderr, map[string]any{"status": "initialized", "owner_principal_id": installation.OwnerPrincipalID, "directory": *directory})
+}
+
+func serverInstallationCatalogSequence(preserved int64) (int64, error) {
+	if preserved < 0 {
+		return 0, errors.New("release catalog acceptance is invalid")
+	}
+	if serverBuildRelease == "" {
+		return preserved, nil
+	}
+	embedded := serverUpdateCatalogMinimum()
+	if embedded < 1 {
+		return 0, errors.New("embedded release catalog sequence is invalid")
+	}
+	if embedded > preserved {
+		return embedded, nil
+	}
+	return preserved, nil
+}
+
+func publishServerCatalogAcceptance(directory string, sequence int64) error {
+	if sequence == 0 {
+		return nil
+	}
+	if err := operator.AcceptServerCatalogSequence(directory, sequence, 0); err != nil {
+		return errors.New("release catalog acceptance could not be published")
+	}
+	return nil
 }
 
 func runUp(args []string, stdout, stderr io.Writer) int {
@@ -736,7 +778,7 @@ func unavailableServerDoctorChecks(gatewayColocated bool) []punarodiagnostic.Che
 		"health_endpoint", "health_listener_private", "host_update_stage", "image_digest_binding", "installed_release", "operator_binary_release", "installation_directory", "installation_paths", "machine_identity",
 		"maintenance_fence", "migration_manifest_binding", "owner_credential_file", "postgres_major", "readiness_endpoint", "recovery_receipt", "relay_enrollment",
 		"relay_protocol", "running_image", "storage_capacity", "storage_credential_isolation", "storage_directory_separation", "tunnel_origin", "tunnel_route",
-		"update_recovery", "update_transaction", "verified_backup",
+		"release_catalog_acceptance", "update_recovery", "update_transaction", "verified_backup",
 		"mail_cutover_legacy_inventory", "mail_cutover_recovery", "mail_cutover_target",
 	}
 	checks := []punarodiagnostic.Check{punarodiagnostic.Fail("installation_configuration", "repair_installation_configuration")}
@@ -790,6 +832,7 @@ func diagnoseServer(ctx context.Context, installation operator.Installation, mac
 	checks = appendKnownServerCheck(checks, "update_transaction", "resume_abort_or_recover_update", extended.UpdateTransaction)
 	checks = appendKnownServerCheck(checks, "recovery_receipt", "repair_update_recovery_receipt", extended.RecoveryReceipt)
 	checks = appendKnownServerCheck(checks, "update_recovery", "resume_abort_or_recover_update", extended.UpdateRecovery)
+	checks = appendKnownServerCheck(checks, "release_catalog_acceptance", "repair_release_catalog", serverDoctorCatalogAcceptanceCheck(ctx, installation.Directory, extended.CatalogSequence))
 	checks = appendKnownServerCheck(checks, "database_listener_private", "repair_database_listener_topology", extended.DatabasePrivate)
 	checks = appendKnownServerCheck(checks, "health_listener_private", "repair_health_listener_topology", extended.HealthPrivate)
 	checks = appendKnownServerCheck(checks, "administration_listener_private", "repair_administration_listener_topology", extended.AdminPrivate)
@@ -1311,6 +1354,14 @@ func createBackupWithUpdate(ctx context.Context, installation operator.Installat
 	if err := verifyInstallationPair(ctx, installation.AppDSNFile, installation.OwnerDSNFile); err != nil {
 		return punarobackup.Manifest{}, "", punaropostgres.UpdateBackupMarker{}, err
 	}
+	catalogSequence, releaseCatalogSnapshot, err := operator.BeginServerCatalogSnapshot(installation.Directory)
+	if err != nil {
+		return punarobackup.Manifest{}, "", punaropostgres.UpdateBackupMarker{}, errors.New("release catalog acceptance cannot be captured safely")
+	}
+	defer releaseCatalogSnapshot()
+	if err := requireBackupCatalogAcceptance(catalogSequence); err != nil {
+		return punarobackup.Manifest{}, "", punaropostgres.UpdateBackupMarker{}, err
+	}
 	owner, err := inspectOwner(ctx, installation.AppDSNFile)
 	if err != nil || owner.ID != installation.OwnerPrincipalID {
 		return punarobackup.Manifest{}, "", punaropostgres.UpdateBackupMarker{}, errors.New("installation owner does not match configuration")
@@ -1330,13 +1381,14 @@ func createBackupWithUpdate(ctx context.Context, installation operator.Installat
 		return punarobackup.Manifest{}, "", punaropostgres.UpdateBackupMarker{}, err
 	}
 	options := punarobackup.CreateOptions{
-		BackupRoot:       installation.BackupDir,
-		BlobRoot:         backupBlobRoot(installation),
-		InstallationFile: operator.ConfigFile(installation.Directory),
-		EnvironmentFile:  operator.EnvFile(installation.Directory),
-		ComposeFile:      operator.OverrideFile(installation.Directory),
-		OwnerDSNFile:     installation.OwnerDSNFile,
-		AppDSNFile:       installation.AppDSNFile,
+		BackupRoot:            installation.BackupDir,
+		BlobRoot:              backupBlobRoot(installation),
+		InstallationFile:      operator.ConfigFile(installation.Directory),
+		EnvironmentFile:       operator.EnvFile(installation.Directory),
+		ComposeFile:           operator.OverrideFile(installation.Directory),
+		OwnerDSNFile:          installation.OwnerDSNFile,
+		AppDSNFile:            installation.AppDSNFile,
+		ServerCatalogSequence: catalogSequence,
 	}
 	if transaction != nil {
 		_, digest, found := strings.Cut(transaction.TargetImage, "@")
@@ -1364,8 +1416,19 @@ func createBackupWithUpdate(ctx context.Context, installation operator.Installat
 	}, nil
 }
 
+func requireBackupCatalogAcceptance(sequence int64) error {
+	if serverBuildRelease != "" && sequence < 1 {
+		return errors.New("release catalog acceptance is required before backup")
+	}
+	return nil
+}
+
 func restoreBackup(ctx context.Context, request restoreRequest) (punarobackup.State, error) {
 	manifest, err := punarobackup.Verify(request.BackupDirectory)
+	if err != nil {
+		return punarobackup.State{}, err
+	}
+	serverCatalogSequence, err := serverInstallationCatalogSequence(manifest.ServerCatalogSequence)
 	if err != nil {
 		return punarobackup.State{}, err
 	}
@@ -1578,7 +1641,7 @@ func restoreBackup(ctx context.Context, request restoreRequest) (punarobackup.St
 				return errors.New("restored timeline state does not match publication")
 			}
 			finalizationStage = "configuration"
-			if err := operator.PublishRestore(prepared); err != nil {
+			if err := operator.PublishRestoreWithCatalogSequence(prepared, serverCatalogSequence); err != nil {
 				return err
 			}
 			finalizationStage = ""

--- a/cmd/punaro/main_test.go
+++ b/cmd/punaro/main_test.go
@@ -445,8 +445,10 @@ func preserveDependencies(t *testing.T) {
 	originalStart, originalProbe, originalIssue, originalListClients, originalRevokeClient := startServices, probe, issueEnrollment, listClients, revokeClient
 	originalBackup, originalListBackups, originalVerifyBackup, originalRestore := createOperatorBackup, listOperatorBackups, verifyOperatorBackup, restoreOperatorBackup
 	originalServerDoctorInspect, originalServerDoctorLoad := serverDoctorInspect, serverDoctorLoad
-	originalUpdateStageCheck := serverDoctorUpdateStageCheck
+	originalUpdateStageCheck, originalCatalogAcceptanceCheck := serverDoctorUpdateStageCheck, serverDoctorCatalogAcceptanceCheck
 	originalMailCutoverPreflight := inspectMailCutoverPreflight
+	originalReconcileUpdateTransaction := reconcileUpdateTransaction
+	originalRunUpdateDocker := runUpdateDocker
 	t.Cleanup(func() {
 		inspectSchema, inspectOwner, migratePristinePair, maintenanceActive = originalInspect, originalOwner, originalMigrate, originalMaintenance
 		createOwner, recoverInstallationOwner = originalCreate, originalRecover
@@ -458,7 +460,10 @@ func preserveDependencies(t *testing.T) {
 		serverDoctorInspect = originalServerDoctorInspect
 		serverDoctorLoad = originalServerDoctorLoad
 		serverDoctorUpdateStageCheck = originalUpdateStageCheck
+		serverDoctorCatalogAcceptanceCheck = originalCatalogAcceptanceCheck
 		inspectMailCutoverPreflight = originalMailCutoverPreflight
+		reconcileUpdateTransaction = originalReconcileUpdateTransaction
+		runUpdateDocker = originalRunUpdateDocker
 	})
 	inspectOwner = func(context.Context, string) (punaropostgres.Principal, error) {
 		return punaropostgres.Principal{ID: "11111111-1111-4111-8111-111111111111", DisplayName: "owner"}, nil
@@ -472,6 +477,7 @@ func preserveDependencies(t *testing.T) {
 		return healthyServerDoctorState()
 	}
 	serverDoctorUpdateStageCheck = directServerDoctorUpdateStage
+	serverDoctorCatalogAcceptanceCheck = func(context.Context, string, int64) knownDoctorBool { return known(true, true) }
 }
 
 func TestServerDoctorDeadlineIncludesInstallationLoad(t *testing.T) {
@@ -697,6 +703,41 @@ func TestDoctorUpdateStageIsolationStaysInsideDeadline(t *testing.T) {
 	started := time.Now()
 	if state := isolatedServerDoctorUpdateStage(ctx, t.TempDir()); state.Known || time.Since(started) > time.Second {
 		t.Fatalf("isolated update-stage state=%#v elapsed=%s", state, time.Since(started))
+	}
+}
+
+func TestDoctorCatalogAcceptanceCommandAndIsolationStayInsideDeadline(t *testing.T) {
+	directory := t.TempDir()
+	if err := os.Chmod(directory, 0o700); err != nil { // #nosec G302 -- private operator-state fixture root.
+		t.Fatal(err)
+	}
+	var stdout bytes.Buffer
+	if code := runDoctorCatalogAcceptanceCheck([]string{"--directory", directory, "--minimum", "3"}, &stdout); code != 0 {
+		t.Fatalf("missing catalog acceptance code=%d output=%q", code, stdout.String())
+	}
+	var state knownDoctorBool
+	if json.Unmarshal(stdout.Bytes(), &state) != nil || !state.Known || state.OK {
+		t.Fatalf("missing catalog acceptance=%#v", state)
+	}
+	if err := operator.AcceptServerCatalogSequence(directory, 4, 3); err != nil {
+		t.Fatal(err)
+	}
+	stdout.Reset()
+	if code := runDoctorCatalogAcceptanceCheck([]string{"--directory", directory, "--minimum", "5"}, &stdout); code != 0 {
+		t.Fatalf("downgrade catalog acceptance code=%d output=%q", code, stdout.String())
+	}
+	state = knownDoctorBool{}
+	if json.Unmarshal(stdout.Bytes(), &state) != nil || !state.Known || state.OK {
+		t.Fatalf("downgrade catalog acceptance=%#v", state)
+	}
+
+	blocker := filepath.Join(t.TempDir(), "blocked-catalog-acceptance-doctor")
+	previous := serverDoctorCatalogAcceptanceExecutable
+	serverDoctorCatalogAcceptanceExecutable = func() (string, error) { return blocker, nil }
+	t.Cleanup(func() { serverDoctorCatalogAcceptanceExecutable = previous })
+	started := time.Now()
+	if state := isolatedServerDoctorCatalogAcceptance(t.Context(), directory, 4); state.Known || time.Since(started) > time.Second {
+		t.Fatalf("isolated catalog acceptance=%#v elapsed=%s", state, time.Since(started))
 	}
 }
 
@@ -1830,6 +1871,11 @@ func TestServerDoctorRequiresRecoveryReceiptAtIrreversibleUpdateBoundary(t *test
 
 func TestInitMigratesPristineBeforeCreatingOwner(t *testing.T) {
 	preserveDependencies(t)
+	originalRelease, originalCatalogSequence := serverBuildRelease, serverBuildCatalogSequence
+	serverBuildRelease, serverBuildCatalogSequence = "v0.0.0-test", "9"
+	t.Cleanup(func() {
+		serverBuildRelease, serverBuildCatalogSequence = originalRelease, originalCatalogSequence
+	})
 	root := t.TempDir()
 	for _, name := range []string{"data", "backup", "data/attachments"} {
 		if err := os.Mkdir(filepath.Join(root, name), 0o700); err != nil {
@@ -1870,6 +1916,44 @@ func TestInitMigratesPristineBeforeCreatingOwner(t *testing.T) {
 	wantBlobDir, canonicalErr := filepath.EvalSymlinks(filepath.Join(root, "data", "attachments"))
 	if err != nil || canonicalErr != nil || !installation.MemoryAPIEnabled || !installation.MemoryMutationsEnabled || !installation.RelayEnabled || !installation.TrustedAttachmentsEnabled || installation.TrustedAttachmentBlobDir != wantBlobDir {
 		t.Fatalf("installation=%#v err=%v", installation, err)
+	}
+	if err := operator.InspectServerCatalogAcceptance(installation.Directory, 9); err != nil {
+		t.Fatalf("release-bound init did not publish catalog acceptance: %v", err)
+	}
+}
+
+func TestServerInstallationCatalogSequencePreservesRestoreHighWater(t *testing.T) {
+	originalRelease, originalCatalogSequence := serverBuildRelease, serverBuildCatalogSequence
+	t.Cleanup(func() {
+		serverBuildRelease, serverBuildCatalogSequence = originalRelease, originalCatalogSequence
+	})
+	serverBuildRelease, serverBuildCatalogSequence = "v0.0.0-test", "9"
+
+	if got, err := serverInstallationCatalogSequence(12); err != nil || got != 12 {
+		t.Fatalf("preserved sequence=%d err=%v", got, err)
+	}
+	if got, err := serverInstallationCatalogSequence(4); err != nil || got != 9 {
+		t.Fatalf("embedded floor sequence=%d err=%v", got, err)
+	}
+	serverBuildCatalogSequence = "invalid"
+	if _, err := serverInstallationCatalogSequence(12); err == nil {
+		t.Fatal("release-bound installation accepted an invalid embedded catalog sequence")
+	}
+}
+
+func TestReleaseBoundBackupRequiresCatalogAcceptance(t *testing.T) {
+	originalRelease := serverBuildRelease
+	t.Cleanup(func() { serverBuildRelease = originalRelease })
+	serverBuildRelease = "v0.0.0-test"
+	if err := requireBackupCatalogAcceptance(0); err == nil {
+		t.Fatal("release-bound backup accepted missing catalog state")
+	}
+	if err := requireBackupCatalogAcceptance(9); err != nil {
+		t.Fatalf("release-bound backup rejected catalog high-water: %v", err)
+	}
+	serverBuildRelease = ""
+	if err := requireBackupCatalogAcceptance(0); err != nil {
+		t.Fatalf("unbound legacy backup rejected pristine state: %v", err)
 	}
 }
 
@@ -1959,6 +2043,11 @@ func TestUpRefusesCompatibleDatabaseWithDifferentOwner(t *testing.T) {
 
 func TestInitResumeRecoversUncertainOwnerOutcome(t *testing.T) {
 	preserveDependencies(t)
+	originalRelease, originalCatalogSequence := serverBuildRelease, serverBuildCatalogSequence
+	serverBuildRelease, serverBuildCatalogSequence = "v0.0.0-test", "9"
+	t.Cleanup(func() {
+		serverBuildRelease, serverBuildCatalogSequence = originalRelease, originalCatalogSequence
+	})
 	root := t.TempDir()
 	for _, name := range []string{"data", "backup"} {
 		if err := os.Mkdir(filepath.Join(root, name), 0o700); err != nil {
@@ -1994,6 +2083,9 @@ func TestInitResumeRecoversUncertainOwnerOutcome(t *testing.T) {
 	stderr.Reset()
 	if code := run([]string{"init", "--resume", "--directory", directory}, &stdout, &stderr); code != 0 {
 		t.Fatalf("resume code=%d stdout=%q stderr=%q", code, stdout.String(), stderr.String())
+	}
+	if err := operator.InspectServerCatalogAcceptance(directory, 9); err != nil {
+		t.Fatalf("release-bound init recovery did not publish catalog acceptance: %v", err)
 	}
 }
 

--- a/cmd/punaro/server_doctor.go
+++ b/cmd/punaro/server_doctor.go
@@ -96,20 +96,54 @@ type serverDoctorRecoveryReceiptRequest struct {
 }
 
 var (
-	serverDoctorPathCheck                 = isolatedServerDoctorPaths
-	serverDoctorPathExecutable            = os.Executable
-	serverDoctorStorageCheck              = isolatedServerDoctorStorage
-	serverDoctorStorageExecutable         = os.Executable
-	serverDoctorBackupCheck               = isolatedServerDoctorBackups
-	serverDoctorBackupExecutable          = os.Executable
-	serverDoctorUpdateStageCheck          = isolatedServerDoctorUpdateStage
-	serverDoctorUpdateStageExecutable     = os.Executable
-	serverDoctorProfileLoad               = isolatedServerDoctorProfile
-	serverDoctorProfileExecutable         = os.Executable
-	serverDoctorRecoveryReceiptCheck      = isolatedServerDoctorRecoveryReceipt
-	serverDoctorRecoveryReceiptExecutable = os.Executable
-	serverDoctorRunningImageCommand       = boundedCommandInDirectory
+	serverDoctorPathCheck                   = isolatedServerDoctorPaths
+	serverDoctorPathExecutable              = os.Executable
+	serverDoctorStorageCheck                = isolatedServerDoctorStorage
+	serverDoctorStorageExecutable           = os.Executable
+	serverDoctorBackupCheck                 = isolatedServerDoctorBackups
+	serverDoctorBackupExecutable            = os.Executable
+	serverDoctorUpdateStageCheck            = isolatedServerDoctorUpdateStage
+	serverDoctorUpdateStageExecutable       = os.Executable
+	serverDoctorCatalogAcceptanceCheck      = isolatedServerDoctorCatalogAcceptance
+	serverDoctorCatalogAcceptanceExecutable = os.Executable
+	serverDoctorProfileLoad                 = isolatedServerDoctorProfile
+	serverDoctorProfileExecutable           = os.Executable
+	serverDoctorRecoveryReceiptCheck        = isolatedServerDoctorRecoveryReceipt
+	serverDoctorRecoveryReceiptExecutable   = os.Executable
+	serverDoctorRunningImageCommand         = boundedCommandInDirectory
 )
+
+func isolatedServerDoctorCatalogAcceptance(ctx context.Context, directory string, minimum int64) knownDoctorBool {
+	executable, err := serverDoctorCatalogAcceptanceExecutable()
+	if err != nil {
+		return knownDoctorBool{}
+	}
+	output, ok := boundedCommandLimit(ctx, 256, executable, "doctor-catalog-acceptance-check", "--directory", directory, "--minimum", strconv.FormatInt(minimum, 10))
+	if !ok {
+		return knownDoctorBool{}
+	}
+	decoder := json.NewDecoder(strings.NewReader(output))
+	var state knownDoctorBool
+	if decoder.Decode(&state) != nil || decoder.Decode(&struct{}{}) != io.EOF || !state.Known {
+		return knownDoctorBool{}
+	}
+	return state
+}
+
+func runDoctorCatalogAcceptanceCheck(args []string, stdout io.Writer) int {
+	flags := flag.NewFlagSet("punaro doctor-catalog-acceptance-check", flag.ContinueOnError)
+	flags.SetOutput(io.Discard)
+	directory := flags.String("directory", "", "installation directory")
+	minimum := flags.Int64("minimum", 0, "embedded release catalog sequence")
+	if flags.Parse(args) != nil || flags.NArg() != 0 || *directory == "" || !filepath.IsAbs(*directory) || filepath.Clean(*directory) != *directory || *minimum < 1 {
+		return 2
+	}
+	state := known(true, operator.InspectServerCatalogAcceptance(*directory, *minimum) == nil)
+	if json.NewEncoder(stdout).Encode(state) != nil {
+		return 1
+	}
+	return 0
+}
 
 func isolatedServerDoctorProfile(ctx context.Context, path string) (serverDoctorProfile, error) {
 	if path == "" || !filepath.IsAbs(path) || filepath.Clean(path) != path {

--- a/cmd/punaro/update_command.go
+++ b/cmd/punaro/update_command.go
@@ -27,6 +27,10 @@ const minimumUpdateFreeBytes = uint64(512 << 20)
 
 const updateMigratorOwnerDSNPath = "/run/secrets/punaro-owner-dsn"
 
+var errUpdateCatalogRequired = errors.New("fresh signed release catalog is required before starting a new update")
+
+var errUpdateCatalogFloor = errors.New("target updater has no valid embedded release catalog floor")
+
 var runUpdateDocker = func(ctx context.Context, directory string, environment []string, arguments ...string) ([]byte, error) {
 	command := exec.CommandContext(ctx, "docker", arguments...) // #nosec G204 -- fixed executable with validated generated paths and digest-pinned image arguments.
 	command.Dir = directory
@@ -34,32 +38,67 @@ var runUpdateDocker = func(ctx context.Context, directory string, environment []
 	return command.CombinedOutput()
 }
 
+var reconcileUpdateTransaction = loadUpdateTransaction
+
+type v5UpdateBridge interface {
+	Update() punaropostgres.UpdateTransaction
+	CommitWritersStopped(context.Context) (punaropostgres.UpdateTransaction, error)
+	Abort() error
+}
+
 type commandUpdateExecutor struct {
-	installation   operator.Installation
-	metadata       punarorelease.Metadata
-	request        punaropostgres.UpdateRequest
-	stage          operator.UpdateStage
-	staged         operator.StagedUpdate
-	bridge         *punaropostgres.V5UpdateBridge
-	recovery       *operator.Installation
-	recoverySchema int64
+	installation    operator.Installation
+	metadata        punarorelease.Metadata
+	request         punaropostgres.UpdateRequest
+	stage           operator.UpdateStage
+	staged          operator.StagedUpdate
+	bridge          v5UpdateBridge
+	orphanedWriters bool
+	recovery        *operator.Installation
+	recoverySchema  int64
+	startGuard      func()
+	startRevalidate func(time.Time) error
+}
+
+type signedUpdateRelease struct {
+	metadata          punarorelease.Metadata
+	manifestSequence  int64
+	manifestSHA256    string
+	publicReleaseKeys []byte
 }
 
 func runUpdate(args []string, stdout, stderr io.Writer) int {
 	flags := flag.NewFlagSet("update", flag.ContinueOnError)
 	flags.SetOutput(stderr)
 	directory := flags.String("directory", "", "absolute installation directory")
-	metadataPath := flags.String("release-metadata", "", "protected target release metadata JSON")
+	manifestPath := flags.String("release-manifest", "", "protected signed target release manifest JSON")
+	signaturePath := flags.String("release-signature", "", "protected detached target release signature JSON")
+	catalogPath := flags.String("release-catalog", "", "protected fresh signed release catalog JSON for a new update")
+	catalogSignaturePath := flags.String("release-catalog-signature", "", "protected detached release catalog signature JSON for a new update")
+	keysPath := flags.String("release-keys-file", "", "protected trusted release public keys JSON")
 	sourceRelease := flags.String("source-release", "", "current release name for installations predating release locks")
 	abort := flags.Bool("abort", false, "restart the previous image and abort before migration")
 	recovery := flags.String("recover", "", "post-migration recovery choice: compatible or restore")
-	if flags.Parse(args) != nil || flags.NArg() != 0 || *directory == "" || *metadataPath == "" || (*recovery != "" && *recovery != "compatible" && *recovery != "restore") || (*abort && *recovery != "") {
+	if flags.Parse(args) != nil {
+		return 2
+	}
+	cleanupUnpublished := *abort && *manifestPath == "" && *signaturePath == "" && *keysPath == "" && *catalogPath == "" && *catalogSignaturePath == "" && *sourceRelease == ""
+	normalInputs := *manifestPath != "" && *signaturePath != "" && *keysPath != ""
+	if flags.NArg() != 0 || *directory == "" || !cleanupUnpublished && !normalInputs || (*catalogPath == "") != (*catalogSignaturePath == "") || (*recovery != "" && *recovery != "compatible" && *recovery != "restore") || (*abort && *recovery != "") {
 		return 2
 	}
 	installation, err := operator.Load(*directory)
 	if err != nil {
 		_, _ = fmt.Fprintln(stderr, "punaro update refused: installation configuration is unavailable")
 		return 1
+	}
+	if cleanupUnpublished {
+		stage, err := cleanupUnpublishedUpdate(context.Background(), installation)
+		if err != nil {
+			_, _ = fmt.Fprintf(stderr, "punaro update cleanup refused: %v\n", err)
+			return 1
+		}
+		return writeJSON(stdout, stderr, map[string]any{"status": "unpublished_stage_aborted", "update_id": stage.UpdateID, "target_release": stage.TargetRelease, "target_image": stage.TargetImage})
 	}
 	schema, err := inspectSchema(context.Background(), installation.AppDSNFile)
 	if err != nil || (schema.Classification != punaropostgres.Compatible && (schema.Classification != punaropostgres.UpgradeRequired || schema.Version != 5)) {
@@ -71,14 +110,10 @@ func runUpdate(args []string, stdout, stderr io.Writer) int {
 		_, _ = fmt.Fprintln(stderr, "punaro update refused: PostgreSQL major is unavailable")
 		return 1
 	}
-	body, err := readReleaseMetadata(*metadataPath)
-	if err != nil {
-		_, _ = fmt.Fprintln(stderr, "punaro update refused: target release metadata is unavailable or unsafe")
-		return 1
-	}
-	metadata, err := punarorelease.Parse(body, punarorelease.Environment{CurrentSchema: schema.Version, PostgreSQLMajor: major})
-	if err != nil || metadata.MigrationManifestSHA256 != punaropostgres.MigrationManifestSHA256() {
-		_, _ = fmt.Fprintln(stderr, "punaro update refused: target release metadata does not match this updater")
+	signedRelease, err := loadSignedUpdateRelease(*manifestPath, *signaturePath, *keysPath, punarorelease.Environment{CurrentSchema: schema.Version, PostgreSQLMajor: major})
+	metadata := signedRelease.metadata
+	if err != nil || !targetReleaseMatchesUpdater(metadata, serverBuildRelease) || metadata.MigrationManifestSHA256 != punaropostgres.MigrationManifestSHA256() {
+		_, _ = fmt.Fprintln(stderr, "punaro update refused: signed target release manifest is unavailable, unsafe, or does not match this updater")
 		return 1
 	}
 	active, activeErr := loadUpdateTransaction(context.Background(), installation, "")
@@ -100,6 +135,10 @@ func runUpdate(args []string, stdout, stderr io.Writer) int {
 	if errors.Is(activeErr, punaropostgres.ErrNotFound) {
 		latest, latestErr := loadLatestUpdateTransaction(context.Background(), installation)
 		if latestErr == nil && (*sourceRelease == "" || *sourceRelease == latest.SourceRelease) && completedUpdateMatches(latest, metadata, installation.Image, *abort, *recovery) {
+			if err := validateUpdateSource(metadata, latest.SourceRelease); err != nil {
+				_, _ = fmt.Fprintf(stderr, "punaro update refused: %v\n", err)
+				return 1
+			}
 			stage := operator.UpdateStage{Directory: installation.Directory, UpdateID: latest.UpdateID, PreviousRelease: latest.SourceRelease, PreviousImage: latest.SourceImage, TargetRelease: latest.TargetRelease, TargetImage: latest.TargetImage}
 			if latest.Phase == punaropostgres.UpdateCommitted || latest.Phase == punaropostgres.UpdateRecovered || latest.Phase == punaropostgres.UpdateAborted {
 				cleanupErr := operator.AbortStage(stage)
@@ -138,6 +177,25 @@ func runUpdate(args []string, stdout, stderr io.Writer) int {
 		_, _ = fmt.Fprintln(stderr, "punaro update requires --source-release for this installation")
 		return 2
 	}
+	if err := validateUpdateSource(metadata, *sourceRelease); err != nil {
+		_, _ = fmt.Fprintf(stderr, "punaro update refused: %v\n", err)
+		return 1
+	}
+	startGuard, startRevalidate, err := authorizeUpdateStart(request, installation.Directory, *catalogPath, *catalogSignaturePath, signedRelease, time.Now().UTC(), serverUpdateCatalogMinimum())
+	if err != nil {
+		_, _ = fmt.Fprintf(stderr, "punaro update refused: %v\n", err)
+		if errors.Is(err, errUpdateCatalogRequired) {
+			return 2
+		}
+		return 1
+	}
+	releaseStartGuard := func() {
+		if startGuard != nil {
+			startGuard()
+			startGuard = nil
+		}
+	}
+	defer releaseStartGuard()
 	if request.UpdateID == "" {
 		updateID := uuid.NewString()
 		if stage.UpdateID != "" {
@@ -157,7 +215,7 @@ func runUpdate(args []string, stdout, stderr io.Writer) int {
 	}
 	executor := &commandUpdateExecutor{
 		installation: installation, metadata: metadata, request: request,
-		stage: stage,
+		stage: stage, startGuard: releaseStartGuard, startRevalidate: startRevalidate,
 	}
 	transaction, err := executeUpdate(context.Background(), updateExecution{Request: request, Abort: *abort, RecoveryMode: *recovery}, executor)
 	if err != nil {
@@ -165,6 +223,39 @@ func runUpdate(args []string, stdout, stderr io.Writer) int {
 		return 1
 	}
 	return writeJSON(stdout, stderr, map[string]any{"status": transaction.Phase, "update_id": transaction.UpdateID, "target_release": transaction.TargetRelease, "target_image": transaction.TargetImage})
+}
+
+func cleanupUnpublishedUpdate(ctx context.Context, installation operator.Installation) (operator.UpdateStage, error) {
+	stage, err := operator.ExistingUpdateStage(installation.Directory)
+	if err != nil {
+		return operator.UpdateStage{}, errors.New("a valid unpublished update stage is required")
+	}
+	staged, err := operator.ResumeUpdateStage(stage)
+	if err != nil || staged.Published || stage.PreviousImage != installation.Image {
+		return operator.UpdateStage{}, errors.New("update stage does not match the installed previous release")
+	}
+	_, unlock, err := operator.BeginServerCatalogSnapshot(installation.Directory)
+	if err != nil {
+		return operator.UpdateStage{}, errors.New("update start lock is unavailable")
+	}
+	defer unlock()
+	recoveryCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), time.Minute)
+	defer cancel()
+	if _, err := reconcileUpdateTransaction(recoveryCtx, installation, stage.UpdateID); err == nil {
+		return operator.UpdateStage{}, errors.New("the staged update has durable database state; rerun the exact update command")
+	} else if !errors.Is(err, punaropostgres.ErrNotFound) {
+		return operator.UpdateStage{}, errors.New("durable update state could not be inspected")
+	}
+	if _, err := reconcileUpdateTransaction(recoveryCtx, installation, ""); err == nil {
+		return operator.UpdateStage{}, errors.New("a different durable update transaction is active")
+	} else if !errors.Is(err, punaropostgres.ErrNotFound) {
+		return operator.UpdateStage{}, errors.New("active update state could not be inspected")
+	}
+	executor := &commandUpdateExecutor{installation: installation, stage: stage}
+	if err := executor.AbortUnpublishedStart(recoveryCtx); err != nil {
+		return operator.UpdateStage{}, err
+	}
+	return stage, nil
 }
 
 func updatePostgresMajor(ctx context.Context, dsnFile string) (int, error) {
@@ -176,26 +267,185 @@ func updatePostgresMajor(ctx context.Context, dsnFile string) (int, error) {
 	return database.PostgreSQLMajor(ctx)
 }
 
-func readReleaseMetadata(path string) ([]byte, error) {
-	if !filepath.IsAbs(path) || filepath.Clean(path) != path {
-		return nil, errors.New("release metadata path is invalid")
-	}
-	info, err := os.Lstat(path)
-	if err != nil || !info.Mode().IsRegular() || info.Size() < 1 || info.Size() > punarorelease.MaximumMetadataBytes || info.Mode().Perm()&0o077 != 0 {
-		return nil, errors.New("release metadata file is unsafe")
-	}
-	file, err := os.Open(path) // #nosec G304 -- explicit protected release metadata path.
+func loadSignedUpdateMetadata(manifestPath, signaturePath, keysPath string, environment punarorelease.Environment) (punarorelease.Metadata, error) {
+	release, err := loadSignedUpdateRelease(manifestPath, signaturePath, keysPath, environment)
+	return release.metadata, err
+}
+
+func loadSignedUpdateRelease(manifestPath, signaturePath, keysPath string, environment punarorelease.Environment) (signedUpdateRelease, error) {
+	manifestBody, err := readProtectedReleaseFile(manifestPath, punarorelease.MaximumManifestBytes)
 	if err != nil {
-		return nil, err
+		return signedUpdateRelease{}, err
+	}
+	signatureBody, err := readProtectedReleaseFile(signaturePath, punarorelease.MaximumEnvelopeBytes)
+	if err != nil {
+		return signedUpdateRelease{}, err
+	}
+	keysBody, err := readProtectedReleaseFile(keysPath, punarorelease.MaximumEnvelopeBytes)
+	if err != nil {
+		return signedUpdateRelease{}, err
+	}
+	metadata, err := punarorelease.ParseSignedManifest(manifestBody, signatureBody, keysBody, environment)
+	if err != nil {
+		return signedUpdateRelease{}, err
+	}
+	manifest, err := punarorelease.ParseReleaseManifest(manifestBody)
+	if err != nil {
+		return signedUpdateRelease{}, err
+	}
+	sum := sha256.Sum256(manifestBody)
+	return signedUpdateRelease{
+		metadata:          metadata,
+		manifestSequence:  manifest.Sequence,
+		manifestSHA256:    hex.EncodeToString(sum[:]),
+		publicReleaseKeys: append([]byte(nil), keysBody...),
+	}, nil
+}
+
+func authorizeUpdateStart(request punaropostgres.UpdateRequest, directory, catalogPath, catalogSignaturePath string, release signedUpdateRelease, now time.Time, embeddedMinimum int64) (func(), func(time.Time) error, error) {
+	if embeddedMinimum < 1 {
+		return nil, nil, errUpdateCatalogFloor
+	}
+	if request.UpdateID != "" {
+		return func() {}, func(time.Time) error { return nil }, nil
+	}
+	if catalogPath == "" || catalogSignaturePath == "" {
+		return nil, nil, errUpdateCatalogRequired
+	}
+	catalogBody, err := readProtectedReleaseFile(catalogPath, punarorelease.MaximumManifestBytes)
+	if err != nil {
+		return nil, nil, errors.New("signed release catalog is unavailable, unsafe, stale, or does not authorize the target")
+	}
+	signatureBody, err := readProtectedReleaseFile(catalogSignaturePath, punarorelease.MaximumEnvelopeBytes)
+	if err != nil {
+		return nil, nil, errors.New("signed release catalog is unavailable, unsafe, stale, or does not authorize the target")
+	}
+	keys, err := punarorelease.ParsePublicKeys(release.publicReleaseKeys)
+	if err != nil {
+		return nil, nil, errors.New("signed release catalog is unavailable, unsafe, stale, or does not authorize the target")
+	}
+	envelope, err := punarorelease.ParseEnvelope(signatureBody)
+	if err != nil || punarorelease.Verify(catalogBody, envelope, keys) != nil {
+		return nil, nil, errors.New("signed release catalog is unavailable, unsafe, stale, or does not authorize the target")
+	}
+	catalog, err := punarorelease.ParseCatalog(catalogBody)
+	if err != nil || !catalog.Fresh(now) || !catalog.Allows(release.metadata.Release, release.manifestSequence, release.manifestSHA256) {
+		return nil, nil, errors.New("signed release catalog is unavailable, unsafe, stale, or does not authorize the target")
+	}
+	unlock, err := operator.BeginServerCatalogAcceptance(directory, catalog.Sequence, embeddedMinimum)
+	if err != nil {
+		return nil, nil, errors.New("signed release catalog is unavailable, unsafe, stale, or does not authorize the target")
+	}
+	revalidate := func(current time.Time) error {
+		if !catalog.Fresh(current) {
+			return errors.New("signed release catalog expired before durable update transaction creation")
+		}
+		return nil
+	}
+	return unlock, revalidate, nil
+}
+
+func (executor *commandUpdateExecutor) ReleaseStartGuard() {
+	if executor.startGuard != nil {
+		executor.startGuard()
+		executor.startGuard = nil
+	}
+}
+
+func (executor *commandUpdateExecutor) RevalidateStart(context.Context) error {
+	if executor.startRevalidate == nil {
+		return errors.New("signed release catalog authorization is unavailable")
+	}
+	return executor.startRevalidate(time.Now().UTC())
+}
+
+func (executor *commandUpdateExecutor) StartTransactionDurable() bool {
+	return executor.bridge == nil
+}
+
+func (executor *commandUpdateExecutor) AbortUnpublishedStart(ctx context.Context) error {
+	recoveryCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), time.Minute)
+	defer cancel()
+	if !executor.orphanedWriters {
+		if _, err := operator.ResumeUpdateStage(executor.stage); err == nil {
+			stopped, stopErr := executor.configuredWritersStopped(recoveryCtx)
+			if stopErr != nil {
+				return errors.New("configured writer state could not be inspected before unpublished stage cleanup")
+			}
+			executor.orphanedWriters = stopped
+		}
+	}
+	if executor.orphanedWriters {
+		return executor.restorePreviousWriterAndAbortStage(recoveryCtx)
+	}
+	return operator.AbortStage(executor.stage)
+}
+
+func (executor *commandUpdateExecutor) AbortPendingStart(ctx context.Context) error {
+	if executor.bridge == nil {
+		return errors.New("pending update start is unavailable")
+	}
+	bridge := executor.bridge
+	executor.bridge = nil
+	recoveryCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), time.Minute)
+	defer cancel()
+	if abortErr := bridge.Abort(); abortErr != nil {
+		durable, durableErr := reconcileUpdateTransaction(recoveryCtx, executor.installation, executor.request.UpdateID)
+		switch {
+		case durableErr == nil && durable.UpdateRequest == executor.request:
+			return errors.Join(abortErr, errors.New("pending update start became durable during rollback"))
+		case durableErr == nil:
+			return errors.Join(abortErr, errors.New("pending update rollback found a different durable transaction"))
+		case errors.Is(durableErr, punaropostgres.ErrNotFound):
+			return errors.Join(abortErr, executor.restorePreviousWriterAndAbortStage(recoveryCtx))
+		default:
+			return errors.Join(abortErr, errors.New("pending update rollback outcome could not be inspected"))
+		}
+	}
+	return executor.restorePreviousWriterAndAbortStage(recoveryCtx)
+}
+
+func (executor *commandUpdateExecutor) restorePreviousWriterAndAbortStage(ctx context.Context) error {
+	if err := startServices(ctx, executor.installation); err != nil {
+		return errors.New("previous writer could not be restarted")
+	}
+	if err := waitForReady(ctx, executor.installation); err != nil {
+		return errors.New("previous writer did not recover readiness")
+	}
+	if err := operator.AbortStage(executor.stage); err != nil {
+		return errors.New("unpublished update stage could not be removed after writer recovery")
+	}
+	executor.orphanedWriters = false
+	return nil
+}
+
+func serverUpdateCatalogMinimum() int64 {
+	sequence, err := strconv.ParseInt(serverBuildCatalogSequence, 10, 64)
+	if err != nil || sequence < 1 {
+		return 0
+	}
+	return sequence
+}
+
+func readProtectedReleaseFile(path string, maximum int64) ([]byte, error) {
+	if !filepath.IsAbs(path) || filepath.Clean(path) != path {
+		return nil, errors.New("release file path is invalid")
+	}
+	if maximum < 1 {
+		return nil, errors.New("release file is unsafe")
+	}
+	file, err := operator.OpenTrustedExternalFile(path, maximum)
+	if err != nil {
+		return nil, errors.New("release file is unsafe")
 	}
 	defer func() { _ = file.Close() }()
 	opened, err := file.Stat()
-	if err != nil || !os.SameFile(info, opened) {
-		return nil, errors.New("release metadata changed during open")
+	if err != nil || !opened.Mode().IsRegular() || opened.Size() < 1 || opened.Size() > maximum {
+		return nil, errors.New("release file changed during open")
 	}
-	body, err := io.ReadAll(io.LimitReader(file, punarorelease.MaximumMetadataBytes+1))
-	if err != nil || len(body) > punarorelease.MaximumMetadataBytes {
-		return nil, errors.New("release metadata is too large")
+	body, err := io.ReadAll(io.LimitReader(file, maximum+1))
+	if err != nil || int64(len(body)) > maximum {
+		return nil, errors.New("release file is too large")
 	}
 	return body, nil
 }
@@ -246,6 +496,17 @@ func metadataMatchesUpdateRequest(metadata punarorelease.Metadata, request punar
 		request.PostgresMajor == metadata.PostgreSQLMajor && request.ReleaseSHA256 == metadata.ReleaseSHA256 && request.ComposeSHA256 == metadata.ComposeSHA256 && request.MigrationManifestSHA256 == metadata.MigrationManifestSHA256
 }
 
+func targetReleaseMatchesUpdater(metadata punarorelease.Metadata, buildRelease string) bool {
+	return buildRelease != "" && metadata.Release == buildRelease
+}
+
+func validateUpdateSource(metadata punarorelease.Metadata, source string) error {
+	if !metadata.SupportsDirectUpdateFrom(source) {
+		return errors.New("signed target release manifest does not support a direct update from the current release")
+	}
+	return nil
+}
+
 func classifyUpdateLookupOpenError(state punaropostgres.SchemaState, inspectErr, openErr error) error {
 	if inspectErr == nil && state.Classification == punaropostgres.UpgradeRequired && state.Version == 5 {
 		return punaropostgres.ErrNotFound
@@ -275,6 +536,7 @@ func (executor *commandUpdateExecutor) PreflightAndPull(ctx context.Context) err
 		}
 		executor.staged = staged
 		orphanedBridge = true
+		executor.orphanedWriters = true
 	}
 	appIdentity, appErr := postgresDatabaseIdentity(ctx, executor.installation.AppDSNFile)
 	ownerIdentity, ownerErr := postgresOwnerDatabaseIdentity(ctx, executor.installation.OwnerDSNFile)
@@ -610,8 +872,27 @@ func (executor *commandUpdateExecutor) Recover(ctx context.Context, transaction 
 func (executor *commandUpdateExecutor) Advance(ctx context.Context, transaction punaropostgres.UpdateTransaction, to punaropostgres.UpdatePhase, marker *punaropostgres.UpdateBackupMarker) (punaropostgres.UpdateTransaction, error) {
 	if executor.bridge != nil && transaction.Phase == punaropostgres.UpdateFenced && to == punaropostgres.UpdateWritersStopped {
 		advanced, err := executor.bridge.CommitWritersStopped(ctx)
+		if err == nil {
+			executor.bridge = nil
+			return advanced, nil
+		}
+		if !errors.Is(err, punaropostgres.ErrV5UpdateBridgeOutcomeUncertain) {
+			return transaction, errors.Join(err, executor.AbortPendingStart(ctx))
+		}
 		executor.bridge = nil
-		return advanced, err
+		recoveryCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), time.Minute)
+		defer cancel()
+		durable, durableErr := reconcileUpdateTransaction(recoveryCtx, executor.installation, transaction.UpdateID)
+		if durableErr == nil {
+			if durable.UpdateRequest == executor.request && durable.Phase == punaropostgres.UpdateWritersStopped {
+				return durable, nil
+			}
+			return transaction, errors.Join(err, errors.New("v5 update bridge durable outcome does not match the staged request"))
+		}
+		if errors.Is(durableErr, punaropostgres.ErrNotFound) {
+			return transaction, errors.Join(err, executor.restorePreviousWriterAndAbortStage(recoveryCtx))
+		}
+		return transaction, errors.Join(err, errors.New("v5 update bridge durable outcome could not be inspected"))
 	}
 	admin, err := punaropostgres.OpenAdministration(ctx, punaropostgres.Config{DSNFile: executor.installation.OwnerDSNFile})
 	if err != nil {

--- a/cmd/punaro/update_command_test.go
+++ b/cmd/punaro/update_command_test.go
@@ -1,16 +1,44 @@
 package main
 
 import (
+	"bytes"
 	"context"
+	"crypto/ed25519"
+	"crypto/rand"
 	"errors"
 	"os"
 	"path/filepath"
+	"runtime"
+	"slices"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/rock3r/punaro/internal/operator"
 	punaropostgres "github.com/rock3r/punaro/internal/postgres"
 	punarorelease "github.com/rock3r/punaro/internal/release"
 )
+
+type fakeV5UpdateBridge struct {
+	update    punaropostgres.UpdateTransaction
+	commit    punaropostgres.UpdateTransaction
+	commitErr error
+	abortErr  error
+	aborts    int
+}
+
+func (bridge *fakeV5UpdateBridge) Update() punaropostgres.UpdateTransaction {
+	return bridge.update
+}
+
+func (bridge *fakeV5UpdateBridge) CommitWritersStopped(context.Context) (punaropostgres.UpdateTransaction, error) {
+	return bridge.commit, bridge.commitErr
+}
+
+func (bridge *fakeV5UpdateBridge) Abort() error {
+	bridge.aborts++
+	return bridge.abortErr
+}
 
 func TestUpdateLookupTreatsOnlyPreBridgeV5AsNoActiveUpdate(t *testing.T) {
 	openErr := errors.New("administration unavailable")
@@ -47,6 +75,19 @@ func TestCompletedUpdateReconciliationRequiresExactPublishedOutcome(t *testing.T
 	}
 }
 
+func TestUpdateSourcePolicyAllowsOnlySignedDirectSources(t *testing.T) {
+	metadata := punarorelease.Metadata{SupportedFrom: []string{"v0.1.0-alpha.11"}}
+	if err := validateUpdateSource(metadata, "v0.1.0-alpha.11"); err != nil {
+		t.Fatalf("signed direct source rejected: %v", err)
+	}
+	if err := validateUpdateSource(metadata, "v0.1.0-alpha.10"); err == nil {
+		t.Fatal("source absent from signed policy accepted")
+	}
+	if err := validateUpdateSource(punarorelease.Metadata{}, "v0.1.0-alpha.11"); err == nil {
+		t.Fatal("empty first-install policy accepted as a server update edge")
+	}
+}
+
 func TestUpdateResumeUsesLocallyVerifiedTargetWithoutRegistryPull(t *testing.T) {
 	directory := testInstallation(t)
 	installation, err := operator.Load(directory)
@@ -75,6 +116,354 @@ func TestUpdateResumeUsesLocallyVerifiedTargetWithoutRegistryPull(t *testing.T) 
 	}
 	if pulled {
 		t.Fatal("durable update resume depended on a fresh registry pull")
+	}
+}
+
+func TestAbortUnpublishedStartRemovesDurableHostStage(t *testing.T) {
+	preserveDependencies(t)
+	directory := testInstallation(t)
+	installation, err := operator.Load(directory)
+	if err != nil {
+		t.Fatal(err)
+	}
+	request := testUpdateRequest()
+	request.SourceImage = installation.Image
+	stage := operator.UpdateStage{Directory: directory, UpdateID: request.UpdateID, PreviousRelease: request.SourceRelease, PreviousImage: request.SourceImage, TargetRelease: request.TargetRelease, TargetImage: request.TargetImage}
+	if _, err := operator.StageUpdate(stage); err != nil {
+		t.Fatal(err)
+	}
+	runUpdateDocker = func(context.Context, string, []string, ...string) ([]byte, error) {
+		return []byte("punarod\n"), nil
+	}
+	executor := &commandUpdateExecutor{installation: installation, request: request, stage: stage}
+	if err := executor.AbortUnpublishedStart(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(filepath.Join(directory, ".update")); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("unpublished update stage remains after authorization failure: %v", err)
+	}
+}
+
+func TestAbortUnpublishedStartPreservesStageWhenWriterStateIsUnknown(t *testing.T) {
+	preserveDependencies(t)
+	directory := testInstallation(t)
+	installation, err := operator.Load(directory)
+	if err != nil {
+		t.Fatal(err)
+	}
+	request := testUpdateRequest()
+	request.SourceImage = installation.Image
+	stage := operator.UpdateStage{Directory: directory, UpdateID: request.UpdateID, PreviousRelease: request.SourceRelease, PreviousImage: request.SourceImage, TargetRelease: request.TargetRelease, TargetImage: request.TargetImage}
+	if _, err := operator.StageUpdate(stage); err != nil {
+		t.Fatal(err)
+	}
+	runUpdateDocker = func(context.Context, string, []string, ...string) ([]byte, error) {
+		return nil, errors.New("injected Docker outage")
+	}
+	executor := &commandUpdateExecutor{installation: installation, request: request, stage: stage}
+	if err := executor.AbortUnpublishedStart(context.Background()); err == nil {
+		t.Fatal("unpublished stage was cleaned without knowing whether the writer was stopped")
+	}
+	if _, err := os.Stat(filepath.Join(directory, ".update")); err != nil {
+		t.Fatalf("stage was not preserved while writer state was unknown: %v", err)
+	}
+}
+
+func TestAbortUnpublishedStartRestoresOrphanedWriterBeforeRemovingStage(t *testing.T) {
+	preserveDependencies(t)
+	directory := testInstallation(t)
+	installation, err := operator.Load(directory)
+	if err != nil {
+		t.Fatal(err)
+	}
+	request := testUpdateRequest()
+	request.SourceImage = installation.Image
+	stage := operator.UpdateStage{Directory: directory, UpdateID: request.UpdateID, PreviousRelease: request.SourceRelease, PreviousImage: request.SourceImage, TargetRelease: request.TargetRelease, TargetImage: request.TargetImage}
+	if _, err := operator.StageUpdate(stage); err != nil {
+		t.Fatal(err)
+	}
+	actions := []string{}
+	startServices = func(context.Context, operator.Installation) error {
+		actions = append(actions, "start_previous")
+		return nil
+	}
+	probe = func(context.Context, string) error {
+		actions = append(actions, "ready_previous")
+		return nil
+	}
+	executor := &commandUpdateExecutor{installation: installation, request: request, stage: stage, orphanedWriters: true}
+	canceled, cancel := context.WithCancel(context.Background())
+	cancel()
+	if err := executor.AbortUnpublishedStart(canceled); err != nil {
+		t.Fatal(err)
+	}
+	if want := []string{"start_previous", "ready_previous"}; !slices.Equal(actions, want) {
+		t.Fatalf("actions=%v want=%v", actions, want)
+	}
+	if _, err := os.Stat(filepath.Join(directory, ".update")); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("orphaned update stage remains after writer recovery: %v", err)
+	}
+}
+
+func TestAbortUnpublishedStartPreservesOrphanedStageWhenWriterCannotRecover(t *testing.T) {
+	preserveDependencies(t)
+	directory := testInstallation(t)
+	installation, err := operator.Load(directory)
+	if err != nil {
+		t.Fatal(err)
+	}
+	request := testUpdateRequest()
+	request.SourceImage = installation.Image
+	stage := operator.UpdateStage{Directory: directory, UpdateID: request.UpdateID, PreviousRelease: request.SourceRelease, PreviousImage: request.SourceImage, TargetRelease: request.TargetRelease, TargetImage: request.TargetImage}
+	if _, err := operator.StageUpdate(stage); err != nil {
+		t.Fatal(err)
+	}
+	startServices = func(context.Context, operator.Installation) error { return errors.New("injected restart failure") }
+	executor := &commandUpdateExecutor{installation: installation, request: request, stage: stage, orphanedWriters: true}
+	if err := executor.AbortUnpublishedStart(context.Background()); err == nil {
+		t.Fatal("orphaned stage cleanup succeeded without recovering the previous writer")
+	}
+	if _, err := os.Stat(filepath.Join(directory, ".update")); err != nil {
+		t.Fatalf("orphaned stage was not preserved for recovery: %v", err)
+	}
+}
+
+func TestRunUpdateAbortCleansConfirmedTransactionFreeStageWithoutReleaseAuthorization(t *testing.T) {
+	preserveDependencies(t)
+	directory := testInstallation(t)
+	installation, err := operator.Load(directory)
+	if err != nil {
+		t.Fatal(err)
+	}
+	request := testUpdateRequest()
+	request.SourceImage = installation.Image
+	stage := operator.UpdateStage{Directory: directory, UpdateID: request.UpdateID, PreviousRelease: request.SourceRelease, PreviousImage: request.SourceImage, TargetRelease: request.TargetRelease, TargetImage: request.TargetImage}
+	if _, err := operator.StageUpdate(stage); err != nil {
+		t.Fatal(err)
+	}
+	actions := []string{}
+	runUpdateDocker = func(context.Context, string, []string, ...string) ([]byte, error) { return nil, nil }
+	startServices = func(context.Context, operator.Installation) error {
+		actions = append(actions, "start_previous")
+		return nil
+	}
+	probe = func(context.Context, string) error {
+		actions = append(actions, "ready_previous")
+		return nil
+	}
+	reconcileUpdateTransaction = func(ctx context.Context, _ operator.Installation, updateID string) (punaropostgres.UpdateTransaction, error) {
+		if ctx.Err() != nil {
+			t.Fatalf("cleanup context is unavailable: %v", ctx.Err())
+		}
+		if updateID != "" && updateID != request.UpdateID {
+			t.Fatalf("unexpected update ID %q", updateID)
+		}
+		return punaropostgres.UpdateTransaction{}, punaropostgres.ErrNotFound
+	}
+	var stdout, stderr bytes.Buffer
+	if code := runUpdate([]string{"--directory", directory, "--abort"}, &stdout, &stderr); code != 0 || !strings.Contains(stdout.String(), `"status": "unpublished_stage_aborted"`) {
+		t.Fatalf("cleanup code=%d stdout=%q stderr=%q", code, stdout.String(), stderr.String())
+	}
+	if !slices.Equal(actions, []string{"start_previous", "ready_previous"}) {
+		t.Fatalf("actions=%v", actions)
+	}
+	if _, err := os.Stat(filepath.Join(directory, ".update")); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("transaction-free stage remains after cleanup: %v", err)
+	}
+}
+
+func TestCleanupUnpublishedUpdatePreservesStageWithDurableTransaction(t *testing.T) {
+	preserveDependencies(t)
+	directory := testInstallation(t)
+	installation, err := operator.Load(directory)
+	if err != nil {
+		t.Fatal(err)
+	}
+	request := testUpdateRequest()
+	request.SourceImage = installation.Image
+	stage := operator.UpdateStage{Directory: directory, UpdateID: request.UpdateID, PreviousRelease: request.SourceRelease, PreviousImage: request.SourceImage, TargetRelease: request.TargetRelease, TargetImage: request.TargetImage}
+	if _, err := operator.StageUpdate(stage); err != nil {
+		t.Fatal(err)
+	}
+	reconcileUpdateTransaction = func(_ context.Context, _ operator.Installation, updateID string) (punaropostgres.UpdateTransaction, error) {
+		if updateID == request.UpdateID {
+			return punaropostgres.UpdateTransaction{UpdateRequest: request, Phase: punaropostgres.UpdateFenced}, nil
+		}
+		return punaropostgres.UpdateTransaction{}, punaropostgres.ErrNotFound
+	}
+	if _, err := cleanupUnpublishedUpdate(context.Background(), installation); err == nil {
+		t.Fatal("cleanup removed a stage with durable database state")
+	}
+	if _, err := os.Stat(filepath.Join(directory, ".update")); err != nil {
+		t.Fatalf("durable stage was not preserved: %v", err)
+	}
+}
+
+func TestAbortPendingStartRecoversFailedBridgeRollbackWhenTransactionIsAbsent(t *testing.T) {
+	preserveDependencies(t)
+	directory := testInstallation(t)
+	installation, err := operator.Load(directory)
+	if err != nil {
+		t.Fatal(err)
+	}
+	request := testUpdateRequest()
+	request.SourceImage = installation.Image
+	request.SourceSchema, request.TargetSchema, request.SchemaMin, request.SchemaMax, request.RollbackFloor = 5, 6, 5, 6, 5
+	stage := operator.UpdateStage{Directory: directory, UpdateID: request.UpdateID, PreviousRelease: request.SourceRelease, PreviousImage: request.SourceImage, TargetRelease: request.TargetRelease, TargetImage: request.TargetImage}
+	if _, err := operator.StageUpdate(stage); err != nil {
+		t.Fatal(err)
+	}
+	actions := []string{}
+	startServices = func(context.Context, operator.Installation) error {
+		actions = append(actions, "start_previous")
+		return nil
+	}
+	probe = func(context.Context, string) error {
+		actions = append(actions, "ready_previous")
+		return nil
+	}
+	reconcileUpdateTransaction = func(ctx context.Context, _ operator.Installation, updateID string) (punaropostgres.UpdateTransaction, error) {
+		if ctx.Err() != nil || updateID != request.UpdateID {
+			t.Fatalf("reconciliation context=%v update_id=%q", ctx.Err(), updateID)
+		}
+		return punaropostgres.UpdateTransaction{}, punaropostgres.ErrNotFound
+	}
+	bridge := &fakeV5UpdateBridge{abortErr: errors.New("injected rollback failure")}
+	executor := &commandUpdateExecutor{installation: installation, request: request, stage: stage, bridge: bridge}
+	canceled, cancel := context.WithCancel(context.Background())
+	cancel()
+	if err := executor.AbortPendingStart(canceled); err == nil {
+		t.Fatal("failed bridge rollback lost its original error")
+	}
+	if executor.bridge != nil || bridge.aborts != 1 || !slices.Equal(actions, []string{"start_previous", "ready_previous"}) {
+		t.Fatalf("bridge_present=%t aborts=%d actions=%v", executor.bridge != nil, bridge.aborts, actions)
+	}
+	if _, err := os.Stat(filepath.Join(directory, ".update")); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("unpublished update stage remains after confirmed-absent rollback recovery: %v", err)
+	}
+}
+
+func TestAbortPendingStartPreservesFailedBridgeRollbackWhenDurabilityIsUnknown(t *testing.T) {
+	preserveDependencies(t)
+	directory := testInstallation(t)
+	installation, err := operator.Load(directory)
+	if err != nil {
+		t.Fatal(err)
+	}
+	request := testUpdateRequest()
+	request.SourceImage = installation.Image
+	request.SourceSchema, request.TargetSchema, request.SchemaMin, request.SchemaMax, request.RollbackFloor = 5, 6, 5, 6, 5
+	stage := operator.UpdateStage{Directory: directory, UpdateID: request.UpdateID, PreviousRelease: request.SourceRelease, PreviousImage: request.SourceImage, TargetRelease: request.TargetRelease, TargetImage: request.TargetImage}
+	if _, err := operator.StageUpdate(stage); err != nil {
+		t.Fatal(err)
+	}
+	reconcileUpdateTransaction = func(context.Context, operator.Installation, string) (punaropostgres.UpdateTransaction, error) {
+		return punaropostgres.UpdateTransaction{}, errors.New("injected database outage")
+	}
+	bridge := &fakeV5UpdateBridge{abortErr: errors.New("injected rollback failure")}
+	executor := &commandUpdateExecutor{installation: installation, request: request, stage: stage, bridge: bridge}
+	if err := executor.AbortPendingStart(context.Background()); err == nil {
+		t.Fatal("unknown bridge rollback outcome unexpectedly recovered")
+	}
+	if _, err := os.Stat(filepath.Join(directory, ".update")); err != nil {
+		t.Fatalf("stage was not preserved while rollback durability was unknown: %v", err)
+	}
+}
+
+func TestV5BridgeCommitReconcilesDurableWritersStoppedOutcome(t *testing.T) {
+	preserveDependencies(t)
+	request := testUpdateRequest()
+	request.SourceSchema, request.TargetSchema, request.SchemaMin, request.SchemaMax, request.RollbackFloor = 5, 6, 5, 6, 5
+	transaction := punaropostgres.UpdateTransaction{UpdateRequest: request, Phase: punaropostgres.UpdateFenced}
+	durable := transaction
+	durable.Phase = punaropostgres.UpdateWritersStopped
+	bridge := &fakeV5UpdateBridge{update: transaction, commit: durable, commitErr: punaropostgres.ErrV5UpdateBridgeOutcomeUncertain}
+	reconcileUpdateTransaction = func(_ context.Context, _ operator.Installation, updateID string) (punaropostgres.UpdateTransaction, error) {
+		if updateID != request.UpdateID {
+			t.Fatalf("reconciled update ID=%q", updateID)
+		}
+		return durable, nil
+	}
+	executor := &commandUpdateExecutor{request: request, bridge: bridge}
+	advanced, err := executor.Advance(context.Background(), transaction, punaropostgres.UpdateWritersStopped, nil)
+	if err != nil || advanced != durable || executor.bridge != nil || bridge.aborts != 0 {
+		t.Fatalf("advanced=%#v err=%v bridge_present=%t aborts=%d", advanced, err, executor.bridge != nil, bridge.aborts)
+	}
+}
+
+func TestV5BridgeCommitFailureRestoresWriterAndRemovesUnpublishedStage(t *testing.T) {
+	for _, test := range []struct {
+		name       string
+		commitErr  error
+		durableErr error
+		wantAborts int
+	}{
+		{name: "precommit", commitErr: errors.New("commit staging failed"), wantAborts: 1},
+		{name: "uncertain absent", commitErr: punaropostgres.ErrV5UpdateBridgeOutcomeUncertain, durableErr: punaropostgres.ErrNotFound},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			preserveDependencies(t)
+			directory := testInstallation(t)
+			installation, err := operator.Load(directory)
+			if err != nil {
+				t.Fatal(err)
+			}
+			request := testUpdateRequest()
+			request.SourceImage = installation.Image
+			request.SourceSchema, request.TargetSchema, request.SchemaMin, request.SchemaMax, request.RollbackFloor = 5, 6, 5, 6, 5
+			transaction := punaropostgres.UpdateTransaction{UpdateRequest: request, Phase: punaropostgres.UpdateFenced}
+			stage := operator.UpdateStage{Directory: directory, UpdateID: request.UpdateID, PreviousRelease: request.SourceRelease, PreviousImage: request.SourceImage, TargetRelease: request.TargetRelease, TargetImage: request.TargetImage}
+			if _, err := operator.StageUpdate(stage); err != nil {
+				t.Fatal(err)
+			}
+			startServices = func(context.Context, operator.Installation) error { return nil }
+			probe = func(context.Context, string) error { return nil }
+			reconcileUpdateTransaction = func(ctx context.Context, _ operator.Installation, _ string) (punaropostgres.UpdateTransaction, error) {
+				if ctx.Err() != nil {
+					t.Fatalf("bridge reconciliation reused canceled operation context: %v", ctx.Err())
+				}
+				return punaropostgres.UpdateTransaction{}, test.durableErr
+			}
+			bridge := &fakeV5UpdateBridge{update: transaction, commitErr: test.commitErr}
+			executor := &commandUpdateExecutor{installation: installation, request: request, stage: stage, bridge: bridge}
+			canceled, cancel := context.WithCancel(context.Background())
+			cancel()
+			advanced, err := executor.Advance(canceled, transaction, punaropostgres.UpdateWritersStopped, nil)
+			if err == nil || advanced != transaction || executor.bridge != nil || bridge.aborts != test.wantAborts {
+				t.Fatalf("advanced=%#v err=%v bridge_present=%t aborts=%d", advanced, err, executor.bridge != nil, bridge.aborts)
+			}
+			if _, err := os.Stat(filepath.Join(directory, ".update")); !errors.Is(err, os.ErrNotExist) {
+				t.Fatalf("unpublished update stage remains after bridge failure recovery: %v", err)
+			}
+		})
+	}
+}
+
+func TestV5BridgeUncertainCommitPreservesStageWhenDurableStateIsUnavailable(t *testing.T) {
+	preserveDependencies(t)
+	directory := testInstallation(t)
+	installation, err := operator.Load(directory)
+	if err != nil {
+		t.Fatal(err)
+	}
+	request := testUpdateRequest()
+	request.SourceImage = installation.Image
+	request.SourceSchema, request.TargetSchema, request.SchemaMin, request.SchemaMax, request.RollbackFloor = 5, 6, 5, 6, 5
+	transaction := punaropostgres.UpdateTransaction{UpdateRequest: request, Phase: punaropostgres.UpdateFenced}
+	stage := operator.UpdateStage{Directory: directory, UpdateID: request.UpdateID, PreviousRelease: request.SourceRelease, PreviousImage: request.SourceImage, TargetRelease: request.TargetRelease, TargetImage: request.TargetImage}
+	if _, err := operator.StageUpdate(stage); err != nil {
+		t.Fatal(err)
+	}
+	reconcileUpdateTransaction = func(context.Context, operator.Installation, string) (punaropostgres.UpdateTransaction, error) {
+		return punaropostgres.UpdateTransaction{}, errors.New("injected database outage")
+	}
+	bridge := &fakeV5UpdateBridge{update: transaction, commitErr: punaropostgres.ErrV5UpdateBridgeOutcomeUncertain}
+	executor := &commandUpdateExecutor{installation: installation, request: request, stage: stage, bridge: bridge}
+	if _, err := executor.Advance(context.Background(), transaction, punaropostgres.UpdateWritersStopped, nil); err == nil {
+		t.Fatal("uncertain bridge outcome passed without durable reconciliation")
+	}
+	if _, err := os.Stat(filepath.Join(directory, ".update")); err != nil {
+		t.Fatalf("stage was not preserved while bridge durability was unknown: %v", err)
 	}
 }
 
@@ -149,4 +538,260 @@ func TestRestoredRecoveryDoctorsExactSourceSchemaBeforePublishing(t *testing.T) 
 	if err := executor.Publish(context.Background(), transaction, true); err != nil {
 		t.Fatalf("restored recovery publication failed: %v", err)
 	}
+}
+
+func TestLoadSignedUpdateMetadataProjectsVerifiedManifest(t *testing.T) {
+	manifestPath, signaturePath, keysPath := signedUpdateFiles(t)
+	metadata, err := loadSignedUpdateMetadata(manifestPath, signaturePath, keysPath, punarorelease.Environment{CurrentSchema: 44, PostgreSQLMajor: 18})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if metadata.Release != "v0.1.0" || metadata.Image != cliTestImage || metadata.Schema != (punarorelease.SchemaRange{Min: 1, Max: 44, Target: 44, RollbackFloor: 1}) || metadata.PostgreSQLMajor != 18 {
+		t.Fatalf("metadata=%#v", metadata)
+	}
+	if metadata.ReleaseSHA256 != cliTestImage[len("registry.example/punaro@sha256:"):] || metadata.ComposeSHA256 != operator.ComposeManifestSHA256() || metadata.MigrationManifestSHA256 != punaropostgres.MigrationManifestSHA256() {
+		t.Fatalf("metadata digests=%#v", metadata)
+	}
+	if len(metadata.SupportedFrom) != 1 || metadata.SupportedFrom[0] != "v0.0.9" {
+		t.Fatalf("metadata supported sources=%#v", metadata.SupportedFrom)
+	}
+}
+
+func TestTargetReleaseMustMatchEmbeddedUpdaterRelease(t *testing.T) {
+	metadata := punarorelease.Metadata{Release: "v0.1.0"}
+	if !targetReleaseMatchesUpdater(metadata, "v0.1.0") {
+		t.Fatal("exact target-release updater was rejected")
+	}
+	if targetReleaseMatchesUpdater(metadata, "v0.0.9") {
+		t.Fatal("source-release updater was accepted for the target manifest")
+	}
+	if targetReleaseMatchesUpdater(metadata, "") {
+		t.Fatal("unidentified updater was accepted for the target manifest")
+	}
+}
+
+func TestAuthorizeUpdateStartRequiresFreshCatalogForNewTransaction(t *testing.T) {
+	manifestPath, signaturePath, keysPath := signedUpdateFiles(t)
+	release, err := loadSignedUpdateRelease(manifestPath, signaturePath, keysPath, punarorelease.Environment{CurrentSchema: 44, PostgreSQLMajor: 18})
+	if err != nil {
+		t.Fatal(err)
+	}
+	catalogPath := filepath.Join(filepath.Dir(manifestPath), punarorelease.CatalogFile)
+	catalogSignaturePath := filepath.Join(filepath.Dir(manifestPath), punarorelease.CatalogSignatureFile)
+	directory := filepath.Dir(manifestPath)
+	now := time.Date(2026, 8, 31, 10, 0, 0, 0, time.UTC)
+	if err := authorizeUpdateStartForTest(punaropostgres.UpdateRequest{}, directory, catalogPath, catalogSignaturePath, release, now, 1); err != nil {
+		t.Fatalf("fresh signed catalog rejected: %v", err)
+	}
+	guard, revalidate, err := authorizeUpdateStart(punaropostgres.UpdateRequest{}, directory, catalogPath, catalogSignaturePath, release, now, 1)
+	if err != nil {
+		t.Fatalf("fresh signed catalog could not be retained for pre-fence recheck: %v", err)
+	}
+	if err := revalidate(time.Date(2026, 9, 6, 10, 0, 0, 0, time.UTC)); err == nil {
+		guard()
+		t.Fatal("catalog expiry during preflight was not rejected before fencing")
+	}
+	guard()
+	if err := authorizeUpdateStartForTest(punaropostgres.UpdateRequest{}, directory, "", "", release, now, 1); !errors.Is(err, errUpdateCatalogRequired) {
+		t.Fatalf("missing catalog error=%v", err)
+	}
+	if err := authorizeUpdateStartForTest(punaropostgres.UpdateRequest{UpdateID: "durable-update"}, "", "", "", signedUpdateRelease{}, now, 100); err != nil {
+		t.Fatalf("exact durable resume required a fresh catalog: %v", err)
+	}
+	for _, floor := range []int64{0, -1} {
+		if err := authorizeUpdateStartForTest(punaropostgres.UpdateRequest{}, directory, catalogPath, catalogSignaturePath, release, now, floor); !errors.Is(err, errUpdateCatalogFloor) {
+			t.Fatalf("invalid embedded floor %d error=%v", floor, err)
+		}
+		if err := authorizeUpdateStartForTest(punaropostgres.UpdateRequest{UpdateID: "durable-update"}, "", "", "", signedUpdateRelease{}, now, floor); !errors.Is(err, errUpdateCatalogFloor) {
+			t.Fatalf("invalid embedded floor %d allowed durable resume: %v", floor, err)
+		}
+	}
+
+	wrongBinding := release
+	wrongBinding.manifestSHA256 = "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+	if err := authorizeUpdateStartForTest(punaropostgres.UpdateRequest{}, directory, catalogPath, catalogSignaturePath, wrongBinding, now, 1); err == nil {
+		t.Fatal("catalog accepted a different manifest binding")
+	}
+	if err := authorizeUpdateStartForTest(punaropostgres.UpdateRequest{}, directory, catalogPath, catalogSignaturePath, release, time.Date(2026, 9, 6, 10, 0, 0, 0, time.UTC), 1); err == nil {
+		t.Fatal("expired catalog authorized a new update")
+	}
+
+	catalogBody, err := os.ReadFile(catalogPath) // #nosec G304 -- fixed test fixture path.
+	if err != nil {
+		t.Fatal(err)
+	}
+	catalogBody = bytes.Replace(catalogBody, []byte(`"current_release":"v0.1.0"`), []byte(`"current_release":"v0.1.1"`), 1)
+	if err := os.WriteFile(catalogPath, catalogBody, 0o600); err != nil { // #nosec G703 -- fixed test fixture path.
+		t.Fatal(err)
+	}
+	if err := authorizeUpdateStartForTest(punaropostgres.UpdateRequest{}, directory, catalogPath, catalogSignaturePath, release, now, 1); err == nil {
+		t.Fatal("tampered catalog authorized a new update")
+	}
+
+	manifestPath, signaturePath, keysPath = signedUpdateFiles(t)
+	release, err = loadSignedUpdateRelease(manifestPath, signaturePath, keysPath, punarorelease.Environment{CurrentSchema: 44, PostgreSQLMajor: 18})
+	if err != nil {
+		t.Fatal(err)
+	}
+	directory = filepath.Dir(manifestPath)
+	catalogPath = filepath.Join(directory, punarorelease.CatalogFile)
+	catalogSignaturePath = filepath.Join(directory, punarorelease.CatalogSignatureFile)
+	if err := operator.AcceptServerCatalogSequence(directory, 2, 0); err != nil {
+		t.Fatal(err)
+	}
+	if err := authorizeUpdateStartForTest(punaropostgres.UpdateRequest{}, directory, catalogPath, catalogSignaturePath, release, now, 1); err == nil {
+		t.Fatal("older still-fresh catalog replayed below the durable high-water")
+	}
+}
+
+func authorizeUpdateStartForTest(request punaropostgres.UpdateRequest, directory, catalogPath, catalogSignaturePath string, release signedUpdateRelease, now time.Time, embeddedMinimum int64) error {
+	unlock, revalidate, err := authorizeUpdateStart(request, directory, catalogPath, catalogSignaturePath, release, now, embeddedMinimum)
+	if err == nil {
+		err = revalidate(now)
+	}
+	if unlock != nil {
+		unlock()
+	}
+	return err
+}
+
+func TestLoadSignedUpdateMetadataRejectsTamperAndUnsafeFiles(t *testing.T) {
+	manifestPath, signaturePath, keysPath := signedUpdateFiles(t)
+	manifestBody, err := os.ReadFile(manifestPath) // #nosec G304 -- fixed test fixture path.
+	if err != nil {
+		t.Fatal(err)
+	}
+	manifestBody = bytes.Replace(manifestBody, []byte(`"release":"v0.1.0"`), []byte(`"release":"v0.1.1"`), 1)
+	if err := os.WriteFile(manifestPath, manifestBody, 0o600); err != nil { // #nosec G703 -- test helper returned this path beneath t.TempDir.
+		t.Fatal(err)
+	}
+	if _, err := loadSignedUpdateMetadata(manifestPath, signaturePath, keysPath, punarorelease.Environment{CurrentSchema: 44, PostgreSQLMajor: 18}); err == nil {
+		t.Fatal("tampered release manifest accepted")
+	}
+
+	if runtime.GOOS != "windows" {
+		manifestPath, signaturePath, keysPath = signedUpdateFiles(t)
+		if err := os.Chmod(signaturePath, 0o644); err != nil { // #nosec G302 -- deliberately unsafe test fixture verifies rejection.
+			t.Fatal(err)
+		}
+		if _, err := loadSignedUpdateMetadata(manifestPath, signaturePath, keysPath, punarorelease.Environment{CurrentSchema: 44, PostgreSQLMajor: 18}); err == nil {
+			t.Fatal("group/world-readable release signature accepted")
+		}
+	}
+
+	manifestPath, signaturePath, keysPath = signedUpdateFiles(t)
+	if err := os.Link(keysPath, keysPath+".link"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := loadSignedUpdateMetadata(manifestPath, signaturePath, keysPath, punarorelease.Environment{CurrentSchema: 44, PostgreSQLMajor: 18}); err == nil {
+		t.Fatal("multiply linked release trust root accepted")
+	}
+
+	manifestPath, signaturePath, keysPath = signedUpdateFiles(t)
+	unsafeDirectory := filepath.Join(filepath.Dir(keysPath), "unsafe")
+	if err := os.Mkdir(unsafeDirectory, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(unsafeDirectory, 0o777); err != nil { // #nosec G302 -- deliberately unsafe ancestor verifies rejection.
+		t.Fatal(err)
+	}
+	unsafeKeysPath := filepath.Join(unsafeDirectory, "punaro-release.pub")
+	keysBody, err := os.ReadFile(keysPath) // #nosec G304 -- fixed test fixture path beneath t.TempDir.
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(unsafeKeysPath, keysBody, 0o600); err != nil { // #nosec G703 -- test path is fixed beneath t.TempDir.
+		t.Fatal(err)
+	}
+	if _, err := loadSignedUpdateMetadata(manifestPath, signaturePath, unsafeKeysPath, punarorelease.Environment{CurrentSchema: 44, PostgreSQLMajor: 18}); err == nil {
+		t.Fatal("release trust root beneath writable ancestor accepted")
+	}
+}
+
+func TestUpdateRejectsLegacyUnsignedMetadataFlag(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	if code := runUpdate([]string{"--directory", "/private/tmp/punaro", "--release-metadata", "/private/tmp/release.json"}, &stdout, &stderr); code != 2 {
+		t.Fatalf("exit code=%d", code)
+	}
+}
+
+func signedUpdateFiles(t *testing.T) (string, string, string) {
+	t.Helper()
+	directory := t.TempDir()
+	if err := os.Chmod(directory, 0o700); err != nil { // #nosec G302 -- private test fixture directory.
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(directory, "punaro-linux-amd64"), []byte("operator"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	assembled, err := punarorelease.Assemble(punarorelease.AssembleRequest{
+		Directory:               directory,
+		Release:                 "v0.1.0",
+		Sequence:                1,
+		PublishedAt:             time.Date(2026, 8, 30, 10, 0, 0, 0, time.UTC),
+		ExpiresAt:               time.Date(2026, 9, 6, 10, 0, 0, 0, time.UTC),
+		MinimumSafeSequence:     1,
+		CatalogSequence:         1,
+		Image:                   cliTestImage,
+		ComposeSHA256:           operator.ComposeManifestSHA256(),
+		MigrationManifestSHA256: punaropostgres.MigrationManifestSHA256(),
+		Database:                punarorelease.SchemaRange{Min: 1, Max: 44, Target: 44, RollbackFloor: 1},
+		PostgreSQLMajor:         18,
+		GatewayProtocol:         punarorelease.ProtocolRange{Min: 1, Max: 1},
+		ClientProtocol:          punarorelease.ProtocolRange{Min: 1, Max: 1},
+		MinimumRecoveryProtocol: 1,
+		MinimumBootstrapRelease: "v0.1.0",
+		SupportedFrom:           []string{"v0.0.9"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	public, private, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	envelope, err := punarorelease.Sign(assembled.ManifestJSON, "punaro-release-1", private)
+	if err != nil {
+		t.Fatal(err)
+	}
+	signatureBody, err := punarorelease.EncodeEnvelope(envelope)
+	if err != nil {
+		t.Fatal(err)
+	}
+	keysBody, err := punarorelease.EncodePublicKeys("punaro-release-1", public)
+	if err != nil {
+		t.Fatal(err)
+	}
+	manifestPath := filepath.Join(directory, punarorelease.ReleaseManifestFile)
+	if err := os.Chmod(manifestPath, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	signaturePath := filepath.Join(directory, punarorelease.ReleaseSignatureFile)
+	if err := os.WriteFile(signaturePath, signatureBody, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	catalogEnvelope, err := punarorelease.Sign(assembled.CatalogJSON, "punaro-release-1", private)
+	if err != nil {
+		t.Fatal(err)
+	}
+	catalogSignatureBody, err := punarorelease.EncodeEnvelope(catalogEnvelope)
+	if err != nil {
+		t.Fatal(err)
+	}
+	catalogPath := filepath.Join(directory, punarorelease.CatalogFile)
+	if err := os.Chmod(catalogPath, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	catalogSignaturePath := filepath.Join(directory, punarorelease.CatalogSignatureFile)
+	if err := os.WriteFile(catalogSignaturePath, catalogSignatureBody, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	keysPath := filepath.Join(directory, "punaro-release.pub")
+	if err := os.WriteFile(keysPath, keysBody, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	for _, path := range []string{manifestPath, signaturePath, catalogPath, catalogSignaturePath, keysPath} {
+		protectUpdateFixtureFile(t, path)
+	}
+	return manifestPath, signaturePath, keysPath
 }

--- a/cmd/punaro/update_orchestrator.go
+++ b/cmd/punaro/update_orchestrator.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"errors"
+	"time"
 
 	punaropostgres "github.com/rock3r/punaro/internal/postgres"
 )
@@ -14,6 +15,11 @@ type updateExecution struct {
 }
 
 type updateExecutor interface {
+	ReleaseStartGuard()
+	RevalidateStart(context.Context) error
+	StartTransactionDurable() bool
+	AbortUnpublishedStart(context.Context) error
+	AbortPendingStart(context.Context) error
 	Active(context.Context) (punaropostgres.UpdateTransaction, error)
 	PreflightAndPull(context.Context) error
 	PrepareResume(context.Context, punaropostgres.UpdateTransaction) error
@@ -33,15 +39,38 @@ func executeUpdate(ctx context.Context, execution updateExecution, executor upda
 	if executor == nil || execution.Request.Validate() != nil {
 		return punaropostgres.UpdateTransaction{}, errors.New("update execution is invalid")
 	}
+	defer executor.ReleaseStartGuard()
 	transaction, err := executor.Active(ctx)
 	if errors.Is(err, punaropostgres.ErrNotFound) {
 		if execution.Abort || execution.RecoveryMode != "" {
 			return punaropostgres.UpdateTransaction{}, errors.New("no update transaction is active")
 		}
 		if err := executor.PreflightAndPull(ctx); err != nil {
-			return punaropostgres.UpdateTransaction{}, err
+			return punaropostgres.UpdateTransaction{}, errors.Join(err, executor.AbortUnpublishedStart(ctx))
+		}
+		if err := executor.RevalidateStart(ctx); err != nil {
+			return punaropostgres.UpdateTransaction{}, errors.Join(err, executor.AbortUnpublishedStart(ctx))
 		}
 		transaction, err = executor.Fence(ctx, execution.Request)
+		if err != nil {
+			fenceErr := err
+			reconcileCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), time.Minute)
+			defer cancel()
+			transaction, err = executor.Active(reconcileCtx)
+			switch {
+			case errors.Is(err, punaropostgres.ErrNotFound):
+				return punaropostgres.UpdateTransaction{}, errors.Join(fenceErr, executor.AbortUnpublishedStart(reconcileCtx))
+			case err != nil:
+				return punaropostgres.UpdateTransaction{}, errors.Join(fenceErr, errors.New("update fence outcome could not be reconciled"))
+			case transaction.UpdateRequest != execution.Request:
+				return transaction, errors.Join(fenceErr, errors.New("reconciled update target does not match the requested release"))
+			default:
+				err = nil
+			}
+		}
+		if err == nil && executor.StartTransactionDurable() {
+			executor.ReleaseStartGuard()
+		}
 	}
 	if err != nil {
 		return punaropostgres.UpdateTransaction{}, err
@@ -85,10 +114,22 @@ func executeUpdate(ctx context.Context, execution updateExecution, executor upda
 	for {
 		switch transaction.Phase {
 		case punaropostgres.UpdateFenced:
+			startCommitPending := !executor.StartTransactionDurable()
 			if err := executor.StopWriters(ctx); err != nil {
+				if startCommitPending {
+					return transaction, errors.Join(err, executor.AbortPendingStart(ctx))
+				}
 				return transaction, err
 			}
+			if startCommitPending {
+				if err := executor.RevalidateStart(ctx); err != nil {
+					return transaction, errors.Join(err, executor.AbortPendingStart(ctx))
+				}
+			}
 			transaction, err = executor.Advance(ctx, transaction, punaropostgres.UpdateWritersStopped, nil)
+			if startCommitPending {
+				executor.ReleaseStartGuard()
+			}
 		case punaropostgres.UpdateWritersStopped:
 			var marker punaropostgres.UpdateBackupMarker
 			marker, err = executor.Backup(ctx, transaction)

--- a/cmd/punaro/update_orchestrator_test.go
+++ b/cmd/punaro/update_orchestrator_test.go
@@ -10,9 +10,17 @@ import (
 )
 
 type fakeUpdateExecutor struct {
-	active  punaropostgres.UpdateTransaction
-	actions []string
-	failAt  string
+	active           punaropostgres.UpdateTransaction
+	actions          []string
+	failAt           string
+	fenceAfterCommit bool
+	deferredStart    bool
+	activeCalls      int
+	failActive       int
+	revalidateCalls  int
+	failRevalidate   int
+	guardReleased    bool
+	guardReleasedAt  int
 }
 
 func (fake *fakeUpdateExecutor) action(name string) error {
@@ -23,7 +31,42 @@ func (fake *fakeUpdateExecutor) action(name string) error {
 	return nil
 }
 
+func (fake *fakeUpdateExecutor) ReleaseStartGuard() {
+	if !fake.guardReleased {
+		fake.guardReleased = true
+		fake.guardReleasedAt = len(fake.actions)
+	}
+}
+
+func (fake *fakeUpdateExecutor) RevalidateStart(context.Context) error {
+	if err := fake.action("revalidate_start"); err != nil {
+		return err
+	}
+	fake.revalidateCalls++
+	if fake.failRevalidate == fake.revalidateCalls {
+		return errors.New("injected catalog expiry")
+	}
+	return nil
+}
+
+func (fake *fakeUpdateExecutor) StartTransactionDurable() bool {
+	return !fake.deferredStart || fake.active.Phase != punaropostgres.UpdateFenced
+}
+
+func (fake *fakeUpdateExecutor) AbortUnpublishedStart(context.Context) error {
+	return fake.action("abort_unpublished_start")
+}
+
+func (fake *fakeUpdateExecutor) AbortPendingStart(context.Context) error {
+	fake.deferredStart = false
+	return fake.action("abort_pending_start")
+}
+
 func (fake *fakeUpdateExecutor) Active(context.Context) (punaropostgres.UpdateTransaction, error) {
+	fake.activeCalls++
+	if fake.activeCalls == fake.failActive {
+		return punaropostgres.UpdateTransaction{}, errors.New("injected active inspection failure")
+	}
 	if fake.active.UpdateID == "" {
 		return punaropostgres.UpdateTransaction{}, punaropostgres.ErrNotFound
 	}
@@ -36,10 +79,13 @@ func (fake *fakeUpdateExecutor) PrepareResume(context.Context, punaropostgres.Up
 	return fake.action("resume_preflight")
 }
 func (fake *fakeUpdateExecutor) Fence(_ context.Context, request punaropostgres.UpdateRequest) (punaropostgres.UpdateTransaction, error) {
-	if err := fake.action("fence"); err != nil {
+	if err := fake.action("fence"); err != nil && !fake.fenceAfterCommit {
 		return punaropostgres.UpdateTransaction{}, err
 	}
 	fake.active = punaropostgres.UpdateTransaction{UpdateRequest: request, Phase: punaropostgres.UpdateFenced}
+	if fake.fenceAfterCommit {
+		return punaropostgres.UpdateTransaction{}, errors.New("injected ambiguous fence failure")
+	}
 	return fake.active, nil
 }
 func (fake *fakeUpdateExecutor) StopWriters(context.Context) error {
@@ -96,9 +142,86 @@ func TestExecuteUpdateOrdersIrreversibleProofsBeforeCommit(t *testing.T) {
 	if err != nil || transaction.Phase != punaropostgres.UpdateCommitted {
 		t.Fatalf("transaction=%#v err=%v", transaction, err)
 	}
-	want := []string{"preflight_pull", "fence", "resume_preflight", "stop_writers", "advance_writers_stopped", "backup", "advance_backup_verified", "advance_migration_started", "migrate", "advance_migrated", "candidate_ready", "advance_candidate_ready", "doctor", "advance_doctor_passed", "publish", "advance_config_published", "advance_committed"}
-	if !reflect.DeepEqual(fake.actions, want) {
-		t.Fatalf("actions=%v want=%v", fake.actions, want)
+	want := []string{"preflight_pull", "revalidate_start", "fence", "resume_preflight", "stop_writers", "advance_writers_stopped", "backup", "advance_backup_verified", "advance_migration_started", "migrate", "advance_migrated", "candidate_ready", "advance_candidate_ready", "doctor", "advance_doctor_passed", "publish", "advance_config_published", "advance_committed"}
+	if !reflect.DeepEqual(fake.actions, want) || !fake.guardReleased || fake.guardReleasedAt != 3 {
+		t.Fatalf("actions=%v want=%v guard_released=%t guard_released_at=%d", fake.actions, want, fake.guardReleased, fake.guardReleasedAt)
+	}
+}
+
+func TestExecuteUpdateReleasesStartGuardWhenCatalogExpiresAfterPreflight(t *testing.T) {
+	fake := &fakeUpdateExecutor{failAt: "revalidate_start"}
+	if _, err := executeUpdate(context.Background(), updateExecution{Request: testUpdateRequest()}, fake); err == nil || !fake.guardReleased || fake.guardReleasedAt != 3 || !reflect.DeepEqual(fake.actions, []string{"preflight_pull", "revalidate_start", "abort_unpublished_start"}) {
+		t.Fatalf("err=%v guard_released=%t guard_released_at=%d actions=%v", err, fake.guardReleased, fake.guardReleasedAt, fake.actions)
+	}
+}
+
+func TestExecuteUpdateCleansStageWhenFailedFenceIsConfirmedAbsent(t *testing.T) {
+	fake := &fakeUpdateExecutor{failAt: "fence"}
+	if _, err := executeUpdate(context.Background(), updateExecution{Request: testUpdateRequest()}, fake); err == nil {
+		t.Fatal("failed fence unexpectedly succeeded")
+	}
+	want := []string{"preflight_pull", "revalidate_start", "fence", "abort_unpublished_start"}
+	if !reflect.DeepEqual(fake.actions, want) || !fake.guardReleased || fake.guardReleasedAt != len(want) {
+		t.Fatalf("actions=%v want=%v guard_released=%t guard_released_at=%d", fake.actions, want, fake.guardReleased, fake.guardReleasedAt)
+	}
+}
+
+func TestExecuteUpdatePreservesStageWhenFailedFenceCannotBeReconciled(t *testing.T) {
+	fake := &fakeUpdateExecutor{failAt: "fence", failActive: 2}
+	if _, err := executeUpdate(context.Background(), updateExecution{Request: testUpdateRequest()}, fake); err == nil {
+		t.Fatal("unreconciled fence unexpectedly succeeded")
+	}
+	want := []string{"preflight_pull", "revalidate_start", "fence"}
+	if !reflect.DeepEqual(fake.actions, want) || !fake.guardReleased || fake.guardReleasedAt != len(want) {
+		t.Fatalf("actions=%v want=%v guard_released=%t guard_released_at=%d", fake.actions, want, fake.guardReleased, fake.guardReleasedAt)
+	}
+}
+
+func TestExecuteUpdateResumesAmbiguousSuccessfulFence(t *testing.T) {
+	fake := &fakeUpdateExecutor{fenceAfterCommit: true}
+	transaction, err := executeUpdate(context.Background(), updateExecution{Request: testUpdateRequest()}, fake)
+	if err != nil || transaction.Phase != punaropostgres.UpdateCommitted {
+		t.Fatalf("transaction=%#v err=%v", transaction, err)
+	}
+	if len(fake.actions) < 4 || !reflect.DeepEqual(fake.actions[:4], []string{"preflight_pull", "revalidate_start", "fence", "resume_preflight"}) || !fake.guardReleased || fake.guardReleasedAt != 3 {
+		t.Fatalf("actions=%v guard_released=%t guard_released_at=%d", fake.actions, fake.guardReleased, fake.guardReleasedAt)
+	}
+}
+
+func TestExecuteUpdateRetainsStartGuardUntilV5BridgeCommit(t *testing.T) {
+	fake := &fakeUpdateExecutor{deferredStart: true}
+	transaction, err := executeUpdate(context.Background(), updateExecution{Request: testUpdateRequest()}, fake)
+	if err != nil || transaction.Phase != punaropostgres.UpdateCommitted {
+		t.Fatalf("transaction=%#v err=%v", transaction, err)
+	}
+	wantPrefix := []string{"preflight_pull", "revalidate_start", "fence", "resume_preflight", "stop_writers", "revalidate_start", "advance_writers_stopped"}
+	if len(fake.actions) < len(wantPrefix) || !reflect.DeepEqual(fake.actions[:len(wantPrefix)], wantPrefix) || !fake.guardReleased || fake.guardReleasedAt != len(wantPrefix) {
+		t.Fatalf("actions=%v want_prefix=%v guard_released=%t guard_released_at=%d", fake.actions, wantPrefix, fake.guardReleased, fake.guardReleasedAt)
+	}
+}
+
+func TestExecuteUpdateRejectsCatalogExpiryBeforeV5BridgeCommit(t *testing.T) {
+	fake := &fakeUpdateExecutor{deferredStart: true, failRevalidate: 2}
+	transaction, err := executeUpdate(context.Background(), updateExecution{Request: testUpdateRequest()}, fake)
+	want := []string{"preflight_pull", "revalidate_start", "fence", "resume_preflight", "stop_writers", "revalidate_start", "abort_pending_start"}
+	if err == nil || transaction.Phase != punaropostgres.UpdateFenced || !reflect.DeepEqual(fake.actions, want) || !fake.guardReleased || fake.guardReleasedAt != len(want) {
+		t.Fatalf("transaction=%#v actions=%v err=%v guard_released=%t guard_released_at=%d", transaction, fake.actions, err, fake.guardReleased, fake.guardReleasedAt)
+	}
+}
+
+func TestExecuteUpdateRecoversV5WritersWhenStopFailsBeforeCommit(t *testing.T) {
+	fake := &fakeUpdateExecutor{deferredStart: true, failAt: "stop_writers"}
+	transaction, err := executeUpdate(context.Background(), updateExecution{Request: testUpdateRequest()}, fake)
+	want := []string{"preflight_pull", "revalidate_start", "fence", "resume_preflight", "stop_writers", "abort_pending_start"}
+	if err == nil || transaction.Phase != punaropostgres.UpdateFenced || !reflect.DeepEqual(fake.actions, want) || !fake.guardReleased || fake.guardReleasedAt != len(want) {
+		t.Fatalf("transaction=%#v actions=%v err=%v guard_released=%t guard_released_at=%d", transaction, fake.actions, err, fake.guardReleased, fake.guardReleasedAt)
+	}
+}
+
+func TestExecuteUpdateReleasesStartGuardWhenPreflightFails(t *testing.T) {
+	fake := &fakeUpdateExecutor{failAt: "preflight_pull"}
+	if _, err := executeUpdate(context.Background(), updateExecution{Request: testUpdateRequest()}, fake); err == nil || !fake.guardReleased || fake.guardReleasedAt != 2 || !reflect.DeepEqual(fake.actions, []string{"preflight_pull", "abort_unpublished_start"}) {
+		t.Fatalf("err=%v guard_released=%t guard_released_at=%d actions=%v", err, fake.guardReleased, fake.guardReleasedAt, fake.actions)
 	}
 }
 

--- a/cmd/punaro/update_release_fixture_unix_test.go
+++ b/cmd/punaro/update_release_fixture_unix_test.go
@@ -1,0 +1,9 @@
+//go:build !windows
+
+package main
+
+import "testing"
+
+func protectUpdateFixtureFile(t *testing.T, _ string) {
+	t.Helper()
+}

--- a/cmd/punaro/update_release_fixture_windows_test.go
+++ b/cmd/punaro/update_release_fixture_windows_test.go
@@ -1,0 +1,28 @@
+//go:build windows
+
+package main
+
+import (
+	"testing"
+
+	"golang.org/x/sys/windows"
+)
+
+func protectUpdateFixtureFile(t *testing.T, path string) {
+	t.Helper()
+	user, err := windows.GetCurrentProcessToken().GetTokenUser()
+	if err != nil || user.User.Sid == nil {
+		t.Fatalf("current user: %v", err)
+	}
+	acl, err := windows.ACLFromEntries([]windows.EXPLICIT_ACCESS{{
+		AccessPermissions: windows.ACCESS_MASK(0x1f01ff),
+		AccessMode:        windows.GRANT_ACCESS,
+		Trustee:           windows.TRUSTEE{TrusteeForm: windows.TRUSTEE_IS_SID, TrusteeValue: windows.TrusteeValueFromSID(user.User.Sid)},
+	}}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := windows.SetNamedSecurityInfo(path, windows.SE_FILE_OBJECT, windows.OWNER_SECURITY_INFORMATION|windows.DACL_SECURITY_INFORMATION|windows.PROTECTED_DACL_SECURITY_INFORMATION, user.User.Sid, nil, acl, nil); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/docs/doctor.md
+++ b/docs/doctor.md
@@ -244,6 +244,7 @@ Database, storage, and update recovery: `database_connection`,
 `database_schema`, `postgres_major`, `storage_capacity`, `verified_backup`,
 `backup_freshness`, `maintenance_fence`, `host_update_stage`,
 `update_transaction`, `recovery_receipt`, `update_recovery`,
+`release_catalog_acceptance`,
 `owner_credential_file`, `application_credential_file`,
 `attachment_blob_directory`, `blob_storage_private`.
 
@@ -265,6 +266,15 @@ deadline-isolated child, so stalled `.update` storage reports
 Recovery-receipt absence and exact receipt binding are inspected in a separate
 deadline-isolated child, so `recovery_receipt` becomes unavailable when its
 storage cannot be observed before the total deadline.
+`release_catalog_acceptance` validates the protected accepted and pending
+server-catalog records and their anti-rollback requirement marker in a
+deadline-isolated child. Release-bound initialization and verified restore
+seed this state, so an installation with a missing record or marker fails
+closed instead of being treated as pristine. Restore the state from a verified
+backup, or rerun release-bound initialization only for a genuinely fresh
+installation; do not hand-edit it. The highest durable sequence must be at
+least the catalog sequence embedded in the running operator release. The check
+never reconciles, edits, or removes the records.
 `database_listener_private` and `administration_listener_private` query
 PostgreSQL's effective `listen_addresses` through the application and owner
 connections respectively; every configured TCP address must be localhost or a

--- a/docs/github-releases.md
+++ b/docs/github-releases.md
@@ -296,6 +296,43 @@ image; it must be `@sha256:` and `release_sha256` must match. The separate
 `deploy/compose/production.yaml` file remains the reference single-node bundle;
 it is not the host-local operator artifact checked during update and doctor.
 
+## Server update boundary
+
+The signed public manifest is also the first-class server update boundary; no
+smaller unsigned metadata document is published or derived. Download the exact
+`punaro-release.json` and `punaro-release.sig` bytes from the immutable release,
+the fresh `punaro-catalog.json` and `punaro-catalog.sig` bytes from the live
+catalog release, and the independently distributed `punaro-release.pub` trust
+root. Copy all five to owner-only regular files, and run:
+
+```sh
+punaro update \
+  --directory /absolute/private/punaro-installation \
+  --release-manifest /absolute/private/releases/RELEASE/punaro-release.json \
+  --release-signature /absolute/private/releases/RELEASE/punaro-release.sig \
+  --release-catalog /absolute/private/releases/catalog/punaro-catalog.json \
+  --release-catalog-signature /absolute/private/releases/catalog/punaro-catalog.sig \
+  --release-keys-file /absolute/private/trust/punaro-release.pub \
+  --source-release CURRENT_RELEASE
+```
+
+Before it creates a transaction, the updater verifies the fresh catalog's
+detached signature and lifetime and requires its exact release, sequence, and
+manifest digest to remain allowed. It then durably advances the installation's
+accepted catalog high-water and rejects a sequence below either that state or
+the catalog sequence embedded by the release workflow in the operator binary.
+A synced pending advance is recovered after a crash, and the same lock remains
+held until the database update transaction exists durably so concurrent starts
+cannot reorder catalog authorization and transaction publication. It then verifies the manifest signature
+against the same protected trust root before it parses or projects any server
+value. Release name, direct source allowlist, digest-pinned image, schema range,
+PostgreSQL major, image digest, Compose digest, and migration-manifest digest
+therefore all come from the same verified bytes. Exact durable retries do not
+consult a later catalog, so retirement blocks new starts without stranding
+recovery. The publisher's public-origin smoke downloads the manifest, signature, and every
+manifest-listed artifact through their unauthenticated GitHub Release URLs and
+verifies those remote bytes before the signed catalog can advance.
+
 ## Bootstrap pull
 
 `punaro-bootstrap` fetches only two-component paths beneath the fixed origin,

--- a/docs/operator-guide.md
+++ b/docs/operator-guide.md
@@ -648,10 +648,12 @@ selected immutable blob has been copied, length/digest checked, synchronized,
 and the complete hidden stage verifies. Only then is the backup renamed into
 view. Failures before rename leave no published backup; a parent-directory sync
 failure reports the published path as durability-uncertain so the operator can
-verify it explicitly. A backup contains the custom
-database dump, generated Punaro configuration, both Punaro database credential
-files, and verified READY blobs. Its manifest lists host TLS, proxy/tunnel,
-Telegram, and OAuth state as external dependencies rather than copying them.
+verify it explicitly. A backup contains the custom database dump, generated
+Punaro configuration, both Punaro database credential files, and verified READY
+blobs. Its verified manifest also records the effective accepted release-catalog
+high-water, including a crash-synced pending acceptance. Its manifest lists host
+TLS, proxy/tunnel, Telegram, and OAuth state as external dependencies rather
+than copying them.
 Keep the backup directory private; optional storage encryption and an off-host
 copy are recommended operational controls.
 
@@ -678,29 +680,34 @@ independent receipt written by the failed update before migration:
 ```
 
 Keep that receipt until the update is committed, recovered, or aborted. It is
-deliberately outside the backup; a v2 update backup cannot authorize its own
-restore.
+deliberately outside the backup; neither a legacy v2 nor a catalog-aware v3
+update backup can authorize its own restore.
 
 Restore re-verifies the complete backup before mutation, stages and verifies
 all blobs, restores the database in one `pg_restore` transaction, preserves the
 installation ID, rotates the timeline, and publishes the new data and generated
-configuration only at the end. Each boundary is recorded in a private durable
-journal beside the new data path. If any post-mutation step fails, stop the old
-stack and retry the exact same command: it resumes the bound journal without
-repeating completed database or timeline mutation. Do not delete or edit the
-journal or target paths. Existing targets on a new request, overlaps,
-symlinks, permissive paths, non-pristine databases, identity drift, and an
-unrotated timeline fail closed. Clients observing the new timeline must discard later
-cursors/caches and re-enumerate authoritative state. Optional gateways remain
-not ready until their external dependencies are supplied or re-enrolled.
+configuration only at the end. The backed-up release-catalog high-water is
+staged and published atomically with that configuration, so disaster recovery
+cannot reopen a release retired before the backup. Each boundary is recorded in
+a private durable journal beside the new data path. If any post-mutation step
+fails, stop the old stack and retry the exact same command: it resumes the bound
+journal without repeating completed database or timeline mutation. Do not
+delete or edit the journal or target paths. Existing targets on a new request,
+overlaps, symlinks, permissive paths, non-pristine databases, identity drift,
+and an unrotated timeline fail closed. Clients observing the new timeline must
+discard later cursors/caches and re-enumerate authoritative state. Optional
+gateways remain not ready until their external dependencies are supplied or
+re-enrolled.
 
-Update-created version 2 backups additionally bind the exact update ID, source
-schema and state coordinates, target release/image digest, exported snapshot,
-and raw manifest digest. Before the database accepts that backup marker, the
-host writes a protected receipt outside the backup. Restore requires both and
-binds the receipt path and digest into its resume journal before mutation.
-Restoring one automatically reconstructs the same fenced update transaction on
-the rotated timeline; it does not reopen writes.
+Update-created backups additionally bind the exact update ID, source schema and
+state coordinates, target release/image digest, exported snapshot, and raw
+manifest digest. Legacy update backups are version 2; release-bound updates
+also bind the accepted catalog high-water and are version 3. Before the
+database accepts that backup marker, the host writes a protected receipt
+outside the backup. Restore requires both and binds the receipt path and digest
+into its resume journal before mutation. Restoring one automatically
+reconstructs the same fenced update transaction on the rotated timeline; it
+does not reopen writes.
 Run restore drills and retain a verified off-host copy before admitting
 irreplaceable data.
 
@@ -714,18 +721,60 @@ bundled production PostgreSQL/profile shape remains M-23.
 
 Run the host-side `punaro` wrapper shipped by the target release; its embedded
 migration manifest and generated Compose template are part of the target
-boundary and a source-release wrapper is intentionally rejected. Use the
-target release's published, protected metadata whose `image` is digest-pinned,
-`release_sha256` equals that image digest without the `sha256:` prefix,
-`compose_sha256` matches the generated Compose artifact, and migration-manifest,
-schema-range, rollback-floor, and PostgreSQL-major values match the target
-release. The file must be an absolute private regular file. On the first update
-from an installation without a release-name lock, supply the current release:
+boundary and a source-release wrapper is intentionally rejected. Use the exact
+published `punaro-release.json` and `punaro-release.sig` for the target, the
+fresh live `punaro-catalog.json` and `punaro-catalog.sig`, and the independently
+provisioned `punaro-release.pub` trust root. Copy all five into single-link
+private regular files owned by the invoking operator and reachable only through
+trusted, non-writable ancestors. Before a new transaction, `punaro update`
+verifies the catalog signature and lifetime and requires its exact
+release/sequence/manifest-digest entry to remain allowed. It verifies the
+detached signature over the exact manifest bytes before projecting the
+digest-pinned image, release/image digest, Compose digest, migration-manifest
+digest, schema range, rollback floor, PostgreSQL major, and `supported_from`
+direct-update allowlist. After recovering the current source release from the
+durable transaction, host stage, or explicit first-update argument, it must
+appear in that signed allowlist before any preflight or database fencing. An
+empty allowlist permits initial installation only, not a server update. There is
+no supported unsigned server-metadata projection. On the first update from an
+installation without a release-name lock, supply the current release:
+
+For every new transaction, the updater also durably records the accepted
+catalog sequence in `accepted-server-catalog.json` under the installation
+directory and publishes the durable anti-rollback requirement marker beside
+it. It rejects a catalog older than either that high-water or the catalog
+sequence embedded in the running target-release wrapper. A crash after the
+pending record is synced cannot lower the accepted sequence: the next new start
+reconciles it before authorization. The catalog-acceptance lock stays held
+through preflight and durable transaction creation. On Windows the updater
+also pins the installation directory and its ancestor chain against rename and
+rejects an ancestor that grants unprivileged delete-child or ACL-takeover
+authority. Catalog freshness is rechecked immediately after preflight and
+before fencing, so a slow image pull cannot carry expired authorization into a
+new transaction. A concurrent new start fails closed instead of overtaking an
+already authorized older catalog. Do not edit or remove the accepted, pending,
+or requirement record;
+`release_catalog_acceptance` in server doctor validates this state without
+changing it. Exact durable transaction resumes bypass catalog reauthorization
+and therefore remain recoverable after retirement.
+
+If a process crash leaves an unpublished host stage but no durable database
+transaction, clean it up without target-release or catalog inputs:
+
+```sh
+punaro update --directory INSTALLATION_DIR --abort
+```
+
+This recovery mode trusts only the protected stage journal, takes the normal
+update-start lock, confirms both the exact update ID and the active transaction
+slot are absent, restarts the previous writer when necessary, and then removes
+the stage. It refuses published, mismatched, unreadable, or transaction-backed
+state. Use the full exact update command for any durable transaction.
 
 The supported host-binary handoff starts from one downloaded target-release
 directory containing `punaro-release.json`, `punaro-release.sig`, and every
-native artifact named by that manifest, plus the independently configured
-public release key. First verify the detached manifest signature with the
+native artifact named by that manifest, plus the fresh live catalog/signature
+pair and independently configured public release key. First verify the detached manifest signature with the
 trusted `punaro-release verify` tool, then verify the complete artifact
 directory against that verified manifest with `punaro-release
 verify-artifacts`. Select the matching verified `punaro-linux-ARCH` artifact
@@ -741,7 +790,11 @@ doctor to replace the executable itself.
 ```sh
 punaro update \
   --directory /absolute/private/punaro-installation \
-  --release-metadata /absolute/private/releases/v0.7.0.json \
+  --release-manifest /absolute/private/releases/v0.7.0/punaro-release.json \
+  --release-signature /absolute/private/releases/v0.7.0/punaro-release.sig \
+  --release-catalog /absolute/private/releases/catalog/punaro-catalog.json \
+  --release-catalog-signature /absolute/private/releases/catalog/punaro-catalog.sig \
+  --release-keys-file /absolute/private/trust/punaro-release.pub \
   --source-release v0.6.0
 ```
 
@@ -757,15 +810,24 @@ configuration is published and the database commit reopens writes.
 
 Rerun the exact command after a crash or uncertain external command. It resumes
 the durable PostgreSQL phase and private host journal without repeating completed
-work or requiring another registry pull. Do not edit `.update`, the release
-metadata, database update rows, or the verified backup. A pre-migration failure
+work, requiring another registry pull, or re-authorizing an already-started
+transaction against a later catalog: retirement prevents new starts but cannot
+strand exact recovery. Do not edit `.update`, the signed release files, database
+update rows, or the verified backup. At the one-time schema-5 bridge, an
+unpublished or uncertain writer-stop outcome is reconciled against the exact
+database update ID; if no transaction became durable, Punaro restarts and
+verifies the previous writer before removing the host stage. A pre-migration failure
 may be abandoned only with the same arguments plus `--abort`; the previous
 digest must start and pass doctor before the fence is released:
 
 ```sh
 punaro update \
   --directory /absolute/private/punaro-installation \
-  --release-metadata /absolute/private/releases/v0.7.0.json \
+  --release-manifest /absolute/private/releases/v0.7.0/punaro-release.json \
+  --release-signature /absolute/private/releases/v0.7.0/punaro-release.sig \
+  --release-catalog /absolute/private/releases/catalog/punaro-catalog.json \
+  --release-catalog-signature /absolute/private/releases/catalog/punaro-catalog.sig \
+  --release-keys-file /absolute/private/trust/punaro-release.pub \
   --source-release v0.6.0 \
   --abort
 ```
@@ -781,7 +843,11 @@ resume the reconstructed transaction from the restored installation:
 ```sh
 punaro update \
   --directory /absolute/private/restored-installation \
-  --release-metadata /absolute/private/releases/v0.7.0.json \
+  --release-manifest /absolute/private/releases/v0.7.0/punaro-release.json \
+  --release-signature /absolute/private/releases/v0.7.0/punaro-release.sig \
+  --release-catalog /absolute/private/releases/catalog/punaro-catalog.json \
+  --release-catalog-signature /absolute/private/releases/catalog/punaro-catalog.sig \
+  --release-keys-file /absolute/private/trust/punaro-release.pub \
   --recover restore
 ```
 

--- a/docs/production-compose.md
+++ b/docs/production-compose.md
@@ -180,10 +180,23 @@ Do not use `/readyz` as this proof, because health and device paths may have
 different routes or policies. Only after this check should a harmless signed
 request be used to prove relay enrollment and the final device origin.
 
-For every later release, use `punaro update --directory INSTALLATION_DIR` with
-the protected release metadata distributed for that release. This preserves the
-same durable update journal and recovery path as the initial installation; do
-not replace `PUNARO_IMAGE` and restart the reference bundle directly.
+For every later release, run the target release's wrapper with the protected
+signed manifest, fresh signed catalog, and independently provisioned trust root:
+
+```sh
+punaro update --directory INSTALLATION_DIR \
+  --source-release CURRENT_RELEASE \
+  --release-manifest RELEASE_DIR/punaro-release.json \
+  --release-signature RELEASE_DIR/punaro-release.sig \
+  --release-catalog CATALOG_DIR/punaro-catalog.json \
+  --release-catalog-signature CATALOG_DIR/punaro-catalog.sig \
+  --release-keys-file TRUST_DIR/punaro-release.pub
+```
+
+This preserves the same durable update journal and recovery path as the initial
+installation; do not derive an unsigned metadata subset, replace
+`PUNARO_IMAGE`, or restart the reference bundle directly. See the complete
+update, abort, and recovery invocations in the operator guide.
 
 Existing installations retain their published configuration through upgrade and
 recovery. Re-run `punaro init --resume --directory INSTALLATION_DIR` only after

--- a/internal/backup/create.go
+++ b/internal/backup/create.go
@@ -49,14 +49,19 @@ type CreateOptions struct {
 	ComposeFile      string
 	OwnerDSNFile     string
 	AppDSNFile       string
-	Now              func() time.Time
-	NewID            func() string
-	Update           *UpdateTarget
+	// ServerCatalogSequence is the effective accepted release-catalog
+	// high-water at backup start. It is content-free security state and is
+	// restored atomically with the installation configuration.
+	ServerCatalogSequence int64
+	Now                   func() time.Time
+	NewID                 func() string
+	Update                *UpdateTarget
 }
 
-// UpdateTarget requests a v2 manifest for one update transaction. Source
-// coordinates are derived from the exported snapshot and cannot be supplied by
-// the caller.
+// UpdateTarget requests update-bound recovery metadata for one transaction.
+// Legacy callers without a catalog high-water produce v2; release-bound callers
+// with a positive ServerCatalogSequence produce v3. Source coordinates are
+// derived from the exported snapshot and cannot be supplied by the caller.
 type UpdateTarget struct {
 	UpdateID          string
 	TargetRelease     string
@@ -66,7 +71,7 @@ type UpdateTarget struct {
 // Create publishes a backup only after its exact snapshot dump, configuration,
 // credentials, and READY blobs all pass size/hash verification.
 func Create(ctx context.Context, options CreateOptions, source Source) (Manifest, string, error) {
-	if source == nil || trustedPrivateDirectory(options.BackupRoot) != nil || !filepath.IsAbs(options.BlobRoot) || filepath.Clean(options.BlobRoot) != options.BlobRoot {
+	if source == nil || options.ServerCatalogSequence < 0 || trustedPrivateDirectory(options.BackupRoot) != nil || !filepath.IsAbs(options.BlobRoot) || filepath.Clean(options.BlobRoot) != options.BlobRoot {
 		return Manifest{}, "", errors.New("backup inputs are unavailable or unsafe")
 	}
 	if options.Now == nil {
@@ -98,7 +103,7 @@ func Create(ctx context.Context, options CreateOptions, source Source) (Manifest
 	if err := validateSnapshot(snapshot); err != nil {
 		return Manifest{}, "", err
 	}
-	manifest := Manifest{Version: 1, BackupID: backupID, CreatedAt: createdAt, SnapshotID: snapshot.ID, SchemaVersion: snapshot.SchemaVersion, State: snapshot.State, ExternalDependencies: []string{"host-tls", "oauth", "reverse-proxy", "telegram", "tunnel"}}
+	manifest := Manifest{Version: 1, BackupID: backupID, CreatedAt: createdAt, SnapshotID: snapshot.ID, SchemaVersion: snapshot.SchemaVersion, State: snapshot.State, ServerCatalogSequence: options.ServerCatalogSequence, ExternalDependencies: []string{"host-tls", "oauth", "reverse-proxy", "telegram", "tunnel"}}
 	if options.Update != nil {
 		manifest.Version = 2
 		manifest.Update = &UpdateMetadata{
@@ -110,6 +115,9 @@ func Create(ctx context.Context, options CreateOptions, source Source) (Manifest
 		if err := validateUpdateMetadata(*manifest.Update); err != nil {
 			return Manifest{}, "", errors.New("backup update target is invalid")
 		}
+	}
+	if options.ServerCatalogSequence > 0 {
+		manifest.Version = 3
 	}
 	if len(snapshot.ReadyBlobs) != 0 && trustedPrivateDirectory(options.BlobRoot) != nil {
 		return Manifest{}, "", errors.New("READY blob root is unavailable or unsafe")

--- a/internal/backup/create_test.go
+++ b/internal/backup/create_test.go
@@ -13,6 +13,7 @@ import (
 
 func TestCreatePublishesOnlyVerifiedSnapshot(t *testing.T) {
 	root, options := createTestInputs(t)
+	options.ServerCatalogSequence = 7
 	blobBody := []byte("immutable ready blob")
 	blobPath := filepath.Join(options.BlobRoot, "sha256", "ready")
 	if err := os.MkdirAll(filepath.Dir(blobPath), 0o700); err != nil {
@@ -55,7 +56,7 @@ func TestCreatePublishesOnlyVerifiedSnapshot(t *testing.T) {
 	if err != nil {
 		t.Fatalf("verify published backup: %v", err)
 	}
-	if verified.BackupID != manifest.BackupID || verified.State != source.snapshot.State {
+	if verified.Version != 3 || verified.BackupID != manifest.BackupID || verified.State != source.snapshot.State || verified.ServerCatalogSequence != 7 {
 		t.Fatalf("published manifest mismatch: %#v", verified)
 	}
 	// #nosec G304 -- fixed child of the private test backup.

--- a/internal/backup/manifest.go
+++ b/internal/backup/manifest.go
@@ -52,9 +52,9 @@ type File struct {
 	SHA256 string `json:"sha256"`
 }
 
-// UpdateMetadata binds a v2 backup to the immutable source and target of one
-// update transaction. It deliberately contains identifiers only, never paths
-// or credentials.
+// UpdateMetadata binds an update backup to the immutable source and target of
+// one update transaction. It deliberately contains identifiers only, never
+// paths or credentials.
 type UpdateMetadata struct {
 	UpdateID           string `json:"update_id"`
 	SourceSchema       int64  `json:"source_schema"`
@@ -87,15 +87,16 @@ type UpdateBinding struct {
 
 // Manifest is the single authoritative index for a published backup.
 type Manifest struct {
-	Version              int             `json:"version"`
-	BackupID             string          `json:"backup_id"`
-	CreatedAt            time.Time       `json:"created_at"`
-	SnapshotID           string          `json:"snapshot_id"`
-	SchemaVersion        int64           `json:"schema_version"`
-	State                State           `json:"state"`
-	Files                []File          `json:"files"`
-	ExternalDependencies []string        `json:"external_dependencies"`
-	Update               *UpdateMetadata `json:"update,omitempty"`
+	Version               int             `json:"version"`
+	BackupID              string          `json:"backup_id"`
+	CreatedAt             time.Time       `json:"created_at"`
+	SnapshotID            string          `json:"snapshot_id"`
+	SchemaVersion         int64           `json:"schema_version"`
+	State                 State           `json:"state"`
+	ServerCatalogSequence int64           `json:"server_catalog_sequence,omitempty"`
+	Files                 []File          `json:"files"`
+	ExternalDependencies  []string        `json:"external_dependencies"`
+	Update                *UpdateMetadata `json:"update,omitempty"`
 }
 
 // Summary is safe, content-free metadata returned by backup list.
@@ -193,11 +194,12 @@ func verifyContext(ctx context.Context, directory string) (Manifest, string, err
 	return manifest, manifestDigest, nil
 }
 
-// BuildUpdateBinding verifies a v2 backup and returns the complete marker that
-// must be recorded before an updater may consume it.
+// BuildUpdateBinding verifies a legacy v2 or catalog-aware v3 update backup and
+// returns the complete marker that must be recorded before an updater may
+// consume it.
 func BuildUpdateBinding(directory string) (UpdateBinding, error) {
 	manifest, digest, err := verify(directory)
-	if err != nil || manifest.Version != 2 || manifest.Update == nil {
+	if err != nil || (manifest.Version != 2 && manifest.Version != 3) || manifest.Update == nil {
 		return UpdateBinding{}, errors.New("update backup is unavailable or invalid")
 	}
 	metadata := *manifest.Update
@@ -210,14 +212,14 @@ func BuildUpdateBinding(directory string) (UpdateBinding, error) {
 	}, nil
 }
 
-// VerifyForUpdate requires a complete marker matching both the decoded v2
+// VerifyForUpdate requires a complete marker matching both the decoded update
 // metadata and the digest of the exact manifest bytes opened for verification.
 func VerifyForUpdate(directory string, binding UpdateBinding) (Manifest, error) {
 	if err := validateUpdateBinding(binding); err != nil {
 		return Manifest{}, err
 	}
 	manifest, digest, err := verify(directory)
-	if err != nil || manifest.Version != 2 || manifest.Update == nil {
+	if err != nil || (manifest.Version != 2 && manifest.Version != 3) || manifest.Update == nil {
 		return Manifest{}, errors.New("update backup is unavailable or invalid")
 	}
 	metadata := *manifest.Update
@@ -384,15 +386,21 @@ func rejectDuplicateJSONKeys(body []byte) error {
 }
 
 func validateManifest(manifest Manifest) error {
-	if (manifest.Version != 1 && manifest.Version != 2) || uuid.Validate(manifest.BackupID) != nil || manifest.CreatedAt.IsZero() || manifest.CreatedAt.Location() != time.UTC || manifest.SchemaVersion <= 0 || uuid.Validate(manifest.State.InstallationID) != nil || uuid.Validate(manifest.State.TimelineID) != nil || manifest.State.ChangeSequence < 0 || len(manifest.Files) == 0 || len(manifest.Files) > maximumFileCount {
+	if (manifest.Version != 1 && manifest.Version != 2 && manifest.Version != 3) || uuid.Validate(manifest.BackupID) != nil || manifest.CreatedAt.IsZero() || manifest.CreatedAt.Location() != time.UTC || manifest.SchemaVersion <= 0 || uuid.Validate(manifest.State.InstallationID) != nil || uuid.Validate(manifest.State.TimelineID) != nil || manifest.State.ChangeSequence < 0 || manifest.ServerCatalogSequence < 0 || len(manifest.Files) == 0 || len(manifest.Files) > maximumFileCount {
 		return errors.New("backup manifest metadata is invalid")
 	}
-	if manifest.Version == 1 && manifest.Update != nil {
+	if manifest.Version == 1 && (manifest.Update != nil || manifest.ServerCatalogSequence != 0) {
 		return errors.New("v1 backup manifest cannot contain update metadata")
 	}
-	if manifest.Version == 2 {
+	if manifest.Version == 2 && manifest.ServerCatalogSequence != 0 {
+		return errors.New("v2 backup manifest cannot contain release catalog acceptance")
+	}
+	if manifest.Version == 3 && manifest.ServerCatalogSequence == 0 {
+		return errors.New("v3 backup manifest requires release catalog acceptance")
+	}
+	if manifest.Version == 2 || manifest.Update != nil {
 		if manifest.Update == nil || validateUpdateMetadata(*manifest.Update) != nil || manifest.Update.SourceSchema != manifest.SchemaVersion || manifest.Update.State() != manifest.State || manifest.Update.ExportedSnapshotID != manifest.SnapshotID {
-			return errors.New("v2 backup update metadata is invalid")
+			return errors.New("backup update metadata is invalid")
 		}
 	}
 	if !validSnapshotID(manifest.SnapshotID) {

--- a/internal/backup/manifest_test.go
+++ b/internal/backup/manifest_test.go
@@ -65,6 +65,39 @@ func TestVerifyAcceptsExactPrivateBackup(t *testing.T) {
 	}
 }
 
+func TestVerifyVersionsReleaseCatalogAcceptanceContract(t *testing.T) {
+	tests := []struct {
+		name       string
+		version    int
+		sequence   int64
+		wantAccept bool
+	}{
+		{name: "legacy v1", version: 1, sequence: 0, wantAccept: true},
+		{name: "v1 cannot carry catalog acceptance", version: 1, sequence: 7},
+		{name: "v2 cannot carry catalog acceptance", version: 2, sequence: 7},
+		{name: "v3 requires catalog acceptance", version: 3, sequence: 0},
+		{name: "v3 catalog-aware backup", version: 3, sequence: 7, wantAccept: true},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			directory := t.TempDir()
+			requirePrivate(t, directory)
+			paths := writeRequiredTestFiles(t, directory)
+			manifest := testManifest(t, directory, paths)
+			manifest.Version = test.version
+			manifest.ServerCatalogSequence = test.sequence
+			if test.version == 2 {
+				manifest.Update = validTestUpdateMetadata(manifest)
+			}
+			writeManifest(t, directory, manifest)
+			_, err := Verify(directory)
+			if (err == nil) != test.wantAccept {
+				t.Fatalf("Verify() error=%v want_accept=%t", err, test.wantAccept)
+			}
+		})
+	}
+}
+
 func TestVerifyForUpdateRequiresExactV2ManifestBinding(t *testing.T) {
 	directory := t.TempDir()
 	requirePrivate(t, directory)
@@ -107,6 +140,25 @@ func TestVerifyForUpdateRequiresExactV2ManifestBinding(t *testing.T) {
 	}
 	if _, err := VerifyForUpdate(directory, binding); err == nil {
 		t.Fatal("update verification accepted a replaced manifest")
+	}
+}
+
+func TestVerifyForUpdateAcceptsCatalogAwareV3Manifest(t *testing.T) {
+	directory := t.TempDir()
+	requirePrivate(t, directory)
+	paths := writeRequiredTestFiles(t, directory)
+	manifest := testManifest(t, directory, paths)
+	manifest.Version = 3
+	manifest.ServerCatalogSequence = 7
+	manifest.Update = validTestUpdateMetadata(manifest)
+	writeManifest(t, directory, manifest)
+	binding, err := BuildUpdateBinding(directory)
+	if err != nil {
+		t.Fatalf("build v3 update binding: %v", err)
+	}
+	verified, err := VerifyForUpdate(directory, binding)
+	if err != nil || verified.Version != 3 || verified.ServerCatalogSequence != 7 {
+		t.Fatalf("verify v3 update backup: manifest=%#v err=%v", verified, err)
 	}
 }
 
@@ -361,6 +413,15 @@ func testManifest(t *testing.T, directory string, paths []string) Manifest {
 		},
 		Files:                files,
 		ExternalDependencies: []string{"host-tls", "oauth", "reverse-proxy", "telegram", "tunnel"},
+	}
+}
+
+func validTestUpdateMetadata(manifest Manifest) *UpdateMetadata {
+	return &UpdateMetadata{
+		UpdateID: "0190ea2e-8a2d-7d42-b320-8515f7604bc1", SourceSchema: manifest.SchemaVersion,
+		InstallationID: manifest.State.InstallationID, TimelineID: manifest.State.TimelineID,
+		ChangeSequence: manifest.State.ChangeSequence, TargetRelease: "v0.7.0",
+		TargetImageDigest: "sha256:" + strings.Repeat("a", 64), ExportedSnapshotID: manifest.SnapshotID,
 	}
 }
 

--- a/internal/operator/authority_lock.go
+++ b/internal/operator/authority_lock.go
@@ -1,23 +1,31 @@
 package operator
 
 import (
-	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 )
 
 func acquireRelayAuthorityLock(directory string) (func(), error) {
+	return acquireOperatorFileLock(directory, ".relay-authority.lock", "relay authority publication")
+}
+
+func acquireCatalogAcceptanceLock(directory string) (func(), error) {
+	return acquireOperatorFileLock(directory, ".catalog-acceptance.lock", "catalog acceptance")
+}
+
+func acquireOperatorFileLock(directory, name, label string) (func(), error) {
 	if requireTrustedPrivateDirectory(directory) != nil {
-		return nil, errors.New("relay authority publication lock is unavailable")
+		return nil, fmt.Errorf("%s lock is unavailable", label)
 	}
-	path := filepath.Join(directory, ".relay-authority.lock")
+	path := filepath.Join(directory, name)
 	file, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE, 0o600) // #nosec G304 -- fixed child of the validated private installation directory.
 	if err != nil {
-		return nil, errors.New("relay authority publication lock is unavailable")
+		return nil, fmt.Errorf("%s lock is unavailable", label)
 	}
 	fail := func() (func(), error) {
 		_ = file.Close()
-		return nil, errors.New("relay authority publication lock is unavailable")
+		return nil, fmt.Errorf("%s lock is unavailable", label)
 	}
 	opened, err := file.Stat()
 	if err != nil || requireTrustedProtectedFile(path, 0) != nil {
@@ -29,7 +37,7 @@ func acquireRelayAuthorityLock(directory string) (func(), error) {
 	}
 	if err := lockRelayAuthorityFile(file); err != nil {
 		_ = file.Close()
-		return nil, errors.New("another relay authority publication is already in progress")
+		return nil, fmt.Errorf("another %s is already in progress", label)
 	}
 	return func() {
 		unlockRelayAuthorityFile(file)

--- a/internal/operator/catalog_acceptance.go
+++ b/internal/operator/catalog_acceptance.go
@@ -1,0 +1,301 @@
+package operator
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+)
+
+const (
+	acceptedCatalogName         = "accepted-server-catalog.json"
+	acceptedCatalogPendingName  = ".accepted-server-catalog.pending.json"
+	acceptedCatalogRequiredName = "accepted-server-catalog.required.json"
+	acceptedCatalogMaximum      = 1024
+	acceptedCatalogRequiredBody = "{\"version\":1}\n"
+)
+
+var (
+	// ErrCatalogSequenceDowngrade reports an attempted server update authorized
+	// by a catalog older than the installation's durable accepted high-water.
+	ErrCatalogSequenceDowngrade = errors.New("release catalog sequence downgrade")
+	// ErrCatalogAcceptanceMissing reports loss of mandatory anti-rollback
+	// state after an installation first adopted catalog-authorized updates.
+	ErrCatalogAcceptanceMissing = errors.New("required release catalog acceptance is missing")
+
+	acceptedCatalogPublicationHook func(string) error
+)
+
+type acceptedCatalogState struct {
+	Version  int   `json:"version"`
+	Sequence int64 `json:"sequence"`
+}
+
+// ServerCatalogSequence returns the effective accepted high-water while
+// holding the same cross-process lock used by update starts. A synced pending
+// publication counts as accepted security state and is recovered first.
+func ServerCatalogSequence(directory string) (int64, error) {
+	sequence, unlock, err := BeginServerCatalogSnapshot(directory)
+	if err != nil {
+		return 0, err
+	}
+	unlock()
+	return sequence, nil
+}
+
+// BeginServerCatalogSnapshot returns the effective accepted high-water and
+// retains the update-start lock. Backup callers must hold the returned release
+// function until the captured manifest has been published or publication has
+// failed, so catalog acceptance and backup publication remain totally ordered.
+func BeginServerCatalogSnapshot(directory string) (int64, func(), error) {
+	if !filepath.IsAbs(directory) || filepath.Clean(directory) != directory {
+		return 0, nil, errors.New("release catalog acceptance is unavailable")
+	}
+	if err := ensureTrustedCatalogDirectory(directory); err != nil {
+		return 0, nil, errors.New("release catalog acceptance is unavailable")
+	}
+	unpin, err := pinTrustedCatalogDirectory(directory)
+	if err != nil {
+		return 0, nil, errors.New("release catalog acceptance is unavailable")
+	}
+	unlockFile, err := acquireCatalogAcceptanceLock(directory)
+	if err != nil {
+		unpin()
+		return 0, nil, err
+	}
+	unlock := func() {
+		unlockFile()
+		unpin()
+	}
+	state, exists, err := recoverAcceptedCatalogState(directory)
+	if err != nil {
+		unlock()
+		return 0, nil, err
+	}
+	required, err := readCatalogAcceptanceRequirement(directory)
+	if err != nil || required && !exists {
+		unlock()
+		if err != nil {
+			return 0, nil, err
+		}
+		return 0, nil, ErrCatalogAcceptanceMissing
+	}
+	if !exists {
+		return 0, unlock, nil
+	}
+	if !required {
+		if err := publishCatalogAcceptanceRequirement(directory); err != nil {
+			unlock()
+			return 0, nil, err
+		}
+	}
+	return state.Sequence, unlock, nil
+}
+
+// AcceptServerCatalogSequence durably advances the monotonic catalog
+// high-water before a new server update transaction may start. A synced
+// pending state is recovered first, so a crash cannot make a previously
+// accepted retirement disappear.
+func AcceptServerCatalogSequence(directory string, sequence, embeddedMinimum int64) error {
+	unlock, err := BeginServerCatalogAcceptance(directory, sequence, embeddedMinimum)
+	if err != nil {
+		return err
+	}
+	unlock()
+	return nil
+}
+
+// BeginServerCatalogAcceptance advances the catalog high-water and retains its
+// cross-process lock. The caller must hold the returned release function until
+// the corresponding update transaction exists durably or the start fails.
+func BeginServerCatalogAcceptance(directory string, sequence, embeddedMinimum int64) (func(), error) {
+	if !filepath.IsAbs(directory) || filepath.Clean(directory) != directory || sequence < 1 || embeddedMinimum < 0 || sequence < embeddedMinimum {
+		return nil, ErrCatalogSequenceDowngrade
+	}
+	if err := ensureTrustedCatalogDirectory(directory); err != nil {
+		return nil, errors.New("release catalog acceptance is unavailable")
+	}
+	unpin, err := pinTrustedCatalogDirectory(directory)
+	if err != nil {
+		return nil, errors.New("release catalog acceptance is unavailable")
+	}
+	unlockFile, err := acquireCatalogAcceptanceLock(directory)
+	if err != nil {
+		unpin()
+		return nil, err
+	}
+	unlock := func() {
+		unlockFile()
+		unpin()
+	}
+	succeeded := false
+	defer func() {
+		if !succeeded {
+			unlock()
+		}
+	}()
+
+	accepted, exists, err := recoverAcceptedCatalogState(directory)
+	if err != nil {
+		return nil, err
+	}
+	required, err := readCatalogAcceptanceRequirement(directory)
+	if err != nil {
+		return nil, err
+	}
+	if required && !exists {
+		return nil, ErrCatalogAcceptanceMissing
+	}
+	if exists && sequence < accepted.Sequence {
+		return nil, ErrCatalogSequenceDowngrade
+	}
+	if exists && sequence == accepted.Sequence {
+		if !required {
+			if err := publishCatalogAcceptanceRequirement(directory); err != nil {
+				return nil, err
+			}
+		}
+		succeeded = true
+		return unlock, nil
+	}
+
+	state := acceptedCatalogState{Version: 1, Sequence: sequence}
+	body, err := json.Marshal(state)
+	if err != nil {
+		return nil, errors.New("release catalog acceptance is unavailable")
+	}
+	body = append(body, '\n')
+	pending := filepath.Join(directory, acceptedCatalogPendingName)
+	if err := writeExclusive(pending, body); err != nil || syncDirectory(directory) != nil {
+		return nil, errors.New("release catalog acceptance is unavailable")
+	}
+	if acceptedCatalogPublicationHook != nil {
+		if err := acceptedCatalogPublicationHook("pending"); err != nil {
+			return nil, errors.New("release catalog acceptance was interrupted")
+		}
+	}
+	if err := os.Rename(pending, filepath.Join(directory, acceptedCatalogName)); err != nil || syncDirectory(directory) != nil {
+		return nil, errors.New("release catalog acceptance is unavailable")
+	}
+	if !required {
+		if err := publishCatalogAcceptanceRequirement(directory); err != nil {
+			return nil, err
+		}
+	}
+	succeeded = true
+	return unlock, nil
+}
+
+// InspectServerCatalogAcceptance validates the durable catalog high-water
+// without changing or reconciling it. Release-bound initialization and restore
+// always publish this state, so absence means the anti-rollback invariant was
+// lost rather than that the installation is pristine.
+func InspectServerCatalogAcceptance(directory string, embeddedMinimum int64) error {
+	if !filepath.IsAbs(directory) || filepath.Clean(directory) != directory || embeddedMinimum < 1 {
+		return errors.New("release catalog acceptance is unavailable")
+	}
+	unpin, err := pinTrustedCatalogDirectory(directory)
+	if err != nil {
+		return errors.New("release catalog acceptance is unavailable")
+	}
+	defer unpin()
+	accepted, acceptedExists, err := readAcceptedCatalogState(filepath.Join(directory, acceptedCatalogName))
+	if err != nil {
+		return err
+	}
+	pending, pendingExists, err := readAcceptedCatalogState(filepath.Join(directory, acceptedCatalogPendingName))
+	if err != nil {
+		return err
+	}
+	required, err := readCatalogAcceptanceRequirement(directory)
+	if err != nil {
+		return err
+	}
+	if !required {
+		return ErrCatalogAcceptanceMissing
+	}
+	if !acceptedExists && !pendingExists {
+		return ErrCatalogAcceptanceMissing
+	}
+	sequence := accepted.Sequence
+	if pendingExists && pending.Sequence > sequence {
+		sequence = pending.Sequence
+	}
+	if sequence < embeddedMinimum {
+		return ErrCatalogSequenceDowngrade
+	}
+	return nil
+}
+
+func recoverAcceptedCatalogState(directory string) (acceptedCatalogState, bool, error) {
+	acceptedPath := filepath.Join(directory, acceptedCatalogName)
+	pendingPath := filepath.Join(directory, acceptedCatalogPendingName)
+	accepted, acceptedExists, err := readAcceptedCatalogState(acceptedPath)
+	if err != nil {
+		return acceptedCatalogState{}, false, err
+	}
+	pending, pendingExists, err := readAcceptedCatalogState(pendingPath)
+	if err != nil {
+		return acceptedCatalogState{}, false, err
+	}
+	if !pendingExists {
+		return accepted, acceptedExists, nil
+	}
+	if acceptedExists && pending.Sequence < accepted.Sequence {
+		if err := os.Remove(pendingPath); err != nil || syncDirectory(directory) != nil {
+			return acceptedCatalogState{}, false, errors.New("release catalog acceptance recovery is unavailable")
+		}
+		return accepted, true, nil
+	}
+	if err := os.Rename(pendingPath, acceptedPath); err != nil || syncDirectory(directory) != nil {
+		return acceptedCatalogState{}, false, errors.New("release catalog acceptance recovery is unavailable")
+	}
+	return pending, true, nil
+}
+
+func readAcceptedCatalogState(path string) (acceptedCatalogState, bool, error) {
+	if _, err := os.Lstat(path); errors.Is(err, os.ErrNotExist) {
+		return acceptedCatalogState{}, false, nil
+	} else if err != nil || requireTrustedCatalogFile(path, acceptedCatalogMaximum) != nil {
+		return acceptedCatalogState{}, false, errors.New("release catalog acceptance is unavailable")
+	}
+	body, err := os.ReadFile(path) // #nosec G304 -- fixed state path beneath a validated installation directory.
+	if err != nil || len(body) == 0 || len(body) > acceptedCatalogMaximum {
+		return acceptedCatalogState{}, false, errors.New("release catalog acceptance is unavailable")
+	}
+	decoder := json.NewDecoder(bytes.NewReader(body))
+	decoder.DisallowUnknownFields()
+	var state acceptedCatalogState
+	if decoder.Decode(&state) != nil || decoder.Decode(&struct{}{}) != io.EOF || state.Version != 1 || state.Sequence < 1 {
+		return acceptedCatalogState{}, false, errors.New("release catalog acceptance is invalid")
+	}
+	return state, true, nil
+}
+
+func readCatalogAcceptanceRequirement(directory string) (bool, error) {
+	path := filepath.Join(directory, acceptedCatalogRequiredName)
+	if _, err := os.Lstat(path); errors.Is(err, os.ErrNotExist) {
+		return false, nil
+	} else if err != nil || requireTrustedCatalogFile(path, acceptedCatalogMaximum) != nil {
+		return false, errors.New("release catalog acceptance requirement is unavailable")
+	}
+	body, err := os.ReadFile(path) // #nosec G304 -- fixed state path beneath a validated installation directory.
+	if err != nil || string(body) != acceptedCatalogRequiredBody {
+		return false, errors.New("release catalog acceptance requirement is invalid")
+	}
+	return true, nil
+}
+
+func publishCatalogAcceptanceRequirement(directory string) error {
+	if exists, err := readCatalogAcceptanceRequirement(directory); err != nil {
+		return err
+	} else if exists {
+		return nil
+	}
+	if err := writeExclusive(filepath.Join(directory, acceptedCatalogRequiredName), []byte(acceptedCatalogRequiredBody)); err != nil || syncDirectory(directory) != nil {
+		return errors.New("release catalog acceptance requirement could not be published")
+	}
+	return nil
+}

--- a/internal/operator/catalog_acceptance_test.go
+++ b/internal/operator/catalog_acceptance_test.go
@@ -1,0 +1,184 @@
+package operator
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestAcceptServerCatalogSequenceIsMonotonicAndIdempotent(t *testing.T) {
+	directory := catalogFixtureDirectory(t)
+	if err := AcceptServerCatalogSequence(directory, 2, 1); err != nil {
+		t.Fatal(err)
+	}
+	if err := AcceptServerCatalogSequence(directory, 2, 1); err != nil {
+		t.Fatalf("exact accepted sequence was not idempotent: %v", err)
+	}
+	if err := AcceptServerCatalogSequence(directory, 1, 1); !errors.Is(err, ErrCatalogSequenceDowngrade) {
+		t.Fatalf("downgrade error=%v", err)
+	}
+	if err := AcceptServerCatalogSequence(directory, 2, 3); !errors.Is(err, ErrCatalogSequenceDowngrade) {
+		t.Fatalf("embedded-floor error=%v", err)
+	}
+}
+
+func TestBeginServerCatalogAcceptanceHoldsLockUntilCallerReleases(t *testing.T) {
+	directory := catalogFixtureDirectory(t)
+	unlock, err := BeginServerCatalogAcceptance(directory, 2, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if competingUnlock, err := BeginServerCatalogAcceptance(directory, 3, 1); err == nil {
+		competingUnlock()
+		t.Fatal("concurrent catalog acceptance acquired the transaction-start lock")
+	}
+	unlock()
+	competingUnlock, err := BeginServerCatalogAcceptance(directory, 3, 1)
+	if err != nil {
+		t.Fatalf("catalog acceptance remained locked after release: %v", err)
+	}
+	competingUnlock()
+}
+
+func TestAcceptServerCatalogSequenceRecoversSyncedPendingHighWater(t *testing.T) {
+	directory := catalogFixtureDirectory(t)
+	acceptedCatalogPublicationHook = func(step string) error {
+		if step == "pending" {
+			return errors.New("crash")
+		}
+		return nil
+	}
+	t.Cleanup(func() { acceptedCatalogPublicationHook = nil })
+	if err := AcceptServerCatalogSequence(directory, 4, 0); err == nil {
+		t.Fatal("injected acceptance interruption was ignored")
+	}
+	acceptedCatalogPublicationHook = nil
+	sequence, err := ServerCatalogSequence(directory)
+	if err != nil || sequence != 4 {
+		t.Fatalf("effective pending high-water sequence=%d err=%v", sequence, err)
+	}
+	if err := AcceptServerCatalogSequence(directory, 3, 0); !errors.Is(err, ErrCatalogSequenceDowngrade) {
+		t.Fatalf("synced pending high-water was not recovered: %v", err)
+	}
+	state, exists, err := readAcceptedCatalogState(filepath.Join(directory, acceptedCatalogName))
+	if err != nil || !exists || state.Sequence != 4 {
+		t.Fatalf("accepted state=%#v exists=%v err=%v", state, exists, err)
+	}
+}
+
+func TestCatalogAcceptanceRequirementRejectsLostHighWater(t *testing.T) {
+	directory := catalogFixtureDirectory(t)
+	if err := AcceptServerCatalogSequence(directory, 4, 1); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Remove(filepath.Join(directory, acceptedCatalogName)); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := BeginServerCatalogAcceptance(directory, 3, 1); !errors.Is(err, ErrCatalogAcceptanceMissing) {
+		t.Fatalf("lost high-water update error=%v", err)
+	}
+	if _, unlock, err := BeginServerCatalogSnapshot(directory); !errors.Is(err, ErrCatalogAcceptanceMissing) || unlock != nil {
+		if unlock != nil {
+			unlock()
+		}
+		t.Fatalf("lost high-water snapshot unlock=%v error=%v", unlock != nil, err)
+	}
+}
+
+func TestCatalogAcceptanceSnapshotMigratesExistingHighWaterRequirement(t *testing.T) {
+	directory := catalogFixtureDirectory(t)
+	if err := writeExclusiveJSON(filepath.Join(directory, acceptedCatalogName), acceptedCatalogState{Version: 1, Sequence: 4}); err != nil {
+		t.Fatal(err)
+	}
+	sequence, unlock, err := BeginServerCatalogSnapshot(directory)
+	if err != nil || sequence != 4 {
+		if unlock != nil {
+			unlock()
+		}
+		t.Fatalf("snapshot sequence=%d err=%v", sequence, err)
+	}
+	unlock()
+	if required, err := readCatalogAcceptanceRequirement(directory); err != nil || !required {
+		t.Fatalf("migrated requirement=%t err=%v", required, err)
+	}
+}
+
+func TestServerCatalogSequenceReturnsZeroForPristineInstallation(t *testing.T) {
+	directory := catalogFixtureDirectory(t)
+	sequence, err := ServerCatalogSequence(directory)
+	if err != nil || sequence != 0 {
+		t.Fatalf("pristine sequence=%d err=%v", sequence, err)
+	}
+}
+
+func TestBeginServerCatalogSnapshotHoldsLockUntilBackupPublication(t *testing.T) {
+	directory := catalogFixtureDirectory(t)
+	if err := AcceptServerCatalogSequence(directory, 2, 1); err != nil {
+		t.Fatal(err)
+	}
+	sequence, releaseSnapshot, err := BeginServerCatalogSnapshot(directory)
+	if err != nil || sequence != 2 {
+		t.Fatalf("snapshot sequence=%d err=%v", sequence, err)
+	}
+	if competingUnlock, err := BeginServerCatalogAcceptance(directory, 3, 1); err == nil {
+		competingUnlock()
+		t.Fatal("catalog acceptance advanced before backup publication released its snapshot")
+	}
+	releaseSnapshot()
+	competingUnlock, err := BeginServerCatalogAcceptance(directory, 3, 1)
+	if err != nil {
+		t.Fatalf("catalog acceptance remained locked after backup publication: %v", err)
+	}
+	competingUnlock()
+}
+
+func TestInspectServerCatalogAcceptance(t *testing.T) {
+	directory := catalogFixtureDirectory(t)
+	if err := InspectServerCatalogAcceptance(directory, 3); err == nil {
+		t.Fatal("missing catalog acceptance passed inspection")
+	}
+	if err := AcceptServerCatalogSequence(directory, 4, 3); err != nil {
+		t.Fatal(err)
+	}
+	if err := InspectServerCatalogAcceptance(directory, 4); err != nil {
+		t.Fatalf("accepted inspection: %v", err)
+	}
+	if err := InspectServerCatalogAcceptance(directory, 5); !errors.Is(err, ErrCatalogSequenceDowngrade) {
+		t.Fatalf("embedded downgrade error=%v", err)
+	}
+	requirement := filepath.Join(directory, acceptedCatalogRequiredName)
+	if err := os.Remove(requirement); err != nil {
+		t.Fatal(err)
+	}
+	if err := InspectServerCatalogAcceptance(directory, 4); !errors.Is(err, ErrCatalogAcceptanceMissing) {
+		t.Fatalf("missing requirement error=%v", err)
+	}
+	if _, err := os.Lstat(requirement); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("inspection repaired missing requirement: %v", err)
+	}
+	if err := AcceptServerCatalogSequence(directory, 4, 3); err != nil {
+		t.Fatalf("restore requirement: %v", err)
+	}
+	if err := os.Remove(requirement); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeExclusive(requirement, []byte("{}\n")); err != nil {
+		t.Fatal(err)
+	}
+	if err := InspectServerCatalogAcceptance(directory, 4); err == nil {
+		t.Fatal("invalid catalog acceptance requirement passed inspection")
+	}
+}
+
+func catalogFixtureDirectory(t *testing.T) string {
+	t.Helper()
+	directory := t.TempDir()
+	if err := os.Chmod(directory, 0o700); err != nil { // #nosec G302 -- private operator-state fixture root.
+		t.Fatal(err)
+	}
+	if err := protectNewOperatorDirectory(directory); err != nil {
+		t.Fatal(err)
+	}
+	return directory
+}

--- a/internal/operator/installation.go
+++ b/internal/operator/installation.go
@@ -152,6 +152,10 @@ func Init(ctx context.Context, options InitOptions, bootstrap BootstrapOwner) (I
 	if err := os.Mkdir(options.Directory, 0o700); err != nil {
 		return Installation{}, errors.New("installation directory must be new")
 	}
+	if err := protectNewOperatorDirectory(options.Directory); err != nil {
+		_ = os.Remove(options.Directory)
+		return Installation{}, errors.New("installation directory could not be protected")
+	}
 	if err := requireTrustedPrivateDirectory(options.Directory); err != nil {
 		_ = os.Remove(options.Directory)
 		return Installation{}, errors.New("installation directory must have trusted ancestors")
@@ -519,6 +523,9 @@ func writeExclusiveWithPersist(path string, body []byte, persist func(*os.File, 
 		_ = file.Close()
 		_ = os.Remove(temporary)
 	}()
+	if err = protectNewOperatorFile(file); err != nil {
+		return err
+	}
 	if err = persist(file, body); err != nil {
 		return err
 	}
@@ -545,6 +552,27 @@ func requireProtectedFile(path string, maximum int64) error {
 		return errors.New("must be a regular file inaccessible to group and other")
 	}
 	return nil
+}
+
+// RequireTrustedProtectedFile validates an owner-controlled bounded file and
+// its ancestor chain for security-sensitive operator inputs.
+func RequireTrustedProtectedFile(path string, maximum int64) error {
+	return requireTrustedProtectedFile(path, maximum)
+}
+
+// RequireTrustedExternalFile applies the stronger no-alias and platform ACL
+// policy required for operator-supplied trust and release inputs. Internal
+// crash-published state intentionally uses RequireTrustedProtectedFile because
+// its completed inode can temporarily retain a known staging link.
+func RequireTrustedExternalFile(path string, maximum int64) error {
+	return requireTrustedExternalFile(path, maximum)
+}
+
+// OpenTrustedExternalFile opens a bounded operator-supplied input and keeps
+// the validated object pinned for the caller. Platform implementations bind
+// ownership and ACL checks to that same open handle where required.
+func OpenTrustedExternalFile(path string, maximum int64) (*os.File, error) {
+	return openTrustedExternalFile(path, maximum)
 }
 
 // CheckPaths returns actionable, content-free failures for installation paths.

--- a/internal/operator/path_security_unix.go
+++ b/internal/operator/path_security_unix.go
@@ -30,13 +30,68 @@ func requireTrustedProtectedFile(path string, maximum int64) error {
 	return requireTrustedDirectoryAncestors(filepath.Dir(filepath.Clean(path)))
 }
 
+func requireTrustedExternalFile(path string, maximum int64) error {
+	file, err := openTrustedExternalFile(path, maximum)
+	if err != nil {
+		return err
+	}
+	return file.Close()
+}
+
+func openTrustedExternalFile(path string, maximum int64) (*os.File, error) {
+	if err := requireTrustedProtectedFile(path, maximum); err != nil {
+		return nil, err
+	}
+	info, err := os.Lstat(path)
+	if err != nil {
+		return nil, errors.New("external file is unsafe")
+	}
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	if !ok || stat.Nlink != 1 {
+		return nil, errors.New("external file must have exactly one link")
+	}
+	file, err := os.Open(path) // #nosec G304 -- explicit operator-supplied release input.
+	if err != nil {
+		return nil, err
+	}
+	opened, err := file.Stat()
+	if err != nil || !os.SameFile(info, opened) || !opened.Mode().IsRegular() || opened.Size() > maximum {
+		_ = file.Close()
+		return nil, errors.New("external file changed during open")
+	}
+	return file, nil
+}
+
+func protectNewOperatorDirectory(string) error { return nil }
+
+func protectNewOperatorFile(*os.File) error { return nil }
+
+func requireTrustedCatalogDirectory(path string) error { return requireTrustedPrivateDirectory(path) }
+
+func ensureTrustedCatalogDirectory(path string) error { return requireTrustedCatalogDirectory(path) }
+
+func pinTrustedCatalogDirectory(path string) (func(), error) {
+	if err := requireTrustedCatalogDirectory(path); err != nil {
+		return nil, err
+	}
+	return func() {}, nil
+}
+
+func requireTrustedCatalogFile(path string, maximum int64) error {
+	return requireTrustedProtectedFile(path, maximum)
+}
+
 func ownedByCurrentUser(path string) bool {
 	info, err := os.Lstat(path)
 	if err != nil {
 		return false
 	}
 	stat, ok := info.Sys().(*syscall.Stat_t)
-	return ok && int(stat.Uid) == os.Getuid()
+	return ok && trustedProtectedFileUID(int(stat.Uid))
+}
+
+func trustedProtectedFileUID(uid int) bool {
+	return uid == os.Getuid()
 }
 
 func runtimeIdentityMatches(installation Installation) bool {

--- a/internal/operator/path_security_unix_test.go
+++ b/internal/operator/path_security_unix_test.go
@@ -4,6 +4,7 @@ package operator
 
 import (
 	"os"
+	"path/filepath"
 	"testing"
 )
 
@@ -17,5 +18,32 @@ func TestTrustedAncestorOwnershipPolicy(t *testing.T) {
 	}
 	if trustedAncestorUID(foreign) {
 		t.Fatal("foreign-owned ancestor was accepted")
+	}
+}
+
+func TestTrustedProtectedFileOwnershipPolicy(t *testing.T) {
+	if !trustedProtectedFileUID(os.Getuid()) {
+		t.Fatal("current user was rejected")
+	}
+	foreign := os.Getuid() + 1
+	if foreign == os.Getuid() {
+		foreign++
+	}
+	if trustedProtectedFileUID(foreign) {
+		t.Fatal("foreign-owned protected file was accepted")
+	}
+}
+
+func TestTrustedProtectedFileAllowsCrashPublishedSecondLink(t *testing.T) {
+	directory := t.TempDir()
+	path := filepath.Join(directory, "published")
+	if err := os.WriteFile(path, []byte("complete"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Link(path, filepath.Join(directory, ".published.tmp-crash")); err != nil {
+		t.Fatal(err)
+	}
+	if err := requireTrustedProtectedFile(path, 64); err != nil {
+		t.Fatalf("complete crash-published state was rejected: %v", err)
 	}
 }

--- a/internal/operator/path_security_windows.go
+++ b/internal/operator/path_security_windows.go
@@ -2,6 +2,17 @@
 
 package operator
 
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+const windowsFullControl = windows.ACCESS_MASK(0x1f01ff)
+
 func requireTrustedPrivateDirectory(path string) error {
 	return requirePrivateDirectory(path)
 }
@@ -10,6 +21,431 @@ func requireTrustedDirectoryAncestors(string) error { return nil }
 
 func requireTrustedProtectedFile(path string, maximum int64) error {
 	return requireProtectedFile(path, maximum)
+}
+
+func requireTrustedExternalFile(path string, maximum int64) error {
+	file, err := openTrustedExternalFile(path, maximum)
+	if err != nil {
+		return err
+	}
+	return file.Close()
+}
+
+// openTrustedExternalFile binds type, link-count, owner, and DACL validation
+// to the same non-reparse handle whose bytes the caller reads. A junction
+// retarget therefore cannot make validation describe a different object.
+func openTrustedExternalFile(path string, maximum int64) (*os.File, error) {
+	name, err := windows.UTF16PtrFromString(path)
+	if err != nil || maximum < 0 {
+		return nil, errors.New("external file is unsafe")
+	}
+	handle, err := windows.CreateFile(
+		name,
+		windows.GENERIC_READ|windows.READ_CONTROL,
+		windows.FILE_SHARE_READ,
+		nil,
+		windows.OPEN_EXISTING,
+		windows.FILE_ATTRIBUTE_NORMAL|windows.FILE_FLAG_OPEN_REPARSE_POINT,
+		0,
+	) // #nosec G304 -- explicit release input is opened without following the final reparse point.
+	if err != nil {
+		return nil, errors.New("external file is unsafe")
+	}
+	if !trustedWindowsFileHandle(handle, maximum, true) || !trustedWindowsACLHandle(handle, 0) {
+		_ = windows.CloseHandle(handle)
+		return nil, errors.New("external file is unsafe")
+	}
+	return os.NewFile(uintptr(handle), path), nil // #nosec G115 -- successful Win32 handles are nonnegative.
+}
+
+func protectNewOperatorDirectory(path string) error {
+	name, err := windows.UTF16PtrFromString(path)
+	if err != nil {
+		return errors.New("operator directory cannot be protected")
+	}
+	handle, err := windows.CreateFile(
+		name,
+		windows.READ_CONTROL|windows.WRITE_DAC,
+		windows.FILE_SHARE_READ|windows.FILE_SHARE_WRITE|windows.FILE_SHARE_DELETE,
+		nil,
+		windows.OPEN_EXISTING,
+		windows.FILE_FLAG_BACKUP_SEMANTICS|windows.FILE_FLAG_OPEN_REPARSE_POINT,
+		0,
+	)
+	if err != nil {
+		return errors.New("operator directory cannot be protected")
+	}
+	defer func() { _ = windows.CloseHandle(handle) }()
+	var details windows.ByHandleFileInformation
+	if err := windows.GetFileInformationByHandle(handle, &details); err != nil || details.FileAttributes&windows.FILE_ATTRIBUTE_DIRECTORY == 0 || details.FileAttributes&windows.FILE_ATTRIBUTE_REPARSE_POINT != 0 {
+		return errors.New("operator directory cannot be protected")
+	}
+	_, acl, err := currentUserWindowsACL(windows.SUB_CONTAINERS_AND_OBJECTS_INHERIT)
+	if err != nil || windows.SetSecurityInfo(handle, windows.SE_FILE_OBJECT, windows.DACL_SECURITY_INFORMATION|windows.PROTECTED_DACL_SECURITY_INFORMATION, nil, nil, acl, nil) != nil || !trustedWindowsACLHandle(handle, windows.OBJECT_INHERIT_ACE|windows.CONTAINER_INHERIT_ACE) {
+		return errors.New("operator directory cannot be protected")
+	}
+	return nil
+}
+
+func protectNewOperatorFile(file *os.File) error {
+	_, acl, err := currentUserWindowsACL(0)
+	if err != nil {
+		return errors.New("operator file cannot be protected")
+	}
+	handle := windows.Handle(file.Fd())
+	if err := windows.SetSecurityInfo(handle, windows.SE_FILE_OBJECT, windows.DACL_SECURITY_INFORMATION|windows.PROTECTED_DACL_SECURITY_INFORMATION, nil, nil, acl, nil); err != nil || !trustedWindowsACLHandle(handle, 0) {
+		return errors.New("operator file cannot be protected")
+	}
+	return nil
+}
+
+func requireTrustedCatalogDirectory(path string) error {
+	unpin, err := pinTrustedCatalogDirectory(path)
+	if err != nil {
+		return err
+	}
+	unpin()
+	return nil
+}
+
+// pinTrustedCatalogDirectory retains non-delete-shared handles for the
+// catalog directory and its complete ancestor chain. The target's protected
+// ACL prevents leaf replacement, while each ancestor must deny unprivileged
+// child deletion and security-descriptor takeover. Rechecking the target file
+// identity after the chain is pinned detects a concurrent path swap.
+func pinTrustedCatalogDirectory(path string) (func(), error) {
+	if !filepath.IsAbs(path) || filepath.Clean(path) != path || requirePrivateDirectory(path) != nil {
+		return nil, errors.New("catalog directory is unsafe")
+	}
+	var handles []windows.Handle
+	closeHandles := func() {
+		for index := len(handles) - 1; index >= 0; index-- {
+			_ = windows.CloseHandle(handles[index])
+		}
+	}
+	current := path
+	for {
+		handle, err := openPinnedWindowsDirectory(current)
+		if err != nil {
+			closeHandles()
+			return nil, errors.New("catalog directory is unsafe")
+		}
+		handles = append(handles, handle)
+		if len(handles) == 1 {
+			if !trustedWindowsACLHandle(handle, windows.OBJECT_INHERIT_ACE|windows.CONTAINER_INHERIT_ACE) {
+				closeHandles()
+				return nil, errors.New("catalog directory is unsafe")
+			}
+		} else if !trustedWindowsCatalogAncestorHandle(handle) {
+			closeHandles()
+			return nil, errors.New("catalog directory ancestors are unsafe")
+		}
+		parent := filepath.Dir(current)
+		if parent == current {
+			break
+		}
+		current = parent
+	}
+	verification, err := openPinnedWindowsDirectory(path)
+	if err != nil || !sameWindowsFile(handles[0], verification) {
+		if err == nil {
+			_ = windows.CloseHandle(verification)
+		}
+		closeHandles()
+		return nil, errors.New("catalog directory changed during validation")
+	}
+	_ = windows.CloseHandle(verification)
+	return closeHandles, nil
+}
+
+func openPinnedWindowsDirectory(path string) (windows.Handle, error) {
+	name, err := windows.UTF16PtrFromString(path)
+	if err != nil {
+		return 0, err
+	}
+	handle, err := windows.CreateFile(
+		name,
+		windows.READ_CONTROL|windows.FILE_READ_ATTRIBUTES,
+		windows.FILE_SHARE_READ|windows.FILE_SHARE_WRITE,
+		nil,
+		windows.OPEN_EXISTING,
+		windows.FILE_FLAG_BACKUP_SEMANTICS|windows.FILE_FLAG_OPEN_REPARSE_POINT,
+		0,
+	)
+	if err != nil {
+		return 0, err
+	}
+	var details windows.ByHandleFileInformation
+	if err := windows.GetFileInformationByHandle(handle, &details); err != nil || details.FileAttributes&windows.FILE_ATTRIBUTE_DIRECTORY == 0 || details.FileAttributes&windows.FILE_ATTRIBUTE_REPARSE_POINT != 0 {
+		_ = windows.CloseHandle(handle)
+		return 0, errors.New("catalog path component is unsafe")
+	}
+	return handle, nil
+}
+
+func sameWindowsFile(first, second windows.Handle) bool {
+	var firstDetails, secondDetails windows.ByHandleFileInformation
+	return windows.GetFileInformationByHandle(first, &firstDetails) == nil &&
+		windows.GetFileInformationByHandle(second, &secondDetails) == nil &&
+		firstDetails.VolumeSerialNumber == secondDetails.VolumeSerialNumber &&
+		firstDetails.FileIndexHigh == secondDetails.FileIndexHigh &&
+		firstDetails.FileIndexLow == secondDetails.FileIndexLow
+}
+
+func trustedWindowsCatalogAncestorHandle(handle windows.Handle) bool {
+	user, err := windows.GetCurrentProcessToken().GetTokenUser()
+	if err != nil || user.User.Sid == nil {
+		return false
+	}
+	system, err := windows.CreateWellKnownSid(windows.WinLocalSystemSid)
+	if err != nil {
+		return false
+	}
+	administrators, err := windows.CreateWellKnownSid(windows.WinBuiltinAdministratorsSid)
+	if err != nil {
+		return false
+	}
+	trustedInstaller, err := windows.StringToSid("S-1-5-80-956008885-3418522649-1831038044-1853292631-2271478464")
+	if err != nil {
+		return false
+	}
+	trusted := func(sid *windows.SID) bool {
+		return sid != nil && (sid.Equals(user.User.Sid) || sid.Equals(system) || sid.Equals(administrators) || sid.Equals(trustedInstaller))
+	}
+	descriptor, err := windows.GetSecurityInfo(handle, windows.SE_FILE_OBJECT, windows.OWNER_SECURITY_INFORMATION|windows.DACL_SECURITY_INFORMATION)
+	if err != nil {
+		return false
+	}
+	owner, _, err := descriptor.Owner()
+	if err != nil || !trusted(owner) {
+		return false
+	}
+	dacl, _, err := descriptor.DACL()
+	if err != nil || dacl == nil {
+		return false
+	}
+	const fileDeleteChild windows.ACCESS_MASK = 0x00000040
+	dangerous := windows.ACCESS_MASK(windows.DELETE | windows.WRITE_DAC | windows.WRITE_OWNER | windows.GENERIC_ALL)
+	dangerous |= fileDeleteChild
+	for index := uint32(0); index < uint32(dacl.AceCount); index++ {
+		var ace *windows.ACCESS_ALLOWED_ACE
+		if windows.GetAce(dacl, index, &ace) != nil || ace == nil {
+			return false
+		}
+		if ace.Header.AceFlags&windows.INHERIT_ONLY_ACE != 0 || ace.Mask&dangerous == 0 {
+			continue
+		}
+		if ace.Header.AceType != windows.ACCESS_ALLOWED_ACE_TYPE {
+			// Deny and audit ACEs do not grant replacement authority. Unknown
+			// allow-object layouts are rejected conservatively below.
+			if ace.Header.AceType == 1 || ace.Header.AceType == 2 || ace.Header.AceType == 3 || ace.Header.AceType == 6 || ace.Header.AceType == 7 || ace.Header.AceType == 8 {
+				continue
+			}
+			return false
+		}
+		aceSID := (*windows.SID)(unsafe.Pointer(&ace.SidStart)) // #nosec G103 -- SidStart is the documented flexible-array start of this ACE's SID.
+		if !trusted(aceSID) {
+			return false
+		}
+	}
+	return true
+}
+
+// ensureTrustedCatalogDirectory performs the one supported legacy migration:
+// an existing published installation with no catalog state and a DACL limited
+// to the current user, LocalSystem, and built-in administrators. Validation
+// and replacement are bound to one non-reparse directory handle.
+func ensureTrustedCatalogDirectory(path string) error {
+	if requireTrustedCatalogDirectory(path) == nil {
+		return nil
+	}
+	name, err := windows.UTF16PtrFromString(path)
+	if err != nil {
+		return errors.New("catalog directory is unsafe")
+	}
+	handle, err := windows.CreateFile(
+		name,
+		windows.READ_CONTROL|windows.WRITE_DAC|windows.FILE_READ_ATTRIBUTES,
+		windows.FILE_SHARE_READ|windows.FILE_SHARE_WRITE,
+		nil,
+		windows.OPEN_EXISTING,
+		windows.FILE_FLAG_BACKUP_SEMANTICS|windows.FILE_FLAG_OPEN_REPARSE_POINT,
+		0,
+	)
+	if err != nil {
+		return errors.New("catalog directory is unsafe")
+	}
+	defer func() { _ = windows.CloseHandle(handle) }()
+	var details windows.ByHandleFileInformation
+	if err := windows.GetFileInformationByHandle(handle, &details); err != nil || details.FileAttributes&windows.FILE_ATTRIBUTE_DIRECTORY == 0 || details.FileAttributes&windows.FILE_ATTRIBUTE_REPARSE_POINT != 0 || !trustedLegacyWindowsACLHandle(handle) {
+		return errors.New("catalog directory is unsafe")
+	}
+	for _, child := range []string{acceptedCatalogName, acceptedCatalogPendingName, acceptedCatalogRequiredName} {
+		if _, err := os.Lstat(filepath.Join(path, child)); !errors.Is(err, os.ErrNotExist) {
+			return errors.New("catalog directory migration is unavailable")
+		}
+	}
+	if requireTrustedLegacyWindowsInstallationFile(filepath.Join(path, configName)) != nil {
+		return errors.New("catalog directory migration is unavailable")
+	}
+	if _, err := Load(path); err != nil {
+		return errors.New("catalog directory migration is unavailable")
+	}
+	_, acl, err := currentUserWindowsACL(windows.SUB_CONTAINERS_AND_OBJECTS_INHERIT)
+	if err != nil || windows.SetSecurityInfo(handle, windows.SE_FILE_OBJECT, windows.DACL_SECURITY_INFORMATION|windows.PROTECTED_DACL_SECURITY_INFORMATION, nil, nil, acl, nil) != nil || !trustedWindowsACLHandle(handle, windows.OBJECT_INHERIT_ACE|windows.CONTAINER_INHERIT_ACE) {
+		return errors.New("catalog directory migration is unavailable")
+	}
+	return requireTrustedCatalogDirectory(path)
+}
+
+func requireTrustedCatalogFile(path string, maximum int64) error {
+	if err := requireProtectedFile(path, maximum); err != nil {
+		return err
+	}
+	name, err := windows.UTF16PtrFromString(path)
+	if err != nil {
+		return errors.New("catalog file is unsafe")
+	}
+	handle, err := windows.CreateFile(
+		name,
+		windows.READ_CONTROL|windows.FILE_READ_ATTRIBUTES,
+		windows.FILE_SHARE_READ|windows.FILE_SHARE_WRITE|windows.FILE_SHARE_DELETE,
+		nil,
+		windows.OPEN_EXISTING,
+		windows.FILE_ATTRIBUTE_NORMAL|windows.FILE_FLAG_OPEN_REPARSE_POINT,
+		0,
+	)
+	if err != nil {
+		return errors.New("catalog file is unsafe")
+	}
+	defer func() { _ = windows.CloseHandle(handle) }()
+	if !trustedWindowsFileHandle(handle, maximum, false) || !trustedWindowsACLHandle(handle, 0) {
+		return errors.New("catalog file is unsafe")
+	}
+	return nil
+}
+
+func trustedWindowsFileHandle(handle windows.Handle, maximum int64, requireSingleLink bool) bool {
+	var details windows.ByHandleFileInformation
+	if err := windows.GetFileInformationByHandle(handle, &details); err != nil || details.FileAttributes&windows.FILE_ATTRIBUTE_REPARSE_POINT != 0 || details.FileAttributes&windows.FILE_ATTRIBUTE_DIRECTORY != 0 || requireSingleLink && details.NumberOfLinks != 1 {
+		return false
+	}
+	size := uint64(details.FileSizeHigh)<<32 | uint64(details.FileSizeLow)
+	return maximum >= 0 && size <= uint64(maximum)
+}
+
+func trustedWindowsACLHandle(handle windows.Handle, expectedFlags uint8) bool {
+	user, err := windows.GetCurrentProcessToken().GetTokenUser()
+	if err != nil || user.User.Sid == nil {
+		return false
+	}
+	descriptor, err := windows.GetSecurityInfo(handle, windows.SE_FILE_OBJECT, windows.OWNER_SECURITY_INFORMATION|windows.DACL_SECURITY_INFORMATION)
+	if err != nil {
+		return false
+	}
+	owner, _, err := descriptor.Owner()
+	if err != nil || owner == nil || !owner.Equals(user.User.Sid) {
+		return false
+	}
+	control, _, err := descriptor.Control()
+	if err != nil || control&windows.SE_DACL_PROTECTED == 0 {
+		return false
+	}
+	dacl, _, err := descriptor.DACL()
+	if err != nil || dacl == nil || dacl.AceCount != 1 {
+		return false
+	}
+	var ace *windows.ACCESS_ALLOWED_ACE
+	if windows.GetAce(dacl, 0, &ace) != nil || ace == nil || ace.Header.AceType != windows.ACCESS_ALLOWED_ACE_TYPE || ace.Header.AceFlags != expectedFlags || ace.Mask != windowsFullControl {
+		return false
+	}
+	// #nosec G103 -- SidStart is the documented flexible-array start of this ACE's SID.
+	aceSID := (*windows.SID)(unsafe.Pointer(&ace.SidStart))
+	return aceSID.Equals(user.User.Sid)
+}
+
+func requireTrustedLegacyWindowsInstallationFile(path string) error {
+	name, err := windows.UTF16PtrFromString(path)
+	if err != nil {
+		return errors.New("legacy installation file is unsafe")
+	}
+	handle, err := windows.CreateFile(
+		name,
+		windows.READ_CONTROL|windows.FILE_READ_ATTRIBUTES,
+		windows.FILE_SHARE_READ|windows.FILE_SHARE_WRITE,
+		nil,
+		windows.OPEN_EXISTING,
+		windows.FILE_ATTRIBUTE_NORMAL|windows.FILE_FLAG_OPEN_REPARSE_POINT,
+		0,
+	)
+	if err != nil {
+		return errors.New("legacy installation file is unsafe")
+	}
+	defer func() { _ = windows.CloseHandle(handle) }()
+	if !trustedWindowsFileHandle(handle, 64<<10, false) || !trustedLegacyWindowsACLHandle(handle) {
+		return errors.New("legacy installation file is unsafe")
+	}
+	return nil
+}
+
+func trustedLegacyWindowsACLHandle(handle windows.Handle) bool {
+	user, err := windows.GetCurrentProcessToken().GetTokenUser()
+	if err != nil || user.User.Sid == nil {
+		return false
+	}
+	system, err := windows.CreateWellKnownSid(windows.WinLocalSystemSid)
+	if err != nil {
+		return false
+	}
+	administrators, err := windows.CreateWellKnownSid(windows.WinBuiltinAdministratorsSid)
+	if err != nil {
+		return false
+	}
+	descriptor, err := windows.GetSecurityInfo(handle, windows.SE_FILE_OBJECT, windows.OWNER_SECURITY_INFORMATION|windows.DACL_SECURITY_INFORMATION)
+	if err != nil {
+		return false
+	}
+	owner, _, err := descriptor.Owner()
+	if err != nil || owner == nil || !owner.Equals(user.User.Sid) {
+		return false
+	}
+	dacl, _, err := descriptor.DACL()
+	if err != nil || dacl == nil || dacl.AceCount == 0 {
+		return false
+	}
+	currentUserFullControl := false
+	for index := uint32(0); index < uint32(dacl.AceCount); index++ {
+		var ace *windows.ACCESS_ALLOWED_ACE
+		if windows.GetAce(dacl, index, &ace) != nil || ace == nil || ace.Header.AceType != windows.ACCESS_ALLOWED_ACE_TYPE {
+			return false
+		}
+		aceSID := (*windows.SID)(unsafe.Pointer(&ace.SidStart)) // #nosec G103 -- SidStart is the documented flexible-array start of this ACE's SID.
+		if aceSID.Equals(user.User.Sid) {
+			currentUserFullControl = currentUserFullControl || ace.Mask&windowsFullControl == windowsFullControl
+			continue
+		}
+		if !aceSID.Equals(system) && !aceSID.Equals(administrators) {
+			return false
+		}
+	}
+	return currentUserFullControl
+}
+
+func currentUserWindowsACL(inheritance uint32) (*windows.SID, *windows.ACL, error) {
+	user, err := windows.GetCurrentProcessToken().GetTokenUser()
+	if err != nil || user.User.Sid == nil {
+		return nil, nil, errors.New("current user is unavailable")
+	}
+	acl, err := windows.ACLFromEntries([]windows.EXPLICIT_ACCESS{{
+		AccessPermissions: windowsFullControl,
+		AccessMode:        windows.GRANT_ACCESS,
+		Inheritance:       inheritance,
+		Trustee:           windows.TRUSTEE{TrusteeForm: windows.TRUSTEE_IS_SID, TrusteeValue: windows.TrusteeValueFromSID(user.User.Sid)},
+	}}, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+	return user.User.Sid, acl, nil
 }
 
 func runtimeIdentityMatches(Installation) bool { return true }

--- a/internal/operator/path_security_windows_test.go
+++ b/internal/operator/path_security_windows_test.go
@@ -1,0 +1,171 @@
+//go:build windows
+
+package operator
+
+import (
+	"context"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	punaropostgres "github.com/rock3r/punaro/internal/postgres"
+	"golang.org/x/sys/windows"
+)
+
+func TestWindowsCatalogAcceptanceRequiresExclusiveACLs(t *testing.T) {
+	directory := t.TempDir()
+	setWindowsOperatorFixtureACL(t, directory, true, "(A;OICI;FW;;;WD)")
+	if err := AcceptServerCatalogSequence(directory, 4, 1); err == nil {
+		t.Fatal("catalog acceptance trusted a shared installation directory")
+	}
+	if err := protectNewOperatorDirectory(directory); err != nil {
+		t.Fatal(err)
+	}
+	if err := AcceptServerCatalogSequence(directory, 4, 1); err != nil {
+		t.Fatal(err)
+	}
+	accepted := filepath.Join(directory, acceptedCatalogName)
+	required := filepath.Join(directory, acceptedCatalogRequiredName)
+	if requireTrustedCatalogFile(accepted, acceptedCatalogMaximum) != nil || requireTrustedCatalogFile(required, acceptedCatalogMaximum) != nil {
+		t.Fatal("catalog acceptance files lack protected current-user-only ACLs")
+	}
+	setWindowsOperatorFixtureACL(t, accepted, false, "(A;;FR;;;WD)")
+	if _, err := ServerCatalogSequence(directory); err == nil {
+		t.Fatal("catalog acceptance trusted a shared high-water file")
+	}
+}
+
+func TestWindowsCatalogAcceptanceMigratesLegacyInstallationACL(t *testing.T) {
+	options := validInitOptions(t)
+	installation, err := Init(context.Background(), options, func(_ context.Context, _ string, name string) (punaropostgres.Principal, error) {
+		return punaropostgres.Principal{ID: "11111111-1111-4111-8111-111111111111", DisplayName: name}, nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	setLegacyWindowsOperatorDirectoryACL(t, installation.Directory)
+	if requireTrustedCatalogDirectory(installation.Directory) == nil {
+		t.Fatal("legacy inherited installation ACL unexpectedly passed strict validation")
+	}
+	sequence, err := ServerCatalogSequence(installation.Directory)
+	if err != nil || sequence != 0 {
+		t.Fatalf("legacy snapshot sequence=%d err=%v", sequence, err)
+	}
+	if err := requireTrustedCatalogDirectory(installation.Directory); err != nil {
+		t.Fatalf("legacy installation ACL was not migrated: %v", err)
+	}
+	if err := AcceptServerCatalogSequence(installation.Directory, 4, 1); err != nil {
+		t.Fatalf("first catalog acceptance after migration: %v", err)
+	}
+}
+
+func TestWindowsCatalogAcceptanceRejectsReplaceableAncestor(t *testing.T) {
+	parent := filepath.Join(t.TempDir(), "operator-parent")
+	if err := os.Mkdir(parent, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	directory := filepath.Join(parent, "catalog")
+	if err := os.Mkdir(directory, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := protectNewOperatorDirectory(directory); err != nil {
+		t.Fatal(err)
+	}
+	setWindowsOperatorFixtureACL(t, parent, true, "(A;;DC;;;WD)")
+	if _, err := pinTrustedCatalogDirectory(directory); err == nil {
+		t.Fatal("catalog acceptance trusted an ancestor that grants delete-child authority")
+	}
+	if err := protectNewOperatorDirectory(parent); err != nil {
+		t.Fatal(err)
+	}
+	unpin, err := pinTrustedCatalogDirectory(directory)
+	if err != nil {
+		t.Fatal(err)
+	}
+	moved := directory + "-moved"
+	if err := os.Rename(directory, moved); err == nil {
+		unpin()
+		t.Fatal("pinned catalog directory allowed concurrent replacement")
+	}
+	unpin()
+	if err := os.Rename(directory, moved); err != nil {
+		t.Fatalf("catalog directory remained pinned after release: %v", err)
+	}
+}
+
+func TestWindowsTrustedExternalFilePinsValidatedHandle(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "release.json")
+	file, err := os.Create(path) // #nosec G304 -- test fixture path.
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := protectNewOperatorFile(file); err != nil {
+		_ = file.Close()
+		t.Fatal(err)
+	}
+	if _, err := file.WriteString("signed release\n"); err != nil {
+		_ = file.Close()
+		t.Fatal(err)
+	}
+	if err := file.Close(); err != nil {
+		t.Fatal(err)
+	}
+	pinned, err := OpenTrustedExternalFile(path, 64)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = pinned.Close() }()
+	if writer, err := os.OpenFile(path, os.O_WRONLY, 0); err == nil { // #nosec G304 -- intentional concurrent-open probe of this test fixture.
+		_ = writer.Close()
+		t.Fatal("validated release handle allowed a concurrent writer")
+	}
+	body, err := io.ReadAll(pinned)
+	if err != nil || string(body) != "signed release\n" {
+		t.Fatalf("body=%q err=%v", body, err)
+	}
+}
+
+func setWindowsOperatorFixtureACL(t *testing.T, path string, directory bool, additionalACE string) {
+	t.Helper()
+	user, err := windows.GetCurrentProcessToken().GetTokenUser()
+	if err != nil || user.User.Sid == nil {
+		t.Fatalf("current user: %v", err)
+	}
+	flags := ""
+	if directory {
+		flags = "OICI"
+	}
+	sid := user.User.Sid.String()
+	descriptor, err := windows.SecurityDescriptorFromString("O:" + sid + "D:P(A;" + flags + ";FA;;;" + sid + ")" + additionalACE)
+	if err != nil {
+		t.Fatal(err)
+	}
+	dacl, _, err := descriptor.DACL()
+	if err != nil || dacl == nil {
+		t.Fatalf("DACL: %v", err)
+	}
+	if err := windows.SetNamedSecurityInfo(path, windows.SE_FILE_OBJECT, windows.OWNER_SECURITY_INFORMATION|windows.DACL_SECURITY_INFORMATION|windows.PROTECTED_DACL_SECURITY_INFORMATION, user.User.Sid, nil, dacl, nil); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func setLegacyWindowsOperatorDirectoryACL(t *testing.T, path string) {
+	t.Helper()
+	user, err := windows.GetCurrentProcessToken().GetTokenUser()
+	if err != nil || user.User.Sid == nil {
+		t.Fatalf("current user: %v", err)
+	}
+	sid := user.User.Sid.String()
+	descriptor, err := windows.SecurityDescriptorFromString("O:" + sid + "D:(A;OICI;FA;;;" + sid + ")(A;OICI;FA;;;SY)(A;OICI;FA;;;BA)")
+	if err != nil {
+		t.Fatal(err)
+	}
+	dacl, _, err := descriptor.DACL()
+	if err != nil || dacl == nil {
+		t.Fatalf("DACL: %v", err)
+	}
+	if err := windows.SetNamedSecurityInfo(path, windows.SE_FILE_OBJECT, windows.OWNER_SECURITY_INFORMATION|windows.DACL_SECURITY_INFORMATION|windows.UNPROTECTED_DACL_SECURITY_INFORMATION, user.User.Sid, nil, dacl, nil); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/operator/restore.go
+++ b/internal/operator/restore.go
@@ -143,12 +143,29 @@ func PrepareRestore(options RestoreOptions) (Installation, error) {
 // PublishRestore atomically publishes generated configuration after verified
 // database/timeline/blob restore has created the new data directory.
 func PublishRestore(installation Installation) error {
+	return PublishRestoreWithCatalogSequence(installation, 0)
+}
+
+// PublishRestoreWithCatalogSequence atomically publishes the restored
+// installation configuration together with its backed-up release-catalog
+// high-water, so disaster recovery cannot make an accepted retirement vanish.
+func PublishRestoreWithCatalogSequence(installation Installation, catalogSequence int64) error {
+	if catalogSequence < 0 {
+		return errors.New("restored release catalog acceptance is invalid")
+	}
 	if uuid.Validate(installation.OwnerPrincipalID) != nil || requireTrustedPrivateDirectory(installation.DataDir) != nil || requireTrustedPrivateDirectory(installation.BackupDir) != nil || requireTrustedProtectedFile(installation.OwnerDSNFile, 64<<10) != nil || requireTrustedProtectedFile(installation.AppDSNFile, 64<<10) != nil || installation.TrustedAttachmentsEnabled && (requireTrustedPrivateDirectory(installation.TrustedAttachmentBlobDir) != nil || !attachmentBlobDirectoryContained(installation.DataDir, installation.TrustedAttachmentBlobDir)) {
 		return errors.New("restored installation inputs are unavailable or unsafe")
 	}
 	if existing, err := Load(installation.Directory); err == nil {
 		if existing == installation {
-			return nil
+			if catalogSequence == 0 {
+				return nil
+			}
+			current, sequenceErr := ServerCatalogSequence(installation.Directory)
+			if sequenceErr == nil && current >= catalogSequence {
+				return nil
+			}
+			return AcceptServerCatalogSequence(installation.Directory, catalogSequence, catalogSequence)
 		}
 		return errors.New("restored installation target belongs to a different request")
 	}
@@ -159,6 +176,9 @@ func PublishRestore(installation Installation) error {
 	if err := os.RemoveAll(stage); err != nil || os.Mkdir(stage, 0o700) != nil {
 		return errors.New("restored installation staging cannot be reserved")
 	}
+	if err := protectNewOperatorDirectory(stage); err != nil {
+		return errors.New("restored installation staging cannot be protected")
+	}
 	published := false
 	defer func() {
 		if !published {
@@ -167,6 +187,11 @@ func PublishRestore(installation Installation) error {
 	}()
 	if requireTrustedPrivateDirectory(stage) != nil || writeExclusive(EnvFile(stage), []byte(daemonEnv(installation))) != nil || writeExclusive(OverrideFile(stage), []byte(composeOverride())) != nil || writeExclusiveJSON(filepath.Join(stage, configName), installation) != nil {
 		return errors.New("restored installation configuration could not be staged")
+	}
+	if catalogSequence > 0 {
+		if err := writeExclusiveJSON(filepath.Join(stage, acceptedCatalogName), acceptedCatalogState{Version: 1, Sequence: catalogSequence}); err != nil || writeExclusive(filepath.Join(stage, acceptedCatalogRequiredName), []byte(acceptedCatalogRequiredBody)) != nil {
+			return errors.New("restored release catalog acceptance could not be staged")
+		}
 	}
 	if syncDirectory(stage) != nil || os.Rename(stage, installation.Directory) != nil || syncDirectory(filepath.Dir(installation.Directory)) != nil {
 		return errors.New("restored installation configuration durability failed")

--- a/internal/operator/restore_test.go
+++ b/internal/operator/restore_test.go
@@ -56,7 +56,7 @@ func TestPrepareAndPublishRestoreCreatesOnlyNewInstallation(t *testing.T) {
 	if err := os.Mkdir(options.DataDir, 0o700); err != nil {
 		t.Fatal(err)
 	}
-	if err := PublishRestore(installation); err != nil {
+	if err := PublishRestoreWithCatalogSequence(installation, 7); err != nil {
 		t.Fatalf("publish: %v", err)
 	}
 	loaded, err := Load(options.Directory)
@@ -65,6 +65,20 @@ func TestPrepareAndPublishRestoreCreatesOnlyNewInstallation(t *testing.T) {
 	}
 	if loaded.OwnerPrincipalID != options.Source.OwnerPrincipalID || loaded.DataDir != options.DataDir || loaded.RuntimeUID == "" || loaded.RuntimeGID == "" || !loaded.MemoryAPIEnabled {
 		t.Fatalf("unexpected restored installation: %#v", loaded)
+	}
+	sequence, err := ServerCatalogSequence(options.Directory)
+	if err != nil || sequence != 7 {
+		t.Fatalf("restored catalog sequence=%d err=%v", sequence, err)
+	}
+	if required, err := readCatalogAcceptanceRequirement(options.Directory); err != nil || !required {
+		t.Fatalf("restored catalog requirement=%t err=%v", required, err)
+	}
+	if err := PublishRestoreWithCatalogSequence(installation, 6); err != nil {
+		t.Fatalf("idempotent restore retried below newer high-water: %v", err)
+	}
+	sequence, err = ServerCatalogSequence(options.Directory)
+	if err != nil || sequence != 7 {
+		t.Fatalf("restore retry lowered catalog sequence=%d err=%v", sequence, err)
 	}
 }
 

--- a/internal/postgres/update_bridge.go
+++ b/internal/postgres/update_bridge.go
@@ -7,6 +7,11 @@ import (
 	"sync"
 )
 
+// ErrV5UpdateBridgeOutcomeUncertain means PostgreSQL did not confirm whether
+// the bridge commit became durable. Callers must inspect the exact update ID
+// before deciding whether to continue or restore the previous writer.
+var ErrV5UpdateBridgeOutcomeUncertain = errors.New("v5 update bridge outcome is uncertain")
+
 // V5UpdateBridge is the one-time transactional bridge from the last schema
 // that predates the durable mutation fence. Its transaction retains exclusive
 // locks on every v5 mutable relation until the caller has stopped all writers.
@@ -141,7 +146,7 @@ func (bridge *V5UpdateBridge) CommitWritersStopped(ctx context.Context) (UpdateT
 	}
 	if err := bridge.transaction.Commit(); err != nil {
 		bridge.close()
-		return UpdateTransaction{}, errors.New("v5 update bridge outcome is uncertain; inspect the durable update transaction")
+		return update, ErrV5UpdateBridgeOutcomeUncertain
 	}
 	bridge.update = update
 	bridge.close()

--- a/internal/release/assemble_test.go
+++ b/internal/release/assemble_test.go
@@ -1,6 +1,8 @@
 package release
 
 import (
+	"crypto/ed25519"
+	"crypto/rand"
 	"crypto/sha256"
 	"encoding/hex"
 	"os"
@@ -66,6 +68,57 @@ func TestAssembleWritesCatalogAndManifestForScannedArtifacts(t *testing.T) {
 	}
 	if _, err := os.Stat(filepath.Join(dir, CatalogFile)); err != nil {
 		t.Fatal(err)
+	}
+}
+
+func TestAssembledSignedManifestIsTheServerUpdateBoundary(t *testing.T) {
+	directory := t.TempDir()
+	if err := os.WriteFile(filepath.Join(directory, "punaro-adapter-linux-amd64"), []byte("adapter"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	assembled, err := Assemble(AssembleRequest{
+		Directory:               directory,
+		Release:                 "v0.1.0",
+		Sequence:                1,
+		PublishedAt:             time.Date(2026, 8, 16, 12, 0, 0, 0, time.UTC),
+		ExpiresAt:               time.Date(2026, 8, 23, 12, 0, 0, 0, time.UTC),
+		MinimumSafeSequence:     1,
+		CatalogSequence:         1,
+		Image:                   "ghcr.io/rock3r/punaro@sha256:" + testDigestA,
+		ComposeSHA256:           testComposeDigest,
+		MigrationManifestSHA256: testMigrateDigest,
+		Database:                SchemaRange{Min: 10, Max: 44, Target: 44, RollbackFloor: 10},
+		PostgreSQLMajor:         18,
+		GatewayProtocol:         ProtocolRange{Min: 1, Max: 1},
+		ClientProtocol:          ProtocolRange{Min: 1, Max: 1},
+		MinimumRecoveryProtocol: 1,
+		MinimumBootstrapRelease: "v0.1.0",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	public, private, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	envelope, err := Sign(assembled.ManifestJSON, "punaro-release-1", private)
+	if err != nil {
+		t.Fatal(err)
+	}
+	signatureBody, err := EncodeEnvelope(envelope)
+	if err != nil {
+		t.Fatal(err)
+	}
+	keysBody, err := EncodePublicKeys("punaro-release-1", public)
+	if err != nil {
+		t.Fatal(err)
+	}
+	metadata, err := ParseSignedManifest(assembled.ManifestJSON, signatureBody, keysBody, Environment{CurrentSchema: 10, PostgreSQLMajor: 18})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if metadata.Release != assembled.Manifest.Release || metadata.Image != assembled.Manifest.Image || metadata.Schema != assembled.Manifest.Database || metadata.PostgreSQLMajor != assembled.Manifest.PostgreSQLMajor || metadata.ReleaseSHA256 != assembled.Manifest.ReleaseSHA256 || metadata.ComposeSHA256 != assembled.Manifest.ComposeSHA256 || metadata.MigrationManifestSHA256 != assembled.Manifest.MigrationManifestSHA256 {
+		t.Fatalf("projected metadata=%#v manifest=%#v", metadata, assembled.Manifest)
 	}
 }
 

--- a/internal/release/metadata.go
+++ b/internal/release/metadata.go
@@ -44,6 +44,7 @@ type SchemaRange struct {
 // exact database compatibility boundary.
 type Metadata struct {
 	Release                 string      `json:"release"`
+	SupportedFrom           []string    `json:"supported_from,omitempty"`
 	Image                   string      `json:"image"`
 	Schema                  SchemaRange `json:"schema"`
 	PostgreSQLMajor         int         `json:"postgres_major"`
@@ -78,9 +79,50 @@ func Parse(body []byte, environment Environment) (Metadata, error) {
 	return metadata, nil
 }
 
+// ParseSignedManifest verifies the exact public release-manifest bytes against
+// the supplied release trust root, then projects the server update boundary.
+// Every projected value comes from the verified manifest; callers cannot add
+// unsigned server metadata during projection.
+func ParseSignedManifest(manifestBody, signatureBody, publicKeysBody []byte, environment Environment) (Metadata, error) {
+	keys, err := ParsePublicKeys(publicKeysBody)
+	if err != nil {
+		return Metadata{}, errors.New("signed release manifest is invalid")
+	}
+	envelope, err := ParseEnvelope(signatureBody)
+	if err != nil || Verify(manifestBody, envelope, keys) != nil {
+		return Metadata{}, errors.New("signed release manifest is invalid")
+	}
+	manifest, err := ParseReleaseManifest(manifestBody)
+	if err != nil {
+		return Metadata{}, errors.New("signed release manifest is invalid")
+	}
+	metadata := Metadata{
+		Release:                 manifest.Release,
+		SupportedFrom:           append([]string(nil), manifest.SupportedFrom...),
+		Image:                   manifest.Image,
+		Schema:                  manifest.Database,
+		PostgreSQLMajor:         manifest.PostgreSQLMajor,
+		ReleaseSHA256:           manifest.ReleaseSHA256,
+		ComposeSHA256:           manifest.ComposeSHA256,
+		MigrationManifestSHA256: manifest.MigrationManifestSHA256,
+	}
+	if metadata.validate(environment) != nil {
+		return Metadata{}, errors.New("signed release manifest is invalid")
+	}
+	return metadata, nil
+}
+
 func (metadata Metadata) validate(environment Environment) error {
 	if !releaseNamePattern.MatchString(metadata.Release) || !validImageDigest(metadata.Image) || !validSHA256(metadata.ReleaseSHA256) || !validSHA256(metadata.ComposeSHA256) || !validSHA256(metadata.MigrationManifestSHA256) {
 		return errors.New("invalid release binding")
+	}
+	if err := validReleaseNameList(metadata.SupportedFrom, maxSupportedFrom); err != nil {
+		return errors.New("invalid release binding")
+	}
+	for _, source := range metadata.SupportedFrom {
+		if source == metadata.Release {
+			return errors.New("invalid release binding")
+		}
 	}
 	_, imageDigest, _ := strings.Cut(metadata.Image, "@sha256:")
 	if metadata.ReleaseSHA256 != imageDigest {
@@ -97,6 +139,18 @@ func (metadata Metadata) validate(environment Environment) error {
 		return errors.New("schema target is incompatible")
 	}
 	return nil
+}
+
+// SupportsDirectUpdateFrom reports whether the signed release policy names
+// source as a permitted direct update edge. An empty list permits no server
+// update; initial installation is handled by the installer instead.
+func (metadata Metadata) SupportsDirectUpdateFrom(source string) bool {
+	for _, supported := range metadata.SupportedFrom {
+		if source == supported {
+			return true
+		}
+	}
+	return false
 }
 
 func validImageDigest(value string) bool {

--- a/internal/release/metadata_test.go
+++ b/internal/release/metadata_test.go
@@ -2,6 +2,9 @@ package release
 
 import (
 	"bytes"
+	"crypto/ed25519"
+	"crypto/rand"
+	"reflect"
 	"strconv"
 	"strings"
 	"testing"
@@ -115,4 +118,126 @@ func TestParseRequiresExactPostgreSQLMajor(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestParseSignedManifestProjectsExactServerUpdateBoundary(t *testing.T) {
+	manifestBody, signatureBody, keysBody := signedServerManifest(t)
+	metadata, err := ParseSignedManifest(manifestBody, signatureBody, keysBody, Environment{CurrentSchema: 10, PostgreSQLMajor: 18})
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := Metadata{
+		Release:                 "v0.1.0",
+		SupportedFrom:           []string{"v0.0.9"},
+		Image:                   "ghcr.io/rock3r/punaro@sha256:" + testDigestA,
+		Schema:                  SchemaRange{Min: 10, Max: 44, Target: 44, RollbackFloor: 10},
+		PostgreSQLMajor:         18,
+		ReleaseSHA256:           testDigestA,
+		ComposeSHA256:           testComposeDigest,
+		MigrationManifestSHA256: testMigrateDigest,
+	}
+	if !reflect.DeepEqual(metadata, want) {
+		t.Fatalf("metadata=%#v want=%#v", metadata, want)
+	}
+}
+
+func TestParseSignedManifestRejectsTamperedServerBindings(t *testing.T) {
+	manifestBody, signatureBody, keysBody := signedServerManifest(t)
+	tamper := func(old, replacement string) []byte {
+		return []byte(strings.Replace(string(manifestBody), old, replacement, 1))
+	}
+	tests := map[string][]byte{
+		"release":          tamper(`"release": "v0.1.0"`, `"release": "v0.1.1"`),
+		"image":            tamper(testDigestA, testDigestB),
+		"schema":           tamper(`"target": 44`, `"target": 43`),
+		"postgres major":   tamper(`"postgres_major": 18`, `"postgres_major": 17`),
+		"release digest":   tamper(`"release_sha256": "`+testDigestA+`"`, `"release_sha256": "`+testDigestB+`"`),
+		"compose digest":   tamper(testComposeDigest, testDigestB),
+		"migration digest": tamper(testMigrateDigest, testDigestC),
+		"supported source": tamper(`"supported_from": ["v0.0.9"]`, `"supported_from": ["v0.0.8"]`),
+	}
+	for name, tampered := range tests {
+		t.Run(name, func(t *testing.T) {
+			if _, err := ParseSignedManifest(tampered, signatureBody, keysBody, Environment{CurrentSchema: 10, PostgreSQLMajor: 18}); err == nil {
+				t.Fatal("tampered signed manifest accepted")
+			}
+		})
+	}
+}
+
+func TestParseSignedManifestRequiresTrustedSignatureAndServerImage(t *testing.T) {
+	manifestBody, signatureBody, _ := signedServerManifest(t)
+	otherPublic, _, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	otherKeys, err := EncodePublicKeys("punaro-release-1", otherPublic)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ParseSignedManifest(manifestBody, signatureBody, otherKeys, Environment{CurrentSchema: 10, PostgreSQLMajor: 18}); err == nil {
+		t.Fatal("manifest signed by an untrusted key accepted")
+	}
+
+	clientOnly := []byte(validReleaseManifestJSON())
+	public, private, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	envelope, err := Sign(clientOnly, "punaro-release-1", private)
+	if err != nil {
+		t.Fatal(err)
+	}
+	clientSignature, err := EncodeEnvelope(envelope)
+	if err != nil {
+		t.Fatal(err)
+	}
+	clientKeys, err := EncodePublicKeys("punaro-release-1", public)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ParseSignedManifest(clientOnly, clientSignature, clientKeys, Environment{CurrentSchema: 10, PostgreSQLMajor: 18}); err == nil {
+		t.Fatal("signed client-only manifest accepted as server update metadata")
+	}
+}
+
+func TestParseSignedManifestEnforcesInstalledEnvironment(t *testing.T) {
+	manifestBody, signatureBody, keysBody := signedServerManifest(t)
+	for name, environment := range map[string]Environment{
+		"schema below range": {CurrentSchema: 9, PostgreSQLMajor: 18},
+		"schema downgrade":   {CurrentSchema: 45, PostgreSQLMajor: 18},
+		"postgres mismatch":  {CurrentSchema: 10, PostgreSQLMajor: 17},
+	} {
+		t.Run(name, func(t *testing.T) {
+			if _, err := ParseSignedManifest(manifestBody, signatureBody, keysBody, environment); err == nil {
+				t.Fatal("incompatible signed manifest accepted")
+			}
+		})
+	}
+}
+
+func signedServerManifest(t *testing.T) ([]byte, []byte, []byte) {
+	t.Helper()
+	body := strings.Replace(validReleaseManifestJSON(), `"supported_from": []`, `"supported_from": ["v0.0.9"]`, 1)
+	body = strings.Replace(body, `"postgres_major": 18,`, `"postgres_major": 18,
+  "image": "ghcr.io/rock3r/punaro@sha256:`+testDigestA+`",
+  "release_sha256": "`+testDigestA+`",`, 1)
+	manifestBody := []byte(body)
+	public, private, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	envelope, err := Sign(manifestBody, "punaro-release-1", private)
+	if err != nil {
+		t.Fatal(err)
+	}
+	signatureBody, err := EncodeEnvelope(envelope)
+	if err != nil {
+		t.Fatal(err)
+	}
+	keysBody, err := EncodePublicKeys("punaro-release-1", public)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return manifestBody, signatureBody, keysBody
 }


### PR DESCRIPTION
Summary:
- make the signed public release manifest the first-class server update boundary
- require protected manifest, detached signature, and trust-root files before projecting exact server fields
- cover assembly, tampering, incompatible environments, unsafe files, and the legacy unsigned flag
- document the exact operator and public-origin flow

Validation:
- make test test-race staticcheck security lint
- go test ./internal/release ./cmd/punaro

Closes #207