### PR TITLE
Add fleet-config copy-on-apply shared skills and addendum rehydration

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -639,16 +639,24 @@ names are never desired state. Publication validates and materializes a
 content-addressed archive **before** changing fleet desired revision; a failed
 publish leaves the prior desired revision unchanged.
 
-v1 source layout is `AGENTS.md`, optional `skills/<name>/` trees rooted by
-`SKILL.md`, and optional `projects/<name>/` trees with the same shape. Skill
-`name` frontmatter must match the directory. Machine-local `AGENTS.md` trailer
-markers are illegal in fleet source and are never archived. `scripts/` files
-may be present as regular files; Punaro never executes them and records no
-destinations or post-install commands.
+v1 source layout is `AGENTS.md`, optional global `skills/<name>/` trees rooted
+by `SKILL.md`, optional `common/<name>/` trees defined once, and optional
+`projects/<name>/` trees. A project opts into a common skill with a regular
+`projects/<name>/skills/<skill>/COMMON` file whose body is empty or the skill
+name. `COMMON` cannot sit next to a private skill tree; dangling `COMMON` is
+rejected; a common skill with no members is valid. Common skills count once
+toward the 64-skill cap and are never written to `~/.agents/skills`. Skill
+`name` frontmatter must match the directory. Reserved live markers
+(`<!-- punaro-managed -->`, `<!-- punaro-addendum -->` / `<!--/punaro-addendum-->`,
+`<!-- user -->` / `<!--/user-->`, and the retired trailer markers) are illegal
+in fleet source and are never archived. `scripts/` files may be present as
+regular files; Punaro never executes them and records no destinations or
+post-install commands.
 
 Validation rejects absolute paths, traversal, links, special files, duplicate
-or case-colliding paths, oversized files, excessive skill counts, and malformed
-skill metadata. Identical input yields identical archive bytes and digest.
+or case-colliding paths, oversized files, excessive skill counts, malformed
+skill metadata, dangling `COMMON`, and `COMMON` mixed with a private skill
+tree. Identical input yields identical archive bytes and digest.
 Product binary releases remain `internal/release`; this pipeline is a separate
 trust domain.
 
@@ -663,14 +671,26 @@ and may write only their own bounded status row (schema 59). There is no client
 publish route. Desired-generation advances emit a payload-free WebSocket wake
 with `topic_id=fleet-config` and `sequence` equal to the generation.
 
-The client reconciler stages a complete tree, applies `AGENTS.md` trailers
-without merging fleet-prefix edits, matches project names only as top-level
-directories under a configured base path (or an explicit override), and keeps
-last-known-good on failed activation. Concurrent reconcile is serialized.
+The client reconciler stages a complete tree, copies destinations as regular
+files only (never dest symlinks, junctions, or `CLAUDE.md` aliases), matches
+project names only as top-level directories under a configured base path (or an
+explicit override), and keeps last-known-good on failed activation. A common
+skill is copied into each present member-project dest; if that project is
+absent on the machine, the skill is absent there. Concurrent reconcile is
+serialized.
 
-Harness projection installs only Punaro-managed `AGENTS.md` and skills.
-Opt-in Claude aliases are POSIX symlinks; Windows uses `os.Symlink` or fails
-closed without copying. Unmanaged Claude files are never overwritten.
+Apply rehydrates each managed dest from the published file, then matching
+machine-local addendums under `~/punaro/addendums` (same layout as the
+published tree; project addendum overrides global), then the live
+`<!-- user -->` … `<!--/user-->` region (created empty if missing). Addendum
+text lives in a marked `<!-- punaro-addendum -->` block that is not the user
+block. `CLAUDE.md` is the composed `AGENTS.md` text plus Claude addendum(s),
+written as a regular file. Addendums are never published, uploaded, or logged.
+Skill bodies and addendums never appear in logs, status, or doctor output.
+
+Harness projection installs only Punaro-managed `AGENTS.md`, `CLAUDE.md`, and
+skills, each marked so a later apply can tell Punaro owns it. An unmarked
+unmanaged dest is a collision: report drift and do not overwrite.
 Activation is reported as immediate, next turn, next session, or restart
 required. Unknown installed harnesses are `unsupported`.
 

--- a/cmd/punaro/fleet_config_command_test.go
+++ b/cmd/punaro/fleet_config_command_test.go
@@ -338,6 +338,39 @@ func TestFleetConfigStatusOmitsContentsAndIncludesClientStates(t *testing.T) {
 	}
 }
 
+func TestFleetConfigStatusAndDoctorOmitSkillAndAddendumBodies(t *testing.T) {
+	preserveFleetConfig(t)
+	directory := testInstallation(t)
+	const skillBody = "unique-skill-body-probe"
+	const addendumBody = "unique-addendum-body-probe"
+	loadFleetDesired = func(context.Context, string) (punaropostgres.FleetDesired, error) {
+		return punaropostgres.FleetDesired{Digest: strings.Repeat("cd", 32), SourceCommit: testPublishCommit, Generation: 2, SkillCount: 1, TotalBytes: 12}, nil
+	}
+	loadFleetClients = func(context.Context, string) ([]punaropostgres.FleetClientStatus, error) {
+		return []punaropostgres.FleetClientStatus{{
+			MachineID: "mac-studio", AppliedDigest: strings.Repeat("cd", 32), State: "current",
+			Activation: "next_turn", TrailerState: "present", AliasState: "disabled", ProjectMatchState: "matched",
+		}}, nil
+	}
+	var stdout bytes.Buffer
+	if code := run([]string{"fleet-config", "status", "--directory", directory}, &stdout, bytes.NewBuffer(nil)); code != 0 {
+		t.Fatalf("code=%d body=%s", code, stdout.String())
+	}
+	body := stdout.String()
+	if strings.Contains(body, skillBody) || strings.Contains(body, addendumBody) {
+		t.Fatalf("status leaked skill or addendum body: %s", body)
+	}
+	var doctor bytes.Buffer
+	if code := run([]string{"doctor", "--directory", directory}, &doctor, bytes.NewBuffer(nil)); code != 0 && doctor.Len() == 0 {
+		// doctor may fail on incomplete fixtures; still inspect printed output
+		t.Logf("doctor code=%d", code)
+	}
+	out := stdout.String() + doctor.String()
+	if strings.Contains(out, skillBody) || strings.Contains(out, addendumBody) {
+		t.Fatalf("CLI leaked skill or addendum body: %s", out)
+	}
+}
+
 func TrailerLeak() string { return fleetconfig.TrailerStart }
 
 func testRelease() fleetconfig.Release {

--- a/docs/fleet-global-agent-config.md
+++ b/docs/fleet-global-agent-config.md
@@ -2,8 +2,9 @@
 
 Status: accepted for implementation of GitHub issues
 [#210](https://github.com/rock3r/punaro/issues/210)–[#217](https://github.com/rock3r/punaro/issues/217)
-plus the three v1 operator additions (machine-global vs project-only trees,
-machine-local `AGENTS.md` trailers, and opt-in Claude aliases).
+plus copy-on-apply shared skills, managed-file marks, and machine-local
+addendum/user rehydration. This contract **replaces** the earlier #214
+trailer-marker and #215 dest-alias/symlink clauses.
 
 This document is the contract. `DESIGN.md` records the protocol and security
 invariants as they land. Binary product releases remain `internal/release`;
@@ -35,10 +36,13 @@ Goals: issues #211–#217 plus:
 1. Machine-global `AGENTS.md`/`skills/` **and** project-only trees matched by
    top-level directory names under a configured base path (default `~/src`) or
    an explicit machine-local path override that is never published back.
-2. A durable machine-local trailer at the bottom of every applied `AGENTS.md`.
-3. Opt-in Claude aliases (`CLAUDE.md` → `AGENTS.md`, and Claude skill dirs onto
-   Agents-flavoured trees): POSIX symlink; Windows supported surviving
-   equivalent or fail closed without copying.
+2. Shared skills defined once under `common/<skill>/`, opted in per project by
+   a regular `COMMON` file. Apply copies them into present member projects as
+   regular files. They are never written to `~/.agents/skills`.
+3. Rehydrate each managed dest from the published file, machine-local addendums
+   under `~/punaro/addendums`, and a preserved `<!-- user -->` region.
+   `CLAUDE.md` is `AGENTS.md` plus Claude addendum(s), as a regular file. No
+   dest symlinks, junctions, or `CLAUDE.md` aliases.
 
 Non-goals: general dotfile sync, arbitrary destinations, executable/plugin
 deployment, recursive workspace discovery, bidirectional editing,
@@ -64,9 +68,11 @@ boxes from a LAN run.
 5. **v1 is data only.** `scripts/` files may exist as regular files. Punaro
    never executes them, never records destinations or post-install commands,
    and never treats mode bits as activation.
-6. **Trailer markers are illegal in fleet source** and reserved on disk.
-   Punaro creates the trailer if missing and preserves it across
-   publish/rollback/reconverge. Fleet-prefix edits are drift, not a merge.
+6. **Reserved live markers are illegal in fleet source** and reserved on disk:
+   `<!-- punaro-managed -->`, `<!-- punaro-addendum -->` /
+   `<!--/punaro-addendum-->`, `<!-- user -->` / `<!--/user-->`. Punaro creates
+   an empty user region if missing and preserves it across
+   publish/rollback/reconverge. Unmarked unmanaged dests are collisions.
 7. **Operator CLI talks to PostgreSQL via the owner DSN** (same pattern as
    `punaro client add` in `cmd/punaro`). Clients talk to signed HTTP on
    `punarod`. Clients have no publish route.
@@ -80,24 +86,33 @@ boxes from a LAN run.
     `internal/release` (signed product artifacts).
 11. **Harness projection is a built-in adapter table**, not a plugin runtime.
     Unknown installed harnesses report `unsupported`.
-12. **Claude aliases are opt-in per machine** in local adapter config. Never
-    overwrite a colliding real Claude file that is not already a Punaro-managed
-    alias.
+12. **Destinations are always regular files.** Apply never creates dest
+    symlinks, junctions, or `CLAUDE.md` aliases. `CLAUDE.md` is composed from
+    `AGENTS.md` plus Claude addendum(s). Never overwrite a colliding real file
+    that is not already Punaro-managed.
 
 ## Source tree layout
 
 A published commit must contain:
 
 ```text
-AGENTS.md                         # required, machine-global
-skills/<skill>/SKILL.md           # optional bounded global skills
-skills/<skill>/**                 # optional data files (never executed)
-projects/<project>/AGENTS.md      # optional project-only
-projects/<project>/skills/...     # optional project skills
+AGENTS.md                              # required, machine-global
+skills/<skill>/SKILL.md                # optional bounded global skills
+skills/<skill>/**                      # optional data files (never executed)
+common/<skill>/SKILL.md                # optional shared skill, defined once
+common/<skill>/**                      # optional data files (never executed)
+projects/<project>/AGENTS.md           # optional project-only
+projects/<project>/skills/<skill>/...  # optional private project skills
+projects/<project>/skills/<skill>/COMMON  # opt-in to common/<skill>/
 ```
 
 No other top-level names. No extra files next to `AGENTS.md`. Empty
-directories are ignored (not archived).
+directories are ignored (not archived). Source still forbids symlinks.
+
+`COMMON` is a regular file whose body is empty or the skill name. It cannot
+sit next to a private skill tree. Dangling `COMMON` (no matching
+`common/<skill>/`) is rejected. A common skill with no members is valid.
+Common skills count once toward the 64 cap.
 
 Project and skill directory names match
 `^[a-z0-9]([a-z0-9._-]{0,62}[a-z0-9])?$` (same shape as `auth.client_installations.machine_id`).
@@ -120,8 +135,10 @@ keys are ignored and not executed.
 | More than 64 skills (global + all projects) | Bound |
 | More than 512 files or 4 MiB total | Bound |
 | Missing global `AGENTS.md` | Required |
-| Global `AGENTS.md` contains trailer start/end markers | Trailer is machine-local |
-| Project `AGENTS.md` contains trailer markers | Same |
+| Global or project `AGENTS.md` contains reserved live markers | Markers are machine-local |
+| `SKILL.md` contains reserved live markers | Same |
+| Dangling `COMMON` (no `common/<skill>/`) | Opt-in without a definition |
+| `COMMON` next to a private skill tree | Mix is illegal |
 | Malformed `SKILL.md` frontmatter | Contract |
 | UTF-8 invalid or NUL in text files (`AGENTS.md`, `SKILL.md`) | Text contract |
 | Executable activation fields, destination lists, or post-install commands in any Punaro-owned metadata | Data only |
@@ -149,7 +166,7 @@ keys are ignored and not executed.
    inside the USTAR name field.
 5. Identical input bytes yield identical archive bytes and digest.
 
-The archive does not include trailer text. Manifest `digest` is the release
+The archive does not include addendum or user text. Manifest `digest` is the release
 identity used as the desired-state key.
 
 ## Trust boundary
@@ -267,7 +284,7 @@ shape. Clients that miss the hint recover on the adapter poll interval.
 
 ## Client reconciler
 
-Lives in `internal/fleetconfig` (pure apply/trailer/match) +
+Lives in `internal/fleetconfig` (pure apply/rehydrate/match) +
 `internal/adapter` / `cmd/punaro-adapter` (HTTP, lock, I/O).
 
 On startup, poll, and `topic_id=fleet-config` wake:
@@ -279,7 +296,7 @@ On startup, poll, and `topic_id=fleet-config` wake:
 5. Stage into a new directory; fsync; atomic publish (`rename` on POSIX,
    `MoveFileEx` replace on Windows).
 6. On failure, retain last-known-good and report `failed` without contents.
-7. After success, project into harnesses and optional aliases.
+7. After success, project into harnesses as regular files, including composed `CLAUDE.md`.
 
 Protected live files: regular files/directories only. Reject symlinks,
 junctions, reparse points, unexpected hard links, world-writable ancestors,
@@ -296,20 +313,46 @@ Default base path `~/src`, overridable in machine-local config.
 - `project_path_overrides` in local config maps a project name to an absolute
   existing directory. Never uploaded.
 
-### Trailer
+### Rehydrate, addendums, and user region
 
-Markers (exact lines):
+Well-known addendum root: `~/punaro/addendums`, same layout as the published
+tree (`AGENTS.md`, `CLAUDE.md`, `skills/`, `common/`, `projects/<p>/…`).
+Addendums are machine-local, never published, never uploaded, never logged.
 
-```text
-<!-- punaro-local-trailer:start -->
-<!-- punaro-local-trailer:end -->
-```
+For each managed dest:
 
-Apply writes `fleet-prefix + "\n" + start + preserved-or-empty-body + end + "\n"`.
-If the live file is missing, create prefix + empty trailer. If the live file
-exists without markers, report collision (`drifted`) and do not overwrite.
-If markers are present, replace only the prefix. Interrupted apply must not
-delete the trailer: stage a complete file then atomic rename.
+1. Start from the published file (a common skill is copied into the member
+   project dest; it is never written to `~/.agents/skills`).
+2. Fold matching addendums. Project addendum overrides global addendum.
+   Put addendum text in:
+
+   ```text
+   <!-- punaro-addendum -->
+   …
+   <!--/punaro-addendum-->
+   ```
+
+   This block is not the user block.
+3. Keep the live user region, creating it empty if missing:
+
+   ```text
+   <!-- user -->
+   …
+   <!--/user-->
+   ```
+
+4. Write the result as a regular file. Mark it `<!-- punaro-managed -->`.
+   Managed skill directories also carry a `.punaro-managed` regular file.
+
+`CLAUDE.md` is `AGENTS.md` plus Claude addendum(s) (for example brevity /
+non-native-English), not a copy or symlink of `AGENTS.md` alone.
+
+If the live file is missing, create published + addendum block + empty user
+region. If the live file exists without the managed mark, report collision
+(`drifted`) and do not overwrite. User-section text survives re-apply.
+Addendum edits appear on the next apply. Interrupted apply must not delete
+the user region: stage a complete file then atomic rename. Last-known-good /
+rollback restores a copied skill.
 
 ### Machine-local config
 
@@ -325,6 +368,9 @@ Stored next to the adapter profile (already a protected file). Schema v1 JSON:
 ```
 
 Empty `project_base_path` means `~/src`. This file is never fleet source.
+`claude_aliases` is ignored: `CLAUDE.md` is always a regular composed file.
+Machine-local addendums are not this JSON file; they live at
+`~/punaro/addendums` and are never published.
 
 ## Harness projection
 
@@ -334,35 +380,34 @@ Built-in adapters, detection + destinations + activation:
 | --- | --- | --- | --- |
 | Portable Agents | project dir exists | `$project/AGENTS.md`, `$project/.agents/skills` | next_turn |
 | Codex plugin | Codex plugin/registration present | same Agents-flavoured paths | next_turn |
-| Claude Code | Claude plugin/registration or `~/.claude` | Agents paths; optional aliases | next_session |
-| Gemini CLI | `GEMINI.md` already present or `~/.gemini` | Agents paths; do not create `GEMINI.md` unless it is already a Punaro alias | next_session |
+| Claude Code | Claude plugin/registration or `~/.claude` | Agents paths plus composed `CLAUDE.md` | next_session |
+| Gemini CLI | `GEMINI.md` already present or `~/.gemini` | Agents paths; do not create `GEMINI.md` unless it is already Punaro-managed | next_session |
 | Unknown installed agent dir | other known vendor dirs | none | `unsupported` |
 
-Install **only** Punaro-managed `AGENTS.md` and skill trees. Never overwrite
-credentials, settings, sessions, caches, or unmanaged local skills. Collision
-or local modification of a managed file is `drifted`.
+Install **only** Punaro-managed `AGENTS.md`, `CLAUDE.md`, and skill trees.
+Never overwrite credentials, settings, sessions, caches, or unmanaged local
+skills. Collision or local modification of an unmarked dest is `drifted`.
 
-### Claude aliases
+Apply always copies regular files. Destinations are never symlinks, junctions,
+or `CLAUDE.md` aliases. A common skill is copied into each present
+member-project dest (`$project/.agents/skills/<skill>/`) and is never written
+to `~/.agents/skills`. If the member project is absent on the machine, that
+skill is absent there.
 
-When `claude_aliases` is true:
+### Claude files
 
-- `$project/CLAUDE.md` → `$project/AGENTS.md`
-- `$project/.claude/skills` → `$project/.agents/skills` if the Claude skills
-  directory is absent or already a Punaro-managed alias
-- Same idea for machine-global files under the Punaro-managed global tree
-
-POSIX: `os.Symlink`. Windows: `os.Symlink` (survives reboot, does not weaken
-ACLs). If symlink creation is unsupported, report `unsupported` and do not
-copy. A colliding regular Claude file that is not a Punaro-managed alias is
-never overwritten.
+`CLAUDE.md` is always a regular file: composed `AGENTS.md` plus Claude
+addendum(s). It is not a symlink, junction, or alias of `AGENTS.md`. A
+colliding regular Claude file that is not Punaro-managed is never overwritten.
 
 ## Status, doctor, Canopi
 
 `punaro fleet-config status` aggregates desired + each enrolled client's
 latest status row. States: `current`, `pending`, `applying`, `failed`,
 `offline`, `drifted`, `unsupported`, `restart_required`. Also print source
-commit, release digest, generation, trailer/alias/project-match **states**,
-and activation enum. Omit contents, host paths, raw errors.
+commit, release digest, generation, managed/user/project-match **states**,
+and activation enum. Omit contents, host paths, raw errors, skill bodies, and
+addendums.
 
 Doctor adds content-free checks with stable codes, for example
 `fleet_config_desired`, `fleet_config_client_stale`, `fleet_config_drifted`,
@@ -382,7 +427,8 @@ Offline: last report older than twice the adapter poll interval (recorded as
   project names, and alias choices cannot change desired fleet state.
 - Revoked clients cannot fetch or report.
 - At-least-once with durable digest identity; never claim exactly-once.
-- No credentials, JWTs, Access headers, `AGENTS.md`, or skill bytes in logs.
+- No credentials, JWTs, Access headers, `AGENTS.md`, skill bytes, or addendum
+  bytes in logs.
 - Independent deployability: `punarod` serves HTTP; adapters apply locally;
   Telegram gateway is untouched.
 - Public origin stays closed; Access is admission, not authorization.
@@ -390,6 +436,7 @@ Offline: last report older than twice the adapter poll interval (recorded as
 ## Observability
 
 Log only digest, generation, client id, state enum, and skill/file counts.
+Never log skill bodies or addendum bodies.
 Metrics: publish success/fail, fetch status codes (not bodies), apply
 success/fail, drift count. Audit events are content-free.
 
@@ -417,22 +464,30 @@ record `lan-unreachable` and stop; do not substitute path simulation.
 
 Minimum scenarios: the parent plan
 `.plans/210-fleet-global-agent-config.md` list (publish with two project trees,
-wake+fetch+apply on three clients, top-level match + override, trailer
-survival, Claude alias or unsupported on Windows, offline reconverge, revoked
+wake+fetch+apply on three clients, top-level match + override, user-section
+survival, regular-file `CLAUDE.md` (not a junction) on Windows, offline reconverge, revoked
 denial, invalid/corrupt/interrupted/drift/unsupported/rollback, repo change
 without publish is a no-op, content-free status/doctor).
 
 ## Tracker updates
 
-GitHub #210–#217 predate the three operator additions. Proposed additions
-(apply to issue bodies; do not silently ship undocumented behavior):
+GitHub #210–#217 predate copy-on-apply shared skills and addendum/user
+rehydration. Proposed additions (apply to issue bodies; do not silently ship
+undocumented behavior). Follow-on issue:
+[#236](https://github.com/rock3r/punaro/issues/236).
 
-- **#210 / #211:** source layout includes `projects/<name>/`; trailer markers
-  are illegal in source; v1 data-only includes `scripts/` as inert files.
-- **#214:** top-level project match, per-machine overrides, trailer create/preserve.
-- **#215:** opt-in Claude aliases, POSIX symlink / Windows fail-closed.
-- **#216:** expose trailer/alias/project-match states without contents.
+- **#210 / #211:** source layout includes `projects/<name>/` and
+  `common/<skill>/` with `COMMON` opt-in; reserved live markers are illegal in
+  source; v1 data-only includes `scripts/` as inert files.
+- **#214 (replaced):** top-level project match and per-machine overrides
+  remain. Machine-local trailer markers are replaced by the managed mark, the
+  addendum block, and the `<!-- user -->` region. Addendums live under
+  `~/punaro/addendums` and are never published.
+- **#215 (replaced):** dest `CLAUDE.md` is a regular composed file
+  (`AGENTS.md` plus Claude addendum(s)), never a symlink, junction, or alias.
+- **#216:** expose managed/user/project-match states without contents.
 - **#217:** LAN hosts `mac-studio`, `coso`, `mattone`; include those scenarios.
+  Copy-on-apply of common skills must stay regular files on POSIX and Windows.
 
 ## Alternatives Considered
 
@@ -442,20 +497,22 @@ GitHub #210–#217 predate the three operator additions. Proposed additions
    could diverge; Punaro would not have a single content-addressed release.
 3. **Reuse `internal/release` product artifacts.** Rejected: different trust
    domain (signed binaries vs operator Git data).
-4. **Copy Claude files instead of symlinks.** Rejected: duplicates drift and
-   weakens the “one fleet prefix” invariant; Windows copy would also bypass
-   the fail-closed ACL requirement.
+4. **Dest `CLAUDE.md` aliases/symlinks (#215).** Replaced: copy-on-apply as a
+   regular file composed from `AGENTS.md` plus Claude addendums avoids
+   Windows junction/reparse dests and keeps Claude-specific addendums off the
+   shared `AGENTS.md` prefix.
 5. **Filesystem blob store for archives.** Deferred: v1 size bound fits
    `bytea`; a blob root would be a new deployable path.
 
 ## Open Questions
 
-None. The parent execution plan already chose commit-only publish, trailer
-markers, top-level match, and fail-closed Windows aliases.
+None. The parent execution plan chose commit-only publish and top-level
+match. Dest copy is regular files only; trailer markers and dest aliases are
+replaced by addendum/user rehydration and composed `CLAUDE.md`.
 
 ## References
 
-- GitHub #210–#217
+- GitHub #210–#217 and [#236](https://github.com/rock3r/punaro/issues/236)
 - `.plans/210-fleet-global-agent-config.md`
 - `DESIGN.md` (wake hints, signed requests, enrollment)
 - `docs/platform-contracts.md`
@@ -466,7 +523,7 @@ markers, top-level match, and fail-closed Windows aliases.
 ## PR Plan
 
 ### PR 1: Define the immutable fleet-global configuration release contract
-- **Description:** Add `internal/fleetconfig` with source layout, strict validation, deterministic materialization, data-only classification, commit-id parsing, and trailer-not-in-source rules. Document the contract. No HTTP, no CLI publish yet.
+- **Description:** Add `internal/fleetconfig` with source layout including `common/` + `COMMON` opt-in, strict validation, deterministic materialization, data-only classification, commit-id parsing, and reserved-live-marker-not-in-source rules. Document the contract. No HTTP, no CLI publish yet.
 - **Files/components affected:** `internal/fleetconfig/`, `docs/fleet-global-agent-config.md`, `DESIGN.md`
 - **Dependencies:** None
 
@@ -481,17 +538,17 @@ markers, top-level match, and fail-closed Windows aliases.
 - **Dependencies:** PR 2
 
 ### PR 4: Add the cross-platform fleet configuration reconciler
-- **Description:** Adapter reconcile on start/poll/wake: fetch, verify, stage, atomic apply, last-known-good, serialized lock, protected files, top-level project match, per-machine overrides, trailer create/preserve, drift on fleet-prefix edits.
-- **Files/components affected:** `internal/fleetconfig/` apply/trailer/match, `internal/adapter/`, `cmd/punaro-adapter/`, `//go:build` platform files
+- **Description:** Adapter reconcile on start/poll/wake: fetch, verify, stage, atomic apply, last-known-good, serialized lock, protected files, top-level project match, per-machine overrides, copy-on-apply regular files, addendum/user rehydrate, drift on unmarked dests.
+- **Files/components affected:** `internal/fleetconfig/` apply/rehydrate/match, `internal/adapter/`, `cmd/punaro-adapter/`, `//go:build` platform files
 - **Dependencies:** PR 3
 
 ### PR 5: Project fleet-global instructions and skills into coding-agent harnesses
-- **Description:** Built-in harness adapters, drift vs merge, activation enums, opt-in Claude aliases (POSIX symlink, Windows equivalent or fail closed, never overwrite unmanaged Claude files).
+- **Description:** Built-in harness adapters, drift vs merge, activation enums, copy-on-apply managed `AGENTS.md`/`CLAUDE.md`/skills (regular files only; `CLAUDE.md` is `AGENTS.md` plus Claude addendum(s); never overwrite unmanaged dests).
 - **Files/components affected:** `internal/fleetconfig/harness.go`, `internal/fleetconfig/alias_*.go`, `cmd/punaro-adapter/`
 - **Dependencies:** PR 4
 
 ### PR 6: Expose fleet configuration convergence in status, doctor, and Canopi
-- **Description:** `punaro fleet-config status` and doctor checks; content-free Canopi/dashboard hooks; trailer/alias/project-match states; no contents/paths/raw errors.
+- **Description:** `punaro fleet-config status` and doctor checks; content-free Canopi/dashboard hooks; managed/user/project-match states; no contents/paths/raw errors/skill bodies/addendums.
 - **Files/components affected:** `cmd/punaro/`, `internal/diagnostic/`, `internal/canopi/`, `docs/user-guide.md`, `docs/operator-guide.md`
 - **Dependencies:** PR 5
 

--- a/internal/adapter/fleet.go
+++ b/internal/adapter/fleet.go
@@ -349,13 +349,16 @@ func aliasState(enabled bool, results map[string]fleetconfig.AliasResult) string
 	if !enabled {
 		return "disabled"
 	}
-	state := "linked"
+	state := "disabled"
 	for _, result := range results {
 		if result.State == "unsupported" {
 			return "unsupported"
 		}
 		if result.State == "collision" {
 			state = "collision"
+		}
+		if result.State == "linked" && state != "collision" {
+			state = "linked"
 		}
 	}
 	return state

--- a/internal/adapter/fleet.go
+++ b/internal/adapter/fleet.go
@@ -292,131 +292,36 @@ func projectLiveTree(request FleetReconcileRequest, tree fleetconfig.Tree, lastP
 			return trailers, errors.New("fleet-config home is unavailable")
 		}
 	}
+	_ = lastPrefixDigests
 	matches := fleetconfig.MatchProjects(request.Local.ProjectBasePath, request.Local.ProjectPathOverrides, tree.Projects(), nil)
-	matched := map[string]string{}
-	for _, match := range matches {
-		if match.Path != "" {
-			matched[match.Name] = match.Path
+	result, err := fleetconfig.ApplyLive(fleetconfig.ApplyLiveRequest{
+		Tree:    tree,
+		Root:    filepath.Join(request.Root, "dest"),
+		Home:    home,
+		Matches: matches,
+	})
+	if err != nil {
+		return trailers, err
+	}
+	for path, collided := range result.Collisions {
+		if collided {
+			trailers[path] = fleetconfig.TrailerResult{State: "collision", Collision: true}
 		}
 	}
-	for _, file := range tree.Files {
-		dest, agents := liveDestination(home, matched, file.Path)
-		if dest == "" {
-			continue
-		}
-		body := file.Data
-		if agents {
-			existing, existed := readExisting(dest)
-			next, result, err := fleetconfig.ApplyAgents(file.Data, existing, existed, lastPrefixDigests[file.Path])
-			if err != nil {
-				return trailers, err
-			}
-			trailers[file.Path] = result
-			if result.Collision {
-				continue
-			}
-			body = next
-		}
-		if err := writeLiveFile(dest, body); err != nil {
-			return trailers, err
-		}
+	if result.Drift && len(trailers) == 0 {
+		trailers["drift"] = fleetconfig.TrailerResult{State: "present", Drift: true}
+	}
+	if len(trailers) == 0 {
+		trailers["AGENTS.md"] = fleetconfig.TrailerResult{State: "present"}
 	}
 	return trailers, nil
 }
 
-func liveDestination(home string, matched map[string]string, path string) (string, bool) {
-	switch {
-	case path == "AGENTS.md":
-		return filepath.Join(home, "AGENTS.md"), true
-	case strings.HasPrefix(path, "skills/"):
-		return filepath.Join(append([]string{home, ".agents"}, strings.Split(path, "/")...)...), false
-	case strings.HasPrefix(path, "projects/"):
-		name, rest, ok := strings.Cut(strings.TrimPrefix(path, "projects/"), "/")
-		if !ok {
-			return "", false
-		}
-		root, found := matched[name]
-		if !found {
-			return "", false
-		}
-		if rest == "AGENTS.md" {
-			return filepath.Join(root, "AGENTS.md"), true
-		}
-		if skillRest, ok := strings.CutPrefix(rest, "skills/"); ok {
-			return filepath.Join(append([]string{root, ".agents", "skills"}, strings.Split(skillRest, "/")...)...), false
-		}
-	}
-	return "", false
-}
-
 func applyClaudeAliases(request FleetReconcileRequest, tree fleetconfig.Tree, matches []fleetconfig.ProjectMatch) map[string]fleetconfig.AliasResult {
-	results := map[string]fleetconfig.AliasResult{}
-	home := request.Home
-	if home != "" {
-		if result, err := fleetconfig.CreateAlias(filepath.Join(home, "AGENTS.md"), filepath.Join(home, "CLAUDE.md"), true); err == nil || result.State != "" {
-			results["global"] = result
-		}
-		if result, _ := fleetconfig.CreateAlias(filepath.Join(home, ".agents", "skills"), filepath.Join(home, ".claude", "skills"), true); result.State != "" {
-			results["global-skills"] = result
-		}
-	}
-	for _, match := range matches {
-		if match.Path == "" {
-			continue
-		}
-		result, _ := fleetconfig.CreateAlias(filepath.Join(match.Path, "AGENTS.md"), filepath.Join(match.Path, "CLAUDE.md"), true)
-		results[match.Name] = result
-		skillResult, _ := fleetconfig.CreateAlias(filepath.Join(match.Path, ".agents", "skills"), filepath.Join(match.Path, ".claude", "skills"), true)
-		results[match.Name+"-skills"] = skillResult
-	}
+	_ = request
 	_ = tree
-	return results
-}
-
-func writeLiveFile(path string, body []byte) error {
-	info, statErr := os.Lstat(path)
-	if statErr == nil && info.Mode()&os.ModeSymlink != 0 {
-		return errors.New("fleet-config live tree is unsafe")
-	}
-	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
-		return errors.New("fleet-config apply failed")
-	}
-	tmp := path + ".punaro-tmp"
-	_ = os.Remove(tmp)
-	file, err := os.OpenFile(tmp, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600) // #nosec G304 -- tmp is a sibling of a validated destination.
-	if err != nil {
-		return errors.New("fleet-config apply failed")
-	}
-	if _, err := file.Write(body); err != nil {
-		_ = file.Close()
-		_ = os.Remove(tmp)
-		return errors.New("fleet-config apply failed")
-	}
-	if err := file.Close(); err != nil {
-		_ = os.Remove(tmp)
-		return errors.New("fleet-config apply failed")
-	}
-	if statErr == nil && info.Mode().IsRegular() {
-		_ = os.Remove(path)
-	}
-	if err := os.Rename(tmp, path); err != nil {
-		_ = os.Remove(tmp)
-		return errors.New("fleet-config apply failed")
-	}
-	return nil
-}
-
-func readExisting(path string) ([]byte, bool) {
-	info, err := os.Lstat(path)
-	if err != nil || !info.Mode().IsRegular() {
-		return nil, false
-	}
-	// #nosec G304 -- live destination fenced by Lstat as a regular file.
-	body, err := os.ReadFile(path)
-	if err != nil {
-		return nil, false
-	}
-	return body, true
+	_ = matches
+	return map[string]fleetconfig.AliasResult{"claude": {State: "disabled"}}
 }
 
 func trailerState(trailers map[string]fleetconfig.TrailerResult) string {

--- a/internal/adapter/fleet_client_test.go
+++ b/internal/adapter/fleet_client_test.go
@@ -269,6 +269,9 @@ func TestReconcileFleetOnceProjectsClaudeAliasesAndUnsupportedHarness(t *testing
 	if result.State != "unsupported" {
 		t.Fatalf("result=%#v", result)
 	}
+	if result.AliasState != "disabled" {
+		t.Fatalf("claude aliases reported %q: %#v", result.AliasState, result)
+	}
 	claude := filepath.Join(home, "CLAUDE.md")
 	info, err := os.Lstat(claude)
 	if err != nil || !info.Mode().IsRegular() || info.Mode()&os.ModeSymlink != 0 {

--- a/internal/adapter/fleet_client_test.go
+++ b/internal/adapter/fleet_client_test.go
@@ -266,17 +266,22 @@ func TestReconcileFleetOnceProjectsClaudeAliasesAndUnsupportedHarness(t *testing
 	if err != nil {
 		t.Fatal(err)
 	}
-	if result.State != "unsupported" || result.AliasState != "linked" {
+	if result.State != "unsupported" {
 		t.Fatalf("result=%#v", result)
 	}
-	if _, err := os.Lstat(filepath.Join(home, "CLAUDE.md")); err != nil {
-		t.Fatalf("global alias missing: %v", err)
+	claude := filepath.Join(home, "CLAUDE.md")
+	info, err := os.Lstat(claude)
+	if err != nil || !info.Mode().IsRegular() || info.Mode()&os.ModeSymlink != 0 {
+		t.Fatalf("global CLAUDE.md must be a regular file info=%v err=%v", info, err)
 	}
-	if _, err := os.Lstat(filepath.Join(home, ".claude", "skills")); err != nil {
-		t.Fatalf("global skills alias missing: %v", err)
+	body, err := os.ReadFile(claude) //nolint:gosec // G304: test fixture under t.TempDir.
+	if err != nil || !strings.Contains(string(body), "# fleet") {
+		t.Fatalf("CLAUDE.md missing AGENTS.md text: %q err=%v", body, err)
 	}
-	if _, err := os.Lstat(filepath.Join(base, "punaro", "CLAUDE.md")); err != nil {
-		t.Fatalf("project alias missing: %v", err)
+	projectClaude := filepath.Join(base, "punaro", "CLAUDE.md")
+	info, err = os.Lstat(projectClaude)
+	if err != nil || !info.Mode().IsRegular() || info.Mode()&os.ModeSymlink != 0 {
+		t.Fatalf("project CLAUDE.md must be a regular file info=%v err=%v", info, err)
 	}
 }
 

--- a/internal/adapter/fleet_unix_test.go
+++ b/internal/adapter/fleet_unix_test.go
@@ -11,31 +11,6 @@ import (
 	"github.com/rock3r/punaro/internal/fleetconfig"
 )
 
-func TestWriteLiveFileDoesNotFollowTmpSymlink(t *testing.T) {
-	t.Parallel()
-	dir := t.TempDir()
-	target := filepath.Join(dir, "secret")
-	if err := os.WriteFile(target, []byte("keep\n"), 0o600); err != nil {
-		t.Fatal(err)
-	}
-	dest := filepath.Join(dir, "AGENTS.md")
-	tmp := dest + ".punaro-tmp"
-	if err := os.Symlink(target, tmp); err != nil {
-		t.Fatal(err)
-	}
-	if err := writeLiveFile(dest, []byte("# fleet\n")); err != nil {
-		t.Fatal(err)
-	}
-	got, err := os.ReadFile(target) //nolint:gosec // G304: test fixture under t.TempDir.
-	if err != nil || string(got) != "keep\n" {
-		t.Fatalf("followed tmp symlink: %q err=%v", got, err)
-	}
-	live, err := os.ReadFile(dest) //nolint:gosec // G304: test fixture under t.TempDir.
-	if err != nil || string(live) != "# fleet\n" {
-		t.Fatalf("live=%q err=%v", live, err)
-	}
-}
-
 func TestReconcileFleetStagingFailureKeepsLiveTree(t *testing.T) {
 	t.Parallel()
 	if os.Geteuid() == 0 {

--- a/internal/fleetconfig/apply.go
+++ b/internal/fleetconfig/apply.go
@@ -3,6 +3,7 @@ package fleetconfig
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -32,7 +33,7 @@ func PublishTree(root string, files map[string][]byte, digest string) error {
 	}
 	unlockFile, err := lockReconcile(filepath.Join(root, "reconcile.lock"))
 	if err != nil {
-		return errors.New("fleet-config reconcile lock failed")
+		return fmt.Errorf("fleet-config reconcile lock failed: %w", err)
 	}
 	defer unlockFile()
 	unlock := ReconcileLock()
@@ -127,7 +128,7 @@ func recoverPublishSwap(live, lastGood, nextGood string) error {
 func RestoreLastGood(root string) error {
 	unlockFile, err := lockReconcile(filepath.Join(root, "reconcile.lock"))
 	if err != nil {
-		return errors.New("fleet-config reconcile lock failed")
+		return fmt.Errorf("fleet-config reconcile lock failed: %w", err)
 	}
 	defer unlockFile()
 	unlock := ReconcileLock()

--- a/internal/fleetconfig/apply.go
+++ b/internal/fleetconfig/apply.go
@@ -16,6 +16,7 @@ type ApplyState struct {
 	PrefixDigests    map[string]string `json:"prefix_digests,omitempty"`
 	LastGoodDigest   string            `json:"last_good_digest,omitempty"`
 	ReportGeneration int64             `json:"report_generation,omitempty"`
+	ProjectPaths     map[string]string `json:"project_paths,omitempty"`
 }
 
 var reconcileMu sync.Mutex

--- a/internal/fleetconfig/apply_live.go
+++ b/internal/fleetconfig/apply_live.go
@@ -1,0 +1,397 @@
+package fleetconfig
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// ApplyLiveRequest is the real start state for dest copy and rehydrate.
+type ApplyLiveRequest struct {
+	Tree         Tree
+	Root         string
+	Home         string
+	AddendumRoot string
+	Matches      []ProjectMatch
+	Logs         io.Writer
+}
+
+// ApplyLiveResult is the content-free outcome of one dest apply.
+type ApplyLiveResult struct {
+	Collisions map[string]bool
+	Drift      bool
+	Written    int
+}
+
+// ApplyLive copies rehydrated regular files to live destinations. Destinations
+// are never symlinks, junctions, or CLAUDE.md aliases. Common skills are copied
+// into present member projects and are never written to ~/.agents/skills.
+func ApplyLive(req ApplyLiveRequest) (ApplyLiveResult, error) {
+	result := ApplyLiveResult{Collisions: map[string]bool{}}
+	if err := Validate(req.Tree); err != nil {
+		return result, err
+	}
+	addendumRoot := req.AddendumRoot
+	if addendumRoot == "" && req.Home != "" {
+		addendumRoot = DefaultAddendumRoot(req.Home)
+	}
+	addendums, err := LoadAddendums(addendumRoot)
+	if err != nil {
+		return result, err
+	}
+	present := map[string]string{}
+	for _, match := range req.Matches {
+		if match.Name != "" && match.Path != "" {
+			present[match.Name] = match.Path
+		}
+	}
+	published := expandDestFiles(req.Tree, present)
+	staged := map[string][]byte{}
+	for _, rel := range destApplyOrder(published) {
+		body := published[rel]
+		live := liveDestPath(req.Home, present, rel)
+		if live == "" {
+			continue
+		}
+		if collision, err := destCollision(rel, live); err != nil {
+			return result, err
+		} else if collision {
+			result.Collisions[rel] = true
+			result.Drift = true
+			continue
+		}
+		next := composeDest(rel, body, published, addendums, live)
+		if err := writeRegularDest(live, next); err != nil {
+			return result, err
+		}
+		if skillDir, ok := skillDirForRel(rel, live); ok {
+			if err := markManagedSkillDir(skillDir); err != nil {
+				return result, err
+			}
+		}
+		staged[rel] = next
+		result.Written++
+	}
+	if req.Root != "" && len(staged) > 0 {
+		if err := PublishTree(req.Root, staged, destSnapshotDigest(staged)); err != nil {
+			return result, err
+		}
+	}
+	if req.Logs != nil {
+		_, _ = io.WriteString(req.Logs, FormatApplyLog(result, req.Tree.SkillCount())+"\n")
+	}
+	return result, nil
+}
+
+// RollbackLive restores last-known-good published dest bytes onto live dests.
+func RollbackLive(req ApplyLiveRequest) error {
+	if req.Root == "" {
+		return errors.New("fleet-config last-known-good is unavailable")
+	}
+	if err := RestoreLastGood(req.Root); err != nil {
+		return err
+	}
+	present := map[string]string{}
+	for _, match := range req.Matches {
+		if match.Name != "" && match.Path != "" {
+			present[match.Name] = match.Path
+		}
+	}
+	current := filepath.Join(req.Root, "current")
+	return filepath.WalkDir(current, func(path string, entry os.DirEntry, err error) error {
+		if err != nil || entry.IsDir() {
+			return err
+		}
+		rel, relErr := filepath.Rel(current, path)
+		if relErr != nil {
+			return errors.New("fleet-config last-known-good restore failed")
+		}
+		slash := filepath.ToSlash(rel)
+		live := liveDestPath(req.Home, present, slash)
+		if live == "" {
+			return nil
+		}
+		body, readErr := os.ReadFile(path) // #nosec G304,G122 -- adapter-owned last-known-good dest snapshot.
+		if readErr != nil {
+			return errors.New("fleet-config last-known-good restore failed")
+		}
+		if err := writeRegularDest(live, body); err != nil {
+			return err
+		}
+		if skillDir, ok := skillDirForRel(slash, live); ok {
+			return markManagedSkillDir(skillDir)
+		}
+		return nil
+	})
+}
+
+// FormatApplyLog is the content-free apply log line. It must not include file bodies.
+func FormatApplyLog(result ApplyLiveResult, skillCount int) string {
+	return fmt.Sprintf("fleet-config apply written=%d collisions=%d skills=%d drift=%t", result.Written, len(result.Collisions), skillCount, result.Drift)
+}
+
+func expandDestFiles(tree Tree, present map[string]string) map[string][]byte {
+	common := map[string]map[string][]byte{}
+	optIns := map[string]map[string]struct{}{}
+	files := map[string][]byte{}
+	for _, file := range tree.Files {
+		switch {
+		case strings.HasPrefix(file.Path, "common/"):
+			skill, rest, ok := splitFirst(strings.TrimPrefix(file.Path, "common/"))
+			if !ok {
+				continue
+			}
+			if common[skill] == nil {
+				common[skill] = map[string][]byte{}
+			}
+			common[skill][rest] = file.Data
+		case strings.HasPrefix(file.Path, "projects/"):
+			project, rest, ok := splitFirst(strings.TrimPrefix(file.Path, "projects/"))
+			if !ok {
+				continue
+			}
+			if skillRest, ok := strings.CutPrefix(rest, "skills/"); ok {
+				skill, name, skillOK := splitFirst(skillRest)
+				if skillOK && name == CommonMarkerName {
+					if optIns[project] == nil {
+						optIns[project] = map[string]struct{}{}
+					}
+					optIns[project][skill] = struct{}{}
+					continue
+				}
+			}
+			if _, ok := present[project]; ok {
+				files[file.Path] = file.Data
+			}
+		case file.Path == "AGENTS.md" || strings.HasPrefix(file.Path, "skills/"):
+			files[file.Path] = file.Data
+		}
+	}
+	for project := range present {
+		for skill := range optIns[project] {
+			for rest, body := range common[skill] {
+				files["projects/"+project+"/skills/"+skill+"/"+rest] = body
+			}
+		}
+	}
+	if _, ok := files["AGENTS.md"]; ok {
+		files["CLAUDE.md"] = files["AGENTS.md"]
+	}
+	for project := range present {
+		if body, ok := files["projects/"+project+"/AGENTS.md"]; ok {
+			files["projects/"+project+"/CLAUDE.md"] = body
+		}
+	}
+	return files
+}
+
+func composeDest(rel string, published []byte, destFiles map[string][]byte, addendums map[string][]byte, livePath string) []byte {
+	existing, _ := readRegularFile(livePath)
+	if !rehydrateRel(rel) {
+		return append([]byte(nil), published...)
+	}
+	if strings.HasSuffix(rel, "/CLAUDE.md") || rel == "CLAUDE.md" {
+		agentsRel := strings.TrimSuffix(rel, "CLAUDE.md") + "AGENTS.md"
+		agentsPublished := destFiles[agentsRel]
+		if len(agentsPublished) == 0 {
+			agentsPublished = published
+		}
+		return ComposeClaudeFile(agentsPublished, ResolveAddendum(addendums, agentsRel), ResolveAddendum(addendums, rel), existing)
+	}
+	return Rehydrate(published, ResolveAddendum(addendums, rel), existing)
+}
+
+func rehydrateRel(rel string) bool {
+	base := rel
+	if i := strings.LastIndex(rel, "/"); i >= 0 {
+		base = rel[i+1:]
+	}
+	return base == "AGENTS.md" || base == "CLAUDE.md" || base == "SKILL.md" || strings.HasSuffix(base, ".md")
+}
+
+func liveDestPath(home string, present map[string]string, rel string) string {
+	switch {
+	case rel == "AGENTS.md" || rel == "CLAUDE.md":
+		if home == "" {
+			return ""
+		}
+		return filepath.Join(home, rel)
+	case strings.HasPrefix(rel, "skills/"):
+		if home == "" {
+			return ""
+		}
+		return filepath.Join(append([]string{home, ".agents"}, strings.Split(rel, "/")...)...)
+	case strings.HasPrefix(rel, "projects/"):
+		name, rest, ok := strings.Cut(strings.TrimPrefix(rel, "projects/"), "/")
+		if !ok {
+			return ""
+		}
+		root, found := present[name]
+		if !found || root == "" {
+			return ""
+		}
+		if rest == "AGENTS.md" || rest == "CLAUDE.md" {
+			return filepath.Join(root, rest)
+		}
+		if skillRest, ok := strings.CutPrefix(rest, "skills/"); ok {
+			return filepath.Join(append([]string{root, ".agents", "skills"}, strings.Split(skillRest, "/")...)...)
+		}
+	}
+	return ""
+}
+
+func destCollision(rel, live string) (bool, error) {
+	if skillDir, ok := skillDirForRel(rel, live); ok && unmanagedSkillDir(skillDir) {
+		return true, nil
+	}
+	info, err := os.Lstat(live)
+	if errors.Is(err, os.ErrNotExist) {
+		return false, nil
+	}
+	if err != nil {
+		return false, errors.New("fleet-config live tree is unsafe")
+	}
+	if info.Mode()&os.ModeSymlink != 0 || destIsJunctionOrReparse(info) {
+		return false, errors.New("fleet-config live tree is unsafe")
+	}
+	if info.IsDir() {
+		return true, nil
+	}
+	if !info.Mode().IsRegular() {
+		return true, nil
+	}
+	body, err := os.ReadFile(live) // #nosec G304 -- live destination fenced by Lstat as a regular file.
+	if err != nil {
+		return false, errors.New("fleet-config live tree is unsafe")
+	}
+	if rehydrateRel(rel) && !IsManagedContent(body) {
+		return true, nil
+	}
+	return false, nil
+}
+
+func skillDirForRel(rel, live string) (string, bool) {
+	rest := ""
+	switch {
+	case strings.HasPrefix(rel, "skills/"):
+		rest = strings.TrimPrefix(rel, "skills/")
+	default:
+		_, after, ok := strings.Cut(rel, "/skills/")
+		if !ok {
+			return "", false
+		}
+		rest = after
+	}
+	_, file, ok := splitFirst(rest)
+	if !ok || file == "" {
+		return "", false
+	}
+	suffix := filepath.FromSlash(file)
+	if !strings.HasSuffix(live, suffix) {
+		return "", false
+	}
+	root := strings.TrimSuffix(live, suffix)
+	return filepath.Clean(root), true
+}
+
+func unmanagedSkillDir(dir string) bool {
+	info, err := os.Lstat(dir)
+	if errors.Is(err, os.ErrNotExist) {
+		return false
+	}
+	if err != nil || !info.IsDir() || info.Mode()&os.ModeSymlink != 0 {
+		return true
+	}
+	return !IsManagedDir(dir)
+}
+
+func markManagedSkillDir(dir string) error {
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return errors.New("fleet-config apply failed")
+	}
+	marker := filepath.Join(dir, ManagedDirMarker)
+	if IsManagedDir(dir) {
+		return nil
+	}
+	return writeRegularDest(marker, nil)
+}
+
+func writeRegularDest(path string, body []byte) error {
+	info, statErr := os.Lstat(path)
+	if statErr == nil && (info.Mode()&os.ModeSymlink != 0 || destIsJunctionOrReparse(info)) {
+		return errors.New("fleet-config live tree is unsafe")
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return errors.New("fleet-config apply failed")
+	}
+	tmp := path + ".punaro-tmp"
+	if err := os.WriteFile(tmp, body, 0o600); err != nil { // #nosec G703 -- dest path fenced by Lstat as a regular file under an apply-owned tree.
+		return errors.New("fleet-config apply failed")
+	}
+	if statErr == nil && info.Mode().IsRegular() {
+		_ = os.Remove(path)
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		_ = os.Remove(tmp)
+		return errors.New("fleet-config apply failed")
+	}
+	out, err := os.Lstat(path)
+	if err != nil || !out.Mode().IsRegular() || destIsJunctionOrReparse(out) {
+		return errors.New("fleet-config live tree is unsafe")
+	}
+	return nil
+}
+
+func readRegularFile(path string) ([]byte, bool) {
+	info, err := os.Lstat(path)
+	if err != nil || !info.Mode().IsRegular() || info.Mode()&os.ModeSymlink != 0 {
+		return nil, false
+	}
+	body, err := os.ReadFile(path) // #nosec G304 -- live destination fenced by Lstat as a regular file.
+	if err != nil {
+		return nil, false
+	}
+	return body, true
+}
+
+func destSnapshotDigest(files map[string][]byte) string {
+	var buf bytes.Buffer
+	for _, path := range sortedKeys(files) {
+		buf.WriteString(path)
+		buf.WriteByte(0)
+		buf.Write(files[path])
+		buf.WriteByte(0)
+	}
+	if buf.Len() == 0 {
+		return DigestBytes([]byte("fleet-config-dest"))
+	}
+	return DigestBytes(buf.Bytes())
+}
+
+func sortedKeys(files map[string][]byte) []string {
+	keys := make([]string, 0, len(files))
+	for path := range files {
+		keys = append(keys, path)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+// destApplyOrder puts nested skill files before SKILL.md so apply cannot
+// rely on map order to mark the skills/<name> root.
+func destApplyOrder(files map[string][]byte) []string {
+	keys := sortedKeys(files)
+	sort.SliceStable(keys, func(i, j int) bool {
+		di, dj := strings.Count(keys[i], "/"), strings.Count(keys[j], "/")
+		if di != dj {
+			return di > dj
+		}
+		return keys[i] < keys[j]
+	})
+	return keys
+}

--- a/internal/fleetconfig/apply_live.go
+++ b/internal/fleetconfig/apply_live.go
@@ -77,6 +77,9 @@ func ApplyLive(req ApplyLiveRequest) (ApplyLiveResult, error) {
 		if err := os.MkdirAll(req.Root, 0o700); err != nil {
 			return result, errors.New("fleet-config apply failed")
 		}
+		if err := pruneMovedProjectDests(req.Home, present, loadDestProjectPaths(req.Root), staged); err != nil {
+			return result, err
+		}
 		digest := destSnapshotDigest(staged)
 		if !sameDestSnapshot(req.Root, digest) {
 			if err := pruneDroppedManagedDests(req.Root, req.Home, destPresent(req.Root, req.Matches), staged); err != nil {
@@ -329,6 +332,9 @@ func unmanagedSkillDir(dir string) bool {
 }
 
 func markManagedSkillDir(dir string) error {
+	if err := rejectUnsafeDestAncestors(filepath.Join(dir, ManagedDirMarker)); err != nil {
+		return err
+	}
 	if err := os.MkdirAll(dir, 0o700); err != nil {
 		return errors.New("fleet-config apply failed")
 	}
@@ -337,6 +343,28 @@ func markManagedSkillDir(dir string) error {
 		return nil
 	}
 	return writeRegularDest(marker, nil)
+}
+
+func rejectUnsafeDestAncestors(path string) error {
+	dir := filepath.Dir(path)
+	for {
+		if dir == "" || dir == "." {
+			return nil
+		}
+		info, err := os.Lstat(dir)
+		if errors.Is(err, os.ErrNotExist) {
+			parent := filepath.Dir(dir)
+			if parent == dir {
+				return nil
+			}
+			dir = parent
+			continue
+		}
+		if err != nil || !info.IsDir() || info.Mode()&os.ModeSymlink != 0 || destIsJunctionOrReparse(info) {
+			return errors.New("fleet-config live tree is unsafe")
+		}
+		return nil
+	}
 }
 
 func writeRegularDest(path string, body []byte) error {
@@ -349,6 +377,9 @@ func writeRegularDest(path string, body []byte) error {
 			return errors.New("fleet-config live tree is unsafe")
 		}
 		statErr = os.ErrNotExist
+	}
+	if err := rejectUnsafeDestAncestors(path); err != nil {
+		return err
 	}
 	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
 		return errors.New("fleet-config apply failed")
@@ -421,6 +452,9 @@ func pruneManagedLiveDests(home string, present map[string]string, dropped []str
 		live := liveDestPath(home, present, slash)
 		if live == "" {
 			continue
+		}
+		if err := rejectUnsafeDestAncestors(live); err != nil {
+			return err
 		}
 		if skillDir, ok := skillDirForRel(slash, live); ok && IsManagedDir(skillDir) {
 			prefix, prefixOK := skillPrefixForRel(slash)
@@ -501,6 +535,26 @@ func projectPresent(matches []ProjectMatch) map[string]string {
 		}
 	}
 	return present
+}
+
+func pruneMovedProjectDests(home string, current, previous map[string]string, staged map[string][]byte) error {
+	for name, oldPath := range previous {
+		newPath := current[name]
+		if name == "" || oldPath == "" || newPath == "" || oldPath == newPath {
+			continue
+		}
+		prefix := "projects/" + name + "/"
+		var dropped []string
+		for rel := range staged {
+			if strings.HasPrefix(rel, prefix) {
+				dropped = append(dropped, rel)
+			}
+		}
+		if err := pruneManagedLiveDests(home, map[string]string{name: oldPath}, dropped, map[string][]byte{}); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func destPresent(root string, matches []ProjectMatch) map[string]string {

--- a/internal/fleetconfig/apply_live.go
+++ b/internal/fleetconfig/apply_live.go
@@ -2,6 +2,7 @@ package fleetconfig
 
 import (
 	"bytes"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -81,8 +82,14 @@ func ApplyLive(req ApplyLiveRequest) (ApplyLiveResult, error) {
 		if err := os.MkdirAll(req.Root, 0o700); err != nil {
 			return result, errors.New("fleet-config apply failed")
 		}
-		if err := PublishTree(req.Root, staged, destSnapshotDigest(staged)); err != nil {
-			return result, err
+		digest := destSnapshotDigest(staged)
+		if !sameDestSnapshot(req.Root, digest) {
+			if err := pruneDroppedManagedDests(req.Root, req.Home, present, staged); err != nil {
+				return result, err
+			}
+			if err := PublishTree(req.Root, staged, digest); err != nil {
+				return result, err
+			}
 		}
 	}
 	if req.Logs != nil {
@@ -333,7 +340,18 @@ func writeRegularDest(path string, body []byte) error {
 		return errors.New("fleet-config apply failed")
 	}
 	tmp := path + ".punaro-tmp"
-	if err := os.WriteFile(tmp, body, 0o600); err != nil { // #nosec G703 -- dest path fenced by Lstat as a regular file under an apply-owned tree.
+	_ = os.Remove(tmp)
+	file, err := os.OpenFile(tmp, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600) // #nosec G304 -- tmp is a sibling of a validated destination.
+	if err != nil {
+		return errors.New("fleet-config apply failed")
+	}
+	if _, err := file.Write(body); err != nil {
+		_ = file.Close()
+		_ = os.Remove(tmp)
+		return errors.New("fleet-config apply failed")
+	}
+	if err := file.Close(); err != nil {
+		_ = os.Remove(tmp)
 		return errors.New("fleet-config apply failed")
 	}
 	if statErr == nil && info.Mode().IsRegular() {
@@ -360,6 +378,76 @@ func readRegularFile(path string) ([]byte, bool) {
 		return nil, false
 	}
 	return body, true
+}
+
+func sameDestSnapshot(root, digest string) bool {
+	body, err := os.ReadFile(filepath.Join(root, "applied.json")) // #nosec G304 -- apply root is created by this process.
+	if err != nil {
+		return false
+	}
+	var state ApplyState
+	if json.Unmarshal(body, &state) != nil || digest == "" {
+		return false
+	}
+	return state.Digest == digest
+}
+
+func pruneDroppedManagedDests(root, home string, present map[string]string, staged map[string][]byte) error {
+	current := filepath.Join(root, "current")
+	info, err := os.Lstat(current)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	if !info.IsDir() || info.Mode()&os.ModeSymlink != 0 {
+		return nil
+	}
+	var removeDirs, removeFiles []string
+	if err := filepath.WalkDir(current, func(path string, entry os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if entry.IsDir() {
+			return nil
+		}
+		rel, relErr := filepath.Rel(current, path)
+		if relErr != nil {
+			return relErr
+		}
+		slash := filepath.ToSlash(rel)
+		if _, kept := staged[slash]; kept {
+			return nil
+		}
+		live := liveDestPath(home, present, slash)
+		if live == "" {
+			return nil
+		}
+		if skillDir, ok := skillDirForRel(slash, live); ok && IsManagedDir(skillDir) {
+			removeDirs = append(removeDirs, skillDir)
+			return nil
+		}
+		body, ok := readRegularFile(live)
+		if !ok || !IsManagedContent(body) {
+			return nil
+		}
+		removeFiles = append(removeFiles, live)
+		return nil
+	}); err != nil {
+		return err
+	}
+	for _, dir := range removeDirs {
+		if err := os.RemoveAll(dir); err != nil {
+			return err
+		}
+	}
+	for _, file := range removeFiles {
+		if err := os.Remove(file); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func destSnapshotDigest(files map[string][]byte) string {

--- a/internal/fleetconfig/apply_live.go
+++ b/internal/fleetconfig/apply_live.go
@@ -78,6 +78,9 @@ func ApplyLive(req ApplyLiveRequest) (ApplyLiveResult, error) {
 		result.Written++
 	}
 	if req.Root != "" && len(staged) > 0 {
+		if err := os.MkdirAll(req.Root, 0o700); err != nil {
+			return result, errors.New("fleet-config apply failed")
+		}
 		if err := PublishTree(req.Root, staged, destSnapshotDigest(staged)); err != nil {
 			return result, err
 		}

--- a/internal/fleetconfig/apply_live.go
+++ b/internal/fleetconfig/apply_live.go
@@ -45,12 +45,7 @@ func ApplyLive(req ApplyLiveRequest) (ApplyLiveResult, error) {
 	if err != nil {
 		return result, err
 	}
-	present := map[string]string{}
-	for _, match := range req.Matches {
-		if match.Name != "" && match.Path != "" {
-			present[match.Name] = match.Path
-		}
-	}
+	present := projectPresent(req.Matches)
 	published := expandDestFiles(req.Tree, present)
 	staged := map[string][]byte{}
 	for _, rel := range destApplyOrder(published) {
@@ -84,12 +79,15 @@ func ApplyLive(req ApplyLiveRequest) (ApplyLiveResult, error) {
 		}
 		digest := destSnapshotDigest(staged)
 		if !sameDestSnapshot(req.Root, digest) {
-			if err := pruneDroppedManagedDests(req.Root, req.Home, present, staged); err != nil {
+			if err := pruneDroppedManagedDests(req.Root, req.Home, destPresent(req.Root, req.Matches), staged); err != nil {
 				return result, err
 			}
 			if err := PublishTree(req.Root, staged, digest); err != nil {
 				return result, err
 			}
+		}
+		if err := persistDestProjectPaths(req.Root, present); err != nil {
+			return result, err
 		}
 	}
 	if req.Logs != nil {
@@ -98,37 +96,39 @@ func ApplyLive(req ApplyLiveRequest) (ApplyLiveResult, error) {
 	return result, nil
 }
 
-// RollbackLive restores last-known-good published dest bytes onto live dests.
+// RollbackLive restores last-known-good published dest bytes onto live dests
+// and removes managed dests that the restored snapshot no longer contains.
 func RollbackLive(req ApplyLiveRequest) error {
 	if req.Root == "" {
 		return errors.New("fleet-config last-known-good is unavailable")
 	}
+	present := destPresent(req.Root, req.Matches)
+	outgoing, err := destSnapshotRels(req.Root)
+	if err != nil {
+		return err
+	}
 	if err := RestoreLastGood(req.Root); err != nil {
 		return err
 	}
-	present := map[string]string{}
-	for _, match := range req.Matches {
-		if match.Name != "" && match.Path != "" {
-			present[match.Name] = match.Path
-		}
-	}
 	current := filepath.Join(req.Root, "current")
-	return filepath.WalkDir(current, func(path string, entry os.DirEntry, err error) error {
-		if err != nil || entry.IsDir() {
-			return err
+	restored := map[string][]byte{}
+	if err := filepath.WalkDir(current, func(path string, entry os.DirEntry, walkErr error) error {
+		if walkErr != nil || entry.IsDir() {
+			return walkErr
 		}
 		rel, relErr := filepath.Rel(current, path)
 		if relErr != nil {
 			return errors.New("fleet-config last-known-good restore failed")
 		}
 		slash := filepath.ToSlash(rel)
-		live := liveDestPath(req.Home, present, slash)
-		if live == "" {
-			return nil
-		}
 		body, readErr := os.ReadFile(path) // #nosec G304,G122 -- adapter-owned last-known-good dest snapshot.
 		if readErr != nil {
 			return errors.New("fleet-config last-known-good restore failed")
+		}
+		restored[slash] = body
+		live := liveDestPath(req.Home, present, slash)
+		if live == "" {
+			return nil
 		}
 		if err := writeRegularDest(live, body); err != nil {
 			return err
@@ -137,7 +137,11 @@ func RollbackLive(req ApplyLiveRequest) error {
 			return markManagedSkillDir(skillDir)
 		}
 		return nil
-	})
+	}); err != nil {
+		return err
+	}
+	dropped := droppedDestRels(outgoing, restored)
+	return pruneManagedLiveDests(req.Home, present, dropped, restored)
 }
 
 // FormatApplyLog is the content-free apply log line. It must not include file bodies.
@@ -393,49 +397,40 @@ func sameDestSnapshot(root, digest string) bool {
 }
 
 func pruneDroppedManagedDests(root, home string, present map[string]string, staged map[string][]byte) error {
-	current := filepath.Join(root, "current")
-	info, err := os.Lstat(current)
-	if errors.Is(err, os.ErrNotExist) {
-		return nil
-	}
+	outgoing, err := destSnapshotRels(root)
 	if err != nil {
 		return err
 	}
-	if !info.IsDir() || info.Mode()&os.ModeSymlink != 0 {
-		return nil
-	}
+	return pruneManagedLiveDests(home, present, droppedDestRels(outgoing, staged), staged)
+}
+
+func pruneManagedLiveDests(home string, present map[string]string, dropped []string, staged map[string][]byte) error {
 	var removeDirs, removeFiles []string
-	if err := filepath.WalkDir(current, func(path string, entry os.DirEntry, walkErr error) error {
-		if walkErr != nil {
-			return walkErr
-		}
-		if entry.IsDir() {
-			return nil
-		}
-		rel, relErr := filepath.Rel(current, path)
-		if relErr != nil {
-			return relErr
-		}
-		slash := filepath.ToSlash(rel)
-		if _, kept := staged[slash]; kept {
-			return nil
-		}
+	seenDir := map[string]struct{}{}
+	for _, slash := range dropped {
 		live := liveDestPath(home, present, slash)
 		if live == "" {
-			return nil
+			continue
 		}
 		if skillDir, ok := skillDirForRel(slash, live); ok && IsManagedDir(skillDir) {
-			removeDirs = append(removeDirs, skillDir)
-			return nil
+			prefix, prefixOK := skillPrefixForRel(slash)
+			if !prefixOK || !stagedHasPrefix(staged, prefix) {
+				if _, seen := seenDir[skillDir]; !seen {
+					removeDirs = append(removeDirs, skillDir)
+					seenDir[skillDir] = struct{}{}
+				}
+				continue
+			}
+			if info, err := os.Lstat(live); err == nil && info.Mode().IsRegular() && info.Mode()&os.ModeSymlink == 0 {
+				removeFiles = append(removeFiles, live)
+			}
+			continue
 		}
 		body, ok := readRegularFile(live)
 		if !ok || !IsManagedContent(body) {
-			return nil
+			continue
 		}
 		removeFiles = append(removeFiles, live)
-		return nil
-	}); err != nil {
-		return err
 	}
 	for _, dir := range removeDirs {
 		if err := os.RemoveAll(dir); err != nil {
@@ -443,11 +438,148 @@ func pruneDroppedManagedDests(root, home string, present map[string]string, stag
 		}
 	}
 	for _, file := range removeFiles {
-		if err := os.Remove(file); err != nil {
+		if err := os.Remove(file); err != nil && !errors.Is(err, os.ErrNotExist) {
 			return err
 		}
 	}
 	return nil
+}
+
+func destSnapshotRels(root string) ([]string, error) {
+	current := filepath.Join(root, "current")
+	info, err := os.Lstat(current)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	if !info.IsDir() || info.Mode()&os.ModeSymlink != 0 {
+		return nil, nil
+	}
+	var rels []string
+	err = filepath.WalkDir(current, func(path string, entry os.DirEntry, walkErr error) error {
+		if walkErr != nil || entry.IsDir() {
+			return walkErr
+		}
+		rel, relErr := filepath.Rel(current, path)
+		if relErr != nil {
+			return relErr
+		}
+		rels = append(rels, filepath.ToSlash(rel))
+		return nil
+	})
+	return rels, err
+}
+
+func droppedDestRels(outgoing []string, staged map[string][]byte) []string {
+	var dropped []string
+	for _, rel := range outgoing {
+		if _, kept := staged[rel]; kept {
+			continue
+		}
+		dropped = append(dropped, rel)
+	}
+	return dropped
+}
+
+func projectPresent(matches []ProjectMatch) map[string]string {
+	present := map[string]string{}
+	for _, match := range matches {
+		if match.Name != "" && match.Path != "" {
+			present[match.Name] = match.Path
+		}
+	}
+	return present
+}
+
+func destPresent(root string, matches []ProjectMatch) map[string]string {
+	present := projectPresent(matches)
+	for name, path := range loadDestProjectPaths(root) {
+		if present[name] == "" && path != "" {
+			present[name] = path
+		}
+	}
+	return present
+}
+
+func loadDestProjectPaths(root string) map[string]string {
+	if root == "" {
+		return nil
+	}
+	body, err := os.ReadFile(filepath.Join(root, "applied.json")) // #nosec G304 -- dest apply root is created by this process.
+	if err != nil {
+		return nil
+	}
+	var state ApplyState
+	if json.Unmarshal(body, &state) != nil {
+		return nil
+	}
+	return state.ProjectPaths
+}
+
+func persistDestProjectPaths(root string, present map[string]string) error {
+	path := filepath.Join(root, "applied.json")
+	body, err := os.ReadFile(path) // #nosec G304 -- dest apply root is created by this process.
+	if err != nil {
+		return errors.New("fleet-config apply state failed")
+	}
+	var state ApplyState
+	if json.Unmarshal(body, &state) != nil {
+		return errors.New("fleet-config apply state failed")
+	}
+	state.ProjectPaths = map[string]string{}
+	for name, dest := range present {
+		if name != "" && dest != "" {
+			state.ProjectPaths[name] = dest
+		}
+	}
+	encoded, err := json.Marshal(state)
+	if err != nil {
+		return errors.New("fleet-config apply state failed")
+	}
+	if err := os.WriteFile(path, append(encoded, '\n'), 0o600); err != nil {
+		return errors.New("fleet-config apply state failed")
+	}
+	return nil
+}
+
+func skillPrefixForRel(rel string) (string, bool) {
+	switch {
+	case strings.HasPrefix(rel, "skills/"):
+		skill, file, ok := splitFirst(strings.TrimPrefix(rel, "skills/"))
+		if !ok || file == "" {
+			return "", false
+		}
+		return "skills/" + skill + "/", true
+	case strings.HasPrefix(rel, "projects/"):
+		name, rest, ok := strings.Cut(strings.TrimPrefix(rel, "projects/"), "/")
+		if !ok {
+			return "", false
+		}
+		skillRest, ok := strings.CutPrefix(rest, "skills/")
+		if !ok {
+			return "", false
+		}
+		skill, file, ok := splitFirst(skillRest)
+		if !ok || file == "" {
+			return "", false
+		}
+		return "projects/" + name + "/skills/" + skill + "/", true
+	}
+	return "", false
+}
+
+func stagedHasPrefix(staged map[string][]byte, prefix string) bool {
+	if prefix == "" {
+		return false
+	}
+	for rel := range staged {
+		if strings.HasPrefix(rel, prefix) {
+			return true
+		}
+	}
+	return false
 }
 
 func destSnapshotDigest(files map[string][]byte) string {

--- a/internal/fleetconfig/apply_live.go
+++ b/internal/fleetconfig/apply_live.go
@@ -130,7 +130,8 @@ func RollbackLive(req ApplyLiveRequest) error {
 		if live == "" {
 			return nil
 		}
-		if err := writeRegularDest(live, body); err != nil {
+		existing, _ := readRegularFile(live)
+		if err := writeRegularDest(live, restoreDestBody(slash, body, existing)); err != nil {
 			return err
 		}
 		if skillDir, ok := skillDirForRel(slash, live); ok {
@@ -271,6 +272,9 @@ func destCollision(rel, live string) (bool, error) {
 		return false, errors.New("fleet-config live tree is unsafe")
 	}
 	if info.Mode()&os.ModeSymlink != 0 || destIsJunctionOrReparse(info) {
+		if isPunaroClaudeAlias(rel, live) {
+			return false, nil
+		}
 		return false, errors.New("fleet-config live tree is unsafe")
 	}
 	if info.IsDir() {
@@ -338,7 +342,13 @@ func markManagedSkillDir(dir string) error {
 func writeRegularDest(path string, body []byte) error {
 	info, statErr := os.Lstat(path)
 	if statErr == nil && (info.Mode()&os.ModeSymlink != 0 || destIsJunctionOrReparse(info)) {
-		return errors.New("fleet-config live tree is unsafe")
+		if !isPunaroClaudeAlias("", path) {
+			return errors.New("fleet-config live tree is unsafe")
+		}
+		if err := os.Remove(path); err != nil {
+			return errors.New("fleet-config live tree is unsafe")
+		}
+		statErr = os.ErrNotExist
 	}
 	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
 		return errors.New("fleet-config apply failed")
@@ -580,6 +590,68 @@ func stagedHasPrefix(staged map[string][]byte, prefix string) bool {
 		}
 	}
 	return false
+}
+
+func restoreDestBody(rel string, snapshot, live []byte) []byte {
+	if !rehydrateRel(rel) {
+		return snapshot
+	}
+	prefix, _, ok := SplitUser(snapshot)
+	if !ok {
+		return snapshot
+	}
+	user := live
+	if _, extracted, ok := SplitUser(live); ok {
+		user = extracted
+	} else if IsManagedContent(live) || bytes.Contains(live, []byte(AddendumStart)) {
+		user = nil
+	}
+	return stitchUser(prefix, user)
+}
+
+func stitchUser(prefix, user []byte) []byte {
+	var buf bytes.Buffer
+	if len(prefix) > 0 {
+		buf.Write(bytes.TrimRight(prefix, "\n"))
+		buf.WriteByte('\n')
+	}
+	buf.WriteString(UserStart)
+	if len(user) > 0 && user[0] != '\n' {
+		buf.WriteByte('\n')
+	}
+	buf.Write(user)
+	if len(user) == 0 || user[len(user)-1] != '\n' {
+		buf.WriteByte('\n')
+	}
+	buf.WriteString(UserEnd)
+	buf.WriteByte('\n')
+	return buf.Bytes()
+}
+
+func isPunaroClaudeAlias(rel, live string) bool {
+	if rel != "" && rel != "CLAUDE.md" && !strings.HasSuffix(rel, "/CLAUDE.md") {
+		return false
+	}
+	if rel == "" && filepath.Base(live) != "CLAUDE.md" {
+		return false
+	}
+	info, err := os.Lstat(live)
+	if err != nil || info.Mode()&os.ModeSymlink == 0 {
+		return false
+	}
+	got, err := os.Readlink(live)
+	if err != nil {
+		return false
+	}
+	expected := filepath.Join(filepath.Dir(live), "AGENTS.md")
+	cleaned := filepath.Clean(got)
+	if cleaned == filepath.Clean(expected) {
+		return true
+	}
+	if filepath.IsAbs(got) {
+		return false
+	}
+	return filepath.Clean(filepath.Join(filepath.Dir(live), got)) == filepath.Clean(expected)
 }
 
 func destSnapshotDigest(files map[string][]byte) string {

--- a/internal/fleetconfig/apply_live_test.go
+++ b/internal/fleetconfig/apply_live_test.go
@@ -1,0 +1,274 @@
+package fleetconfig
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const (
+	skillBodyProbe       = "unique-skill-body-probe"
+	addendumBodyProbe    = "unique-addendum-body-probe"
+	userBodyProbe        = "unique-user-body-probe"
+	claudeAddendumProbe  = "unique-claude-addendum-probe"
+	globalAddendumProbe  = "unique-global-addendum-probe"
+	projectAddendumProbe = "unique-project-addendum-probe"
+)
+
+func TestApplyLiveSkipsCommonSkillWhenMemberProjectMissing(t *testing.T) {
+	t.Parallel()
+	home := t.TempDir()
+	root := t.TempDir()
+	tree := commonMemberTree(skillMarkdown("shared", skillBodyProbe), false)
+	result, err := ApplyLive(ApplyLiveRequest{
+		Tree:    tree,
+		Root:    root,
+		Home:    home,
+		Matches: []ProjectMatch{{Name: "punaro", Kind: "unmatched"}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Drift {
+		t.Fatalf("missing member reported drift: %#v", result)
+	}
+	if _, err := os.Lstat(filepath.Join(home, "src", "punaro", ".agents", "skills", "shared", "SKILL.md")); !os.IsNotExist(err) {
+		t.Fatal("copied common skill onto an absent member project")
+	}
+	assertCommonSkillAbsentFromHomeAgents(t, home)
+}
+
+func TestApplyLiveReportsUnmanagedDestCollisionWithoutOverwrite(t *testing.T) {
+	t.Parallel()
+	home := t.TempDir()
+	project := filepath.Join(home, "src", "punaro")
+	if err := os.MkdirAll(project, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	unmanaged := []byte("unmanaged-dest-bytes-keep\n")
+	dest := filepath.Join(project, "AGENTS.md")
+	if err := os.WriteFile(dest, unmanaged, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	skillDestDir := filepath.Join(project, ".agents", "skills", "shared")
+	if err := os.MkdirAll(skillDestDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	skillDest := filepath.Join(skillDestDir, "SKILL.md")
+	if err := os.WriteFile(skillDest, []byte("unmanaged-skill-keep\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	tree := commonMemberTree(skillMarkdown("shared", skillBodyProbe), false)
+	result, err := ApplyLive(ApplyLiveRequest{
+		Tree:    tree,
+		Root:    t.TempDir(),
+		Home:    home,
+		Matches: []ProjectMatch{{Name: "punaro", Path: project, Kind: "matched"}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.Drift {
+		t.Fatal("unmanaged dest collision did not report drift")
+	}
+	if !result.Collisions["projects/punaro/AGENTS.md"] {
+		t.Fatalf("missing AGENTS collision: %#v", result.Collisions)
+	}
+	got, err := os.ReadFile(dest) //nolint:gosec // G304: test fixture under t.TempDir.
+	if err != nil || !bytes.Equal(got, unmanaged) {
+		t.Fatalf("overwrote unmanaged AGENTS.md: %q err=%v", got, err)
+	}
+	gotSkill, err := os.ReadFile(skillDest) //nolint:gosec // G304: test fixture under t.TempDir.
+	if err != nil || string(gotSkill) != "unmanaged-skill-keep\n" {
+		t.Fatalf("overwrote unmanaged skill dest: %q err=%v", gotSkill, err)
+	}
+	if _, err := os.Lstat(filepath.Join(skillDestDir, "scripts", "run.sh")); !os.IsNotExist(err) {
+		t.Fatal("copied nested skill file into an unmanaged skill tree")
+	}
+	if IsManagedDir(skillDestDir) {
+		t.Fatal("marked an unmanaged skill directory as managed")
+	}
+	if result.Collisions["projects/punaro/skills/shared/scripts/run.sh"] != true {
+		t.Fatalf("nested unmanaged skill file was not a collision: %#v", result.Collisions)
+	}
+}
+
+func TestApplyLiveNestedSkillFileBeforeSkillMarkdownStillCopies(t *testing.T) {
+	t.Parallel()
+	home := t.TempDir()
+	project := filepath.Join(home, "src", "punaro")
+	if err := os.MkdirAll(project, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	tree := commonMemberTree(skillMarkdown("shared", skillBodyProbe), false)
+	if _, err := ApplyLive(ApplyLiveRequest{
+		Tree:    tree,
+		Root:    t.TempDir(),
+		Home:    home,
+		Matches: []ProjectMatch{{Name: "punaro", Path: project, Kind: "matched"}},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	skillRoot := filepath.Join(project, ".agents", "skills", "shared")
+	skillDest := filepath.Join(skillRoot, "SKILL.md")
+	nested := filepath.Join(skillRoot, "scripts", "run.sh")
+	assertRegularCopiedSkill(t, nested)
+	assertRegularCopiedSkill(t, skillDest)
+	if !IsManagedDir(skillRoot) {
+		t.Fatal("skill root is not marked managed after nested-file-first copy")
+	}
+	if IsManagedDir(filepath.Join(skillRoot, "scripts")) {
+		t.Fatal("marked nested parent instead of the skills/<name> root")
+	}
+	body, err := os.ReadFile(skillDest) //nolint:gosec // G304: test fixture under t.TempDir.
+	if err != nil || !strings.Contains(string(body), skillBodyProbe) {
+		t.Fatalf("SKILL.md missing after nested copy: %q err=%v", body, err)
+	}
+}
+
+func TestApplyLiveCopiesCommonSkillAsRegularFileOnPOSIX(t *testing.T) {
+	t.Parallel()
+	home, project, dest, _ := applyCopiedCommonSkill(t, skillMarkdown("shared", skillBodyProbe), nil)
+	assertRegularCopiedSkill(t, dest)
+	body, err := os.ReadFile(dest) //nolint:gosec // G304: test fixture under t.TempDir.
+	if err != nil || !strings.Contains(string(body), skillBodyProbe) {
+		t.Fatalf("dest missing published common skill: %q err=%v", body, err)
+	}
+	if !IsManagedContent(body) {
+		t.Fatal("copied skill file is not marked managed")
+	}
+	skillRoot := filepath.Dir(dest)
+	if !IsManagedDir(skillRoot) {
+		t.Fatal("copied skill directory is not marked managed")
+	}
+	assertRegularCopiedSkill(t, filepath.Join(skillRoot, "scripts", "run.sh"))
+	agents, err := os.ReadFile(filepath.Join(project, "AGENTS.md")) //nolint:gosec // G304: test fixture under t.TempDir.
+	if err != nil || !IsManagedContent(agents) {
+		t.Fatalf("project AGENTS.md unmanaged: %q err=%v", agents, err)
+	}
+	claude := filepath.Join(project, "CLAUDE.md")
+	assertRegularCopiedSkill(t, claude)
+	claudeBody, err := os.ReadFile(claude) //nolint:gosec // G304: test fixture under t.TempDir.
+	if err != nil || !IsManagedContent(claudeBody) {
+		t.Fatalf("project CLAUDE.md unmanaged: %q err=%v", claudeBody, err)
+	}
+	assertCommonSkillAbsentFromHomeAgents(t, home)
+	if _, err := os.Lstat(filepath.Join(home, ".agents", "skills", "global-demo", "SKILL.md")); err != nil {
+		t.Fatalf("global skill missing from ~/.agents/skills: %v", err)
+	}
+}
+
+func TestApplyLiveRollbackRestoresCopiedSkill(t *testing.T) {
+	t.Parallel()
+	home := t.TempDir()
+	project := filepath.Join(home, "src", "punaro")
+	if err := os.MkdirAll(project, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	root := t.TempDir()
+	matches := []ProjectMatch{{Name: "punaro", Path: project, Kind: "matched"}}
+	v1 := commonMemberTree(skillMarkdown("shared", "copied-skill-v1"), false)
+	req := ApplyLiveRequest{Tree: v1, Root: root, Home: home, Matches: matches}
+	if _, err := ApplyLive(req); err != nil {
+		t.Fatal(err)
+	}
+	v2 := commonMemberTree(skillMarkdown("shared", "copied-skill-v2"), false)
+	req.Tree = v2
+	if _, err := ApplyLive(req); err != nil {
+		t.Fatal(err)
+	}
+	dest := filepath.Join(project, ".agents", "skills", "shared", "SKILL.md")
+	got, err := os.ReadFile(dest) //nolint:gosec // G304: test fixture under t.TempDir.
+	if err != nil || !strings.Contains(string(got), "copied-skill-v2") {
+		t.Fatalf("expected v2 dest %q err=%v", got, err)
+	}
+	if err := RollbackLive(req); err != nil {
+		t.Fatal(err)
+	}
+	got, err = os.ReadFile(dest) //nolint:gosec // G304: test fixture under t.TempDir.
+	if err != nil || !strings.Contains(string(got), "copied-skill-v1") || strings.Contains(string(got), "copied-skill-v2") {
+		t.Fatalf("rollback did not restore copied skill: %q err=%v", got, err)
+	}
+	assertRegularCopiedSkill(t, dest)
+}
+
+func applyCopiedCommonSkill(t *testing.T, skillBody string, addendums map[string]string) (home, project, skillDest, addendumRoot string) {
+	t.Helper()
+	home = t.TempDir()
+	project = filepath.Join(home, "src", "punaro")
+	if err := os.MkdirAll(project, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	addendumRoot = filepath.Join(home, "punaro", "addendums")
+	if len(addendums) > 0 {
+		writeTreeAt(t, addendumRoot, addendums)
+	}
+	tree := commonMemberTree(skillBody, true)
+	if _, err := ApplyLive(ApplyLiveRequest{
+		Tree:         tree,
+		Root:         t.TempDir(),
+		Home:         home,
+		AddendumRoot: addendumRoot,
+		Matches:      []ProjectMatch{{Name: "punaro", Path: project, Kind: "matched"}},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	skillDest = filepath.Join(project, ".agents", "skills", "shared", "SKILL.md")
+	return home, project, skillDest, addendumRoot
+}
+
+func assertRegularCopiedSkill(t *testing.T, dest string) {
+	t.Helper()
+	info, err := os.Lstat(dest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !info.Mode().IsRegular() {
+		t.Fatalf("dest %s is not a regular file mode=%v", dest, info.Mode())
+	}
+	if info.Mode()&os.ModeSymlink != 0 || destIsJunctionOrReparse(info) {
+		t.Fatalf("dest %s is a symlink, junction, or reparse point", dest)
+	}
+	if _, err := os.Readlink(dest); err == nil {
+		t.Fatalf("dest %s is a symlink", dest)
+	}
+}
+
+func assertCommonSkillAbsentFromHomeAgents(t *testing.T, home string) {
+	t.Helper()
+	if _, err := os.Lstat(filepath.Join(home, ".agents", "skills", "shared")); !os.IsNotExist(err) {
+		t.Fatal("wrote common skill to ~/.agents/skills")
+	}
+}
+
+func commonMemberTree(skillBody string, includeGlobal bool) Tree {
+	files := []File{
+		{Path: "AGENTS.md", Data: []byte("# fleet\n")},
+		{Path: "common/shared/SKILL.md", Data: []byte(skillBody)},
+		{Path: "common/shared/scripts/run.sh", Data: []byte("#!/bin/sh\necho unused\n")},
+		{Path: "projects/punaro/AGENTS.md", Data: []byte("# punaro\n")},
+		{Path: "projects/punaro/skills/shared/COMMON", Data: []byte("shared\n")},
+	}
+	if includeGlobal {
+		files = append(files, File{
+			Path: "skills/global-demo/SKILL.md",
+			Data: []byte(skillMarkdown("global-demo", "Global demo skill.")),
+		})
+	}
+	return Tree{Files: files}
+}
+
+func writeTreeAt(t *testing.T, root string, files map[string]string) {
+	t.Helper()
+	for path, body := range files {
+		full := filepath.Join(append([]string{root}, strings.Split(path, "/")...)...)
+		if err := os.MkdirAll(filepath.Dir(full), 0o700); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(full, []byte(body), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+}

--- a/internal/fleetconfig/apply_live_test.go
+++ b/internal/fleetconfig/apply_live_test.go
@@ -355,6 +355,114 @@ func TestApplyLiveRemovesManagedDestsWhenProjectDropped(t *testing.T) {
 	}
 }
 
+func TestApplyLiveReplacesClaudeAliasWithRegularFile(t *testing.T) {
+	t.Parallel()
+	home := t.TempDir()
+	project := filepath.Join(home, "src", "punaro")
+	if err := os.MkdirAll(project, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	agents := filepath.Join(project, "AGENTS.md")
+	if err := os.WriteFile(agents, []byte("# leftover\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	alias := filepath.Join(project, "CLAUDE.md")
+	if err := os.Symlink(agents, alias); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ApplyLive(ApplyLiveRequest{
+		Tree:    Tree{Files: []File{{Path: "AGENTS.md", Data: []byte("# fleet\n")}, {Path: "projects/punaro/AGENTS.md", Data: []byte("# punaro\n")}}},
+		Root:    t.TempDir(),
+		Home:    home,
+		Matches: []ProjectMatch{{Name: "punaro", Path: project, Kind: "matched"}},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	assertRegularCopiedSkill(t, alias)
+	body, err := os.ReadFile(alias) //nolint:gosec // G304: test fixture under t.TempDir.
+	if err != nil || !strings.Contains(string(body), "# punaro") || !IsManagedContent(body) {
+		t.Fatalf("did not replace Punaro Claude alias: %q err=%v", body, err)
+	}
+}
+
+func TestApplyLiveRejectsUnrelatedClaudeSymlink(t *testing.T) {
+	t.Parallel()
+	home := t.TempDir()
+	project := filepath.Join(home, "src", "punaro")
+	if err := os.MkdirAll(project, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	outside := filepath.Join(home, "outside.md")
+	if err := os.WriteFile(outside, []byte("keep-out\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(outside, filepath.Join(project, "CLAUDE.md")); err != nil {
+		t.Fatal(err)
+	}
+	_, err := ApplyLive(ApplyLiveRequest{
+		Tree:    Tree{Files: []File{{Path: "AGENTS.md", Data: []byte("# fleet\n")}, {Path: "projects/punaro/AGENTS.md", Data: []byte("# punaro\n")}}},
+		Root:    t.TempDir(),
+		Home:    home,
+		Matches: []ProjectMatch{{Name: "punaro", Path: project, Kind: "matched"}},
+	})
+	if err == nil {
+		t.Fatal("accepted an unrelated CLAUDE.md symlink")
+	}
+}
+
+func TestApplyLiveRollbackPreservesCurrentUserRegion(t *testing.T) {
+	t.Parallel()
+	home := t.TempDir()
+	project := filepath.Join(home, "src", "punaro")
+	if err := os.MkdirAll(project, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	root := t.TempDir()
+	matches := []ProjectMatch{{Name: "punaro", Path: project, Kind: "matched"}}
+	v1 := Tree{Files: []File{
+		{Path: "AGENTS.md", Data: []byte("# fleet v1\n")},
+		{Path: "projects/punaro/AGENTS.md", Data: []byte("# punaro v1\n")},
+	}}
+	req := ApplyLiveRequest{Tree: v1, Root: root, Home: home, Matches: matches}
+	if _, err := ApplyLive(req); err != nil {
+		t.Fatal(err)
+	}
+	v2 := Tree{Files: []File{
+		{Path: "AGENTS.md", Data: []byte("# fleet v2\n")},
+		{Path: "projects/punaro/AGENTS.md", Data: []byte("# punaro v2\n")},
+	}}
+	req.Tree = v2
+	if _, err := ApplyLive(req); err != nil {
+		t.Fatal(err)
+	}
+	dest := filepath.Join(project, "AGENTS.md")
+	live, err := os.ReadFile(dest) //nolint:gosec // G304: test fixture under t.TempDir.
+	if err != nil {
+		t.Fatal(err)
+	}
+	prefix, _, ok := SplitUser(live)
+	if !ok {
+		t.Fatalf("v2 apply did not create user markers: %s", live)
+	}
+	if err := os.WriteFile(dest, Rehydrate(prefix, nil, []byte("\n"+userBodyProbe+"\n")), 0o600); err != nil { //nolint:gosec // G703: test fixture under t.TempDir.
+		t.Fatal(err)
+	}
+	if err := RollbackLive(req); err != nil {
+		t.Fatal(err)
+	}
+	got, err := os.ReadFile(dest) //nolint:gosec // G304: test fixture under t.TempDir.
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(got), "# punaro v1") || strings.Contains(string(got), "# punaro v2") {
+		t.Fatalf("rollback did not restore last-good prefix: %s", got)
+	}
+	_, user, ok := SplitUser(got)
+	if !ok || !strings.Contains(string(user), userBodyProbe) {
+		t.Fatalf("rollback discarded current user region: %s", got)
+	}
+}
+
 func TestApplyLiveRollbackRemovesDestsAbsentFromLastGood(t *testing.T) {
 	t.Parallel()
 	home := t.TempDir()

--- a/internal/fleetconfig/apply_live_test.go
+++ b/internal/fleetconfig/apply_live_test.go
@@ -355,6 +355,73 @@ func TestApplyLiveRemovesManagedDestsWhenProjectDropped(t *testing.T) {
 	}
 }
 
+func TestApplyLiveRejectsSymlinkedDestAncestor(t *testing.T) {
+	t.Parallel()
+	home := t.TempDir()
+	elsewhere := filepath.Join(home, "elsewhere")
+	if err := os.MkdirAll(elsewhere, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(elsewhere, filepath.Join(home, ".agents")); err != nil {
+		t.Fatal(err)
+	}
+	_, err := ApplyLive(ApplyLiveRequest{
+		Tree: Tree{Files: []File{
+			{Path: "AGENTS.md", Data: []byte("# fleet\n")},
+			{Path: "skills/global-demo/SKILL.md", Data: []byte(skillMarkdown("global-demo", "Global demo skill."))},
+		}},
+		Root: t.TempDir(),
+		Home: home,
+	})
+	if err == nil {
+		t.Fatal("wrote dests through a symlinked ~/.agents ancestor")
+	}
+	if _, err := os.Lstat(filepath.Join(elsewhere, "skills", "global-demo", "SKILL.md")); !os.IsNotExist(err) {
+		t.Fatal("created dests inside the symlink target")
+	}
+}
+
+func TestApplyLivePrunesOldPathWhenProjectMappingMoves(t *testing.T) {
+	t.Parallel()
+	home := t.TempDir()
+	first := filepath.Join(home, "src", "punaro")
+	second := filepath.Join(home, "src", "punaro-moved")
+	for _, dir := range []string{first, second} {
+		if err := os.MkdirAll(dir, 0o700); err != nil {
+			t.Fatal(err)
+		}
+	}
+	root := t.TempDir()
+	tree := Tree{Files: []File{
+		{Path: "AGENTS.md", Data: []byte("# fleet\n")},
+		{Path: "projects/punaro/AGENTS.md", Data: []byte("# punaro\n")},
+	}}
+	req := ApplyLiveRequest{
+		Tree:    tree,
+		Root:    root,
+		Home:    home,
+		Matches: []ProjectMatch{{Name: "punaro", Path: first, Kind: "matched"}},
+	}
+	if _, err := ApplyLive(req); err != nil {
+		t.Fatal(err)
+	}
+	oldDest := filepath.Join(first, "AGENTS.md")
+	if _, err := os.Lstat(oldDest); err != nil {
+		t.Fatal(err)
+	}
+	req.Matches = []ProjectMatch{{Name: "punaro", Path: second, Kind: "override"}}
+	if _, err := ApplyLive(req); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Lstat(oldDest); !os.IsNotExist(err) {
+		t.Fatal("left managed dests at the previous project path")
+	}
+	got, err := os.ReadFile(filepath.Join(second, "AGENTS.md")) //nolint:gosec // G304: test fixture under t.TempDir.
+	if err != nil || !IsManagedContent(got) {
+		t.Fatalf("missing dest at the new project path: %q err=%v", got, err)
+	}
+}
+
 func TestApplyLiveReplacesClaudeAliasWithRegularFile(t *testing.T) {
 	t.Parallel()
 	home := t.TempDir()

--- a/internal/fleetconfig/apply_live_test.go
+++ b/internal/fleetconfig/apply_live_test.go
@@ -258,6 +258,139 @@ func TestApplyLiveRemovesDroppedManagedSkill(t *testing.T) {
 	}
 }
 
+func TestApplyLiveRetainsSkillWhenNestedFileDropped(t *testing.T) {
+	t.Parallel()
+	home := t.TempDir()
+	project := filepath.Join(home, "src", "punaro")
+	if err := os.MkdirAll(project, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	root := t.TempDir()
+	matches := []ProjectMatch{{Name: "punaro", Path: project, Kind: "matched"}}
+	req := ApplyLiveRequest{Tree: commonMemberTree(skillMarkdown("shared", skillBodyProbe), false), Root: root, Home: home, Matches: matches}
+	if _, err := ApplyLive(req); err != nil {
+		t.Fatal(err)
+	}
+	skillRoot := filepath.Join(project, ".agents", "skills", "shared")
+	nested := filepath.Join(skillRoot, "scripts", "run.sh")
+	if _, err := os.Lstat(nested); err != nil {
+		t.Fatal(err)
+	}
+	req.Tree = Tree{Files: []File{
+		{Path: "AGENTS.md", Data: []byte("# fleet\n")},
+		{Path: "common/shared/SKILL.md", Data: []byte(skillMarkdown("shared", skillBodyProbe))},
+		{Path: "projects/punaro/AGENTS.md", Data: []byte("# punaro\n")},
+		{Path: "projects/punaro/skills/shared/COMMON", Data: []byte("shared\n")},
+	}}
+	if _, err := ApplyLive(req); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Lstat(nested); !os.IsNotExist(err) {
+		t.Fatal("left a dropped nested skill file")
+	}
+	skillDest := filepath.Join(skillRoot, "SKILL.md")
+	got, err := os.ReadFile(skillDest) //nolint:gosec // G304: test fixture under t.TempDir.
+	if err != nil || !strings.Contains(string(got), skillBodyProbe) {
+		t.Fatalf("dropped retained skill while pruning nested file: %q err=%v", got, err)
+	}
+	if !IsManagedDir(skillRoot) {
+		t.Fatal("unmarked retained skill directory while pruning nested file")
+	}
+}
+
+func TestApplyLiveRemovesManagedDestsWhenProjectDropped(t *testing.T) {
+	t.Parallel()
+	home := t.TempDir()
+	punaro := filepath.Join(home, "src", "punaro")
+	other := filepath.Join(home, "src", "other")
+	for _, dir := range []string{punaro, other} {
+		if err := os.MkdirAll(dir, 0o700); err != nil {
+			t.Fatal(err)
+		}
+	}
+	root := t.TempDir()
+	withBoth := Tree{Files: []File{
+		{Path: "AGENTS.md", Data: []byte("# fleet\n")},
+		{Path: "common/shared/SKILL.md", Data: []byte(skillMarkdown("shared", skillBodyProbe))},
+		{Path: "projects/punaro/AGENTS.md", Data: []byte("# punaro\n")},
+		{Path: "projects/punaro/skills/shared/COMMON", Data: []byte("shared\n")},
+		{Path: "projects/other/AGENTS.md", Data: []byte("# other\n")},
+		{Path: "projects/other/skills/shared/COMMON", Data: []byte("shared\n")},
+	}}
+	req := ApplyLiveRequest{
+		Tree:    withBoth,
+		Root:    root,
+		Home:    home,
+		Matches: []ProjectMatch{{Name: "punaro", Path: punaro, Kind: "matched"}, {Name: "other", Path: other, Kind: "matched"}},
+	}
+	if _, err := ApplyLive(req); err != nil {
+		t.Fatal(err)
+	}
+	otherAgents := filepath.Join(other, "AGENTS.md")
+	otherClaude := filepath.Join(other, "CLAUDE.md")
+	otherSkill := filepath.Join(other, ".agents", "skills", "shared", "SKILL.md")
+	for _, path := range []string{otherAgents, otherClaude, otherSkill} {
+		if _, err := os.Lstat(path); err != nil {
+			t.Fatalf("missing first-apply dest %s: %v", path, err)
+		}
+	}
+	req.Tree = Tree{Files: []File{
+		{Path: "AGENTS.md", Data: []byte("# fleet\n")},
+		{Path: "common/shared/SKILL.md", Data: []byte(skillMarkdown("shared", skillBodyProbe))},
+		{Path: "projects/punaro/AGENTS.md", Data: []byte("# punaro\n")},
+		{Path: "projects/punaro/skills/shared/COMMON", Data: []byte("shared\n")},
+	}}
+	req.Matches = []ProjectMatch{{Name: "punaro", Path: punaro, Kind: "matched"}}
+	if _, err := ApplyLive(req); err != nil {
+		t.Fatal(err)
+	}
+	for _, path := range []string{otherAgents, otherClaude, otherSkill} {
+		if _, err := os.Lstat(path); !os.IsNotExist(err) {
+			t.Fatalf("left managed dest after project drop: %s", path)
+		}
+	}
+	punaroAgents, err := os.ReadFile(filepath.Join(punaro, "AGENTS.md")) //nolint:gosec // G304: test fixture under t.TempDir.
+	if err != nil || !IsManagedContent(punaroAgents) {
+		t.Fatalf("dropped retained project dest: %q err=%v", punaroAgents, err)
+	}
+}
+
+func TestApplyLiveRollbackRemovesDestsAbsentFromLastGood(t *testing.T) {
+	t.Parallel()
+	home := t.TempDir()
+	project := filepath.Join(home, "src", "punaro")
+	if err := os.MkdirAll(project, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	root := t.TempDir()
+	matches := []ProjectMatch{{Name: "punaro", Path: project, Kind: "matched"}}
+	v1 := commonMemberTree(skillMarkdown("shared", "copied-skill-v1"), false)
+	req := ApplyLiveRequest{Tree: v1, Root: root, Home: home, Matches: matches}
+	if _, err := ApplyLive(req); err != nil {
+		t.Fatal(err)
+	}
+	v2 := commonMemberTree(skillMarkdown("shared", "copied-skill-v2"), true)
+	req.Tree = v2
+	if _, err := ApplyLive(req); err != nil {
+		t.Fatal(err)
+	}
+	extra := filepath.Join(home, ".agents", "skills", "global-demo", "SKILL.md")
+	if _, err := os.Lstat(extra); err != nil {
+		t.Fatal(err)
+	}
+	if err := RollbackLive(req); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Lstat(extra); !os.IsNotExist(err) {
+		t.Fatal("rollback left dests absent from last-good")
+	}
+	dest := filepath.Join(project, ".agents", "skills", "shared", "SKILL.md")
+	got, err := os.ReadFile(dest) //nolint:gosec // G304: test fixture under t.TempDir.
+	if err != nil || !strings.Contains(string(got), "copied-skill-v1") || strings.Contains(string(got), "copied-skill-v2") {
+		t.Fatalf("rollback did not restore copied skill: %q err=%v", got, err)
+	}
+}
+
 func applyCopiedCommonSkill(t *testing.T, skillBody string, addendums map[string]string) (home, project, skillDest, addendumRoot string) {
 	t.Helper()
 	home = t.TempDir()

--- a/internal/fleetconfig/apply_live_test.go
+++ b/internal/fleetconfig/apply_live_test.go
@@ -194,6 +194,70 @@ func TestApplyLiveRollbackRestoresCopiedSkill(t *testing.T) {
 	assertRegularCopiedSkill(t, dest)
 }
 
+func TestApplyLiveUnchangedReapplyKeepsLastGood(t *testing.T) {
+	t.Parallel()
+	home := t.TempDir()
+	project := filepath.Join(home, "src", "punaro")
+	if err := os.MkdirAll(project, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	root := t.TempDir()
+	matches := []ProjectMatch{{Name: "punaro", Path: project, Kind: "matched"}}
+	v1 := commonMemberTree(skillMarkdown("shared", "copied-skill-v1"), false)
+	req := ApplyLiveRequest{Tree: v1, Root: root, Home: home, Matches: matches}
+	if _, err := ApplyLive(req); err != nil {
+		t.Fatal(err)
+	}
+	v2 := commonMemberTree(skillMarkdown("shared", "copied-skill-v2"), false)
+	req.Tree = v2
+	if _, err := ApplyLive(req); err != nil {
+		t.Fatal(err)
+	}
+	req.Tree = v2
+	if _, err := ApplyLive(req); err != nil {
+		t.Fatal(err)
+	}
+	if err := RollbackLive(req); err != nil {
+		t.Fatal(err)
+	}
+	dest := filepath.Join(project, ".agents", "skills", "shared", "SKILL.md")
+	got, err := os.ReadFile(dest) //nolint:gosec // G304: test fixture under t.TempDir.
+	if err != nil || !strings.Contains(string(got), "copied-skill-v1") || strings.Contains(string(got), "copied-skill-v2") {
+		t.Fatalf("unchanged reapply rotated last-good: %q err=%v", got, err)
+	}
+}
+
+func TestApplyLiveRemovesDroppedManagedSkill(t *testing.T) {
+	t.Parallel()
+	home := t.TempDir()
+	project := filepath.Join(home, "src", "punaro")
+	if err := os.MkdirAll(project, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	root := t.TempDir()
+	matches := []ProjectMatch{{Name: "punaro", Path: project, Kind: "matched"}}
+	withSkill := commonMemberTree(skillMarkdown("shared", skillBodyProbe), false)
+	req := ApplyLiveRequest{Tree: withSkill, Root: root, Home: home, Matches: matches}
+	if _, err := ApplyLive(req); err != nil {
+		t.Fatal(err)
+	}
+	dest := filepath.Join(project, ".agents", "skills", "shared", "SKILL.md")
+	if _, err := os.Lstat(dest); err != nil {
+		t.Fatal(err)
+	}
+	withoutSkill := Tree{Files: []File{
+		{Path: "AGENTS.md", Data: []byte("# fleet\n")},
+		{Path: "projects/punaro/AGENTS.md", Data: []byte("# punaro\n")},
+	}}
+	req.Tree = withoutSkill
+	if _, err := ApplyLive(req); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Lstat(dest); !os.IsNotExist(err) {
+		t.Fatal("left a dropped managed skill")
+	}
+}
+
 func applyCopiedCommonSkill(t *testing.T, skillBody string, addendums map[string]string) (home, project, skillDest, addendumRoot string) {
 	t.Helper()
 	home = t.TempDir()

--- a/internal/fleetconfig/apply_live_unix_test.go
+++ b/internal/fleetconfig/apply_live_unix_test.go
@@ -1,0 +1,34 @@
+//go:build unix
+
+package fleetconfig
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestWriteRegularDestDoesNotFollowTmpSymlink(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	target := filepath.Join(dir, "secret")
+	if err := os.WriteFile(target, []byte("keep\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	dest := filepath.Join(dir, "AGENTS.md")
+	tmp := dest + ".punaro-tmp"
+	if err := os.Symlink(target, tmp); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeRegularDest(dest, []byte("# fleet\n")); err != nil {
+		t.Fatal(err)
+	}
+	got, err := os.ReadFile(target) //nolint:gosec // G304: test fixture under t.TempDir.
+	if err != nil || string(got) != "keep\n" {
+		t.Fatalf("followed tmp symlink: %q err=%v", got, err)
+	}
+	live, err := os.ReadFile(dest) //nolint:gosec // G304: test fixture under t.TempDir.
+	if err != nil || string(live) != "# fleet\n" {
+		t.Fatalf("live=%q err=%v", live, err)
+	}
+}

--- a/internal/fleetconfig/apply_live_windows_test.go
+++ b/internal/fleetconfig/apply_live_windows_test.go
@@ -1,0 +1,31 @@
+//go:build windows
+
+package fleetconfig
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestApplyLiveCopiesCommonSkillAsRegularFileNotJunction(t *testing.T) {
+	t.Parallel()
+	_, _, dest, _ := applyCopiedCommonSkill(t, skillMarkdown("shared", skillBodyProbe), nil)
+	info, err := os.Lstat(dest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !info.Mode().IsRegular() {
+		t.Fatalf("windows dest is not a regular file mode=%v", info.Mode())
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		t.Fatal("windows dest is a symlink")
+	}
+	if destIsJunctionOrReparse(info) {
+		t.Fatal("windows dest is a junction or reparse point")
+	}
+	body, err := os.ReadFile(dest) //nolint:gosec // G304: test fixture under t.TempDir.
+	if err != nil || !strings.Contains(string(body), skillBodyProbe) {
+		t.Fatalf("windows dest missing published skill: %q err=%v", body, err)
+	}
+}

--- a/internal/fleetconfig/common_test.go
+++ b/internal/fleetconfig/common_test.go
@@ -1,0 +1,206 @@
+package fleetconfig
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestValidateRejectsDanglingCOMMON(t *testing.T) {
+	t.Parallel()
+	root := writeTree(t, map[string]string{
+		"AGENTS.md":                            "# fleet\n",
+		"projects/punaro/AGENTS.md":            "# punaro\n",
+		"projects/punaro/skills/shared/COMMON": "shared\n",
+	})
+	tree, err := InspectRoot(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := Validate(tree); err == nil {
+		t.Fatal("accepted dangling COMMON with no common/shared tree")
+	}
+}
+
+func TestValidateRejectsCOMMONNextToPrivateSkill(t *testing.T) {
+	t.Parallel()
+	root := writeTree(t, map[string]string{
+		"AGENTS.md":                              "# fleet\n",
+		"common/shared/SKILL.md":                 skillMarkdown("shared", "Shared skill."),
+		"projects/punaro/AGENTS.md":              "# punaro\n",
+		"projects/punaro/skills/shared/COMMON":   "shared\n",
+		"projects/punaro/skills/shared/SKILL.md": skillMarkdown("shared", "Private mix."),
+	})
+	tree, err := InspectRoot(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := Validate(tree); err == nil {
+		t.Fatal("accepted COMMON next to a private skill tree")
+	}
+}
+
+func TestValidateRejectsCOMMONNextToPrivateSkillData(t *testing.T) {
+	t.Parallel()
+	root := writeTree(t, map[string]string{
+		"AGENTS.md":                               "# fleet\n",
+		"common/shared/SKILL.md":                  skillMarkdown("shared", "Shared skill."),
+		"projects/punaro/AGENTS.md":               "# punaro\n",
+		"projects/punaro/skills/shared/COMMON":    "",
+		"projects/punaro/skills/shared/notes.txt": "private notes\n",
+	})
+	tree, err := InspectRoot(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := Validate(tree); err == nil {
+		t.Fatal("accepted COMMON next to private skill data")
+	}
+}
+
+func TestValidateAcceptsCommonSkillWithNoMembers(t *testing.T) {
+	t.Parallel()
+	root := writeTree(t, map[string]string{
+		"AGENTS.md":                    "# fleet\n",
+		"common/shared/SKILL.md":       skillMarkdown("shared", "Shared skill."),
+		"common/shared/scripts/run.sh": "#!/bin/sh\necho unused\n",
+	})
+	tree, err := InspectRoot(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := Validate(tree); err != nil {
+		t.Fatalf("rejected common skill with no members: %v", err)
+	}
+	if tree.SkillCount() != 1 {
+		t.Fatalf("skill count=%d", tree.SkillCount())
+	}
+}
+
+func TestValidateCountsCommonSkillOnceTowardCap(t *testing.T) {
+	t.Parallel()
+	files := map[string]string{
+		"AGENTS.md":                "# fleet\n",
+		"projects/alpha/AGENTS.md": "# alpha\n",
+		"projects/beta/AGENTS.md":  "# beta\n",
+	}
+	for i := 0; i < MaxSkills; i++ {
+		name := skillName(i)
+		files["common/"+name+"/SKILL.md"] = skillMarkdown(name, "Shared "+name+".")
+		files["projects/alpha/skills/"+name+"/COMMON"] = name + "\n"
+		files["projects/beta/skills/"+name+"/COMMON"] = ""
+	}
+	root := writeTree(t, files)
+	tree, err := InspectRoot(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := Validate(tree); err != nil {
+		t.Fatalf("rejected 64 common skills opted in by two members: %v", err)
+	}
+	if tree.SkillCount() != MaxSkills {
+		t.Fatalf("common skills counted more than once: %d", tree.SkillCount())
+	}
+
+	over := Tree{Files: append(append([]File(nil), tree.Files...), File{
+		Path: "skills/overflow/SKILL.md",
+		Data: []byte(skillMarkdown("overflow", "One past the cap.")),
+	})}
+	if err := Validate(over); err == nil {
+		t.Fatal("accepted more than 64 skills when common members were expanded")
+	}
+}
+
+func TestValidateAcceptsEmptyOrNamedCOMMON(t *testing.T) {
+	t.Parallel()
+	root := writeTree(t, map[string]string{
+		"AGENTS.md":                            "# fleet\n",
+		"common/shared/SKILL.md":               skillMarkdown("shared", "Shared skill."),
+		"projects/punaro/AGENTS.md":            "# punaro\n",
+		"projects/punaro/skills/shared/COMMON": "",
+		"projects/canopi/AGENTS.md":            "# canopi\n",
+		"projects/canopi/skills/shared/COMMON": "shared\n",
+	})
+	tree, err := InspectRoot(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := Validate(tree); err != nil {
+		t.Fatalf("rejected valid COMMON bodies: %v", err)
+	}
+}
+
+func TestValidateRejectsCOMMONBodyThatIsNotSkillName(t *testing.T) {
+	t.Parallel()
+	root := writeTree(t, map[string]string{
+		"AGENTS.md":                            "# fleet\n",
+		"common/shared/SKILL.md":               skillMarkdown("shared", "Shared skill."),
+		"projects/punaro/AGENTS.md":            "# punaro\n",
+		"projects/punaro/skills/shared/COMMON": "other\n",
+	})
+	tree, err := InspectRoot(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := Validate(tree); err == nil {
+		t.Fatal("accepted COMMON body that is not empty or the skill name")
+	}
+}
+
+func TestInspectRootRejectsSymlinkInCommonSkill(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "AGENTS.md"), []byte("# fleet\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(root, "common", "shared"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "common", "shared", "SKILL.md"), []byte(skillMarkdown("shared", "Shared skill.")), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink("SKILL.md", filepath.Join(root, "common", "shared", "link.md")); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := InspectRoot(root); err == nil {
+		t.Fatal("accepted symlink in common skill source")
+	}
+}
+
+func TestValidateRejectsReservedLiveMarkersInSource(t *testing.T) {
+	t.Parallel()
+	for _, marker := range []string{UserStart, UserEnd, AddendumStart, AddendumEnd, ManagedMark, TrailerStart, TrailerEnd} {
+		root := writeTree(t, map[string]string{
+			"AGENTS.md": "# fleet\n" + marker + "\n",
+		})
+		tree, err := InspectRoot(root)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := Validate(tree); err == nil {
+			t.Fatalf("accepted reserved marker %q in published AGENTS.md", marker)
+		}
+	}
+}
+
+func TestValidateErrorOmitsSkillBody(t *testing.T) {
+	t.Parallel()
+	root := writeTree(t, map[string]string{
+		"AGENTS.md":                             "# fleet\n",
+		"common/shared/SKILL.md":                skillMarkdown("shared", skillBodyProbe),
+		"projects/punaro/AGENTS.md":             "# punaro\n",
+		"projects/punaro/skills/missing/COMMON": "",
+	})
+	tree, err := InspectRoot(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = Validate(tree)
+	if err == nil {
+		t.Fatal("accepted dangling COMMON")
+	}
+	if strings.Contains(err.Error(), skillBodyProbe) {
+		t.Fatalf("validation error logged skill body: %v", err)
+	}
+}

--- a/internal/fleetconfig/dest_copy_other.go
+++ b/internal/fleetconfig/dest_copy_other.go
@@ -1,0 +1,9 @@
+//go:build !windows
+
+package fleetconfig
+
+import "os"
+
+func destIsJunctionOrReparse(info os.FileInfo) bool {
+	return info != nil && info.Mode()&os.ModeSymlink != 0
+}

--- a/internal/fleetconfig/dest_copy_windows.go
+++ b/internal/fleetconfig/dest_copy_windows.go
@@ -1,0 +1,19 @@
+//go:build windows
+
+package fleetconfig
+
+import (
+	"os"
+	"syscall"
+)
+
+func destIsJunctionOrReparse(info os.FileInfo) bool {
+	if info == nil {
+		return false
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return true
+	}
+	data, ok := info.Sys().(*syscall.Win32FileAttributeData)
+	return ok && data.FileAttributes&syscall.FILE_ATTRIBUTE_REPARSE_POINT != 0
+}

--- a/internal/fleetconfig/rehydrate.go
+++ b/internal/fleetconfig/rehydrate.go
@@ -1,0 +1,208 @@
+package fleetconfig
+
+import (
+	"bytes"
+	"errors"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// DefaultAddendumRoot is the well-known machine-local addendum tree.
+func DefaultAddendumRoot(home string) string {
+	return filepath.Join(home, "punaro", "addendums")
+}
+
+// LoadAddendums reads a machine-local addendum tree. Missing roots are empty.
+func LoadAddendums(root string) (map[string][]byte, error) {
+	if root == "" {
+		return map[string][]byte{}, nil
+	}
+	info, err := os.Lstat(root)
+	if errors.Is(err, os.ErrNotExist) {
+		return map[string][]byte{}, nil
+	}
+	if err != nil {
+		return nil, errors.New("fleet-config addendum root is unavailable")
+	}
+	if !info.IsDir() || info.Mode()&os.ModeSymlink != 0 {
+		return nil, errors.New("fleet-config addendum root must be a directory")
+	}
+	files := map[string][]byte{}
+	err = filepath.WalkDir(root, func(path string, entry fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return errors.New("fleet-config addendum walk failed")
+		}
+		rel, relErr := filepath.Rel(root, path)
+		if relErr != nil {
+			return errors.New("fleet-config addendum path is invalid")
+		}
+		if rel == "." {
+			return nil
+		}
+		slash, pathErr := canonicalPath(filepath.ToSlash(rel))
+		if pathErr != nil {
+			return pathErr
+		}
+		info, err := entry.Info()
+		if err != nil {
+			return errors.New("fleet-config addendum walk failed")
+		}
+		if info.Mode()&os.ModeSymlink != 0 {
+			return errors.New("fleet-config addendum must not contain links")
+		}
+		if entry.IsDir() {
+			return nil
+		}
+		if !info.Mode().IsRegular() {
+			return errors.New("fleet-config addendum contains a special file")
+		}
+		if extraHardLink(info) {
+			return errors.New("fleet-config addendum contains a special file")
+		}
+		if err := classifyAddendumPath(slash); err != nil {
+			return err
+		}
+		if info.Size() > MaxFileBytes {
+			return errors.New("fleet-config file is too large")
+		}
+		data, err := os.ReadFile(path) // #nosec G304,G122 -- Lstat-bounded walk of a caller-selected addendum tree.
+		if err != nil {
+			return errors.New("fleet-config addendum walk failed")
+		}
+		files[slash] = data
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return files, nil
+}
+
+func classifyAddendumPath(path string) error {
+	if path == "CLAUDE.md" {
+		return nil
+	}
+	if _, err := classifyPath(path); err == nil {
+		return nil
+	}
+	if strings.HasPrefix(path, "projects/") {
+		project, rest, ok := splitFirst(strings.TrimPrefix(path, "projects/"))
+		if ok && rest == "CLAUDE.md" && entryNamePattern.MatchString(project) {
+			return nil
+		}
+	}
+	return errors.New("fleet-config addendum layout is invalid")
+}
+
+// ResolveAddendum returns the addendum for a published path. A project
+// addendum overrides a matching global addendum.
+func ResolveAddendum(files map[string][]byte, path string) []byte {
+	if files == nil {
+		return nil
+	}
+	if body, ok := files[path]; ok {
+		return body
+	}
+	if !strings.HasPrefix(path, "projects/") {
+		return nil
+	}
+	_, rest, ok := splitFirst(strings.TrimPrefix(path, "projects/"))
+	if !ok {
+		return nil
+	}
+	if rest == "AGENTS.md" || rest == "CLAUDE.md" {
+		return files[rest]
+	}
+	if skillRest, ok := strings.CutPrefix(rest, "skills/"); ok {
+		skill, file, skillOK := splitFirst(skillRest)
+		if !skillOK {
+			return nil
+		}
+		if body, ok := files["common/"+skill+"/"+file]; ok {
+			return body
+		}
+		return files["skills/"+skill+"/"+file]
+	}
+	return nil
+}
+
+// Rehydrate composes a managed dest from a published file, the winning
+// addendum, and the live user region.
+func Rehydrate(published, addendum, existing []byte) []byte {
+	user := existing
+	if _, extracted, ok := SplitUser(existing); ok {
+		user = extracted
+	} else if IsManagedContent(existing) || bytes.Contains(existing, []byte(AddendumStart)) {
+		user = nil
+	}
+	return composeManaged(published, addendum, user)
+}
+
+// ComposeClaudeFile writes AGENTS.md plus Claude addendum(s) as a regular file.
+func ComposeClaudeFile(agentsPublished, agentsAddendum, claudeAddendum, existing []byte) []byte {
+	var addendum bytes.Buffer
+	if len(agentsAddendum) > 0 {
+		addendum.Write(bytes.TrimRight(agentsAddendum, "\n"))
+		addendum.WriteByte('\n')
+	}
+	if len(claudeAddendum) > 0 {
+		addendum.Write(bytes.TrimRight(claudeAddendum, "\n"))
+		addendum.WriteByte('\n')
+	}
+	return Rehydrate(agentsPublished, addendum.Bytes(), existing)
+}
+
+func composeManaged(published, addendum, user []byte) []byte {
+	var buf bytes.Buffer
+	if len(published) > 0 {
+		buf.Write(bytes.TrimRight(published, "\n"))
+		buf.WriteByte('\n')
+	}
+	buf.WriteString(ManagedMark)
+	buf.WriteByte('\n')
+	buf.WriteString(AddendumStart)
+	buf.WriteByte('\n')
+	if len(addendum) > 0 {
+		buf.Write(bytes.TrimRight(addendum, "\n"))
+		buf.WriteByte('\n')
+	}
+	buf.WriteString(AddendumEnd)
+	buf.WriteByte('\n')
+	buf.WriteString(UserStart)
+	if len(user) > 0 && user[0] != '\n' {
+		buf.WriteByte('\n')
+	}
+	buf.Write(user)
+	if len(user) == 0 || user[len(user)-1] != '\n' {
+		buf.WriteByte('\n')
+	}
+	buf.WriteString(UserEnd)
+	buf.WriteByte('\n')
+	return buf.Bytes()
+}
+
+// IsManagedContent reports whether live bytes carry the Punaro ownership mark.
+func IsManagedContent(data []byte) bool {
+	return bytes.Contains(data, []byte(ManagedMark))
+}
+
+// IsManagedDir reports whether a skill destination directory is Punaro-owned.
+func IsManagedDir(path string) bool {
+	info, err := os.Lstat(filepath.Join(path, ManagedDirMarker))
+	return err == nil && info.Mode().IsRegular() && info.Mode()&os.ModeSymlink == 0
+}
+
+// SplitUser extracts the live user region when markers are present.
+func SplitUser(content []byte) (prefix, user []byte, ok bool) {
+	text := string(content)
+	start := strings.Index(text, UserStart)
+	end := strings.LastIndex(text, UserEnd)
+	if start < 0 || end < 0 || end < start {
+		return nil, nil, false
+	}
+	prefix = []byte(strings.TrimRight(text[:start], "\n"))
+	user = []byte(text[start+len(UserStart) : end])
+	return prefix, user, true
+}

--- a/internal/fleetconfig/rehydrate_test.go
+++ b/internal/fleetconfig/rehydrate_test.go
@@ -1,0 +1,253 @@
+package fleetconfig
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	punarodiagnostic "github.com/rock3r/punaro/internal/diagnostic"
+)
+
+func TestResolveAddendumProjectOverridesGlobal(t *testing.T) {
+	t.Parallel()
+	files := map[string][]byte{
+		"AGENTS.md":                              []byte(globalAddendumProbe + "\n"),
+		"projects/punaro/AGENTS.md":              []byte(projectAddendumProbe + "\n"),
+		"common/shared/SKILL.md":                 []byte("global-skill-addendum\n"),
+		"projects/punaro/skills/shared/SKILL.md": []byte("project-skill-addendum\n"),
+	}
+	got := ResolveAddendum(files, "projects/punaro/AGENTS.md")
+	if !bytes.Contains(got, []byte(projectAddendumProbe)) {
+		t.Fatalf("missing project addendum: %q", got)
+	}
+	if bytes.Contains(got, []byte(globalAddendumProbe)) {
+		t.Fatalf("kept overridden global addendum: %q", got)
+	}
+	fallback := ResolveAddendum(files, "projects/other/AGENTS.md")
+	if !bytes.Contains(fallback, []byte(globalAddendumProbe)) {
+		t.Fatalf("missing global fallback addendum: %q", fallback)
+	}
+	skill := ResolveAddendum(files, "projects/punaro/skills/shared/SKILL.md")
+	if !bytes.Contains(skill, []byte("project-skill-addendum")) || bytes.Contains(skill, []byte("global-skill-addendum")) {
+		t.Fatalf("skill addendum override failed: %q", skill)
+	}
+	commonFallback := ResolveAddendum(files, "projects/other/skills/shared/SKILL.md")
+	if !bytes.Contains(commonFallback, []byte("global-skill-addendum")) {
+		t.Fatalf("missing common skill fallback addendum: %q", commonFallback)
+	}
+}
+
+func TestRehydratePutsAddendumInMarkedNonUserBlock(t *testing.T) {
+	t.Parallel()
+	got := Rehydrate([]byte("# published\n"), []byte(projectAddendumProbe+"\n"), nil)
+	text := string(got)
+	if !strings.Contains(text, "# published") {
+		t.Fatalf("missing published text: %s", text)
+	}
+	if !strings.Contains(text, projectAddendumProbe) {
+		t.Fatalf("missing addendum text: %s", text)
+	}
+	if !strings.Contains(text, AddendumStart) || !strings.Contains(text, AddendumEnd) {
+		t.Fatalf("addendum not in a marked block: %s", text)
+	}
+	if !strings.Contains(text, UserStart) || !strings.Contains(text, UserEnd) {
+		t.Fatalf("missing user region: %s", text)
+	}
+	if !IsManagedContent(got) {
+		t.Fatalf("missing managed mark: %s", text)
+	}
+	_, user, ok := SplitUser(got)
+	if !ok {
+		t.Fatal("composed file missing user markers")
+	}
+	if strings.Contains(string(user), projectAddendumProbe) {
+		t.Fatal("addendum text landed in the user block")
+	}
+	if strings.Contains(string(user), AddendumStart) {
+		t.Fatal("addendum markers nested in the user block")
+	}
+}
+
+func TestComposeClaudeFileIsAgentsPlusClaudeAddendum(t *testing.T) {
+	t.Parallel()
+	got := ComposeClaudeFile([]byte("# punaro agents\n"), []byte("agents-addendum\n"), []byte(claudeAddendumProbe+"\n"), nil)
+	text := string(got)
+	if !strings.Contains(text, "# punaro agents") {
+		t.Fatalf("CLAUDE.md missing AGENTS.md text: %s", text)
+	}
+	if !strings.Contains(text, claudeAddendumProbe) {
+		t.Fatalf("CLAUDE.md missing Claude addendum: %s", text)
+	}
+	if !strings.Contains(text, AddendumStart) {
+		t.Fatalf("CLAUDE.md addendum unmarked: %s", text)
+	}
+	if !IsManagedContent(got) {
+		t.Fatal("CLAUDE.md missing managed mark")
+	}
+}
+
+func TestApplyLiveClaudeFileIsAgentsPlusAddendumRegularFile(t *testing.T) {
+	t.Parallel()
+	_, project, _, _ := applyCopiedCommonSkill(t, skillMarkdown("shared", skillBodyProbe), map[string]string{
+		"CLAUDE.md":                 claudeAddendumProbe + "\n",
+		"projects/punaro/CLAUDE.md": "project-" + claudeAddendumProbe + "\n",
+		"AGENTS.md":                 globalAddendumProbe + "\n",
+		"projects/punaro/AGENTS.md": projectAddendumProbe + "\n",
+	})
+	dest := filepath.Join(project, "CLAUDE.md")
+	assertRegularCopiedSkill(t, dest)
+	body, err := os.ReadFile(dest) //nolint:gosec // G304: test fixture under t.TempDir.
+	if err != nil {
+		t.Fatal(err)
+	}
+	text := string(body)
+	if !strings.Contains(text, "# punaro") {
+		t.Fatalf("CLAUDE.md missing project AGENTS.md: %s", text)
+	}
+	if !strings.Contains(text, "project-"+claudeAddendumProbe) {
+		t.Fatalf("CLAUDE.md missing project Claude addendum: %s", text)
+	}
+	if strings.Contains(text, claudeAddendumProbe) && !strings.Contains(text, "project-"+claudeAddendumProbe) {
+		t.Fatalf("CLAUDE.md used overridden global Claude addendum: %s", text)
+	}
+	if _, err := os.Readlink(dest); err == nil {
+		t.Fatal("CLAUDE.md is a symlink alias of AGENTS.md")
+	}
+}
+
+func TestApplyLiveUserSectionSurvivesReapply(t *testing.T) {
+	t.Parallel()
+	home := t.TempDir()
+	project := filepath.Join(home, "src", "punaro")
+	if err := os.MkdirAll(project, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	root := t.TempDir()
+	matches := []ProjectMatch{{Name: "punaro", Path: project, Kind: "matched"}}
+	v1 := Tree{Files: []File{
+		{Path: "AGENTS.md", Data: []byte("# fleet v1\n")},
+		{Path: "projects/punaro/AGENTS.md", Data: []byte("# punaro v1\n")},
+	}}
+	if _, err := ApplyLive(ApplyLiveRequest{Tree: v1, Root: root, Home: home, Matches: matches}); err != nil {
+		t.Fatal(err)
+	}
+	dest := filepath.Join(project, "AGENTS.md")
+	live, err := os.ReadFile(dest) //nolint:gosec // G304: test fixture under t.TempDir.
+	if err != nil {
+		t.Fatal(err)
+	}
+	prefix, _, ok := SplitUser(live)
+	if !ok {
+		t.Fatalf("first apply did not create user markers: %s", live)
+	}
+	edited := Rehydrate(prefix, nil, []byte("\n"+userBodyProbe+"\n"))
+	if err := os.WriteFile(dest, edited, 0o600); err != nil { //nolint:gosec // G703: test fixture under t.TempDir.
+		t.Fatal(err)
+	}
+	v2 := Tree{Files: []File{
+		{Path: "AGENTS.md", Data: []byte("# fleet v2\n")},
+		{Path: "projects/punaro/AGENTS.md", Data: []byte("# punaro v2\n")},
+	}}
+	if _, err := ApplyLive(ApplyLiveRequest{Tree: v2, Root: root, Home: home, Matches: matches}); err != nil {
+		t.Fatal(err)
+	}
+	got, err := os.ReadFile(dest) //nolint:gosec // G304: test fixture under t.TempDir.
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(got), "# punaro v2") {
+		t.Fatalf("re-apply did not update published prefix: %s", got)
+	}
+	_, user, ok := SplitUser(got)
+	if !ok || !strings.Contains(string(user), userBodyProbe) {
+		t.Fatalf("user section did not survive re-apply: %s", got)
+	}
+}
+
+func TestApplyLiveAddendumEditsAppearOnNextApply(t *testing.T) {
+	t.Parallel()
+	home := t.TempDir()
+	project := filepath.Join(home, "src", "punaro")
+	if err := os.MkdirAll(project, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	addendumRoot := filepath.Join(home, "punaro", "addendums")
+	writeTreeAt(t, addendumRoot, map[string]string{
+		"projects/punaro/AGENTS.md": "addendum-v1\n",
+	})
+	root := t.TempDir()
+	matches := []ProjectMatch{{Name: "punaro", Path: project, Kind: "matched"}}
+	tree := Tree{Files: []File{
+		{Path: "AGENTS.md", Data: []byte("# fleet\n")},
+		{Path: "projects/punaro/AGENTS.md", Data: []byte("# punaro\n")},
+	}}
+	req := ApplyLiveRequest{Tree: tree, Root: root, Home: home, AddendumRoot: addendumRoot, Matches: matches}
+	if _, err := ApplyLive(req); err != nil {
+		t.Fatal(err)
+	}
+	dest := filepath.Join(project, "AGENTS.md")
+	first, err := os.ReadFile(dest) //nolint:gosec // G304: test fixture under t.TempDir.
+	if err != nil || !strings.Contains(string(first), "addendum-v1") {
+		t.Fatalf("first apply missing addendum: %q err=%v", first, err)
+	}
+	writeTreeAt(t, addendumRoot, map[string]string{
+		"projects/punaro/AGENTS.md": "addendum-v2\n",
+	})
+	if _, err := ApplyLive(req); err != nil {
+		t.Fatal(err)
+	}
+	second, err := os.ReadFile(dest) //nolint:gosec // G304: test fixture under t.TempDir.
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(second), "addendum-v2") {
+		t.Fatalf("changed addendum did not appear: %s", second)
+	}
+	if strings.Contains(string(second), "addendum-v1") {
+		t.Fatalf("stale addendum remained: %s", second)
+	}
+}
+
+func TestApplyLiveAndStatusOmitSkillAndAddendumBodies(t *testing.T) {
+	t.Parallel()
+	var logs bytes.Buffer
+	home := t.TempDir()
+	project := filepath.Join(home, "src", "punaro")
+	if err := os.MkdirAll(project, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	addendumRoot := filepath.Join(home, "punaro", "addendums")
+	writeTreeAt(t, addendumRoot, map[string]string{
+		"projects/punaro/skills/shared/SKILL.md": addendumBodyProbe + "\n",
+		"CLAUDE.md":                              addendumBodyProbe + "-claude\n",
+	})
+	tree := commonMemberTree(skillMarkdown("shared", skillBodyProbe), false)
+	result, err := ApplyLive(ApplyLiveRequest{
+		Tree:         tree,
+		Root:         t.TempDir(),
+		Home:         home,
+		AddendumRoot: addendumRoot,
+		Matches:      []ProjectMatch{{Name: "punaro", Path: project, Kind: "matched"}},
+		Logs:         &logs,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	logLine := logs.String() + FormatApplyLog(result, tree.SkillCount())
+	for _, token := range []string{skillBodyProbe, addendumBodyProbe, "# punaro"} {
+		if strings.Contains(logLine, token) {
+			t.Fatalf("apply log contained body token %q: %s", token, logLine)
+		}
+	}
+	var checkBuf bytes.Buffer
+	for _, check := range punarodiagnostic.FleetConfigChecks("digest", []string{"current", "drifted"}) {
+		checkBuf.WriteString(check.Code)
+		checkBuf.WriteString(string(check.Status))
+		checkBuf.WriteString(check.Remediation)
+	}
+	if strings.Contains(checkBuf.String(), skillBodyProbe) || strings.Contains(checkBuf.String(), addendumBodyProbe) {
+		t.Fatalf("doctor output contained bodies: %s", checkBuf.String())
+	}
+}

--- a/internal/fleetconfig/tree.go
+++ b/internal/fleetconfig/tree.go
@@ -10,6 +10,20 @@ const (
 	TrailerStart = "<!-- punaro-local-trailer:start -->"
 	// TrailerEnd closes the machine-local trailer.
 	TrailerEnd = "<!-- punaro-local-trailer:end -->"
+	// UserStart opens the preserved live user region. It is illegal in fleet source.
+	UserStart = "<!-- user -->"
+	// UserEnd closes the preserved live user region.
+	UserEnd = "<!--/user-->"
+	// AddendumStart opens the machine-local addendum block. It is illegal in fleet source.
+	AddendumStart = "<!-- punaro-addendum -->"
+	// AddendumEnd closes the machine-local addendum block.
+	AddendumEnd = "<!--/punaro-addendum-->"
+	// ManagedMark records that Punaro owns a live AGENTS.md, CLAUDE.md, or skill file.
+	ManagedMark = "<!-- punaro-managed -->"
+	// ManagedDirMarker is the regular file that marks a managed skill directory.
+	ManagedDirMarker = ".punaro-managed"
+	// CommonMarkerName is the project opt-in file for a shared common skill.
+	CommonMarkerName = "COMMON"
 	// MaxFileBytes is the per-file bound for v1 source files.
 	MaxFileBytes = 256 << 10
 	// MaxSkills bounds global plus project skills.

--- a/internal/fleetconfig/validate.go
+++ b/internal/fleetconfig/validate.go
@@ -23,6 +23,7 @@ func Validate(tree Tree) error {
 	folded := map[string]struct{}{}
 	hasGlobalAgents := false
 	skills := map[string]struct{}{}
+	dataSkills := map[string]struct{}{}
 	commonDefined := map[string]struct{}{}
 	projectSkills := map[string]*projectSkillFiles{}
 	var optIns []classifiedPath
@@ -75,6 +76,7 @@ func Validate(tree Tree) error {
 			if isTextPath(path) && containsReservedLiveMarkers(file.Data) {
 				return errors.New("fleet-config source must not contain reserved live markers")
 			}
+			dataSkills[kind.skillKey] = struct{}{}
 			noteProjectSkillFile(projectSkills, kind, false)
 		case pathCommonOptIn:
 			if err := validateCOMMON(kind.skill, file.Data); err != nil {
@@ -84,8 +86,16 @@ func Validate(tree Tree) error {
 			optIns = append(optIns, kind)
 		}
 	}
-	if !hasGlobalAgents {
-		return errors.New("fleet-config source requires AGENTS.md")
+	if !hasGlobalAgents || total < 1 {
+		if !hasGlobalAgents {
+			return errors.New("fleet-config source requires AGENTS.md")
+		}
+		return errors.New("fleet-config source layout is invalid")
+	}
+	for key := range dataSkills {
+		if _, ok := skills[key]; !ok {
+			return errors.New("fleet-config skill path is invalid")
+		}
 	}
 	if len(skills) > MaxSkills {
 		return errors.New("fleet-config source has too many skills")
@@ -262,12 +272,22 @@ func parseSkillFrontmatter(data []byte) (string, string, error) {
 	description := ""
 	for _, line := range strings.Split(body, "\n") {
 		line = strings.TrimRight(line, "\r")
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" || strings.HasPrefix(trimmed, "#") {
+			continue
+		}
 		key, value, ok := strings.Cut(line, ":")
 		if !ok {
-			continue
+			return "", "", errors.New("missing frontmatter")
 		}
 		key = strings.TrimSpace(key)
 		value = strings.TrimSpace(value)
+		if key == "" || strings.ContainsAny(key, " \t") {
+			return "", "", errors.New("missing frontmatter")
+		}
+		if unclosedScalar(value) {
+			return "", "", errors.New("missing frontmatter")
+		}
 		switch key {
 		case "name":
 			name = value
@@ -279,6 +299,22 @@ func parseSkillFrontmatter(data []byte) (string, string, error) {
 		return "", "", errors.New("missing frontmatter fields")
 	}
 	return name, description, nil
+}
+
+func unclosedScalar(value string) bool {
+	if strings.HasPrefix(value, "[") && !strings.HasSuffix(value, "]") {
+		return true
+	}
+	if strings.HasPrefix(value, "{") && !strings.HasSuffix(value, "}") {
+		return true
+	}
+	if strings.HasPrefix(value, "\"") && !strings.HasSuffix(value, "\"") {
+		return true
+	}
+	if strings.HasPrefix(value, "'") && !strings.HasSuffix(value, "'") {
+		return true
+	}
+	return false
 }
 
 func isTextPath(path string) bool {

--- a/internal/fleetconfig/validate.go
+++ b/internal/fleetconfig/validate.go
@@ -23,7 +23,9 @@ func Validate(tree Tree) error {
 	folded := map[string]struct{}{}
 	hasGlobalAgents := false
 	skills := map[string]struct{}{}
-	dataSkills := map[string]struct{}{}
+	commonDefined := map[string]struct{}{}
+	projectSkills := map[string]*projectSkillFiles{}
+	var optIns []classifiedPath
 	for _, file := range tree.Files {
 		path, err := canonicalPath(file.Path)
 		if err != nil {
@@ -62,26 +64,41 @@ func Validate(tree Tree) error {
 				return err
 			}
 			skills[kind.skillKey] = struct{}{}
+			if kind.scope == "common" {
+				commonDefined[kind.skill] = struct{}{}
+			}
+			noteProjectSkillFile(projectSkills, kind, false)
 		case pathSkillData:
 			if bytes.Contains(file.Data, []byte{0}) && isTextPath(path) {
 				return errors.New("fleet-config text file is invalid")
 			}
-			dataSkills[kind.skillKey] = struct{}{}
+			if isTextPath(path) && containsReservedLiveMarkers(file.Data) {
+				return errors.New("fleet-config source must not contain reserved live markers")
+			}
+			noteProjectSkillFile(projectSkills, kind, false)
+		case pathCommonOptIn:
+			if err := validateCOMMON(kind.skill, file.Data); err != nil {
+				return err
+			}
+			noteProjectSkillFile(projectSkills, kind, true)
+			optIns = append(optIns, kind)
 		}
 	}
-	if !hasGlobalAgents || total < 1 {
-		if !hasGlobalAgents {
-			return errors.New("fleet-config source requires AGENTS.md")
-		}
-		return errors.New("fleet-config source layout is invalid")
-	}
-	for key := range dataSkills {
-		if _, ok := skills[key]; !ok {
-			return errors.New("fleet-config skill path is invalid")
-		}
+	if !hasGlobalAgents {
+		return errors.New("fleet-config source requires AGENTS.md")
 	}
 	if len(skills) > MaxSkills {
 		return errors.New("fleet-config source has too many skills")
+	}
+	for _, entry := range projectSkills {
+		if entry.optIn && entry.other > 0 {
+			return errors.New("fleet-config COMMON cannot mix with a private skill tree")
+		}
+	}
+	for _, opt := range optIns {
+		if _, ok := commonDefined[opt.skill]; !ok {
+			return errors.New("fleet-config COMMON does not name a common skill")
+		}
 	}
 	return nil
 }
@@ -93,12 +110,37 @@ const (
 	pathProjectAgents
 	pathSkillMarkdown
 	pathSkillData
+	pathCommonOptIn
 )
 
 type classifiedPath struct {
 	class    pathClass
 	skill    string
 	skillKey string
+	project  string
+	scope    string
+}
+
+type projectSkillFiles struct {
+	optIn bool
+	other int
+}
+
+func noteProjectSkillFile(projectSkills map[string]*projectSkillFiles, kind classifiedPath, optIn bool) {
+	if kind.project == "" || kind.skill == "" {
+		return
+	}
+	key := kind.project + "/" + kind.skill
+	entry := projectSkills[key]
+	if entry == nil {
+		entry = &projectSkillFiles{}
+		projectSkills[key] = entry
+	}
+	if optIn {
+		entry.optIn = true
+		return
+	}
+	entry.other++
 }
 
 func classifyPath(path string) (classifiedPath, error) {
@@ -107,37 +149,19 @@ func classifyPath(path string) (classifiedPath, error) {
 	}
 	switch {
 	case strings.HasPrefix(path, "skills/"):
-		skill, rest, ok := splitFirst(strings.TrimPrefix(path, "skills/"))
-		if !ok || !entryNamePattern.MatchString(skill) || rest == "" {
-			return classifiedPath{}, errors.New("fleet-config skill path is invalid")
-		}
-		if rest == "SKILL.md" {
-			return classifiedPath{class: pathSkillMarkdown, skill: skill, skillKey: "./skills/" + skill}, nil
-		}
-		if _, err := canonicalPath(rest); err != nil {
-			return classifiedPath{}, err
-		}
-		return classifiedPath{class: pathSkillData, skill: skill, skillKey: "./skills/" + skill}, nil
+		return classifySkillPath("global", "", strings.TrimPrefix(path, "skills/"))
+	case strings.HasPrefix(path, "common/"):
+		return classifySkillPath("common", "", strings.TrimPrefix(path, "common/"))
 	case strings.HasPrefix(path, "projects/"):
 		project, rest, ok := splitFirst(strings.TrimPrefix(path, "projects/"))
 		if !ok || !entryNamePattern.MatchString(project) || rest == "" {
 			return classifiedPath{}, errors.New("fleet-config project path is invalid")
 		}
 		if rest == agentsSuffix {
-			return classifiedPath{class: pathProjectAgents}, nil
+			return classifiedPath{class: pathProjectAgents, project: project}, nil
 		}
 		if strings.HasPrefix(rest, "skills/") {
-			skill, skillRest, skillOK := splitFirst(strings.TrimPrefix(rest, "skills/"))
-			if !skillOK || !entryNamePattern.MatchString(skill) || skillRest == "" {
-				return classifiedPath{}, errors.New("fleet-config skill path is invalid")
-			}
-			if skillRest == "SKILL.md" {
-				return classifiedPath{class: pathSkillMarkdown, skill: skill, skillKey: project + "/" + skill}, nil
-			}
-			if _, err := canonicalPath(skillRest); err != nil {
-				return classifiedPath{}, err
-			}
-			return classifiedPath{class: pathSkillData, skill: skill, skillKey: project + "/" + skill}, nil
+			return classifySkillPath("project", project, strings.TrimPrefix(rest, "skills/"))
 		}
 		return classifiedPath{}, errors.New("fleet-config source layout is invalid")
 	default:
@@ -145,12 +169,40 @@ func classifyPath(path string) (classifiedPath, error) {
 	}
 }
 
+func classifySkillPath(scope, project, rest string) (classifiedPath, error) {
+	skill, skillRest, ok := splitFirst(rest)
+	if !ok || !entryNamePattern.MatchString(skill) || skillRest == "" {
+		return classifiedPath{}, errors.New("fleet-config skill path is invalid")
+	}
+	key := scope + "/" + skill
+	if scope == "project" {
+		key = project + "/" + skill
+	}
+	classified := classifiedPath{skill: skill, skillKey: key, project: project, scope: scope}
+	if skillRest == "SKILL.md" {
+		classified.class = pathSkillMarkdown
+		return classified, nil
+	}
+	if skillRest == CommonMarkerName {
+		if scope != "project" {
+			return classifiedPath{}, errors.New("fleet-config skill path is invalid")
+		}
+		classified.class = pathCommonOptIn
+		return classified, nil
+	}
+	if _, err := canonicalPath(skillRest); err != nil {
+		return classifiedPath{}, err
+	}
+	classified.class = pathSkillData
+	return classified, nil
+}
+
 func validateAgents(data []byte) error {
 	if !utf8.Valid(data) || bytes.Contains(data, []byte{0}) {
 		return errors.New("fleet-config text file is invalid")
 	}
-	if bytes.Contains(data, []byte(TrailerStart)) || bytes.Contains(data, []byte(TrailerEnd)) {
-		return errors.New("fleet-config source must not contain a machine-local trailer")
+	if containsReservedLiveMarkers(data) {
+		return errors.New("fleet-config source must not contain reserved live markers")
 	}
 	return nil
 }
@@ -159,11 +211,35 @@ func validateSkillMarkdown(directory string, data []byte) error {
 	if !utf8.Valid(data) || bytes.Contains(data, []byte{0}) {
 		return errors.New("fleet-config text file is invalid")
 	}
+	if containsReservedLiveMarkers(data) {
+		return errors.New("fleet-config source must not contain reserved live markers")
+	}
 	name, description, err := parseSkillFrontmatter(data)
 	if err != nil || name != directory || description == "" {
 		return errors.New("fleet-config skill metadata is invalid")
 	}
 	return nil
+}
+
+func validateCOMMON(skill string, data []byte) error {
+	if !utf8.Valid(data) || bytes.Contains(data, []byte{0}) {
+		return errors.New("fleet-config text file is invalid")
+	}
+	text := strings.TrimSpace(string(data))
+	if text != "" && text != skill {
+		return errors.New("fleet-config COMMON file is invalid")
+	}
+	return nil
+}
+
+func containsReservedLiveMarkers(data []byte) bool {
+	markers := []string{TrailerStart, TrailerEnd, UserStart, UserEnd, AddendumStart, AddendumEnd, ManagedMark}
+	for _, marker := range markers {
+		if bytes.Contains(data, []byte(marker)) {
+			return true
+		}
+	}
+	return false
 }
 
 func parseSkillFrontmatter(data []byte) (string, string, error) {
@@ -186,22 +262,12 @@ func parseSkillFrontmatter(data []byte) (string, string, error) {
 	description := ""
 	for _, line := range strings.Split(body, "\n") {
 		line = strings.TrimRight(line, "\r")
-		trimmed := strings.TrimSpace(line)
-		if trimmed == "" || strings.HasPrefix(trimmed, "#") {
-			continue
-		}
 		key, value, ok := strings.Cut(line, ":")
 		if !ok {
-			return "", "", errors.New("missing frontmatter")
+			continue
 		}
 		key = strings.TrimSpace(key)
 		value = strings.TrimSpace(value)
-		if key == "" || strings.ContainsAny(key, " \t") {
-			return "", "", errors.New("missing frontmatter")
-		}
-		if unclosedScalar(value) {
-			return "", "", errors.New("missing frontmatter")
-		}
 		switch key {
 		case "name":
 			name = value
@@ -213,22 +279,6 @@ func parseSkillFrontmatter(data []byte) (string, string, error) {
 		return "", "", errors.New("missing frontmatter fields")
 	}
 	return name, description, nil
-}
-
-func unclosedScalar(value string) bool {
-	if strings.HasPrefix(value, "[") && !strings.HasSuffix(value, "]") {
-		return true
-	}
-	if strings.HasPrefix(value, "{") && !strings.HasSuffix(value, "}") {
-		return true
-	}
-	if strings.HasPrefix(value, "\"") && !strings.HasSuffix(value, "\"") {
-		return true
-	}
-	if strings.HasPrefix(value, "'") && !strings.HasSuffix(value, "'") {
-		return true
-	}
-	return false
 }
 
 func isTextPath(path string) bool {


### PR DESCRIPTION
Closes #236.

Publish `common/<skill>/` once, copy into opted-in member projects as regular files, mark managed destinations, and rehydrate AGENTS/CLAUDE/skills from the published tree plus machine-local addendums and a preserved user section.

Destinations are never symlinks, junctions, or CLAUDE.md aliases. `COMMON` is a regular opt-in file (empty or skill name), cannot sit next to a private skill tree, and dangling COMMON is rejected.

Stacked on current `main` after the fleet-config HTTP/adapter series.